### PR TITLE
Add semantic seed selection with type filtering for focused crawling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,11 @@ tmp/
 
 # Downloaded libraries (use setup scripts to install)
 lib/
+
+# ONNX models (download locally, too large for git)
+models/
+
+# LiteDB databases (test artifacts)
+*.db
+*.db-shm
+*.db-wal

--- a/src/unifyweaver/targets/csharp_query_runtime/PtHarness.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/PtHarness.cs
@@ -35,5 +35,49 @@ namespace UnifyWeaver.QueryRuntime
             using var crawler = new PtCrawler(dbPath, config, embeddingProvider);
             crawler.IngestOnce(emitEmbeddings);
         }
+
+        /// <summary>
+        /// Perform semantic-driven fixed-point crawl: use semantic search to find relevant starting points,
+        /// then crawl through their children to build a focused subset of the knowledge graph.
+        /// </summary>
+        /// <param name="seedQuery">Semantic query to find starting points (e.g., "physics quantum mechanics")</param>
+        /// <param name="sourceDb">Database path containing indexed documents with embeddings</param>
+        /// <param name="targetDb">Database path for the crawled subset</param>
+        /// <param name="embeddingProvider">Embedding provider for semantic search</param>
+        /// <param name="fetchConfig">Function to create XmlSourceConfig for fetching document by ID</param>
+        /// <param name="topSeeds">Number of seed documents to start from (default 100)</param>
+        /// <param name="minScore">Minimum similarity score for seeds (default 0.5)</param>
+        /// <param name="maxDepth">Maximum crawl depth from seeds (default 3)</param>
+        public static void RunSemanticCrawl(
+            string seedQuery,
+            string sourceDb,
+            string targetDb,
+            IEmbeddingProvider embeddingProvider,
+            Func<string, XmlSourceConfig> fetchConfig,
+            int topSeeds = 100,
+            double minScore = 0.5,
+            int maxDepth = 3)
+        {
+            // Use semantic search to find seed IDs
+            List<string> seeds;
+            using (var searcher = new PtSearcher(sourceDb, embeddingProvider))
+            {
+                Console.WriteLine($"Finding seeds via semantic search: \"{seedQuery}\"");
+                seeds = searcher.GetSeedIds(seedQuery, topSeeds, minScore);
+                Console.WriteLine($"Found {seeds.Count} seed documents (minScore >= {minScore})");
+            }
+
+            if (seeds.Count == 0)
+            {
+                Console.WriteLine("No seeds found - try lowering minScore or using a different query");
+                return;
+            }
+
+            // Crawl from the semantic seeds
+            Console.WriteLine($"Starting fixed-point crawl from {seeds.Count} seeds (maxDepth={maxDepth})...");
+            using var crawler = new PtCrawler(targetDb, fetchConfig(seeds[0]), embeddingProvider);
+            crawler.FixedPoint(seeds, fetchConfig, maxDepth);
+            Console.WriteLine("Semantic crawl complete");
+        }
     }
 }

--- a/src/unifyweaver/targets/csharp_query_runtime/PtHarness.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/PtHarness.cs
@@ -48,6 +48,7 @@ namespace UnifyWeaver.QueryRuntime
         /// <param name="topSeeds">Number of seed documents to start from (default 100)</param>
         /// <param name="minScore">Minimum similarity score for seeds (default 0.5)</param>
         /// <param name="maxDepth">Maximum crawl depth from seeds (default 3)</param>
