### PR TITLE
Add pearltrees preset and namespace map to XML metadata

### DIFF
--- a/docs/guides/csharp_xml_sources.md
+++ b/docs/guides/csharp_xml_sources.md
@@ -30,6 +30,7 @@ The generated plan uses `XmlStreamReader` which:
 - If your fragments carry namespaces (Pearltrees uses `pt:`), both local and `prefix:local` keys are emitted.
 - For stream-friendly files, keep one fragment per delimiter (NUL or newline). Avoid multi-line fragments when using `record_separator(line_feed)`.
 - Optional `NestedProjection=true` builds a nested dictionary (children grouped under parent keys) instead of a flat map.
+- Optional `pearltrees(true)` sets default namespace prefixes (`pt`, `dcterms`) and keeps CDATA text (e.g., titles) intact. You can also pass `namespace_prefixes([Uri-Prefix,...])` and `treat_cdata(true|false)` explicitly.
 
 ## Future: Pearltrees helper
 Pearltrees RDF exports use `pt:` plus CDATA-wrapped titles. A specialized helper could subclass the XML reader to apply Pearltrees defaults (prefix map, CDATA handling) automatically. For now, the generic reader already preserves CDATA and injects a `pt` prefix for Pearltrees namespaces; set `record_format(xml)` and a suitable delimiter. 

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -478,6 +478,7 @@ verify_xml_dynamic_source_plan_ :-
     csharp_query_target:render_plan_to_csharp(Plan, Source),
     sub_string(Source, _, _, _, 'XmlStreamReader'),
     sub_string(Source, _, _, _, 'test_xml_fragments.txt'),
+    sub_string(Source, _, _, _, 'TreatPearltreesCDataAsText = true'),
     % Validate dictionary projection picks up local + qualified keys
     maybe_run_query_runtime(Plan, [
         "_{id:1, name:Alpha, '@lang':en}",
@@ -498,6 +499,20 @@ verify_xml_nested_projection_plan_ :-
     sub_string(Source, _, _, _, 'XmlStreamReader'),
     sub_string(Source, _, _, _, 'NestedProjection = true'),
     sub_string(Source, _, _, _, 'test_xml_fragments.txt').
+
+verify_xml_pearltrees_preset_plan :-
+    setup_call_cleanup(
+        setup_xml_pearltrees_source,
+        verify_xml_pearltrees_preset_plan_(),
+        cleanup_xml_pearltrees_source
+    ).
+
+verify_xml_pearltrees_preset_plan_ :-
+    csharp_query_target:build_query_plan(test_pt_item/1, [target(csharp_query)], Plan),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'XmlStreamReader'),
+    sub_string(Source, _, _, _, 'NamespacePrefixes'),
+    sub_string(Source, _, _, _, 'TreatPearltreesCDataAsText = true').
 
 setup_csv_dynamic_source :-
     source(csv, test_users, [csv_file('test_data/test_users.csv'), has_header(true)]),
@@ -573,6 +588,20 @@ cleanup_xml_dynamic_source_nested :-
     retractall(user:test_xml_item_nested(_)),
     retractall(dynamic_source_compiler:dynamic_source_def(test_xml_items_nested/1, _, _)),
     retractall(dynamic_source_compiler:dynamic_source_metadata(test_xml_items_nested/1, _)).
+
+setup_xml_pearltrees_source :-
+    source(xml, test_pt_items, [
+        file('test_data/test_xml_fragments.txt'),
+        record_format(xml),
+        record_separator(line_feed),
+        pearltrees(true)
+    ]),
+    assertz(user:(test_pt_item(Row) :- test_pt_items(Row))).
+
+cleanup_xml_pearltrees_source :-
+    retractall(user:test_pt_item(_)),
+    retractall(dynamic_source_compiler:dynamic_source_def(test_pt_items/1, _, _)),
+    retractall(dynamic_source_compiler:dynamic_source_metadata(test_pt_items/1, _)).
 
 cleanup_json_schema_source :-
     retractall(user:test_product_record(_)),


### PR DESCRIPTION
Introduce a pearltrees(true) option that injects default prefixes and CDATA handling into XML metadata, pass namespace maps/CDATa flags through to XmlStreamReader in generated C#, add a plan test for the pearltrees preset, and document the new options in the C# XML guide.