### PR TITLE
fix(rust): Update Rust vector search dependencies and API compatibility for modern toolchain

### DIFF
--- a/src/unifyweaver/targets/rust_runtime/searcher.rs
+++ b/src/unifyweaver/targets/rust_runtime/searcher.rs
@@ -1,7 +1,6 @@
 use redb::{Database, ReadableTable, TableDefinition};
 use serde_json::Value;
 use std::sync::Arc;
-use std::collections::HashSet;
 use crate::embedding::EmbeddingProvider;
 
 const OBJECTS: TableDefinition<&str, &str> = TableDefinition::new("objects");
@@ -13,7 +12,7 @@ pub struct PtSearcher {
     embedder: EmbeddingProvider,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchResult {
     pub id: String,
     pub score: f32,

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -655,5 +655,5 @@ dep_to_toml(sha2, "sha2 = \"0.10\"").
 dep_to_toml(hex, "hex = \"0.4\"").
 dep_to_toml(uuid, "uuid = { version = \"1.4\", features = [\"v4\"] }").
 dep_to_toml(redb, "redb = \"1.4.0\"").
-dep_to_toml(quick_xml, "quick-xml = \"0.30\"").
-dep_to_toml(candle, "candle-core = \"0.3.0\"\ncandle-nn = \"0.3.0\"\ncandle-transformers = \"0.3.0\"\ntokenizers = \"0.15\"\nanyhow = \"1.0\"").
+dep_to_toml(quick_xml, "quick-xml = \"0.38\"").
+dep_to_toml(candle, "candle-core = \"0.9\"\ncandle-nn = \"0.9\"\ncandle-transformers = \"0.9\"\ntokenizers = \"0.22\"\nanyhow = \"1.0\"").


### PR DESCRIPTION
PR Description                                                                                                                                               
                                                                                                                                                             
Summary                                                                                                                                                      
                                                                                                                                                             
Fixes compilation issues in the Rust vector search target by updating dependencies to modern versions and adapting to API changes in Candle 0.9, quick-xml 0.
, and tokenizers 0.22. The feat/rust-vectors branch can now build and run                                                                                    
successfully in standard Linux environments (tested in WSL2).                                                                                                
                                                                                                                                                             
Problem                                                                                                                                                      
                                                                                                                                                             
The original implementation used outdated dependency versions with conflicting transitive dependencies:                                                      
- Candle 0.3.0 had incompatible rand crate version conflicts                                                                                                 
- Quick-xml 0.30 API has changed significantly                                                                                                               
- Tokenizers 0.15 is outdated                                                                                                                                
- Code couldn't compile on modern Rust toolchains                                                                                                            
                                                                                                                                                             
Changes                                                                                                                                                      
                                                                                                                                                             
Dependency Updates                                                                                                                                           
                                                                                                                                                             
- candle-core, candle-nn, candle-transformers: 0.3.0 → 0.9                                                                                                   
- tokenizers: 0.15 → 0.22                                                                                                                                    
- quick-xml: 0.30 → 0.38                                                                                                                                     
- Added: serde with derive feature for JSON serialization                                                                                                    
                                                                                                                                                             
API Compatibility Fixes                                                                                                                                      
                                                                                                                                                             
embedding.rs:                                                                                                                                                
- Updated VarBuilder::from_safetensors → VarBuilder::from_mmaped_safetensors                                                                                 
- Updated BertModel::new → BertModel::load                                                                                                                   
- Updated model.forward() to accept 3 parameters (added None for attention mask)                                                                             
- Added proper Config for all-MiniLM-L6-v2 (384-dimensional embeddings, 6 layers)                                                                            
                                                                                                                                                             
crawler.rs:                                                                                                                                                  
- Fixed XML text parsing: e.unescape() → std::str::from_utf8(e.as_ref()) for quick-xml 0.38                                                                  
- Fixed nested XML element handling: only track top-level objects with IDs                                                                                   
- Added else branch to restore object if end tag doesn't match (prevents nested elements from corrupting parent)                                             
                                                                                                                                                             
searcher.rs:                                                                                                                                                 
- Added #[derive(serde::Serialize)] to SearchResult struct                                                                                                   
- Removed unused HashSet import                                                                                                                              
                                                                                                                                                             
rust_target.pl:                                                                                                                                              
- Updated dependency version mappings in dep_to_toml/2 predicates                                                                                            
                                                                                                                                                             
Testing                                                                                                                                                      
                                                                                                                                                             
Tested successfully in WSL2 Ubuntu environment:                                                                                                              
- ✅ Project compiles without errors                                                                                                                          
- ✅ Loads all-MiniLM-L6-v2 BERT model (91MB safetensors format)                                                                                              
- ✅ Parses RDF files with nested XML elements                                                                                                                
- ✅ Text search functional                                                                                                                                   
- ✅ Embedding generation working                                                                                                                             
- ⚠️ Vector search has minor normalization bug (can be fixed in follow-up)                                                                                   
                                                                                                                                                             
Model Compatibility                                                                                                                                          
                                                                                                                                                             
The code now properly supports all-MiniLM-L6-v2 (sentence-transformers model):                                                                               
- 384-dimensional embeddings (matches Python ONNX implementation)                                                                                            
- 6-layer transformer                                                                                                                                        
- Compatible with Hugging Face model hub                                                                                                                     
                                                                                                                                                             
Breaking Changes                                                                                                                                             
                                                                                                                                                             
None - this is a fix to make the existing feature work. The API for users remains unchanged.                                                                 
                                                                                                                                                             
Future Work                                                                                                                                                  
                                                                                                                                                             
- Fix vector search normalization bug (shape mismatch in scalar division)                                                                                    
- Consider ONNX runtime support for consistency with Python target                                                                                           
- Add model config auto-detection from config.json                                                                                                           
- Performance optimization for CPU inference                                                                                                                 
                                                                                                                                                             
---                                                                                                                                                          
Fixes: Enables Rust vector search compilation and basic functionality                                                                                        
Tested: WSL2 Ubuntu with Rust 1.91.1, Cargo 1.91.1, SWI-Prolog 9.2.9                                                                                         
                                                                                                                                                             
� Generated with https://claude.com/claude-code                                                                                                              
                                                                                                                                                             
Co-Authored-By: Claude noreply@anthropic.com                                                                                                                 