### PR TITLE
Add C# generator dependency-group integration test and fix duplicate assignments

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1673,7 +1673,7 @@ compile_joins([], Builtins, Head, FirstGoal, Config, Code) :-
     % Build output
     findall(Assign,
         (   nth0(I, HeadArgs, Arg),
-            (   var(Arg),
+            (   var(Arg) ->
                 (   find_var_access(Arg, AccumPairs, Src, SrcIdx)
                 ->  format(user_output, 'DEBUG output arg ~w uses ~w arg~w~n', [Arg, Src, SrcIdx]),
                     format(string(Assign), "{ \"arg~w\", ~w[\"arg~w\"] }", [I, Src, SrcIdx])
@@ -1713,9 +1713,11 @@ compile_nway_join([], Builtins, Head, AccumPairs, Config, _, Code) :-
     % Build output
     findall(Assign,
         (   nth0(I, HeadArgs, Arg),
-            (   var(Arg),
-                find_var_access(Arg, AccumPairs, Src, SrcIdx)
-            ->  format(string(Assign), "{ \"arg~w\", ~w[\"arg~w\"] }", [I, Src, SrcIdx])
+            (   var(Arg) ->
+                (   find_var_access(Arg, AccumPairs, Src, SrcIdx)
+                ->  format(string(Assign), "{ \"arg~w\", ~w[\"arg~w\"] }", [I, Src, SrcIdx])
+                ;   fail
+                )
             ;   translate_expr_common(Arg, VarMap, Config, Expr)
             ->  format(string(Assign), "{ \"arg~w\", ~w }", [I, Expr])
             ;   format(string(Assign), "{ \"arg~w\", \"~w\" }", [I, Arg])

--- a/tests/core/test_csharp_generator_janus.pl
+++ b/tests/core/test_csharp_generator_janus.pl
@@ -1,0 +1,103 @@
+/**
+ * C# Generator Target Tests (dependency groups) using Janus Bridge
+ *
+ * Compiles generator-mode C# for a dependency group and runs the produced
+ * program via the Python helper. Requires dotnet CLI, Python, and Janus.
+ */
+
+:- module(test_csharp_generator_janus, [
+    test_csharp_generator_dep_group/0
+]).
+
+:- use_module(library(plunit)).
+:- use_module(library(janus)).
+
+:- dynamic python_helper_ready/0.
+%% test_file_dir(-Dir)
+%  Directory of this test file.
+test_file_dir(Dir) :-
+    absolute_file_name('tests/core', Dir, [file_type(directory)]).
+
+%% setup_paths_and_python/0
+%  Ensure library paths and Python helper are available, then load csharp_target.
+setup_paths_and_python :-
+    test_file_dir(Dir),
+    absolute_file_name('../../src/unifyweaver/targets', TargetDir,
+                       [relative_to(Dir), file_type(directory)]),
+    (   user:file_search_path(library, TargetDir)
+    ->  true
+    ;   asserta(user:file_search_path(library, TargetDir))
+    ),
+    absolute_file_name('../../src/unifyweaver/core', CoreDir,
+                       [relative_to(Dir), file_type(directory)]),
+    (   user:file_search_path(library, CoreDir)
+    ->  true
+    ;   asserta(user:file_search_path(library, CoreDir))
+    ),
+    ensure_python_helper(Dir),
+    use_module(library(csharp_target)).
+
+ensure_python_helper(_Dir) :-
+    python_helper_ready, !.
+ensure_python_helper(Dir) :-
+    absolute_file_name('../helpers', HelpersDir,
+                       [relative_to(Dir), file_type(directory)]),
+    py_add_lib_dir(HelpersDir),
+    py_call(importlib:import_module('csharp_test_helper'), _),
+    asserta(python_helper_ready).
+
+check_dotnet_available :-
+    setup_paths_and_python,
+    py_call(csharp_test_helper:get_dotnet_version(), Version),
+    (   Version = @(none)
+    ->  format('[CSharpGeneratorJanusTest] WARNING: dotnet CLI not found~n'),
+        fail
+    ;   format('[CSharpGeneratorJanusTest] dotnet version: ~w~n', [Version])
+    ).
+
+setup_test_data :-
+    cleanup_test_data,
+    assertz(user:cg_edge(a, b)),
+    assertz(user:cg_edge(b, c)),
+    assertz(user:(cg_path(X, Y) :- cg_edge(X, Y))),
+    assertz(user:(cg_path(X, Y) :- cg_edge(X, Z), cg_path(Z, Y))).
+
+cleanup_test_data :-
+    maplist(retractall, [
+        user:cg_edge(_, _),
+        user:cg_path(_, _)
+    ]),
+    catch(abolish(user:cg_edge/2), _, true),
+    catch(abolish(user:cg_path/2), _, true).
+
+build_program_stub(Stub) :-
+    Stub = "\npublic static class Program {\n    public static int Main() {\n        var result = UnifyWeaver.Generated.CgPath_Module.Solve();\n        foreach (var fact in result) {\n            var arg0 = fact.Args.ContainsKey(\"arg0\") ? fact.Args[\"arg0\"] : \"\";\n            var arg1 = fact.Args.ContainsKey(\"arg1\") ? fact.Args[\"arg1\"] : \"\";\n            System.Console.WriteLine($\"{fact.Relation}:{arg0}:{arg1}\");\n        }\n        return 0;\n    }\n}\n".
+
+:- begin_tests(csharp_generator_janus, [
+    setup(setup_paths_and_python),
+    condition(check_dotnet_available)
+]).
+
+test(generator_dependency_group, [
+    setup(setup_test_data),
+    cleanup(cleanup_test_data),
+    condition(check_dotnet_available)
+]) :-
+    csharp_target:compile_predicate_to_csharp(cg_path/2, [mode(generator)], GenCode),
+    build_program_stub(Stub),
+    atom_concat(GenCode, Stub, FullCode),
+    py_call(csharp_test_helper:assert_output_contains(FullCode, "cg_path:a:c", 'csharp_dep_group'),
+            Result),
+    (   Result.success == @(true),
+        Result.assertion_passed == @(true)
+    ->  true
+    ;   format(user_error, '[CSharpGeneratorJanusTest] Helper result: ~w~n', [Result]),
+        assertion(Result.success == @(true)),
+        assertion(Result.assertion_passed == @(true))
+    ).
+
+:- end_tests(csharp_generator_janus).
+
+test_csharp_generator_dep_group :-
+    format('~n=== Running C# Generator Dependency-Group Tests ===~n~n'),
+    run_tests(csharp_generator_janus).


### PR DESCRIPTION
  - add a Janus/dotnet integration test (tests/core/test_csharp_generator_janus.pl) that compiles cg_path/2
    with supporting cg_edge/2, runs the generated C# via the Python helper, and asserts dependency-group
    output (cg_path:a:c)
  - fix generator output assembly to avoid duplicate argN assignments when multiple variables alias the same
    source, preventing C# runtime dictionary key collisions
  - tests: & "C:\Program Files\swipl\bin\swipl.exe" -f none -g "consult('tests/core/
    test_csharp_generator_janus.pl'), run_tests(csharp_generator_janus)" -t halt