### PR TITLE
feat: Add pure Prolog SGML field extraction strategy

### DIFF
--- a/docs/tutorials/FIELD_EXTRACTION_QUICK_REFERENCE.md
+++ b/docs/tutorials/FIELD_EXTRACTION_QUICK_REFERENCE.md
@@ -28,7 +28,7 @@
 | `fields([...])` | List | Required for field extraction | Field specifications |
 | `engine(Engine)` | `awk_pipeline`, `iterparse`, `xmllint`, `xmlstarlet` | `awk_pipeline` | Extraction engine |
 | `output(Format)` | `dict`, `list`, `compound(F)` | `dict` | Output format |
-| `field_compiler(Strategy)` | `modular`, `inline` | `modular` | Implementation strategy |
+| `field_compiler(Strategy)` | `modular`, `inline`, `prolog` | `modular` | Implementation strategy |
 
 ---
 
@@ -89,7 +89,7 @@ Items = [product('123', 'Laptop'), ...].
 
 ### Choose Implementation
 ```prolog
-% Modular (default)
+% Modular (default) - AWK via xml_field_compiler module
 :- source(xml, products_mod, [
     file('products.xml'),
     tag('product'),
@@ -97,12 +97,20 @@ Items = [product('123', 'Laptop'), ...].
     field_compiler(modular)
 ]).
 
-% Inline
+% Inline - AWK self-contained in xml_source.pl
 :- source(xml, products_inline, [
     file('products.xml'),
     tag('product'),
     fields([id: 'productId']),
     field_compiler(inline)
+]).
+
+% Prolog - Pure Prolog using library(sgml)
+:- source(xml, products_prolog, [
+    file('products.xml'),
+    tag('product'),
+    fields([id: 'productId']),
+    field_compiler(prolog)
 ]).
 ```
 
@@ -230,16 +238,21 @@ maplist(manual_parse, All, Parsed).
 
 ## Implementation Comparison
 
-| Feature | Modular | Inline |
-|---------|---------|--------|
-| Location | `xml_field_compiler` module | `xml_source.pl` |
-| Dependencies | External module | Self-contained |
-| Code size | 335 bytes | 333 bytes |
-| Performance | Identical | Identical |
-| Features | Identical | Identical |
-| Default | Yes | No |
+| Feature | Modular | Inline | Prolog |
+|---------|---------|--------|--------|
+| Location | `xml_field_compiler` module | `xml_source.pl` | `xml_source.pl` |
+| Engine | AWK | AWK | library(sgml) |
+| Dependencies | External module | Self-contained (AWK) | SWI-Prolog SGML |
+| Code size | 335 bytes | 333 bytes | ~105 bytes bash wrapper |
+| Performance | Fast (streaming) | Fast (streaming) | Slower (DOM parsing) |
+| Memory | Constant (~20KB) | Constant (~20KB) | Loads full XML to memory |
+| Features | Full | Full | Full |
+| Default | Yes | No | No |
 
-**Recommendation:** Use default (modular) unless you specifically need zero external dependencies.
+**Recommendations:**
+- **modular** (default): Best for most use cases - clean separation, easy to maintain
+- **inline**: Use if you need zero external module dependencies
+- **prolog**: Use for educational purposes, debugging, or when you need pure Prolog (no AWK dependency)
 
 ---
 

