### PR TITLE
Handle negated dependencies in C# generator and add dep‑group integration test

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -72,7 +72,12 @@ predicate_dependencies(Name/Arity, Dependencies) :-
                 body_to_list(Body, Terms),
                 member(Term, Terms),
                 \+ constraint_goal(Term),
-                term_signature(Term, Dep),
+                (   Term =.. ['\\+', Inner]
+                ->  term_signature(Inner, Dep)
+                ;   Term =.. [not, Inner]
+                ->  term_signature(Inner, Dep)
+                ;   term_signature(Term, Dep)
+                ),
                 (   predicate_defined(Dep)
                 ;   dynamic_source_metadata(Dep, _)
                 )


### PR DESCRIPTION
      - include negated calls in dependency closure and fix generator var mapping so negation checks use
        correct args
      - ensure generator output assembly doesn’t duplicate assignments that crash on runtime dictionaries
      - add Janus/dotnet integration tests for dependency groups with negation (cg_path/2 over cg_edge/2
        + cg_blocked/2)
      - tests: & "C:\Program Files\swipl\bin\swipl.exe" -f none -g "consult('tests/core/
        test_csharp_generator_janus.pl'), run_tests(csharp_generator_janus)" -t halt