### PR TITLE
fix: Prevent infinite recursion in Python HTTP server route functions

### DIFF
--- a/src/unifyweaver/glue/network_glue.pl
+++ b/src/unifyweaver/glue/network_glue.pl
@@ -259,16 +259,17 @@ if __name__ == "__main__":
 python_endpoint_route(endpoint(Path, Handler, Opts), Code) :-
     option_or_default(methods(Methods), Opts, ['POST']),
     methods_to_python_list(Methods, MethodsList),
+    path_to_func_name(Path, RouteName),
     format(atom(Code), '
 @app.route("~w", methods=~w)
-def ~w():
+def ~w_route():
     try:
         data = request.get_json() if request.is_json else {}
         result = ~w(data.get("data"))
         return jsonify({"success": True, "data": result})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 400
-', [Path, MethodsList, Handler, Handler]).
+', [Path, MethodsList, RouteName, Handler]).
 
 methods_to_python_list(Methods, List) :-
     maplist(method_to_string, Methods, Strings),


### PR DESCRIPTION
## Summary

Fixes a bug in Phase 5 (network_glue) where generated Python Flask route functions would infinitely recurse when invoked.

## Problem

The `python_endpoint_route/3` predicate used the `Handler` parameter for both:
1. The Flask route function name
2. The function being called inside the route

This caused generated code like:

```python
@app.route("/process", methods=["POST"])
def process_handler():  # <- named after Handler
    ...
    result = process_handler(data.get("data"))  # <- calls itself!
```

## Solution

Changed the route function naming to use `path_to_func_name/2` to derive a unique name from the path, appending `_route` suffix:

```python
@app.route("/process", methods=["POST"])
def _process_route():  # <- derived from path
    ...
    result = process_handler(data.get("data"))  # <- calls the actual handler
```

## Changes

### `src/unifyweaver/glue/network_glue.pl`

```diff
 python_endpoint_route(endpoint(Path, Handler, Opts), Code) :-
     option_or_default(methods(Methods), Opts, ['POST']),
     methods_to_python_list(Methods, MethodsList),
+    path_to_func_name(Path, RouteName),
     format(atom(Code), '
 @app.route("~w", methods=~w)
-def ~w():
+def ~w_route():
     try:
         data = request.get_json() if request.is_json else {}
         result = ~w(data.get("data"))
         ...
-', [Path, MethodsList, Handler, Handler]).
+', [Path, MethodsList, RouteName, Handler]).
```

## Testing

| Test Suite | Result |
|------------|--------|
| `test_native_glue.pl` (Phase 4) | ✓ All 56 tests passed |
| `test_network_glue.pl` (Phase 5) | ✓ All 90 tests passed |

### Runtime verification

```bash
# Generated Go code compiles and runs
$ go build test_native.go && echo "alice\t100" | ./test_native
alice	100

# Generated Rust code compiles and runs
$ rustc test_native.rs && echo "alice\t100" | ./test_native_rs
alice	100

# Generated Python code is syntactically valid
$ python3 -m py_compile test_server_fixed.py
(no errors)
```

## Related

- Phase 5 introduced in #208
- Similar fix pattern to #209 (Phase 2-3 bugs)
