### PR TITLE
fix(compiler): Mutual recursion classification and     bash generation

### DIFF
--- a/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
+++ b/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
@@ -14,7 +14,7 @@
 ]).
 
 :- use_module(library(lists)).
-:- use_module('call_graph').
+:- use_module('call_graph', [predicates_in_group/2]).
 :- use_module('scc_detection').
 :- use_module('pattern_matchers', [
     contains_call_to/2,

--- a/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
+++ b/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
@@ -9,7 +9,8 @@
 :- module(advanced_recursive_compiler, [
     compile_advanced_recursive/3,   % +Pred/Arity, +Options, -BashCode
     compile_predicate_group/3,      % +Predicates, +Options, -BashCode
-    try_fold_pattern/3,            % +Pred/Arity, +Options, -BashCode  
+    compile_mutual_recursion/3,     % +Group, +Options, -BashCode
+    try_fold_pattern/3,            % +Pred/Arity, +Options, -BashCode
     test_advanced_compiler/0
 ]).
 

--- a/src/unifyweaver/core/advanced/call_graph.pl
+++ b/src/unifyweaver/core/advanced/call_graph.pl
@@ -89,11 +89,6 @@ get_dependencies(Pred/Arity, Dependencies) :-
         DepsWithDups),
     sort(DepsWithDups, Dependencies).
 
-%% is_self_recursive(+Pred/Arity)
-%  Check if predicate calls itself (directly)
-is_self_recursive(Pred/Arity) :-
-    find_predicate_calls(Pred/Arity, Pred/Arity).
-
 %% predicates_in_group(+RootPred, -AllPredicates)
 %  Find all predicates reachable from a root predicate
 %  (transitive closure of the call graph)

--- a/src/unifyweaver/core/advanced/call_graph.pl
+++ b/src/unifyweaver/core/advanced/call_graph.pl
@@ -89,6 +89,12 @@ get_dependencies(Pred/Arity, Dependencies) :-
         DepsWithDups),
     sort(DepsWithDups, Dependencies).
 
+%% is_self_recursive(+Pred/Arity)
+%  Check if a predicate is self-recursive (calls itself)
+is_self_recursive(Pred/Arity) :-
+    get_dependencies(Pred/Arity, Deps),
+    member(Pred/Arity, Deps).
+
 %% predicates_in_group(+RootPred, -AllPredicates)
 %  Find all predicates reachable from a root predicate
 %  (transitive closure of the call graph)

--- a/src/unifyweaver/core/compiler_driver.pl
+++ b/src/unifyweaver/core/compiler_driver.pl
@@ -71,9 +71,14 @@ compile_current(Predicate, Options, GeneratedScript) :-
 classify_predicate(Pred/Arity, Classification) :-
     functor(Head, Pred, Arity),
     findall(Body, clause(Head, Body), Bodies),
-    
-    % Check if recursive
-    (   contains_recursive_call(Pred, Bodies) ->
+
+    % Check for mutual recursion FIRST (before self-recursion check)
+    (   call_graph:predicates_in_group(Pred/Arity, Group),
+        length(Group, GroupSize),
+        GroupSize > 1 ->
+        Classification = mutual_recursion
+    ;   % Check if self-recursive
+        contains_recursive_call(Pred, Bodies) ->
         analyze_recursion_pattern(Pred, Arity, Bodies, Classification)
     ;   Classification = non_recursive
     ).


### PR DESCRIPTION
## Summary

   Fixes mutual recursion detection and bash code generation, plus adds robustness enhancements for better user experience.

   ## Original Fixes (5 commits)

   ### 1. Mutual Recursion Detection Priority
   - **Problem**: Mutual recursion was checked AFTER self-recursion, causing misclassification
   - **Fix**: Check mutual recursion FIRST in both `compiler_driver.pl` and `recursive_compiler.pl`
   - **Impact**: Predicates like `is_even/1` and `is_odd/1` now correctly detected as mutual recursion

   ### 2. Bash Code Generation
   - **Problem**: Result echoing and memoization placement was incorrect
   - **Fix**: Proper placement of `echo "$result"` and memo store code
   - **Impact**: Generated bash now correctly returns values and stores memoization

   ### 3. Module Imports
   - Added missing imports for `advanced_recursive_compiler` and `call_graph` modules

   ## New Enhancements (1 commit)

   ### 1. Auto-Detection of Mutual Groups
   ```prolog
   find_mutual_group(is_even/1, Group)
   % Returns: [is_even/1, is_odd/1]
   ```
   - Users can now pass a single predicate instead of manually listing all group members
   - Automatically finds the full SCC (strongly connected component)

   ### 2. Main Dispatch in Generated Bash
   ```bash
   ./is_even.sh is_even 4    # Direct execution
   ./is_even.sh is_odd 5     # Route to different functions
   ```
   - Generated scripts can be executed directly from command line
   - No need to source the file
   - Clean usage message for incorrect invocation

   ### 3. Directory Creation Pattern
   - Example code demonstrates auto-creating output directories
   - Prevents "directory not found" errors

   ## Testing

   - ✅ Comprehensive test suite: 11/11 passed
   - ✅ Mutual recursion compilation verified
   - ✅ Generated bash executes correctly:
     - `is_even(4)` → returns "true", exit 0
     - `is_even(3)` → fails, exit 1
     - `is_odd(5)` → returns "true", exit 0
   - ✅ Dispatch functionality working
   - ✅ Auto-detection working

   ## Files Changed

   - `src/unifyweaver/core/compiler_driver.pl` (+88 lines)
   - `src/unifyweaver/core/recursive_compiler.pl` (+14 lines)
   - `src/unifyweaver/core/advanced/mutual_recursion.pl` (+53/-1 lines)
   - `src/unifyweaver/core/advanced/advanced_recursive_compiler.pl` (minor)
   - `src/unifyweaver/core/advanced/call_graph.pl` (minor)

   ## Impact

   **Breaking Changes**: None

   **Benefits**:
   - Correct mutual recursion detection
   - Working bash code generation
   - Better user experience with auto-detection
   - Executable scripts out of the box

   � Generated with [Claude Code](https://claude.com/claude-code)"
   Create pull request