### PR TITLE
Implement Key Construction for Rust Target

### DIFF
--- a/NEXT_CHAT_CONTEXT.md
+++ b/NEXT_CHAT_CONTEXT.md
@@ -2,22 +2,27 @@
 
 ## Project State (Dec 2025)
 - **Core Targets**: Semantic Capability Parity (Python, Go, C#).
-- **Graph RAG**: Verified.
-- **Key Construction**: Verified.
-- **Query Filters**: **Implemented & Verified**.
-    - Ported Go target filtering logic to Python procedural mode.
-    - Supports `Age >= 18`, `X \= Y`, etc.
+- **Graph RAG**: Verified (Vector & CPU/Text).
+- **Bookmark Suggestions**: Verified.
+- **Key Construction**:
+    - **Python**: Verified (`generate_key/2`).
+    - **Rust**: **Partially Implemented**.
+        - `generate_key/2` compiler logic implemented in `rust_target.pl`.
+        - Supports `composite`, `hash`, `uuid`.
+        - Dependencies (`sha2`, `hex`, `uuid`) added to Cargo generation.
+- **Rust Semantic Runtime**: Proposed (`RUST_SEMANTIC_PROPOSAL.md`).
 - **Environment**: `gemini` CLI v0.18.4. `pwsh` missing.
 
-## Validated Flows
-1.  **Full Graph RAG**: Index -> Search -> Context.
-2.  **Bookmark Suggestions**: Tree View output.
-3.  **Filtering**: Declarative filtering in procedural Python pipelines.
-
 ## Active Proposals
-### PowerShell Semantic Target
-- **Status**: Ready for implementation.
+### 1. PowerShell Semantic Target
+- **Status**: Accepted. Pending implementation.
+
+### 2. Rust Semantic Target
+- **Status**: Phase 1 (Key Construction) Complete.
+- **Next Steps**:
+    - Implement `rust_runtime` library (importer, crawler).
+    - Implement `crawler_run` and `graph_search` in Rust target.
 
 ## Next Steps
-1.  **Merge `feat/python-filters`**.
-2.  **Start PowerShell Implementation**.
+1.  **Merge `feat/rust-keys`**.
+2.  **Start PowerShell Implementation** (as originally planned before Rust diversion).

--- a/RUST_SEMANTIC_PROPOSAL.md
+++ b/RUST_SEMANTIC_PROPOSAL.md
@@ -1,0 +1,67 @@
+# Rust Semantic Target Proposal
+
+## Objective
+Achieve **Semantic Capability Parity** with the Python and Go targets in the Rust backend. This includes:
+1.  **Streaming XML Ingestion** (`source(xml)`).
+2.  **Vector Embeddings** (via ONNX Runtime).
+3.  **Vector Search** (Cosine Similarity).
+4.  **Local Storage** (SQLite via `rusqlite`).
+5.  **Graph RAG** (Vector + Link Traversal).
+
+## Architecture
+
+### 1. Rust Semantic Runtime (`src/unifyweaver/targets/rust_runtime/`)
+We will create a reusable Rust library that the generated code can depend on or inline.
+
+*   **`importer.rs`**: Manages SQLite connection.
+    *   *Crate*: `rusqlite`
+    *   *Tables*: `objects`, `embeddings`, `links`.
+*   **`crawler.rs`**: High-performance XML streaming.
+    *   *Crate*: `quick-xml`
+    *   *Features*: Link extraction (`rdf:resource`), flattening.
+*   **`embedding.rs`**: Vector generation.
+    *   *Crate*: `ort` (ONNX Runtime bindings) or `candle-core`.
+*   **`searcher.rs`**: Search logic.
+    *   *Features*: Vector Search, Text Search (SQL LIKE), Graph Traversal (1-hop).
+*   **`llm.rs`**: LLM integration.
+    *   *Implementation*: Wrapper around `gemini` CLI via `std::process::Command`.
+
+### 2. Key Construction (`generate_key/2`)
+Port the key generation logic from Go/Python.
+*   **Strategies**: `composite`, `hash` (via `sha2`), `uuid` (via `uuid` crate).
+*   **Implementation**: Modify `rust_target.pl` to generate Rust expressions.
+
+### 3. Compilation Model
+The `rust_target.pl` will be updated to:
+*   Detect `semantic` mode or specific predicates (`crawler_run`, `graph_search`).
+*   Generate a `Cargo.toml` with necessary dependencies (`rusqlite`, `quick-xml`, `tokio`, `anyhow`).
+*   Generate `main.rs` that orchestrates the runtime components.
+
+## Implementation Plan
+
+### Phase 1: Key Construction & Basic Logic
+*   Implement `generate_key/2` support in `rust_target.pl`.
+*   Add `sha2` and `uuid` to dependency detection.
+
+### Phase 2: Runtime Foundation (SQLite + Crawler)
+*   Create `rust_runtime` directory.
+*   Implement `importer.rs` (SQLite schema).
+*   Implement `crawler.rs` (XML parsing).
+
+### Phase 3: Search & RAG
+*   Implement `searcher.rs` (Vector/Text search).
+*   Implement `graph_search` predicate translation.
+
+## Dependencies
+```toml
+[dependencies]
+rusqlite = { version = "0.29", features = ["bundled"] }
+quick-xml = "0.30"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["full"] }
+anyhow = "1.0"
+sha2 = "0.10"
+uuid = { version = "1.4", features = ["v4"] }
+# ort = "..." (Optional for embeddings)
+```


### PR DESCRIPTION
## Description
This PR initiates the **Rust Semantic Target** implementation by porting the key construction logic from the Go/Python targets. It allows the Rust target to generate composite, hashed, and UUID keys, which is a prerequisite for database integration.

### Key Changes

#### 1. Compiler (`rust_target.pl`)
*   **`generate_key/2` Support**: Implemented logic to extract and compile key generation goals.
*   **Strategies**:
    *   `composite([...])`: Compiles to Rust `format!("{}{}", ...)` macro.
    *   `hash(Expr)`: Compiles to `sha2::Sha256` hashing (using `hex` crate for encoding).
    *   `uuid()`: Compiles to `uuid::Uuid::new_v4()`.
*   **Dependency Management**: Updated `detect_dependencies` and `generate_cargo_toml` to automatically include `sha2`, `hex`, and `uuid` crates when these features are used.
*   **Implicit Source Handling**: Updated `compile_single_rule_to_rust` to handle implicit source predicates (where the head arguments define the input schema), aligning it with how `generate_key` is typically used in ETL pipelines.

### Documentation
*   Added `RUST_SEMANTIC_PROPOSAL.md`: Outlines the roadmap for full Semantic Capability Parity in Rust (SQLite, XML Streaming, Vector Search).

### Verification
*   Verified with `examples/test_rust_key.pl` (manual test).
*   Confirmed correct Rust code generation:
    ```rust
    let key_1 = format!("{}{}{}", parts[0], "_", parts[1]);
    let key_2 = { use sha2::{Sha256, Digest}; ... };
    ```
