### PR TITLE
feat: Add cross-target glue Phase 1 - target registry and mapping

### DIFF
--- a/src/unifyweaver/core/target_mapping.pl
+++ b/src/unifyweaver/core/target_mapping.pl
@@ -1,0 +1,325 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Target Mapping - Maps predicates to compilation targets and locations
+ *
+ * This module tracks which target should compile each predicate, and
+ * where that predicate should execute (location) and how it connects
+ * to other predicates (transport).
+ */
+
+:- module(target_mapping, [
+    % Target declarations
+    declare_target/2,           % declare_target(Pred/Arity, Target)
+    declare_target/3,           % declare_target(Pred/Arity, Target, Options)
+    undeclare_target/1,         % undeclare_target(Pred/Arity)
+
+    % Location declarations
+    declare_location/2,         % declare_location(Pred/Arity, Options)
+    undeclare_location/1,       % undeclare_location(Pred/Arity)
+
+    % Connection declarations
+    declare_connection/3,       % declare_connection(Pred1/Arity1, Pred2/Arity2, Options)
+    undeclare_connection/2,     % undeclare_connection(Pred1/Arity1, Pred2/Arity2)
+
+    % Queries
+    predicate_target/2,         % predicate_target(Pred/Arity, Target)
+    predicate_target_options/3, % predicate_target_options(Pred/Arity, Target, Options)
+    predicate_location/2,       % predicate_location(Pred/Arity, Location)
+    connection_transport/3,     % connection_transport(Pred1, Pred2, Transport)
+    connection_options/3,       % connection_options(Pred1, Pred2, Options)
+
+    % Resolution (with defaults)
+    resolve_location/2,         % resolve_location(Pred/Arity, Location)
+    resolve_transport/3,        % resolve_transport(Pred1, Pred2, Transport)
+
+    % Listing
+    list_mappings/1,            % list_mappings(Mappings)
+    list_connections/1,         % list_connections(Connections)
+
+    % Validation
+    validate_mapping/2          % validate_mapping(Pred/Arity, Errors)
+]).
+
+:- use_module(library(lists)).
+:- use_module(target_registry).
+
+%% ============================================
+%% Dynamic storage
+%% ============================================
+
+:- dynamic user_target/3.       % user_target(Pred/Arity, Target, Options)
+:- dynamic user_location/2.     % user_location(Pred/Arity, Options)
+:- dynamic user_connection/3.   % user_connection(Pred1/Arity1, Pred2/Arity2, Options)
+
+%% ============================================
+%% Target Declarations
+%% ============================================
+
+%% declare_target(+Pred/Arity, +Target)
+%  Declare which target should compile a predicate.
+%
+%  Example:
+%    :- declare_target(filter_logs/2, awk).
+%
+declare_target(Pred/Arity, Target) :-
+    declare_target(Pred/Arity, Target, []).
+
+%% declare_target(+Pred/Arity, +Target, +Options)
+%  Declare target with additional options.
+%
+%  Options:
+%    - optimize(speed | size | memory)
+%    - streaming(true | false)
+%    - priority(N) - for conflict resolution
+%
+%  Example:
+%    :- declare_target(process/2, go, [optimize(speed), streaming(true)]).
+%
+declare_target(Pred/Arity, Target, Options) :-
+    atom(Pred),
+    integer(Arity),
+    Arity >= 0,
+    atom(Target),
+    is_list(Options),
+    % Remove existing mapping if present
+    retractall(user_target(Pred/Arity, _, _)),
+    assertz(user_target(Pred/Arity, Target, Options)).
+
+%% undeclare_target(+Pred/Arity)
+%  Remove a target declaration.
+%
+undeclare_target(Pred/Arity) :-
+    retractall(user_target(Pred/Arity, _, _)).
+
+%% ============================================
+%% Location Declarations
+%% ============================================
+
+%% declare_location(+Pred/Arity, +Options)
+%  Declare where a predicate should execute.
+%
+%  Options:
+%    - process(same | separate)
+%    - host(Hostname)
+%    - port(Port)
+%
+%  Example:
+%    :- declare_location(ml_model/2, [host('ml-server'), port(8080)]).
+%
+declare_location(Pred/Arity, Options) :-
+    atom(Pred),
+    integer(Arity),
+    Arity >= 0,
+    is_list(Options),
+    retractall(user_location(Pred/Arity, _)),
+    assertz(user_location(Pred/Arity, Options)).
+
+%% undeclare_location(+Pred/Arity)
+%  Remove a location declaration.
+%
+undeclare_location(Pred/Arity) :-
+    retractall(user_location(Pred/Arity, _)).
+
+%% ============================================
+%% Connection Declarations
+%% ============================================
+
+%% declare_connection(+Pred1/Arity1, +Pred2/Arity2, +Options)
+%  Declare how two predicates should communicate.
+%
+%  Options:
+%    - transport(pipe | socket | http | grpc)
+%    - format(tsv | json | binary)
+%    - buffer(none | line | block(Size))
+%    - timeout(Seconds)
+%    - retry(Count)
+%
+%  Example:
+%    :- declare_connection(producer/2, consumer/2, [transport(pipe), format(json)]).
+%
+declare_connection(Pred1/Arity1, Pred2/Arity2, Options) :-
+    atom(Pred1), integer(Arity1), Arity1 >= 0,
+    atom(Pred2), integer(Arity2), Arity2 >= 0,
+    is_list(Options),
+    % Store in canonical order (alphabetically by predicate name)
+    canonical_pair(Pred1/Arity1, Pred2/Arity2, P1, P2),
+    retractall(user_connection(P1, P2, _)),
+    assertz(user_connection(P1, P2, Options)).
+
+%% undeclare_connection(+Pred1/Arity1, +Pred2/Arity2)
+%  Remove a connection declaration.
+%
+undeclare_connection(Pred1/Arity1, Pred2/Arity2) :-
+    canonical_pair(Pred1/Arity1, Pred2/Arity2, P1, P2),
+    retractall(user_connection(P1, P2, _)).
+
+%% canonical_pair(+A, +B, -First, -Second)
+%  Order a pair canonically for storage.
+%
+canonical_pair(A, B, A, B) :- A @=< B, !.
+canonical_pair(A, B, B, A).
+
+%% ============================================
+%% Queries
+%% ============================================
+
+%% predicate_target(?Pred/Arity, ?Target)
+%  Query which target compiles a predicate.
+%
+predicate_target(Pred/Arity, Target) :-
+    user_target(Pred/Arity, Target, _).
+
+%% predicate_target_options(?Pred/Arity, ?Target, ?Options)
+%  Query target with options.
+%
+predicate_target_options(Pred/Arity, Target, Options) :-
+    user_target(Pred/Arity, Target, Options).
+
+%% predicate_location(?Pred/Arity, ?Location)
+%  Query explicit location options for a predicate.
+%
+predicate_location(Pred/Arity, Location) :-
+    user_location(Pred/Arity, Location).
+
+%% connection_transport(+Pred1, +Pred2, -Transport)
+%  Get the declared transport between two predicates.
+%
+connection_transport(Pred1, Pred2, Transport) :-
+    connection_options(Pred1, Pred2, Options),
+    member(transport(Transport), Options).
+
+%% connection_options(?Pred1, ?Pred2, ?Options)
+%  Query connection options between predicates.
+%
+connection_options(Pred1, Pred2, Options) :-
+    canonical_pair(Pred1, Pred2, P1, P2),
+    user_connection(P1, P2, Options).
+
+%% ============================================
+%% Resolution (with defaults)
+%% ============================================
+
+%% resolve_location(+Pred/Arity, -Location)
+%  Resolve the location for a predicate, using defaults if not declared.
+%
+resolve_location(Pred/Arity, Location) :-
+    % Check for explicit location
+    user_location(Pred/Arity, Options),
+    !,
+    options_to_location(Options, Location).
+
+resolve_location(Pred/Arity, Location) :-
+    % Use default based on target
+    predicate_target(Pred/Arity, Target),
+    !,
+    target_registry:default_location(Target, Location).
+
+resolve_location(_, local_process).  % Ultimate fallback
+
+%% options_to_location(+Options, -Location)
+%  Convert location options to a location term.
+%
+options_to_location(Options, remote(Host)) :-
+    member(host(Host), Options),
+    !.
+options_to_location(Options, in_process) :-
+    member(process(same), Options),
+    !.
+options_to_location(Options, local_process) :-
+    member(process(separate), Options),
+    !.
+options_to_location(_, local_process).  % Default
+
+%% resolve_transport(+Pred1, +Pred2, -Transport)
+%  Resolve the transport between two predicates, using defaults if not declared.
+%
+resolve_transport(Pred1, Pred2, Transport) :-
+    % Check for explicit connection
+    connection_transport(Pred1, Pred2, Transport),
+    !.
+
+resolve_transport(Pred1, Pred2, Transport) :-
+    % Use default based on locations
+    resolve_location(Pred1, Loc1),
+    resolve_location(Pred2, Loc2),
+    target_registry:default_transport(Loc1, Loc2, Transport).
+
+%% ============================================
+%% Listing
+%% ============================================
+
+%% list_mappings(-Mappings)
+%  Get all predicate-to-target mappings.
+%  Returns list of mapping(Pred/Arity, Target, Options).
+%
+list_mappings(Mappings) :-
+    findall(
+        mapping(Pred/Arity, Target, Options),
+        user_target(Pred/Arity, Target, Options),
+        Mappings
+    ).
+
+%% list_connections(-Connections)
+%  Get all connection declarations.
+%  Returns list of connection(Pred1, Pred2, Options).
+%
+list_connections(Connections) :-
+    findall(
+        connection(P1, P2, Options),
+        user_connection(P1, P2, Options),
+        Connections
+    ).
+
+%% ============================================
+%% Validation
+%% ============================================
+
+%% validate_mapping(+Pred/Arity, -Errors)
+%  Validate a mapping and return any errors.
+%
+validate_mapping(Pred/Arity, Errors) :-
+    findall(Error, mapping_error(Pred/Arity, Error), Errors).
+
+%% mapping_error(+Pred/Arity, -Error)
+%  Check for specific mapping errors.
+%
+mapping_error(Pred/Arity, error(no_target, Pred/Arity)) :-
+    \+ user_target(Pred/Arity, _, _).
+
+mapping_error(Pred/Arity, error(unknown_target, Target)) :-
+    user_target(Pred/Arity, Target, _),
+    \+ target_registry:target_exists(Target).
+
+mapping_error(Pred/Arity, error(invalid_location_option, Option)) :-
+    user_location(Pred/Arity, Options),
+    member(Option, Options),
+    \+ valid_location_option(Option).
+
+%% valid_location_option(+Option)
+%  Check if a location option is valid.
+%
+valid_location_option(process(same)).
+valid_location_option(process(separate)).
+valid_location_option(host(H)) :- atom(H).
+valid_location_option(port(P)) :- integer(P), P > 0, P < 65536.
+
+%% ============================================
+%% Directive support
+%% ============================================
+
+%% Allow using as directives
+:- multifile user:term_expansion/2.
+
+user:term_expansion((:- target(Pred, Target)), []) :-
+    declare_target(Pred, Target).
+
+user:term_expansion((:- target(Pred, Target, Options)), []) :-
+    declare_target(Pred, Target, Options).
+
+user:term_expansion((:- location(Pred, Options)), []) :-
+    declare_location(Pred, Options).
+
+user:term_expansion((:- connection(P1, P2, Options)), []) :-
+    declare_connection(P1, P2, Options).

