### PR TITLE
Add JSONPath selector support to JSON dynamic sources

### DIFF
--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -516,6 +516,21 @@ Generating a typed record via `schema/1`:
 % Row = ProductRecord { Id = P001, Name = Laptop, Price = 999 }
 ```
 
+Selecting via JSONPath (using wildcards and recursive descent):
+
+```prolog
+:- source(json, order_first_items, [
+    json_file('test_data/test_orders.json'),
+    columns([
+        jsonpath('$.order.customer.name'),
+        jsonpath('$.items[*].product')
+    ])
+]).
+
+?- order_first_items(Customer, Product).
+% Customer = Alice,  Product = Laptop
+```
+
 **Generated bash:**
 ```bash
 extract_names() {

--- a/docs/guides/json_to_litedb_streaming.md
+++ b/docs/guides/json_to_litedb_streaming.md
@@ -36,6 +36,7 @@ Claude can read those files (or their documentation in `skills/skill_json_source
 
 - `schema/1` produces a typed record, so downstream C# already has strongly typed fields.
 - For column-based projections, use `columns/1` instead of `schema/1`.
+- Complex selectors are available via `jsonpath('$.orders[*].total')`; strings beginning with `$` are treated as JSONPath automatically.
 - Additional options: `record_separator/1`, `field_separator/1`, `return_object(true)` if you want raw `JsonObject` rows.
 
 ## Streaming into LiteDB (conceptual pipeline)

--- a/docs/proposals/json_stream_reader.md
+++ b/docs/proposals/json_stream_reader.md
@@ -11,6 +11,7 @@
 - `JsonStreamReader` inside `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs` consumes newline/NUL-delimited streams or JSON arrays via `System.Text.Json`.
 - `csharp_query_target` inspects the metadata and emits either column-oriented projections or schema-generated POCO records (see `schema/1` + `record_type/1` in `src/unifyweaver/sources.pl`).
 - Validation rules for JSON sources live in `src/unifyweaver/sources.pl`, with coverage in `tests/core/test_json_source_validation.pl`.
+- Column and schema selectors now accept `jsonpath/1` expressions (root, wildcards, recursive descent); generators emit `JsonColumnSelectorConfig` so the runtime evaluates JSONPath selectors directly.
 
 ## Requirements (Completed)
 
@@ -32,24 +33,18 @@
 
 ## Roadmap
 
-1. **JSONPath selectors**
-   - Accept `jsonpath('$..orders[*].total')` entries inside `columns/1` or `schema/1`.
-   - Embed a lightweight JSONPath evaluator in `QueryRuntime` (or vendored helper) so selectors can walk arrays/object unions.
-   - Update metadata extraction in `dynamic_source_compiler` to stash selector intent for downstream targets.
-   - Tests: expand `tests/core/test_csharp_query_target.pl` with fixtures covering nested arrays and invalid selectors.
-
-2. **Nested POCO schemas**
+1. **Nested POCO schemas**
    - Extend `schema/1` to allow references to sub-records, e.g., `field(address, '$.address', record('AddressRecord'))`.
    - `csharp_query_target` should emit multiple record declarations plus factory helpers, wiring parent/child construction logic.
    - Add `record_namespace/1` so playbooks can isolate generated types.
    - Tests + docs demonstrating multi-level objects flowing through dotnet execution.
 
-3. **Reader-level resilience**
+2. **Reader-level resilience**
    - Null-handling policy (`null_policy(fail|skip|default(Value))`) and string-to-number coercion toggles.
    - Support JSON Lines streams explicitly via `record_format=jsonl` with configurable separators.
    - Better diagnostics surfaced through `test_json_source_validation.pl` for malformed metadata.
 
-4. **Documentation & skills**
+3. **Documentation & skills**
    - Update `skills/skill_json_sources.md` once JSONPath/nested schemas land.
    - Add agent guidance for selecting temp locations + schema best practices.
    - Keep this proposal in sync with implementation details so Claude/Codex agents can reason about capabilities quickly.

--- a/skills/skill_json_sources.md
+++ b/skills/skill_json_sources.md
@@ -13,6 +13,12 @@ Use this skill whenever a playbook instructs you to read JSON data via `source/3
   ]).
   ```
 
+## JSONPath selectors
+- Use `jsonpath('$.orders[*].total')` to select data when simple dot paths are insufficient.
+- Supported features: root `$`, dotted properties, bracket properties (`['foo']`), array indices `[0]`, wildcards `[*]`, and recursive descent `..name`.
+- Works in both `columns/1` and `schema/1`. Wildcards currently return the first matching value.
+- Strings that already begin with `$` are automatically treated as JSONPath selectors, so `columns(['$.orders[0].id'])` also works.
+
 ## Return-object mode
 - Use when you want full JSON objects as rows.
 - Requirements:

--- a/src/unifyweaver/sources.pl
+++ b/src/unifyweaver/sources.pl
@@ -196,9 +196,7 @@ validate_schema_field(field(Name, Path, Type)) :-
     ->  true
     ;   throw(error(domain_error(json_schema_field_name, Name), _))
     ),
-    (   atom(Path)
-    ->  true
-    ;   string(Path)
+    (   validate_schema_path(Path)
     ->  true
     ;   throw(error(domain_error(json_schema_field_path, Path), _))
     ),
@@ -208,6 +206,16 @@ validate_schema_field(field(Name, Path, Type)) :-
     ).
 validate_schema_field(Term) :-
     throw(error(domain_error(json_schema_field, Term), _)).
+
+validate_schema_path(jsonpath(Path)) :-
+    !,
+    validate_schema_path(Path).
+validate_schema_path(Path) :-
+    (   atom(Path)
+    ->  true
+    ;   string(Path)
+    ->  true
+    ).
 
 validate_schema_type(string).
 validate_schema_type(integer).
@@ -221,6 +229,9 @@ validate_schema_type(json).
 validate_column_entries(Columns) :-
     maplist(validate_column_entry, Columns).
 
+validate_column_entry(jsonpath(Path)) :-
+    !,
+    validate_column_entry(Path).
 validate_column_entry(Column) :-
     (   atom(Column)
     ->  atom_string(Column, String)

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -686,6 +686,27 @@ namespace UnifyWeaver.QueryRuntime
                 }
             }
         }
+
+        private static bool TryGetArrayElement(JsonElement arrayElement, int index, out JsonElement value)
+        {
+            if (index < 0)
+            {
+                value = default;
+                return false;
+            }
+            var currentIndex = 0;
+            foreach (var child in arrayElement.EnumerateArray())
+            {
+                if (currentIndex == index)
+                {
+                    value = child;
+                    return true;
+                }
+                currentIndex++;
+            }
+            value = default;
+            return false;
+        }
     }
 }
 
@@ -867,12 +888,20 @@ public enum JsonColumnType
     Json
 }
 
-public sealed record JsonSchemaFieldConfig(string PropertyName, string Path, JsonColumnType ColumnType);
+public enum JsonColumnSelectorKind
+{
+    Path,
+    JsonPath
+}
+
+public sealed record JsonColumnSelectorConfig(string Selector, JsonColumnSelectorKind Kind);
+
+public sealed record JsonSchemaFieldConfig(string PropertyName, string Path, JsonColumnSelectorKind SelectorKind, JsonColumnType ColumnType);
 
 public sealed record JsonSourceConfig
 {
     public string InputPath { get; init; } = string.Empty;
-    public string[] Columns { get; init; } = Array.Empty<string>();
+    public JsonColumnSelectorConfig[] ColumnSelectors { get; init; } = Array.Empty<JsonColumnSelectorConfig>();
     public RecordSeparatorKind RecordSeparator { get; init; } = RecordSeparatorKind.LineFeed;
     public int SkipRows { get; init; } = 0;
     public int ExpectedWidth { get; init; } = 0;
@@ -885,7 +914,7 @@ public sealed record JsonSourceConfig
     public sealed class JsonStreamReader
     {
         private readonly JsonSourceConfig _config;
-        private readonly ColumnPath[] _paths;
+        private readonly IJsonSelector[] _selectors;
         private readonly SchemaFieldRuntime[] _schemaFields;
         private readonly bool _returnObject;
         private readonly Type? _targetType;
@@ -902,8 +931,14 @@ public sealed record JsonSourceConfig
             _returnObject = _config.ReturnObject;
 
             _schemaFields = _config.SchemaFields?
-                .Select(field => new SchemaFieldRuntime(field.PropertyName, new ColumnPath(field.Path), field.ColumnType))
+                .Select(field => new SchemaFieldRuntime(
+                    field.PropertyName,
+                    JsonSelectorFactory.Create(field.Path, field.SelectorKind),
+                    field.ColumnType))
                 .ToArray() ?? Array.Empty<SchemaFieldRuntime>();
+            _selectors = _config.ColumnSelectors?
+                .Select(selector => JsonSelectorFactory.Create(selector.Selector, selector.Kind))
+                .ToArray() ?? Array.Empty<IJsonSelector>();
 
             if (_returnObject)
             {
@@ -918,27 +953,14 @@ public sealed record JsonSourceConfig
                 _targetType = null;
             }
 
-            if (_schemaFields.Length > 0)
+            if (_schemaFields.Length > 0 && !_returnObject)
             {
-                if (!_returnObject)
-                {
-                    throw new ArgumentException("SchemaFields require ReturnObject=true.", nameof(config));
-                }
-                _paths = Array.Empty<ColumnPath>();
+                throw new ArgumentException("SchemaFields require ReturnObject=true.", nameof(config));
             }
-            else if (_returnObject)
+
+            if (!_returnObject && _selectors.Length == 0)
             {
-                _paths = Array.Empty<ColumnPath>();
-            }
-            else
-            {
-                if (_config.Columns is null || _config.Columns.Length == 0)
-                {
-                    throw new ArgumentException("Columns must be provided for JSON sources when ReturnObject is false.", nameof(config));
-                }
-                _paths = _config.Columns
-                    .Select(column => new ColumnPath(column))
-                    .ToArray();
+                throw new ArgumentException("Columns must be provided for JSON sources when ReturnObject is false.", nameof(config));
             }
         }
 
@@ -953,10 +975,10 @@ public sealed record JsonSourceConfig
             var trimmed = text.TrimStart();
             var width = _returnObject
                 ? Math.Max(_config.ExpectedWidth, 1)
-                : Math.Max(_config.ExpectedWidth, _paths.Length);
+                : Math.Max(_config.ExpectedWidth, _selectors.Length);
             if (width <= 0)
             {
-                width = _returnObject ? 1 : _paths.Length;
+                width = _returnObject ? 1 : _selectors.Length;
             }
             if (_config.TreatArrayAsStream && trimmed.StartsWith("[", StringComparison.Ordinal))
             {
@@ -1077,15 +1099,22 @@ public sealed record JsonSourceConfig
 
         private object[] ProjectRow(JsonElement element, int width)
         {
-            if (_paths.Length == 0)
+            if (_selectors.Length == 0)
             {
                 throw new InvalidDataException("JSON columns must be specified.");
             }
 
             var result = new object[width];
-            for (var i = 0; i < _paths.Length && i < width; i++)
+            for (var i = 0; i < _selectors.Length && i < width; i++)
             {
-                result[i] = _paths[i].Evaluate(element);
+                if (_selectors[i].TryEvaluateElement(element, out var selected))
+                {
+                    result[i] = ConvertJsonValue(selected);
+                }
+                else
+                {
+                    result[i] = null;
+                }
             }
             return result;
         }
@@ -1203,7 +1232,24 @@ public sealed record JsonSourceConfig
             }
         }
 
-        private sealed class ColumnPath
+        private interface IJsonSelector
+        {
+            bool TryEvaluateElement(JsonElement element, out JsonElement result);
+        }
+
+        private static class JsonSelectorFactory
+        {
+            public static IJsonSelector Create(string selector, JsonColumnSelectorKind kind)
+            {
+                return kind switch
+                {
+                    JsonColumnSelectorKind.JsonPath => new JsonPathExpression(selector),
+                    _ => new ColumnPath(selector)
+                };
+            }
+        }
+
+        private sealed class ColumnPath : IJsonSelector
         {
             private readonly PathStep[] _steps;
             private readonly string _raw;
@@ -1386,6 +1432,307 @@ public sealed record JsonSourceConfig
             public static PathStep ForIndex(int index) =>
                 new PathStep(PathStepKind.Index, null, index);
         }
+
+        private sealed class JsonPathExpression : IJsonSelector
+        {
+            private readonly JsonPathToken[] _tokens;
+
+            public JsonPathExpression(string expression)
+            {
+                if (string.IsNullOrWhiteSpace(expression))
+                {
+                    throw new ArgumentException("JSONPath selector cannot be empty.", nameof(expression));
+                }
+                _tokens = JsonPathParser.Parse(expression);
+            }
+
+            public bool TryEvaluateElement(JsonElement element, out JsonElement result)
+            {
+                var matches = JsonPathEvaluator.Evaluate(element, _tokens);
+                if (matches.Count > 0)
+                {
+                    result = matches[0];
+                    return true;
+                }
+                result = default;
+                return false;
+            }
+        }
+
+        private readonly record struct JsonPathToken(JsonPathTokenKind Kind, string? Text = null, int Index = -1);
+
+        private enum JsonPathTokenKind
+        {
+            Root,
+            Property,
+            WildcardProperty,
+            RecursiveProperty,
+            AnyRecursive,
+            Index,
+            WildcardIndex
+        }
+
+        private static class JsonPathParser
+        {
+            public static JsonPathToken[] Parse(string expression)
+            {
+                var tokens = new List<JsonPathToken>();
+                var span = expression.AsSpan();
+                var i = 0;
+                while (i < span.Length)
+                {
+                    var ch = span[i];
+                    if (char.IsWhiteSpace(ch))
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (ch == '$')
+                    {
+                        tokens.Add(new JsonPathToken(JsonPathTokenKind.Root));
+                        i++;
+                        continue;
+                    }
+
+                    if (ch == '.')
+                    {
+                        if (i + 1 < span.Length && span[i + 1] == '.')
+                        {
+                            i += 2;
+                            if (i < span.Length && span[i] == '*')
+                            {
+                                tokens.Add(new JsonPathToken(JsonPathTokenKind.AnyRecursive));
+                                i++;
+                                continue;
+                            }
+                            var recursiveName = ReadName(span, ref i);
+                            tokens.Add(new JsonPathToken(JsonPathTokenKind.RecursiveProperty, recursiveName));
+                        }
+                        else
+                        {
+                            i++;
+                            if (i < span.Length && span[i] == '*')
+                            {
+                                tokens.Add(new JsonPathToken(JsonPathTokenKind.WildcardProperty));
+                                i++;
+                                continue;
+                            }
+                            var name = ReadName(span, ref i);
+                            tokens.Add(new JsonPathToken(JsonPathTokenKind.Property, name));
+                        }
+                        continue;
+                    }
+
+                    if (ch == '[')
+                    {
+                        i++;
+                        if (i < span.Length && (span[i] == '"' || span[i] == '\''))
+                        {
+                            var quote = span[i++];
+                            var builder = new StringBuilder();
+                            while (i < span.Length && span[i] != quote)
+                            {
+                                builder.Append(span[i]);
+                                i++;
+                            }
+                            if (i >= span.Length)
+                            {
+                                throw new InvalidDataException($"Unterminated quoted token in JSONPath '{expression}'.");
+                            }
+                            i++; // skip quote
+                            if (i >= span.Length || span[i] != ']')
+                            {
+                                throw new InvalidDataException($"Missing closing ] in JSONPath '{expression}'.");
+                            }
+                            i++;
+                            tokens.Add(new JsonPathToken(JsonPathTokenKind.Property, builder.ToString()));
+                            continue;
+                        }
+                        var end = expression.IndexOf(']', i);
+                        if (end < 0)
+                        {
+                            throw new InvalidDataException($"Missing closing ] in JSONPath '{expression}'.");
+                        }
+                        var slice = expression.Substring(i, end - i).Trim();
+                        if (slice == "*")
+                        {
+                            tokens.Add(new JsonPathToken(JsonPathTokenKind.WildcardIndex));
+                        }
+                        else if (int.TryParse(slice, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx))
+                        {
+                            tokens.Add(new JsonPathToken(JsonPathTokenKind.Index, null, idx));
+                        }
+                        else
+                        {
+                            tokens.Add(new JsonPathToken(JsonPathTokenKind.Property, slice));
+                        }
+                        i = end + 1;
+                        continue;
+                    }
+
+                    var fallback = ReadName(span, ref i);
+                    if (!string.IsNullOrEmpty(fallback))
+                    {
+                        tokens.Add(new JsonPathToken(JsonPathTokenKind.Property, fallback));
+                    }
+                }
+
+                return tokens.ToArray();
+            }
+
+            private static string ReadName(ReadOnlySpan<char> span, ref int index)
+            {
+                var start = index;
+                while (index < span.Length && IsNameChar(span[index]))
+                {
+                    index++;
+                }
+                return span.Slice(start, index - start).ToString();
+            }
+
+            private static bool IsNameChar(char ch) =>
+                char.IsLetterOrDigit(ch) || ch == '_' || ch == '-';
+        }
+
+        private static class JsonPathEvaluator
+        {
+            public static List<JsonElement> Evaluate(JsonElement root, JsonPathToken[] tokens)
+            {
+                var current = new List<JsonElement> { root };
+                foreach (var token in tokens)
+                {
+                    var next = new List<JsonElement>();
+                    foreach (var element in current)
+                    {
+                        ApplyToken(element, token, next);
+                    }
+                    current = next;
+                    if (current.Count == 0)
+                    {
+                        break;
+                    }
+                }
+                return current;
+            }
+
+            private static void ApplyToken(JsonElement element, JsonPathToken token, List<JsonElement> output)
+            {
+                switch (token.Kind)
+                {
+                    case JsonPathTokenKind.Root:
+                        output.Add(element);
+                        break;
+                    case JsonPathTokenKind.Property:
+                        if (element.ValueKind == JsonValueKind.Object &&
+                            token.Text is not null &&
+                            element.TryGetProperty(token.Text, out var property))
+                        {
+                            output.Add(property);
+                        }
+                        break;
+                    case JsonPathTokenKind.WildcardProperty:
+                        if (element.ValueKind == JsonValueKind.Object)
+                        {
+                            foreach (var property in element.EnumerateObject())
+                            {
+                                output.Add(property.Value);
+                            }
+                        }
+                        break;
+                    case JsonPathTokenKind.RecursiveProperty:
+                        if (token.Text is not null)
+                        {
+                            CollectRecursiveProperties(element, token.Text, output);
+                        }
+                        break;
+                    case JsonPathTokenKind.AnyRecursive:
+                        CollectAllDescendants(element, output);
+                        break;
+                case JsonPathTokenKind.Index:
+                    if (element.ValueKind == JsonValueKind.Array &&
+                        token.Index >= 0 &&
+                        TryGetArrayElement(element, token.Index, out var selected))
+                    {
+                        output.Add(selected);
+                    }
+                    break;
+                    case JsonPathTokenKind.WildcardIndex:
+                        if (element.ValueKind == JsonValueKind.Array)
+                        {
+                            foreach (var child in element.EnumerateArray())
+                            {
+                                output.Add(child);
+                            }
+                        }
+                        break;
+                }
+            }
+
+            private static void CollectRecursiveProperties(JsonElement element, string name, List<JsonElement> output)
+            {
+                if (element.ValueKind == JsonValueKind.Object)
+                {
+                    if (element.TryGetProperty(name, out var property))
+                    {
+                        output.Add(property);
+                    }
+                    foreach (var child in element.EnumerateObject())
+                    {
+                        CollectRecursiveProperties(child.Value, name, output);
+                    }
+                }
+                else if (element.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var child in element.EnumerateArray())
+                    {
+                        CollectRecursiveProperties(child, name, output);
+                    }
+                }
+            }
+
+        private static void CollectAllDescendants(JsonElement element, List<JsonElement> output)
+        {
+            output.Add(element);
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var property in element.EnumerateObject())
+                {
+                    CollectAllDescendants(property.Value, output);
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var child in element.EnumerateArray())
+                {
+                    CollectAllDescendants(child, output);
+                }
+            }
+        }
+
+        private static bool TryGetArrayElement(JsonElement arrayElement, int index, out JsonElement value)
+        {
+            if (index < 0)
+            {
+                value = default;
+                return false;
+            }
+
+            var currentIndex = 0;
+            foreach (var child in arrayElement.EnumerateArray())
+            {
+                if (currentIndex == index)
+                {
+                    value = child;
+                    return true;
+                }
+                currentIndex++;
+            }
+
+            value = default;
+            return false;
+        }
+    }
 
         private static Type ResolveTargetType(string typeName)
         {


### PR DESCRIPTION
  - Allow columns/1 and schema/1 to use jsonpath/1 selectors (or $-prefixed strings), surface selector metadata via
    dynamic_source_compiler, and teach sources.pl to validate the new syntax.
  - Update the C# generator/runtime (JsonColumnSelectorConfig, JSONPath parser/evaluator) so JSON dynamic sources can
    pull nested data with wildcards/recursive descent, including schema-generated POCOs.
  - Add regression tests (tests/core/test_json_source_validation.pl, tests/core/test_csharp_query_target.pl) and
    document the capability in EXTENDED_README, skills/skill_json_sources.md, and the JSON reader proposal/guide.