### PR TITLE
Fix complex RIGHT JOIN chains with multiple disjunctions

### DIFF
--- a/PR_RIGHT_JOIN_CHAINS_FIX.md
+++ b/PR_RIGHT_JOIN_CHAINS_FIX.md
@@ -1,0 +1,256 @@
+# Fix Complex RIGHT JOIN Chains (Phase 3d Fix)
+
+## Summary
+
+Fixes the **known limitation** from Phase 3d where RIGHT JOIN chains with multiple disjunctions didn't compile correctly.
+
+### What's Fixed
+
+✅ **RIGHT JOIN chains** - Pattern `(A ; null), (B ; null), C` now generates correct SQL
+✅ **Multiple disjunctions** - Recursively handles all leading disjunctions
+✅ **Backwards compatible** - All previous tests continue to pass
+
+## Problem
+
+**Before this fix**, the pattern `(t1 ; null), (t2 ; null), t3` generated incomplete SQL:
+
+```sql
+SELECT t1.a, unknown, t3.c    ← "unknown" instead of t2.b
+FROM t1
+RIGHT JOIN t3;                 ← Missing t2!
+```
+
+**Root cause:** `compile_right_join_clause/6` only extracted the FIRST disjunction, treating Rest as a list of simple goals. When Rest contained another disjunction `(t2 ; null)`, it couldn't handle it.
+
+## Solution
+
+Adopted the same approach used by LEFT JOIN: **extract ALL leading disjunctions** before processing.
+
+### New Predicates
+
+#### 1. `extract_leading_disjunctions/3`
+
+Extracts all disjunctions that appear before any non-disjunction goal:
+
+```prolog
+%% Pattern: (t1 ; null), (t2 ; null), t3
+extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals)
+% → LeadingDisjunctions = [(t1 ; null), (t2 ; null)]
+% → RemainingGoals = [t3]
+```
+
+#### 2. `process_right_joins/5`
+
+Iteratively processes goals (both disjunctions and regular tables) to generate RIGHT JOIN clauses:
+
+```prolog
+process_right_joins([Goal|Rest], AccTables, [JoinClause|RestJoins], [Table|RestTables], AllNullVars) :-
+    % Handle both (table ; null) and regular table goals
+    (   Goal = (TableGoal ; Fallback)
+    ->  extract_null_bindings(Fallback, NullVars),
+        Table = TableGoal
+    ;   NullVars = [],
+        Table = Goal
+    ),
+    generate_right_join_sql(AccTables, Table, JoinClause),
+    append(AccTables, [Table], NewAccTables),
+    process_right_joins(Rest, NewAccTables, RestJoins, RestTables, RestNullVars),
+    append(NullVars, RestNullVars, AllNullVars).
+```
+
+### Updated Predicate
+
+#### `compile_right_join_clause/6`
+
+Now uses the new approach:
+
+```prolog
+compile_right_join_clause(Name, Arity, Body, Head, Options, SQLCode) :-
+    % Extract ALL leading disjunctions
+    extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals),
+    LeadingDisjunctions \= [],
+
+    % First disjunction = FROM table
+    LeadingDisjunctions = [FirstDisj|RestDisjs],
+    FirstDisj = (FirstTable ; FirstFallback),
+    extract_null_bindings(FirstFallback, FirstNullVars),
+    generate_from_clause([FirstTable], FromClause),
+
+    % Combine remaining disjunctions + regular goals
+    append(RestDisjs, RemainingGoals, AllRightGoals),
+
+    % Process all to generate RIGHT JOINs
+    process_right_joins(AllRightGoals, [FirstTable], JoinClauses, AllRightTables, RestNullVars),
+
+    % ... generate SELECT and combine ...
+```
+
+## Test Results
+
+### Test 1: Simple RIGHT JOIN ✅ (Still Works)
+
+**Pattern:**
+```prolog
+order_customers(Product, Name) :-
+    (customers(CId, Name, _) ; Name = null),
+    orders(_, CId, Product, _).
+```
+
+**Generated:**
+```sql
+SELECT orders.product, customers.name
+FROM customers
+RIGHT JOIN orders ON orders.customer_id = customers.id;
+```
+
+### Test 2: FULL OUTER JOIN ✅ (Still Works)
+
+**Pattern:**
+```prolog
+all_customer_orders(Name, Product) :-
+    (customers(CId, Name, _) ; Name = null),
+    (orders(_, CId, Product, _) ; Product = null).
+```
+
+**Generated:**
+```sql
+SELECT customers.name, orders.product
+FROM customers
+FULL OUTER JOIN orders ON orders.customer_id = customers.id;
+```
+
+### Test 3: RIGHT JOIN Chain ✅ (FIXED!)
+
+**Pattern:**
+```prolog
+right_chain(A, B, C) :-
+    (t1(X, A) ; A = null),
+    (t2(Y, X, B) ; B = null, X = null),
+    t3(_, Y, C).
+```
+
+**Before (broken):**
+```sql
+SELECT t1.a, unknown, t3.c    ← Wrong!
+FROM t1
+RIGHT JOIN t3;                 ← Missing t2!
+```
+
+**After (fixed):**
+```sql
+SELECT t1.a, t2.b, t3.c        ← Correct!
+FROM t1
+RIGHT JOIN t2 ON t2.x = t1.x   ← t2 included!
+RIGHT JOIN t3 ON t3.y = t2.y;
+```
+
+### Backwards Compatibility ✅
+
+All previous tests continue to pass:
+
+```bash
+$ swipl test_sql_left_join.pl
+✓ Test 1: Basic LEFT JOIN
+✓ Test 2: Multi-column LEFT JOIN
+✓ Test 3: Nested LEFT JOINs
+✓ Test 4: LEFT JOIN with WHERE
+
+$ swipl test_mixed_joins.pl
+✓ Test 1: One INNER, One LEFT
+✓ Test 2: Two INNER, One LEFT
+✓ Test 3: One INNER, Two LEFT
+```
+
+## Implementation Details
+
+### Algorithm Flow
+
+1. **Extract leading disjunctions:**
+   - `(t1 ; null), (t2 ; null), t3`
+   - → `[(t1 ; null), (t2 ; null)]` + `[t3]`
+
+2. **First disjunction = FROM:**
+   - `FROM t1`
+
+3. **Process remaining (disjunctions + regular tables):**
+   - `[(t2 ; null), t3]` → Generate RIGHT JOIN for each
+   - `RIGHT JOIN t2 ON ...`
+   - `RIGHT JOIN t3 ON ...`
+
+4. **Generate SELECT:**
+   - Include all tables: `t1.a, t2.b, t3.c`
+   - Mark NULL-able columns from disjunction fallbacks
+
+### Pattern Matching
+
+`extract_leading_disjs_iter/4` recursively extracts disjunctions:
+
+```prolog
+extract_leading_disjs_iter((Disj, Rest), Acc, AllDisjs, Remaining) :-
+    Disj = (_ ; _),  % Is a disjunction
+    !,
+    extract_leading_disjs_iter(Rest, [Disj|Acc], AllDisjs, Remaining).
+
+extract_leading_disjs_iter(Rest, Acc, AllDisjs, Remaining) :-
+    % Hit a non-disjunction
+    Acc \= [],
+    reverse(Acc, AllDisjs),
+    conjunction_to_list(Rest, Remaining).
+```
+
+## Files Modified
+
+### Core Implementation
+- **`src/unifyweaver/targets/sql_target.pl`** (+61 lines, -35 lines)
+  - Added `extract_leading_disjunctions/3`
+  - Added `extract_leading_disjs_iter/4`
+  - Added `process_right_joins/5`
+  - Updated `compile_right_join_clause/6` to use new approach
+  - Removed obsolete `generate_right_join_chain/3` (replaced by `process_right_joins/5`)
+
+### Documentation
+- **`proposals/RIGHT_JOIN_CHAINS_FIX.md`** (new, design document)
+- **`PR_RIGHT_JOIN_CHAINS_FIX.md`** (this file)
+
+### Debug Tools
+- **`debug_right_chain.pl`** (new, debug script used during development)
+
+## Breaking Changes
+
+**None.** This is a pure bug fix that completes the Phase 3d implementation.
+
+## Related Work
+
+- **Phase 3** (PR #172): LEFT JOIN support
+- **Phase 3b** (PR #174): Nested LEFT JOINs
+- **Phase 3c** (PR #175): Mixed INNER/LEFT JOINs
+- **Phase 3d** (PR #176): RIGHT JOIN and FULL OUTER JOIN
+- **Phase 3d Fix** (This PR): Complete RIGHT JOIN chain support
+
+## Impact
+
+This fix completes the RIGHT JOIN feature set, removing the documented limitation. Users can now write complex RIGHT JOIN chains with multiple disjunctions, enabling more expressive queries.
+
+### Example Use Case
+
+```prolog
+% Analytics: Show all transactions, with optional customer and account info
+all_transactions(TxId, CustomerName, AccountType) :-
+    (customers(CustId, CustomerName, _) ; CustomerName = null),
+    (accounts(AcctId, CustId, AccountType) ; AccountType = null),
+    transactions(TxId, AcctId, _, _).  % All transactions preserved
+```
+
+**Generates:**
+```sql
+SELECT transactions.id, customers.name, accounts.type
+FROM customers
+RIGHT JOIN accounts ON accounts.customer_id = customers.id
+RIGHT JOIN transactions ON transactions.account_id = accounts.id;
+```
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>

--- a/proposals/RIGHT_JOIN_CHAINS_FIX.md
+++ b/proposals/RIGHT_JOIN_CHAINS_FIX.md
@@ -1,0 +1,224 @@
+# Fix Complex RIGHT JOIN Chains (Phase 3d Fix)
+
+**Date:** 2025-12-04
+**Status:** Implementation
+**Issue:** RIGHT JOIN chains with multiple disjunctions don't compile correctly
+
+## Problem
+
+**Current behavior** for pattern `(t1 ; null), (t2 ; null), t3`:
+```sql
+FROM t1
+RIGHT JOIN t3    ← Missing t2!
+```
+
+**Expected behavior:**
+```sql
+FROM t1
+RIGHT JOIN t2 ON t2.x = t1.x
+RIGHT JOIN t3 ON t3.y = t2.y
+```
+
+## Root Cause
+
+Current `compile_right_join_clause/6` only handles the FIRST disjunction:
+
+```prolog
+Body = ((LeftGoal ; Fallback), Rest),  % Only extracts first disjunction
+conjunction_to_list(Rest, RightGoals),  % [(t2 ; null), t3]
+separate_goals(RightGoals, ...), % Can't handle (t2 ; null) as a goal!
+```
+
+When `Rest` contains another disjunction `(t2 ; null)`, `conjunction_to_list` returns it as a single element `[(t2 ; null), t3]`. Then `separate_goals` doesn't know how to handle the complex goal `(t2 ; null)` - it's neither a simple table nor a constraint.
+
+## Solution: Extract ALL Leading Disjunctions
+
+Use the same approach as LEFT JOIN, but adapted for RIGHT JOIN semantics:
+
+### LEFT JOIN (for reference)
+```prolog
+% Pattern: t1, (t2 ; null), (t3 ; null)
+extract_all_disjunctions(Body, LeftPart, Disjunctions)
+% → LeftPart = t1
+% → Disjunctions = [(t2 ; null), (t3 ; null)]
+```
+
+### RIGHT JOIN (new)
+```prolog
+% Pattern: (t1 ; null), (t2 ; null), t3
+extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals)
+% → LeadingDisjunctions = [(t1 ; null), (t2 ; null)]
+% → RemainingGoals = [t3]
+```
+
+## Implementation Plan
+
+### 1. Add `extract_leading_disjunctions/3`
+
+Extract all disjunctions that appear BEFORE any non-disjunction goal:
+
+```prolog
+%% extract_leading_disjunctions(+Body, -LeadingDisjunctions, -RemainingGoals)
+%  Extract all leading disjunctions (RIGHT JOIN pattern)
+%
+extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals) :-
+    extract_leading_disjs_iter(Body, [], LeadingDisjunctions, RemainingGoals).
+
+extract_leading_disjs_iter((Disj, Rest), Acc, AllDisjs, Remaining) :-
+    Disj = (_ ; _),  % Is a disjunction
+    !,
+    extract_leading_disjs_iter(Rest, [Disj|Acc], AllDisjs, Remaining).
+extract_leading_disjs_iter((Disj ; _), Acc, AllDisjs, []) :-
+    % Final goal is a disjunction
+    !,
+    reverse([Disj|Acc], AllDisjs).
+extract_leading_disjs_iter(Rest, Acc, AllDisjs, Remaining) :-
+    % Hit a non-disjunction
+    Acc \= [],
+    reverse(Acc, AllDisjs),
+    conjunction_to_list(Rest, Remaining).
+```
+
+### 2. Add `process_right_joins/5`
+
+Similar to `process_left_joins` but generates RIGHT JOINs:
+
+```prolog
+%% process_right_joins(+Goals, +AccTables, -JoinClauses, -AllTables, -AllNullVars)
+%  Process goals iteratively to generate RIGHT JOIN clauses
+%  Goals can be disjunctions or regular table goals
+%
+process_right_joins([], _, [], [], []).
+process_right_joins([Goal|Rest], AccTables, [JoinClause|RestJoins], [Table|RestTables], AllNullVars) :-
+    % Check if Goal is a disjunction
+    (   Goal = (TableGoal ; Fallback)
+    ->  % Disjunction - extract table and NULL bindings
+        extract_null_bindings(Fallback, NullVars),
+        Table = TableGoal
+    ;   % Regular table goal
+        NullVars = [],
+        Table = Goal
+    ),
+
+    % Generate RIGHT JOIN for this table
+    generate_right_join_sql(AccTables, Table, JoinClause),
+
+    % Add this table to accumulated
+    append(AccTables, [Table], NewAccTables),
+
+    % Recurse
+    process_right_joins(Rest, NewAccTables, RestJoins, RestTables, RestNullVars),
+
+    % Accumulate NULL vars
+    append(NullVars, RestNullVars, AllNullVars).
+```
+
+### 3. Update `compile_right_join_clause/6`
+
+Replace the current implementation:
+
+```prolog
+compile_right_join_clause(Name, Arity, Body, Head, Options, SQLCode) :-
+    % Extract ALL leading disjunctions
+    extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals),
+
+    % Verify we have at least one leading disjunction
+    LeadingDisjunctions \= [],
+
+    % First disjunction is FROM
+    LeadingDisjunctions = [FirstDisj|RestDisjs],
+    FirstDisj = (FirstTable ; FirstFallback),
+    extract_null_bindings(FirstFallback, FirstNullVars),
+
+    % Generate FROM clause
+    generate_from_clause([FirstTable], FromClause),
+
+    % Combine remaining disjunctions and regular goals
+    append(RestDisjs, RemainingGoals, AllRightGoals),
+
+    % Process all right goals (disjunctions + regular) to generate RIGHT JOINs
+    process_right_joins(AllRightGoals, [FirstTable], JoinClauses, AllRightTables, RestNullVars),
+
+    % Combine NULL vars
+    append(FirstNullVars, RestNullVars, AllNullVars),
+
+    % Combine all JOINs
+    atomic_list_concat(JoinClauses, '\n', AllJoins),
+
+    % Generate SELECT
+    Head =.. [Name|HeadArgs],
+    AllTableGoals = [FirstTable|AllRightTables],
+    generate_select_for_nested_joins(HeadArgs, [FirstTable], AllRightTables, AllNullVars, SelectClause),
+
+    % Generate WHERE (no constraints in simple RIGHT JOIN)
+    WhereClause = '',
+
+    % Combine
+    (member(format(Format), Options) -> true ; Format = view),
+    (member(view_name(ViewName), Options) -> true ; ViewName = Name),
+    combine_left_join_sql(Format, ViewName, SelectClause, FromClause, AllJoins, WhereClause, SQLCode).
+```
+
+## Test Cases
+
+### Test 1: Simple RIGHT JOIN (existing, should still work)
+```prolog
+order_customers(Product, Name) :-
+    (customers(CId, Name, _) ; Name = null),
+    orders(_, CId, Product, _).
+```
+
+**Expected:**
+```sql
+FROM customers
+RIGHT JOIN orders ON orders.customer_id = customers.id
+```
+
+### Test 2: RIGHT JOIN Chain (currently broken)
+```prolog
+right_chain(A, B, C) :-
+    (t1(X, A) ; A = null),
+    (t2(Y, X, B) ; B = null, X = null),
+    t3(_, Y, C).
+```
+
+**Expected:**
+```sql
+FROM t1
+RIGHT JOIN t2 ON t2.x = t1.x
+RIGHT JOIN t3 ON t3.y = t2.y
+```
+
+### Test 3: Mixed disjunctions (new)
+```prolog
+mixed(A, B, C, D) :-
+    (t1(X, A) ; A = null),
+    t2(Y, X, B),  % No disjunction
+    (t3(Z, Y, C) ; C = null, Z = null),
+    t4(_, Z, D).
+```
+
+**Issue:** This is ambiguous! First disjunction suggests RIGHT JOIN, but t2 has no disjunction (INNER JOIN?), then another disjunction (LEFT JOIN?).
+
+**Decision:** For now, this should FAIL pattern detection. Only support pure RIGHT JOIN chains where:
+- All leading goals are disjunctions OR
+- All leading goals are disjunctions, followed by regular goals (all treated as RIGHT JOINs)
+
+## Success Criteria
+
+- ✅ Test 1 (simple RIGHT JOIN) still works
+- ✅ Test 2 (RIGHT JOIN chain) generates correct SQL
+- ✅ Test 3 (FULL OUTER) still works
+- ✅ All backwards compatibility tests pass
+- ✅ SQLite validation for chain pattern
+
+## Files to Modify
+
+- `src/unifyweaver/targets/sql_target.pl`
+  - Add `extract_leading_disjunctions/3`
+  - Add `process_right_joins/5`
+  - Update `compile_right_join_clause/6`
+
+---
+
+**Status:** Ready to implement


### PR DESCRIPTION
## Summary

Fixes the **known limitation** from Phase 3d where RIGHT JOIN chains with multiple disjunctions didn't compile correctly.

### What's Fixed

✅ **RIGHT JOIN chains** - Pattern `(A ; null), (B ; null), C` now generates correct SQL
✅ **Multiple disjunctions** - Recursively handles all leading disjunctions
✅ **Backwards compatible** - All previous tests continue to pass

## Problem

**Before this fix**, the pattern `(t1 ; null), (t2 ; null), t3` generated incomplete SQL:

```sql
SELECT t1.a, unknown, t3.c    ← "unknown" instead of t2.b
FROM t1
RIGHT JOIN t3;                 ← Missing t2!
```

**Root cause:** `compile_right_join_clause/6` only extracted the FIRST disjunction, treating Rest as a list of simple goals. When Rest contained another disjunction `(t2 ; null)`, it couldn't handle it.

## Solution

Adopted the same approach used by LEFT JOIN: **extract ALL leading disjunctions** before processing.

### New Predicates

#### 1. `extract_leading_disjunctions/3`

Extracts all disjunctions that appear before any non-disjunction goal:

```prolog
%% Pattern: (t1 ; null), (t2 ; null), t3
extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals)
% → LeadingDisjunctions = [(t1 ; null), (t2 ; null)]
% → RemainingGoals = [t3]
```

#### 2. `process_right_joins/5`

Iteratively processes goals (both disjunctions and regular tables) to generate RIGHT JOIN clauses:

```prolog
process_right_joins([Goal|Rest], AccTables, [JoinClause|RestJoins], [Table|RestTables], AllNullVars) :-
    % Handle both (table ; null) and regular table goals
    (   Goal = (TableGoal ; Fallback)
    ->  extract_null_bindings(Fallback, NullVars),
        Table = TableGoal
    ;   NullVars = [],
        Table = Goal
    ),
    generate_right_join_sql(AccTables, Table, JoinClause),
    append(AccTables, [Table], NewAccTables),
    process_right_joins(Rest, NewAccTables, RestJoins, RestTables, RestNullVars),
    append(NullVars, RestNullVars, AllNullVars).
```

### Updated Predicate

#### `compile_right_join_clause/6`

Now uses the new approach:

```prolog
compile_right_join_clause(Name, Arity, Body, Head, Options, SQLCode) :-
    % Extract ALL leading disjunctions
    extract_leading_disjunctions(Body, LeadingDisjunctions, RemainingGoals),
    LeadingDisjunctions \= [],

    % First disjunction = FROM table
    LeadingDisjunctions = [FirstDisj|RestDisjs],
    FirstDisj = (FirstTable ; FirstFallback),
    extract_null_bindings(FirstFallback, FirstNullVars),
    generate_from_clause([FirstTable], FromClause),

    % Combine remaining disjunctions + regular goals
    append(RestDisjs, RemainingGoals, AllRightGoals),

    % Process all to generate RIGHT JOINs
    process_right_joins(AllRightGoals, [FirstTable], JoinClauses, AllRightTables, RestNullVars),

    % ... generate SELECT and combine ...
```

## Test Results

### Test 1: Simple RIGHT JOIN ✅ (Still Works)

**Pattern:**
```prolog
order_customers(Product, Name) :-
    (customers(CId, Name, _) ; Name = null),
    orders(_, CId, Product, _).
```

**Generated:**
```sql
SELECT orders.product, customers.name
FROM customers
RIGHT JOIN orders ON orders.customer_id = customers.id;
```

### Test 2: FULL OUTER JOIN ✅ (Still Works)

**Pattern:**
```prolog
all_customer_orders(Name, Product) :-
    (customers(CId, Name, _) ; Name = null),
    (orders(_, CId, Product, _) ; Product = null).
```

**Generated:**
```sql
SELECT customers.name, orders.product
FROM customers
FULL OUTER JOIN orders ON orders.customer_id = customers.id;
```

### Test 3: RIGHT JOIN Chain ✅ (FIXED!)

**Pattern:**
```prolog
right_chain(A, B, C) :-
    (t1(X, A) ; A = null),
    (t2(Y, X, B) ; B = null, X = null),
    t3(_, Y, C).
```

**Before (broken):**
```sql
SELECT t1.a, unknown, t3.c    ← Wrong!
FROM t1
RIGHT JOIN t3;                 ← Missing t2!
```

**After (fixed):**
```sql
SELECT t1.a, t2.b, t3.c        ← Correct!
FROM t1
RIGHT JOIN t2 ON t2.x = t1.x   ← t2 included!
RIGHT JOIN t3 ON t3.y = t2.y;
```

### Backwards Compatibility ✅

All previous tests continue to pass:

```bash
$ swipl test_sql_left_join.pl
✓ Test 1: Basic LEFT JOIN
✓ Test 2: Multi-column LEFT JOIN
✓ Test 3: Nested LEFT JOINs
✓ Test 4: LEFT JOIN with WHERE

$ swipl test_mixed_joins.pl
✓ Test 1: One INNER, One LEFT
✓ Test 2: Two INNER, One LEFT
✓ Test 3: One INNER, Two LEFT
```

## Implementation Details

### Algorithm Flow

1. **Extract leading disjunctions:**
   - `(t1 ; null), (t2 ; null), t3`
   - → `[(t1 ; null), (t2 ; null)]` + `[t3]`

2. **First disjunction = FROM:**
   - `FROM t1`

3. **Process remaining (disjunctions + regular tables):**
   - `[(t2 ; null), t3]` → Generate RIGHT JOIN for each
   - `RIGHT JOIN t2 ON ...`
   - `RIGHT JOIN t3 ON ...`

4. **Generate SELECT:**
   - Include all tables: `t1.a, t2.b, t3.c`
   - Mark NULL-able columns from disjunction fallbacks

### Pattern Matching

`extract_leading_disjs_iter/4` recursively extracts disjunctions:

```prolog
extract_leading_disjs_iter((Disj, Rest), Acc, AllDisjs, Remaining) :-
    Disj = (_ ; _),  % Is a disjunction
    !,
    extract_leading_disjs_iter(Rest, [Disj|Acc], AllDisjs, Remaining).

extract_leading_disjs_iter(Rest, Acc, AllDisjs, Remaining) :-
    % Hit a non-disjunction
    Acc \= [],
    reverse(Acc, AllDisjs),
    conjunction_to_list(Rest, Remaining).
```

## Files Modified

### Core Implementation
- **`src/unifyweaver/targets/sql_target.pl`** (+61 lines, -35 lines)
  - Added `extract_leading_disjunctions/3`
  - Added `extract_leading_disjs_iter/4`
  - Added `process_right_joins/5`
  - Updated `compile_right_join_clause/6` to use new approach
  - Removed obsolete `generate_right_join_chain/3` (replaced by `process_right_joins/5`)

### Documentation
- **`proposals/RIGHT_JOIN_CHAINS_FIX.md`** (new, design document)
- **`PR_RIGHT_JOIN_CHAINS_FIX.md`** (this file)

### Debug Tools
- **`debug_right_chain.pl`** (new, debug script used during development)

## Breaking Changes

**None.** This is a pure bug fix that completes the Phase 3d implementation.

## Related Work

- **Phase 3** (PR #172): LEFT JOIN support
- **Phase 3b** (PR #174): Nested LEFT JOINs
- **Phase 3c** (PR #175): Mixed INNER/LEFT JOINs
- **Phase 3d** (PR #176): RIGHT JOIN and FULL OUTER JOIN
- **Phase 3d Fix** (This PR): Complete RIGHT JOIN chain support

## Impact

This fix completes the RIGHT JOIN feature set, removing the documented limitation. Users can now write complex RIGHT JOIN chains with multiple disjunctions, enabling more expressive queries.

### Example Use Case

```prolog
% Analytics: Show all transactions, with optional customer and account info
all_transactions(TxId, CustomerName, AccountType) :-
    (customers(CustId, CustomerName, _) ; CustomerName = null),
    (accounts(AcctId, CustId, AccountType) ; AccountType = null),
    transactions(TxId, AcctId, _, _).  % All transactions preserved
```

**Generates:**
```sql
SELECT transactions.id, customers.name, accounts.type
FROM customers
RIGHT JOIN accounts ON accounts.customer_id = customers.id
RIGHT JOIN transactions ON transactions.account_id = accounts.id;
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
