### PR TITLE
Document case-insensitive XML tag matching for awk pipeline

### DIFF
--- a/docs/tutorials/DECLARATIVE_FIELD_EXTRACTION_TUTORIAL.md
+++ b/docs/tutorials/DECLARATIVE_FIELD_EXTRACTION_TUTORIAL.md
@@ -23,6 +23,7 @@ UnifyWeaver now supports **declarative field extraction** - you specify WHAT fie
 ```prolog
 % Extract whole elements
 extract_elements('data.xml', 'product', awk_pipeline, Products),
+extract_elements('data.xml', 'product', awk_pipeline, [case_insensitive(true)], Products),
 
 % Manually parse each one (imperative!)
 maplist(parse_product_xml, Products, ParsedProducts).

--- a/docs/tutorials/FIELD_EXTRACTION_QUICK_REFERENCE.md
+++ b/docs/tutorials/FIELD_EXTRACTION_QUICK_REFERENCE.md
@@ -29,6 +29,7 @@
 | `engine(Engine)` | `awk_pipeline`, `iterparse`, `xmllint`, `xmlstarlet` | `awk_pipeline` | Extraction engine |
 | `output(Format)` | `dict`, `list`, `compound(F)` | `dict` | Output format |
 | `field_compiler(Strategy)` | `modular`, `inline` | `modular` | Implementation strategy |
+| `case_insensitive(Bool)` | `true`, `false` | `false` | Case-insensitive tag match (awk_pipeline) |
 
 ---
 
@@ -72,6 +73,17 @@ output(compound(item))
 
 ?- products(Items).
 Items = [_{id: '123', name: 'Laptop'}, ...].
+```
+
+### Case-insensitive Tag Match (awk)
+```prolog
+:- source(xml, products_ci, [
+    file('products.xml'),
+    tag('product'),
+    fields([id: 'productId', name: 'productName']),
+    engine(awk_pipeline),
+    case_insensitive(true)
+]).
 ```
 
 ### With Custom Output


### PR DESCRIPTION
  - Added case_insensitive(true) option to the XML declarative examples, and noted -v icase=1 for direct awk usage.
  - Updated quick reference and tutorial to show case-insensitive tag matching with awk_pipeline.
  - Under the hood, select_xml_elements.awk now accepts icase, and the xml_source awk template passes it through.