### PR TITLE
Add coverage for multi-support dependency groups in the C# generator

### DIFF
--- a/tests/core/test_csharp_generator_depgroups.pl
+++ b/tests/core/test_csharp_generator_depgroups.pl
@@ -1,0 +1,44 @@
+:- module(test_csharp_generator_depgroups, [
+    test_csharp_generator_multi_support/0
+]).
+
+:- use_module(library(plunit)).
+:- use_module('../../src/unifyweaver/targets/csharp_target.pl').
+
+setup_data :-
+    cleanup_data,
+    assertz(user:dg_base(a)),
+    assertz(user:dg_base(b)),
+    assertz(user:dg_link(a, b)),
+    assertz(user:(dg_mid(X, Y) :- dg_base(X), dg_link(X, Y))),
+    assertz(user:(dg_target(X, Y) :- dg_mid(X, Y), dg_base(Y))).
+
+cleanup_data :-
+    maplist(retractall, [
+        user:dg_base(_),
+        user:dg_link(_, _),
+        user:dg_mid(_, _),
+        user:dg_target(_, _)
+    ]),
+    catch(abolish(user:dg_base/1), _, true),
+    catch(abolish(user:dg_link/2), _, true),
+    catch(abolish(user:dg_mid/2), _, true),
+    catch(abolish(user:dg_target/2), _, true).
+
+:- begin_tests(csharp_generator_depgroups).
+
+test(multi_supporting_predicates, [
+    setup(setup_data),
+    cleanup(cleanup_data)
+]) :-
+    csharp_target:compile_predicate_to_csharp(dg_target/2, [mode(generator)], Cs),
+    sub_string(Cs, _, _, _, "class DgTarget_Module"),
+    sub_string(Cs, _, _, _, "dg_mid"),
+    sub_string(Cs, _, _, _, "dg_base"),
+    sub_string(Cs, _, _, _, "dg_link"),
+    !.
+
+:- end_tests(csharp_generator_depgroups).
+
+test_csharp_generator_multi_support :-
+    run_tests(csharp_generator_depgroups).


### PR DESCRIPTION
      - add a plunit test to compile a dependency group with transitive supporting predicates (dg_target →
        dg_mid → dg_base/dg_link)
      - ensure generator output includes supporting predicates and compiles successfully
      - tests: swipl command above