### PR TITLE
Document and test C# XML dynamic sources

### DIFF
--- a/docs/guides/csharp_xml_sources.md
+++ b/docs/guides/csharp_xml_sources.md
@@ -1,0 +1,33 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+Copyright (c) 2025 John William Creighton (@s243a)
+-->
+
+# C# XML Dynamic Sources
+
+This is a quick note for agent users of the C# query target.
+
+## Minimal recipe
+
+```prolog
+:- source(xml, xml_rows, [
+    file('test_data/test_xml_fragments.txt'),
+    record_format(xml),        % important: tells the C# target to use XmlStreamReader
+    record_separator(line_feed) % or nul if your fragments are NUL-delimited
+]).
+
+:- dynamic_source(xml_row/1, xml_rows, []).
+```
+
+The generated plan uses `XmlStreamReader` which:
+- Splits on `\n` or `\0`
+- Projects each fragment into a dictionary keyed by local name, fully-qualified name, and prefix form (e.g., `pt:id`)
+- Includes attributes with an `@` prefix (e.g., `@lang`, `@pt:code`)
+
+## Notes and quirks
+- CDATA content is preserved as text (e.g., `<![CDATA[Hacktivism]]>` → `Hacktivism`).
+- If your fragments carry namespaces (Pearltrees uses `pt:`), both local and `prefix:local` keys are emitted.
+- For stream-friendly files, keep one fragment per delimiter (NUL or newline). Avoid multi-line fragments when using `record_separator(line_feed)`.
+
+## Future: Pearltrees helper
+Pearltrees RDF exports use `pt:` plus CDATA-wrapped titles. A specialized helper could subclass the XML reader to apply Pearltrees defaults (prefix map, CDATA handling) automatically. For now, the generic reader already preserves CDATA and prefix keys; set `record_format(xml)` and a suitable delimiter. 

--- a/playbooks/examples_library/csharp_examples.md
+++ b/playbooks/examples_library/csharp_examples.md
@@ -117,3 +117,5 @@ Write-Host "Success: C# program compiled and executed successfully."
 # Remove-Item -Recurse -Force $tmpDir
 # Remove-Item -Force "tmp/fib_csharp.pl"
 ```
+- `unifyweaver.execution.csharp_json_schema` — Generate typed JSON queries from schema hints.
+- `unifyweaver.execution.csharp_xml_fragments` — Read NUL/LF-delimited XML fragments via XmlStreamReader, projecting elements/attributes (prefix + qualified keys) into rows.

--- a/test_data/test_xml_fragments.txt
+++ b/test_data/test_xml_fragments.txt
@@ -1,3 +1,3 @@
-<item><id>1</id><name>Alpha</name></item>
-<item><id>2</id><name>Beta</name></item>
+<item><id>1</id><name lang="en">Alpha</name></item>
+<pt:item xmlns:pt="http://www.pearltrees.com/rdf/0.1/#" code="X"><pt:id code="A1"><![CDATA[2]]></pt:id><title><![CDATA[Hacktivism]]></title></pt:item>
 <item><id>3</id><name>Gamma</name></item>

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -477,7 +477,13 @@ verify_xml_dynamic_source_plan_ :-
     csharp_query_target:build_query_plan(test_xml_item/1, [target(csharp_query)], Plan),
     csharp_query_target:render_plan_to_csharp(Plan, Source),
     sub_string(Source, _, _, _, 'XmlStreamReader'),
-    sub_string(Source, _, _, _, 'test_xml_fragments.txt').
+    sub_string(Source, _, _, _, 'test_xml_fragments.txt'),
+    % Validate dictionary projection picks up local + qualified keys
+    maybe_run_query_runtime(Plan, [
+        "_{id:1, name:Alpha, '@lang':en}",
+        "_{id:2, title:Hacktivism, 'pt:item':Hacktivism, '@code':X, '@pt:id':2, '@pt:code':A1}",
+        "_{id:3, name:Gamma}"
+    ]).
 
 setup_csv_dynamic_source :-
     source(csv, test_users, [csv_file('test_data/test_users.csv'), has_header(true)]),


### PR DESCRIPTION
Adds a pearltrees-like XML fragment fixture, extends the C# plan test to validate XmlStreamReader projections (prefix/qualified/attribute keys), documents how to use XML dynamic sources in C#, and registers a new XML example record in the  C# example library. Includes notes on CDATA/prefix handling and a future Pearltrees helper.