### PR TITLE
Add C# XML fragments playbook

### DIFF
--- a/playbooks/csharp_xml_fragments_playbook.md
+++ b/playbooks/csharp_xml_fragments_playbook.md
@@ -1,0 +1,34 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# C# XML Fragments Playbook
+
+This playbook shows how to stream XML fragments into the C# query runtime using `XmlStreamReader`.
+
+## Inputs
+- `record_format(xml)` with fragments separated by NUL or LF
+- Optional: `pearltrees(true)` to set `pt`/`dcterms` prefixes and keep CDATA text
+- Optional: `namespace_prefixes([Uri-Prefix,...])`, `treat_cdata(true|false)`, `nested_projection(true)` for nested dictionaries
+
+## Steps (Prolog)
+```prolog
+:- source(xml, xml_rows, [
+    file('test_data/test_xml_fragments.txt'),
+    record_format(xml),
+    record_separator(line_feed),
+    pearltrees(true)         % default prefixes and CDATA handling
+]).
+
+:- dynamic_source(xml_row/1, xml_rows, []).
+```
+
+## What the C# plan emits
+- `XmlStreamReader` with `NamespacePrefixes` and `TreatPearltreesCDataAsText = true`
+- Keys for local, qualified, and prefix forms (e.g., `title`, `pt:title`, `http://...# : title`)
+- Attributes under `@prefix:name` (e.g., `@pt:code`)
+
+## Notes
+- Keep one fragment per delimiter (NUL or newline) for streaming.
+- CDATA content (e.g., pearltrees titles) is preserved as text.
+- Set `nested_projection(true)` if you want nested dictionaries instead of a flat map.

--- a/playbooks/examples_library/csharp_examples.md
+++ b/playbooks/examples_library/csharp_examples.md
@@ -119,3 +119,5 @@ Write-Host "Success: C# program compiled and executed successfully."
 ```
 - `unifyweaver.execution.csharp_json_schema` — Generate typed JSON queries from schema hints.
 - `unifyweaver.execution.csharp_xml_fragments` — Read NUL/LF-delimited XML fragments via XmlStreamReader, projecting elements/attributes (prefix + qualified keys) into rows.
+
+- `unifyweaver.execution.csharp_xml_fragments_playbook` — Playbook for streaming XML fragments (pearltrees preset, prefixes/CDATa defaults).


### PR DESCRIPTION
Document how to stream XML fragments into the C# query runtime (XmlStreamReader), including pearltrees defaults, namespace/CDATa options, and nested projection; register the playbook in the C# examples library.