--- a/src/unifyweaver/core/target_registry.pl
+++ b/src/unifyweaver/core/target_registry.pl
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Target Registry - Central registry for UnifyWeaver compilation targets
+ *
+ * This module manages metadata about available targets, their runtime families,
+ * and capabilities. It enables cross-target glue to determine how targets
+ * should communicate.
+ */
+
+:- module(target_registry, [
+    % Target registration
+    register_target/3,          % register_target(Name, Family, Capabilities)
+    unregister_target/1,        % unregister_target(Name)
+
+    % Target queries
+    target_exists/1,            % target_exists(Name)
+    target_family/2,            % target_family(Target, Family)
+    target_capabilities/2,      % target_capabilities(Target, Capabilities)
+    targets_same_family/2,      % targets_same_family(Target1, Target2)
+
+    % Family queries
+    family_targets/2,           % family_targets(Family, Targets)
+
+    % Listing
+    list_targets/1,             % list_targets(Targets)
+    list_families/1,            % list_families(Families)
+
+    % Location defaults
+    default_location/2,         % default_location(Target, Location)
+    default_transport/3         % default_transport(Location1, Location2, Transport)
+]).
+
+:- use_module(library(lists)).
+
+%% ============================================
+%% Dynamic storage for targets
+%% ============================================
+
+:- dynamic registered_target/3.  % registered_target(Name, Family, Capabilities)
+
+%% ============================================
+%% Target Registration
+%% ============================================
+
+%% register_target(+Name, +Family, +Capabilities)
+%  Register a new target with its runtime family and capabilities.
+%  Capabilities is a list of atoms describing what the target supports.
+%
+%  Example:
+%    register_target(python, python, [streaming, pipes, libraries, ml])
+%
+register_target(Name, Family, Capabilities) :-
+    atom(Name),
+    atom(Family),
+    is_list(Capabilities),
+    (   registered_target(Name, _, _)
+    ->  retract(registered_target(Name, _, _))
+    ;   true
+    ),
+    assertz(registered_target(Name, Family, Capabilities)).
+
+%% unregister_target(+Name)
+%  Remove a target from the registry.
+%
+unregister_target(Name) :-
+    retractall(registered_target(Name, _, _)).
+
+%% ============================================
+%% Target Queries
+%% ============================================
+
+%% target_exists(+Name)
+%  True if a target with the given name is registered.
+%
+target_exists(Name) :-
+    registered_target(Name, _, _).
+
+%% target_family(?Target, ?Family)
+%  Query or check the runtime family of a target.
+%
+target_family(Target, Family) :-
+    registered_target(Target, Family, _).
+
+%% target_capabilities(?Target, ?Capabilities)
+%  Query the capabilities list of a target.
+%
+target_capabilities(Target, Capabilities) :-
+    registered_target(Target, _, Capabilities).
+
+%% targets_same_family(+Target1, +Target2)
+%  True if both targets belong to the same runtime family.
+%  Targets in the same family can communicate in-process.
+%
+targets_same_family(Target1, Target2) :-
+    target_family(Target1, Family),
+    target_family(Target2, Family).
+
+%% ============================================
+%% Family Queries
+%% ============================================
+
+%% family_targets(+Family, -Targets)
+%  Get all targets belonging to a runtime family.
+%
+family_targets(Family, Targets) :-
+    findall(T, target_family(T, Family), Targets).
+
+%% ============================================
+%% Listing
+%% ============================================
+
+%% list_targets(-Targets)
+%  Get a list of all registered target names.
+%
+list_targets(Targets) :-
+    findall(Name, registered_target(Name, _, _), Targets).
+
+%% list_families(-Families)
+%  Get a list of all unique runtime families.
+%
+list_families(Families) :-
+    findall(F, registered_target(_, F, _), AllFamilies),
+    sort(AllFamilies, Families).
+
+%% ============================================
+%% Location and Transport Defaults
+%% ============================================
+
+%% default_location(+Target, -Location)
+%  Get the default location type for a target.
+%  Most targets default to local_process.
+%
+default_location(Target, in_process) :-
+    target_family(Target, Family),
+    in_process_family(Family),
+    !.
+default_location(_, local_process).
+
+%% in_process_family(+Family)
+%  Families that support in-process communication.
+%
+in_process_family(dotnet).
+in_process_family(jvm).
+
+%% default_transport(+Location1, +Location2, -Transport)
+%  Get the default transport for communicating between two locations.
+%
+default_transport(in_process, in_process, direct) :- !.
+default_transport(local_process, local_process, pipe) :- !.
+default_transport(local_process, remote(_), http) :- !.
+default_transport(remote(_), local_process, http) :- !.
+default_transport(remote(_), remote(_), http) :- !.
+default_transport(_, _, pipe).  % Fallback
+
+%% ============================================
+%% Built-in Target Definitions
+%% ============================================
+
+%% Initialize built-in targets on module load
+register_builtin_targets :-
+    % Shell family - always separate processes, pipe communication
+    register_target(bash, shell, [streaming, pipes, process_control, scripting]),
+    register_target(awk, shell, [streaming, pipes, regex, aggregation, text_processing]),
+
+    % Python family
+    register_target(python, python, [streaming, pipes, libraries, ml, data_science]),
+    register_target(ironpython, dotnet, [streaming, dotnet_interop, scripting]),
+
+    % .NET family - can share process
+    register_target(csharp, dotnet, [compiled, streaming, linq, async]),
+    register_target(fsharp, dotnet, [compiled, streaming, functional, linq]),
+    register_target(powershell, dotnet, [scripting, streaming, system_admin, dotnet_interop]),
+
+    % JVM family - can share process
+    register_target(java, jvm, [compiled, streaming, enterprise]),
+    register_target(scala, jvm, [compiled, streaming, functional]),
+    register_target(clojure, jvm, [compiled, streaming, functional, lisp]),
+    register_target(jython, jvm, [scripting, jvm_interop]),
+
+    % Native family - compiled binaries
+    register_target(go, native, [compiled, streaming, concurrency, cross_platform]),
+    register_target(rust, native, [compiled, streaming, memory_safe, performance]),
+    register_target(c, native, [compiled, performance, low_level]),
+
+    % Database
+    register_target(sql, database, [queries, transactions, relational]).
+
+:- register_builtin_targets.
+
+%% ============================================
+%% Capability Queries
+%% ============================================
+
+%% target_has_capability(+Target, +Capability)
+%  Check if a target has a specific capability.
+%
+target_has_capability(Target, Capability) :-
+    target_capabilities(Target, Caps),
+    member(Capability, Caps).
+
+%% targets_with_capability(+Capability, -Targets)
+%  Find all targets that have a specific capability.
+%
+targets_with_capability(Capability, Targets) :-
+    findall(T, target_has_capability(T, Capability), Targets).

