### PR TITLE
Refine parallel playbook and add example-library tooling**

### DIFF
--- a/docs/development/playbooks/best_practices.md
+++ b/docs/development/playbooks/best_practices.md
@@ -7,7 +7,8 @@
 - Reference external code samples, databases, or docs
 - Use troubleshooting and validation tables
 - Limit inline code to essentials; link out for details
-- Encourage peer or agent review for clarity
+- **Reference, Don't Repeat**: Link to external documentation, skill definitions, or example records instead of embedding large blocks of code or explanation. Keep the playbook as a concise guide.
+- **Encapsulate Complex Execution**: For any execution sequence that involves more than one or two simple commands, encapsulate the entire workflow into a single, executable script within the example library. The playbook's execution direction should then be a single step: "Extract and execute record X". This makes the agent's job trivial and the process far more robust.
 
 ## Don'ts
 - Embed extensive code or scripts in playbook files

--- a/docs/development/playbooks/specification.md
+++ b/docs/development/playbooks/specification.md
@@ -15,6 +15,7 @@ Set standards for authoring agent-friendly, concise, and adaptable playbooks acr
 - Favor readable Markdown sections and clear headers.
 - Minimize embedded code; link to the example database or project docs when possible.
 - Use bullet points and tables for comparisons, when appropriate.
