### PR TITLE
perf: add relation indexing to C# generator and document standalone usage

### DIFF
--- a/docs/usage/csharp_generator.md
+++ b/docs/usage/csharp_generator.md
@@ -1,0 +1,33 @@
+# C# Generator Mode Quickstart (Standalone Fixed-Point)
+
+This path emits self-contained C# (facts + ApplyRule\_* + Solve) that runs without the managed QueryRuntime.
+
+## Generate
+- In Prolog: `compile_predicate_to_csharp(pred/arity, [mode(generator)], Code).`
+- The output is a single C# module with:
+  - `Fact` record (structural equality for dicts + enumerable args).
+  - `GetInitialFacts` (base facts from user clauses).
+  - `ApplyRule_*` methods for rules.
+  - `Solve()` fixpoint loop.
+
+## Run (tests use Janus)
+- Tests call into `csharp_test_helper:compile_and_run(Code, Name)` which writes a temp `Program.cs` + csproj, builds with `dotnet`, and executes.
+- You can do the same manually: write `Code` to a file, create a minimal csproj targeting `net9.0`, `dotnet build`, then run the produced exe/dll.
+
+## What’s supported
+- Joins, builtins, stratified negation.
+- Aggregates:
+  - `aggregate_all/3`: count, sum, min, max, set, bag.
+  - `aggregate/4` grouped: sum, min, max, set, bag.
+  - At most one aggregate goal per rule; when present with joins, it must be last.
+- Dependency groups and fixpoint evaluation are handled inside the generated module.
+
+## Recent performance tweak
+- Generated `Solve()` now builds a per-relation index each iteration:
+  - `relIndex: Dictionary<string, List<Fact>>` derived from the current `total`.
+  - Joins and aggregates iterate over relation buckets instead of scanning all facts.
+  - Semantics unchanged; reduces work for rules that focus on specific relations.
+
+## Cross-target direction
+- The generator shares helpers (`common_generator`) with other targets; the goal is a common generator API across languages (joins/negation/aggregates) with per-target renderers.
+- This C# generator is the current reference for the standalone fixed-point path.


### PR DESCRIPTION
  Description:

  - Build a per-relation index each fixpoint iteration and thread it into generated rule/aggregate code so joins/aggregates scan relation
    buckets instead of the whole fact set; semantics unchanged.
  - Keep aggregate, grouping, negation, and join behavior intact (all generator aggregate suites still pass).
  - Add docs/usage/csharp_generator.md documenting standalone generator mode, supported features, and the new indexing tweak.

  Tests: C# generator aggregate suites (count, grouped sum, grouped min/max/set/bag, set/bag, joins, negation) via SWI+Janus+dotnet.