### PR TITLE
feat(rust): Add Semantic Runtime Foundation (Redb Importer + Crawler)

### DIFF
--- a/NEXT_CHAT_CONTEXT.md
+++ b/NEXT_CHAT_CONTEXT.md
@@ -2,15 +2,12 @@
 
 ## Project State (Dec 2025)
 - **Core Targets**: Semantic Capability Parity (Python, Go, C#).
-- **Graph RAG**: Verified (Vector & CPU/Text).
+- **Graph RAG**: Verified.
 - **Bookmark Suggestions**: Verified.
-- **Key Construction**:
-    - **Python**: Verified (`generate_key/2`).
-    - **Rust**: **Partially Implemented**.
-        - `generate_key/2` compiler logic implemented in `rust_target.pl`.
-        - Supports `composite`, `hash`, `uuid`.
-        - Dependencies (`sha2`, `hex`, `uuid`) added to Cargo generation.
-- **Rust Semantic Runtime**: Proposed (`RUST_SEMANTIC_PROPOSAL.md`).
+- **Key Construction**: Verified (Python & Rust Phase 1).
+- **Rust Semantic Runtime**: **Phase 2 Initiated**.
+    - `importer.rs` (Redb) and `crawler.rs` (quick-xml) created in `src/unifyweaver/targets/rust_runtime/`.
+    - `rust_target.pl` updated to detect `redb`/`quick-xml` dependencies.
 - **Environment**: `gemini` CLI v0.18.4. `pwsh` missing.
 
 ## Active Proposals
@@ -18,11 +15,13 @@
 - **Status**: Accepted. Pending implementation.
 
 ### 2. Rust Semantic Target
-- **Status**: Phase 1 (Key Construction) Complete.
+- **Status**: Phase 2 (Runtime Foundation) In Progress.
 - **Next Steps**:
-    - Implement `rust_runtime` library (importer, crawler).
-    - Implement `crawler_run` and `graph_search` in Rust target.
+    - Create `searcher.rs` (Vector/Text Search).
+    - Implement the compiler logic to inline these runtime files into the generated project.
+    - Implement `crawler_run` translation.
 
 ## Next Steps
-1.  **Merge `feat/rust-keys`**.
-2.  **Start PowerShell Implementation** (as originally planned before Rust diversion).
+1.  **Merge `feat/rust-runtime-v1`**.
+2.  **Finish Rust Runtime** (Searcher, LLM).
+3.  **Start PowerShell Implementation**.

--- a/src/unifyweaver/targets/rust_runtime/crawler.rs
+++ b/src/unifyweaver/targets/rust_runtime/crawler.rs
@@ -1,0 +1,99 @@
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+use serde_json::{Map, Value};
+use std::fs::File;
+use std::io::BufReader;
+use crate::importer::PtImporter;
+
+pub struct PtCrawler {
+    importer: PtImporter,
+}
+
+impl PtCrawler {
+    pub fn new(importer: PtImporter) -> Self {
+        Self { importer }
+    }
+
+    pub fn crawl(&self, seeds: &[String], _max_depth: usize) -> Result<(), Box<dyn std::error::Error>> {
+        for seed in seeds {
+            // Assume seed is a file path for now
+            println!("Processing {}", seed);
+            self.process_file(seed)?;
+        }
+        Ok(())
+    }
+
+    fn process_file(&self, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let file = File::open(path)?;
+        let file_len = file.metadata()?.len();
+        let mut reader = Reader::from_reader(BufReader::new(file));
+        reader.config_mut().trim_text(true);
+
+        let mut buf = Vec::new();
+        let mut current_obj: Option<Map<String, Value>> = None;
+        let mut current_tag = String::new();
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(e)) => {
+                    let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    // Flatten: Only care about leaf nodes or direct children of root?
+                    // Strategy: Every element with an ID is an object.
+                    // Attributes are props. Children text is props.
+                    
+                    let mut obj = Map::new();
+                    let mut obj_id = String::new();
+                    
+                    // Extract attributes
+                    for attr in e.attributes() {
+                        let attr = attr?;
+                        let key = String::from_utf8_lossy(attr.key.as_ref());
+                        let val = String::from_utf8_lossy(&attr.value);
+                        
+                        if key == "rdf:about" || key == "id" || key.ends_with("about") {
+                            obj_id = val.to_string();
+                        }
+                        
+                        // Link extraction
+                        if key == "rdf:resource" || key.ends_with("resource") {
+                            // Store link logic handled later or here?
+                            // If this is a child element, the parent ID is needed.
+                            // Current simplistic approach: Flat stream.
+                        }
+                        
+                        obj.insert(format!("@{}", key), Value::String(val.to_string()));
+                    }
+                    
+                    if !obj_id.is_empty() {
+                        current_obj = Some(obj);
+                        current_tag = tag;
+                    }
+                }
+                Ok(Event::Text(e)) => {
+                    if let Some(ref mut obj) = current_obj {
+                        let text = e.unescape()?.to_string();
+                        if !text.is_empty() {
+                            obj.insert("text".to_string(), Value::String(text));
+                        }
+                    }
+                }
+                Ok(Event::End(e)) => {
+                    let tag = String::from_utf8_lossy(e.name().as_ref());
+                    if let Some(obj) = current_obj.take() {
+                        if tag == current_tag {
+                            // Object complete
+                            if let Some(Value::String(id)) = obj.get("@rdf:about").or(obj.get("@id")) {
+                                self.importer.upsert_object(id, &tag, &Value::Object(obj))?;
+                            }
+                        }
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => return Err(Box::new(e)),
+                _ => (),
+            }
+            buf.clear();
+        }
+        Ok(())
+    }
+}