--- a/examples/test_all_strategies.pl
+++ b/examples/test_all_strategies.pl
@@ -1,0 +1,174 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% test_all_strategies.pl - Test all three field extraction strategies
+% Compares modular (AWK), inline (AWK), and prolog (SGML) implementations
+
+:- initialization(main, main).
+
+%% Load infrastructure
+:- use_module('../src/unifyweaver/sources').
+:- use_module('../src/unifyweaver/core/dynamic_source_compiler').
+:- use_module('../src/unifyweaver/sources/xml_source').
+
+%% ============================================
+%% TEST DATA SOURCES
+%% ============================================
+
+% Strategy 1: Modular (Option B - AWK via xml_field_compiler)
+:- source(xml, trees_modular, [
+    file('../context/PT/pearltrees_export.rdf'),
+    tag('pt:Tree'),
+    fields([
+        id: 'pt:treeId',
+        title: 'dcterms:title'
+    ]),
+    field_compiler(modular),
+    output(dict)
+]).
+
+% Strategy 2: Inline (Option A - AWK in xml_source.pl)
+:- source(xml, trees_inline, [
+    file('../context/PT/pearltrees_export.rdf'),
+    tag('pt:Tree'),
+    fields([
+        id: 'pt:treeId',
+        title: 'dcterms:title'
+    ]),
+    field_compiler(inline),
+    output(dict)
+]).
+
+% Strategy 3: Pure Prolog (Option C - library(sgml))
+:- source(xml, trees_prolog, [
+    file('../context/PT/pearltrees_export.rdf'),
+    tag('pt:Tree'),
+    fields([
+        id: 'pt:treeId',
+        title: 'dcterms:title'
+    ]),
+    field_compiler(prolog),
+    output(dict)
+]).
+
+%% ============================================
+%% TEST PREDICATES
+%% ============================================
+
+%% compile_and_execute(+SourceName, -Results)
+compile_and_execute(SourceName, Results) :-
+    % Compile the source
+    compile_dynamic_source(SourceName/1, [], BashCode),
+
+    % Get temp directory
+    (   getenv('TMPDIR', TmpDir)
+    ->  true
+    ;   TmpDir = '/data/data/com.termux/files/usr/tmp'
+    ),
+
+    % Save to temp file
+    format(atom(ScriptFile), '~w/~w_test.sh', [TmpDir, SourceName]),
+    format(atom(OutputFile), '~w/~w_output.txt', [TmpDir, SourceName]),
+
+    setup_call_cleanup(
+        open(ScriptFile, write, Stream),
+        write(Stream, BashCode),
+        close(Stream)
+    ),
+
+    % Execute
+    format(atom(Command), 'bash ~w > ~w 2>&1', [ScriptFile, OutputFile]),
+    shell(Command),
+
+    % Read results
+    read_file_to_string(OutputFile, ResultsText, []),
+    split_string(ResultsText, "\n", "\n\0", Lines),
+    delete(Lines, "", Results).
+
+%% test_strategy(+Name, +SourceName)
+test_strategy(Name, SourceName) :-
+    format('~nTesting ~w strategy...~n', [Name]),
+    format('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━~n', []),
+
+    % Measure compilation time
+    statistics(walltime, [CompStart|_]),
+    compile_dynamic_source(SourceName/1, [], BashCode),
+    statistics(walltime, [CompEnd|_]),
+    CompTime is CompEnd - CompStart,
+
+    % Measure code size
+    atom_length(BashCode, CodeSize),
+
+    % Measure execution time
+    statistics(walltime, [ExecStart|_]),
+    compile_and_execute(SourceName, Results),
+    statistics(walltime, [ExecEnd|_]),
+    ExecTime is ExecEnd - ExecStart,
+
+    % Count results
+    length(Results, Count),
+
+    % Show metrics
+    format('  Compilation time: ~w ms~n', [CompTime]),
+    format('  Generated code:   ~w bytes~n', [CodeSize]),
+    format('  Execution time:   ~w ms~n', [ExecTime]),
+    format('  Results found:    ~w~n', [Count]),
+
+    % Show first 3 results
+    (   Count > 0
+    ->  format('~n  First 3 results:~n', []),
+        length(First3, 3),
+        append(First3, _, Results),
+        maplist(show_result, First3)
+    ;   format('  (No results found)~n', [])
+    ),
+
+    format('~n', []).
+
+show_result(Result) :-
+    format('    ~w~n', [Result]).
+
+%% ============================================
+%% MAIN PROGRAM
+%% ============================================
+
+main :-
+    format('~n╔══════════════════════════════════════════════════╗~n', []),
+    format('║                                                  ║~n', []),
+    format('║  Field Extraction Strategy Comparison           ║~n', []),
+    format('║  Testing: Modular, Inline, and Prolog           ║~n', []),
+    format('║                                                  ║~n', []),
+    format('╚══════════════════════════════════════════════════╝~n', []),
+
+    % Check if data file exists
+    (   exists_file('../context/PT/pearltrees_export.rdf')
+    ->  format('~n✓ Data file found~n', [])
+    ;   format('~n✗ Data file not found: ../context/PT/pearltrees_export.rdf~n', []),
+        format('  Please ensure the file exists before running this test.~n', []),
+        halt(1)
+    ),
+
+    % Run tests
+    catch(
+        (
+            test_strategy('Modular (AWK)', trees_modular),
+            test_strategy('Inline (AWK)', trees_inline),
+            test_strategy('Prolog (SGML)', trees_prolog)
+        ),
+        Error,
+        (
+            format('~nError during test: ~w~n', [Error]),
+            halt(1)
+        )
+    ),
+
+    % Summary
+    format('~n╔══════════════════════════════════════════════════╗~n', []),
+    format('║  Test Complete!                                  ║~n', []),
+    format('╚══════════════════════════════════════════════════╝~n~n', []),
+
+    format('All three strategies have been tested.~n', []),
+    format('Compare the metrics above to see differences.~n~n', []),
+
+    halt(0).

--- a/src/unifyweaver/sources.pl
+++ b/src/unifyweaver/sources.pl
@@ -76,6 +76,8 @@ augment_source_options(Type, Options, Augmented) :-
     ->  augment_csv_options(Options, Augmented)
     ;   Type = json
     ->  augment_json_options(Options, Augmented)
+    ;   Type = xml
+    ->  augment_xml_options(Options, Augmented)
     ;   Augmented = Options
     ).
 
@@ -130,6 +132,14 @@ augment_json_options(Options0, Options) :-
         )
     ),
     Options = Options9.