--- a/src/unifyweaver/glue/pipe_glue.pl
+++ b/src/unifyweaver/glue/pipe_glue.pl
@@ -1,0 +1,422 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Pipe Glue - Generate glue code for pipe-based inter-target communication
+ *
+ * This module generates reader/writer code for TSV and JSON pipe protocols,
+ * enabling targets to communicate via Unix pipes.
+ */
+
+:- module(pipe_glue, [
+    % Writer generation (producer side)
+    generate_pipe_writer/4,     % generate_pipe_writer(Target, Fields, Options, Code)
+
+    % Reader generation (consumer side)
+    generate_pipe_reader/4,     % generate_pipe_reader(Target, Fields, Options, Code)
+
+    % Format helpers
+    generate_tsv_writer/3,      % generate_tsv_writer(Target, Fields, Code)
+    generate_tsv_reader/3,      % generate_tsv_reader(Target, Fields, Code)
+    generate_json_writer/3,     % generate_json_writer(Target, Fields, Code)
+    generate_json_reader/3,     % generate_json_reader(Target, Fields, Code)
+
+    % Orchestrator generation
+    generate_pipeline_script/3  % generate_pipeline_script(Steps, Options, Script)
+]).
+
+:- use_module(library(lists)).
+
+%% ============================================
+%% Writer Generation (Producer Side)
+%% ============================================
+
+%% generate_pipe_writer(+Target, +Fields, +Options, -Code)
+%  Generate code that writes records to stdout in the specified format.
+%
+%  Target: awk, python, bash, go, rust, etc.
+%  Fields: List of field names
+%  Options: [format(tsv|json), ...]
+%  Code: Generated code string
+%
+generate_pipe_writer(Target, Fields, Options, Code) :-
+    (   member(format(json), Options)
+    ->  generate_json_writer(Target, Fields, Code)
+    ;   generate_tsv_writer(Target, Fields, Code)
+    ).
+
+%% ============================================
+%% TSV Writers
+%% ============================================
+
+%% generate_tsv_writer(+Target, +Fields, -Code)
+%  Generate TSV output code for a target.
+%
+generate_tsv_writer(awk, Fields, Code) :-
+    fields_to_awk_print(Fields, PrintExpr),
+    format(atom(Code), 'print ~w', [PrintExpr]).
+
+generate_tsv_writer(python, Fields, Code) :-
+    fields_to_python_list(Fields, FieldList),
+    format(atom(Code),
+        'print("\\t".join(str(x) for x in [~w]))',
+        [FieldList]).
+
+generate_tsv_writer(bash, Fields, Code) :-
+    fields_to_bash_echo(Fields, EchoExpr),
+    format(atom(Code), 'echo -e "~w"', [EchoExpr]).
+
+generate_tsv_writer(go, Fields, Code) :-
+    fields_to_go_printf(Fields, FormatStr, Args),
+    format(atom(Code),
+        'fmt.Printf("~w\\n", ~w)',
+        [FormatStr, Args]).
+
+generate_tsv_writer(rust, Fields, Code) :-
+    fields_to_rust_println(Fields, FormatStr, Args),
+    format(atom(Code),
+        'println!("~w", ~w);',
+        [FormatStr, Args]).
+
+%% ============================================
+%% TSV Readers
+%% ============================================
+
+%% generate_tsv_reader(+Target, +Fields, -Code)
+%  Generate TSV input parsing code for a target.
+%
+generate_tsv_reader(awk, Fields, Code) :-
+    % AWK automatically splits on FS, fields are $1, $2, etc.
+    fields_to_awk_assign(Fields, Assignments),
+    format(atom(Code), '~w', [Assignments]).
+
+generate_tsv_reader(python, Fields, Code) :-
+    fields_to_python_unpack(Fields, UnpackCode),
+    format(atom(Code),
+'import sys
+for line in sys.stdin:
+    fields = line.rstrip("\\n").split("\\t")
+    ~w
+    # Process record here',
+        [UnpackCode]).
+
+generate_tsv_reader(bash, Fields, Code) :-
+    fields_to_bash_read(Fields, ReadVars),
+    format(atom(Code),
+'while IFS=$\'\\t\' read -r ~w; do
+    # Process record here
+done',
+        [ReadVars]).
+
+generate_tsv_reader(go, Fields, Code) :-
+    fields_to_go_scan(Fields, ScanCode),
+    format(atom(Code),
+'scanner := bufio.NewScanner(os.Stdin)
+for scanner.Scan() {
+    fields := strings.Split(scanner.Text(), "\\t")
+    ~w
+    // Process record here
+}',
+        [ScanCode]).
+
+generate_tsv_reader(rust, Fields, Code) :-
+    fields_to_rust_parse(Fields, ParseCode),
+    format(atom(Code),
+'use std::io::{self, BufRead};
+let stdin = io::stdin();
+for line in stdin.lock().lines() {
+    let line = line.unwrap();
+    let fields: Vec<&str> = line.split(\'\\t\').collect();
+    ~w
+    // Process record here
+}',
+        [ParseCode]).
+
+%% ============================================
+%% JSON Writers
+%% ============================================
+
+%% generate_json_writer(+Target, +Fields, -Code)
+%  Generate JSON Lines output code for a target.
+%
+generate_json_writer(awk, Fields, Code) :-
+    fields_to_awk_json(Fields, JsonExpr),
+    format(atom(Code), 'print "~w"', [JsonExpr]).
+
+generate_json_writer(python, Fields, Code) :-
+    fields_to_python_dict(Fields, DictExpr),
+    format(atom(Code),
+'import json
+print(json.dumps(~w))',
+        [DictExpr]).
+
+generate_json_writer(go, Fields, Code) :-
+    fields_to_go_json(Fields, StructCode, MarshalCode),
+    format(atom(Code),
+'~w
+jsonBytes, _ := json.Marshal(~w)
+fmt.Println(string(jsonBytes))',
+        [StructCode, MarshalCode]).
+
+generate_json_writer(rust, Fields, Code) :-
+    fields_to_rust_json(Fields, JsonCode),
+    format(atom(Code),
+'let json = serde_json::json!(~w);
+println!("{}", json);',
+        [JsonCode]).
+
+%% ============================================
+%% JSON Readers
+%% ============================================
+
+%% generate_json_reader(+Target, +Fields, -Code)
+%  Generate JSON Lines input parsing code for a target.
+%
+generate_json_reader(python, Fields, Code) :-
+    fields_to_python_json_extract(Fields, ExtractCode),
+    format(atom(Code),
+'import sys, json
+for line in sys.stdin:
+    record = json.loads(line)
+    ~w
+    # Process record here',
+        [ExtractCode]).
+
+generate_json_reader(go, Fields, Code) :-
+    fields_to_go_json_decode(Fields, DecodeCode),
+    format(atom(Code),
+'scanner := bufio.NewScanner(os.Stdin)
+for scanner.Scan() {
+    var record map[string]interface{}
+    json.Unmarshal([]byte(scanner.Text()), &record)
+    ~w
+    // Process record here
+}',
+        [DecodeCode]).
+
+generate_json_reader(rust, Fields, Code) :-
+    fields_to_rust_json_parse(Fields, ParseCode),
+    format(atom(Code),
+'use std::io::{self, BufRead};
+use serde_json::Value;
+let stdin = io::stdin();
+for line in stdin.lock().lines() {
+    let record: Value = serde_json::from_str(&line.unwrap()).unwrap();
+    ~w
+    // Process record here
+}',
+        [ParseCode]).
+
+%% ============================================
+%% Reader/Writer with Options
+%% ============================================
+
+%% generate_pipe_reader(+Target, +Fields, +Options, -Code)
+%  Generate code that reads records from stdin.
+%
+generate_pipe_reader(Target, Fields, Options, Code) :-
+    (   member(format(json), Options)
+    ->  generate_json_reader(Target, Fields, Code)
+    ;   generate_tsv_reader(Target, Fields, Code)
+    ).
+
+%% ============================================
+%% Pipeline Orchestrator
+%% ============================================
+
+%% generate_pipeline_script(+Steps, +Options, -Script)
+%  Generate a bash script that orchestrates a pipeline of targets.
+%
+%  Steps: List of step(Pred/Arity, Target, ScriptPath)
+%  Options: [input(File), output(File), ...]
+%  Script: Generated bash script
+%
+generate_pipeline_script(Steps, Options, Script) :-
+    steps_to_commands(Steps, Commands),
+    (   member(input(InputFile), Options)
+    ->  format(atom(InputCmd), 'cat "~w"', [InputFile])
+    ;   InputCmd = 'cat -'  % Read from stdin
+    ),
+    (   member(output(OutputFile), Options)
+    ->  format(atom(OutputRedir), ' > "~w"', [OutputFile])
+    ;   OutputRedir = ''
+    ),
+    join_commands(Commands, PipelineCmd),
+    format(atom(Script),
+'#!/bin/bash
+# Generated UnifyWeaver Pipeline
+set -euo pipefail
+
+~w \\
+    | ~w~w
+',
+        [InputCmd, PipelineCmd, OutputRedir]).
+
+%% steps_to_commands(+Steps, -Commands)
+%  Convert pipeline steps to shell commands.
+%
+steps_to_commands([], []).
+steps_to_commands([step(_, Target, ScriptPath)|Rest], [Cmd|RestCmds]) :-
+    target_to_command(Target, ScriptPath, Cmd),
+    steps_to_commands(Rest, RestCmds).
+
+%% target_to_command(+Target, +ScriptPath, -Command)
+%  Generate the shell command to run a target's script.
+%
+target_to_command(awk, ScriptPath, Cmd) :-
+    format(atom(Cmd), 'awk -f "~w"', [ScriptPath]).
+target_to_command(python, ScriptPath, Cmd) :-
+    format(atom(Cmd), 'python3 "~w"', [ScriptPath]).
+target_to_command(bash, ScriptPath, Cmd) :-
+    format(atom(Cmd), 'bash "~w"', [ScriptPath]).
+target_to_command(go, ScriptPath, Cmd) :-
+    % Assumes pre-compiled binary
+    format(atom(Cmd), '"~w"', [ScriptPath]).
+target_to_command(rust, ScriptPath, Cmd) :-
+    % Assumes pre-compiled binary
+    format(atom(Cmd), '"~w"', [ScriptPath]).
+
+%% join_commands(+Commands, -Joined)
+%  Join commands with pipe and line continuation.
+%
+join_commands([Cmd], Cmd) :- !.
+join_commands([Cmd|Rest], Joined) :-
+    join_commands(Rest, RestJoined),
+    format(atom(Joined), '~w \\~n    | ~w', [Cmd, RestJoined]).
+
+%% ============================================
+%% Field Conversion Helpers
+%% ============================================
+
+%% AWK helpers
+fields_to_awk_print(Fields, Expr) :-
+    length(Fields, N),
+    numlist(1, N, Indices),
+    maplist(awk_field_ref, Indices, Refs),
+    atomic_list_concat(Refs, ' "\\t" ', Expr).
+
+awk_field_ref(N, Ref) :-
+    format(atom(Ref), '$~w', [N]).
+
+fields_to_awk_assign(Fields, Assignments) :-
+    length(Fields, N),
+    numlist(1, N, Indices),
+    maplist(awk_field_assign, Fields, Indices, AssignList),
+    atomic_list_concat(AssignList, '\n    ', Assignments).
+
+awk_field_assign(Field, N, Assign) :-
+    format(atom(Assign), '~w = $~w', [Field, N]).
+
+fields_to_awk_json(Fields, JsonExpr) :-
+    maplist(awk_json_field, Fields, JsonFields),
+    atomic_list_concat(JsonFields, ', ', JsonBody),
+    format(atom(JsonExpr), '{~w}', [JsonBody]).
+
+awk_json_field(Field, JsonField) :-
+    format(atom(JsonField), '\\"~w\\": \\"" ~w "\\""', [Field, Field]).
+
+%% Python helpers
+fields_to_python_list(Fields, FieldList) :-
+    atomic_list_concat(Fields, ', ', FieldList).
+
+fields_to_python_unpack(Fields, Code) :-
+    length(Fields, N),
+    numlist(0, N, Indices0),
+    Indices0 = [_|Indices],  % Skip 0, use 0..N-1
+    maplist(python_field_assign, Fields, Indices, Assigns),
+    atomic_list_concat(Assigns, '\n    ', Code).
+
+python_field_assign(Field, Index, Assign) :-
+    format(atom(Assign), '~w = fields[~w]', [Field, Index]).
+
+fields_to_python_dict(Fields, DictExpr) :-
+    maplist(python_dict_entry, Fields, Entries),
+    atomic_list_concat(Entries, ', ', Body),
+    format(atom(DictExpr), '{~w}', [Body]).
+
+python_dict_entry(Field, Entry) :-
+    format(atom(Entry), '"~w": ~w', [Field, Field]).
+
+fields_to_python_json_extract(Fields, Code) :-
+    maplist(python_json_extract, Fields, Extracts),
+    atomic_list_concat(Extracts, '\n    ', Code).
+
+python_json_extract(Field, Extract) :-
+    format(atom(Extract), '~w = record.get("~w")', [Field, Field]).
+
+%% Bash helpers
+fields_to_bash_echo(Fields, EchoExpr) :-
+    maplist(bash_var_ref, Fields, Refs),
+    atomic_list_concat(Refs, '\\t', EchoExpr).
+
+bash_var_ref(Field, Ref) :-
+    format(atom(Ref), '$~w', [Field]).
+
+fields_to_bash_read(Fields, ReadVars) :-
+    atomic_list_concat(Fields, ' ', ReadVars).
+
+%% Go helpers
+fields_to_go_printf(Fields, FormatStr, Args) :-
+    length(Fields, N),
+    findall('%v', between(1, N, _), Formats),
+    atomic_list_concat(Formats, '\\t', FormatStr),
+    atomic_list_concat(Fields, ', ', Args).
+
+fields_to_go_scan(Fields, Code) :-
+    length(Fields, N),
+    numlist(0, N, Indices0),
+    Indices0 = [_|Indices],
+    maplist(go_field_assign, Fields, Indices, Assigns),
+    atomic_list_concat(Assigns, '\n    ', Code).
+
+go_field_assign(Field, Index, Assign) :-
+    format(atom(Assign), '~w := fields[~w]', [Field, Index]).
+
+fields_to_go_json(Fields, StructCode, MarshalCode) :-
+    % Simplified: use map
+    StructCode = '',
+    maplist(go_map_entry, Fields, Entries),
+    atomic_list_concat(Entries, ', ', Body),
+    format(atom(MarshalCode), 'map[string]interface{}{~w}', [Body]).
+
+go_map_entry(Field, Entry) :-
+    format(atom(Entry), '"~w": ~w', [Field, Field]).
+
+fields_to_go_json_decode(Fields, Code) :-
+    maplist(go_json_extract, Fields, Extracts),
+    atomic_list_concat(Extracts, '\n    ', Code).
+
+go_json_extract(Field, Extract) :-
+    format(atom(Extract), '~w := record["~w"]', [Field, Field]).
+
+%% Rust helpers
+fields_to_rust_println(Fields, FormatStr, Args) :-
+    length(Fields, N),
+    findall('{}', between(1, N, _), Formats),
+    atomic_list_concat(Formats, '\\t', FormatStr),
+    atomic_list_concat(Fields, ', ', Args).
+
+fields_to_rust_parse(Fields, Code) :-
+    length(Fields, N),
+    numlist(0, N, Indices0),
+    Indices0 = [_|Indices],
+    maplist(rust_field_assign, Fields, Indices, Assigns),
+    atomic_list_concat(Assigns, '\n    ', Code).
+
+rust_field_assign(Field, Index, Assign) :-
+    format(atom(Assign), 'let ~w = fields[~w];', [Field, Index]).
+
+fields_to_rust_json(Fields, JsonCode) :-
+    maplist(rust_json_entry, Fields, Entries),
+    atomic_list_concat(Entries, ', ', Body),
+    format(atom(JsonCode), '{~w}', [Body]).
+
+rust_json_entry(Field, Entry) :-
+    format(atom(Entry), '"~w": ~w', [Field, Field]).
+
+fields_to_rust_json_parse(Fields, Code) :-
+    maplist(rust_json_extract, Fields, Extracts),
+    atomic_list_concat(Extracts, '\n    ', Code).
+
+rust_json_extract(Field, Extract) :-
+    format(atom(Extract), 'let ~w = &record["~w"];', [Field, Field]).

--- a/tests/core/test_target_mapping.pl
+++ b/tests/core/test_target_mapping.pl
@@ -1,0 +1,270 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Unit tests for target_mapping module
+ */
+
+:- use_module('../../src/unifyweaver/core/target_registry').
+:- use_module('../../src/unifyweaver/core/target_mapping').
+
+%% ============================================
+%% Test Helpers
+%% ============================================
+
+run_tests :-
+    format('~n=== Target Mapping Tests ===~n~n'),
+    cleanup,
+    run_all_tests,
+    cleanup,
+    format('~nAll tests passed!~n').
+
+run_all_tests :-
+    test_declare_target,
+    test_declare_target_options,
+    test_declare_location,
+    test_declare_connection,
+    test_resolve_location,
+    test_resolve_transport,
+    test_listing,
+    test_validation.
+
+cleanup :-
+    % Clean up any test declarations
+    retractall(target_mapping:user_target(_, _, _)),
+    retractall(target_mapping:user_location(_, _)),
+    retractall(target_mapping:user_connection(_, _, _)).
+
+assert_true(Goal, TestName) :-
+    (   call(Goal)
+    ->  format('  ✓ ~w~n', [TestName])
+    ;   format('  ✗ ~w FAILED~n', [TestName]),
+        fail
+    ).
+
+assert_false(Goal, TestName) :-
+    (   \+ call(Goal)
+    ->  format('  ✓ ~w~n', [TestName])
+    ;   format('  ✗ ~w FAILED (expected false)~n', [TestName]),
+        fail
+    ).
+
+assert_equal(Got, Expected, TestName) :-
+    (   Got == Expected
+    ->  format('  ✓ ~w~n', [TestName])
+    ;   format('  ✗ ~w FAILED: got ~w, expected ~w~n', [TestName, Got, Expected]),
+        fail
+    ).
+
+%% ============================================
+%% Test: Declare Target
+%% ============================================
+
+test_declare_target :-
+    format('Test: Declare target~n'),
+
+    % Declare a target
+    declare_target(filter/2, awk),
+    assert_true(predicate_target(filter/2, awk), 'filter/2 maps to awk'),
+
+    % Declare another
+    declare_target(analyze/3, python),
+    assert_true(predicate_target(analyze/3, python), 'analyze/3 maps to python'),
+
+    % Undeclare
+    undeclare_target(filter/2),
+    assert_false(predicate_target(filter/2, _), 'filter/2 undeclared'),
+
+    % Cleanup
+    undeclare_target(analyze/3),
+    format('~n').
+
+%% ============================================
+%% Test: Declare Target with Options
+%% ============================================
+
+test_declare_target_options :-
+    format('Test: Declare target with options~n'),
+
+    % Declare with options
+    declare_target(process/2, go, [optimize(speed), streaming(true)]),
+
+    predicate_target_options(process/2, Target, Options),
+    assert_equal(Target, go, 'process/2 maps to go'),
+    assert_true(member(optimize(speed), Options), 'has optimize option'),
+    assert_true(member(streaming(true), Options), 'has streaming option'),
+
+    % Re-declare overwrites
+    declare_target(process/2, rust, [memory_safe(true)]),
+    predicate_target_options(process/2, NewTarget, NewOptions),
+    assert_equal(NewTarget, rust, 'process/2 now maps to rust'),
+    assert_true(member(memory_safe(true), NewOptions), 'has new option'),
+    assert_false(member(optimize(speed), NewOptions), 'old option gone'),
+
+    undeclare_target(process/2),
+    format('~n').
+
+%% ============================================
+%% Test: Declare Location
+%% ============================================
+
+test_declare_location :-
+    format('Test: Declare location~n'),
+
+    % Local separate process
+    declare_location(worker/1, [process(separate)]),
+    predicate_location(worker/1, WorkerLoc),
+    assert_true(member(process(separate), WorkerLoc), 'worker has separate process'),
+
+    % Remote
+    declare_location(ml_model/2, [host('ml-server.local'), port(8080)]),
+    predicate_location(ml_model/2, MlLoc),
+    assert_true(member(host('ml-server.local'), MlLoc), 'ml_model has host'),
+    assert_true(member(port(8080), MlLoc), 'ml_model has port'),
+
+    undeclare_location(worker/1),
+    undeclare_location(ml_model/2),
+    format('~n').
+
+%% ============================================
+%% Test: Declare Connection
+%% ============================================
+
+test_declare_connection :-
+    format('Test: Declare connection~n'),
+
+    % Declare connection
+    declare_connection(producer/2, consumer/2, [transport(pipe), format(json)]),
+
+    connection_transport(producer/2, consumer/2, Transport),
+    assert_equal(Transport, pipe, 'connection uses pipe'),
+
+    connection_options(producer/2, consumer/2, Options),
+    assert_true(member(format(json), Options), 'connection uses json format'),
+
+    % Order shouldn't matter for lookup
+    connection_transport(consumer/2, producer/2, Transport2),
+    assert_equal(Transport2, pipe, 'reverse lookup works'),
+
+    undeclare_connection(producer/2, consumer/2),
+    assert_false(connection_transport(producer/2, consumer/2, _), 'connection removed'),
+    format('~n').
+
+%% ============================================
+%% Test: Resolve Location
+%% ============================================
+
+test_resolve_location :-
+    format('Test: Resolve location~n'),
+
+    % With explicit location
+    declare_target(remote_pred/1, python),
+    declare_location(remote_pred/1, [host('worker.local')]),
+    resolve_location(remote_pred/1, Loc1),
+    assert_equal(Loc1, remote('worker.local'), 'explicit remote location resolved'),
+
+    % With default (based on target family)
+    declare_target(dotnet_pred/1, csharp),
+    resolve_location(dotnet_pred/1, Loc2),
+    assert_equal(Loc2, in_process, 'csharp defaults to in_process'),
+
+    declare_target(shell_pred/1, bash),
+    resolve_location(shell_pred/1, Loc3),
+    assert_equal(Loc3, local_process, 'bash defaults to local_process'),
+
+    % Unknown predicate falls back to local_process
+    resolve_location(unknown/0, Loc4),
+    assert_equal(Loc4, local_process, 'unknown defaults to local_process'),
+
+    undeclare_target(remote_pred/1),
+    undeclare_location(remote_pred/1),
+    undeclare_target(dotnet_pred/1),
+    undeclare_target(shell_pred/1),
+    format('~n').
+
+%% ============================================
+%% Test: Resolve Transport
+%% ============================================
+
+test_resolve_transport :-
+    format('Test: Resolve transport~n'),
+
+    % With explicit connection
+    declare_connection(pred_a/1, pred_b/1, [transport(socket)]),
+    resolve_transport(pred_a/1, pred_b/1, T1),
+    assert_equal(T1, socket, 'explicit transport resolved'),
+
+    % Without explicit - uses location defaults
+    declare_target(local_a/1, bash),
+    declare_target(local_b/1, python),
+    resolve_transport(local_a/1, local_b/1, T2),
+    assert_equal(T2, pipe, 'local_process to local_process defaults to pipe'),
+
+    % In-process
+    declare_target(cs_a/1, csharp),
+    declare_target(cs_b/1, powershell),
+    resolve_transport(cs_a/1, cs_b/1, T3),
+    assert_equal(T3, direct, 'in_process to in_process defaults to direct'),
+
+    undeclare_connection(pred_a/1, pred_b/1),
+    undeclare_target(local_a/1),
+    undeclare_target(local_b/1),
+    undeclare_target(cs_a/1),
+    undeclare_target(cs_b/1),
+    format('~n').
+
+%% ============================================
+%% Test: Listing
+%% ============================================
+
+test_listing :-
+    format('Test: Listing~n'),
+
+    declare_target(list_test_a/1, awk),
+    declare_target(list_test_b/2, python),
+    declare_connection(list_test_a/1, list_test_b/2, [transport(pipe)]),
+
+    list_mappings(Mappings),
+    assert_true(member(mapping(list_test_a/1, awk, _), Mappings), 'mappings includes list_test_a'),
+    assert_true(member(mapping(list_test_b/2, python, _), Mappings), 'mappings includes list_test_b'),
+
+    list_connections(Connections),
+    length(Connections, N),
+    assert_true(N >= 1, 'at least one connection'),
+
+    undeclare_target(list_test_a/1),
+    undeclare_target(list_test_b/2),
+    undeclare_connection(list_test_a/1, list_test_b/2),
+    format('~n').
+
+%% ============================================
+%% Test: Validation
+%% ============================================
+
+test_validation :-
+    format('Test: Validation~n'),
+
+    % Valid mapping
+    declare_target(valid_pred/1, python),
+    validate_mapping(valid_pred/1, Errors1),
+    assert_equal(Errors1, [], 'valid mapping has no errors'),
+
+    % Missing target
+    validate_mapping(unmapped_pred/1, Errors2),
+    assert_true(member(error(no_target, unmapped_pred/1), Errors2), 'missing target detected'),
+
+    % Unknown target (register a fake one first)
+    retractall(target_mapping:user_target(fake_target_pred/1, _, _)),
+    assertz(target_mapping:user_target(fake_target_pred/1, nonexistent_target, [])),
+    validate_mapping(fake_target_pred/1, Errors3),
+    assert_true(member(error(unknown_target, nonexistent_target), Errors3), 'unknown target detected'),
+
+    undeclare_target(valid_pred/1),
+    retractall(target_mapping:user_target(fake_target_pred/1, _, _)),
+    format('~n').
+
+%% ============================================
+%% Main
+%% ============================================
+
+:- initialization(run_tests, main).

--- a/tests/core/test_target_registry.pl
+++ b/tests/core/test_target_registry.pl
@@ -1,0 +1,204 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Unit tests for target_registry module
+ */
+
+:- use_module('../../src/unifyweaver/core/target_registry').
+
+%% ============================================
+%% Test Helpers
+%% ============================================
+
+run_tests :-
+    format('~n=== Target Registry Tests ===~n~n'),
+    run_all_tests,
+    format('~nAll tests passed!~n').
+
+run_all_tests :-
+    test_builtin_targets,
+    test_target_family,
+    test_same_family,
+    test_capabilities,
+    test_custom_target,
+    test_default_location,
+    test_default_transport,
+    test_listing.
+
+assert_true(Goal, TestName) :-
+    (   call(Goal)
+    ->  format('  ✓ ~w~n', [TestName])
+    ;   format('  ✗ ~w FAILED~n', [TestName]),
+        fail
+    ).
+
+assert_false(Goal, TestName) :-
+    (   \+ call(Goal)
+    ->  format('  ✓ ~w~n', [TestName])
+    ;   format('  ✗ ~w FAILED (expected false)~n', [TestName]),
+        fail
+    ).
+
+assert_equal(Got, Expected, TestName) :-
+    (   Got == Expected
+    ->  format('  ✓ ~w~n', [TestName])
+    ;   format('  ✗ ~w FAILED: got ~w, expected ~w~n', [TestName, Got, Expected]),
+        fail
+    ).
+
+%% ============================================
+%% Test: Built-in Targets
+%% ============================================
+
+test_builtin_targets :-
+    format('Test: Built-in targets~n'),
+    assert_true(target_exists(bash), 'bash exists'),
+    assert_true(target_exists(awk), 'awk exists'),
+    assert_true(target_exists(python), 'python exists'),
+    assert_true(target_exists(go), 'go exists'),
+    assert_true(target_exists(rust), 'rust exists'),
+    assert_true(target_exists(csharp), 'csharp exists'),
+    assert_true(target_exists(sql), 'sql exists'),
+    assert_false(target_exists(nonexistent), 'nonexistent does not exist'),
+    format('~n').
+
+%% ============================================
+%% Test: Target Family
+%% ============================================
+
+test_target_family :-
+    format('Test: Target families~n'),
+    target_family(bash, BashFamily),
+    assert_equal(BashFamily, shell, 'bash is shell family'),
+
+    target_family(awk, AwkFamily),
+    assert_equal(AwkFamily, shell, 'awk is shell family'),
+
+    target_family(csharp, CsharpFamily),
+    assert_equal(CsharpFamily, dotnet, 'csharp is dotnet family'),
+
+    target_family(go, GoFamily),
+    assert_equal(GoFamily, native, 'go is native family'),
+
+    target_family(python, PythonFamily),
+    assert_equal(PythonFamily, python, 'python is python family'),
+    format('~n').
+
+%% ============================================
+%% Test: Same Family
+%% ============================================
+
+test_same_family :-
+    format('Test: Same family detection~n'),
+    assert_true(targets_same_family(bash, awk), 'bash and awk same family'),
+    assert_true(targets_same_family(csharp, powershell), 'csharp and powershell same family'),
+    assert_true(targets_same_family(go, rust), 'go and rust same family'),
+    assert_false(targets_same_family(bash, python), 'bash and python different families'),
+    assert_false(targets_same_family(csharp, go), 'csharp and go different families'),
+    format('~n').
+
+%% ============================================
+%% Test: Capabilities
+%% ============================================
+
+test_capabilities :-
+    format('Test: Target capabilities~n'),
+    target_capabilities(awk, AwkCaps),
+    assert_true(member(streaming, AwkCaps), 'awk has streaming'),
+    assert_true(member(regex, AwkCaps), 'awk has regex'),
+    assert_true(member(aggregation, AwkCaps), 'awk has aggregation'),
+
+    target_capabilities(python, PyCaps),
+    assert_true(member(libraries, PyCaps), 'python has libraries'),
+    assert_true(member(ml, PyCaps), 'python has ml'),
+    format('~n').
+
+%% ============================================
+%% Test: Custom Target Registration
+%% ============================================
+
+test_custom_target :-
+    format('Test: Custom target registration~n'),
+
+    % Register custom target
+    register_target(my_custom, custom_family, [feature1, feature2]),
+    assert_true(target_exists(my_custom), 'custom target exists after registration'),
+
+    target_family(my_custom, CustomFamily),
+    assert_equal(CustomFamily, custom_family, 'custom target has correct family'),
+
+    target_capabilities(my_custom, CustomCaps),
+    assert_true(member(feature1, CustomCaps), 'custom target has feature1'),
+
+    % Unregister
+    unregister_target(my_custom),
+    assert_false(target_exists(my_custom), 'custom target gone after unregister'),
+    format('~n').
+
+%% ============================================
+%% Test: Default Location
+%% ============================================
+
+test_default_location :-
+    format('Test: Default location~n'),
+
+    % .NET targets default to in_process
+    default_location(csharp, CsharpLoc),
+    assert_equal(CsharpLoc, in_process, 'csharp defaults to in_process'),
+
+    default_location(powershell, PsLoc),
+    assert_equal(PsLoc, in_process, 'powershell defaults to in_process'),
+
+    % Shell targets default to local_process
+    default_location(bash, BashLoc),
+    assert_equal(BashLoc, local_process, 'bash defaults to local_process'),
+
+    default_location(awk, AwkLoc),
+    assert_equal(AwkLoc, local_process, 'awk defaults to local_process'),
+    format('~n').
+
+%% ============================================
+%% Test: Default Transport
+%% ============================================
+
+test_default_transport :-
+    format('Test: Default transport~n'),
+
+    default_transport(in_process, in_process, DirectTransport),
+    assert_equal(DirectTransport, direct, 'in_process to in_process uses direct'),
+
+    default_transport(local_process, local_process, PipeTransport),
+    assert_equal(PipeTransport, pipe, 'local_process to local_process uses pipe'),
+
+    default_transport(local_process, remote(somehost), HttpTransport1),
+    assert_equal(HttpTransport1, http, 'local to remote uses http'),
+
+    default_transport(remote(host1), remote(host2), HttpTransport2),
+    assert_equal(HttpTransport2, http, 'remote to remote uses http'),
+    format('~n').
+
+%% ============================================
+%% Test: Listing
+%% ============================================
+
+test_listing :-
+    format('Test: Listing~n'),
+
+    list_targets(Targets),
+    assert_true(member(bash, Targets), 'targets list includes bash'),
+    assert_true(member(python, Targets), 'targets list includes python'),
+    length(Targets, N),
+    assert_true(N > 10, 'more than 10 targets registered'),
+
+    list_families(Families),
+    assert_true(member(shell, Families), 'families list includes shell'),
+    assert_true(member(dotnet, Families), 'families list includes dotnet'),
+    assert_true(member(native, Families), 'families list includes native'),
+    format('~n').
+
+%% ============================================
+%% Main
+%% ============================================
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
## Summary

Implements the foundation for cross-target communication, enabling predicates compiled to different targets to communicate seamlessly.

This is Phase 1 of the cross-target glue system as described in `docs/design/cross-target-glue/`.

## Changes

### Core Modules

**`src/unifyweaver/core/target_registry.pl`** - Central registry for target metadata
- 15+ built-in targets: bash, awk, python, go, rust, csharp, powershell, sql, etc.
- Runtime families: shell, python, dotnet, jvm, native, database
- Capability tracking (streaming, regex, ml, aggregation, etc.)
- Default location/transport resolution based on runtime family

**`src/unifyweaver/core/target_mapping.pl`** - Predicate-to-target declarations
- `declare_target/2,3` - Map predicates to compilation targets
- `declare_location/2` - Specify where predicates execute
- `declare_connection/3` - Specify transport between predicates
- Automatic resolution with sensible defaults
- Validation for mappings

**`src/unifyweaver/glue/pipe_glue.pl`** - Glue code generation for pipes
- TSV and JSON reader/writer templates
- Support for AWK, Python, Bash, Go, Rust
- Pipeline orchestrator script generation

### Tests

- `tests/core/test_target_registry.pl` - 40+ assertions
- `tests/core/test_target_mapping.pl` - 30+ assertions

All tests pass.

## Usage Example

```prolog
:- use_module('src/unifyweaver/core/target_registry').
:- use_module('src/unifyweaver/core/target_mapping').

% Declare which target compiles each predicate
:- declare_target(filter_logs/2, awk).
:- declare_target(analyze_data/2, python).
:- declare_target(store_results/2, sql).

% Query resolved transport (defaults to pipe for different runtimes)
?- resolve_transport(filter_logs/2, analyze_data/2, Transport).
Transport = pipe.

% Same runtime family uses direct (in-process)
:- declare_target(cs_logic/2, csharp).
:- declare_target(ps_script/2, powershell).
?- resolve_transport(cs_logic/2, ps_script/2, Transport).
Transport = direct.
```

## Design Decisions

1. **Location vs Transport** - Locations (arity 1) describe where things run; transports (arity 2) describe how they connect
2. **Runtime Family Affinity** - Same family defaults to in-process/direct; different families default to local_process/pipe
3. **Sensible Defaults** - Works out of the box; explicit declarations override defaults

## Next Steps

- Phase 2: Shell Integration (AWK ↔ Python pipe communication)
- Phase 3: .NET Integration (C# ↔ PowerShell in-process)

## Test Plan

```bash
# Run registry tests
swipl tests/core/test_target_registry.pl

# Run mapping tests
swipl tests/core/test_target_mapping.pl
```

## Files Changed

- `src/unifyweaver/core/target_registry.pl` (new)
- `src/unifyweaver/core/target_mapping.pl` (new)
- `src/unifyweaver/glue/pipe_glue.pl` (new)
- `tests/core/test_target_registry.pl` (new)
- `tests/core/test_target_mapping.pl` (new)

**Total: 1,428 insertions(+)**