--- a/src/unifyweaver/targets/rust_runtime/importer.rs
+++ b/src/unifyweaver/targets/rust_runtime/importer.rs
@@ -1,0 +1,70 @@
+use redb::{Database, Error, ReadableTable, TableDefinition, WriteTransaction};
+use serde_json::Value;
+use std::sync::Arc;
+
+// Table Definitions
+// Objects: ID -> JSON String
+const OBJECTS: TableDefinition<&str, &str> = TableDefinition::new("objects");
+// Embeddings: ID -> Byte Array (f32 vector)
+const EMBEDDINGS: TableDefinition<&str, &[u8]> = TableDefinition::new("embeddings");
+// Links: Source -> Target (Note: Redb doesn't support multimap natively easily in 1 table without composite keys)
+// For 1-to-N links, we'll use a composite key: "source|target" -> ""
+const LINKS: TableDefinition<&str, &str> = TableDefinition::new("links");
+
+pub struct PtImporter {
+    db: Arc<Database>,
+}
+
+impl PtImporter {
+    pub fn new(path: &str) -> Result<Self, Error> {
+        let db = Database::create(path)?;
+        let db_arc = Arc::new(db);
+        
+        // Initialize tables
+        let write_txn = db_arc.begin_write()?;
+        {
+            write_txn.open_table(OBJECTS)?;
+            write_txn.open_table(EMBEDDINGS)?;
+            write_txn.open_table(LINKS)?;
+        }
+        write_txn.commit()?;
+
+        Ok(Self { db: db_arc })
+    }
+
+    pub fn upsert_object(&self, id: &str, _obj_type: &str, data: &Value) -> Result<(), Error> {
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(OBJECTS)?;
+            table.insert(id, data.to_string().as_str())?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    pub fn upsert_embedding(&self, id: &str, vector: &[f32]) -> Result<(), Error> {
+        // Convert f32 slice to u8 slice
+        let byte_len = vector.len() * 4;
+        let byte_ptr = vector.as_ptr() as *const u8;
+        let byte_slice = unsafe { std::slice::from_raw_parts(byte_ptr, byte_len) };
+
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(EMBEDDINGS)?;
+            table.insert(id, byte_slice)?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    pub fn upsert_link(&self, source: &str, target: &str) -> Result<(), Error> {
+        let key = format!("{}|{}", source, target);
+        let write_txn = self.db.begin_write()?;
+        {
+            let mut table = write_txn.open_table(LINKS)?;
+            table.insert(key.as_str(), "")?;
+        }
+        write_txn.commit()?;
+        Ok(())
+    }
+}

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -25,7 +25,7 @@
 
 :- dynamic json_schema_def/2.
 
-json_schema(SchemaName, Fields) :- 
+json_schema(SchemaName, Fields) :-
     (   validate_schema_fields(Fields)
     ->  retractall(json_schema_def(SchemaName, _)),
         assertz(json_schema_def(SchemaName, Fields))
@@ -34,11 +34,11 @@ json_schema(SchemaName, Fields) :-
     ).
 
 validate_schema_fields([]).
-validate_schema_fields([field(Name, Type)|Rest]) :- 
+validate_schema_fields([field(Name, Type)|Rest]) :-
     atom(Name),
     valid_json_type(Type),
     validate_schema_fields(Rest).
-validate_schema_fields([Invalid|_]) :- 
+validate_schema_fields([Invalid|_]) :-
     format('ERROR: Invalid field specification: ~w~n', [Invalid]),
     fail.
 
@@ -50,13 +50,13 @@ valid_json_type(array).
 valid_json_type(object).
 valid_json_type(any).
 
-get_json_schema(SchemaName, Fields) :- 
+get_json_schema(SchemaName, Fields) :-
     json_schema_def(SchemaName, Fields), !.
-get_json_schema(SchemaName, _) :- 
+get_json_schema(SchemaName, _) :-
     format('ERROR: Schema not found: ~w~n', [SchemaName]),
     fail.
 
-get_field_type(SchemaName, FieldName, Type) :- 
+get_field_type(SchemaName, FieldName, Type) :-
     get_json_schema(SchemaName, Fields),
     member(field(FieldName, Type), Fields), !.
 get_field_type(_SchemaName, _FieldName, serde_json_value).
@@ -65,7 +65,7 @@ get_field_type(_SchemaName, _FieldName, serde_json_value).
 %% PUBLIC API
 %% ============================================ 
 
-compile_predicate_to_rust(PredIndicator, Options, RustCode) :- 
+compile_predicate_to_rust(PredIndicator, Options, RustCode) :-
     PredIndicator = Pred/Arity,
     format('=== Compiling ~w/~w to Rust ===~n', [Pred, Arity]),
 
@@ -83,7 +83,7 @@ compile_predicate_to_rust(PredIndicator, Options, RustCode) :-
     ;   compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode)
     ).
 
-compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :- 
+compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
     option(field_delimiter(FieldDelim), Options, colon),
     option(include_main(IncludeMain), Options, true),
     option(unique(Unique), Options, true),
@@ -105,7 +105,7 @@ is_fact_clause(_-true).
 %% COMPILATION MODES
 %% ============================================ 
 
-compile_facts_to_rust(_Pred, _Arity, Clauses, FieldDelim, RustCode) :- 
+compile_facts_to_rust(_Pred, _Arity, Clauses, FieldDelim, RustCode) :-
     map_field_delimiter(FieldDelim, DelimChar),
     
     findall(Entry, 
@@ -129,7 +129,7 @@ fn main() {
 }
 ', [EntriesCode]).
 
-compile_single_rule_to_rust(_Pred, _Arity, Head, Body, FieldDelim, Unique, IncludeMain, RustCode) :- 
+compile_single_rule_to_rust(_Pred, _Arity, Head, Body, FieldDelim, Unique, IncludeMain, RustCode) :-
     Head =.. [_|HeadArgs],
     
     extract_predicates(Body, Predicates),
@@ -158,7 +158,7 @@ compile_single_rule_to_rust(_Pred, _Arity, Head, Body, FieldDelim, Unique, Inclu
                 ;   var(Arg), member((Var, RustVar), KeyMap), Arg == Var ->
                     format(string(OutputPart), "~w", [RustVar])
                 ;   atom(Arg) ->
-                    format(string(OutputPart), '\"~w\"', [Arg])
+                    format(string(OutputPart), '"~w"', [Arg])
                 ;   OutputPart = "\"unknown\""
                 )
             ),
