### PR TITLE
Support nested JSON schema records in dynamic sources

### DIFF
--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -531,6 +531,29 @@ Selecting via JSONPath (using wildcards and recursive descent):
 % Customer = Alice,  Product = Laptop
 ```
 
+Combining schema + nested records:
+
+```prolog
+:- source(json, order_summaries, [
+    json_file('test_data/test_orders.json'),
+    schema([
+        field(order, 'order', record('OrderRecord', [
+            field(id, 'id', string),
+            field(customer, 'customer.name', string)
+        ])),
+        field(first_item, 'items[0]', record('LineItemRecord', [
+            field(product, 'product', string),
+            field(total, 'total', double)
+        ]))
+    ]),
+    record_type('OrderSummaryRecord')
+]).
+
+?- order_summaries(Row).
+% Row = OrderSummaryRecord { Order = OrderRecord { Id = SO1, Customer = Alice },
+%                            FirstItem = LineItemRecord { Product = Laptop, Total = 1200 } }
+```
+
 **Generated bash:**
 ```bash
 extract_names() {

--- a/docs/guides/json_to_litedb_streaming.md
+++ b/docs/guides/json_to_litedb_streaming.md
@@ -37,6 +37,7 @@ Claude can read those files (or their documentation in `skills/skill_json_source
 - `schema/1` produces a typed record, so downstream C# already has strongly typed fields.
 - For column-based projections, use `columns/1` instead of `schema/1`.
 - Complex selectors are available via `jsonpath('$.orders[*].total')`; strings beginning with `$` are treated as JSONPath automatically.
+- Nested data can be modeled inline with `record(Type, Fields)` so LiteDB insert scripts receive fully materialised child objects (helpful for documents like orders → line items).
 - Additional options: `record_separator/1`, `field_separator/1`, `return_object(true)` if you want raw `JsonObject` rows.
 
 ## Streaming into LiteDB (conceptual pipeline)

--- a/docs/proposals/json_stream_reader.md
+++ b/docs/proposals/json_stream_reader.md
@@ -12,6 +12,7 @@
 - `csharp_query_target` inspects the metadata and emits either column-oriented projections or schema-generated POCO records (see `schema/1` + `record_type/1` in `src/unifyweaver/sources.pl`).
 - Validation rules for JSON sources live in `src/unifyweaver/sources.pl`, with coverage in `tests/core/test_json_source_validation.pl`.
 - Column and schema selectors now accept `jsonpath/1` expressions (root, wildcards, recursive descent); generators emit `JsonColumnSelectorConfig` so the runtime evaluates JSONPath selectors directly.
+- Nested records are available via `field(Name, Path, record(Type, Fields))`; code generation emits every record type, and the runtime instantiates sub-records recursively (see `tests/core/test_csharp_query_target.pl:verify_json_nested_schema_record_plan/0`).
 
 ## Requirements (Completed)
 
@@ -33,18 +34,12 @@
 
 ## Roadmap
 
-1. **Nested POCO schemas**
-   - Extend `schema/1` to allow references to sub-records, e.g., `field(address, '$.address', record('AddressRecord'))`.
-   - `csharp_query_target` should emit multiple record declarations plus factory helpers, wiring parent/child construction logic.
-   - Add `record_namespace/1` so playbooks can isolate generated types.
-   - Tests + docs demonstrating multi-level objects flowing through dotnet execution.
-
-2. **Reader-level resilience**
+1. **Reader-level resilience**
    - Null-handling policy (`null_policy(fail|skip|default(Value))`) and string-to-number coercion toggles.
    - Support JSON Lines streams explicitly via `record_format=jsonl` with configurable separators.
    - Better diagnostics surfaced through `test_json_source_validation.pl` for malformed metadata.
 
-3. **Documentation & skills**
+2. **Documentation & skills**
    - Update `skills/skill_json_sources.md` once JSONPath/nested schemas land.
    - Add agent guidance for selecting temp locations + schema best practices.
    - Keep this proposal in sync with implementation details so Claude/Codex agents can reason about capabilities quickly.

--- a/skills/skill_json_sources.md
+++ b/skills/skill_json_sources.md
@@ -51,11 +51,33 @@ Use this skill whenever a playbook instructs you to read JSON data via `source/3
           field(price, 'price', double)
       ]),
       record_type('ProductRecord')
