### PR TITLE
feat(go): Compile Semantic Predicates (Crawler/Search)

### DIFF
--- a/PR_GO_CRAWLER.md
+++ b/PR_GO_CRAWLER.md
@@ -1,0 +1,28 @@
+# feat(go): Compile Semantic Predicates (Crawler/Search)
+
+## Summary
+This PR integrates the Semantic Runtime into the Go compiler (`go_target.pl`), enabling the translation of `semantic_search/3` and `crawler_run/2` predicates into valid Go code that utilizes the `hugot` (embedding) and `bbolt` (storage) based runtime library.
+
+## Changes
+- **`go_target.pl`**:
+    - Implemented `compile_semantic_rule_go` to generate `main()` logic for semantic operations.
+    - Added `crawler_run` logic to initialize `PtCrawler` and start crawling.
+    - Added `semantic_search` logic to embed query and search vector store.
+    - Ensure necessary imports (`unifyweaver/targets/go_runtime/...`) are generated.
+- **Tests**:
+    - Updated `tests/core/test_go_semantic_compilation.pl` to verify `crawler_run` compilation.
+
+## Usage
+```prolog
+run_crawler :- crawler_run(['http://example.com'], 3).
+```
+
+Compiles to:
+```go
+// ... imports ...
+func main() {
+    // ... init store/embedder ...
+    craw := crawler.NewCrawler(store, emb)
+    craw.Crawl([]string{"http://example.com"}, int(3))
+}
+```

--- a/tests/core/test_go_semantic_compilation.pl
+++ b/tests/core/test_go_semantic_compilation.pl
@@ -26,5 +26,20 @@ test(go_semantic_search) :-
     
     retractall(user:search_go(_)).
 
+test(go_crawler_run) :-
+    retractall(user:run_crawl_const),
+    assertz((user:run_crawl_const :- crawler_run(['http://example.com'], 3))),
+    
+    compile_predicate_to_go(user:run_crawl_const/0, [], Code),
+    
+    % Check imports
+    sub_string(Code, _, _, _, "unifyweaver/targets/go_runtime/crawler"),
+    
+    % Check logic
+    sub_string(Code, _, _, _, "crawler.NewCrawler"),
+    sub_string(Code, _, _, _, "craw.Crawl([]string{\"http://example.com\"}, int(3))"),
+    
+    retractall(user:run_crawl_const).
+
 :- end_tests(go_semantic_compilation).
 


### PR DESCRIPTION
## Summary
This PR integrates the Semantic Runtime into the Go compiler (`go_target.pl`), enabling the translation of `semantic_search/3` and `crawler_run/2` predicates into valid Go code that utilizes the `hugot` (embedding) and `bbolt` (storage) based runtime library.

## Changes
- **`go_target.pl`**:
    - Implemented `compile_semantic_rule_go` to generate `main()` logic for semantic operations.
    - Added `crawler_run` logic to initialize `PtCrawler` and start crawling.
    - Added `semantic_search` logic to embed query and search vector store.
    - Ensure necessary imports (`unifyweaver/targets/go_runtime/...`) are generated.
- **Tests**:
    - Updated `tests/core/test_go_semantic_compilation.pl` to verify `crawler_run` compilation.

## Usage
```prolog
run_crawler :- crawler_run(['http://example.com'], 3).
```

Compiles to:
```go
// ... imports ...
func main() {
    // ... init store/embedder ...
    craw := crawler.NewCrawler(store, emb)
    craw.Crawl([]string{"http://example.com"}, int(3))
}
```
