### PR TITLE
feat(python): Add Key Construction Logic from Go Target

### DIFF
--- a/NEXT_CHAT_CONTEXT.md
+++ b/NEXT_CHAT_CONTEXT.md
@@ -2,27 +2,25 @@
 
 ## Project State (Dec 2025)
 - **Core Targets**: Semantic Capability Parity (Python, Go, C#).
-- **Graph RAG (Vector)**: Implemented and verified.
-- **CPU-Only RAG**: Verified. Supports Text Search and Lazy Embedding.
-- **Bookmark Suggestions**: **Implemented and Verified**.
-    - Ported C# `FindBookmarkPlacements` logic to Python `PtSearcher`.
-    - `suggest_bookmarks/2` predicate added to Python target.
-    - Supports "Tree View" output for context.
-    - Supports `mode(text)` for CPU-only usage.
+- **Graph RAG**: Verified (Vector & CPU/Text).
+- **Bookmark Suggestions**: Verified.
+- **Key Construction**: **Ported to Python**.
+    - Added `generate_key(Strategy, Var)` to Python target.
+    - Supports `composite([F1, F2])`, `hash(E)`, `uuid()`.
+    - Allows declarative construction of composite keys for SQLite storage.
+- **Environment**: `gemini` CLI v0.18.4. `pwsh` missing.
 
 ## Validated Flows
-### 1. Full Graph RAG
-- Index -> Vector Search -> Context -> LLM.
-
-### 2. Bookmark Suggestions
-- Index -> `suggest_bookmarks('Topic', [mode(text)], Suggestions)`.
-- Returns a formatted ASCII tree showing candidate locations for the new topic.
+1.  **Full Graph RAG**: Index -> Vector Search -> Context -> LLM.
+2.  **Bookmark Suggestions**: Index -> `suggest_bookmarks(...)`.
+3.  **Key Generation**: `process(Rec) :- generate_key(composite([field(name), literal(_), field(id)]), Key), ...`
 
 ## Active Proposals
 ### PowerShell Semantic Target
-- Proposal in `POWERSHELL_SEMANTIC_PROPOSAL.md`.
-- **Next Step**: Implementation.
+- **Goal**: Native PowerShell implementation of XML streaming and Vector Search.
+- **Status**: Proposal accepted (`POWERSHELL_SEMANTIC_PROPOSAL.md`).
+- **Next Step**: Implement `src/unifyweaver/targets/powershell_target.pl`.
 
 ## Next Steps
-1.  **Merge `feat/python-suggestions`**: Contains the new suggestion logic.
+1.  **Merge `feat/python-keys`**: Contains the new key generation logic.
 2.  **Start PowerShell Implementation**.


### PR DESCRIPTION
## Description
This PR ports the key construction logic recently added to the Go target into the Python target. It enables declarative generation of composite, hashed, and UUID keys directly within Prolog predicates, which is essential for building robust ETL pipelines and database keys.

### Key Changes

#### 1. Compiler (`python_target.pl`)
*   **Added `translate_goal(generate_key(Strategy, Var), Code)`**:
    *   Compiles the `generate_key/2` predicate into Python code.
*   **Added `compile_python_key_expr(Strategy, PyExpr)`**:
    *   Recursively compiles key strategies into Python string expressions.
    *   **Supported Strategies**:
        *   `field(Var)`: Uses the variable's value.
        *   `literal(Text)`: Uses a string literal.
        *   `composite([List])`: Concatenates multiple parts (e.g., `Name + '_' + ID`).
        *   `hash(Expr)`: SHA-256 hash of the inner expression.
        *   `uuid()`: Generates a random UUID v4.
*   **Fixed `translate_goal`**:
    *   Updated `get_dict` and `=` to robustly handle variables using a new `is_var_term/1` helper (handling both unbound vars and `'$VAR'(_)` from `numbervars`).

### Usage Example
```prolog
process_user(User) :-
    get_dict(name, User, Name),
    get_dict(role, User, Role),
    
    % Create a composite ID
    generate_key(composite([Name, literal('_'), Role]), ID),
    
    % Create a secure hash
    generate_key(hash(ID), Hash),
    
    % Add to record
    User.id = ID,
    User.hash = Hash.
```

### Verification
*   Verified with `examples/key_gen_test.pl` (manual test).
*   Confirmed correct Python code generation for all supported strategies.
*   Confirmed correct execution and output JSON.