@@ -210,7 +210,7 @@ fn main() {
 %% AGGREGATION COMPILATION
 %% ============================================ 
 
-compile_aggregation_to_rust(_Pred, _Arity, AggOp, _FieldDelim, IncludeMain, RustCode) :- 
+compile_aggregation_to_rust(_Pred, _Arity, AggOp, _FieldDelim, IncludeMain, RustCode) :-
     generate_aggregation_logic(AggOp, Logic),
     
     (   IncludeMain ->
@@ -226,7 +226,7 @@ fn main() {
 %% JSON INPUT COMPILATION
 %% ============================================ 
 
-compile_json_input_to_rust(Pred, Arity, Options, RustCode) :- 
+compile_json_input_to_rust(Pred, Arity, Options, RustCode) :-
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
 
@@ -255,7 +255,7 @@ fn main() {
 %% JSON OUTPUT COMPILATION
 %% ============================================ 
 
-compile_json_output_to_rust(Pred, Arity, Options, RustCode) :- 
+compile_json_output_to_rust(Pred, Arity, Options, RustCode) :-
     atom_string(Pred, PredStr),
     functor(Head, Pred, Arity),
     findall(Head-Body, user:clause(Head, Body), Clauses),
@@ -298,7 +298,7 @@ generate_aggregation_logic(avg, "let (c, s) = io::stdin().lock().lines().filter_
 generate_aggregation_logic(min, "if let Some(m) = io::stdin().lock().lines().filter_map(|l| l.ok()?.trim().parse::<f64>().ok()).min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)) { println!(\"{}\", m); }").
 generate_aggregation_logic(max, "if let Some(m) = io::stdin().lock().lines().filter_map(|l| l.ok()?.trim().parse::<f64>().ok()).max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)) { println!(\"{}\", m); }").
 
-generate_json_input_logic(JsonOps, Head, SchemaName, DelimChar, Unique, ScriptBody) :- 
+generate_json_input_logic(JsonOps, Head, SchemaName, DelimChar, Unique, ScriptBody) :-
     Head =.. [_|HeadArgs],
     findall(ExtractLine, (
         nth1(Pos, HeadArgs, Arg),
@@ -326,7 +326,7 @@ generate_json_input_logic(JsonOps, Head, SchemaName, DelimChar, Unique, ScriptBo
         }
     }', [UniqueDecl, ExtractCode, OutputExpr, UniqueCheck]).
 
-rust_json_extract_code(Var, Field, Type, Code) :- 
+rust_json_extract_code(Var, Field, Type, Code) :-
     atom_string(Field, FieldStr),
     (   Type = any -> format(string(Code), 'let ~w = json_data.get(\"~s\").cloned().unwrap_or(Value::Null);', [Var, FieldStr])
     ;   format_type_for_json(Type, RustType),
@@ -335,7 +335,7 @@ rust_json_extract_code(Var, Field, Type, Code) :-
                 None => continue,
             };', [Var, RustType, FieldStr])
     ).
-ust_json_path_extract_code(Var, Path, Type, Code) :- 
+ust_json_path_extract_code(Var, Path, Type, Code) :-
     atomic_list_concat(Path, '/', PathStr),
     (   Type = any -> format(string(Code), 'let ~w = json_data.pointer(\"/~s\").cloned().unwrap_or(Value::Null);', [Var, PathStr])
     ;   format_type_for_json(Type, RustType),
@@ -355,7 +355,10 @@ generate_json_output_struct(PredName, Head, StructDef) :-
         format(string(FieldLine), '    #[serde(rename = "~w")]\n    pub ~w: ~s,', [FieldName, FieldName, RustType])
     ), FieldLines),
     atomic_list_concat(FieldLines, '\n', FieldsStr),
-    format(string(StructDef), '#[derive(Serialize)]\nstruct ~w {\n~s\n}', [PredName, FieldsStr]).
+    format(string(StructDef), '#[derive(Serialize)]
+struct ~w {
+~s
+}', [PredName, FieldsStr]).
 
 generate_json_output_logic(Head, _DelimChar, ScriptBody) :-
     Head =.. [PredName|HeadArgs],
@@ -377,7 +380,7 @@ build_source_map_([], _, []).
 build_source_map_([Arg|Rest], Idx, [(Arg, Idx)|Map]) :- NextIdx is Idx + 1, build_source_map_(Rest, NextIdx, Map).
 
 build_rust_concat([Single], _, Format) :- !, format(string(Format), "String::from(~s)", [Single]).
-build_rust_concat(Parts, Delim, Format) :- 
+build_rust_concat(Parts, Delim, Format) :-
     atomic_list_concat(Parts, ', ', Args),
     maplist(rust_format_placeholder, Parts, Placeholders),
     atomic_list_concat(Placeholders, Delim, FmtStr),
@@ -459,11 +462,11 @@ compile_rust_key_expr_list([H|T], SourceMap, KeyMap, [HC|TC]) :-
 field_to_json_op(Field-Var, json_field(Field, Var)).
 
 generate_rust_constraints([], _, "").
-generate_rust_constraints(Constraints, SourceMap, Code) :- 
+generate_rust_constraints(Constraints, SourceMap, Code) :-
     findall(Check, (member(C, Constraints), constraint_to_rust(C, SourceMap, Check)), Checks),
     atomic_list_concat(Checks, '\n', Code).
 
-constraint_to_rust(Comparison, SourceMap, Code) :- 
+constraint_to_rust(Comparison, SourceMap, Code) :-
     Comparison =.. [Op, L, R], map_rust_op(Op, RO), term_to_rust_numeric(L, SourceMap, LC), term_to_rust_numeric(R, SourceMap, RC),
     format(string(Code), "if !(~s ~s ~s) { continue; }", [LC, RO, RC]).
 
@@ -473,7 +476,7 @@ term_to_rust_numeric(Var, SourceMap, Code) :- var(Var), member((V, I), SourceMap
 term_to_rust_numeric(Num, _, Num) :- number(Num).
 
 generate_rust_match_constraints([], _, "", "", false).
-generate_rust_match_constraints(Matches, SourceMap, InitCode, CheckCode, true) :- 
+generate_rust_match_constraints(Matches, SourceMap, InitCode, CheckCode, true) :-
     findall((Init, Check), (
         member(match(Var, Pattern), Matches),
         var(Var), member((V, Idx), SourceMap), Var == V,
@@ -500,7 +503,7 @@ format_type_for_json(any, "Value").
 
 write_rust_program(Code, Path) :- open(Path, write, S), write(S, Code), close(S), format('Rust program written to: ~w~n', [Path]).
 
-write_rust_project(RustCode, ProjectDir) :- 
+write_rust_project(RustCode, ProjectDir) :-
     make_directory_path(ProjectDir),
     directory_file_path(ProjectDir, 'src', SrcDir), make_directory_path(SrcDir),
     directory_file_path(SrcDir, 'main.rs', MainPath), write_rust_program(RustCode, MainPath),
@@ -519,10 +522,12 @@ detect_dependencies(Code, Deps) :-
         ;   sub_string(Code, _, _, _, 'use sha2::'), Dep = sha2
         ;   sub_string(Code, _, _, _, 'hex::encode'), Dep = hex
         ;   sub_string(Code, _, _, _, 'uuid::Uuid'), Dep = uuid
+        ;   sub_string(Code, _, _, _, 'use redb::'), Dep = redb
+        ;   sub_string(Code, _, _, _, 'use quick_xml::'), Dep = quick_xml
         ),
         DepsList),
     sort(DepsList, Deps).
-generate_cargo_toml(Name, Deps, Content) :- 
+generate_cargo_toml(Name, Deps, Content) :-
     format(string(Header), '[package]\nname = "~w"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\n', [Name]),
     maplist(dep_to_toml, Deps, DepLines),
     atomic_list_concat(DepLines, '\n', DepBlock),
@@ -534,3 +539,5 @@ dep_to_toml(serde_json, "serde_json = \"1.0\"").
 dep_to_toml(sha2, "sha2 = \"0.10\"").
 dep_to_toml(hex, "hex = \"0.4\"").
 dep_to_toml(uuid, "uuid = { version = \"1.4\", features = [\"v4\"] }").
+dep_to_toml(redb, "redb = \"1.4.0\"").
+dep_to_toml(quick_xml, "quick-xml = \"0.30\"").


### PR DESCRIPTION
## Description
This PR lays the groundwork for the **Rust Semantic Target** runtime environment. It introduces the first two core components: `PtImporter` (storage) and `PtCrawler` (ingestion), and updates the compiler to handle their dependencies.

### Key Changes

#### 1. Runtime Library (`src/unifyweaver/targets/rust_runtime/`)
*   **`importer.rs`**: 
    *   Implements a **Redb**-based storage engine (Pure Rust, Embedded, ACID).
    *   Defines tables for `objects`, `embeddings`, and `links`.
    *   Provides `upsert_object`, `upsert_embedding` (converting f32 slices to byte blobs), and `upsert_link`.
*   **`crawler.rs`**:
    *   Implements a streaming XML parser using **quick-xml**.
    *   Handles flattening of XML structure into `serde_json` Objects.
    *   Extracts `rdf:about`, `id` for identity.
    *   Extracts `rdf:resource` for simple link detection (stubbed).

#### 2. Compiler (`rust_target.pl`)
*   **Dependency Detection**: Updated `detect_dependencies` to recognize `use redb::` and `use quick_xml::` statements in the generated code.
*   **Cargo Generation**: Updated `dep_to_toml` to inject the correct versions for `redb` ("1.4.0") and `quick-xml` ("0.30").

### Design Decision
We chose **Redb** over `rusqlite` to maintain a "Pure Rust" compilation path, avoiding the need for C compilers/linkers on the target machine, which simplifies cross-compilation and deployment (e.g., for Termux or Windows).

### Next Steps
*   Implement `searcher.rs` (Vector/Text search).
*   Update `compile_predicate_to_rust` to inline these runtime files into the generated project structure.
