### PR TITLE
Fix RDF/XML attribute extraction to use element-scoped keys

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1113,6 +1113,24 @@ namespace UnifyWeaver.QueryRuntime.Dynamic
                 var attrQualified = attr.Name.ToString();
                 var attrPrefix = ResolvePrefix(attr.Name);
 
+                // Element-scoped attribute keys (prevents conflicts when multiple child elements have same attribute)
+                // e.g., "seeAlso@rdf:resource" and "parentTree@rdf:resource" are now distinct
+                map[$"{local}@{attrLocal}"] = attr.Value;
+                map[$"{qualified}@{attrQualified}"] = attr.Value;
+                if (!string.IsNullOrEmpty(prefix))
+                {
+                    map[$"{prefix}:{local}@{attrLocal}"] = attr.Value;
+                }
+                if (!string.IsNullOrEmpty(attrPrefix))
+                {
+                    map[$"{local}@{attrPrefix}:{attrLocal}"] = attr.Value;
+                    if (!string.IsNullOrEmpty(prefix))
+                    {
+                        map[$"{prefix}:{local}@{attrPrefix}:{attrLocal}"] = attr.Value;
+                    }
+                }
+
+                // Global attribute keys (backward compatibility - may conflict if multiple elements have same attribute)
                 map[$"@{attrLocal}"] = attr.Value;
                 map[$"@{attrQualified}"] = attr.Value;
                 if (!string.IsNullOrEmpty(attrPrefix))


### PR DESCRIPTION
Problem                                                                                                                                       
                                                                                                                                              
When parsing RDF/XML documents, the AddElement method in QueryRuntime.cs stored attributes from all child elements using global keys          
(e.g., @rdf:resource). This caused conflicts when multiple elements had the same attribute name - the last value would overwrite earlier      
ones.                                                                                                                                         
                                                                                                                                              
Example conflict in Pearltrees RDF:                                                                                                           
<rdfs:seeAlso rdf:resource="https://pearltrees.com/id123"/>      <!-- Lost! -->                                                               
<pt:parentTree rdf:resource="https://pearltrees.com/id456"/>     <!-- Wins -->                                                                
                                                                                                                                              
Both were stored as @rdf:resource, so the seeAlso target was overwritten by the parentTree value.                                             
                                                                                                                                              
Solution                                                                                                                                      
                                                                                                                                              
Store element-scoped attribute keys in addition to global keys:                                                                               
- Element-scoped: seeAlso@rdf:resource and parentTree@rdf:resource (unambiguous)                                                              
- Global keys: Kept for backward compatibility (may still conflict)                                                                           
                                                                                                                                              
This allows RDF consumers to access attributes unambiguously while maintaining compatibility with existing code.                              
                                                                                                                                              
Changes                                                                                                                                       
                                                                                                                                              
1. QueryRuntime.cs - AddElement method (lines 1110-1141)                                                                                      
                                                                                                                                              
- Added element-scoped attribute storage before global keys                                                                                   
- Format: {elementName}@{attributeName}                                                                                                       
- Multiple namespace variations for flexibility:                                                                                              
  - seeAlso@rdf:resource                                                                                                                      
  - seeAlso@{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource                                                                             
  - rdfs:seeAlso@rdf:resource                                                                                                                 
  - etc.                                                                                                                                      
- Global keys preserved at end for backward compatibility                                                                                     
                                                                                                                                              
2. RebuildPeartreesHierarchy/Program.cs                                                                                                       
                                                                                                                                              
- Updated to look for element-scoped seeAlso@rdf:resource keys                                                                                
- Falls back to old global keys for databases created before this fix                                                                         
- Now successfully extracts tree→tree relationships via RefPearl.seeAlso                                                                      
- Added comprehensive tree-to-tree relationship extraction                                                                                    
                                                                                                                                              
Impact                                                                                                                                        
                                                                                                                                              
This is a general RDF/XML fix, not specific to Pearltrees. Any RDF/XML ingestion will benefit from proper element-scoped attribute            
storage.                                                                                                                                      
                                                                                                                                              
Testing                                                                                                                                       
                                                                                                                                              
Re-ingested Pearltrees RDF export (11,867 documents) and ran rebuild tool:                                                                    
- ✅ 1,996 trees with Children (tree→pearl relationships)                                                                                      
- ✅ 1,996 trees with ChildTrees (tree→tree relationships via RefPearl.seeAlso)                                                                
- ✅ 6,725 pearls with ParentTree                                                                                                              
- ✅ 6,725 RefPearls with seeAlso extracted successfully                                                                                       
                                                                                                                                              
Before this fix: 0 tree→tree relationships extracted (seeAlso data was lost)                                                                  
After this fix: 6,725 tree→tree relationships extracted successfully                                                                          
                                                                                                                                              
Backward Compatibility                                                                                                                        
                                                                                                                                              
- ✅ Global attribute keys still stored (old code continues working)                                                                           
- ✅ Element-scoped keys added (new code gets unambiguous access)                                                                              
- ✅ RebuildPeartreesHierarchy tool works with both old and new databases                                                                      