### PR TITLE
Add JSON Lines and configurable null handling to JSON dynamic sources

### DIFF
--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -554,6 +554,27 @@ Combining schema + nested records:
 %                            FirstItem = LineItemRecord { Product = Laptop, Total = 1200 } }
 ```
 
+Streaming JSON Lines (`record_format(jsonl)`) with null-handling policy:
+
+```prolog
+:- source(json, order_second_items, [
+    json_file('test_data/test_orders.jsonl'),
+    record_format(jsonl),
+    columns([
+        jsonpath('$.order.customer.name'),
+        jsonpath('$.items[1].product')
+    ]),
+    null_policy(default('N/A'))
+]).
+
+?- order_second_items(Customer, SecondProduct).
+% Customer = Alice, SecondProduct = Mouse
+% Customer = Bob,   SecondProduct = 'N/A'
+% Customer = Charlie, SecondProduct = 'N/A'
+```
+
+`null_policy(fail|skip|default(Value))` controls how missing fields behave: fail immediately, skip the row, or substitute the provided default string.
+
 **Generated bash:**
 ```bash
 extract_names() {

--- a/docs/guides/json_to_litedb_streaming.md
+++ b/docs/guides/json_to_litedb_streaming.md
@@ -38,6 +38,8 @@ Claude can read those files (or their documentation in `skills/skill_json_source
 - For column-based projections, use `columns/1` instead of `schema/1`.
 - Complex selectors are available via `jsonpath('$.orders[*].total')`; strings beginning with `$` are treated as JSONPath automatically.
 - Nested data can be modeled inline with `record(Type, Fields)` so LiteDB insert scripts receive fully materialised child objects (helpful for documents like orders → line items).
+- For newline-delimited feeds, set `record_format(jsonl)` so UnifyWeaver treats each line as a JSON object.
+- Handle partial data via `null_policy/1` (e.g., `null_policy(skip)` to drop incomplete rows, or `null_policy(default('N/A'))` when placeholders are acceptable before inserting into LiteDB).
 - Additional options: `record_separator/1`, `field_separator/1`, `return_object(true)` if you want raw `JsonObject` rows.
 
 ## Streaming into LiteDB (conceptual pipeline)

--- a/docs/proposals/json_stream_reader.md
+++ b/docs/proposals/json_stream_reader.md
@@ -13,6 +13,8 @@
 - Validation rules for JSON sources live in `src/unifyweaver/sources.pl`, with coverage in `tests/core/test_json_source_validation.pl`.
 - Column and schema selectors now accept `jsonpath/1` expressions (root, wildcards, recursive descent); generators emit `JsonColumnSelectorConfig` so the runtime evaluates JSONPath selectors directly.
 - Nested records are available via `field(Name, Path, record(Type, Fields))`; code generation emits every record type, and the runtime instantiates sub-records recursively (see `tests/core/test_csharp_query_target.pl:verify_json_nested_schema_record_plan/0`).
+- JSON Lines streams are supported via `record_format(jsonl)`, which disables array parsing and reads one JSON object per line.
+- Null-handling policies (`null_policy(fail|skip|default(Value))`) apply to column projections so runtime callers can reject, drop, or replace incomplete rows.
 
 ## Requirements (Completed)
 
@@ -35,11 +37,10 @@
 ## Roadmap
 
 1. **Reader-level resilience**
-   - Null-handling policy (`null_policy(fail|skip|default(Value))`) and string-to-number coercion toggles.
-   - Support JSON Lines streams explicitly via `record_format=jsonl` with configurable separators.
+   - String-to-number coercion toggles.
    - Better diagnostics surfaced through `test_json_source_validation.pl` for malformed metadata.
+   - Provide per-column null overrides (e.g., allow nulls for selected selectors only).
 
 2. **Documentation & skills**
-   - Update `skills/skill_json_sources.md` once JSONPath/nested schemas land.
-   - Add agent guidance for selecting temp locations + schema best practices.
+   - Extend playbooks with full JSON-to-target walkthroughs (PowerShell, LiteDB, etc.).
    - Keep this proposal in sync with implementation details so Claude/Codex agents can reason about capabilities quickly.

--- a/skills/skill_json_sources.md
+++ b/skills/skill_json_sources.md
@@ -79,6 +79,25 @@ Use this skill whenever a playbook instructs you to read JSON data via `source/3
   ```
 - Generated C# includes `OrderRecord`, `LineItemRecord`, and `OrderSummaryRecord`; runtime instantiates nested POCOs automatically.
 
+## JSON Lines + null policies
+- Use `record_format(jsonl)` when streaming newline-delimited JSON (`*.jsonl`). This disables automatic array parsing so each line is treated as an independent object.
+- `null_policy/1` controls how missing projections behave:
+  - `null_policy(fail)` → throw immediately when a column evaluates to null.
+  - `null_policy(skip)` → skip any row containing null projections.
+  - `null_policy(default(Value))` → substitute `Value` (stored as a string) whenever null appears; useful for placeholders like `"N/A"` or `"0"`.
+- Example:
+  ```prolog
+  :- source(json, order_second_items, [
+      json_file('test_data/test_orders.jsonl'),
+      record_format(jsonl),
+      columns([
+          jsonpath('$.order.customer.name'),
+          jsonpath('$.items[1].product')
+      ]),
+      null_policy(default('N/A'))
+  ]).
+  ```
+
 ## Validation expectations
 - Missing `columns/1` (when `return_object(false)`) causes a `domain_error(json_columns, _)`.
 - Column count must equal predicate arity.

--- a/test_data/test_orders.jsonl
+++ b/test_data/test_orders.jsonl
@@ -1,0 +1,3 @@
+{"order":{"id":"SO1","customer":{"name":"Alice"}},"items":[{"product":"Laptop","total":1200},{"product":"Mouse","total":25}]}
+{"order":{"id":"SO2","customer":{"name":"Bob"}},"items":[{"product":"Mouse","total":25}]}
+{"order":{"id":"SO3","customer":{"name":"Charlie"}},"items":[{"product":"Keyboard","total":75}]}

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -26,6 +26,9 @@
 :- dynamic user:test_product_record/1.
 :- dynamic user:test_jsonpath_projection/2.
 :- dynamic user:test_order_summary/1.
+:- dynamic user:test_orders_jsonl/3.
+:- dynamic user:test_json_null_skip/2.
+:- dynamic user:test_json_null_default/2.
 
 test_csharp_query_target :-
     configure_csharp_query_options,
@@ -46,6 +49,9 @@ test_csharp_query_target :-
     verify_json_jsonpath_source_plan,
     verify_json_schema_source_plan,
     verify_json_nested_schema_record_plan,
+    verify_json_jsonl_source_plan,
+    verify_json_null_policy_skip_plan,
+    verify_json_null_policy_default_plan,
     verify_json_object_source_plan,
     cleanup_test_data,
     writeln('=== C# query target tests complete ===').
@@ -388,6 +394,47 @@ verify_json_nested_schema_record_plan_ :-
         'OrderSummaryRecord { Order = OrderRecord { Id = SO3, Customer = Charlie }, FirstItem = LineItemRecord { Product = Keyboard, Total = 75 } }'
     ]).
 
+verify_json_jsonl_source_plan :-
+    setup_call_cleanup(
+        setup_json_jsonl_source,
+        verify_json_jsonl_source_plan_(),
+        cleanup_json_jsonl_source
+    ).
+
+verify_json_jsonl_source_plan_ :-
+    csharp_query_target:build_query_plan(test_orders_jsonl/3, [target(csharp_query)], Plan),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'test_orders.jsonl'),
+    sub_string(Source, _, _, _, 'TreatArrayAsStream = false'),
+    maybe_run_query_runtime(Plan, ['Alice,Laptop,1200', 'Bob,Mouse,25', 'Charlie,Keyboard,75']).
+
+verify_json_null_policy_skip_plan :-
+    setup_call_cleanup(
+        setup_json_null_skip_source,
+        verify_json_null_policy_skip_plan_(),
+        cleanup_json_null_skip_source
+    ).
+
+verify_json_null_policy_skip_plan_ :-
+    csharp_query_target:build_query_plan(test_json_null_skip/2, [target(csharp_query)], Plan),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'JsonNullPolicy.Skip'),
+    maybe_run_query_runtime(Plan, ['Alice,Mouse']).
+
+verify_json_null_policy_default_plan :-
+    setup_call_cleanup(
+        setup_json_null_default_source,
+        verify_json_null_policy_default_plan_(),
+        cleanup_json_null_default_source
+    ).
+
+verify_json_null_policy_default_plan_ :-
+    csharp_query_target:build_query_plan(test_json_null_default/2, [target(csharp_query)], Plan),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'JsonNullPolicy.Default'),
+    sub_string(Source, _, _, _, 'NullReplacement = "N/A"'),
+    maybe_run_query_runtime(Plan, ['Alice,Mouse', 'Bob,N/A', 'Charlie,N/A']).
+
 verify_json_object_source_plan :-
     setup_call_cleanup(
         setup_json_object_source,
@@ -480,6 +527,54 @@ cleanup_json_nested_schema_source :-
     retractall(user:test_order_summary(_)),
     retractall(dynamic_source_compiler:dynamic_source_def(test_order_summary_source/1, _, _)),
     retractall(dynamic_source_compiler:dynamic_source_metadata(test_order_summary_source/1, _)).
+
+setup_json_jsonl_source :-
+    source(json, test_orders_jsonl_source, [
+        json_file('test_data/test_orders.jsonl'),
+        record_format(jsonl),
+        columns(['order.customer.name', 'items[0].product', 'items[0].total'])
+    ]),
+    assertz(user:(test_orders_jsonl(Customer, Product, Total) :-
+        test_orders_jsonl_source(Customer, Product, Total))).
+
+cleanup_json_jsonl_source :-
+    retractall(user:test_orders_jsonl(_, _, _)),
+    retractall(dynamic_source_compiler:dynamic_source_def(test_orders_jsonl_source/3, _, _)),
+    retractall(dynamic_source_compiler:dynamic_source_metadata(test_orders_jsonl_source/3, _)).
+
+setup_json_null_skip_source :-
+    source(json, test_json_null_skip_source, [
+        json_file('test_data/test_orders.json'),
+        columns([
+            jsonpath('$.order.customer.name'),
+            jsonpath('$.items[1].product')
+        ]),
+        null_policy(skip)
+    ]),
+    assertz(user:(test_json_null_skip(Customer, Product) :-
+        test_json_null_skip_source(Customer, Product))).
+
+cleanup_json_null_skip_source :-
+    retractall(user:test_json_null_skip(_, _)),
+    retractall(dynamic_source_compiler:dynamic_source_def(test_json_null_skip_source/2, _, _)),
+    retractall(dynamic_source_compiler:dynamic_source_metadata(test_json_null_skip_source/2, _)).
+
+setup_json_null_default_source :-
+    source(json, test_json_null_default_source, [
+        json_file('test_data/test_orders.json'),
+        columns([
+            jsonpath('$.order.customer.name'),
+            jsonpath('$.items[1].product')
+        ]),
+        null_policy(default('N/A'))
+    ]),
+    assertz(user:(test_json_null_default(Customer, Product) :-
+        test_json_null_default_source(Customer, Product))).
+
+cleanup_json_null_default_source :-
+    retractall(user:test_json_null_default(_, _)),
+    retractall(dynamic_source_compiler:dynamic_source_def(test_json_null_default_source/2, _, _)),
+    retractall(dynamic_source_compiler:dynamic_source_metadata(test_json_null_default_source/2, _)).
 
 setup_json_orders_source :-
     source(json, test_orders, [

--- a/tests/core/test_json_source_validation.pl
+++ b/tests/core/test_json_source_validation.pl
@@ -101,6 +101,33 @@ test(schema_supports_nested_records, []) :-
         cleanup_dynamic_source(nested_schema_source/1)
     ).
 
+test(jsonl_record_format, []) :-
+    setup_call_cleanup(
+        true,
+        once(source(json, jsonl_source,
+            [ json_file('test_data/test_orders.jsonl'),
+              record_format(jsonl),
+              columns([jsonpath('$.order.customer.name')])
+            ])),
+        cleanup_dynamic_source(jsonl_source/1)
+    ).
+
+test(invalid_null_policy,
+     [error(domain_error(json_null_policy, invalid))]) :-
+    source(json, bad_null_policy,
+        [ json_file('test_data/test_products.json'),
+          columns([id]),
+          null_policy(invalid)
+        ]).
+
+test(invalid_null_policy_value,
+     [error(domain_error(json_null_policy_value, _))]) :-
+    source(json, bad_null_policy_value,
+        [ json_file('test_data/test_products.json'),
+          columns([id]),
+          null_policy(default([bad]))
+        ]).
+
 :- end_tests(json_source_validation).
 
 :- initialization(main).


### PR DESCRIPTION
  Description:

  - Allow record_format(jsonl) so JSON sources can read newline-delimited streams; set treat_array_as_stream
    accordingly.
  - Introduce null_policy/1 (allow, fail, skip, default(Value)) and thread it through metadata and the C# runtime so
    column projections can enforce row-level null handling.
  - Update docs (EXTENDED_README, skills/skill_json_sources, docs/guides/json_to_litedb_streaming.md, docs/
    proposals/json_stream_reader.md) plus tests (tests/core/test_json_source_validation.pl, tests/core/
    test_csharp_query_target.pl) and add a JSONL fixture (test_data/test_orders.jsonl).

  Tests run:

  - swipl -q -f init.pl -s tests/core/test_json_source_validation.pl -g test_json_source_validation -t halt
  - SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
    test_csharp_query_target:test_csharp_query_target -t halt (allow ~4 minutes; it completes)

  Push with git push origin feature/json-null-policy then open/merge the PR before cloning into WSL.