### PR TITLE
fix(compiler): Prevent traversal into built-in predicates

### DIFF
--- a/src/unifyweaver/core/dependency_analyzer.pl
+++ b/src/unifyweaver/core/dependency_analyzer.pl
@@ -53,7 +53,12 @@ body_dependencies(\+ A, Deps) :-
     body_dependencies(A, Deps).
 body_dependencies(Goal, [Functor/Arity]) :-
     compound(Goal),
-    functor(Goal, Functor, Arity).
+    functor(Goal, Functor, Arity),
+    \+ predicate_property(Goal, built_in),
+    !.
+body_dependencies(Goal, []) :-
+    compound(Goal),
+    predicate_property(Goal, built_in).
 
 %% exclude_original(+AllDeps, +OriginalFunctor, -FilteredDeps)
 %  Remove the original predicate from the list of dependencies to avoid self-recursion.


### PR DESCRIPTION
The dependency analyzer was incorrectly identifying built-in arithmetic predicates (e.g., `>/2`, `is/2`) as dependencies. This caused the compiler driver to fail with a permission error when it tried to introspect these private, built-in procedures.

This fix modifies the analyzer to check the `predicate_property/2` for the `built_in` property. It now correctly ignores built-in predicates, only identifying user-defined goals as dependencies.

This resolves the compilation failure for predicates containing arithmetic operations.