### PR TITLE
Fix C# dynamic source harness and CSV metadata

### DIFF
--- a/test_data/test_sales.tsv
+++ b/test_data/test_sales.tsv
@@ -1,0 +1,4 @@
+order_id	product	total
+SO1	Laptop	1200
+SO2	Mouse	25
+SO3	Keyboard	75


### PR DESCRIPTION
## Summary
- normalize the test harness so dotnet output comparisons are accurate and exercise the CSV plan end-to-end
- emit clean enum literals plus absolute CSV paths for dynamic sources so the generated C# builds and reads data
correctly
- keep dynamic source registration/cleanup balanced via setup_call_cleanup/3

## Testing
- swipl -q -s tests/core/test_csharp_query_target.pl -g test_csharp_query_target:test_csharp_query_target -t halt

Everything is committed; once you push we’re ready for the PR