### PR TITLE
feat(sources): Native SQLite Source Plugin

### DIFF
--- a/PR_SQLITE_SOURCE.md
+++ b/PR_SQLITE_SOURCE.md
@@ -1,0 +1,21 @@
+# feat(sources): Native SQLite Source Plugin
+
+## Summary
+This PR adds a new `source(sqlite, ...)` plugin that enables UnifyWeaver to query SQLite databases directly using the `sqlite3` command-line tool. This provides a performant, language-agnostic way to ingest data from SQLite into the UnifyWeaver pipeline without requiring a Python wrapper.
+
+## Changes
+- **`sqlite_source.pl`**: Implements the source compiler. Generates Bash code that invokes `sqlite3`.
+- **`sources.pl`**: Registers the `sqlite` source type and validates options.
+- **Tests**: Added `tests/core/test_sqlite_source.pl`.
+
+## Usage
+```prolog
+:- source(sqlite, users, [
+    sqlite_file('data.db'),
+    query('SELECT name, age FROM users WHERE active = 1'),
+    output_format(tsv)
+]).
+```
+
+## Dependencies
+- `sqlite3` (CLI tool) must be installed.

--- a/PR_SQLITE_SOURCE.md
+++ b/PR_SQLITE_SOURCE.md
@@ -7,6 +7,7 @@ This PR adds a new `source(sqlite, ...)` plugin that enables UnifyWeaver to quer
 - **`sqlite_source.pl`**: Implements the source compiler. Generates Bash code that invokes `sqlite3`.
 - **`sources.pl`**: Registers the `sqlite` source type and validates options.
 - **Tests**: Added `tests/core/test_sqlite_source.pl`.
+- **Documentation**: Updated `README.md` and `docs/EXTENDED_README.md`.
 
 ## Usage
 ```prolog

--- a/README.md
+++ b/README.md
@@ -214,11 +214,31 @@ sibling(X, Y)     % Same parent, different children
     cache_duration(3600)
 ]).
 
-% Python with SQLite
-:- source(python, get_users, [
-    sqlite_query('SELECT name, age FROM users WHERE active = 1'),
-    database('app.db')
+% Python with SQLite                             
+
+:- source(python, get_users, [                   
+
+    sqlite_query('SELECT name, age FROM users WHE
+
+RE active = 1'),                                 
+
+    database('app.db')                           
+
+]).                                              
+
+
+
+% Native SQLite (v0.2)
+
+:- source(sqlite, active_users, [
+
+    sqlite_file('app.db'),
+
+    query('SELECT name, age FROM users WHERE active = 1')
+
 ]).
+
+
 
 % JSON processing with jq                        
 :- source(json, extract_names, [                 

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -715,6 +715,25 @@ PYTHON_EOF
 }
 ```
 
+### SQLite Plugin (Native)
+
+Query SQLite databases directly using the `sqlite3` command-line tool (faster than Python wrapper for simple queries):
+
+```prolog
+:- source(sqlite, high_value_orders, [
+    sqlite_file('data/orders.db'),
+    query('SELECT id, total FROM orders WHERE total > 1000'),
+    output_format(tsv)
+]).
+```
+
+**Generated bash:**
+```bash
+high_value_orders() {
+    sqlite3 -separator '	' -noheader "data/orders.db" "SELECT id, total FROM orders WHERE total > 1000"
+}
+```
+
 ### C# Plugin (LiteDB Integration)
 
 UnifyWeaver supports C# data sources with automatic compilation and LiteDB integration.

--- a/src/unifyweaver/sources.pl
+++ b/src/unifyweaver/sources.pl
@@ -78,9 +78,18 @@ augment_source_options(Type, Options, Augmented) :-
     ->  augment_json_options(Options, Augmented)
     ;   Type = yaml
     ->  augment_yaml_options(Options, Augmented)
+    ;   Type = sqlite
+    ->  augment_sqlite_options(Options, Augmented)
     ;   Type = xml
     ->  augment_xml_options(Options, Augmented)
     ;   Augmented = Options
+    ).
+
+augment_sqlite_options(Options0, Options) :-
+    (   option(sqlite_file(File), Options0)
+    ->  absolute_file_name(File, Abs),
+        ensure_option(input(file(Abs)), Options0, Options)
+    ;   Options = Options0
     ).
 
 augment_yaml_options(Options0, Options) :-

