### PR TITLE
Integrate Rust Semantic Runtime into Compiler (Phase 3)

### DIFF
--- a/NEXT_CHAT_CONTEXT.md
+++ b/NEXT_CHAT_CONTEXT.md
@@ -5,22 +5,16 @@
 - **Graph RAG**: Verified.
 - **Bookmark Suggestions**: Verified.
 - **Key Construction**: Verified.
-- **Rust Semantic Runtime**: **Phase 2 Almost Complete**.
-    - `importer.rs` (Redb), `crawler.rs` (quick-xml), `searcher.rs` (Text/Graph), `llm.rs` (Gemini) are implemented.
-    - `rust_target.pl` now copies these files to the generated project.
+- **Rust Semantic Runtime**: **Phase 3 Complete (Integration)**.
+    - Runtime modules (`importer`, `crawler`, `searcher`, `llm`) are complete.
+    - Compiler (`rust_target.pl`) now detects semantic predicates (`crawler_run`) and generates a `main.rs` that orchestrates the runtime components.
+    - `rust_semantic_playbook.pl` verifies the full compilation flow.
 - **Environment**: `gemini` CLI v0.18.4. `pwsh` missing.
 
 ## Active Proposals
 ### 1. PowerShell Semantic Target
 - **Status**: Accepted. Pending implementation.
 
-### 2. Rust Semantic Target
-- **Status**: Runtime files created.
-- **Next Steps**:
-    - Implement `compile_predicate_to_rust` logic to *use* these runtime files (generate `main.rs` calls).
-    - Implement `translate_goal` for `crawler_run`, `graph_search`.
-
 ## Next Steps
-1.  **Merge `feat/rust-runtime-v2`**.
-2.  **Finish Rust Compiler Integration**.
-3.  **Start PowerShell Implementation**.
+1.  **Merge `feat/rust-integration`**.
+2.  **Start PowerShell Implementation**.

--- a/examples/rust_semantic_playbook.pl
+++ b/examples/rust_semantic_playbook.pl
@@ -2,5 +2,10 @@
 :- use_module('../src/unifyweaver/targets/rust_target').
 
 main :-
-    Code = 'fn main() { println!("Runtime Test"); }',
+    % Assert to user module so compile_predicate_to_rust (which uses user:clause) can find it
+    Term = (index_data(_) :- crawler_run(["data.xml"], 1)),
+    assertz(user:Term),
+
+    % Compile the semantic predicate
+    compile_predicate_to_rust(user:index_data/1, [], Code),
     write_rust_project(Code, 'output/rust_semantic_test').


### PR DESCRIPTION
## Description
This PR connects the dots for the Rust Semantic Target. It updates the `rust_target` compiler to recognize semantic predicates (like `crawler_run/2` and `graph_search/4`) and generate a `main.rs` that correctly orchestrates the runtime modules (`importer`, `crawler`, `searcher`, `llm`) implemented in Phase 2.

### Key Changes

#### 1. Compiler (`src/unifyweaver/targets/rust_target.pl`)
*   **Semantic Mode Detection**: Added `is_semantic_predicate/1` to detect when a predicate body contains semantic goals.
*   **`compile_semantic_mode/5`**: New compilation path that:
    *   Generates a `main.rs` with module declarations (`mod importer`, etc.) and imports.
    *   Initializes the runtime stack: `PtImporter`, `PtCrawler`, `PtSearcher`.
    *   Translates the predicate body into Rust method calls on these runtime objects.
*   **Translation Rules**:
    *   `crawler_run(Seeds, Depth)` -> `crawler.crawl(&vec![...], depth)?`
    *   `graph_search(Q, K, H, R)` -> `searcher.graph_search(q, k, h, mode)?`

#### 2. Verification (`examples/rust_semantic_playbook.pl`)
*   Updated the playbook to use the real `crawler_run` predicate instead of a stub.
*   **Result**: The compiler successfully generates a full Rust project (`output/rust_semantic_test`) containing:
    *   `Cargo.toml` (with dependencies).
    *   `src/main.rs` (with logic).
    *   `src/{importer,crawler,searcher,llm}.rs` (copied from runtime).

### Next Steps
*   This completes the initial implementation of the Rust Semantic Target.
*   Future work can focus on optimizing the Redb schema (e.g., reverse indices for graph traversal) and implementing the "Vector Search" part of `PtSearcher` (currently falls back to text search).
