### PR TITLE
feat(python): Semantic Playbook & Runtime Fixes

### DIFF
--- a/PR_SEMANTIC_PLAYBOOK.md
+++ b/PR_SEMANTIC_PLAYBOOK.md
@@ -1,0 +1,16 @@
+# feat(python): Semantic Playbook & Runtime Fixes
+
+## Summary
+This PR validates the Python Semantic Runtime with a real-world playbook (`examples/semantic_playbook.pl`) that indexes and searches an RDF export from Pearltrees. It includes critical fixes to the XML flattening logic and ONNX runtime configuration to ensure stability on constrained environments (e.g., Termux).
+
+## Changes
+- **Playbook:** Added `semantic_playbook.pl` and `run_semantic_demo.sh` to demonstrate end-to-end indexing and search.
+- **Runtime Fixes:**
+    - `crawler.py`: Fixed logic to preserve child elements (e.g., titles) when processing parent nodes, ensuring data is not lost before embedding.
+    - `onnx_embedding.py`: Explicitly request `CPUExecutionProvider` to improve compatibility.
+    - `python_target.pl`: Added atomic assignment support (`Var = Atom`) and fixed regex escaping for runtime inlining.
+
+## Usage
+```bash
+./examples/run_semantic_demo.sh
+```

--- a/examples/run_semantic_demo.sh
+++ b/examples/run_semantic_demo.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Ensure we are in the project root
+cd "$(dirname "$0")/.."
+
+echo "1. Generating Python scripts..."
+swipl -g main -t halt examples/semantic_playbook.pl
+
+echo "2. Running Indexer (Parsing & Embedding)..."
+# Check if model exists
+if [ ! -f models/model.onnx ]; then
+    echo "Model not found. Please run 'curl ...' (see previous steps) or expect failure."
+    # Attempt download if missing?
+    mkdir -p models
+    curl -L -o models/model.onnx https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx
+    curl -L -o models/vocab.txt https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/vocab.txt
+fi
+
+echo "{}" | python3 run_index.py
+
+echo "3. Running Search..."
+echo "{}" | python3 run_search.py | head -n 5
+
+echo "Done."

--- a/examples/semantic_playbook.pl
+++ b/examples/semantic_playbook.pl
@@ -1,0 +1,44 @@
+:- module(semantic_playbook, [main/0]).
+:- use_module('../src/unifyweaver/targets/python_target').
+
+% Define indexing logic
+index_pt(_) :-
+    % Use the actual RDF file path
+    File = 'context/PT/pearltrees_export.rdf',
+    crawler_run([File], 1).
+
+% Define search logic (generic)
+% This predicate expects Query to be passed, but our compiler 
+% currently compiles static logic or reads from stdin.
+% To make a dynamic search tool, we'd read Query from stdin.
+% For this playbook, we'll compile a hardcoded query for demonstration.
+
+% Helper to compile the indexer
+compile_indexer :-
+    format('Compiling indexer...~n', []),
+    compile_predicate_to_python(semantic_playbook:index_pt/1, [mode(procedural)], Code),
+    setup_call_cleanup(
+        open('run_index.py', write, S),
+        write(S, Code),
+        close(S)
+    ),
+    format('Generated run_index.py~n', []).
+
+% Helper to compile a searcher for a specific topic
+compile_searcher(Topic) :-
+    format('Compiling searcher for "~w"...~n', [Topic]),
+    % Dynamic clause generation
+    Term = (search_topic(Results) :- semantic_search(Topic, 5, Results)),
+    assertz(user:Term),
+    compile_predicate_to_python(user:search_topic/1, [mode(procedural)], Code),
+    setup_call_cleanup(
+        open('run_search.py', write, S),
+        write(S, Code),
+        close(S)
+    ),
+    retractall(user:search_topic(_)),
+    format('Generated run_search.py~n', []).
+
+main :-
+    compile_indexer,
+    compile_searcher('physics').

--- a/src/unifyweaver/targets/python_runtime/onnx_embedding.py
+++ b/src/unifyweaver/targets/python_runtime/onnx_embedding.py
@@ -12,7 +12,12 @@ class OnnxEmbeddingProvider(IEmbeddingProvider):
     def __init__(self, model_path, vocab_path):
         if not ort:
             raise ImportError("onnxruntime not installed")
-        self.sess = ort.InferenceSession(model_path)
+        try:
+            self.sess = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+        except Exception:
+            # Fallback if specific provider fails or API differs
+            self.sess = ort.InferenceSession(model_path)
+            
         self.vocab = self._load_vocab(vocab_path)
         self.cls_token_id = 101
         self.sep_token_id = 102

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -423,6 +423,13 @@ translate_goal(=(Var, Dict), Code) :-
     atomic_list_concat(PyPairList, ', ', PairsStr),
     format(string(Code), "    ~w = {~s}\n", [PyVar, PairsStr]).
 
+translate_goal(=(Var, Value), Code) :-
+    atomic(Value),
+    !,
+    var_to_python(Var, PyVar),
+    var_to_python(Value, PyVal),
+    format(string(Code), "    ~w = ~w\n", [PyVar, PyVal]).
+
 translate_goal(>(Var, Value), Code) :-
     !,
     var_to_python(Var, PyVar),
@@ -523,6 +530,12 @@ var_to_python(Atom, Quoted) :-
 var_to_python(Number, Number) :- 
     number(Number), 
     !.
+var_to_python(List, PyList) :-
+    is_list(List),
+    !,
+    maplist(var_to_python, List, Elems),
+    atomic_list_concat(Elems, ', ', Inner),
+    format(string(PyList), "[~w]", [Inner]).
 var_to_python(Term, String) :-
     term_string(Term, String).
 
@@ -1968,7 +1981,7 @@ semantic_runtime_helpers(Code) :-
         (   exists_file(File)
         ->  read_file_to_string(File, Raw, []),
             % Remove relative imports 'from .embedding import'
-            re_replace("from \\\\.embedding import.*", "", Raw, Content)
+            re_replace("from \\.embedding import.*", "", Raw, Content)
         ;   format(string(Content), "# ERROR: Runtime file ~w not found\\n", [File])
         )
     ), Contents),


### PR DESCRIPTION
## Summary
This PR validates the Python Semantic Runtime with a real-world playbook (`examples/semantic_playbook.pl`) that indexes and searches an RDF export from Pearltrees. It includes critical fixes to the XML flattening logic and ONNX runtime configuration to ensure stability on constrained environments (e.g., Termux).

## Changes
- **Playbook:** Added `semantic_playbook.pl` and `run_semantic_demo.sh` to demonstrate end-to-end indexing and search.
- **Runtime Fixes:**
    - `crawler.py`: Fixed logic to preserve child elements (e.g., titles) when processing parent nodes, ensuring data is not lost before embedding.
    - `onnx_embedding.py`: Explicitly request `CPUExecutionProvider` to improve compatibility.
    - `python_target.pl`: Added atomic assignment support (`Var = Atom`) and fixed regex escaping for runtime inlining.

## Usage
```bash
./examples/run_semantic_demo.sh
```
