### PR TITLE
fix: Correct Python field indexing and C# string syntax in glue gener…

### DIFF
--- a/src/unifyweaver/glue/dotnet_glue.pl
+++ b/src/unifyweaver/glue/dotnet_glue.pl
@@ -602,8 +602,7 @@ for line in sys.stdin:
             var psi = new ProcessStartInfo
             {
                 FileName = PythonPath,
-                Arguments = $"-c \\"{wrappedScript.Replace("\\"", "\\\\\\"")}\\""
-",
+                Arguments = $"-c \\"{wrappedScript.Replace("\\"", "\\\\\\"")}\\"",
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,

--- a/src/unifyweaver/glue/shell_glue.pl
+++ b/src/unifyweaver/glue/shell_glue.pl
@@ -251,8 +251,8 @@ python_reader(json, _Fields, _SkipHeader, Code) :-
 
 python_field_dict(Fields, Dict) :-
     length(Fields, N),
-    numlist(0, N, Indices0),
-    Indices0 = [_|Indices],
+    N1 is N - 1,
+    numlist(0, N1, Indices),
     maplist(python_dict_pair, Fields, Indices, Pairs),
     atomic_list_concat(Pairs, ', ', PairStr),
     format(atom(Dict), '{~w}', [PairStr]).


### PR DESCRIPTION
## Summary

Fixes two bugs discovered during runtime testing of cross-target glue phases 1-3:

- **Python scripts fail with IndexError** - Generated Python code used 1-based array indexing instead of 0-based
- **C# code fails to compile** - CPython bridge had syntax errors in string literal

## Changes

### `src/unifyweaver/glue/shell_glue.pl`

Fixed `python_field_dict/2` to generate correct 0-based indices for Python array access.

**Before:** `numlist(0, N, Indices0), Indices0 = [_|Indices]` → generates indices `[1, 2, ...]`

**After:** `N1 is N - 1, numlist(0, N1, Indices)` → generates indices `[0, 1, ...]`

### `src/unifyweaver/glue/dotnet_glue.pl`

Fixed `ExecuteStream` method's `ProcessStartInfo.Arguments` property which had an errant newline and extra quote character causing C# compilation errors.

## Testing

| Test Suite | Result |
|------------|--------|
| `test_target_registry.pl` | ✓ All passed |
| `test_target_mapping.pl` | ✓ All passed |
| `test_shell_glue.pl` | ✓ All passed |
| `test_dotnet_glue.pl` | ✓ All passed |

### Runtime verification

```bash
# Python script now works correctly
$ echo -e "alice\t100\nbob\t200" | python3 generated_script.py
alice	100
bob	200

# C# code now compiles
$ dotnet build
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

## Related

Fixes issues in code introduced by:
- #204 (Phase 1)
- #205 (Phase 2)
- #206 (Phase 3)