-  ]).
+  ]). 
 
   ?- product_rows(Row).
   % yields ProductRecord { Id = P001, Name = Laptop, Price = 999 }
   ```
+
+## Nested schema records
+- Return structured sub-objects by using `record(TypeName, Fields)` (or `record(Fields)` to auto-name from the field).
+- Nested selectors are evaluated relative to the selected sub-object; JSONPath and dot notation both work.
+- Example:
+  ```prolog
+  :- source(json, order_rows, [
+      json_file('test_data/test_orders.json'),
+      schema([
+          field(order, 'order', record('OrderRecord', [
+              field(id, 'id', string),
+              field(customer, 'customer.name', string)
+          ])),
+          field(first_item, 'items[0]', record('LineItemRecord', [
+              field(product, 'product', string),
+              field(total, 'total', double)
+          ]))
+      ]),
+      record_type('OrderSummaryRecord')
+  ]).
+  ```
+- Generated C# includes `OrderRecord`, `LineItemRecord`, and `OrderSummaryRecord`; runtime instantiates nested POCOs automatically.
 
 ## Validation expectations
 - Missing `columns/1` (when `return_object(false)`) causes a `domain_error(json_columns, _)`.

--- a/src/unifyweaver/core/dynamic_source_compiler.pl
+++ b/src/unifyweaver/core/dynamic_source_compiler.pl
@@ -227,10 +227,11 @@ extract_io_metadata(Pred/Arity, Options, Meta) :-
     option(return_object(ReturnObject0), Options, false),
     normalize_boolean(ReturnObject0, ReturnObject),
     (   option(schema(SchemaRaw), Options)
-    ->  normalize_schema_fields(SchemaRaw, SchemaFields),
-        schema_record_name(Pred/Arity, Options, RecordType),
+    ->  schema_record_name(Pred/Arity, Options, RecordType),
+        normalize_schema_structure(SchemaRaw, RecordType, SchemaFields, SchemaRecords),
         format(atom(SchemaFullName), 'UnifyWeaver.Generated.~w', [RecordType])
     ;   SchemaFields = [],
+        SchemaRecords = [],
         RecordType = none,
         SchemaFullName = none
     ),
@@ -251,6 +252,7 @@ extract_io_metadata(Pred/Arity, Options, Meta) :-
         type_hint:TypeHint,
         return_object:ReturnObject,
         schema_fields:SchemaFields,
+        schema_records:SchemaRecords,
         schema_type:RecordType
     }.
 
@@ -330,13 +332,21 @@ normalize_selector_path(Value, String) :-
     ;   throw(error(domain_error(json_column_entry, Value), _))
     ).
 
-normalize_schema_fields([], []) :- !.
-normalize_schema_fields([field(Name, Path, Type)|Rest], [schema_field{name:NameAtom, path:PathString, selector_kind:Kind, type:TypeAtom}|Tail]) :-
+normalize_schema_structure(SchemaRaw, RootType, Fields, [schema_record{type:RootType, fields:Fields}|NestedRecords]) :-
+    normalize_schema_fields(SchemaRaw, Fields, [], NestedRecords).
+
+normalize_schema_fields([], [], Acc, Acc) :- !.
+normalize_schema_fields([field(Name, Path, Type)|Rest], [FieldDict|Tail], AccIn, AccOut) :-
     normalize_schema_name(Name, NameAtom),
     normalize_schema_path(Path, PathString, Kind),
-    normalize_schema_type(Type, TypeAtom),
-    normalize_schema_fields(Rest, Tail).
-normalize_schema_fields([Invalid|_], _) :-
+    normalize_schema_type(Type, NameAtom, FieldMeta, AccIn, AccNext),
+    FieldDict = FieldMeta.put(_{
+        name:NameAtom,
+        path:PathString,
+        selector_kind:Kind
+    }),
+    normalize_schema_fields(Rest, Tail, AccNext, AccOut).
+normalize_schema_fields([Invalid|_], _, _, _) :-
     throw(error(domain_error(json_schema_field, Invalid), _)).
 
 normalize_schema_name(Name, Atom) :-
@@ -356,14 +366,36 @@ normalize_schema_path(Path, String, Kind) :-
     ;   Kind = column_path
     ).
 
-normalize_schema_type(Type, Normalized) :-
+normalize_schema_type(record(Fields), FieldName, FieldDict, AccIn, AccOut) :-
+    default_nested_record_type(FieldName, RecordType),
+    normalize_schema_type(record(RecordType, Fields), FieldName, FieldDict, AccIn, AccOut).
+normalize_schema_type(record(RecordType, Fields), _FieldName, FieldDict, AccIn, AccOut) :-
+    (   is_list(Fields),
+        Fields \= []
+    ->  normalize_schema_fields(Fields, NestedFields, AccIn, NestedRecords),
+        FieldDict = schema_field{
+            column_type:json,
+            field_kind:record,
+            record_type:RecordType,
+            nested_fields:NestedFields
+        },
+        AccOut = [schema_record{type:RecordType, fields:NestedFields}|NestedRecords]
+    ;   throw(error(domain_error(json_schema_record_fields, Fields), _))
+    ).
+normalize_schema_type(Type, _FieldName, FieldDict, Records, Records) :-
     (   atom(Type)
     ->  atom_string(Type, String)
     ;   string(Type)
     ->  String = Type
     ),
     string_lower(String, Lower),
-    atom_string(Normalized, Lower).
+    atom_string(Normalized, Lower),
+    FieldDict = schema_field{
+        column_type:Normalized,
+        field_kind:value,
+        record_type:none,
+        nested_fields:[]
+    }.
 
 schema_record_name(Pred/_, Options, RecordType) :-
     (   option(record_type(Type), Options)
@@ -377,6 +409,14 @@ default_record_type(Pred, RecordType) :-
     maplist(capitalise_string, Parts, Caps),
     atomic_list_concat(Caps, '', Base),
     atom_concat(Base, 'Row', Temp),
+    atom_string(RecordType, Temp).
+
+default_nested_record_type(FieldName, RecordType) :-
+    atom_string(FieldName, NameStr),
+    split_string(NameStr, '_', '_', Parts),
+    maplist(capitalise_string, Parts, Caps),
+    atomic_list_concat(Caps, '', Base),
+    atom_concat(Base, 'Record', Temp),
     atom_string(RecordType, Temp).
 
 capitalise_string(Input, Output) :-

--- a/src/unifyweaver/sources.pl
+++ b/src/unifyweaver/sources.pl
@@ -200,7 +200,9 @@ validate_schema_field(field(Name, Path, Type)) :-
     ->  true
     ;   throw(error(domain_error(json_schema_field_path, Path), _))
     ),
-    (   validate_schema_type(Type)
+    (   validate_schema_record_type(Type)
+    ->  true
+    ;   validate_schema_type(Type)
     ->  true
     ;   throw(error(domain_error(json_schema_field_type, Type), _))
     ).
@@ -225,6 +227,20 @@ validate_schema_type(double).
 validate_schema_type(number).
 validate_schema_type(boolean).
 validate_schema_type(json).
+
+validate_schema_record_type(record(Fields)) :-
+    !,
+    validate_nested_schema_fields(Fields).
+validate_schema_record_type(record(_Name, Fields)) :-
+    !,
+    validate_nested_schema_fields(Fields).
+validate_schema_record_type(_).
+
+validate_nested_schema_fields(Fields) :-
+    (   is_list(Fields)
+    ->  maplist(validate_schema_field, Fields)
+    ;   throw(error(domain_error(json_schema_record_fields, Fields), _))
+    ).
 
 validate_column_entries(Columns) :-
     maplist(validate_column_entry, Columns).

--- a/tests/core/test_json_source_validation.pl
+++ b/tests/core/test_json_source_validation.pl
@@ -85,6 +85,22 @@ test(schema_allows_jsonpath_paths, []) :-
         cleanup_dynamic_source(jsonpath_schema/1)
     ).
 
+test(schema_supports_nested_records, []) :-
+    setup_call_cleanup(
+        true,
+        once(source(json, nested_schema_source,
+            [ json_file('test_data/test_orders.json'),
+              schema([
+                  field(order, 'order', record('OrderRecord', [
+                      field(id, 'id', string),
+                      field(customer, 'customer.name', string)
+                  ]))
+              ]),
+              record_type('OrderWrapper')
+            ])),
+        cleanup_dynamic_source(nested_schema_source/1)
+    ).
+
 :- end_tests(json_source_validation).
 
 :- initialization(main).


### PR DESCRIPTION
Description:

  - Extend schema/1 so fields can declare nested records (record(Type, Fields)), with the compiler generating record
    metadata for every level and the C# target emitting each POCO.
  - Enhance JsonStreamReader to evaluate nested selectors (JSONPath or dot notation) and instantiate child records
    recursively via JsonSchemaFieldConfig.
  - Add regression coverage (tests/core/test_json_source_validation.pl, tests/core/test_csharp_query_target.pl) and
    document the feature in EXTENDED_README, skills/skill_json_sources.md, the JSON reader proposal, and the LiteDB
    guide.

  Tests:

  - swipl -q -f init.pl -s tests/core/test_json_source_validation.pl -g test_json_source_validation -t halt
  - SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
    test_csharp_query_target:test_csharp_query_target -t halt