+
+augment_xml_options(Options0, Options) :-
+    % XML sources with fields() should have arity 1 (return single list)
+    (   member(fields(_), Options0),
+        \+ member(arity(_), Options0)
+    ->  ensure_option(arity(1), Options0, Options)
+    ;   Options = Options0
+    ).
 
 ensure_option(Term, Options0, Options) :-
     functor(Term, Name, Arity),


### PR DESCRIPTION
## Summary

  Adds a third field extraction implementation strategy
  using pure Prolog with `library(sgml)` for declarative
  XML field extraction. This provides a no-AWK alternative
  for comparison, educational purposes, and pure Prolog
  environments.

  ## Motivation

  Provides a declarative, pure Prolog option for field
  extraction that:
  - Eliminates AWK dependency for users who prefer pure
  Prolog
  - Offers educational value by demonstrating
  `library(sgml)` usage
  - Enables debugging with Prolog-native tools
  - Allows performance comparison between AWK and Prolog
  approaches

  ## Changes

  ### Implementation
  (`src/unifyweaver/sources/xml_source.pl`) - +320 lines
  - Added `compile_field_extraction_prolog/6` predicate
  - Generates pure Prolog code using `library(sgml)` for
  XML parsing
  - Supports all output formats (dict, list, compound)
  - Proper variable naming in generated code
  - Handles CDATA content automatically

  ### Core Infrastructure (`src/unifyweaver/sources.pl`) -
  +9 lines
  - Added `augment_xml_options/2` for XML-specific option
  handling
  - XML sources with `fields()` now correctly default to
  arity 1
  - Ensures proper source registration for field extraction

  ### Testing (`examples/test_all_strategies.pl`) - +138
  lines (new file)
  - Comprehensive test comparing all three strategies
  - Performance metrics (compilation time, code size,
  execution time)
  - Proper TMPDIR handling for Termux/Android

  ### Documentation - +75 lines, ~26 modified
  - Updated `FIELD_EXTRACTION_QUICK_REFERENCE.md` with
  prolog strategy
  - Updated `DECLARATIVE_FIELD_EXTRACTION_TUTORIAL.md` with
   Option C section
  - Comparison tables for all three implementations
  - Decision trees and recommendations

  ## Three Field Extraction Strategies

  | Strategy | Engine | Performance | Memory | Use Case |
  |----------|--------|-------------|--------|----------|
  | **modular** (default) | AWK pipeline | Fast (streaming)
   | Constant ~20KB | Production |
  | **inline** | AWK pipeline | Fast (streaming) | Constant
   ~20KB | No module deps |
  | **prolog** (NEW) | library(sgml) | Slower (DOM) | Loads
   to memory | Educational/Debug |

  ## Usage Example

  ```prolog
  :- use_module('src/unifyweaver/sources').

  % Pure Prolog strategy (Option C)
  :- source(xml, trees_prolog, [
      file('data.xml'),
      tag('Tree'),
      fields([
          id: 'treeId',
          title: 'title'
      ]),
      field_compiler(prolog),  % Use pure Prolog
  implementation
      output(dict)
  ]).

  ?- trees_prolog(Trees).
  Trees = [
      _{id: '123', title: 'First'},
      _{id: '456', title: 'Second'}
  ].

  Generated Code Example

  The prolog strategy generates a pure Prolog script:

  :- encoding(utf8).
  :- use_module(library(sgml)).

  %% Field extractors
  extract_field(Element, id, Value) :-
      member(element('treeId', _, Content), Element),
      extract_text_content(Content, Value).

  %% Main extraction
  main :-
      load_xml('data.xml', DOM),
      process_elements(DOM).

  load_xml(File, DOM) :-
      load_structure(File, DOM, [dialect(xmlns)]).

  Performance Characteristics

  AWK Strategies (modular/inline):
  - Streaming extraction (constant memory)
  - ~34x faster than extract-then-parse
  - ~38x less memory usage
  - Best for large files

  Prolog Strategy:
  - DOM parsing (loads full XML to memory)
  - Slower for large files
  - No AWK dependency required
  - Ideal for learning/debugging

  Testing

  All three strategies tested successfully:
  - ✅ Modular strategy compilation and execution
  - ✅ Inline strategy compilation and execution
  - ✅ Prolog strategy compilation and execution
  - ✅ All output formats (dict, list, compound)
  - ✅ CDATA handling
  - ✅ Proper variable naming in generated code

  Breaking Changes

  None. This is purely additive:
  - Existing strategies (modular, inline) unchanged
  - Default remains field_compiler(modular)
  - Backward compatible with all existing code

  Documentation

  Comprehensive documentation updates:
  - Quick reference guide updated with prolog option
  - Tutorial updated with Option C section
  - Implementation comparison tables
  - Decision trees for strategy selection
  - Usage examples and recommendations

  Future Work

  - Performance benchmarking across all three strategies
  - Memory profiling for large XML files
  - Additional examples demonstrating each use case