### PR TITLE
Implement Database Query Filters (Python)

### DIFF
--- a/NEXT_CHAT_CONTEXT.md
+++ b/NEXT_CHAT_CONTEXT.md
@@ -2,25 +2,22 @@
 
 ## Project State (Dec 2025)
 - **Core Targets**: Semantic Capability Parity (Python, Go, C#).
-- **Graph RAG**: Verified (Vector & CPU/Text).
-- **Bookmark Suggestions**: Verified.
-- **Key Construction**: **Ported to Python**.
-    - Added `generate_key(Strategy, Var)` to Python target.
-    - Supports `composite([F1, F2])`, `hash(E)`, `uuid()`.
-    - Allows declarative construction of composite keys for SQLite storage.
+- **Graph RAG**: Verified.
+- **Key Construction**: Verified.
+- **Query Filters**: **Implemented & Verified**.
+    - Ported Go target filtering logic to Python procedural mode.
+    - Supports `Age >= 18`, `X \= Y`, etc.
 - **Environment**: `gemini` CLI v0.18.4. `pwsh` missing.
 
 ## Validated Flows
-1.  **Full Graph RAG**: Index -> Vector Search -> Context -> LLM.
-2.  **Bookmark Suggestions**: Index -> `suggest_bookmarks(...)`.
-3.  **Key Generation**: `process(Rec) :- generate_key(composite([field(name), literal(_), field(id)]), Key), ...`
+1.  **Full Graph RAG**: Index -> Search -> Context.
+2.  **Bookmark Suggestions**: Tree View output.
+3.  **Filtering**: Declarative filtering in procedural Python pipelines.
 
 ## Active Proposals
 ### PowerShell Semantic Target
-- **Goal**: Native PowerShell implementation of XML streaming and Vector Search.
-- **Status**: Proposal accepted (`POWERSHELL_SEMANTIC_PROPOSAL.md`).
-- **Next Step**: Implement `src/unifyweaver/targets/powershell_target.pl`.
+- **Status**: Ready for implementation.
 
 ## Next Steps
-1.  **Merge `feat/python-keys`**: Contains the new key generation logic.
+1.  **Merge `feat/python-filters`**.
 2.  **Start PowerShell Implementation**.

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -448,6 +448,30 @@ translate_goal(>(Var, Value), Code) :-
     var_to_python(Value, PyValue),
     format(string(Code), "    if not (~w > ~w): return\n", [PyVar, PyValue]).
 
+translate_goal(<(Var, Value), Code) :-
+    !,
+    var_to_python(Var, PyVar),
+    var_to_python(Value, PyValue),
+    format(string(Code), "    if not (~w < ~w): return\n", [PyVar, PyValue]).
+
+translate_goal(>=(Var, Value), Code) :-
+    !,
+    var_to_python(Var, PyVar),
+    var_to_python(Value, PyValue),
+    format(string(Code), "    if not (~w >= ~w): return\n", [PyVar, PyValue]).
+
+translate_goal(=<(Var, Value), Code) :-
+    !,
+    var_to_python(Var, PyVar),
+    var_to_python(Value, PyValue),
+    format(string(Code), "    if not (~w <= ~w): return\n", [PyVar, PyValue]).
+
+translate_goal(\=(Var, Value), Code) :-
+    !,
+    var_to_python(Var, PyVar),
+    var_to_python(Value, PyValue),
+    format(string(Code), "    if not (~w != ~w): return\n", [PyVar, PyValue]).
+
 % Match predicate support for procedural mode
 translate_goal(match(Var, Pattern), Code) :-
     !,


### PR DESCRIPTION
## Description
This PR ports the database query filtering logic (comparison operators) from the Go target to the Python target's procedural mode. It allows users to write declarative Prolog filters like `Age >= 18` or `Role \= 'banned'`, which are then compiled into efficient Python `if` checks.

### Key Changes

#### 1. Compiler (`python_target.pl`)
*   **Added `translate_goal` clauses**:
    *   `<(Var, Value)` -> `if not (var < val): return`
    *   `>=(Var, Value)` -> `if not (var >= val): return`
    *   `=<(Var, Value)` -> `if not (var <= val): return` (Mapped to `<=`)
    *   `\=(Var, Value)` -> `if not (var != val): return` (Mapped to `!=`)
*   **Parity**: This brings the Python target to feature parity with the recent Go target Phase 8a changes for filtering.

### Usage Example
```prolog
filter_users(User) :-
    get_dict(age, User, Age),
    % Keep only adults
    Age >= 18,
    % Exclude seniors
    Age < 65.
```

### Verification
*   Verified with `examples/filter_test.pl` (manual test).
*   Confirmed correct Python code generation for all operators.
*   Confirmed correct runtime behavior (filtering JSON input).
