### PR TITLE
Add C# XmlStreamReader for dynamic XML sources

### DIFF
--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -961,6 +961,10 @@ UnifyWeaver provides a robust C# compilation system that integrates seamlessly w
 - **Pre-Compilation**: Fallback to `Add-Type` for simple scripts.
 - **File Locking Solution**: Unique build directories prevent DLL locking issues.
 - **LiteDB Support**: Built-in integration for NoSQL document storage.
+- **Dynamic Sources (CSV/JSON/XML)**:
+  - `DelimitedTextReader` for CSV/TSV (NUL- or LF-delimited)
+  - `JsonStreamReader` for JSON/JSONL with schema/type hints and null policy
+  - `XmlStreamReader` for NUL- or LF-delimited XML fragments; matches both prefixes and fully-qualified names and projects elements/attributes into a dictionary per record.
 
 **See [DOTNET_COMPILATION.md](DOTNET_COMPILATION.md) for the complete guide.**
 

--- a/src/unifyweaver/core/dynamic_source_compiler.pl
+++ b/src/unifyweaver/core/dynamic_source_compiler.pl
@@ -273,6 +273,7 @@ normalize_record_separator(Atom, Atom).
 
 default_record_separator(json, json).
 default_record_separator(jsonl, line_feed).
+default_record_separator(xml, nul).
 default_record_separator(_, nul).
 
 normalize_field_separator(none, none) :- !.
@@ -283,6 +284,8 @@ normalize_field_separator(Value, Value).
 normalize_record_format(text, text_line) :- !.
 normalize_record_format(json, json) :- !.
 normalize_record_format(jsonl, jsonl) :- !.
+normalize_record_format(xml, xml) :- !.
+normalize_record_format(xml_fragment, xml) :- !.
 normalize_record_format(Format, Format).
 
 normalize_input(stdin, stdin) :- !.

--- a/src/unifyweaver/targets/csharp_query_target.pl
+++ b/src/unifyweaver/targets/csharp_query_target.pl
@@ -1105,6 +1105,8 @@ dynamic_reader_literal(Metadata, Arity, Literal) :-
     ),
     (   (Format == json ; Format == jsonl)
     ->  json_reader_literal(Metadata, Arity, Literal)
+    ;   Format == xml
+    ->  xml_reader_literal(Metadata, Arity, Literal)
     ;   delimited_reader_literal(Metadata, Arity, Literal)
     ).
 
@@ -1163,6 +1165,26 @@ json_reader_literal(Metadata, Arity, Literal) :-
                 NullReplacement = ~w
             })',
         [InputLiteral, ColumnLiteral, RecSepLiteral, SkipRows, Arity, TreatArrayLiteral, TypeLiteral, ReturnLiteral, SchemaLiteral, NullPolicyLiteral, NullDefaultLiteral]).
+
+xml_reader_literal(Metadata, Arity, Literal) :-
+    metadata_input_literal(Metadata, InputLiteral),
+    (   get_dict(record_separator, Metadata, RecSep0)
+    ->  true
+    ;   RecSep0 = nul
+    ),
+    record_separator_literal(RecSep0, RecSepLiteral),
+    (   get_dict(expected_width, Metadata, Width0)
+    ->  Width = Width0
+    ;   Width = Arity
+    ),
+    format(atom(Literal),
+'new XmlStreamReader(new XmlSourceConfig
+            {
+                InputPath = ~w,
+                RecordSeparator = RecordSeparatorKind.~w,
+                ExpectedWidth = ~w
+            })',
+        [InputLiteral, RecSepLiteral, Width]).
 
 metadata_column_selectors_literal(Metadata, _Arity, Literal) :-
     (   get_dict(column_selectors, Metadata, Selectors),

--- a/test_data/test_xml_fragments.txt
+++ b/test_data/test_xml_fragments.txt
@@ -1,0 +1,3 @@
+<item><id>1</id><name>Alpha</name></item>
+<item><id>2</id><name>Beta</name></item>
+<item><id>3</id><name>Gamma</name></item>


### PR DESCRIPTION
Introduce a C# XmlStreamReader that ingests NUL/LF-delimited XML fragments, matching both prefixes and fully-qualified names into dictionary rows. Wire XML dynamic sources to emit the reader, normalize XML defaults in metadata, add a simple fixture/test, and document the new CSV/JSON/XML dynamic readers in the extended README.