### PR TITLE
fix: Eliminate SIGPIPE warnings with timeout + tee solution

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -449,7 +449,21 @@ generate_descendant_template(PredStr, BashCode) :-
 {{pred}}_check() {
     local start="$1"
     local target="$2"
-    {{pred}}_all "$start" | grep -q "^$start:$target$" && echo "$start:$target"
+    local tmpflag="/tmp/{{pred}}_found_$$"
+    local timeout_duration="5s"
+    
+    # Timeout prevents infinite execution, tee prevents SIGPIPE
+    timeout "$timeout_duration" {{pred}}_all "$start" | 
+    tee >(grep -q "^$start:$target$" && touch "$tmpflag") >/dev/null
+    
+    if [[ -f "$tmpflag" ]]; then
+        echo "$start:$target"
+        rm -f "$tmpflag"
+        return 0
+    else
+        rm -f "$tmpflag"
+        return 1
+    fi
 }
 
 # Stream function


### PR DESCRIPTION
- Replace direct pipe to 'grep -q' with timeout + tee pattern
- Prevents broken pipe warnings that could interfere with Gemini CLI streaming
- Uses temporary flag files to capture grep results safely
- Implements 5-second timeout to prevent infinite execution
- Applied to both template_system.pl and recursive_compiler.pl

Technical details:
- Old: ancestor_all | grep -q (causes SIGPIPE when grep exits early)
- New: timeout 5s ancestor_all | tee >(grep -q && touch flag) >/dev/null
- Tee keeps one output path open, preventing pipe break
- Flag file captures grep success/failure status
- Bounded execution time for safety

Fixes the core issue identified in broken pipe analysis. Tested: Full test suite runs without SIGPIPE warnings.