### PR TITLE
feat(python): Add relation tracking and stratified negation to generator mode

### DIFF
--- a/examples/parents.jsonl
+++ b/examples/parents.jsonl
@@ -1,4 +1,4 @@
-{"arg0": "john", "arg1": "mary"}
-{"arg0": "mary", "arg1": "sue"}
-{"arg0": "sue", "arg1": "alice"}
-{"arg0": "john", "arg1": "bob"}
+{"relation": "parent", "arg0": "john", "arg1": "mary"}
+{"relation": "parent", "arg0": "mary", "arg1": "sue"}
+{"relation": "parent", "arg0": "sue", "arg1": "alice"}
+{"relation": "parent", "arg0": "john", "arg1": "bob"}


### PR DESCRIPTION
## Summary
Enhances Python generator mode with **relation tracking**, **stratified negation**, and **robust variable mapping**. Fixes critical variable identity bug in join translation. Enables production-ready multi-predicate Datalog queries with negation.

## Motivation
The initial generator mode implementation had fundamental limitations:
- **No predicate distinction**: `FrozenDict` couldn't distinguish `parent(a,b)` from `edge(a,b)` 
- **No negation**: Couldn't express rules like `bachelor(X) :- person(X), \+ married(X)`
- **Broken variable mapping**: `translate_expr` always assumed `fact.get('arg0')`
- **Variable identity bug**: Join conditions unified variables instead of checking identity, breaking transitive closure

These limitations made generator mode unsuitable for real-world Datalog applications.

## Key Changes

### 1. Relation Tracking in FrozenDict ✨
**Before:**
```python
FrozenDict.from_dict({'arg0': 'john', 'arg1': 'mary'})  # Which predicate?
```

**After:**
```python
FrozenDict.from_dict({'relation': 'parent', 'arg0': 'john', 'arg1': 'mary'})
```

**Implementation:**
- Added `relation` field to all generated `FrozenDict` instances
- Updated all rule translation functions to check and emit relation:
  - `translate_fact_rule`: Emits `'relation': 'pred_name'`
  - `translate_copy_rule_with_builtins`: Checks `fact.get('relation') == 'goal_pred'`
  - `translate_binary_join_with_constraints`: Checks both `fact` and `other` relations
  - `translate_nway_join`: Checks `fact` and all `join_N` relations
  - Disjunction variants: All updated with relation checks

**Impact:** Enables correct multi-predicate queries and negation.

### 2. Stratified Negation 🔥
Implemented full support for `\+ Goal` and `not(Goal)`:

```prolog
% Example: Find unmarried people
bachelor(X) :- person(X), \+ married(X).
```

**Generated Python:**
```python
def _apply_rule_1(fact, total):
    if fact.get('relation') == 'person' and 'arg0' in fact:
        # Construct negated fact
        negated = FrozenDict.from_dict({
            'relation': 'married',
            'arg0': fact.get('arg0')
        })
        if negated not in total:  # Stratified negation check
            yield FrozenDict.from_dict({
                'relation': 'bachelor',
                'arg0': fact.get('arg0')
            })
```

**Implementation:**
- Updated `is_builtin_goal/1` to recognize `\+` and `not`
- Added `translate_negation/3` to generate Python negation checks
- Handles variables, atoms, and numbers in negated goals
- Assumes safe negation (variables bound by positive goals)

### 3. Robust Variable Mapping 🛠️
**Before (BROKEN):**
```prolog
translate_expr(Var, PythonExpr) :-
    var(Var), !,
    PythonExpr = "fact.get('arg0')".  % ALWAYS arg0!
```

**After:**
```prolog
translate_expr(Var, VarMap, PythonExpr) :-
    var(Var), !,
    memberchk(Var-Access, VarMap),  % Look up correct mapping
    PythonExpr = Access.
```

**Implementation:**
- Added `build_variable_map/2`: Maps variables to their sources
  - `[Goal-"fact"]` → `{X: "fact.get('arg0')", Y: "fact.get('arg1')"}`
  - `[Goal1-"fact", Goal2-"other"]` → Multi-goal mapping
  - `[G1-"fact", G2-"join_1", G3-"join_2"]` → N-way mappings
- Updated all `translate_builtin` clauses to use `VarMap`
- Updated all callers to build and pass `VarMap`

**Impact:** Built-in constraints now work correctly in all contexts.