--- a/src/unifyweaver/sources/sqlite_source.pl
+++ b/src/unifyweaver/sources/sqlite_source.pl
@@ -1,0 +1,107 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% sqlite_source.pl - SQLite source plugin for dynamic sources
+% Compiles predicates that read data from SQLite databases using sqlite3 CLI
+
+:- module(sqlite_source, []).
+
+:- use_module(library(lists)).
+:- use_module('../core/template_system').
+:- use_module('../core/dynamic_source_compiler').
+
+%% Register this plugin on load
+:- initialization(
+    register_source_type(sqlite, sqlite_source),
+    now
+).
+
+%% ============================================ 
+%% PLUGIN INTERFACE
+%% ============================================ 
+
+source_info(info(
+    name('SQLite Source'),
+    version('1.0.0'),
+    description('Query SQLite databases using sqlite3 command line tool'),
+    supported_arities([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+)).
+
+validate_config(Config) :-
+    (   member(sqlite_file(File), Config)
+    ->  (
+            exists_file(File)
+        ->  true
+        ;   format('Warning: SQLite file ~w does not exist~n', [File])
+        )
+    ;   format('Error: SQLite source requires sqlite_file(File)~n', []),
+        fail
+    ),
+    
+    (   member(query(_), Config)
+    ->  true
+    ;   format('Error: SQLite source requires query(SQL)~n', []),
+        fail
+    ).
+
+compile_source(Pred/Arity, Config, Options, BashCode) :-
+    format('  Compiling SQLite source: ~w/~w~n', [Pred, Arity]),
+    
+    validate_config(Config),
+    append(Config, Options, AllOptions),
+    
+    member(sqlite_file(DbFile), AllOptions),
+    member(query(Query), AllOptions),
+    
+    % Output format
+    (   member(output_format(Format), AllOptions)
+    ->  true
+    ;   Format = tsv
+    ),
+    
+    % Determine delimiter based on format
+    (   Format == tsv -> Separator = '\t'
+    ;   Format == csv -> Separator = ','
+    ;   Format == list -> Separator = '|'
+    ;   Separator = ':' % Default
+    ),
+    
+    atom_string(Pred, PredStr),
+    
+    render_named_template(sqlite_cli_source,
+        [
+            pred=PredStr,
+            db_file=DbFile,
+            query=Query,
+            separator=Separator
+        ],
+        [source_order([file, generated])],
+        BashCode).
+
+%% ============================================ 
+%% TEMPLATES
+%% ============================================ 
+
+:- multifile template_system:template/2.
+
+template_system:template(sqlite_cli_source, '#!/bin/bash
+# {{pred}} - SQLite source ({{db_file}})
+
+{{pred}}() {
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        echo "Error: sqlite3 is required for {{pred}}" >&2
+        return 1
+    fi
+    
+    sqlite3 -separator ''{{separator}}'' -noheader "{{db_file}}" "{{query}}"
+}
+
+{{pred}}_stream() {
+    {{pred}}
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    {{pred}} "$@"
+fi
+').

--- a/tests/core/test_sqlite_source.pl
+++ b/tests/core/test_sqlite_source.pl
@@ -1,0 +1,57 @@
+:- module(test_sqlite_source, [run_tests/0]).
+
+:- use_module(library(plunit)).
+:- use_module(src/unifyweaver/sources/sqlite_source).
+:- use_module(library(process)).
+
+run_tests :- 
+    run_tests([sqlite_source]).
+
+:- begin_tests(sqlite_source).
+
+test(basic_query) :-
+    DbFile = 'test.db',
+    (   path_to_sqlite(Sqlite)
+    ->  setup_db(Sqlite, DbFile),
+        
+        sqlite_source:compile_source(get_users/2, [
+            sqlite_file(DbFile),
+            query('SELECT name, age FROM users')
+        ], [], BashCode),
+        
+        % Write script
+        Script = 'run_sqlite.sh',
+        setup_call_cleanup(
+            open(Script, write, S),
+            write(S, BashCode),
+            close(S)
+        ),
+        
+        % Run script
+        setup_call_cleanup(
+            process_create(path(bash), [Script], [stdout(pipe(Out)), process(PID)]),
+            (
+                read_string(Out, _, Output),
+                process_wait(PID, ExitStatus),
+                assertion(ExitStatus == exit(0))
+            ),
+            close(Out)
+        ),
+        
+        % Verify output (tsv default)
+        split_string(Output, "\n", "", Lines),
+        assertion(member("alice\t30", Lines)),
+        assertion(member("bob\t25", Lines)),
+        
+        delete_file(Script),
+        delete_file(DbFile)
+    ;   true
+    ).
+
+setup_db(Sqlite, DbFile) :-
+    process_create(Sqlite, [DbFile, "CREATE TABLE users (name TEXT, age INTEGER); INSERT INTO users VALUES ('alice', 30); INSERT INTO users VALUES ('bob', 25);"], []).
+
+path_to_sqlite(path(sqlite3)) :-
+    catch(process_create(path(sqlite3), ['--version'], [stdout(null)]), _, fail).
+
+:- end_tests(sqlite_source).


### PR DESCRIPTION
## Summary
This PR adds a new `source(sqlite, ...)` plugin that enables UnifyWeaver to query SQLite databases directly using the `sqlite3` command-line tool. This provides a performant, language-agnostic way to ingest data from SQLite into the UnifyWeaver pipeline without requiring a Python wrapper.

## Changes
- **`sqlite_source.pl`**: Implements the source compiler. Generates Bash code that invokes `sqlite3`.
- **`sources.pl`**: Registers the `sqlite` source type and validates options.
- **Tests**: Added `tests/core/test_sqlite_source.pl`.
- **Documentation**: Updated `README.md` and `docs/EXTENDED_README.md`.

## Usage
```prolog
:- source(sqlite, users, [
    sqlite_file('data.db'),
    query('SELECT name, age FROM users WHERE active = 1'),
    output_format(tsv)
]).
```

## Dependencies
- `sqlite3` (CLI tool) must be installed.