### PR TITLE
feat: Add Phase 6a deployment glue - SSH deployment and lifecycle man…

### DIFF
--- a/src/unifyweaver/glue/deployment_glue.pl
+++ b/src/unifyweaver/glue/deployment_glue.pl
@@ -1,0 +1,815 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Deployment Glue - Automatic deployment and lifecycle management for remote services
+ *
+ * This module provides:
+ * - SSH-based deployment with agent forwarding
+ * - Service lifecycle management (start/stop/restart)
+ * - Change detection and automatic redeployment
+ * - Security validation (encryption requirements)
+ * - Generated deployment scripts
+ */
+
+:- module(deployment_glue, [
+    % Service declarations
+    declare_service/2,              % declare_service(+Name, +Options)
+    service_config/2,               % service_config(?Name, ?Options)
+    undeclare_service/1,            % undeclare_service(+Name)
+
+    % Deployment method declarations
+    declare_deploy_method/3,        % declare_deploy_method(+Service, +Method, +Options)
+    deploy_method_config/3,         % deploy_method_config(?Service, ?Method, ?Options)
+
+    % Source tracking
+    declare_service_sources/2,      % declare_service_sources(+Service, +SourcePatterns)
+    service_sources/2,              % service_sources(?Service, ?Sources)
+
+    % Change detection
+    compute_source_hash/2,          % compute_source_hash(+Service, -Hash)
+    check_for_changes/2,            % check_for_changes(+Service, -Changes)
+    store_deployed_hash/2,          % store_deployed_hash(+Service, +Hash)
+    deployed_hash/2,                % deployed_hash(?Service, ?Hash)
+
+    % Lifecycle hooks
+    declare_lifecycle_hook/3,       % declare_lifecycle_hook(+Service, +Event, +Action)
+    lifecycle_hooks/2,              % lifecycle_hooks(?Service, ?Hooks)
+
+    % Security validation
+    validate_security/2,            % validate_security(+Service, -Errors)
+    requires_encryption/1,          % requires_encryption(+Service)
+    is_local_service/1,             % is_local_service(+Service)
+
+    % Deployment script generation
+    generate_deploy_script/3,       % generate_deploy_script(+Service, +Options, -Script)
+    generate_ssh_deploy/3,          % generate_ssh_deploy(+Service, +Options, -Script)
+    generate_systemd_unit/3,        % generate_systemd_unit(+Service, +Options, -Unit)
+    generate_health_check_script/3, % generate_health_check_script(+Service, +Options, -Script)
+
+    % Deployment operations
+    deploy_service/2,               % deploy_service(+Service, -Result)
+    service_status/2,               % service_status(+Service, -Status)
+
+    % Lifecycle operations
+    start_service/2,                % start_service(+Service, -Result)
+    stop_service/2,                 % stop_service(+Service, -Result)
+    restart_service/2               % restart_service(+Service, -Result)
+]).
+
+:- use_module(library(lists)).
+:- use_module(library(process)).
+:- use_module(library(filesex)).
+:- use_module(library(sha)).
+
+%% ============================================
+%% Dynamic Storage
+%% ============================================
+
+:- dynamic service_db/2.            % service_db(Name, Options)
+:- dynamic deploy_method_db/3.      % deploy_method_db(Service, Method, Options)
+:- dynamic service_sources_db/2.    % service_sources_db(Service, Sources)
+:- dynamic deployed_hash_db/2.      % deployed_hash_db(Service, Hash)
+:- dynamic lifecycle_hook_db/3.     % lifecycle_hook_db(Service, Event, Action)
+
+%% ============================================
+%% Service Declarations
+%% ============================================
+
+%% declare_service(+Name, +Options)
+%  Declare a remote service with its configuration.
+%
+%  Options:
+%    - host(Host)           : Remote hostname or IP
+%    - port(Port)           : Service port (default: 8080)
+%    - target(Target)       : Compilation target (python, go, rust, etc.)
+%    - entry_point(File)    : Main file to execute
+%    - lifecycle(Type)      : persistent | transient | on_demand | pipeline_bound
+%    - transport(T)         : http | https | ssh (default: https for remote)
+%    - idle_timeout(Secs)   : For transient services
+%    - max_lifetime(Secs)   : Maximum runtime
+%
+declare_service(Name, Options) :-
+    atom(Name),
+    is_list(Options),
+    retractall(service_db(Name, _)),
+    assertz(service_db(Name, Options)).
+
+%% service_config(?Name, ?Options)
+%  Query service configuration.
+%
+service_config(Name, Options) :-
+    service_db(Name, Options).
+
+%% undeclare_service(+Name)
+%  Remove a service declaration.
+%
+undeclare_service(Name) :-
+    retractall(service_db(Name, _)),
+    retractall(deploy_method_db(Name, _, _)),
+    retractall(service_sources_db(Name, _)),
+    retractall(deployed_hash_db(Name, _)),
+    retractall(lifecycle_hook_db(Name, _, _)).
+
+%% ============================================
+%% Deployment Method Declarations
+%% ============================================
+
+%% declare_deploy_method(+Service, +Method, +Options)
+%  Declare deployment method for a service.
+%
+%  Method: ssh | docker | local
+%
+%  SSH Options:
+%    - host(Host)           : Remote host
+%    - user(User)           : SSH user
+%    - agent(Bool)          : Use SSH agent (default: true)
+%    - key_file(Path)       : Explicit key file
+%    - remote_dir(Path)     : Deployment directory on remote
+%
+declare_deploy_method(Service, Method, Options) :-
+    atom(Service),
+    atom(Method),
+    is_list(Options),
+    retractall(deploy_method_db(Service, _, _)),
+    assertz(deploy_method_db(Service, Method, Options)).
+
+%% deploy_method_config(?Service, ?Method, ?Options)
+%  Query deployment method configuration.
+%
+deploy_method_config(Service, Method, Options) :-
+    deploy_method_db(Service, Method, Options).
+
+%% ============================================
+%% Source Tracking
+%% ============================================
+
+%% declare_service_sources(+Service, +SourcePatterns)
+%  Declare source files/patterns for change detection.
+%
+%  SourcePatterns: List of file paths or glob patterns
+%    e.g., ['src/ml/**/*.py', 'models/*.pkl', 'requirements.txt']
+%
+declare_service_sources(Service, SourcePatterns) :-
+    atom(Service),
+    is_list(SourcePatterns),
+    retractall(service_sources_db(Service, _)),
+    assertz(service_sources_db(Service, SourcePatterns)).
+
+%% service_sources(?Service, ?Sources)
+%  Query service source patterns.
+%
+service_sources(Service, Sources) :-
+    service_sources_db(Service, Sources).
+
+%% ============================================
+%% Change Detection
+%% ============================================
+
+%% compute_source_hash(+Service, -Hash)
+%  Compute SHA256 hash of all source files for a service.
+%
+compute_source_hash(Service, Hash) :-
+    service_sources_db(Service, Patterns),
+    expand_source_patterns(Patterns, Files),
+    sort(Files, SortedFiles),  % Deterministic order
+    compute_files_hash(SortedFiles, Hash).
+
+%% expand_source_patterns(+Patterns, -Files)
+%  Expand glob patterns to actual file paths.
+%
+expand_source_patterns([], []).
+expand_source_patterns([Pattern|Rest], AllFiles) :-
+    expand_file_name(Pattern, MatchedFiles),
+    include(exists_file, MatchedFiles, ExistingFiles),
+    expand_source_patterns(Rest, RestFiles),
+    append(ExistingFiles, RestFiles, AllFiles).
+
+%% compute_files_hash(+Files, -Hash)
+%  Compute combined hash of multiple files.
+%
+compute_files_hash(Files, Hash) :-
+    maplist(file_content_for_hash, Files, Contents),
+    atomic_list_concat(Contents, Combined),
+    sha_hash(Combined, HashBytes, [algorithm(sha256)]),
+    hash_bytes_to_hex(HashBytes, Hash).
+
+%% file_content_for_hash(+File, -Content)
+%  Read file content for hashing, including filename for uniqueness.
+%
+file_content_for_hash(File, Content) :-
+    (   exists_file(File)
+    ->  read_file_to_string(File, FileContent, []),
+        format(atom(Content), '~w:~w', [File, FileContent])
+    ;   format(atom(Content), '~w:missing', [File])
+    ).
+
+%% hash_bytes_to_hex(+Bytes, -Hex)
+%  Convert hash bytes to hexadecimal string.
+%
+hash_bytes_to_hex(Bytes, Hex) :-
+    maplist(byte_to_hex, Bytes, HexParts),
+    atomic_list_concat(HexParts, Hex).
+
+byte_to_hex(Byte, Hex) :-
+    format(atom(Hex), '~`0t~16r~2|', [Byte]).
+
+%% check_for_changes(+Service, -Changes)
+%  Check if service sources have changed since last deployment.
+%
+%  Changes = no_changes | changed(OldHash, NewHash) | never_deployed
+%
+check_for_changes(Service, Changes) :-
+    compute_source_hash(Service, CurrentHash),
+    (   deployed_hash_db(Service, DeployedHash)
+    ->  (   CurrentHash == DeployedHash
+        ->  Changes = no_changes
+        ;   Changes = changed(DeployedHash, CurrentHash)
+        )
+    ;   Changes = never_deployed
+    ).
+
+%% store_deployed_hash(+Service, +Hash)
+%  Store the hash of deployed sources.
+%
+store_deployed_hash(Service, Hash) :-
+    retractall(deployed_hash_db(Service, _)),
+    assertz(deployed_hash_db(Service, Hash)).
+
+%% deployed_hash(?Service, ?Hash)
+%  Query deployed hash.
+%
+deployed_hash(Service, Hash) :-
+    deployed_hash_db(Service, Hash).
+
+%% ============================================
+%% Lifecycle Hooks
+%% ============================================
+
+%% declare_lifecycle_hook(+Service, +Event, +Action)
+%  Declare a lifecycle hook for a service.
+%
+%  Events:
+%    - pre_shutdown       : Before stopping service
+%    - post_shutdown      : After stopping service
+%    - pre_deploy         : Before deployment
+%    - post_deploy        : After deployment
+%    - on_health_failure  : When health check fails
+%
+%  Action: Atom or compound term describing the action
+%    - drain_connections
+%    - save_state
+%    - health_check
+%    - warm_cache
+%    - custom(Command)
+%
+declare_lifecycle_hook(Service, Event, Action) :-
+    atom(Service),
+    atom(Event),
+    assertz(lifecycle_hook_db(Service, Event, Action)).
+
+%% lifecycle_hooks(?Service, ?Hooks)
+%  Query all lifecycle hooks for a service.
+%
+lifecycle_hooks(Service, Hooks) :-
+    findall(hook(Event, Action), lifecycle_hook_db(Service, Event, Action), Hooks).
+
+%% ============================================
+%% Security Validation
+%% ============================================
+
+%% validate_security(+Service, -Errors)
+%  Validate security requirements for a service.
+%  Returns empty list if valid, otherwise list of error terms.
+%
+validate_security(Service, Errors) :-
+    service_config(Service, Options),
+    findall(Error, security_violation(Service, Options, Error), Errors).
+
+%% security_violation(+Service, +Options, -Error)
+%  Check for specific security violations.
+%
+security_violation(_Service, Options, Error) :-
+    member(host(Host), Options),
+    \+ is_localhost(Host),
+    member(transport(http), Options),
+    Error = remote_requires_encryption(Host).
+
+security_violation(_Service, Options, Error) :-
+    member(host(Host), Options),
+    \+ is_localhost(Host),
+    \+ member(transport(_), Options),
+    Error = remote_missing_transport(Host).
+
+%% is_localhost(+Host)
+%  Check if host is localhost.
+%
+is_localhost(localhost).
+is_localhost('127.0.0.1').
+is_localhost('::1').
+
+%% requires_encryption(+Service)
+%  Check if service requires encryption.
+%
+requires_encryption(Service) :-
+    service_config(Service, Options),
+    member(host(Host), Options),
+    \+ is_localhost(Host).
+
+%% is_local_service(+Service)
+%  Check if service is local (doesn't require encryption).
+%
+is_local_service(Service) :-
+    service_config(Service, Options),
+    (   \+ member(host(_), Options)
+    ;   member(host(Host), Options),
+        is_localhost(Host)
+    ).
+
+%% ============================================
+%% Deployment Script Generation
+%% ============================================
+
+%% generate_deploy_script(+Service, +Options, -Script)
+%  Generate deployment script based on configured method.
+%
+generate_deploy_script(Service, Options, Script) :-
+    deploy_method_config(Service, Method, MethodOptions),
+    merge_options(Options, MethodOptions, MergedOptions),
+    generate_deploy_script_for_method(Method, Service, MergedOptions, Script).
+
+generate_deploy_script_for_method(ssh, Service, Options, Script) :-
+    generate_ssh_deploy(Service, Options, Script).
+generate_deploy_script_for_method(local, Service, Options, Script) :-
+    generate_local_deploy(Service, Options, Script).
+
+%% generate_ssh_deploy(+Service, +Options, -Script)
+%  Generate SSH deployment script.
+%
+generate_ssh_deploy(Service, Options, Script) :-
+    service_config(Service, ServiceOptions),
+
+    % Extract required options (check Options first, then ServiceOptions, then default)
+    option_or_default(host, Options, ServiceOptions, 'localhost', Host),
+    option_or_default(user, Options, ServiceOptions, 'deploy', User),
+    option_or_default(remote_dir, Options, ServiceOptions, '/opt/unifyweaver/services', BaseRemoteDir),
+    option_or_default(port, Options, ServiceOptions, 8080, Port),
+    option_or_default(target, Options, ServiceOptions, python, Target),
+    option_or_default(entry_point, Options, ServiceOptions, 'server.py', EntryPoint),
+
+    % Build remote directory path
+    format(atom(RemoteDir), '~w/~w', [BaseRemoteDir, Service]),
+
+    % Get source patterns for rsync
+    (   service_sources(Service, Sources)
+    ->  true
+    ;   Sources = ['.']
+    ),
+
+    % Get lifecycle hooks
+    lifecycle_hooks(Service, Hooks),
+
+    % Generate script
+    generate_ssh_script_content(Service, Host, User, RemoteDir, Port, Target,
+                                 EntryPoint, Sources, Hooks, Script).
+
+%% generate_ssh_script_content/10
+%  Generate the actual SSH deployment script content.
+%
+generate_ssh_script_content(Service, Host, User, RemoteDir, Port, Target,
+                            EntryPoint, _Sources, Hooks, Script) :-
+    % Pre-shutdown hooks
+    generate_hook_commands(Hooks, pre_shutdown, Host, User, PreShutdownCmds),
+
+    % Post-deploy hooks
+    generate_hook_commands(Hooks, post_deploy, Host, User, PostDeployCmds),
+
+    % Generate startup command based on target
+    generate_startup_command(Target, EntryPoint, Port, StartupCmd),
+
+    format(atom(Script), '#!/bin/bash
+# Deployment script for ~w
+# Generated by UnifyWeaver deployment_glue
+
+set -euo pipefail
+
+SERVICE="~w"
+HOST="~w"
+USER="~w"
+REMOTE_DIR="~w"
+PORT="~w"
+
+echo "=== Deploying ${SERVICE} to ${HOST} ==="
+
+# Check SSH agent
+if ! ssh-add -l &>/dev/null; then
+    echo "Warning: SSH agent not running or no keys loaded"
+    echo "Attempting connection anyway..."
+fi
+
+# Check connectivity
+echo "Checking connectivity..."
+if ! ssh -o ConnectTimeout=10 "${USER}@${HOST}" "echo ok" >/dev/null 2>&1; then
+    echo "Error: Cannot connect to ${HOST}"
+    exit 1
+fi
+
+~w
+
+# Create remote directory
+echo "Creating remote directory..."
+ssh "${USER}@${HOST}" "mkdir -p ${REMOTE_DIR}"
+
+# Sync sources
+echo "Syncing sources..."
+rsync -avz --delete \\
+    --exclude "*.pyc" \\
+    --exclude "__pycache__" \\
+    --exclude ".git" \\
+    --exclude "*.log" \\
+    ./ "${USER}@${HOST}:${REMOTE_DIR}/"
+
+# Install dependencies if requirements.txt exists
+echo "Installing dependencies..."
+ssh "${USER}@${HOST}" "cd ${REMOTE_DIR} && \\
+    if [ -f requirements.txt ]; then \\
+        pip install -r requirements.txt; \\
+    elif [ -f go.mod ]; then \\
+        go mod download; \\
+    elif [ -f Cargo.toml ]; then \\
+        cargo build --release; \\
+    fi"
+
+# Restart service
+echo "Restarting service..."
+ssh "${USER}@${HOST}" "cd ${REMOTE_DIR} && \\
+    pkill -f \\"~w\\" || true && \\
+    nohup ~w > service.log 2>&1 &"
+
+~w
+
+echo "=== Deployment complete ==="
+echo "Service ~w running on ${HOST}:${PORT}"
+', [Service, Service, Host, User, RemoteDir, Port,
+    PreShutdownCmds, EntryPoint, StartupCmd, PostDeployCmds, Service]).
+
+%% generate_hook_commands(+Hooks, +Event, +Host, +User, -Commands)
+%  Generate shell commands for lifecycle hooks.
+%
+generate_hook_commands(Hooks, Event, Host, User, Commands) :-
+    findall(Cmd, (
+        member(hook(Event, Action), Hooks),
+        hook_to_command(Action, Host, User, Cmd)
+    ), CmdList),
+    (   CmdList == []
+    ->  Commands = ''
+    ;   atomic_list_concat(CmdList, '\n', Commands)
+    ).
+
+%% hook_to_command(+Action, +Host, +User, -Command)
+%  Convert a lifecycle action to a shell command.
+%
+hook_to_command(drain_connections, Host, User, Cmd) :-
+    format(atom(Cmd), 'echo "Draining connections..."\nssh "~w@~w" "sleep 5"  # Allow connections to drain', [User, Host]).
+hook_to_command(health_check, Host, _User, Cmd) :-
+    format(atom(Cmd), 'echo "Running health check..."\nfor i in {1..30}; do\n    if curl -sf "http://~w:${PORT}/health" >/dev/null; then\n        echo "Health check passed"\n        break\n    fi\n    sleep 1\ndone', [Host]).
+hook_to_command(warm_cache, Host, User, Cmd) :-
+    format(atom(Cmd), 'echo "Warming cache..."\nssh "~w@~w" "curl -s http://localhost:${PORT}/warmup || true"', [User, Host]).
+hook_to_command(save_state, Host, User, Cmd) :-
+    format(atom(Cmd), 'echo "Saving state..."\nssh "~w@~w" "cd ${REMOTE_DIR} && ./save_state.sh || true"', [User, Host]).
+hook_to_command(custom(Command), Host, User, Cmd) :-
+    format(atom(Cmd), 'echo "Running custom hook..."\nssh "~w@~w" "~w"', [User, Host, Command]).
+
+%% generate_startup_command(+Target, +EntryPoint, +Port, -Command)
+%  Generate startup command based on target language.
+%
+generate_startup_command(python, EntryPoint, Port, Cmd) :-
+    format(atom(Cmd), 'python3 ~w --port ~w', [EntryPoint, Port]).
+generate_startup_command(go, EntryPoint, Port, Cmd) :-
+    format(atom(Cmd), './~w -port ~w', [EntryPoint, Port]).
+generate_startup_command(rust, EntryPoint, Port, Cmd) :-
+    format(atom(Cmd), './target/release/~w --port ~w', [EntryPoint, Port]).
+generate_startup_command(node, EntryPoint, Port, Cmd) :-
+    format(atom(Cmd), 'node ~w --port ~w', [EntryPoint, Port]).
+generate_startup_command(_, EntryPoint, Port, Cmd) :-
+    format(atom(Cmd), './~w --port ~w', [EntryPoint, Port]).
+
+%% generate_local_deploy(+Service, +Options, -Script)
+%  Generate local deployment script (no SSH).
+%
+generate_local_deploy(Service, _Options, Script) :-
+    service_config(Service, ServiceOptions),
+    option_or_default(port, ServiceOptions, 8080, Port),
+    option_or_default(target, ServiceOptions, python, Target),
+    option_or_default(entry_point, ServiceOptions, 'server.py', EntryPoint),
+
+    generate_startup_command(Target, EntryPoint, Port, StartupCmd),
+
+    format(atom(Script), '#!/bin/bash
+# Local deployment script for ~w
+# Generated by UnifyWeaver deployment_glue
+
+set -euo pipefail
+
+SERVICE="~w"
+PORT="~w"
+
+echo "=== Starting ${SERVICE} locally ==="
+
+# Install dependencies
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+elif [ -f go.mod ]; then
+    go build .
+elif [ -f Cargo.toml ]; then
+    cargo build --release
+fi
+
+# Stop existing instance
+pkill -f "~w" || true
+
+# Start service
+nohup ~w > service.log 2>&1 &
+
+echo "Service ~w running on localhost:${PORT}"
+', [Service, Service, Port, EntryPoint, StartupCmd, Service]).
+
+%% ============================================
+%% Systemd Unit Generation
+%% ============================================
+
+%% generate_systemd_unit(+Service, +Options, -Unit)
+%  Generate systemd service unit file.
+%
+generate_systemd_unit(Service, Options, Unit) :-
+    service_config(Service, ServiceOptions),
+
+    option_or_default(remote_dir, Options, '/opt/unifyweaver/services', BaseDir),
+    option_or_default(user, Options, 'deploy', User),
+    option_or_default(target, ServiceOptions, python, Target),
+    option_or_default(entry_point, ServiceOptions, 'server.py', EntryPoint),
+    option_or_default(port, ServiceOptions, 8080, Port),
+
+    format(atom(WorkDir), '~w/~w', [BaseDir, Service]),
+    generate_startup_command(Target, EntryPoint, Port, ExecStart),
+
+    format(atom(Unit), '[Unit]
+Description=UnifyWeaver Service: ~w
+After=network.target
+
+[Service]
+Type=simple
+User=~w
+WorkingDirectory=~w
+ExecStart=~w
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+', [Service, User, WorkDir, ExecStart]).
+
+%% ============================================
+%% Health Check Script Generation
+%% ============================================
+
+%% generate_health_check_script(+Service, +Options, -Script)
+%  Generate health check script.
+%
+generate_health_check_script(Service, Options, Script) :-
+    service_config(Service, ServiceOptions),
+
+    option_or_default(host, Options, ServiceOptions, 'localhost', Host),
+    option_or_default(port, ServiceOptions, 8080, Port),
+    option_or_default(health_endpoint, Options, '/health', Endpoint),
+    option_or_default(timeout, Options, 5, Timeout),
+    option_or_default(retries, Options, 3, Retries),
+
+    % Determine protocol
+    (   is_localhost(Host)
+    ->  Protocol = 'http'
+    ;   Protocol = 'https'
+    ),
+
+    format(atom(Script), '#!/bin/bash
+# Health check script for ~w
+# Generated by UnifyWeaver deployment_glue
+
+HOST="~w"
+PORT="~w"
+ENDPOINT="~w"
+TIMEOUT="~w"
+RETRIES="~w"
+PROTOCOL="~w"
+
+URL="${PROTOCOL}://${HOST}:${PORT}${ENDPOINT}"
+
+for i in $(seq 1 $RETRIES); do
+    if curl -sf --max-time $TIMEOUT "$URL" >/dev/null; then
+        echo "OK: ~w is healthy"
+        exit 0
+    fi
+    echo "Attempt $i/$RETRIES failed, retrying..."
+    sleep 2
+done
+
+echo "CRITICAL: ~w health check failed after $RETRIES attempts"
+exit 2
+', [Service, Host, Port, Endpoint, Timeout, Retries, Protocol, Service, Service]).
+
+%% ============================================
+%% Deployment Operations
+%% ============================================
+
+%% deploy_service(+Service, -Result)
+%  Execute deployment for a service.
+%
+deploy_service(Service, Result) :-
+    % Validate security first
+    validate_security(Service, SecurityErrors),
+    (   SecurityErrors \== []
+    ->  Result = error(security_validation_failed(SecurityErrors))
+    ;   % Check for changes
+        check_for_changes(Service, Changes),
+        (   Changes == no_changes
+        ->  Result = unchanged
+        ;   % Generate and execute deployment
+            generate_deploy_script(Service, [], Script),
+            execute_deployment(Script, ExecResult),
+            (   ExecResult == success
+            ->  % Store new hash
+                compute_source_hash(Service, NewHash),
+                store_deployed_hash(Service, NewHash),
+                Result = deployed(Changes)
+            ;   Result = error(deployment_failed(ExecResult))
+            )
+        )
+    ).
+
+%% execute_deployment(+Script, -Result)
+%  Execute a deployment script.
+%
+execute_deployment(Script, Result) :-
+    % Write script to temp file
+    tmp_file_stream(text, TmpFile, Stream),
+    write(Stream, Script),
+    close(Stream),
+
+    % Make executable and run
+    process_create(path(chmod), ['+x', TmpFile], []),
+    catch(
+        (   process_create(path(bash), [TmpFile],
+                [stdout(pipe(Out)), stderr(pipe(Err))]),
+            read_string(Out, _, _OutStr),
+            read_string(Err, _, _ErrStr),
+            close(Out),
+            close(Err),
+            Result = success
+        ),
+        Error,
+        Result = error(Error)
+    ),
+
+    % Cleanup
+    delete_file(TmpFile).
+
+%% service_status(+Service, -Status)
+%  Check status of a deployed service.
+%
+service_status(Service, Status) :-
+    service_config(Service, Options),
+    (   member(host(Host), Options)
+    ->  true
+    ;   Host = localhost
+    ),
+    (   member(port(Port), Options)
+    ->  true
+    ;   Port = 8080
+    ),
+
+    % Determine protocol
+    (   is_localhost(Host)
+    ->  Protocol = 'http'
+    ;   Protocol = 'https'
+    ),
+
+    format(atom(URL), '~w://~w:~w/health', [Protocol, Host, Port]),
+
+    catch(
+        (   http_open(URL, Stream, [timeout(5)]),
+            close(Stream),
+            Status = running
+        ),
+        _,
+        Status = stopped
+    ).
+
+%% ============================================
+%% Lifecycle Operations
+%% ============================================
+
+%% start_service(+Service, -Result)
+%  Start a service.
+%
+start_service(Service, Result) :-
+    deploy_method_config(Service, Method, Options),
+    start_service_method(Method, Service, Options, Result).
+
+start_service_method(ssh, Service, Options, Result) :-
+    service_config(Service, ServiceOptions),
+    option_or_default(host, Options, ServiceOptions, 'localhost', Host),
+    option_or_default(user, Options, ServiceOptions, 'deploy', User),
+    format(atom(Cmd), 'ssh ~w@~w "systemctl --user start ~w"', [User, Host, Service]),
+    shell(Cmd, ExitCode),
+    (   ExitCode == 0
+    ->  Result = started
+    ;   Result = error(start_failed(ExitCode))
+    ).
+
+start_service_method(local, Service, _Options, Result) :-
+    format(atom(Cmd), 'systemctl --user start ~w', [Service]),
+    shell(Cmd, ExitCode),
+    (   ExitCode == 0
+    ->  Result = started
+    ;   Result = error(start_failed(ExitCode))
+    ).
+
+%% stop_service(+Service, -Result)
+%  Stop a service.
+%
+stop_service(Service, Result) :-
+    deploy_method_config(Service, Method, Options),
+    stop_service_method(Method, Service, Options, Result).
+
+stop_service_method(ssh, Service, Options, Result) :-
+    service_config(Service, ServiceOptions),
+    option_or_default(host, Options, ServiceOptions, 'localhost', Host),
+    option_or_default(user, Options, ServiceOptions, 'deploy', User),
+
+    % Execute pre-shutdown hooks
+    lifecycle_hooks(Service, Hooks),
+    generate_hook_commands(Hooks, pre_shutdown, Host, User, PreCmds),
+    (   PreCmds \== ''
+    ->  format(atom(PreCmd), 'ssh ~w@~w "~w"', [User, Host, PreCmds]),
+        shell(PreCmd, _)
+    ;   true
+    ),
+
+    format(atom(Cmd), 'ssh ~w@~w "systemctl --user stop ~w"', [User, Host, Service]),
+    shell(Cmd, ExitCode),
+    (   ExitCode == 0
+    ->  Result = stopped
+    ;   Result = error(stop_failed(ExitCode))
+    ).
+
+stop_service_method(local, Service, _Options, Result) :-
+    format(atom(Cmd), 'systemctl --user stop ~w', [Service]),
+    shell(Cmd, ExitCode),
+    (   ExitCode == 0
+    ->  Result = stopped
+    ;   Result = error(stop_failed(ExitCode))
+    ).
+
+%% restart_service(+Service, -Result)
+%  Restart a service.
+%
+restart_service(Service, Result) :-
+    stop_service(Service, StopResult),
+    (   StopResult = stopped
+    ->  start_service(Service, Result)
+    ;   StopResult = error(_)
+    ->  % Try to start anyway
+        start_service(Service, Result)
+    ;   Result = StopResult
+    ).
+
+%% ============================================
+%% Helper Predicates
+%% ============================================
+
+%% option_or_default(+Key, +Options1, +Options2, +Default, -Value)
+%  Get option value from Options1, then Options2, then Default.
+%
+option_or_default(Key, Options1, Options2, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options1)
+    ->  true
+    ;   member(Term, Options2)
+    ->  true
+    ;   Value = Default
+    ).
+
+option_or_default(Key, Options, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+%% merge_options(+Options1, +Options2, -Merged)
+%  Merge two option lists, Options1 takes precedence.
+%
+merge_options(Options1, Options2, Merged) :-
+    append(Options1, Options2, Merged).

--- a/tests/glue/test_deployment_glue.pl
+++ b/tests/glue/test_deployment_glue.pl
@@ -1,0 +1,355 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Tests for deployment_glue.pl - Phase 6a
+ */
+
+:- use_module('../../src/unifyweaver/glue/deployment_glue').
+
+:- dynamic test_passed/1.
+:- dynamic test_failed/2.
+
+%% ============================================
+%% Test Runner
+%% ============================================
+
+run_all_tests :-
+    retractall(test_passed(_)),
+    retractall(test_failed(_, _)),
+
+    format('~n=== Deployment Glue Tests (Phase 6a) ===~n~n'),
+
+    run_test_group('Service Declarations', [
+        test_declare_service,
+        test_service_config_query,
+        test_undeclare_service
+    ]),
+
+    run_test_group('Deployment Methods', [
+        test_declare_deploy_method,
+        test_deploy_method_query
+    ]),
+
+    run_test_group('Source Tracking', [
+        test_declare_service_sources,
+        test_service_sources_query
+    ]),
+
+    run_test_group('Security Validation', [
+        test_security_local_http_allowed,
+        test_security_remote_http_blocked,
+        test_security_remote_https_allowed,
+        test_requires_encryption,
+        test_is_local_service
+    ]),
+
+    run_test_group('Lifecycle Hooks', [
+        test_declare_lifecycle_hook,
+        test_lifecycle_hooks_query
+    ]),
+
+    run_test_group('SSH Deploy Script Generation', [
+        test_generate_ssh_deploy_basic,
+        test_generate_ssh_deploy_with_hooks
+    ]),
+
+    run_test_group('Systemd Unit Generation', [
+        test_generate_systemd_unit
+    ]),
+
+    run_test_group('Health Check Script Generation', [
+        test_generate_health_check_script
+    ]),
+
+    run_test_group('Local Deploy Script Generation', [
+        test_generate_local_deploy
+    ]),
+
+    print_summary.
+
+run_test_group(GroupName, Tests) :-
+    format('~w:~n', [GroupName]),
+    maplist(run_single_test, Tests),
+    format('~n').
+
+run_single_test(Test) :-
+    (   catch(call(Test), Error, (
+            assertz(test_failed(Test, Error)),
+            format('  ✗ ~w: ~w~n', [Test, Error]),
+            fail
+        ))
+    ->  assertz(test_passed(Test)),
+        format('  ✓ ~w~n', [Test])
+    ;   (   \+ test_failed(Test, _)
+        ->  assertz(test_failed(Test, 'assertion failed')),
+            format('  ✗ ~w: assertion failed~n', [Test])
+        ;   true
+        )
+    ).
+
+print_summary :-
+    findall(T, test_passed(T), Passed),
+    findall(T, test_failed(T, _), Failed),
+    length(Passed, PassCount),
+    length(Failed, FailCount),
+    Total is PassCount + FailCount,
+    format('~n=== Summary ===~n'),
+    format('Passed: ~w/~w~n', [PassCount, Total]),
+    (   FailCount > 0
+    ->  format('Failed: ~w~n', [FailCount]),
+        forall(test_failed(T, Reason), format('  - ~w: ~w~n', [T, Reason]))
+    ;   format('All tests passed!~n')
+    ).
+
+%% ============================================
+%% Service Declaration Tests
+%% ============================================
+
+test_declare_service :-
+    % Clean up
+    undeclare_service(test_service),
+
+    % Declare a service
+    declare_service(test_service, [
+        host('example.com'),
+        port(8080),
+        target(python),
+        entry_point('server.py'),
+        lifecycle(persistent),
+        transport(https)
+    ]),
+
+    % Verify it exists
+    service_config(test_service, Options),
+    member(host('example.com'), Options),
+    member(port(8080), Options),
+    member(target(python), Options).
+
+test_service_config_query :-
+    % Query existing service
+    service_config(test_service, Options),
+    is_list(Options),
+    member(transport(https), Options).
+
+test_undeclare_service :-
+    % Declare and undeclare
+    declare_service(temp_service, [host('temp.com')]),
+    service_config(temp_service, _),
+    undeclare_service(temp_service),
+    \+ service_config(temp_service, _).
+
+%% ============================================
+%% Deployment Method Tests
+%% ============================================
+
+test_declare_deploy_method :-
+    declare_deploy_method(test_service, ssh, [
+        host('example.com'),
+        user('deploy'),
+        agent(true),
+        remote_dir('/opt/services')
+    ]),
+    deploy_method_config(test_service, ssh, Options),
+    member(user('deploy'), Options).
+
+test_deploy_method_query :-
+    deploy_method_config(test_service, Method, Options),
+    Method == ssh,
+    member(remote_dir('/opt/services'), Options).
+
+%% ============================================
+%% Source Tracking Tests
+%% ============================================
+
+test_declare_service_sources :-
+    declare_service_sources(test_service, [
+        'src/**/*.py',
+        'requirements.txt'
+    ]),
+    service_sources(test_service, Sources),
+    member('src/**/*.py', Sources).
+
+test_service_sources_query :-
+    service_sources(test_service, Sources),
+    length(Sources, 2).
+
+%% ============================================
+%% Security Validation Tests
+%% ============================================
+
+test_security_local_http_allowed :-
+    undeclare_service(local_service),
+    declare_service(local_service, [
+        host(localhost),
+        port(8080),
+        transport(http)
+    ]),
+    validate_security(local_service, Errors),
+    Errors == [].
+
+test_security_remote_http_blocked :-
+    undeclare_service(insecure_service),
+    declare_service(insecure_service, [
+        host('remote.example.com'),
+        port(8080),
+        transport(http)
+    ]),
+    validate_security(insecure_service, Errors),
+    Errors \== [],
+    member(remote_requires_encryption('remote.example.com'), Errors).
+
+test_security_remote_https_allowed :-
+    undeclare_service(secure_service),
+    declare_service(secure_service, [
+        host('remote.example.com'),
+        port(8080),
+        transport(https)
+    ]),
+    validate_security(secure_service, Errors),
+    Errors == [].
+
+test_requires_encryption :-
+    requires_encryption(secure_service),
+    \+ requires_encryption(local_service).
+
+test_is_local_service :-
+    is_local_service(local_service),
+    \+ is_local_service(secure_service).
+
+%% ============================================
+%% Lifecycle Hook Tests
+%% ============================================
+
+test_declare_lifecycle_hook :-
+    % Clean existing hooks
+    retractall(lifecycle_hook_db(test_service, _, _)),
+
+    declare_lifecycle_hook(test_service, pre_shutdown, drain_connections),
+    declare_lifecycle_hook(test_service, post_deploy, health_check),
+
+    lifecycle_hooks(test_service, Hooks),
+    member(hook(pre_shutdown, drain_connections), Hooks),
+    member(hook(post_deploy, health_check), Hooks).
+
+test_lifecycle_hooks_query :-
+    lifecycle_hooks(test_service, Hooks),
+    length(Hooks, 2).
+
+%% ============================================
+%% SSH Deploy Script Tests
+%% ============================================
+
+test_generate_ssh_deploy_basic :-
+    undeclare_service(ssh_test_service),
+    declare_service(ssh_test_service, [
+        host('worker.example.com'),
+        port(9000),
+        target(python),
+        entry_point('app.py')
+    ]),
+    declare_deploy_method(ssh_test_service, ssh, [
+        user('ubuntu'),
+        remote_dir('/home/ubuntu/services')
+    ]),
+
+    % Use generate_deploy_script which merges method options properly
+    generate_deploy_script(ssh_test_service, [], Script),
+
+    % Verify script contains expected elements
+    sub_atom(Script, _, _, _, '#!/bin/bash'),
+    sub_atom(Script, _, _, _, 'worker.example.com'),
+    sub_atom(Script, _, _, _, 'ubuntu'),
+    sub_atom(Script, _, _, _, 'rsync'),
+    sub_atom(Script, _, _, _, 'python3 app.py').
+
+test_generate_ssh_deploy_with_hooks :-
+    undeclare_service(hooked_service),
+    declare_service(hooked_service, [
+        host('prod.example.com'),
+        port(8080),
+        target(go),
+        entry_point('server')
+    ]),
+    declare_deploy_method(hooked_service, ssh, [
+        user('deploy')
+    ]),
+    declare_lifecycle_hook(hooked_service, pre_shutdown, drain_connections),
+    declare_lifecycle_hook(hooked_service, post_deploy, health_check),
+
+    generate_ssh_deploy(hooked_service, [], Script),
+
+    sub_atom(Script, _, _, _, 'Draining connections'),
+    sub_atom(Script, _, _, _, 'health check').
+
+%% ============================================
+%% Systemd Unit Tests
+%% ============================================
+
+test_generate_systemd_unit :-
+    undeclare_service(systemd_service),
+    declare_service(systemd_service, [
+        port(3000),
+        target(node),
+        entry_point('index.js')
+    ]),
+
+    generate_systemd_unit(systemd_service, [user('nodeapp')], Unit),
+
+    sub_atom(Unit, _, _, _, '[Unit]'),
+    sub_atom(Unit, _, _, _, '[Service]'),
+    sub_atom(Unit, _, _, _, '[Install]'),
+    sub_atom(Unit, _, _, _, 'User=nodeapp'),
+    sub_atom(Unit, _, _, _, 'node index.js').
+
+%% ============================================
+%% Health Check Script Tests
+%% ============================================
+
+test_generate_health_check_script :-
+    undeclare_service(health_service),
+    declare_service(health_service, [
+        host('api.example.com'),
+        port(443)
+    ]),
+
+    generate_health_check_script(health_service, [
+        health_endpoint('/status'),
+        timeout(10),
+        retries(5)
+    ], Script),
+
+    sub_atom(Script, _, _, _, '#!/bin/bash'),
+    sub_atom(Script, _, _, _, 'api.example.com'),
+    sub_atom(Script, _, _, _, '/status'),
+    sub_atom(Script, _, _, _, 'TIMEOUT="10"'),
+    sub_atom(Script, _, _, _, 'RETRIES="5"'),
+    sub_atom(Script, _, _, _, 'https').  % Should use HTTPS for remote
+
+%% ============================================
+%% Local Deploy Script Tests
+%% ============================================
+
+test_generate_local_deploy :-
+    undeclare_service(local_app),
+    declare_service(local_app, [
+        port(5000),
+        target(python),
+        entry_point('main.py')
+    ]),
+    declare_deploy_method(local_app, local, []),
+
+    generate_deploy_script(local_app, [], Script),
+
+    sub_atom(Script, _, _, _, '#!/bin/bash'),
+    sub_atom(Script, _, _, _, 'python3 main.py'),
+    sub_atom(Script, _, _, _, 'PORT="5000"').
+
+%% ============================================
+%% Main Entry Point
+%% ============================================
+
+:- initialization((
+    run_all_tests,
+    halt
+), main).


### PR DESCRIPTION
## Summary

Implements Phase 6a "Deployment Foundation" of the cross-target glue system, providing SSH-based deployment, lifecycle management, change detection, and security validation.

## New Module: `deployment_glue.pl`

~820 lines of Prolog implementing automatic deployment infrastructure.

### Service Declarations
- `declare_service/2` - Register services with configuration (host, port, target, lifecycle)
- `declare_deploy_method/3` - Configure SSH or local deployment method
- `declare_service_sources/2` - Track source files for change detection
- `declare_lifecycle_hook/3` - Register pre/post deployment hooks

### Security by Default
- Remote services **require encryption** (HTTPS or SSH)
- HTTP only allowed for localhost
- `validate_security/2` - Check and report security violations
- `requires_encryption/1` / `is_local_service/1` - Query security requirements

### Change Detection
- `compute_source_hash/2` - SHA256 hash of all tracked source files
- `check_for_changes/2` - Returns `no_changes`, `changed(Old, New)`, or `never_deployed`
- `store_deployed_hash/2` - Record deployed version for future comparison

### Script Generation
- `generate_deploy_script/3` - Generate deployment script based on configured method
- `generate_ssh_deploy/3` - Full SSH deployment script with:
  - SSH agent check
  - Connectivity verification
  - rsync file synchronization
  - Dependency installation (pip, go mod, cargo)
  - Service restart with lifecycle hooks
- `generate_systemd_unit/3` - Generate systemd service unit files
- `generate_health_check_script/3` - Health check with configurable retries

### Lifecycle Management
- `deploy_service/2` - Execute deployment with change detection
- `start_service/2`, `stop_service/2`, `restart_service/2`
- Lifecycle hooks: `drain_connections`, `save_state`, `health_check`, `warm_cache`, `custom(Cmd)`

## Example Usage

```prolog
% Declare a Python ML service
:- declare_service(ml_predictor, [
    host('ml.example.com'),
    port(8080),
    target(python),
    entry_point('server.py'),
    transport(https)
]).

% Configure SSH deployment
:- declare_deploy_method(ml_predictor, ssh, [
    user('deploy'),
    remote_dir('/opt/services')
]).

% Track sources for change detection
:- declare_service_sources(ml_predictor, [
    'src/**/*.py',
    'models/*.pkl',
    'requirements.txt'
]).

% Add lifecycle hooks
:- declare_lifecycle_hook(ml_predictor, pre_shutdown, drain_connections).
:- declare_lifecycle_hook(ml_predictor, post_deploy, health_check).

% Generate deployment script
generate_deploy_script(ml_predictor, [], Script).
```

## Tests

19 test assertions across 9 test groups:

| Group | Tests |
|-------|-------|
| Service Declarations | 3 |
| Deployment Methods | 2 |
| Source Tracking | 2 |
| Security Validation | 5 |
| Lifecycle Hooks | 2 |
| SSH Deploy Script | 2 |
| Systemd Unit | 1 |
| Health Check Script | 1 |
| Local Deploy Script | 1 |

All tests passing.

## Files Changed

- `src/unifyweaver/glue/deployment_glue.pl` (new) - 820 lines
- `tests/glue/test_deployment_glue.pl` (new) - 350 lines

## Test Plan

```bash
swipl -g "run_all_tests" -t halt tests/glue/test_deployment_glue.pl
```

## Phase 6 Roadmap

- [x] **Phase 6a**: Deployment foundation (this PR)
- [ ] **Phase 6b**: Advanced deployment (rollback, multi-host, graceful shutdown)
- [ ] **Phase 6c**: Error handling (retry, fallback, circuit breaker)
- [ ] **Phase 6d**: Monitoring (health checks, metrics, logging)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