+- For complex, multi-step `Execution Directions`, prefer creating a single, machine-readable script in the example database. The playbook should then simply instruct the agent to extract and execute that record. This keeps the playbook high-level while providing unambiguous, testable implementation details.
 
 ## Example Template
 ```

--- a/docs/playbooks/parsing/README.md
+++ b/docs/playbooks/parsing/README.md
@@ -1,0 +1,25 @@
+# Playbook Record Parsers
+
+Playbooks reference example records instead of embedding scripts. Use one of the parsers below (in preference order) to extract a record into a temporary file before execution.
+
+| Priority | Tool | Path / Install | Notes |
+| --- | --- | --- | --- |
+| 1 | Perl Extractor | `scripts/utils/extract_records.pl` | Default choice. Supports `--format`, `--query`, `--file-filter`. Documented in [skills/skill_extract_records.md](../../skills/skill_extract_records.md). |
+| 2 | Python Extractor | `docs/playbooks/parsing/extract_records.py` (future) | Placeholder for a dependency-free Python implementation. Until it lands, fall back to option 3. |
+| 3 | `parsc` | [GitHub: parsc](https://github.com/s243a/parsc) | External CLI from @s243a. Use when Perl isn’t available; convert Markdown to JSON and filter records programmatically. |
+
+## Usage Pattern (Perl Extractor)
+```bash
+scripts/utils/extract_records.pl \
+  --format content \
+  --query "record.name.here" \
+  playbooks/examples_library/example_file.md \
+  > tmp/extracted.sh
+```
+
+Set `TMP_FOLDER` (and related env vars) before executing the extracted script. Clean up the temporary artifacts when done.
+
+## Adding New Parsers
+1. Implement the parser (e.g., Python) in this directory.
+2. Provide a short README entry describing invocation, dependencies, and compatibility.
+3. Update `skills/skill_extract_records.md` to mention the new option/reference.

--- a/examples/parallel_execution_playbook.md
+++ b/examples/parallel_execution_playbook.md
@@ -1,42 +1,33 @@
 # Playbook: Parallel Execution Pipeline
 
-## 1. Introduction & Intent
-This playbook demonstrates UnifyWeaver's MapReduce-style parallel execution capabilities. The goal is to partition a dataset, process the partitions in parallel using multiple bash processes, and aggregate the results.
+## Audience
+This playbook is a high-level guide for coding agents (Gemini CLI, Claude Code, etc.). Agents do not handwrite scripts here—they orchestrate UnifyWeaver to generate and run the MapReduce pipeline by referencing example records and skills.
 
-This playbook serves as a high-level guide for an agent. The concrete implementation details are encapsulated in a structured, executable example in the example library.
+## Workflow Overview
+Use UnifyWeaver to synthesize the entire MapReduce flow:
+1. Partition the logical input stream (1..1000) into fixed-size chunks; each chunk becomes one worker invocation.
+2. Declare the worker (“map”) component once; UnifyWeaver emits the bash script that sums integers from STDIN.
+3. In Prolog, register the `fixed_size` partitioner and the `bash_fork` backend, then call `backend_execute/4` so UnifyWeaver forks bash jobs for every partition.
+4. Reduce by iterating over the `result(PartitionID, Output)` terms and summing their payloads. Compare the aggregate with the arithmetic-series expectation (see [4]).
 
-## 2. Workflow Overview
-The overall workflow follows a MapReduce pattern:
-1.  A "worker" script is defined to perform the "map" step on a single partition of data.
-2.  A Prolog script orchestrates the pipeline, first partitioning a dataset into chunks.
-3.  The orchestrator then uses a parallel backend (e.g., `bash_fork`) to execute the worker script across all partitions simultaneously.
-4.  Finally, the results from all workers are collected and aggregated (the "reduce" step) to produce a final result.
+## Agent Inputs
+Reference the following artifacts instead of embedding raw commands:
+1. **Executable Record** – `unifyweaver.execution.parallel_sum_pipeline` in `playbooks/examples_library/parallel_examples.md`.
+2. **Parser Catalog** – `docs/playbooks/parsing/README.md` lists the available extractors (Perl, Python, `parsc`) and usage order.
+3. **Extraction Skill** – `skills/skill_extract_records.md` documents CLI flags and environment notes.
+4. **Reviewer Reference** – `docs/development/testing/playbooks/parallel_execution_playbook__reference.md` for validation details.
 
-## 3. Inputs & Outputs
-### Inputs
-- An agent command to extract and execute a script from the example library.
+## Execution Guidance
+1. Choose a parser per [2] (preferred order: Perl script `scripts/utils/extract_records.pl`, Python implementation, then `parsc`). Extract record [1] into a temporary bash file.
+2. Ensure `TMP_FOLDER` (and optional `WORKER_SCRIPT`) resolve to a writable directory. Execute the extracted script; it materializes the worker, generates the Prolog orchestrator, and drives `backend_execute/4` to launch the parallel run.
+3. Confirm the final log matches the expectation in [4]. For failures, inspect the generated script or the `bash_fork` logs; parser-specific troubleshooting lives in [2] and [3].
 
-### Outputs
-- **Final Result:** The string `SUCCESS: Final sum is 500500` printed to standard output.
-- **Exit Code:** The script should exit with status code `0`.
+## Expected Outcome
+- Successful runs print `SUCCESS: ...` with the arithmetic sum and exit 0 (see [4] for exact wording).
+- Errors typically stem from TMP misconfiguration or unsupported parser choice; reconsult [2]/[3].
 
-## 4. Execution Directions
-To run this parallel pipeline, extract the content of the `unifyweaver.execution.parallel_sum_pipeline` record from the example library and execute it as a bash script.
-
-### Example Agent Command
-```bash
-# 1. Extract the execution script from the library
-scripts/utils/extract_records.pl --format content --query "unifyweaver.execution.parallel_sum_pipeline" "education/UnifyWeaver_Education/book-workflow/examples_library/parallel_examples.md" > tmp/run_parallel_test.sh
-
-# 2. Execute the extracted script
-bash tmp/run_parallel_test.sh
-```
-
-## 5. References
-- **Implementation Example:** `unifyweaver.execution.parallel_sum_pipeline` in `education/UnifyWeaver_Education/book-workflow/examples_library/parallel_examples.md`
-- **Original Demo:** `examples/demo_partition_parallel.pl`
-- **Extraction Skill:** `skills/skill_extract_records.md`
-
-## 6. Troubleshooting/Validation
-- **Expected Output:** The command should execute without errors and print the line `SUCCESS: Final sum is 500500`.
-- **Common Errors:** If the script fails, inspect the contents of `tmp/run_parallel_test.sh` and the output of the `swipl` command within it to diagnose the issue. Ensure all paths are correct and necessary modules are available.
+## Citations
+[1] playbooks/examples_library/parallel_examples.md (`unifyweaver.execution.parallel_sum_pipeline`)  
+[2] docs/playbooks/parsing/README.md  
+[3] skills/skill_extract_records.md  
+[4] docs/development/testing/playbooks/parallel_execution_playbook__reference.md

--- a/playbooks/examples_library/parallel_examples.md
+++ b/playbooks/examples_library/parallel_examples.md
@@ -1,0 +1,100 @@
+---
+file_type: UnifyWeaver Example Library
+---
+
+# Parallel Execution Examples
+
+This file contains examples of how to run parallel execution pipelines.
+
+---
+
+### Example: Parallel Sum (MapReduce Style)
+
+This example demonstrates a full MapReduce-style pipeline to calculate a sum in parallel.
+
+> [!example-record]
+> id: 2025-11-13-parallel-sum
+> name: unifyweaver.execution.parallel_sum_pipeline
+> description: A full pipeline that partitions a list of numbers, sums each partition in parallel, and aggregates the results.
+
+```bash
+#!/bin/bash
+#
+# This script demonstrates a full MapReduce-style pipeline.
+# It is designed to be extracted and run directly.
+
+# --- Config ---
+TMP_FOLDER="${TMP_FOLDER:-tmp}"
+WORKER_SCRIPT="$TMP_FOLDER/sum_worker.sh"
+PIPELINE_SCRIPT="$TMP_FOLDER/parallel_pipeline.pl"
+
+# --- Step 1: Create Worker Script (The "Map" function) ---
+echo "Creating worker script..."
+mkdir -p "$TMP_FOLDER"
+cat > "$WORKER_SCRIPT" <<'EOF'
+#!/bin/bash
+sum=0
+while IFS= read -r line; do
+    if [[ "$line" =~ ^[0-9]+$ ]]; then
+        sum=$((sum + line))
+    fi
+done
+echo "$sum"
+EOF
+if command -v chmod >/dev/null 2>&1; then
+    chmod +x "$WORKER_SCRIPT"
+fi
+
+# --- Step 2: Create Prolog Orchestrator ---
+echo "Creating Prolog orchestrator..."
+cat > "$PIPELINE_SCRIPT" <<'EOF'
+:- use_module('src/unifyweaver/core/partitioner').
+:- use_module('src/unifyweaver/core/partitioners/fixed_size').
+:- use_module('src/unifyweaver/core/parallel_backend').
+:- use_module('src/unifyweaver/core/backends/bash_fork').
+
+aggregate_sums(Results, TotalSum) :-
+    findall(Sum,
+            (   member(result(_, Output), Results),
+                atom_string(Output, OutputStr),
+                split_string(OutputStr, "\n", " \t\r", [SumStr|_]),
+                number_string(Sum, SumStr)
+            ),
+            Sums),
+    sum_list(Sums, TotalSum).
+
+setup_system :-
+    register_backend(bash_fork, bash_fork_backend),
+    register_partitioner(fixed_size, fixed_size_partitioner).
+
+run_pipeline :-
+    setup_system,
+    numlist(1, 1000, Numbers),
+    partitioner_init(fixed_size(rows(100)), [], PHandle),
+    partitioner_partition(PHandle, Numbers, Partitions),
+    partitioner_cleanup(PHandle),
+    backend_init(bash_fork(workers(4)), BHandle),
+    resolve_worker_script(WorkerScript),
+    backend_execute(BHandle, Partitions, WorkerScript, Results),
+    backend_cleanup(BHandle),
+    aggregate_sums(Results, TotalSum),
+    ExpectedSum is 1000 * 1001 / 2,
+    (   TotalSum =:= ExpectedSum ->
+        format('SUCCESS: Final sum is ~w~n', [TotalSum])
+    ;   format('FAILURE: Expected ~w but got ~w~n', [ExpectedSum, TotalSum]),
+        halt(1)
+    ).
+
+resolve_worker_script(WorkerScript) :-
+    (   getenv('WORKER_SCRIPT', WorkerScript)
+    ->  true
+    ;   WorkerScript = 'tmp/sum_worker.sh'
+    ).
+EOF
+
+# --- Step 3: Execute the Pipeline ---
+echo "Executing pipeline..."
+export TMP_FOLDER WORKER_SCRIPT
+swipl -g "consult('$PIPELINE_SCRIPT'), run_pipeline, halt"
+
+```

--- a/skills/skill_extract_records.md
+++ b/skills/skill_extract_records.md
@@ -15,27 +15,36 @@ Use this tool when you are given a path to a Markdown file or directory and your
 *   You need to handle multi-line content blocks reliably.
 *   You need the output in a structured format like JSON.
 
-## 3. Tool: `extract_records.pl`
+## 3. Tooling Options
+
+Preferred parser order (see [docs/playbooks/parsing/README.md](../docs/playbooks/parsing/README.md) for details):
+1. `scripts/utils/extract_records.pl` (Perl, built-in)
+2. Python extractor (future, documented in the parser README)
+3. External `parsc` CLI (when Perl/Python are unavailable)
+
+The remainder of this skill covers option #1, which ships with the repo.
+
+### 3.1. Tool: `extract_records.pl`
 
 The implementation of this skill is the Perl script `scripts/utils/extract_records.pl`.
 
-### 3.1. Command-Line Interface
+#### Command-Line Interface
 
 ```
 extract_records [OPTIONS] [PATH...]
 ```
 
-### 3.2. Options
+#### Options
 
 | Flag | Argument | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `-s`, `--separator` | `<char>` | `\0` | The character for separating output records. |
 | `-f`, `--format` | `full`\|`content`\|`json` | `full` | The output format for each record. |
 | `-q`, `--query` | `<pattern>` | (none) | A regex pattern to filter records by their `name` metadata. |
-| `--file-filter` | `<key=value>` | `file_type=UnifyWeaver Example Library` | Filters files based on their YAML frontmatter. Use `"all"` to disable. |
+| `--file-filter` | `<key=value>` | `file_type=UnifyWeaver Example Library` | Filters files based on their YAML frontmatter. Use `all` (or empty) to disable. |
 | `-h`, `--help` | | | Display the help message. |
 
-### 3.3. Output Formats
+#### Output Formats
 
 - **`full`:** Outputs the entire original Markdown block for each matching record.
 - **`content`:** Outputs only the raw content of the record's code block.
@@ -45,8 +54,4 @@ extract_records [OPTIONS] [PATH...]
 
 For concrete usage patterns, an agent should query the example library.
 
-**Example Query:**
-To find examples of how to use this tool, run the following command:
-```bash
-scripts/utils/extract_records.pl --query "unifyweaver.tool_usage.extract_*" "education/UnifyWeaver_Education/book-workflow/examples_library/tool_usage_examples.md"
-```
+**Example Query:** see the parser README and the playbook example library for concrete invocations tied to current playbooks.


### PR DESCRIPTION
- add a project-local example library (playbooks/examples_library/parallel_examples.md) containing the executable unifyweaver.execution.parallel_sum_pipeline record; update the Perl extractor to handle YAML front matter cleanly and support --file-filter all
- rewrite examples/parallel_execution_playbook.md to be an agent-facing guide: audience section, UnifyWeaver-centric workflow, citation-style inputs, and pointers to parser/skill docs instead of inline commands
- document parser options in docs/playbooks/parsing/README.md and mention the preferred parser order in skills/skill_extract_records.md

  These changes let agents execute the parallel playbook entirely within the main repo, using the new parser catalog to extract scripts.