### PR TITLE
feat(xml_source): add xmllint engine with optional namespace repair

### DIFF
--- a/docs/XML_PARSING_TOOLS_INSTALLATION.md
+++ b/docs/XML_PARSING_TOOLS_INSTALLATION.md
@@ -1,0 +1,624 @@
+# XML Parsing Tools Installation Guide
+
+This guide covers installation of XML parsing tools for the `xml_source` plugin on various platforms.
+
+## Overview
+
+The `xml_source` plugin supports multiple parsing engines:
+
+1. **lxml (Python)** - Recommended for large files (true streaming, constant memory)
+2. **xmllint** - Standard Linux tool (part of libxml2-utils)
+3. **xmlstarlet** - Alternative CLI tool (NOT recommended for large files due to memory issues)
+
+## Installation by Platform
+
+### Linux (Debian/Ubuntu)
+
+#### Install lxml (Recommended)
+```bash
+# Using pip (Python package manager)
+pip3 install lxml
+
+# Or using system package manager
+sudo apt-get update
+sudo apt-get install python3-lxml
+```
+
+#### Install xmllint
+```bash
+sudo apt-get update
+sudo apt-get install libxml2-utils
+```
+
+#### Install xmlstarlet (Optional)
+```bash
+sudo apt-get update
+sudo apt-get install xmlstarlet
+```
+
+### Linux (RHEL/CentOS/Fedora)
+
+#### Install lxml
+```bash
+# Using pip
+pip3 install lxml
+
+# Or using system package manager
+sudo dnf install python3-lxml    # Fedora
+sudo yum install python3-lxml    # RHEL/CentOS
+```
+
+#### Install xmllint
+```bash
+sudo dnf install libxml2         # Fedora
+sudo yum install libxml2         # RHEL/CentOS
+```
+
+#### Install xmlstarlet
+```bash
+sudo dnf install xmlstarlet      # Fedora
+sudo yum install xmlstarlet      # RHEL/CentOS
+```
+
+### Linux (Arch)
+
+#### Install lxml
+```bash
+# Using pip
+pip3 install lxml
+
+# Or using system package manager
+sudo pacman -S python-lxml
+```
+
+#### Install xmllint
+```bash
+sudo pacman -S libxml2
+```
+
+#### Install xmlstarlet
+```bash
+sudo pacman -S xmlstarlet
+```
+
+### macOS
+
+#### Install lxml
+```bash
+# Using pip
+pip3 install lxml
+
+# Or using Homebrew
+brew install libxml2 libxslt
+pip3 install lxml
+```
+
+#### Install xmllint
+```bash
+# xmllint comes pre-installed on macOS
+# To update to latest version:
+brew install libxml2
+```
+
+#### Install xmlstarlet
+```bash
+brew install xmlstarlet
+```
+
+### Windows (WSL - Windows Subsystem for Linux)
+
+Use the Linux (Ubuntu) instructions above within your WSL environment.
+
+#### WSL PATH priority fix
+
+When running the UnifyWeaver test suite from PowerShell (or another Windows shell) the inherited `PATH` may list Windows directories before the WSL ones, causing tools such as `xmlstarlet` to resolve to Windows shims or not be found. To align the environment with what WSL expects:
+
+```bash
+source scripts/testing/reorder-path.sh
+```
+
+This script reorders `$PATH` so the Linux directories from `/etc/environment` take precedence. Every automated test run that shells out from the Windows side should source it before invoking `swipl`.
+
+### Windows (Native - via Cygwin)
+
+#### Install lxml
+
+⚠️ **Important:** On Cygwin, `pip3 install lxml` will FAIL unless you install development packages first. The easiest approach is to use the pre-compiled binary.
+
+**Option 1: Pre-compiled Binary (EASIEST - Recommended)**
+1. Close Cygwin terminal
+2. Run Cygwin's `setup-x86_64.exe` or `setup-x86.exe`
+3. Search for and select:
+   - `python39-lxml` (or `python3-lxml` - pre-compiled lxml package)
+
+   **Note:** The package name may vary by Cygwin version. Search for "lxml" in the package list.
+
+4. Complete installation
+5. Open Cygwin terminal and verify:
+   ```bash
+   python3 -c "import lxml; print('lxml version:', lxml.__version__)"
+   ```
+
+**Option 2: Compile from Source (Advanced - Requires Multiple Packages)**
+
+⚠️ **Only use this if pre-compiled package is unavailable**
+
+1. Close Cygwin terminal
+2. Run Cygwin's `setup-x86_64.exe` or `setup-x86.exe`
+3. Search for and install ALL of these packages:
+   - `python39` (or latest Python 3.x)
+   - `python39-devel` (Python development headers - REQUIRED)
+   - `libxml2-devel` (XML library headers - REQUIRED)
+   - `libxslt-devel` (XSLT library headers - REQUIRED)
+   - `gcc-core` (C compiler - REQUIRED)
+   - `gcc-g++` (C++ compiler - may be needed)
+   - `zlib-devel` (compression library - REQUIRED)
+   - `make` (build tool)
+
+4. Complete installation and restart Cygwin terminal
+5. Verify packages are installed:
+   ```bash
+   # Check for development headers
+   ls /usr/include/libxml2/libxml/
+   ls /usr/include/libxslt/
+   ```
+
+6. Now try pip:
+   ```bash
+   pip3 install lxml
+   ```
+
+**If compilation still fails:** Use Option 1 (pre-compiled binary) instead
+
+#### Install xmllint
+```bash
+# Install via Cygwin setup.exe
+# Package: libxml2
+```
+
+#### Install xmlstarlet
+```bash
+# Install via Cygwin setup.exe
+# Package: xmlstarlet
+```
+
+### Windows (Native - via Chocolatey)
+
+#### Install Python and lxml
+```powershell
+# From PowerShell (as Administrator)
+choco install python3
+pip3 install lxml
+```
+
+#### Install xmlstarlet
+```powershell
+choco install xmlstarlet
+```
+
+## Verification
+
+### Verify lxml installation
+```bash
+python3 -c "import lxml; print('lxml version:', lxml.__version__)"
+```
+
+Expected output:
+```
+lxml version: 5.x.x
+```
+
+### Verify xmllint installation
+```bash
+xmllint --version
+```
+
+Expected output:
+```
+xmllint: using libxml version 20xxx
+   compiled with: Threads Tree Output Push Reader Patterns Writer SAXv1 FTP HTTP DTDValid HTML Legacy C14N Catalog XPath XPointer XInclude Iconv ICU ISO8859X Unicode Regexps Automata Schemas Schematron Modules Debug Zlib Lzma
+```
+
+**Understanding version numbers:**
+- Version shown is in hex format
+- Example: `20910` = libxml2 version 2.9.10 (2.09.10 in hex)
+- Example: `21004` = libxml2 version 2.10.4
+
+**Check package version (Linux only):**
+```bash
+# Debian/Ubuntu (WSL)
+dpkg -l | grep libxml2-utils
+
+# RHEL/CentOS/Fedora
+rpm -q libxml2
+
+# Arch
+pacman -Q libxml2
+```
+
+**Check package version (Cygwin):**
+```bash
+# Using cygcheck
+cygcheck -c libxml2
+
+# Or search Cygwin packages
+cygcheck -p xmllint
+```
+
+### Verify xmlstarlet installation
+```bash
+xmlstarlet --version
+```
+
+Expected output:
+```
+1.6.1
+compiled against libxml2 2.x.x, linked with 20xxx
+compiled against libxslt 1.x.x, linked with 10xxx
+```
+
+### Verify xmllint extraction (project)
+```bash
+source scripts/testing/reorder-path.sh
+swipl -s tests/core/test_xml_source.pl \
+      -g "run_tests([xml_source:xmllint_extraction])" \
+      -t halt
+```
+
+The test prints each extracted record to stdout so you can confirm namespaces and CDATA blocks look correct.
+
+To compare the output when namespace repair is disabled, run:
+
+```bash
+swipl -s tests/core/test_xml_source.pl \
+      -g "run_tests([xml_source:xmllint_extraction_without_namespace_fix])" \
+      -t halt
+```
+
+This variant demonstrates the behaviour with `namespace_fix(false)` set in the source configuration.
+
+## Troubleshooting
+
+### Quick Reference - Common Errors
+
+| Error Message | Platform | Solution |
+|---------------|----------|----------|
+| `Error: Please make sure the libxml2 and libxslt development packages are installed` | WSL/Ubuntu | [Install dev packages](#lxml-installation-fails-on-wsl-windows-subsystem-for-linux) |
+| `Error: Please make sure the libxml2 and libxslt development packages are installed` | Cygwin | [Use Cygwin Setup](#lxml-installation-fails-on-cygwin) |
+| `Getting requirements to build wheel did not run successfully` | WSL/Linux | [Install dev packages](#lxml-installation-fails-on-wsl-windows-subsystem-for-linux) |
+| `pip3: command not found` | WSL | [Install pip](#wsl-specific-issues) |
+| `Permission denied` | Any | [Use --user flag](#permission-denied-errors) |
+| Compilation hangs/takes forever | Cygwin | [Use pre-compiled binary](#lxml-installation-fails-on-cygwin) |
+
+### lxml installation fails on WSL (Windows Subsystem for Linux)
+
+**Error:** `Error: Please make sure the libxml2 and libxslt development packages are installed.`
+
+This is the most common issue when installing lxml on WSL/Ubuntu. The error occurs because lxml needs to compile C extensions and requires development libraries.
+
+**Solution:**
+```bash
+# Install all required development packages
+sudo apt-get update
+sudo apt-get install -y python3-dev libxml2-dev libxslt1-dev zlib1g-dev
+
+# Now install lxml
+pip3 install lxml
+```
+
+**Alternative (pre-compiled binary):**
+```bash
+# Use the system package instead of pip
+sudo apt-get install python3-lxml
+```
+
+**Verify installation:**
+```bash
+python3 -c "import lxml; print('lxml version:', lxml.__version__)"
+```
+
+### lxml installation fails on Cygwin
+
+⚠️ **This is a very common issue on Cygwin. The pre-compiled binary approach is strongly recommended.**
+
+**Error:** `Error: Please make sure the libxml2 and libxslt development packages are installed.`
+
+```
+Collecting lxml
+  Using cached lxml-6.0.2.tar.gz (4.1 MB)
+  Installing build dependencies ... done
+  Getting requirements to build wheel ... error
+  error: subprocess-exited-with-error
+
+  × Getting requirements to build wheel did not run successfully.
+  │ exit code: 1
+  ╰─> [3 lines of output]
+      Building lxml version 6.0.2.
+      Building without Cython.
+      Error: Please make sure the libxml2 and libxslt development packages are installed.
+```
+
+**This error means:** Cygwin's pip is trying to compile lxml from source, but the C development libraries are missing.
+
+**Solution 1: Use Pre-compiled Binary (EASIEST - Recommended)**
+
+This completely avoids compilation and pip:
+
+1. **Close Cygwin terminal**
+2. **Run Cygwin Setup:** `setup-x86_64.exe` (usually in `C:\cygwin64\`)
+3. **Search for lxml:**
+   - In the package search box, type: `lxml`
+   - Look for: `python39-lxml` or `python3-lxml`
+   - Click the "Skip" button to change it to a version number (this installs it)
+4. **Complete installation** (click Next through the dialogs)
+5. **Open Cygwin terminal and verify:**
+   ```bash
+   python3 -c "import lxml; print('Success! lxml version:', lxml.__version__)"
+   ```
+
+**Solution 2: Install Development Packages (Advanced)**
+
+Only use this if the pre-compiled package is not available:
+
+1. **Close Cygwin terminal**
+2. **Run Cygwin Setup:** `setup-x86_64.exe`
+3. **Install ALL of these packages:**
+
+   Search for each package and select it:
+   - `python39-devel` - Python development headers
+   - `libxml2-devel` - XML library headers
+   - `libxslt-devel` - XSLT library headers
+   - `gcc-core` - C compiler
+   - `gcc-g++` - C++ compiler (may be needed)
+   - `zlib-devel` - Compression library
+   - `make` - Build tool
+
+4. **Complete installation**
+5. **Restart Cygwin terminal**
+6. **Verify development files are present:**
+   ```bash
+   ls /usr/include/libxml2/libxml/ 2>/dev/null && echo "libxml2-devel: OK" || echo "libxml2-devel: MISSING"
+   ls /usr/include/libxslt/ 2>/dev/null && echo "libxslt-devel: OK" || echo "libxslt-devel: MISSING"
+   which gcc && echo "gcc: OK" || echo "gcc: MISSING"
+   ```
+
+7. **If all show "OK", try pip again:**
+   ```bash
+   pip3 install lxml
+   ```
+
+**Solution 3: Use apt-cyg (if installed)**
+
+If you have `apt-cyg` package manager:
+```bash
+apt-cyg install python39-devel libxml2-devel libxslt-devel gcc-core gcc-g++ zlib-devel make
+pip3 install lxml
+```
+
+**Still failing?**
+- Use Solution 1 (pre-compiled binary)
+- Or use WSL instead of Cygwin (easier for Python packages)
+
+**Verify installation:**
+```bash
+python3 -c "import lxml; print('lxml version:', lxml.__version__)"
+```
+
+### lxml installation fails on Linux
+
+**Error:** Compilation errors about missing headers
+
+**Solution for Debian/Ubuntu:**
+```bash
+sudo apt-get update
+sudo apt-get install -y python3-dev libxml2-dev libxslt1-dev zlib1g-dev
+pip3 install lxml
+```
+
+**Solution for RHEL/CentOS/Fedora:**
+```bash
+sudo dnf install python3-devel libxml2-devel libxslt-devel zlib-devel
+pip3 install lxml
+```
+
+### lxml installation fails on macOS
+
+**Error:** Compilation errors or missing Xcode tools
+
+**Solution:**
+```bash
+# Install Xcode command line tools
+xcode-select --install
+
+# Install dependencies via Homebrew
+brew install libxml2 libxslt
+
+# Set compiler flags and install
+CFLAGS="-I$(brew --prefix libxml2)/include -I$(brew --prefix libxslt)/include" \
+LDFLAGS="-L$(brew --prefix libxml2)/lib -L$(brew --prefix libxslt)/lib" \
+pip3 install lxml
+```
+
+### Permission denied errors
+
+**Error:** `Permission denied` or `Access denied` when installing with pip
+
+**Solution 1 - Install for current user only:**
+```bash
+pip3 install --user lxml
+```
+
+**Solution 2 - Use virtual environment (Recommended):**
+```bash
+# Create virtual environment
+python3 -m venv ~/venv
+source ~/venv/bin/activate
+
+# Install in virtual environment
+pip3 install lxml
+```
+
+**Solution 3 - Use sudo (Not recommended):**
+```bash
+# Only if absolutely necessary
+sudo pip3 install lxml
+```
+
+### Multiple Python versions
+
+**Problem:** Wrong Python version being used
+
+**Solution:**
+```bash
+# Check which python3 is being used
+which python3
+python3 --version
+
+# Check all installed Python versions
+ls -la /usr/bin/python*
+
+# Use specific version if needed
+python3.11 -m pip install lxml
+
+# Or create version-specific alias
+alias python3='/usr/bin/python3.11'
+```
+
+### WSL-specific issues
+
+**Problem:** `pip3: command not found`
+
+**Solution:**
+```bash
+# Install pip
+sudo apt-get update
+sudo apt-get install python3-pip
+```
+
+**Problem:** Old pip version causing issues
+
+**Solution:**
+```bash
+# Upgrade pip
+python3 -m pip install --upgrade pip
+```
+
+### Verification failures
+
+**Problem:** Installation succeeds but import fails
+
+**Check Python path:**
+```bash
+python3 -c "import sys; print('\n'.join(sys.path))"
+```
+
+**Check installation location:**
+```bash
+pip3 show lxml
+```
+
+**Reinstall cleanly:**
+```bash
+pip3 uninstall lxml
+pip3 install --no-cache-dir lxml
+```
+
+### Advanced: Debugging pip compilation issues
+
+If you need to troubleshoot why pip compilation is failing, you can preserve the temporary build folders for inspection.
+
+**Keep build files for debugging:**
+```bash
+# Preserve temporary build directory
+pip3 install --no-clean lxml
+
+# This will leave the build files in a temporary directory when it fails
+# The path will be shown in the error output, e.g.:
+# /tmp/pip-install-xxxxxx/lxml/
+```
+
+**Verbose output for detailed error messages:**
+```bash
+# Get detailed build output
+pip3 install -v lxml          # Verbose
+pip3 install -vv lxml         # More verbose
+pip3 install -vvv lxml        # Maximum verbosity
+```
+
+**Combine both for maximum debugging info:**
+```bash
+# Keep build files AND show detailed output
+pip3 install --no-clean -vvv lxml 2>&1 | tee pip-lxml-debug.log
+
+# This saves all output to pip-lxml-debug.log for analysis
+```
+
+**Inspect build files:**
+```bash
+# After a failed build with --no-clean, you can inspect:
+# - C compiler command line arguments
+# - Header file locations
+# - Linker flags
+# - Build scripts
+
+# Example: Check if development headers were found
+grep -r "libxml/tree.h" /tmp/pip-install-*/lxml/
+```
+
+**Version comparison:**
+- **Pre-compiled package (Cygwin):** lxml 4.7.1 (older but stable)
+- **pip from source (WSL):** lxml 6.0.2 (latest)
+
+The newer version may have performance improvements and bug fixes. If you need the latest version on Cygwin, you can attempt the compilation approach, but be prepared to install all development packages listed in the [Cygwin troubleshooting section](#lxml-installation-fails-on-cygwin).
+
+## Engine Selection Recommendations
+
+### For Large Files (>100MB)
+- **Recommended:** `engine(iterparse)` - Uses lxml, constant memory usage
+- **Alternative:** `engine(xmllint_stream)` - Native tool, but limited functionality
+
+### For Small Files (<10MB)
+- **Recommended:** `engine(iterparse)` - Still the best option
+- **Alternative:** `engine(xmllint_xpath)` - If lxml unavailable
+
+### When Python/lxml Unavailable
+- **Use:** `engine(xmllint_stream)` - Basic streaming support
+- **Note:** May have limitations with complex tag filtering
+
+## Memory Usage Comparison
+
+Based on Perplexity research and testing:
+
+| Engine | Memory Usage | Large File Support | Installation Complexity |
+|--------|--------------|-------------------|------------------------|
+| lxml (iterparse) | Constant (~10MB) | ✅ Excellent | Medium (requires pip) |
+| xmllint --stream | Variable | ⚠️ Limited | Low (pre-installed) |
+| xmlstarlet sel | Loads full file | ❌ Poor | Low (package manager) |
+
+## Dependencies for UnifyWeaver
+
+### Minimal Setup (Basic Functionality)
+```bash
+# Just xmllint (usually pre-installed on Linux/macOS)
+sudo apt-get install libxml2-utils
+```
+
+### Recommended Setup (Full Functionality)
+```bash
+# Install both lxml and xmllint
+pip3 install lxml
+sudo apt-get install libxml2-utils
+```
+
+### Complete Setup (All Engines)
+```bash
+# Install all tools
+pip3 install lxml
+sudo apt-get install libxml2-utils xmlstarlet
+```
+
+## See Also
+
+- [XML Source Plugin Documentation](./proposals/xml_source/SPECIFICATION.md)
+- [Firewall Configuration Guide](./FIREWALL_GUIDE.md)
+- [Python Source Plugin](../src/unifyweaver/sources/python_source.pl)

--- a/docs/proposals/xml_source/FUTURE_XML_TOOLING.md
+++ b/docs/proposals/xml_source/FUTURE_XML_TOOLING.md
@@ -1,0 +1,76 @@
+# Future XML Tooling Directions
+
+This note captures ideas for building out UnifyWeaver’s XML capabilities beyond the current `xml_source` plugin. It is a scratchpad—update it as new use cases appear or when we learn more about the tools.
+
+## 1. Engine Landscape (Current & Potential)
+
+| Engine/Tool | Strengths | Weaknesses | Notes / Possible Work |
+|-------------|-----------|------------|-----------------------|
+| **Python / lxml.etree.iterparse** (`engine(iterparse)`) | True streaming; deterministic memory usage; Python’s full power (XPath, XSLT, schema validation via `lxml` add-ons) | Requires `lxml` wheel; Python dependency | - Extend to expose incremental XPath filters (e.g. allow users to supply Python predicates for complex conditions)<br>- Explore packaging a reusable Python module so other plugins can reuse the streaming logic |
+| **xmllint** (`engine(xmllint)`) | Part of `libxml2` suite; fast XPath evaluator; rich CLI options (validation, XInclude, DTD processing) | CLI emits concatenated output; currently relies on embedded Python for splitting/reformatting; streaming support limited to validation | - Investigate pure-shell splitter to drop Python dependency when `namespace_fix(false)`<br>- Add configuration hooks for validation options (`--schema`, `--relaxng`, `--noout` etc.)<br>- Consider piping into other UnifyWeaver-friendly tools (`xmllint | jq`, `| awk`, etc.) |
+| **xmlstarlet** (`engine(xmlstarlet)`) | Select + transform; supports large library of operations (edits, transforms, formatting); ubiquitous on Linux | Loads document in memory; CLI syntax is verbose; namespace handling requires manual declarations | - Document best practices for big queries (e.g. how to pre-limit scope)<br>- Provide helper templates for frequent tasks (attribute extraction, XSLT invocation) |
+| **Other libxml2 tools** (`xmllint` family) | `xmllint` supports HTML tidy, canonicalisation, etc. | N/A | - Explore additional subcommands (e.g. `--format`, `--c14n`) as dedicated UnifyWeaver transforms |
+| **Saxon / Java-based processors** | Full XPath/XQuery/XSLT 3.0; streaming; schema-aware processing | Requires JVM; heavier footprint; licensing for Saxon-EE | - Candidate for advanced transformations; would need firewall/workflow adjustments |
+| **Rust/Go XML libs** | High-performance streaming; typed pipelines | Need new runtimes + sandbox permissions | - Worth tracking if we add Rust/Go targets in future |
+
+## 2. Short-Term Ideas
+
+1. **Python-free xmllint splitter**  
+   Prototype a bash/awk (or Perl) pipeline to segment `xmllint --xpath` output into null-delimited records. If feasible, make namespace repair opt-in without pulling Python.
+
+2. **XPath helper library**  
+   Create a small Prolog helper that builds XPath expressions (including namespace bindings) to avoid hand-rolled strings in multiple places. Could support `descendant::`, attribute filters, etc.
+
+3. **Namespace registry**  
+   Move `known_namespace/2` into a shared configuration file so projects can add prefixes once and have them available to all engines (xmllint/xmlstarlet/potential future ones).
+
+4. **Enhanced test coverage**  
+   Add sample XML fixtures with:
+   - default namespaces (no prefixes),
+   - multiple prefixes referencing the same URI,
+   - large CDATA sections and mixed content,
+   to ensure each engine emits the expected fragments.
+
+## 3. Medium-Term Opportunities
+
+1. **Validation Workflow**  
+   - Provide a new plugin or option (`validate(schema(Path))`) that runs `xmllint --schema`, `--relaxng`, or `--dtdvalid`.  
+   - Capture validation errors and surface them in UnifyWeaver logs/tests.
+
+2. **XSLT & Transformation Support**  
+   - `xmlstarlet tr stylesheet.xsl file.xml` or `xsltproc`.  
+   - Could compile into streaming pipelines for transforming XML into CSV/JSON for downstream tools.
+
+3. **Selective Extraction**  
+   - Support attribute-only extraction (e.g. stream values of `@rdf:about`).  
+   - Possibly integrate with `xmlstarlet sel -T -t -m` for templated output.
+
+4. **Incremental Parsing with Buffers**  
+   - Extend iterparse engine to supply context objects (e.g. parent attributes, path) by augmenting the embedded Python code.  
+   - Investigate chunking large text nodes for memory control.
+
+## 4. Longer-Term Vision
+
+1. **Unified XML Toolkit Module**  
+   - Factor out common namespace/XPath utilities.  
+   - Provide a consistent interface so new engines can be swapped in with minimal changes.
+
+2. **Streaming Query Language**  
+   - Build a DSL around XPath-lite expressions that choose the right engine automatically, similar to how `jq` does for JSON.  
+   - Extend `xml_source` to compile full pipelines (select → transform → output).
+
+3. **Cross-Language Interop**  
+   - Explore hooking into `libxml2` bindings for other languages (Rust `xmlparser`, Go `encoding/xml`) for performance-critical tasks.  
+   - Could be packaged as optional engines if the tooling is installed.
+
+4. **XML + Semantic Web**  
+   - Many datasets (RDF/XML, Atom, RSS) benefit from higher-level handling (e.g. RDF to triples). Consider dedicated plugins that convert XML sources into RDF triples or graph queries.
+
+## 5. Open Questions
+
+- When do we prefer CLI tools over Python, given the extra dependencies?  
+- What is the threshold (file size, complexity) where xmlstarlet becomes impractical?  
+- Should namespace repair be configurable at the global level instead of per-source?  
+- How do we best expose XPath/XSLT knowledge to LLM agents (docs, prompts, helper predicates)?
+
+Document status: **brainstorm**. Refine as we gather more experience with real XML workloads.

--- a/docs/proposals/xml_source/HANDOFF_BACK_TO_GEMINI.md
+++ b/docs/proposals/xml_source/HANDOFF_BACK_TO_GEMINI.md
@@ -1,0 +1,109 @@
+# Handoff Back to Gemini — XML Source Test Fix
+
+**Date:** 2025-10-30  
+**From:** cline.bot  
+**To:** Gemini
+
+---
+
+## 1. Summary
+
+- Targeted issue: `read_util:read_stream_to_codes/2` was being called with uninstantiated stream arguments inside `check_lxml_available/0`, triggered during `xml_source:compile_source/4` when the lxml availability check failed.  
+- Resolution: rewrote the availability check to iterate over multiple Python interpreter candidates, spawning each within a `setup_call_cleanup/3` block so that stream handles are only read if process creation succeeds, and are always closed afterward. Exceptions from missing executables are ignored; other errors are reported and cause failure.  
+- Verification: WSL-based Prolog test `tests/core/test_xml_source.pl` (`run_tests/0`) now passes (`basic_extraction` succeeds, only original choicepoint warning remains). No other files required changes.
+
+---
+
+## 2. Root Cause
+
+The original implementation of `check_lxml_available/0` hard-coded a call to `C:\Windows\System32\wsl.exe` and wrapped it in a `catch/3` that, on any exception, still attempted to read the `Out` and `Err` pipes. When the executable could not be spawned (e.g., path mismatch on some systems), the stream variables never instantiated; the subsequent `read_stream_to_codes/2` calls raised the instantiation error observed in PLUnit.
+
+---
+
+## 3. Changes Made
+
+| File | Description |
+| ---- | ----------- |
+| `src/unifyweaver/sources/xml_source.pl` | Added `library(process)` and `library(readutil)` imports. Replaced `check_lxml_available/0` with a candidate-driven implementation that safely manages process handles and handles missing interpreters gracefully. |
+
+---
+
+## 4. Key Code Snippet
+
+Updated `check_lxml_available/0`:
+
+```prolog
+check_lxml_available :-
+    python_lxml_candidates(Candidates),
+    member(Exec-Args, Candidates),
+    python_lxml_check(Exec, Args),
+    !.
+
+check_lxml_available :-
+    format('lxml check failed using all configured interpreters.~n', []),
+    fail.
+
+python_lxml_candidates([
+    path(python3)-['-c', 'import lxml'],
+    path(py)-['-3', '-c', 'import lxml'],
+    path(wsl)-['python3', '-c', 'import lxml'],
+    path('C:\\Windows\\System32\\wsl.exe')-['python3', '-c', 'import lxml']
+]).
+
+python_lxml_check(Exec, Args) :-
+    catch(
+        setup_call_cleanup(
+            process_create(Exec, Args, [stdout(pipe(Out)), stderr(pipe(Err)), process(Process)]),
+            (
+                read_stream_to_codes(Out, OutCodes),
+                read_stream_to_codes(Err, ErrCodes),
+                process_wait(Process, ExitStatus),
+                (   ExitStatus = exit(0)
+                ->  true
+                ;   format('lxml check via ~q failed (status ~w). stdout: ~s, stderr: ~s~n',
+                           [Exec, ExitStatus, OutCodes, ErrCodes]),
+                    fail
+                )
+            ),
+            (   close(Out),
+                close(Err)
+            )
+        ),
+        Error,
+        (   (   Error = error(existence_error(_, _), _)
+            ->  fail                 % interpreter not present — try next candidate
+            ;   format('lxml check via ~q raised exception: ~q~n', [Exec, Error]),
+                fail
+            )
+        )
+    ).
+```
+
+This approach ensures `read_stream_to_codes/2` is only called when the stream handles exist, and any missing interpreter simply causes iteration to advance to the next candidate.
+
+---
+
+## 5. Tests Executed
+
+```
+wsl swipl -s tests/core/test_xml_source.pl -g run_tests -t halt
+```
+
+Result: `basic_extraction` passes; the runner emits the existing choicepoint warning but no errors.
+
+---
+
+## 6. Files Modified
+
+- `src/unifyweaver/sources/xml_source.pl`
+
+_No other files touched._
+
+---
+
+## 7. Next Steps / Recommendations
+
+- If future platforms require different Python entry points, extend `python_lxml_candidates/1` accordingly.  
+- Implement the `xmllint` fallback engine when ready; the current fix ensures the test suite no longer errors out before reaching that branch.
+
+This document should give you all context needed to understand the applied fix and resume work.

--- a/docs/proposals/xml_source/HANDOFF_TO_CLINE.md
+++ b/docs/proposals/xml_source/HANDOFF_TO_CLINE.md
@@ -1,0 +1,52 @@
+# Handoff to cline.bot - XML Source Test Failure
+
+**Date:** 2025-10-30
+**From:** Gemini
+**To:** cline.bot
+
+## 1. The Goal
+
+The primary goal is to fix the persistent test failure for the `xml_source.pl` plugin. The specific test that is failing is the `basic_extraction` test in `tests/core/test_xml_source.pl`.
+
+## 2. The Error
+
+The test fails with the following error:
+
+```
+read_util:read_stream_to_codes/2: Arguments are not sufficiently instantiated
+```
+
+This error occurs when running the plunit test suite for `xml_source.pl`. It seems to be related to stream handling within the test runner, but the root cause is likely a subtle issue in the `xml_source.pl` file itself.
+
+## 3. What I Have Tried
+
+I have tried numerous approaches to debug this issue, including:
+
+*   **Simplifying the test case:** I have simplified the test case to a single call to `xml_source:compile_source/4`, but the error persists.
+*   **Checking for syntax errors:** I have checked for and fixed several syntax errors in `xml_source.pl`.
+*   **Verifying file updates:** I have confirmed that the test file is being updated correctly.
+*   **Creating a new test file:** I created a new test file with a different name to rule out caching issues, but the error remained.
+*   **Investigating side effects:** I investigated the `initialization/2` directive and temporarily removed `format/2` calls from the `dynamic_source_compiler.pl` file, but this did not solve the problem.
+*   **Different test commands:** I have tried various ways to run the `swipl` command, including using the full path, running from different directories, and using different command-line options.
+*   **Error handling:** I have added error handling to the test case to capture stdout and stderr from the executed script, but the error occurs before the script is even executed.
+
+## 4. The Current State
+
+*   The `xml_source.pl` file is located at `src/unifyweaver/sources/xml_source.pl`.
+*   The test file is `tests/core/test_xml_source.pl`.
+*   A simple test case in `tests/core/test_simple.pl` passes, which suggests that the test environment is likely correct.
+*   The current hypothesis is that there is a subtle issue in `xml_source.pl` that is causing the plunit test runner to fail in an unexpected way.
+
+## 5. The Request to `cline.bot`
+
+Your task is to focus solely on fixing the `read_util:read_stream_to_codes/2: Arguments are not sufficiently instantiated` error and getting the `basic_extraction` test in `test_xml_source.pl` to pass.
+
+Please do not add any new features or refactor the code beyond what is necessary to fix the test.
+
+Here are the relevant files:
+
+*   `src/unifyweaver/sources/xml_source.pl`
+*   `tests/core/test_xml_source.pl`
+*   `tests/test_data/sample.rdf`
+
+Thank you for your help.

--- a/docs/proposals/xml_source/HANDOFF_TO_LLM_XMLSTARLET.md
+++ b/docs/proposals/xml_source/HANDOFF_TO_LLM_XMLSTARLET.md
@@ -1,0 +1,78 @@
+# Handoff to LLM - XML Source xmlstarlet Test Failure
+
+**Date:** 2025-10-30
+**From:** Gemini
+**To:** Another LLM
+
+## 1. The Goal
+
+The primary goal is to fix the persistent test failure for the `xmlstarlet_extraction` test in `tests/core/test_xml_source.pl`.
+
+## 2. The Error
+
+The `xmlstarlet_extraction` test is failing with the following error:
+
+```
+test_xml_xmlstarlet.sh: line 5: /usr/bin/xmlstarlet: command not found
+```
+
+This error indicates that the `xmlstarlet` executable cannot be found when the generated bash script (`test_xml_xmlstarlet.sh`) is executed.
+
+## 3. What I Have Tried
+
+*   **Confirmed `xmlstarlet` installation:** I have verified that `xmlstarlet` is installed and in the WSL path by running `wsl which xmlstarlet`, which returned `/usr/bin/xmlstarlet`.
+*   **Used full path in template:** I have modified the `xml_xmlstarlet_source` template in `src/unifyweaver/sources/xml_source.pl` to use the full absolute path to `xmlstarlet` (`/usr/bin/xmlstarlet`) in the generated bash script.
+*   **Debugged engine detection:** I have added extensive debug output to `check_lxml_available` and `python_lxml_check` to ensure the engine detection mechanism is working correctly. For the `xmlstarlet_extraction` test, the `engine(xmlstarlet)` option is explicitly set, so `detect_available_engine` is not called.
+
+## 4. The Current State
+
+*   The `basic_extraction` test (using the `iterparse` engine) is passing, confirming that the core plugin logic and the Python/lxml integration are working.
+*   The `xmlstarlet_extraction` test (explicitly setting `engine(xmlstarlet)`) is failing because the generated bash script cannot find `/usr/bin/xmlstarlet`, even though the full path is used in the template and `xmlstarlet` is confirmed to be present at that path within WSL.
+*   The generated bash script `test_xml_xmlstarlet.sh` contains the line: `/usr/bin/xmlstarlet sel -N pt="http://www.pearltrees.com/xmlns/pearl-trees#" -t -c "{{xpath}}" "{{file}}" | awk '{printf "%s\0", $0}'`
+
+## 5. The Hypothesis
+
+The most likely cause is an environment issue within the bash script's execution context. It appears that the `PATH` or other critical environment variables are not being correctly inherited or set when the bash script is executed via `process_create(path(bash), ['test_xml_xmlstarlet.sh'], ...)` from within the WSL environment. This prevents the bash shell from finding `/usr/bin/xmlstarlet`, even when the full path is provided.
+
+## 6. The Request to the other LLM
+
+Your task is to focus solely on fixing the `xmlstarlet: command not found` error in the generated bash script for the `xmlstarlet_extraction` test.
+
+*   **Investigate why the bash script is not finding `/usr/bin/xmlstarlet`**, even with the full path specified.
+*   **Propose a solution** that ensures `xmlstarlet` is correctly executed within the generated bash script.
+*   The goal is to get the `xmlstarlet_extraction` test in `test_xml_source.pl` to pass.
+*   Please do not add any new features or refactor the code beyond what is necessary to fix this specific test failure.
+
+Here are the relevant files:
+
+*   `src/unifyweaver/sources/xml_source.pl` (contains the template for the bash script)
+*   `tests/core/test_xml_source.pl` (contains the failing test)
+*   `tests/test_data/sample.rdf` (sample XML file)
+
+
+## 7. Additional Context: Persistent Environment Setup Issues (reorder-path.sh)
+
+A separate, critical blocking issue, which appears to be related to the overall environment setup for running tests within WSL from the agent's context, involves a script named `reorder-path.sh`. This script is designed to manipulate the `PATH` environment variable within WSL to prioritize Linux paths over Windows paths. The user has provided a working version of this script, located in their WSL home directory (`~`).
+
+**Problem Encountered:**
+Despite multiple attempts, the agent has been unable to reliably and consistently create and/or source this `reorder-path.sh` script within the WSL environment before running `swipl` tests. Each attempt has resulted in either:
+*   The script not being found when listed via `wsl ls`.
+*   Syntax errors (`unexpected EOF`, `syntax error`) when sourced, even after verifying the script content when it *could* be read.
+*   Rejection by the system for "safety reasons" due to complex quoting when attempting to create it via `wsl bash -c ...` commands.
+
+**Attempts to create/manage reorder-path.sh:**
+*   Using `write_file` with Windows paths (resulted in file not being found by WSL tools).
+*   Using `write_file` with constructed WSL paths (resulted in file not being found).
+*   Using `wsl bash -c "cat > ... << 'EOF_SCRIPT' ... EOF_SCRIPT"` (rejected due to complex quoting).
+*   Using `wsl bash -c "echo -e 'script_content' > ..."` (rejected due to complex quoting).
+*   Using `wsl bash -c "printf '%s' 'script_content' > ..."` (rejected due to complex quoting).
+
+**Hypothesis:**
+There is a fundamental misunderstanding or limitation in how the agent's `write_file` tool interacts with the WSL filesystem, or how complex multi-line script content with special characters and quotes can be reliably passed to `wsl bash -c` for file creation.
+
+**Request for Assistance Regarding reorder-path.sh:**
+Please investigate and propose a robust method for the agent to:
+1.  **Reliably create or ensure the presence of the `reorder-path.sh` script** on the WSL filesystem at a known location (e.g., in `~/`).
+2.  **Ensure this script can be successfully sourced** before running the `swipl` test command (`source ~/reorder-path.sh && swipl ...`).
+
+This is currently a blocking issue for consistently replicating the expected `$PATH` environment for the `xmlstarlet` tests.

--- a/docs/proposals/xml_source/IMPLEMENTATION_STRATEGY.md
+++ b/docs/proposals/xml_source/IMPLEMENTATION_STRATEGY.md
@@ -1,0 +1,130 @@
+# XML Source Plugin Implementation Strategy
+
+## 1. Overview
+
+This document describes the implementation strategy for the `xml_source` plugin. The plugin will be implemented in Prolog and will generate a bash script that executes a small Python script to extract data from XML files in a streaming fashion.
+
+## 2. Plugin Structure
+
+A new file, `src/unifyweaver/sources/xml_source.pl`, will be created. This file will contain the Prolog code for the plugin. The structure of the file will be similar to other source plugins, such as `python_source.pl`.
+
+### Key Predicates
+
+*   `source_info/1`: Provides metadata about the plugin.
+*   `validate_config/1`: Validates the configuration options (`xml_file`, `tags`, `engine`).
+*   `compile_source/4`: The main entry point for compiling the source. It will extract the configuration and call the bash code generator.
+*   `generate_xml_bash/5`: A helper predicate to generate the bash code using the template system.
+*   `template_system:template/2`: A multifile predicate that defines the bash template for the `xml_source`.
+
+## 3. XML Parsing Tool: Python with `lxml`
+
+We will use a generated Python script with the `lxml` library for parsing XML. This approach ensures true streaming and constant memory usage, which is crucial for large files.
+
+### `lxml.etree.iterparse`
+
+The generated Python script will use `lxml.etree.iterparse` to iterate over the XML file. This function parses the file incrementally, allowing us to process elements one by one and discard them to save memory.
+
+### Python Script Sketch
+
+The generated bash script will embed a Python script similar to the following:
+
+```python
+#!/usr/bin/env python3
+import sys
+from lxml import etree
+
+file = "{{file}}"
+tags = set("{{tags}}".split(','))
+null = b'\0'
+
+# Capture namespace map from the root
+context = etree.iterparse(file, events=('start', 'end'))
+event, root = next(context)
+nsmap = root.nsmap or {}
+
+def expand(tag):
+    if ':' in tag:
+        pfx, local = tag.split(':', 1)
+        uri = nsmap.get(pfx)
+        return f'{{{uri}}}{local}' if uri else tag
+    return tag
+
+want = {expand(t) for t in tags}
+
+for event, elem in context:
+    if event == 'end' and elem.tag in want:
+        sys.stdout.buffer.write(etree.tostring(elem))
+        sys.stdout.buffer.write(null)
+        # Memory release pattern
+        elem.clear()
+        while elem.getprevious() is not None:
+            del elem.getparent()[0]
+        root.clear()
+```
+
+## 4. Bash Code Generation
+
+We will create a new bash template named `xml_source` in `xml_source.pl`. This template will contain the bash code that executes the embedded Python script.
+
+### Template Placeholders
+
+The template will have the following placeholders:
+
+*   `{{pred}}`: The name of the predicate.
+*   `{{python_script}}`: The generated Python script.
+
+### Generated Script
+
+The generated script will look like this:
+
+```bash
+#!/bin/bash
+# {{pred}} - XML source
+
+{{pred}}() {
+    python3 -c '{{python_script}}'
+}
+
+{{pred}}_stream() {
+    {{pred}}
+}
+
+# ... (auto-execute boilerplate)
+```
+
+## 5. Firewall Configuration
+
+The use of `python3` and the `lxml` library will require an update to the firewall rules. We will need to add `python3` to the list of allowed services and `lxml` to the list of allowed Python modules.
+
+This will be done by adding the following to the default firewall configuration in `src/unifyweaver/core/firewall_v2.pl`:
+
+```prolog
+service(bash, executable(python3)),
+python_module(lxml)
+```
+
+We will add this to the `firewall_default/1` predicate.
+
+## 6. Testing Strategy
+
+To ensure the `xml_source` plugin works correctly, we will create a new test suite.
+
+### Test Files
+
+1.  **Sample RDF File:** A sample `test.rdf` file will be created in the `test_data` directory. This file will contain a mix of tags, including the ones we want to extract.
+2.  **Test Prolog File:** A new test file, `tests/core/test_xml_source.pl`, will be created. This file will contain the following tests:
+    *   A test that compiles an `xml_source` and verifies the generated bash script and embedded Python script.
+    *   A test that runs the generated script and checks if it correctly extracts the specified tags.
+    *   A test that checks for proper handling of multiple tags.
+    *   A test that ensures the output is correctly separated by the null character.
+    *   A test with a large XML file to verify the streaming and memory performance (optional).
+
+## 7. Implementation Steps
+
+1.  Update the planning documents (this is already done).
+2.  Create the `xml_source.pl` file with the structure outlined above.
+3.  Implement the bash template that embeds the Python script.
+4.  Update the firewall rules in `firewall_v2.pl`.
+5.  Create the test files (`test.rdf` and `test_xml_source.pl`).
+6.  Implement the tests.
+7.  Run the tests to verify the implementation.

--- a/docs/proposals/xml_source/PHILOSOPHY.md
+++ b/docs/proposals/xml_source/PHILOSOPHY.md
@@ -1,0 +1,47 @@
+# XML Source Plugin Philosophy
+
+## 1. Introduction
+
+This document outlines the philosophy behind a new proposed data source for UnifyWeaver, designed to extract data from XML and RDF documents. The initial request was for an "rdf source" to handle Pearltrees data, but this document proposes a more generic "XML source" that is more broadly applicable.
+
+## 2. Naming: `xml_source` vs. `rdf_source`
+
+The proposed name for this new feature is `xml_source`.
+
+**Rationale:**
+
+*   **Generality:** While the initial use case is an RDF file from Pearltrees, the core task is extracting elements from an XML-based document. RDF/XML is a specific serialization of RDF, but it is still XML. By naming it `xml_source`, we create a more generic and reusable tool that can be applied to a wider range of XML files, not just RDF.
+*   **Future-Proofing:** A generic `xml_source` can be extended in the future to support other XML-related tasks, such as attribute extraction or more complex XPath queries. Naming it `rdf_source` would limit its perceived scope.
+*   **Clarity:** The name `xml_source` clearly communicates that the plugin operates on XML data. This is more accurate than `rdf_source`, which might imply a deeper understanding of RDF semantics, which is not the immediate goal.
+
+## 3. Core Principles
+
+The `xml_source` plugin will be designed with the following principles in mind:
+
+*   **True Streaming and Memory Efficiency:** The plugin must process XML files in a true streaming fashion, with constant memory usage, even for very large files. This means that after an element is extracted and emitted, the memory it occupied should be released immediately.
+*   **Simplicity and Ease of Use:** The plugin should be easy to configure and use. The primary configuration will be the file path and a list of tags to extract.
+*   **Declarative Configuration:** Users will define the XML source declaratively in their Prolog files, specifying the tags they want to extract.
+*   **Integration with UnifyWeaver:** The plugin will be fully integrated into the UnifyWeaver ecosystem, including the firewall for security and the template system for code generation.
+
+## 4. The "Filter" Concept: Extracting Multiple Tags
+
+The user suggested the concept of a "filter" to specify which tags to extract. This is a crucial feature for making the plugin flexible.
+
+We will implement this with a `tags` option, which will accept a list of tag names. For example:
+
+```prolog
+:- source(xml, my_data, [
+    xml_file('data.rdf'),
+    tags(['pt:Tree', 'pt:Page'])
+]).
+```
+
+This will instruct the plugin to extract all `<pt:Tree>` and `<pt:Page>` elements from the `data.rdf` file.
+
+## 5. Tooling
+
+The implementation will rely on a true streaming XML parser to ensure constant memory usage. The proposed solution is to use a small, generated Python script that leverages the `lxml.etree.iterparse` functionality. This approach allows for efficient processing of very large XML files by parsing and emitting elements one by one, and then immediately releasing them from memory. This choice will be detailed further in the `IMPLEMENTATION_STRATEGY.md` document.
+
+## 6. Conclusion
+
+By adopting the name `xml_source` and focusing on a simple, stream-based design, we can create a powerful and flexible tool for extracting data from XML documents within the UnifyWeaver framework. This approach not only satisfies the immediate requirement of processing Pearltrees RDF data but also provides a solid foundation for future enhancements.

--- a/docs/proposals/xml_source/SPECIFICATION.md
+++ b/docs/proposals/xml_source/SPECIFICATION.md
@@ -1,0 +1,92 @@
+# XML Source Plugin Specification
+
+## 1. Overview
+
+This document provides a detailed specification for the `xml_source` plugin. This plugin allows users to extract XML elements from a file based on a list of specified tags.
+
+## 2. Configuration
+
+The `xml_source` plugin is configured using the `source/3` predicate, with the source type `xml`. The following options are available in the configuration list:
+
+*   `xml_file(FilePath)`: (Required) The path to the input XML or RDF file.
+*   `tags(TagList)`: (Required) A list of XML tag names to extract. The tags can include namespace prefixes (e.g., `'pt:Tree'`).
+*   `engine(Engine)`: (Optional) The parsing engine to use. The following engines are supported:
+    *   `iterparse` (default): Streaming parser based on Python's `lxml.etree.iterparse`. This engine provides constant memory usage and is suitable for very large files.
+    *   `xmllint`: CLI fallback that shells out to `xmllint --xpath` and rehydrates namespace declarations in the extracted fragments. Useful when `lxml` is unavailable but the `libxml2-utils` package is installed.
+    *   `xmlstarlet`: CLI fallback that shells out via `xmlstarlet sel`. Fast for small inputs but loads the full document in memory.
+*   `namespace_fix(Boolean)`: (Optional, xmllint-only) Controls whether namespace declarations are rehydrated onto each extracted fragment. Defaults to `true`. Set to `false` if downstream tooling already understands inherited prefixes and you want to avoid the additional processing.
+
+### Example Configuration
+
+```prolog
+:- source(xml, pearltrees_data, [
+    xml_file('path/to/your/data.rdf'),
+    tags(['pt:Tree', 'pt:Page'])
+]).
+```
+
+## 3. Output Format
+
+The `xml_source` plugin generates a bash script that streams the full XML elements matching the specified tags. The elements are separated by the null character (`\0`).
+
+### Example Output
+
+Given the following input XML:
+
+```xml
+<root>
+  <pt:Tree id="1">...</pt:Tree>
+  <other>...</other>
+  <pt:Page id="2">...</pt:Page>
+</root>
+```
+
+And the configuration:
+
+```prolog
+:- source(xml, my_data, [
+    xml_file('my.xml'),
+    tags(['pt:Tree', 'pt:Page'])
+]).
+```
+
+The generated script `my_data_stream` would produce the following output:
+
+```
+<pt:Tree id="1">...</pt:Tree>\0<pt:Page id="2">...</pt:Page>\0
+```
+
+(Where `\0` represents the null character).
+
+## 4. Generated Bash Interface
+
+The compiled `xml_source` will provide the following bash functions:
+
+*   `<predicate_name>()`: Streams the extracted XML elements, separated by the null character.
+*   `<predicate_name>_stream()`: An alias for `<predicate_name>()`.
+
+### Example Usage
+
+```bash
+# Source the generated script
+source my_data.sh
+
+# Stream all extracted elements
+my_data_stream
+
+# Process the stream using other tools
+my_data_stream | xargs -0 -n 1 echo "Found element:"
+```
+
+## 5. Arity
+
+The `xml_source` plugin will only support arity 1, where the single argument will be the full XML element as a string.
+
+## 6. Error Handling
+
+The plugin will perform the following checks during compilation:
+
+*   Verify that `xml_file` and `tags` are provided.
+*   Check if the `xml_file` exists and issue a warning if it doesn't.
+
+The generated script will rely on Python 3 and the `lxml` library. If `python3` is not in the path or if the `lxml` library is not installed, the script will fail at runtime. This dependency will be documented.

--- a/docs/proposals/xml_source/TECHNICAL_ANALYSIS.md
+++ b/docs/proposals/xml_source/TECHNICAL_ANALYSIS.md
@@ -1,0 +1,449 @@
+# XML Source Technical Analysis
+
+**Date:** 2025-10-30
+**Status:** DRAFT - Under Discussion
+**Purpose:** Technical analysis for implementing xml_source plugin
+
+## Executive Summary
+
+This document analyzes implementation options for the `xml_source` plugin, comparing Python-based streaming (lxml) vs shell-based approaches (xmllint/xmlstarlet). The analysis considers memory efficiency, tool availability, UnifyWeaver architecture, and firewall integration.
+
+## Problem Statement
+
+We need to extract XML elements from large RDF/XML files (potentially multi-GB) and stream them as null-delimited records. **Critical requirement:** Memory usage must remain constant - after emitting each element, its memory must be immediately released.
+
+### Example Use Case
+
+Extract Pearltrees RDF data:
+```prolog
+:- source(xml, pearltrees, [
+    xml_file('export.rdf'),
+    tags(['pt:Tree', 'pt:Page', 'pt:Note'])
+]).
+```
+
+Expected behavior: Stream millions of elements without memory growth.
+
+## Current UnifyWeaver Architecture
+
+### Source Plugins
+Source plugins generate **Bash scripts** that call tools/languages. They do NOT generate code in other target languages.
+
+**Existing source plugins:**
+- `csv_source.pl` - Generates Bash using `awk`
+- `json_source.pl` - Generates Bash using `jq`
+- `awk_source.pl` - Generates Bash using `awk`
+- `http_source.pl` - Generates Bash using `curl`
+- `python_source.pl` - Generates Bash that embeds Python via heredoc
+
+### Key Pattern: python_source.pl
+
+The `python_source.pl` plugin (331 lines) establishes the pattern for embedding Python in Bash:
+
+```bash
+#!/bin/bash
+my_predicate() {
+    timeout 30 python3 /dev/fd/3 3<<'PYTHON'
+import sys
+# Python code here
+PYTHON
+}
+```
+
+**Key features:**
+- Python code embedded via heredoc pattern
+- Timeout support
+- Error handling
+- Multiple templates (basic, stdin, sqlite)
+- Already tested and working
+
+### Target Languages vs Tools
+
+**UnifyWeaver has 2 target languages:**
+1. Bash (default)
+2. PowerShell
+
+**Important distinction:**
+- **Target language** = Output format of compilation (bash scripts or PowerShell scripts)
+- **Tool/Engine** = External program called by generated script (awk, jq, python3, curl, etc.)
+
+**We are NOT adding Python as a target language.** We are using Python as a tool, like we already do with awk, jq, and curl.
+
+## Tool Availability Analysis
+
+### Current System (Ubuntu 22.04 WSL)
+```
+✅ python3 - Available
+❌ lxml - NOT installed (requires: pip3 install lxml)
+❌ xmllint - NOT available (requires: apt-get install libxml2-utils)
+❌ xmlstarlet - NOT available (requires: apt-get install xmlstarlet)
+```
+
+### Typical Linux Server
+- **xmllint:** Usually pre-installed (part of libxml2)
+- **python3:** Usually pre-installed
+- **lxml:** Rarely pre-installed (requires pip)
+- **xmlstarlet:** Rarely pre-installed
+
+### macOS
+- **xmllint:** Pre-installed
+- **python3:** Pre-installed (10.15+)
+- **lxml:** Not pre-installed
+- **xmlstarlet:** Not available (requires Homebrew)
+
+### Windows (Native)
+- **All tools:** Not available by default
+- **via WSL:** Use Linux instructions
+- **via Cygwin:** Available via package manager
+- **via Chocolatey:** xmlstarlet available
+
+## Implementation Options
+
+### Option 1: lxml (Python iterparse) - RECOMMENDED
+
+**Implementation approach:**
+```prolog
+% Reuse python_source.pl pattern
+generate_xml_bash(Pred, File, Tags, Options, BashCode) :-
+    generate_lxml_python_code(File, Tags, PythonCode),
+    % Use existing python_source template pattern
+    render_template(python_streaming_source,
+                   [pred=Pred, python_code=PythonCode],
+                   BashCode).
+```
+
+**Generated Bash:**
+```bash
+#!/bin/bash
+pearltrees_stream() {
+    python3 /dev/fd/3 3<<'PYTHON'
+import sys
+from lxml import etree
+
+file = "export.rdf"
+tags = {'pt:Tree', 'pt:Page'}
+null = b'\0'
+
+context = etree.iterparse(file, events=('start', 'end'))
+event, root = next(context)
+nsmap = root.nsmap or {}
+
+def expand(tag):
+    if ':' in tag:
+        pfx, local = tag.split(':', 1)
+        uri = nsmap.get(pfx)
+        return f'{{{uri}}}{local}' if uri else tag
+    return tag
+
+want = {expand(t) for t in tags}
+
+for event, elem in context:
+    if event == 'end' and elem.tag in want:
+        sys.stdout.buffer.write(etree.tostring(elem))
+        sys.stdout.buffer.write(null)
+        # Memory release - THE CRITICAL PART
+        elem.clear()
+        while elem.getprevious() is not None:
+            del elem.getparent()[0]
+        root.clear()
+PYTHON
+}
+```
+
+**Pros:**
+- ✅ **True constant memory** (Perplexity confirmed)
+- ✅ Reuses existing python_source.pl patterns
+- ✅ Robust namespace handling (critical for RDF)
+- ✅ Well-tested memory release pattern
+- ✅ Firewall already allows python3
+- ✅ Works with existing UnifyWeaver architecture
+- ✅ Same pattern as csv_source (bash calling tool)
+
+**Cons:**
+- ⚠️ Requires lxml installation (`pip3 install lxml`)
+- ⚠️ Adds Python library dependency
+
+**Firewall impact:**
+```prolog
+% Already exists:
+allowed_service(bash, executable(python3)) :-
+    \+ denied_service(bash, executable(python3)).
+
+% Optional - add module checking:
+allowed_python_module(lxml) :-
+    \+ denied_python_module(lxml).
+```
+
+**Estimated implementation time:** 4-6 hours
+- Plugin code: 2-3 hours (reuse python_source.pl)
+- Tests: 1-2 hours
+- Documentation: 1 hour
+
+### Option 2: xmllint --stream
+
+**Implementation approach:**
+```bash
+#!/bin/bash
+pearltrees_stream() {
+    xmllint --stream --pattern '//pt:Tree|//pt:Page' "$xml_file" \
+        | grep -E '<(pt:Tree|pt:Page)' \
+        | tr '\n' '\0'
+}
+```
+
+**Note:** This is a simplified example. Real implementation would need more sophisticated parsing.
+
+**Pros:**
+- ✅ Usually pre-installed on Linux/macOS
+- ✅ No external dependencies
+- ✅ Simple implementation
+
+**Cons:**
+- ❌ **Perplexity review:** xmllint --stream is "designed for validation/debugging"
+- ❌ **Limited functionality:** Pattern matching doesn't serialize full subtrees easily
+- ❌ **Partial streaming:** May still buffer internally
+- ❌ **Complex namespace handling:** Requires manual XPath setup
+- ❌ **Output format issues:** Not designed for null-delimited element streaming
+
+**Firewall impact:**
+```prolog
+allowed_service(bash, executable(xmllint)) :-
+    \+ denied_service(bash, executable(xmllint)).
+```
+
+**Estimated implementation time:** 6-8 hours
+- More complex due to limited tooling
+- Needs custom parsing logic
+- Namespace handling complexity
+
+### Option 3: xmlstarlet sel - NOT RECOMMENDED
+
+**Why NOT recommended:**
+
+From Perplexity research:
+> "xmlstarlet sel compiles an XSLT and applies it to each input document, which requires loading the XML into a libxml2/libxslt tree rather than using a streaming reader, so memory from matched subtrees is not released immediately after emission."
+
+**Critical issue:** Loads entire file into memory. Fails our primary requirement.
+
+**Verdict:** Do not implement this option.
+
+## Recommendation: Phased Approach
+
+### Phase 1: lxml Implementation (Primary)
+
+**Implement lxml-based engine as the default:**
+
+```prolog
+:- source(xml, my_data, [
+    xml_file('data.rdf'),
+    tags(['pt:Tree']),
+    engine(iterparse)  % default
+]).
+```
+
+**Rationale:**
+1. Meets memory requirements (confirmed by Perplexity)
+2. Reuses proven python_source.pl patterns
+3. Minimal new code needed
+4. Firewall already configured for python3
+
+### Phase 2: xmllint Fallback (Optional)
+
+**Add xmllint engine for limited use cases:**
+
+```prolog
+:- source(xml, my_data, [
+    xml_file('small.xml'),
+    tags(['item']),
+    engine(xmllint)  % for small files only
+]).
+```
+
+**Use cases:**
+- Environments where lxml unavailable
+- Small files where streaming unnecessary
+- Simple tag structures without complex namespaces
+
+### Phase 3: Documentation & Testing
+
+**Required documentation:**
+- Installation guide (✅ DONE - XML_PARSING_TOOLS_INSTALLATION.md)
+- Engine comparison table
+- Memory usage benchmarks
+- Namespace handling examples
+
+**Required tests:**
+- Small RDF file (basic functionality)
+- Large RDF file (memory stress test)
+- Multiple namespaces (Pearltrees use case)
+- Error handling (missing files, bad XML)
+
+## Open Questions for Discussion
+
+### 1. lxml Dependency Management
+
+**Question:** How should we handle the lxml dependency?
+
+**Options:**
+A. **Document only** - Installation guide shows how to install, user responsible
+B. **Runtime check** - Plugin checks if lxml available, graceful error if not
+C. **Auto-install** - Try to pip install lxml if missing (risky)
+D. **Fallback** - Try lxml first, fall back to xmllint if unavailable
+
+**My recommendation:** Option B + D
+- Check at compile time if lxml available
+- Warn user with installation instructions if missing
+- Optionally fall back to xmllint for small files
+
+### 2. Engine Auto-Selection
+
+**Question:** Should we auto-detect which engine to use?
+
+**Options:**
+A. **Explicit only** - User must specify `engine(iterparse)` or `engine(xmllint)`
+B. **Smart default** - Check if lxml available, use it; otherwise try xmllint
+C. **File-size based** - Use streaming (lxml) for large files, xmllint for small
+
+**My recommendation:** Option B
+- Default to `engine(iterparse)` if lxml available
+- Fall back to `engine(xmllint)` if not
+- User can override with explicit `engine()` option
+
+### 3. Python Code Generation
+
+**Question:** Should we generate Python code inline (like python_source.pl) or as external files?
+
+**Options:**
+A. **Inline (heredoc)** - Python code embedded in Bash script (like python_source.pl)
+B. **External file** - Generate .py file alongside .sh file
+C. **Hybrid** - Inline for simple cases, external for complex
+
+**My recommendation:** Option A (Inline)
+- Consistent with python_source.pl
+- Single file deployment
+- No file management issues
+- Can reference external Python files via python_file() option if needed
+
+### 4. Namespace Handling
+
+**Question:** How should we handle XML namespaces?
+
+**Current approach in Gemini's plan:**
+- Extract namespace map from root element
+- Expand prefixed tags using nsmap
+- Example: `'pt:Tree'` → `'{http://www.pearltrees.com/xmlns/...}Tree'`
+
+**Concerns:**
+- What if namespace prefixes differ in the file?
+- What if user wants to match by namespace URI directly?
+
+**Options:**
+A. **Prefix-based** - Match using prefixes as user provides (pt:Tree)
+B. **URI-based** - User provides full URIs, we match exactly
+C. **Flexible** - Support both prefix and URI matching
+
+**My recommendation:** Option A with C as extension
+- Start with prefix-based (simpler for users)
+- Document that prefixes must match file's namespace declarations
+- Consider adding URI-based matching in future version
+
+### 5. Memory Verification
+
+**Question:** Should we add memory usage monitoring/verification?
+
+**Options:**
+A. **Trust lxml** - Rely on known lxml behavior, no monitoring
+B. **Optional debug** - Add `debug(memory)` option for testing
+C. **Built-in checks** - Monitor and warn if memory grows unexpectedly
+
+**My recommendation:** Option A for now, B for testing
+- lxml iterparse + clear pattern is well-established
+- Add memory profiling to test suite
+- Document memory characteristics
+
+### 6. Error Handling for Malformed XML
+
+**Question:** What should happen if XML is malformed?
+
+**Options:**
+A. **Fail fast** - Stop processing, return error
+B. **Skip element** - Log warning, continue with next element
+C. **Configurable** - User chooses via `error_handling(fail|skip|silent)`
+
+**My recommendation:** Option C
+- Default to `error_handling(fail)` for safety
+- Allow `error_handling(skip)` for resilient processing
+- Consistent with python_source.pl error handling pattern
+
+## Implementation Checklist
+
+### Prerequisites
+- [ ] Review and approve this technical analysis
+- [ ] Decide on open questions (1-6 above)
+- [ ] Update Gemini's planning docs with decisions
+
+### Phase 1: Core Implementation
+- [ ] Create `src/unifyweaver/sources/xml_source.pl`
+- [ ] Implement lxml iterparse engine
+- [ ] Add firewall rules (python3, lxml module check)
+- [ ] Generate Python code using template system
+- [ ] Add namespace handling logic
+
+### Phase 2: Testing
+- [ ] Create `tests/test_data/sample.rdf` (small test file)
+- [ ] Create `tests/core/test_xml_source.pl`
+- [ ] Test basic element extraction
+- [ ] Test multiple namespaces
+- [ ] Test null-delimited output
+- [ ] Memory stress test (large file)
+
+### Phase 3: Documentation
+- [ ] Update `docs/proposals/xml_source/SPECIFICATION.md`
+- [ ] Update `docs/proposals/xml_source/IMPLEMENTATION_STRATEGY.md`
+- [ ] Create usage examples
+- [ ] Document namespace handling
+- [ ] Document memory characteristics
+
+### Phase 4: Integration
+- [ ] Add to `examples/data_sources_demo.pl`
+- [ ] Update CHANGELOG.md
+- [ ] Update README.md (if needed)
+
+### Optional: xmllint Fallback
+- [ ] Implement xmllint engine
+- [ ] Add engine auto-detection
+- [ ] Add engine comparison tests
+- [ ] Document engine selection
+
+## Timeline Estimate
+
+**Phase 1 (lxml core):** 4-6 hours
+- Plugin implementation: 2-3 hours
+- Basic testing: 1-2 hours
+- Documentation updates: 1 hour
+
+**Phase 2 (comprehensive testing):** 2-3 hours
+- Test suite: 1-2 hours
+- Memory profiling: 1 hour
+
+**Phase 3 (xmllint fallback):** 3-4 hours (optional)
+- Implementation: 2 hours
+- Testing: 1 hour
+- Documentation: 1 hour
+
+**Total: 6-9 hours** (core) or **9-13 hours** (with fallback)
+
+## References
+
+- Perplexity research on xmlstarlet/xmllint memory behavior
+- Gemini's planning documents in `docs/proposals/xml_source/`
+- Existing `src/unifyweaver/sources/python_source.pl` (331 lines)
+- Installation guide: `docs/XML_PARSING_TOOLS_INSTALLATION.md`
+
+## Next Steps
+
+1. **Review this analysis** - Discuss open questions
+2. **Make decisions** - Resolve questions 1-6
+3. **Update planning docs** - Incorporate decisions into Gemini's docs
+4. **Share with Gemini** - Provide clear implementation guidance
+5. **Begin implementation** - Start with Phase 1 (lxml core)

--- a/scripts/testing/reorder-path.sh
+++ b/scripts/testing/reorder-path.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Reorder $PATH so that directories defined in /etc/environment's PATH
+# take precedence, without duplicates. Run with: source ./reorder-path.sh
+
+set -euo pipefail
+
+# Extract PATH value from /etc/environment (supports PATH="..." or PATH=...)
+etc_env_line="$(grep -E '^[[:space:]]*PATH=' /etc/environment | head -n1 || true)"
+if [[ -z "${etc_env_line}" ]]; then
+  echo "No PATH found in /etc/environment" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Strip leading PATH= and surrounding quotes if present
+etc_env_path="${etc_env_line#*=}"
+etc_env_path="${etc_env_path%"}"
+etc_env_path="${etc_env_path#"}"
+
+# Helper: remove exact directory matches from PATH
+remove_from_path() {
+  local target="$1"
+  local IFS=':'
+  read -r -a parts <<< "${PATH:-}"
+  local out=""
+  for p in "${parts[@]}"; do
+    [[ -z "$p" ]] && continue
+    if [[ "$p" != "$target" ]]; then
+      out="${out:+$out:}$p"
+    fi
+  done
+  PATH="$out"
+}
+
+# Process baseline dirs from right-to-left so final order matches /etc/environment
+IFS=':' read -r -a base_parts <<< "${etc_env_path}"
+for (( i=${#base_parts[@]}-1; i>=0; i-- )); do
+  dir="${base_parts[i]}"
+  [[ -z "$dir" ]] && continue
+  # Normalize trivial trailing slashes
+  dir="${dir%/}"
+  remove_from_path "$dir"
+  PATH="${dir}${PATH:+:${PATH}}"
+done
+
+# Optional final de-dup pass (defensive), preserving first occurrence
+dedup() {
+  local IFS=':'
+  read -r -a parts <<< "${PATH:-}"
+  local -A seen=()
+  local out=""
+  for p in "${parts[@]}"; do
+    [[ -z "$p" ]] && continue
+    p="${p%/}"
+    if [[ -z "${seen[$p]:-}" ]]; then
+      seen[$p]=1
+      out="${out:+$out:}$p"
+    fi
+  done
+  PATH="$out"
+}
+dedup
+
+# Export updated PATH for the current shell
+export PATH

--- a/scripts/testing/reorder-path.sh
+++ b/scripts/testing/reorder-path.sh
@@ -27,7 +27,7 @@ remove_from_path() {
     if [[ "$p" != "$target" ]]; then
       out="${out:+$out:}$p"
     fi
-  done
+done
   PATH="$out"
 }
 
@@ -55,7 +55,7 @@ dedup() {
       seen[$p]=1
       out="${out:+$out:}$p"
     fi
-  done
+done
   PATH="$out"
 }
 dedup

--- a/scripts/testing/reorder-path.sh
+++ b/scripts/testing/reorder-path.sh
@@ -13,8 +13,11 @@ fi
 
 # Strip leading PATH= and surrounding quotes if present
 etc_env_path="${etc_env_line#*=}"
-etc_env_path="${etc_env_path%"}"
-etc_env_path="${etc_env_path#"}"
+if [[ ${etc_env_path} == \"*\" ]]; then
+  etc_env_path="${etc_env_path:1:-1}"
+elif [[ ${etc_env_path} == \'*\' ]]; then
+  etc_env_path="${etc_env_path:1:-1}"
+fi
 
 # Helper: remove exact directory matches from PATH
 remove_from_path() {

--- a/src/unifyweaver/sources/xml_source.pl
+++ b/src/unifyweaver/sources/xml_source.pl
@@ -57,9 +57,18 @@ validate_config(Config) :-
     % Validate engine if specified
     (   member(engine(Engine), Config)
     ->  (
-            (Engine == iterparse ; Engine == xmlstarlet)
+            memberchk(Engine, [iterparse, xmllint, xmlstarlet])
         ->  true
-        ;   format('Error: invalid engine ~w. Must be one of [iterparse, xmlstarlet]~n', [Engine]),
+        ;   format('Error: invalid engine ~w. Must be one of [iterparse, xmllint, xmlstarlet]~n', [Engine]),
+            fail
+        )
+    ;   true
+    ),
+    % Optional namespace repair flag (bool)
+    (   member(namespace_fix(Value), Config)
+    ->  (   memberchk(Value, [true, false])
+        ->  true
+        ;   format('Error: namespace_fix(~w) must be true or false~n', [Value]),
             fail
         )
     ;   true
@@ -75,11 +84,15 @@ detect_available_engine(Engine) :-
     (
         check_lxml_available
     ->  Engine = iterparse
+    ;   check_xmllint_available
+    ->  Engine = xmllint,
+        format('Warning: lxml not found, using xmllint streaming fallback~n', [])
     ;   check_xmlstarlet_available
     ->  Engine = xmlstarlet,
-        format('Warning: lxml not found, using xmlstarlet (limited functionality)~n', [])
+        format('Warning: lxml/xmllint not found, using xmlstarlet (limited functionality)~n', [])
     ;   format('Error: No XML parsing engine available~n', []),
         format('  Install lxml: pip3 install lxml~n', []),
+        format('  Or install xmllint: apt-get install libxml2-utils~n', []),
         format('  Or install xmlstarlet: apt-get install xmlstarlet~n', []),
         fail
     ).
@@ -97,7 +110,13 @@ check_lxml_available :-
 
 python_lxml_candidates([
     path(python3)-['-c', 'import lxml'],
-    path(py)-['-3', '-c', 'import lxml']
+    path(py)-['-3', '-c', 'import lxml'],
+    '/usr/bin/python3'-['-c', 'import lxml'],
+    '/bin/python3'-['-c', 'import lxml'],
+    path(wsl)-['python3', '-c', 'import lxml'],
+    'C:\\Windows\\System32\\wsl.exe'-['python3', '-c', 'import lxml'],
+    '/mnt/c/Windows/System32/wsl.exe'-['python3', '-c', 'import lxml'],
+    '/c/Windows/System32/wsl.exe'-['python3', '-c', 'import lxml']
 ]).
 
 python_lxml_check(Exec, Args) :-
@@ -132,19 +151,107 @@ python_lxml_check(Exec, Args) :-
         )
     ).
 
+%% check_xmllint_available
+%  Check if xmllint is available.
+check_xmllint_available :-
+    xmllint_candidates(Candidates),
+    member(Exec-Args, Candidates),
+    xmllint_check(Exec, Args),
+    !.
+check_xmllint_available :-
+    format('xmllint check failed using all configured candidates.~n', []),
+    fail.
+
+xmllint_candidates([
+    path(xmllint)-['--version'],
+    '/usr/bin/xmllint'-['--version'],
+    '/bin/xmllint'-['--version'],
+    path(wsl)-['xmllint', '--version'],
+    'C:\\Windows\\System32\\wsl.exe'-['xmllint', '--version'],
+    '/mnt/c/Windows/System32/wsl.exe'-['xmllint', '--version'],
+    '/c/Windows/System32/wsl.exe'-['xmllint', '--version']
+]).
+
+xmllint_check(Exec, Args) :-
+    catch(
+        setup_call_cleanup(
+            process_create(Exec, Args, [stdout(pipe(Out)), stderr(pipe(Err)), process(Process)]),
+            (
+                read_stream_to_codes(Out, OutCodes),
+                read_stream_to_codes(Err, ErrCodes),
+                process_wait(Process, ExitStatus),
+                (
+                    ExitStatus = exit(0)
+                ->  true
+                ;   format('xmllint check via ~q failed (status ~w). stdout: ~s, stderr: ~s~n',
+                           [Exec, ExitStatus, OutCodes, ErrCodes]),
+                    fail
+                )
+            ),
+            (
+                close(Out),
+                close(Err)
+            )
+        ),
+        Error,
+        (
+            (   Error = error(existence_error(_, _), _)
+            ->  fail
+            ;   format('xmllint check via ~q raised exception: ~q~n', [Exec, Error]),
+                fail
+            )
+        )
+    ).
+
 %% check_xmlstarlet_available
 %  Check if xmlstarlet is available.
 check_xmlstarlet_available :-
-    writeln('Checking for xmlstarlet...'),
+    xmlstarlet_candidates(Candidates),
+    member(Exec-Args, Candidates),
+    xmlstarlet_check(Exec, Args),
+    !.
+check_xmlstarlet_available :-
+    format('xmlstarlet check failed using all configured candidates.~n', []),
+    fail.
+
+xmlstarlet_candidates([
+    path(xmlstarlet)-['--version'],
+    '/usr/bin/xmlstarlet'-['--version'],
+    '/bin/xmlstarlet'-['--version'],
+    path(wsl)-['xmlstarlet', '--version'],
+    'C:\\Windows\\System32\\wsl.exe'-['xmlstarlet', '--version'],
+    '/mnt/c/Windows/System32/wsl.exe'-['xmlstarlet', '--version'],
+    '/c/Windows/System32/wsl.exe'-['xmlstarlet', '--version']
+]).
+
+xmlstarlet_check(Exec, Args) :-
     catch(
-        process_create(path(xmlstarlet),
-                      ['--version'],
-                      [stdout(pipe(Out)), stderr(pipe(Err))]),
-        _,
-        (   read_stream_to_codes(Out, OutCodes),
-            read_stream_to_codes(Err, ErrCodes),
-            format('xmlstarlet check failed. stdout: ~s, stderr: ~s~n', [OutCodes, ErrCodes]),
-            fail
+        setup_call_cleanup(
+            process_create(Exec, Args, [stdout(pipe(Out)), stderr(pipe(Err)), process(Process)]),
+            (
+                read_stream_to_codes(Out, OutCodes),
+                read_stream_to_codes(Err, ErrCodes),
+                process_wait(Process, ExitStatus),
+                (
+                    ExitStatus = exit(0)
+                ->  true
+                ;   format('xmlstarlet check via ~q failed (status ~w). stdout: ~s, stderr: ~s~n',
+                           [Exec, ExitStatus, OutCodes, ErrCodes]),
+                    fail
+                )
+            ),
+            (
+                close(Out),
+                close(Err)
+            )
+        ),
+        Error,
+        (
+            (   Error = error(existence_error(_, _), _)
+            ->  fail
+            ;   format('xmlstarlet check via ~q raised exception: ~q~n', [Exec, Error]),
+                fail
+            )
         )
     ).
 
@@ -166,6 +273,7 @@ compile_source(Pred/Arity, Config, Options, BashCode) :-
     % Extract required parameters
     member(xml_file(File), AllOptions),
     member(tags(Tags), AllOptions),
+    namespace_fix_option(AllOptions, NamespaceFix),
 
     % Detect or use specified engine
     (   member(engine(Engine), AllOptions)
@@ -182,8 +290,17 @@ compile_source(Pred/Arity, Config, Options, BashCode) :-
             [pred=PredStr, python_code=PythonCode],
             [source_order([file, generated])],
             BashCode)
+    ;   Engine == xmllint
+    ->  generate_xmllint_bash(Pred, File, Tags, NamespaceFix, BashCode)
     ;   Engine == xmlstarlet
     ->  generate_xmlstarlet_bash(Pred, File, Tags, BashCode)
+    ).
+
+%% namespace_fix_option(+Options, -FixBool)
+namespace_fix_option(Options, Fix) :-
+    (   member(namespace_fix(Value), Options)
+    ->  Fix = Value
+    ;   Fix = true
     ).
 
 %% ============================================ 
@@ -232,6 +349,13 @@ tags_to_python_set(Tags, Set) :-
     maplist(quote_atom, Tags, QuotedTags),
     atomic_list_concat(QuotedTags, ', ', Set).
 
+%% tags_to_python_list(+Tags, -List)
+%  Convert a list of Prolog atoms to a Python list string.
+tags_to_python_list(Tags, List) :-
+    maplist(quote_atom, Tags, QuotedTags),
+    atomic_list_concat(QuotedTags, ', ', Inner),
+    format(atom(List), '[~w]', [Inner]).
+
 %% quote_atom(+Atom, -Quoted)
 %  Quote a Prolog atom for Python.
 quote_atom(Atom, Quoted) :-
@@ -247,6 +371,24 @@ generate_xmlstarlet_bash(Pred, File, Tags, BashCode) :-
         [source_order([file, generated])],
         BashCode).
 
+%% generate_xmllint_bash(+Pred, +File, +Tags, +NamespaceFix, -BashCode)
+%  Generate bash code for xmllint engine
+generate_xmllint_bash(Pred, File, Tags, NamespaceFix, BashCode) :-
+    tags_to_xmllint_xpath(Tags, XPath),
+    tags_to_python_list(Tags, TagsList),
+    namespace_map_python(NamespaceMap),
+    atom_string(Pred, PredStr),
+    boolean_py_literal(NamespaceFix, RepairLiteral),
+    render_named_template(xml_xmllint_source,
+        [pred=PredStr,
+         file=File,
+         xpath=XPath,
+         tags_py_list=TagsList,
+         namespace_map_py=NamespaceMap,
+         repair_flag_py=RepairLiteral],
+        [source_order([file, generated])],
+        BashCode).
+
 %% tags_to_xpath(+Tags, -XPath)
 %  Convert a list of tags to an XPath expression.
 tags_to_xpath(Tags, XPath) :-
@@ -256,6 +398,44 @@ tags_to_xpath(Tags, XPath) :-
 tag_to_xpath(Tag, XPath) :-
     atom_string(Tag, TagStr),
     string_concat("//", TagStr, XPath).
+
+%% tags_to_xmllint_xpath(+Tags, -XPath)
+%  Convert tags to an XPath expression suitable for xmllint.
+tags_to_xmllint_xpath(Tags, XPath) :-
+    maplist(tag_to_xmllint_expr, Tags, XPathList),
+    atomic_list_concat(XPathList, ' | ', XPath).
+
+tag_to_xmllint_expr(Tag, XPath) :-
+    (   sub_atom(Tag, _, _, _, ':')
+    ->  atomic_list_concat([Prefix, Local], ':', Tag),
+        (   known_namespace(Prefix, Uri)
+        ->  format(atom(XPath), '//*[local-name()="~w" and namespace-uri()="~w"]', [Local, Uri])
+        ;   format(atom(XPath), '//*[name()="~w"]', [Tag])
+        )
+    ;   format(atom(XPath), '//~w', [Tag])
+    ).
+
+%% namespace_map_python(-Dict)
+%  Produce a Python dictionary literal for known namespaces.
+namespace_map_python(Dict) :-
+    findall(Entry, known_namespace_entry(Entry), Entries),
+    atomic_list_concat(Entries, ', ', Inner),
+    format(atom(Dict), '{~w}', [Inner]).
+
+known_namespace_entry(Entry) :-
+    known_namespace(Prefix, Uri),
+    atom_string(Prefix, PrefixStr),
+    atom_string(Uri, UriStr),
+    format(atom(Entry), '\'~s\': \'~s\'', [PrefixStr, UriStr]).
+
+%% known_namespace(+Prefix, -URI)
+known_namespace(pt, 'http://www.pearltrees.com/xmlns/pearl-trees#').
+known_namespace(rdf, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#').
+known_namespace(dcterms, 'http://purl.org/dc/terms/').
+
+%% boolean_py_literal(+Bool, -Literal)
+boolean_py_literal(true, 'True').
+boolean_py_literal(false, 'False').
 
 %% ============================================ 
 %% BASH TEMPLATES
@@ -282,19 +462,164 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 ').
 
-% Template for xmllint engine
-template_system:template(xml_xmlstarlet_source, '#!/bin/bash
-# {{pred}} - XML source (xmlstarlet)
+template_system:template(xml_xmllint_source, Template) :-
+    atomic_list_concat([
+        '#!/bin/bash\n',
+        '# {{pred}} - XML source (xmllint)\n',
+        '\n',
+        '{{pred}}() {\n',
+        '    local resolved=""\n',
+        '    local -a cmd=()\n',
+        '\n',
+        '    if resolved=$(command -v xmllint 2>/dev/null); then\n',
+        '        cmd=("$resolved")\n',
+        '    elif [[ -x /usr/bin/xmllint ]]; then\n',
+        '        cmd=("/usr/bin/xmllint")\n',
+        '    elif resolved=$(command -v wsl 2>/dev/null); then\n',
+        '        cmd=("$resolved" "xmllint")\n',
+        '    elif [[ -x /mnt/c/Windows/System32/wsl.exe ]]; then\n',
+        '        cmd=("/mnt/c/Windows/System32/wsl.exe" "xmllint")\n',
+        '    elif [[ -x /c/Windows/System32/wsl.exe ]]; then\n',
+        '        cmd=("/c/Windows/System32/wsl.exe" "xmllint")\n',
+        '    else\n',
+        '        echo "xmllint not found; install libxml2-utils or adjust PATH." >&2\n',
+        '        return 127\n',
+        '    fi\n',
+        '\n',
+        '    python3 - <<\'PY\' "${cmd[@]}" -- \'{{file}}\' \'{{xpath}}\'\n',
+        'import re\n',
+        'import subprocess\n',
+        'import sys\n',
+        '\n',
+        'TAGS = {{tags_py_list}}\n',
+        'NAMESPACE_MAP = {{namespace_map_py}}\n',
+        'REPAIR = {{repair_flag_py}}\n',
+        '\n',
+        'def run_xmllint(cmd, xml_file, xpath):\n',
+        '    proc = subprocess.run(cmd + ["--xpath", xpath, xml_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)\n',
+        '    if proc.returncode == 0:\n',
+        '        return proc.stdout\n',
+        '    if proc.returncode == 10 and "XPath set is empty" in proc.stderr:\n',
+        '        return ""\n',
+        '    sys.stderr.write(proc.stderr)\n',
+        '    raise SystemExit(proc.returncode)\n',
+        '\n',
+        'def extract_records(data, tags):\n',
+        '    records = []\n',
+        '    pos = 0\n',
+        '    length = len(data)\n',
+        '    while True:\n',
+        '        next_start = None\n',
+        '        next_tag = None\n',
+        '        for tag in tags:\n',
+        '            marker = f"<{tag}"\n',
+        '            idx = data.find(marker, pos)\n',
+        '            if idx != -1 and (next_start is None or idx < next_start):\n',
+        '                next_start = idx\n',
+        '                next_tag = tag\n',
+        '        if next_start is None:\n',
+        '            break\n',
+        '        end_token = f"</{next_tag}>"\n',
+        '        end_idx = data.find(end_token, next_start)\n',
+        '        if end_idx == -1:\n',
+        '            break\n',
+        '        end_idx += len(end_token)\n',
+        '        tail = end_idx\n',
+        '        while tail < length and data[tail] in "\\r\\n\\t ":\n',
+        '            tail += 1\n',
+        '        records.append(data[next_start:tail])\n',
+        '        pos = tail\n',
+        '    return records\n',
+        '\n',
+        'def ensure_namespaces(record):\n',
+        '    first_gt = record.find(">")\n',
+        '    if first_gt == -1:\n',
+        '        return record\n',
+        '    header = record[:first_gt]\n',
+        '    needed = []\n',
+        '    prefixes = set(re.findall(r"[<\\s]([A-Za-z_][\\w.-]*):", record))\n',
+        '    for prefix in sorted(prefixes):\n',
+        '        if prefix == "xml":\n',
+        '            continue\n',
+        '        uri = NAMESPACE_MAP.get(prefix)\n',
+        '        if not uri:\n',
+        '            continue\n',
+        '        if f"xmlns:{prefix}=" not in header:\n',
+        '            needed.append(f"xmlns:{prefix}={chr(34)}{uri}{chr(34)}")\n',
+        '    if not needed:\n',
+        '        return record\n',
+        '    insert_pos = record.find(" ")\n',
+        '    if insert_pos == -1 or insert_pos > first_gt:\n',
+        '        insert_pos = first_gt\n',
+        '    insertion = " " + " ".join(needed)\n',
+        '    return record[:insert_pos] + insertion + record[insert_pos:]\n',
+        '\n',
+        'def main():\n',
+        '    argv = sys.argv[1:]\n',
+        '    if "--" not in argv:\n',
+        '        raise SystemExit("internal error: missing separator")\n',
+        '    sep = argv.index("--")\n',
+        '    cmd = argv[:sep]\n',
+        '    xml_file = argv[sep + 1]\n',
+        '    xpath = argv[sep + 2]\n',
+        '    data = run_xmllint(cmd, xml_file, xpath)\n',
+        '    if not data:\n',
+        '        return\n',
+        '    for record in extract_records(data, TAGS):\n',
+        '        fixed = ensure_namespaces(record) if REPAIR else record\n',
+        '        sys.stdout.buffer.write(fixed.encode("utf-8"))\n',
+        '        sys.stdout.buffer.write(b"\\0")\n',
+        '\n',
+        'if __name__ == "__main__":\n',
+        '    main()\n',
+        'PY\n',
+        '}\n',
+        '\n',
+        '{{pred}}_stream() {\n',
+        '    {{pred}}\n',
+        '}\n',
+        '\n',
+        'if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then\n',
+        '    {{pred}} "$@"\n',
+        'fi\n'
+    ], Template).
 
-{{pred}}() {
-    /usr/bin/xmlstarlet sel -N pt="http://www.pearltrees.com/xmlns/pearl-trees#" -t -c "{{xpath}}" "{{file}}" | awk \'{printf "%s\0", $0}\'
-}
-
-{{pred}}_stream() {
-    {{pred}}
-}
-
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    {{pred}} "$@"
-fi
-').
+% Template for xmlstarlet engine
+template_system:template(xml_xmlstarlet_source, Template) :-
+    atomic_list_concat([
+        '#!/bin/bash\n',
+        '# {{pred}} - XML source (xmlstarlet)\n',
+        '\n',
+        '{{pred}}() {\n',
+        '    local resolved=""\n',
+        '    local -a cmd=()\n',
+        '\n',
+        '    if resolved=$(command -v xmlstarlet 2>/dev/null); then\n',
+        '        cmd=("$resolved")\n',
+        '    elif [[ -x /usr/bin/xmlstarlet ]]; then\n',
+        '        cmd=("/usr/bin/xmlstarlet")\n',
+        '    elif resolved=$(command -v wsl 2>/dev/null); then\n',
+        '        cmd=("$resolved" "xmlstarlet")\n',
+        '    elif [[ -x /mnt/c/Windows/System32/wsl.exe ]]; then\n',
+        '        cmd=("/mnt/c/Windows/System32/wsl.exe" "xmlstarlet")\n',
+        '    elif [[ -x /c/Windows/System32/wsl.exe ]]; then\n',
+        '        cmd=("/c/Windows/System32/wsl.exe" "xmlstarlet")\n',
+        '    else\n',
+        '        echo "xmlstarlet not found; install xmlstarlet or switch to the iterparse engine." >&2\n',
+        '        return 127\n',
+        '    fi\n',
+        '\n',
+        '    local sentinel="__XMLSTARLET_RECORD__"\n',
+        '\n',
+        '    "${cmd[@]}" sel -N pt="http://www.pearltrees.com/xmlns/pearl-trees#" -t -m "{{xpath}}" -c "." -o "${sentinel}" -n "{{file}}" |\n',
+        '        awk -v RS="${sentinel}\\n" -v ORS="" ''length($0) {printf "%s%c", $0, 0}''\n',
+        '}\n',
+        '\n',
+        '{{pred}}_stream() {\n',
+        '    {{pred}}\n',
+        '}\n',
+        '\n',
+        'if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then\n',
+        '    {{pred}} "$@"\n',
+        'fi\n'
+    ], Template).

--- a/src/unifyweaver/sources/xml_source.pl
+++ b/src/unifyweaver/sources/xml_source.pl
@@ -287,7 +287,7 @@ template_system:template(xml_xmlstarlet_source, '#!/bin/bash
 # {{pred}} - XML source (xmlstarlet)
 
 {{pred}}() {
-    xmlstarlet sel -N pt="http://www.pearltrees.com/xmlns/pearl-trees#" -t -c "{{xpath}}" "{{file}}" | awk \'{printf "%s\0", $0}\'
+    /usr/bin/xmlstarlet sel -N pt="http://www.pearltrees.com/xmlns/pearl-trees#" -t -c "{{xpath}}" "{{file}}" | awk \'{printf "%s\0", $0}\'
 }
 
 {{pred}}_stream() {

--- a/src/unifyweaver/sources/xml_source.pl
+++ b/src/unifyweaver/sources/xml_source.pl
@@ -1,0 +1,294 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% xml_source.pl - XML source plugin for dynamic sources
+% Compiles predicates that read data from XML files using a streaming parser
+
+:- module(xml_source, [compile_source/4, generate_lxml_python_code/3]).
+
+:- use_module(library(lists)).
+:- use_module(library(readutil)).
+:- use_module(library(process)).
+:- use_module('../core/template_system').
+:- use_module('../core/dynamic_source_compiler').
+
+%% Register this plugin on load
+:- initialization(
+    register_source_type(xml, xml_source),
+    now
+).
+
+%% ============================================ 
+%% PLUGIN INTERFACE
+%% ============================================ 
+
+%% source_info(-Info)
+%  Provide information about this source plugin
+source_info(info(
+    name('XML Source'),
+    version('1.0.0'),
+    description('Extract XML elements using a streaming parser'),
+    supported_arities([1])
+)).
+
+%% validate_config(+Config)
+%  Validate configuration for XML source
+validate_config(Config) :-
+    % Must have xml_file
+    (   member(xml_file(File), Config),
+        (
+            exists_file(File)
+        ->  true
+        ;   format('Warning: XML file ~w does not exist~n', [File])
+        )
+    ->  true
+    ;   format('Error: XML source requires xml_file(File)~n', []),
+        fail
+    ),
+    % Must have tags
+    (   member(tags(Tags), Config),
+        is_list(Tags),
+        Tags \= []
+    ->  true
+    ;   format('Error: XML source requires non-empty tags(List)~n', []),
+        fail
+    ),
+    % Validate engine if specified
+    (   member(engine(Engine), Config)
+    ->  (
+            (Engine == iterparse ; Engine == xmlstarlet)
+        ->  true
+        ;   format('Error: invalid engine ~w. Must be one of [iterparse, xmlstarlet]~n', [Engine]),
+            fail
+        )
+    ;   true
+    ).
+
+%% ============================================ 
+%% ENGINE DETECTION
+%% ============================================ 
+
+%% detect_available_engine(-Engine)
+%  Auto-detect the best available XML parsing engine.
+detect_available_engine(Engine) :-
+    (
+        check_lxml_available
+    ->  Engine = iterparse
+    ;   check_xmlstarlet_available
+    ->  Engine = xmlstarlet,
+        format('Warning: lxml not found, using xmlstarlet (limited functionality)~n', [])
+    ;   format('Error: No XML parsing engine available~n', []),
+        format('  Install lxml: pip3 install lxml~n', []),
+        format('  Or install xmlstarlet: apt-get install xmlstarlet~n', []),
+        fail
+    ).
+    
+    %% check_lxml_available
+    %  Check if lxml is available.
+    check_lxml_available :-
+        python_lxml_candidates(Candidates),
+        member(Exec-Args, Candidates),
+        python_lxml_check(Exec, Args),
+        !.
+    
+    check_lxml_available :-
+        format('lxml check failed using all configured interpreters.~n', []),
+        fail.
+    
+    python_lxml_candidates([
+        path(python3)-['-c', 'import lxml'],
+        path(py)-['-3', '-c', 'import lxml']
+    ]).
+    
+    python_lxml_check(Exec, Args) :-
+        catch(
+            setup_call_cleanup(
+                process_create(Exec, Args, [stdout(pipe(Out)), stderr(pipe(Err)), process(Process)]),
+                (
+                    read_stream_to_codes(Out, OutCodes),
+                    read_stream_to_codes(Err, ErrCodes),
+                    process_wait(Process, ExitStatus),
+                    (
+                        ExitStatus = exit(0)
+                    ->  true
+                    ;   format('lxml check via ~q failed (status ~w). stdout: ~s, stderr: ~s~n',
+                               [Exec, ExitStatus, OutCodes, ErrCodes]),
+                        fail
+                    )
+                ),
+                (
+                    close(Out),
+                    close(Err)
+                )
+            ),
+            Error,
+            (
+                (   Error = error(existence_error(_, _), _)
+                ->  fail
+                ;   format('lxml check via ~q raised exception: ~q~n', [Exec, Error]),
+                    fail
+                )
+            )
+        ).
+    
+    %% check_xmlstarlet_available
+    %  Check if xmlstarlet is available.
+    check_xmlstarlet_available :-
+        catch(
+            process_create(path(xmlstarlet),
+                          ['--version'],
+                          [stdout(null), stderr(null)]),
+            _, 
+            fail
+        ).
+%% ============================================ 
+%% COMPILATION
+%% ============================================ 
+
+%% compile_source(+Pred/Arity, +Config, +Options, -BashCode)
+%  Compile XML source to bash code
+compile_source(Pred/Arity, Config, Options, BashCode) :-
+    format('  Compiling XML source: ~w/~w~n', [Pred, Arity]),
+
+    % Validate configuration
+    validate_config(Config),
+
+    % Merge config and options
+    append(Config, Options, AllOptions),
+
+    % Extract required parameters
+    member(xml_file(File), AllOptions),
+    member(tags(Tags), AllOptions),
+
+    % Detect or use specified engine
+    (   member(engine(Engine), AllOptions)
+    ->  true
+    ;   detect_available_engine(Engine)
+    ),
+
+    % Generate code based on engine
+    (
+        Engine == iterparse
+    ->  generate_lxml_python_code(File, Tags, PythonCode),
+        atom_string(Pred, PredStr),
+        render_named_template(xml_iterparse_source,
+            [pred=PredStr, python_code=PythonCode],
+            [source_order([file, generated])],
+            BashCode)
+    ;   Engine == xmlstarlet
+    ->  generate_xmllint_bash(Pred, File, Tags, BashCode)
+    ).
+
+%% ============================================ 
+%% PYTHON CODE GENERATION
+%% ============================================ 
+
+%% generate_lxml_python_code(+File, +Tags, -PythonCode)
+%  Generate Python code for lxml iterparse
+generate_lxml_python_code(File, Tags, PythonCode) :-
+    tags_to_python_set(Tags, TagsSet),
+    atomic_list_concat([
+        "import sys\n",
+        "from lxml import etree\n\n",
+        "file = \"", File, "\"\n",
+        "tags = {", TagsSet, "}\n",
+        "null = b'\0'\n\n",
+        "# Parse with namespace handling\n",
+        "context = etree.iterparse(file, events=('start', 'end'), recover=True)\n",
+        "event, root = next(context)\n",
+        "nsmap = root.nsmap or {}\n\n",
+        "def expand(tag):\n",
+        "    if ':' in tag:\n",
+        "        pfx, local = tag.split(':', 1)\n",
+        "        uri = nsmap.get(pfx)\n",
+        "        if uri:\n",
+        "            return '{' + uri + '}' + local\n",
+        "        else:\n",
+        "            return tag\n",
+        "    return tag\n\n",
+        "want = {expand(t) for t in tags}\n\n",
+        "# Stream with memory release\n",
+        "for event, elem in context:\n",
+        "    if event == 'end' and elem.tag in want:\n",
+        "        sys.stdout.buffer.write(etree.tostring(elem))\n",
+        "        sys.stdout.buffer.write(null)\n",
+        "        # Release memory immediately\n",
+        "        elem.clear()\n",
+        "        while elem.getprevious() is not None:\n",
+        "            del elem.getparent()[0]\n",
+        "        root.clear()\n"
+    ], PythonCode).
+
+%% tags_to_python_set(+Tags, -Set)
+%  Convert a list of Prolog atoms to a Python set string.
+tags_to_python_set(Tags, Set) :-
+    maplist(quote_atom, Tags, QuotedTags),
+    atomic_list_concat(QuotedTags, ', ', Set).
+
+%% quote_atom(+Atom, -Quoted)
+%  Quote a Prolog atom for Python.
+quote_atom(Atom, Quoted) :-
+    format(atom(Quoted), '\'~w\'', [Atom]).
+
+%% generate_xmllint_bash(+Pred, +File, +Tags, -BashCode)
+%  Generate bash code for xmllint engine
+generate_xmllint_bash(Pred, File, Tags, BashCode) :-
+    tags_to_xpath(Tags, XPath),
+    atom_string(Pred, PredStr),
+    render_named_template(xml_xmllint_source,
+        [pred=PredStr, file=File, xpath=XPath],
+        [source_order([file, generated])],
+        BashCode).
+
+%% tags_to_xpath(+Tags, -XPath)
+%  Convert a list of tags to an XPath expression.
+tags_to_xpath(Tags, XPath) :-
+    maplist(tag_to_xpath, Tags, XPathList),
+    atomic_list_concat(XPathList, ' | ', XPath).
+
+tag_to_xpath(Tag, XPath) :-
+    atom_string(Tag, TagStr),
+    string_concat("//", TagStr, XPath).
+
+%% ============================================ 
+%% BASH TEMPLATES
+%% ============================================ 
+
+:- multifile template_system:template/2.
+
+% Template for lxml iterparse engine
+template_system:template(xml_iterparse_source, '#!/bin/bash
+# {{pred}} - XML source (lxml iterparse)
+
+{{pred}}() {
+    python3 /dev/fd/3 3<<\'EOF\'
+{{python_code}}
+EOF
+}
+
+{{pred}}_stream() {
+    {{pred}}
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    {{pred}} "$@"
+fi
+').
+
+% Template for xmllint engine
+template_system:template(xml_xmllint_source, '#!/bin/bash
+# {{pred}} - XML source (xmllint)
+
+{{pred}}() {
+    xmllint --xpath "{{xpath}}" "{{file}}" | awk \'{printf "%s\0", $0}\'
+}
+
+{{pred}}_stream() {
+    {{pred}}
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    {{pred}} "$@"
+fi
+').

--- a/src/unifyweaver/sources/xml_source.pl
+++ b/src/unifyweaver/sources/xml_source.pl
@@ -135,12 +135,17 @@ python_lxml_check(Exec, Args) :-
 %% check_xmlstarlet_available
 %  Check if xmlstarlet is available.
 check_xmlstarlet_available :-
+    writeln('Checking for xmlstarlet...'),
     catch(
         process_create(path(xmlstarlet),
                       ['--version'],
-                      [stdout(null), stderr(null)]),
+                      [stdout(pipe(Out)), stderr(pipe(Err))]),
         _,
-        fail
+        (   read_stream_to_codes(Out, OutCodes),
+            read_stream_to_codes(Err, ErrCodes),
+            format('xmlstarlet check failed. stdout: ~s, stderr: ~s~n', [OutCodes, ErrCodes]),
+            fail
+        )
     ).
 
 %% ============================================ 

--- a/src/unifyweaver/sources/xml_source.pl
+++ b/src/unifyweaver/sources/xml_source.pl
@@ -177,7 +177,7 @@ compile_source(Pred/Arity, Config, Options, BashCode) :-
             [source_order([file, generated])],
             BashCode)
     ;   Engine == xmlstarlet
-    ->  generate_xmllint_bash(Pred, File, Tags, BashCode)
+    ->  generate_xmlstarlet_bash(Pred, File, Tags, BashCode)
     ).
 
 %% ============================================ 
@@ -231,12 +231,12 @@ tags_to_python_set(Tags, Set) :-
 quote_atom(Atom, Quoted) :-
     format(atom(Quoted), '\'~w\'', [Atom]).
 
-%% generate_xmllint_bash(+Pred, +File, +Tags, -BashCode)
-%  Generate bash code for xmllint engine
-generate_xmllint_bash(Pred, File, Tags, BashCode) :-
+%% generate_xmlstarlet_bash(+Pred, +File, +Tags, -BashCode)
+%  Generate bash code for xmlstarlet engine
+generate_xmlstarlet_bash(Pred, File, Tags, BashCode) :-
     tags_to_xpath(Tags, XPath),
     atom_string(Pred, PredStr),
-    render_named_template(xml_xmllint_source,
+    render_named_template(xml_xmlstarlet_source,
         [pred=PredStr, file=File, xpath=XPath],
         [source_order([file, generated])],
         BashCode).
@@ -277,11 +277,11 @@ fi
 ').
 
 % Template for xmllint engine
-template_system:template(xml_xmllint_source, '#!/bin/bash
-# {{pred}} - XML source (xmllint)
+template_system:template(xml_xmlstarlet_source, '#!/bin/bash
+# {{pred}} - XML source (xmlstarlet)
 
 {{pred}}() {
-    xmllint --xpath "{{xpath}}" "{{file}}" | awk \'{printf "%s\0", $0}\'
+    xmlstarlet sel -t -c "{{xpath}}" "{{file}}" | awk \'{printf "%s\0", $0}\'
 }
 
 {{pred}}_stream() {

--- a/tests/core/test_xml_source.pl
+++ b/tests/core/test_xml_source.pl
@@ -1,0 +1,34 @@
+:- module(test_xml_source, [run_tests/0]).
+
+:- use_module(library(plunit)).
+:- use_module(src/unifyweaver/sources/xml_source).
+:- use_module(library(process)).
+
+run_tests :-
+    run_tests([xml_source]).
+
+:- begin_tests(xml_source).
+
+test(basic_extraction) :-
+    % Compile the source
+    xml_source:compile_source(test_xml/1, [
+        xml_file('tests/test_data/sample.rdf'),
+        tags(['pt:Tree'])
+    ], [], BashCode),
+
+    % Write the generated script to a file
+    open('test_xml.sh', write, Stream, [newline(posix)]),
+    write(Stream, BashCode),
+    close(Stream),
+
+    % Execute the script and capture the output
+    process_create(path(bash), ['test_xml.sh'], [stdout(pipe(Out))]),
+    read_stream_to_codes(Out, Codes),
+    close(Out),
+
+    format('stdout: ~s~n', [Codes]),
+
+    % Clean up
+    delete_file('test_xml.sh').
+
+:- end_tests(xml_source).

--- a/tests/core/test_xml_source.pl
+++ b/tests/core/test_xml_source.pl
@@ -26,9 +26,36 @@ test(basic_extraction) :-
     read_stream_to_codes(Out, Codes),
     close(Out),
 
-    format('stdout: ~s~n', [Codes]),
+    % The output should be null-delimited. Count the null characters.
+    include(=(0), Codes, Nulls),
+    length(Nulls, 2),
 
     % Clean up
     delete_file('test_xml.sh').
+
+test(xmlstarlet_extraction) :-
+    % Compile the source with xmlstarlet engine
+    xml_source:compile_source(test_xml/1, [
+        xml_file('tests/test_data/sample.rdf'),
+        tags(['pt:Tree']),
+        engine(xmlstarlet)
+    ], [], BashCode),
+
+    % Write the generated script to a file
+    open('test_xml_xmlstarlet.sh', write, Stream, [newline(posix)]),
+    write(Stream, BashCode),
+    close(Stream),
+
+    % Execute the script and capture the output
+    process_create(path(bash), ['test_xml_xmlstarlet.sh'], [stdout(pipe(Out))]),
+    read_stream_to_codes(Out, Codes),
+    close(Out),
+
+    % The output should be null-delimited. Count the null characters.
+    include(=(0), Codes, Nulls),
+    length(Nulls, 2),
+
+    % Clean up
+    delete_file('test_xml_xmlstarlet.sh').
 
 :- end_tests(xml_source).

--- a/tests/core/test_xml_source.pl
+++ b/tests/core/test_xml_source.pl
@@ -3,6 +3,9 @@
 :- use_module(library(plunit)).
 :- use_module(src/unifyweaver/sources/xml_source).
 :- use_module(library(process)).
+:- use_module(library(apply)). % for exclude/3
+
+:- set_test_options([output(always)]).
 
 run_tests :-
     run_tests([xml_source]).
@@ -11,51 +14,191 @@ run_tests :-
 
 test(basic_extraction) :-
     % Compile the source
-    xml_source:compile_source(test_xml/1, [
+    once(xml_source:compile_source(test_xml/1, [
         xml_file('tests/test_data/sample.rdf'),
         tags(['pt:Tree'])
-    ], [], BashCode),
+    ], [], BashCode)),
 
     % Write the generated script to a file
-    open('test_xml.sh', write, Stream, [newline(posix)]),
-    write(Stream, BashCode),
-    close(Stream),
+    setup_call_cleanup(
+        open('test_xml.sh', write, Stream, [newline(posix)]),
+        write(Stream, BashCode),
+        close(Stream)
+    ),
 
     % Execute the script and capture the output
-    process_create(path(bash), ['test_xml.sh'], [stdout(pipe(Out))]),
-    read_stream_to_codes(Out, Codes),
-    close(Out),
+    setup_call_cleanup(
+        process_create(path(bash), ['test_xml.sh'], [stdout(pipe(Out)), process(PID)]),
+        (
+            read_stream_to_codes(Out, Codes),
+            process_wait(PID, ExitStatus),
+            assertion(ExitStatus == exit(0))
+        ),
+        close(Out)
+    ),
 
     % The output should be null-delimited. Count the null characters.
     include(=(0), Codes, Nulls),
     length(Nulls, 2),
+
+    % Decode records and show them for visibility
+    codes_to_records(Codes, Records),
+    length(Records, 2),
+    report_records(iterparse, Records),
+
+    % Basic content assertions
+    forall(member(R, Records), sub_string(R, _, _, _, "<pt:Tree")),
+    records_contains(Records, "Test Tree 1"),
+    records_contains(Records, "Test Tree 2"),
 
     % Clean up
     delete_file('test_xml.sh').
 
 test(xmlstarlet_extraction) :-
     % Compile the source with xmlstarlet engine
-    xml_source:compile_source(test_xml/1, [
+    once(xml_source:compile_source(test_xml/1, [
         xml_file('tests/test_data/sample.rdf'),
         tags(['pt:Tree']),
         engine(xmlstarlet)
-    ], [], BashCode),
+    ], [], BashCode)),
 
     % Write the generated script to a file
-    open('test_xml_xmlstarlet.sh', write, Stream, [newline(posix)]),
-    write(Stream, BashCode),
-    close(Stream),
+    setup_call_cleanup(
+        open('test_xml_xmlstarlet.sh', write, Stream, [newline(posix)]),
+        write(Stream, BashCode),
+        close(Stream)
+    ),
 
     % Execute the script and capture the output
-    process_create(path(bash), ['test_xml_xmlstarlet.sh'], [stdout(pipe(Out))]),
-    read_stream_to_codes(Out, Codes),
-    close(Out),
+    setup_call_cleanup(
+        process_create(path(bash), ['test_xml_xmlstarlet.sh'], [stdout(pipe(Out)), process(PID)]),
+        (
+            read_stream_to_codes(Out, Codes),
+            process_wait(PID, ExitStatus),
+            assertion(ExitStatus == exit(0))
+        ),
+        close(Out)
+    ),
 
     % The output should be null-delimited. Count the null characters.
     include(=(0), Codes, Nulls),
     length(Nulls, 2),
 
+    % Decode records and show them for visibility
+    codes_to_records(Codes, Records),
+    length(Records, 2),
+    report_records(xmlstarlet, Records),
+
+    % Basic content assertions
+    forall(member(R, Records), sub_string(R, _, _, _, "<pt:Tree")),
+    records_contains(Records, "Test Tree 1"),
+    records_contains(Records, "Test Tree 2"),
+
     % Clean up
     delete_file('test_xml_xmlstarlet.sh').
 
+test(xmllint_extraction) :-
+    % Compile the source with xmllint engine
+    once(xml_source:compile_source(test_xml/1, [
+        xml_file('tests/test_data/sample.rdf'),
+        tags(['pt:Tree']),
+        engine(xmllint)
+    ], [], BashCode)),
+
+    % Write the generated script to a file
+    setup_call_cleanup(
+        open('test_xml_xmllint.sh', write, Stream, [newline(posix)]),
+        write(Stream, BashCode),
+        close(Stream)
+    ),
+
+    % Execute the script and capture the output
+    setup_call_cleanup(
+        process_create(path(bash), ['test_xml_xmllint.sh'], [stdout(pipe(Out)), process(PID)]),
+        (
+            read_stream_to_codes(Out, Codes),
+            process_wait(PID, ExitStatus),
+            assertion(ExitStatus == exit(0))
+        ),
+        close(Out)
+    ),
+
+    % The output should be null-delimited. Count the null characters.
+    include(=(0), Codes, Nulls),
+    length(Nulls, 2),
+
+    % Decode records and show them for visibility
+    codes_to_records(Codes, Records),
+    length(Records, 2),
+    report_records(xmllint, Records),
+
+    % Basic content assertions
+    forall(member(R, Records), sub_string(R, _, _, _, "<pt:Tree")),
+    records_contains(Records, "Test Tree 1"),
+    records_contains(Records, "Test Tree 2"),
+
+    % Clean up
+    delete_file('test_xml_xmllint.sh').
+
+test(xmllint_extraction_without_namespace_fix) :-
+    % Compile the source with xmllint engine but disable namespace repair
+    once(xml_source:compile_source(test_xml_ns/1, [
+        xml_file('tests/test_data/sample.rdf'),
+        tags(['pt:Tree']),
+        engine(xmllint),
+        namespace_fix(false)
+    ], [], BashCode)),
+
+    setup_call_cleanup(
+        open('test_xml_xmllint_no_fix.sh', write, Stream, [newline(posix)]),
+        write(Stream, BashCode),
+        close(Stream)
+    ),
+
+    setup_call_cleanup(
+        process_create(path(bash), ['test_xml_xmllint_no_fix.sh'], [stdout(pipe(Out)), process(PID)]),
+        (
+            read_stream_to_codes(Out, Codes),
+            process_wait(PID, ExitStatus),
+            assertion(ExitStatus == exit(0))
+        ),
+        close(Out)
+    ),
+
+    include(=(0), Codes, Nulls),
+    length(Nulls, 2),
+
+    codes_to_records(Codes, Records),
+    length(Records, 2),
+    report_records(xmllint_no_fix, Records),
+
+    forall(member(R, Records), sub_string(R, _, _, _, "<pt:Tree")),
+    records_contains(Records, "Test Tree 1"),
+    records_contains(Records, "Test Tree 2"),
+    forall(member(R, Records), \+ sub_string(R, _, _, _, "xmlns:")),
+
+    delete_file('test_xml_xmllint_no_fix.sh').
+
 :- end_tests(xml_source).
+
+codes_to_records(Codes, Records) :-
+    string_codes(String, Codes),
+    split_string(String, "\u0000", "\u0000", RawRecords),
+    exclude(=( ""), RawRecords, Records).
+
+report_records(Label, Records) :-
+    forall(nth1(Index, Records, Record),
+           print_message(informational, xml_record(Label, Index, Record))).
+
+records_contains(Records, Needle) :-
+    once((
+        member(Record, Records),
+        sub_string(Record, _, _, _, Needle)
+    )).
+
+:- multifile prolog:message//1.
+
+prolog:message(xml_record(Label, Index, Record)) -->
+    [ '~w record ~d:'-[Label, Index], nl,
+      '~s'-[Record], nl
+    ].

--- a/tests/test_data/sample.rdf
+++ b/tests/test_data/sample.rdf
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:pt="http://www.pearltrees.com/xmlns/pearl-trees#"
+         xmlns:dcterms="http://purl.org/dc/terms/">
+  <pt:Tree rdf:about="https://www.pearltrees.com/t/test1/id1">
+    <dcterms:title><![CDATA[Test Tree 1]]></dcterms:title>
+    <pt:treeId>1</pt:treeId>
+  </pt:Tree>
+  <pt:Page rdf:about="https://www.pearltrees.com/p/test/id2">
+    <dcterms:title><![CDATA[Test Page]]></dcterms:title>
+  </pt:Page>
+  <pt:Tree rdf:about="https://www.pearltrees.com/t/test2/id3">
+    <dcterms:title><![CDATA[Test Tree 2]]></dcterms:title>
+    <pt:treeId>3</pt:treeId>
+  </pt:Tree>
+</rdf:RDF>


### PR DESCRIPTION
## Summary
  - add xmllint as a selectable xml_source engine with optional namespace_fix/1 flag
  - broaden engine detection to cover xmllint alongside iterparse and xmlstarlet
  - expand PLUnit coverage, docs, and future-work notes for all XML tooling variants

## Testing
  - swipl -s tests/core/test_xml_source.pl -g run_tests -t halt