### PR TITLE
docs: Add comprehensive guide for C# external compilation and LiteDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ A Prolog-to-Bash compiler that transforms declarative logic programs into effici
 
 ### C# Target Family (v0.1)
 - **Query Runtime (`target(csharp_query)`)** - Generates relational plans executed by a shared .NET engine with semi-naive fixpoint evaluation.
-- **Mutual recursion support** - Even/odd style dependencies now run entirely inside the C# runtime, matching Bash behaviour for SCC groups.
-- **Arithmetic & constraints** - LINQ-based pipelines honour `is/2`, comparisons, and deduplication semantics (`HashSet<T>` distinct).
-- **Streaming codegen (`target(csharp_codegen)`)** - Emit standalone C# projects that mirror the Bash streaming templates for simple predicates.
-- **Configurable artefacts** - Choose between direct C# emission, reusable plans, or let `target(csharp)` select the best backend automatically.
+- **External Compilation** - Robust `dotnet build` integration with dependency support and file locking prevention.
+- **LiteDB Integration** - Built-in support for NoSQL document storage.
+- **Mutual recursion support** - Even/odd style dependencies now run entirely inside the C# runtime.
+- **Arithmetic & constraints** - LINQ-based pipelines honour `is/2`, comparisons, and deduplication.
+- **Streaming codegen (`target(csharp_codegen)`)** - Emit standalone C# projects that mirror Bash streaming templates.
+
+**See [C# Compilation Guide](docs/DOTNET_COMPILATION.md) for details.**
 
 ### Data Source Plugin System (v0.1)
 - **5 Production-Ready Plugins** - CSV/TSV, AWK, Python, HTTP, JSON data sources

--- a/docs/DOTNET_COMPILATION.md
+++ b/docs/DOTNET_COMPILATION.md
@@ -1,0 +1,118 @@
+# C# Compilation & .NET Integration Guide
+
+UnifyWeaver provides robust support for integrating C# code into your Prolog-to-Bash/PowerShell pipelines. This guide covers the compilation strategies, architecture, and integration with external libraries like LiteDB.
+
+## Compilation Strategies
+
+UnifyWeaver supports two primary strategies for compiling C# code, automatically selected based on your environment and needs.
+
+### 1. External Compilation (`external_compile`)
+
+This is the **recommended** strategy for robust development. It uses the .NET SDK (`dotnet build`) to compile C# code into DLLs, which are then loaded by PowerShell.
+
+**Benefits:**
+- **Dependency Management**: Supports NuGet packages (`<PackageReference>`) and local DLL references.
+- **Isolation**: Compilation happens in a separate process, preventing "assembly already loaded" errors.
+- **File Locking Solution**: Uses unique, timestamped build directories to ensure that recompiling code doesn't fail due to file locks held by the PowerShell process.
+
+**Requirements:**
+- .NET SDK installed (`dotnet` command available).
+
+**How it works:**
+1. UnifyWeaver generates a unique build directory (e.g., `tmp/Build_MySource_123456`).
+2. It generates a `.csproj` file with necessary references.
+3. It runs `dotnet build` to produce a DLL.
+4. The generated PowerShell script loads this DLL using `Add-Type -Path ...`.
+
+### 2. Pre-Compilation (`pre_compile`)
+
+This is a **fallback** strategy that uses PowerShell's built-in `Add-Type` cmdlet to compile C# code on the fly.
+
+**Benefits:**
+- **No SDK Required**: Works on systems with just the .NET Runtime (standard on Windows).
+- **Simplicity**: No intermediate build artifacts or project files.
+
+**Limitations:**
+- **File Locking**: Once an assembly is loaded, it cannot be unloaded. Recompiling the same class in the same session will fail.
+- **Dependencies**: Harder to manage complex NuGet dependencies.
+
+**When to use:**
+- Simple scripts without external dependencies.
+- Environments where the .NET SDK is not installed.
+
+## Automatic Selection
+
+UnifyWeaver's `dotnet_source` module automatically selects the best strategy:
+
+1. Checks if `dotnet` is available in the system PATH.
+2. If available, defaults to `external_compile`.
+3. If not available, falls back to `pre_compile`.
+
+You can force a specific strategy in your source definition (though usually not necessary):
+
+```prolog
+:- source(dotnet, my_predicate, [
+    compilation_strategy(pre_compile),  % Force Add-Type
+    ...
+]).
+```
+
+## LiteDB Integration
+
+UnifyWeaver includes built-in support for LiteDB, a lightweight, serverless NoSQL document store. This allows you to stream data into a structured database and query it efficiently.
+
+### Setup
+
+Use the included setup scripts to download the LiteDB DLL:
+
+**Bash/WSL:**
+```bash
+bash scripts/setup/setup_litedb.sh
+```
+
+**PowerShell:**
+```powershell
+.\scripts\setup\setup_litedb.ps1
+```
+
+This places `LiteDB.dll` in the `lib/` directory.
+
+### Usage Example
+
+Here is how to define a source that loads data into LiteDB:
+
+```prolog
+:- source(dotnet, load_products, [
+    arity(0),
+    target(powershell),
+    csharp_inline('
+using LiteDB;
+using System.IO;
+
+namespace UnifyWeaver.Generated {
+    public class Handler {
+        public string Process() {
+            using (var db = new LiteDatabase("data.db")) {
+                var col = db.GetCollection("products");
+                col.Insert(new BsonDocument { ["name"] = "Widget", ["price"] = 9.99 });
+                return "Inserted";
+            }
+        }
+    }
+}
+'),
+    references(['lib/LiteDB.dll'])  % Reference the DLL
+]).
+```
+
+## Solving DLL File Locking
+
+A common issue in PowerShell development is that once a DLL is loaded, the file is locked by the process and cannot be overwritten. This makes iterative development (compile -> run -> fix -> compile) difficult.
+
+**UnifyWeaver's Solution:**
+When using `external_compile`, UnifyWeaver generates a **unique build directory** for every compilation (e.g., using a timestamp).
+
+- **Build 1:** `tmp/Build_Source_A_1001/bin/Debug/net8.0/Source_A.dll`
+- **Build 2:** `tmp/Build_Source_A_1002/bin/Debug/net8.0/Source_A.dll`
+
+Because the file path changes, PowerShell treats it as a new assembly, avoiding the lock on the previous file. The template automatically cleans up old build artifacts to prevent disk clutter.

--- a/docs/DOTNET_COMPILATION.md
+++ b/docs/DOTNET_COMPILATION.md
@@ -19,7 +19,7 @@ This is the **recommended** strategy for robust development. It uses the .NET SD
 - .NET SDK installed (`dotnet` command available).
 
 **How it works:**
-1. UnifyWeaver generates a unique build directory (e.g., `tmp/Build_MySource_123456`).
+1. UnifyWeaver generates a unique build directory in your OS temp folder (for example `%TEMP%/unifyweaver_dotnet_build/Build_MySource_123456`).
 2. It generates a `.csproj` file with necessary references.
 3. It runs `dotnet build` to produce a DLL.
 4. The generated PowerShell script loads this DLL using `Add-Type -Path ...`.
@@ -48,12 +48,16 @@ UnifyWeaver's `dotnet_source` module automatically selects the best strategy:
 2. If available, defaults to `external_compile`.
 3. If not available, falls back to `pre_compile`.
 
-You can force a specific strategy in your source definition (though usually not necessary):
+You can override the default selection when necessary:
 
 ```prolog
 :- source(dotnet, my_predicate, [
-    compilation_strategy(pre_compile),  % Force Add-Type
-    ...
+    external_compile(false),  % Force Add-Type even if dotnet is available
+    pre_compile(true)
+]).
+
+:- source(dotnet, other_predicate, [
+    external_compile(true)     % Force dotnet build even if auto-detect fails
 ]).
 ```
 

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -18,10 +18,11 @@ This document provides comprehensive documentation for UnifyWeaver, including de
 5. [Data Source Plugin System](#data-source-plugin-system)
 6. [Firewall and Security](#firewall-and-security)
 7. [PowerShell Target](#powershell-target)
-8. [Complete Examples](#complete-examples)
-9. [Architecture Deep Dive](#architecture-deep-dive)
-10. [Testing Guide](#testing-guide)
-11. [Troubleshooting](#troubleshooting)
+8. [C# Target Family](#c-target-family)
+9. [Complete Examples](#complete-examples)
+10. [Architecture Deep Dive](#architecture-deep-dive)
+11. [Testing Guide](#testing-guide)
+12. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -376,6 +377,7 @@ UnifyWeaver v0.0.2 introduces a powerful plugin system for integrating external 
 │  - JSON Plugin                             │
 │  - HTTP Plugin                             │
 │  - Python Plugin                           │
+│  - C# Plugin (LiteDB)                      │
 └────────────────┬────────────────────────────┘
                  │
                  ↓
@@ -684,6 +686,25 @@ PYTHON_EOF
 }
 ```
 
+### C# Plugin (LiteDB Integration)
+
+UnifyWeaver supports C# data sources with automatic compilation and LiteDB integration.
+
+**LiteDB Inserter:**
+```prolog
+:- source(dotnet, load_products, [
+    arity(0),
+    target(powershell),
+    csharp_inline('
+using LiteDB;
+// ... C# code ...
+'),
+    references(['lib/LiteDB.dll'])
+]).
+```
+
+**See [C# Compilation Guide](DOTNET_COMPILATION.md) for full details.**
+
 ### Complete ETL Pipeline Example
 
 ```prolog
@@ -929,6 +950,23 @@ For complete PowerShell documentation, see:
 - [POWERSHELL_PURE_VS_BAAS.md](POWERSHELL_PURE_VS_BAAS.md)
 
 ---
+
+## C# Target Family
+
+UnifyWeaver provides a robust C# compilation system that integrates seamlessly with PowerShell.
+
+### Features
+
+- **External Compilation**: Uses `dotnet build` for robust dependency management and isolation.
+- **Pre-Compilation**: Fallback to `Add-Type` for simple scripts.
+- **File Locking Solution**: Unique build directories prevent DLL locking issues.
+- **LiteDB Support**: Built-in integration for NoSQL document storage.
+
+**See [DOTNET_COMPILATION.md](DOTNET_COMPILATION.md) for the complete guide.**
+
+---
+
+
 
 ## Complete Examples
 


### PR DESCRIPTION
### Summary
This PR updates the documentation to reflect the recently implemented external C# compilation features and LiteDB integration. It introduces a dedicated guide for .NET compilation strategies and updates the main documentation files to include these new capabilities.

### Key Changes
*   **New Guide**: Created `docs/DOTNET_COMPILATION.md` which covers:
    *   **External Compilation (`external_compile`)**: Using `dotnet build` for robust development.
    *   **Pre-Compilation (`pre_compile`)**: Fallback strategy using `Add-Type`.
    *   **File Locking Solution**: Explanation of unique build directories in `%TEMP%`.
    *   **LiteDB Integration**: Setup and usage examples.
    *   **Configuration**: How to force specific compilation modes (`external_compile(true/false)`).
*   **Updated `README.md`**:
    *   Updated "C# Target Family" section to highlight external compilation and LiteDB.
    *   Added link to the new compilation guide.
*   **Updated `docs/EXTENDED_README.md`**:
    *   Added "C# Target Family" section.
    *   Added "C# Plugin (LiteDB)" subsection to the Data Source Plugin System.
    *   Updated Table of Contents.

### Benefits
*   Provides clear instructions for users on how to use the new robust C# features.
*   Explains the "why" and "how" behind the file locking solution.
*   Documents the configuration options for controlling compilation behavior.