+        /// <param name="typeFilter">Optional type filter for seeds (e.g., "pt:Tree" for trees only, null for all types)</param>
         public static void RunSemanticCrawl(
             string seedQuery,
             string sourceDb,
@@ -56,14 +57,16 @@ namespace UnifyWeaver.QueryRuntime
             Func<string, XmlSourceConfig> fetchConfig,
             int topSeeds = 100,
             double minScore = 0.5,
-            int maxDepth = 3)
+            int maxDepth = 3,
+            string? typeFilter = null)
         {
             // Use semantic search to find seed IDs
             List<string> seeds;
             using (var searcher = new PtSearcher(sourceDb, embeddingProvider))
             {
-                Console.WriteLine($"Finding seeds via semantic search: \"{seedQuery}\"");
-                seeds = searcher.GetSeedIds(seedQuery, topSeeds, minScore);
+                var filterDesc = typeFilter != null ? $" (type: {typeFilter})" : "";
+                Console.WriteLine($"Finding seeds via semantic search: \"{seedQuery}\"{filterDesc}");
+                seeds = searcher.GetSeedIds(seedQuery, topSeeds, minScore, typeFilter);
                 Console.WriteLine($"Found {seeds.Count} seed documents (minScore >= {minScore})");
             }
 

--- a/src/unifyweaver/targets/csharp_query_runtime/PtSearcher.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/PtSearcher.cs
@@ -30,6 +30,21 @@ namespace UnifyWeaver.QueryRuntime
         public void Dispose() => _db?.Dispose();
 
         /// <summary>
+        /// Get document IDs for use as crawler seeds based on semantic search.
+        /// Useful for focused crawling: find relevant starting points, then crawl their children.
+        /// Example: GetSeedIds("physics quantum mechanics", 100) → Top 100 physics-related IDs
+        /// </summary>
+        /// <param name="query">Semantic query describing desired topic</param>
+        /// <param name="topK">Number of seed IDs to return (default 100)</param>
+        /// <param name="minScore">Minimum similarity score (0-1, default 0.5 for quality seeds)</param>
+        /// <returns>List of document IDs ranked by relevance</returns>
+        public List<string> GetSeedIds(string query, int topK = 100, double minScore = 0.5)
+        {
+            var results = SearchSimilar(query, topK, minScore);
+            return results.Select(r => r.Id).ToList();
+        }
+
+        /// <summary>
         /// Search for documents similar to the query text.
         /// </summary>
         /// <param name="query">Search query text</param>

--- a/src/unifyweaver/targets/csharp_query_runtime/PtSearcher.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/PtSearcher.cs
@@ -37,10 +37,11 @@ namespace UnifyWeaver.QueryRuntime
         /// <param name="query">Semantic query describing desired topic</param>
         /// <param name="topK">Number of seed IDs to return (default 100)</param>
         /// <param name="minScore">Minimum similarity score (0-1, default 0.5 for quality seeds)</param>
+        /// <param name="typeFilter">Optional type filter (e.g., "pt:Tree" for trees only, null for all types)</param>
         /// <returns>List of document IDs ranked by relevance</returns>
-        public List<string> GetSeedIds(string query, int topK = 100, double minScore = 0.5)
+        public List<string> GetSeedIds(string query, int topK = 100, double minScore = 0.5, string? typeFilter = null)
         {
-            var results = SearchSimilar(query, topK, minScore);
+            var results = SearchSimilar(query, topK, minScore, typeFilter);
             return results.Select(r => r.Id).ToList();
         }
 
@@ -50,8 +51,9 @@ namespace UnifyWeaver.QueryRuntime
         /// <param name="query">Search query text</param>
         /// <param name="topK">Number of results to return (default 10)</param>
         /// <param name="minScore">Minimum similarity score (0-1, default 0.0)</param>
+        /// <param name="typeFilter">Optional type filter (e.g., "pt:Tree" to return only trees, null for all types)</param>
         /// <returns>List of search results with scores</returns>
-        public List<SearchResult> SearchSimilar(string query, int topK = 10, double minScore = 0.0)
+        public List<SearchResult> SearchSimilar(string query, int topK = 10, double minScore = 0.0, string? typeFilter = null)
         {
             if (string.IsNullOrWhiteSpace(query))
             {
@@ -76,6 +78,13 @@ namespace UnifyWeaver.QueryRuntime
                 {
                     // Look up the actual document
                     var entity = GetEntity(id);
+
+                    // Apply type filter if specified
+                    if (typeFilter != null && entity?.Type != typeFilter)
+                    {
+                        continue;
+                    }
+
                     results.Add(new SearchResult
                     {
                         Id = id,


### PR DESCRIPTION
## Overview

  Enables **automatic discovery of crawler starting points** using natural language queries instead of manual ID
  specification. Addresses the problem of building focused subsets from large knowledge graphs when you don't know which
  document IDs are relevant.

  ## Key Features

  ### 1. Semantic Seed Selection
  Use natural language to find crawler starting points:

  ```csharp
  var seeds = searcher.GetSeedIds(
      query: "quantum mechanics physics",
      topK: 100,
      minScore: 0.5
  );
  // Returns: ["physics-001", "quantum-042", ...] - top 100 physics-related IDs

  2. Type Filtering for Diverse Coverage

  Filter by document type to avoid clustering seeds within the same organizational nodes:

  var seeds = searcher.GetSeedIds(
      query: "physics",
      topK: 100,
      minScore: 0.5,
      typeFilter: "pt:Tree"  // Only trees, exclude pearls
  );

  Why this matters: Without type filtering, you might get 50 pearls all belonging to the same 5 trees (redundant starting
  points). With tree filtering, you get 50 distinct organizational nodes, ensuring broad graph coverage.

  3. End-to-End Semantic Crawling

  PtHarness.RunSemanticCrawl() combines semantic search with fixed-point crawling:

  PtHarness.RunSemanticCrawl(
      seedQuery: "physics",
      sourceDb: "full_database.db",      // 11,867 documents
      targetDb: "physics_subset.db",     // Focused output
      embeddingProvider: embeddingProvider,
      fetchConfig: id => configForId(id),
      topSeeds: 100,
      minScore: 0.5,
      maxDepth: 3,
      typeFilter: "pt:Tree"  // Diverse starting points
  );

  Implementation

  New APIs:
  - PtSearcher.GetSeedIds() - Extract document IDs from semantic search results
  - PtSearcher.SearchSimilar() with typeFilter - Filter results by document type
  - PtHarness.RunSemanticCrawl() - Semantic search → type filter → seed selection → crawl

  Files Changed:
  - src/unifyweaver/targets/csharp_query_runtime/PtSearcher.cs - Added GetSeedIds() and type filtering
  - src/unifyweaver/targets/csharp_query_runtime/PtHarness.cs - Added RunSemanticCrawl()
  - playbooks/examples_library/litedb_xml_fixedpoint_examples.md - Comprehensive documentation
  - .gitignore - Exclude ONNX models and LiteDB test files

  Test Results

  Successfully tested with all-MiniLM-L6-v2 embeddings:

  === Semantic Crawl Demo ===
  Finding seeds via semantic search: "quantum mechanics physics" (type: pt:Tree)
  Found 2 seed documents (minScore >= 0.3)
  Starting fixed-point crawl from 2 seeds (maxDepth=2)...
  Semantic crawl complete
  Semantic crawl result: 3 documents in physics-focused subset
  SEMANTIC_CRAWL_OK

  Type filtering successfully excluded pearls, selecting only trees for diverse coverage.

  Use Cases

  1. Domain-Specific Subsets: Extract ML/AI content from general knowledge graph via "machine learning artificial
  intelligence" query
  2. Exploratory Research: Find documents related to "transformer neural networks" and their connections
  3. Data Filtering: Build clean subsets before sharing (exclude sensitive topics)
  4. Focused Crawling: Start with high-quality semantic seeds, expand through graph relationships

  Documentation

  Added comprehensive documentation covering:
  - API reference with examples
  - Type filtering rationale and benefits
  - Performance characteristics
  - Real-world use cases
  - Comparison: manual vs semantic seed selection

  ---
  Before: var seeds = new[] { "physics-001", "physics-002" }; ❌ Manual, incomplete, tedious

  After: var seeds = searcher.GetSeedIds("physics", topK: 100, typeFilter: "pt:Tree"); ✅ Automatic, comprehensive, diverse