### 4. Critical Variable Identity Bug Fix 🐛
**The Bug:**
```prolog
% WRONG: nth0 unifies variables!
findall(Var-Idx1-Idx2,
    (nth0(Idx1, Args1, Var),      % Unifies Var with Args1[Idx1]
     nth0(Idx2, Args2, Var)),     % Then tries to find same value
    JoinVars)
```

This caused:
- `ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z)` → Incorrect: `other.get('arg0') == fact.get('arg0')`
- Output: `{'arg0': X, 'arg1': X}` instead of `{'arg0': X, 'arg1': Z}`

**The Fix:**
```prolog
% CORRECT: Check variable identity with ==
findall(Var-Idx1-Idx2,
    (nth0(Idx1, Args1, V1),
     nth0(Idx2, Args2, V2),
     V1 == V2,                    % Identity check!
     Var = V1),
    JoinVars)
```

**Files Fixed:**
- `translate_binary_join/6`: Join condition detection
- `translate_binary_join/6`: Output mapping
- `build_output_mapping/5`: N-way join output

**Impact:** Transitive closure and recursive joins now work correctly.

## Examples

### Transitive Closure (Now Works!)
```prolog
ancestor(X, Y) :- parent(X, Y).
ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).
```

**Generated Code:**
```python
def _apply_rule_2(fact, total):
    if fact.get('relation') == 'parent' and 'arg0' in fact and 'arg1' in fact:
        for other in total:
            if (other.get('arg0') == fact.get('arg1') and    # ✅ Correct join!
                other.get('relation') == 'ancestor'):
                yield FrozenDict.from_dict({
                    'relation': 'ancestor',
                    'arg0': fact.get('arg0'),      # X
                    'arg1': other.get('arg1')      # ✅ Z (not X!)
                })
```

### Negation Example
```prolog
eligible(X) :- applicant(X), \+ rejected(X), age(X, N), N >= 18.
```

**Works with:**
- Relation checks on all predicates
- Proper variable mapping for `N >= 18`
- Negation check for `rejected(X)`

## Testing

### Test Coverage
- ✅ All 6 existing tests pass
- ✅ New test: `negation_generator` - Verifies negation code generation
- ✅ No singleton warnings
- ✅ End-to-end: `examples/compile_family.pl` generates correct `ancestor.py`

### Files Modified
- `src/unifyweaver/targets/python_target.pl` (+~100 lines net)
  - `is_builtin_goal/1`: Added `\+`, `not`
  - `translate_builtin/3`: Added negation clauses
  - `translate_negation/3`: New predicate
  - `build_variable_map/2`: New predicate
  - `translate_expr/3`: Now takes `VarMap`
  - `translate_builtins/3`: Now takes `VarMap`
  - All rule translation: Relation checks + VarMap
  - `translate_binary_join/6`: Fixed variable identity
  - `build_output_mapping/5`: Fixed variable identity

- `tests/core/test_python_generator.pl` (+18 lines)
  - Added `negation_generator` test

- `docs/tutorials/transitive_closure_tutorial.md` (updated)
  - All code snippets show `relation` field
  - Updated JSONL examples

- `examples/parents.jsonl` (updated)
  - Added `relation: "parent"` to all records

## Migration Impact

**Backward Compatibility: ⚠️ BREAKING**

Existing JSONL input files must add `relation` field:

**Before:**
```json
{"arg0": "john", "arg1": "mary"}
```

**After:**
```json
{"relation": "parent", "arg0": "john", "arg1": "mary"}
```

Generated Python code is compatible (FrozenDict API unchanged).

## Performance
No performance regression. Minor overhead:
- Relation field check: O(1) dictionary lookup
- Additional field in FrozenDict: Negligible memory impact

## Future Work
- **Aggregation**: `count`, `sum` (requires stratification analysis)
- **Magic Sets**: Query optimization
- **Unsafe negation detection**: Warn on unbound variables in `\+`

## Related
- Base implementation: PR #XXX (Python generator mode)
- Design doc: `docs/proposals/python_generator_mode.md`
- Tutorial: `docs/tutorials/transitive_closure_tutorial.md`

---

**Why This Matters:**

Python generator mode now supports **production-ready Datalog** with:
- ✅ Multi-predicate queries (relation tracking)
- ✅ Stratified negation (closed-world semantics)
- ✅ Correct transitive closure (variable identity fix)
- ✅ Built-in constraints (robust variable mapping)