### PR TITLE
#Add Phase 7a: Container Deployment (Docker & Kubernetes) [EXPERIMENTAL]

### DIFF
--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -1,0 +1,225 @@
+# Test Coverage Documentation
+
+This document describes the test coverage for UnifyWeaver's cross-target glue system, with particular attention to what is and is NOT tested.
+
+## Overview
+
+| Phase | Module | Unit Tests | Integration Tests | Production Ready |
+|-------|--------|------------|-------------------|------------------|
+| 1-5 | Core glue modules | ✅ Yes | ⚠️ Partial | ✅ Yes |
+| 6a-d | deployment_glue.pl | ✅ Yes | ⚠️ Partial | ✅ Yes |
+| 7a | Container deployment | ✅ Yes | ❌ No | ⚠️ Experimental |
+
+## Test Categories
+
+### Unit Tests (What We Have)
+
+Unit tests verify that predicates:
+- Accept correct input and reject invalid input
+- Store and retrieve configuration correctly
+- Generate expected output strings/structures
+- Handle edge cases in logic
+
+**These tests run without external dependencies.**
+
+### Integration Tests (What's Needed for Production)
+
+Integration tests would verify:
+- Generated code actually executes
+- External services respond correctly
+- End-to-end workflows complete successfully
+
+**These require actual infrastructure (Docker, Kubernetes, SSH servers, etc.)**
+
+---
+
+## Phase 6: Deployment Glue
+
+### Phase 6a-b: Deployment Foundation
+
+| Feature | Unit Test | Integration Test | Notes |
+|---------|-----------|------------------|-------|
+| Service declarations | ✅ | N/A | Configuration storage |
+| Deploy method config | ✅ | N/A | Configuration storage |
+| Source tracking | ✅ | N/A | Configuration storage |
+| Security validation | ✅ | N/A | Logic validation |
+| SSH script generation | ✅ | ❌ | Generates scripts, doesn't execute |
+| Systemd unit generation | ✅ | ❌ | Generates units, doesn't install |
+| Multi-host deployment | ✅ | ❌ | Generates scripts for each host |
+| Rollback scripts | ✅ | ❌ | Generates scripts, doesn't execute |
+
+**To fully test:** Would need SSH access to test servers, systemd environments.
+
+### Phase 6c: Error Handling
+
+| Feature | Unit Test | Integration Test | Notes |
+|---------|-----------|------------------|-------|
+| Retry policy config | ✅ | N/A | Configuration storage |
+| Retry execution | ✅ | ⚠️ | Tests with mock predicates |
+| Fallback config | ✅ | N/A | Configuration storage |
+| Fallback execution | ✅ | ⚠️ | Tests with mock predicates |
+| Circuit breaker config | ✅ | N/A | Configuration storage |
+| Circuit state transitions | ✅ | N/A | State machine logic |
+| Timeout config | ✅ | N/A | Configuration storage |
+| Protected call | ✅ | ⚠️ | Tests with mock predicates |
+
+**Status:** Reasonably well tested. Mock predicates simulate success/failure scenarios.
+
+### Phase 6d: Monitoring
+
+| Feature | Unit Test | Integration Test | Notes |
+|---------|-----------|------------------|-------|
+| Health check config | ✅ | N/A | Configuration storage |
+| Health status tracking | ✅ | ❌ | Would need HTTP endpoints |
+| Metrics config | ✅ | N/A | Configuration storage |
+| Metric recording | ✅ | N/A | In-memory storage |
+| Prometheus export | ✅ | ❌ | Format verified, not scraped |
+| Logging config | ✅ | N/A | Configuration storage |
+| Log events | ✅ | N/A | In-memory storage |
+| Alert config | ✅ | N/A | Configuration storage |
+| Alert triggering | ✅ | ❌ | Doesn't send real notifications |
+
+**To fully test:** Would need Prometheus server, actual HTTP services, notification endpoints.
+
+---
+
+## Phase 7a: Container Deployment [EXPERIMENTAL]
+
+**⚠️ WARNING: All Phase 7a features are experimental.**
+
+### Test Coverage
+
+| Feature | What's Tested | What's NOT Tested |
+|---------|---------------|-------------------|
+| `declare_docker_config/2` | Config stored/retrieved | N/A |
+| `generate_dockerfile/3` | Output contains expected strings | Dockerfile builds successfully |
+| `generate_dockerignore/3` | Output contains expected patterns | N/A |
+| `docker_image_tag/2` | Tag format correct | Image exists |
+| `build_docker_image/3` | Command string generated | Docker actually builds |
+| `push_docker_image/3` | Command string generated | Push succeeds |
+| `declare_compose_config/2` | Config stored/retrieved | N/A |
+| `generate_docker_compose/3` | YAML structure correct | `docker-compose up` works |
+| `declare_k8s_config/2` | Config stored/retrieved | N/A |
+| `generate_k8s_deployment/3` | YAML contains required fields | `kubectl apply` succeeds |
+| `generate_k8s_service/3` | YAML contains required fields | Service routes traffic |
+| `generate_k8s_configmap/3` | YAML contains required fields | ConfigMap created |
+| `generate_k8s_ingress/3` | YAML contains required fields | Ingress routes traffic |
+| `generate_helm_chart/3` | Chart structure created | `helm install` works |
+| `declare_registry/2` | Config stored/retrieved | N/A |
+| `login_registry/2` | Command string generated | Login succeeds |
+| `deploy_to_k8s/3` | Commands generated | Deployment succeeds |
+| `scale_k8s_deployment/4` | Command generated | Scaling works |
+
+### What Unit Tests Verify
+
+```prolog
+% Example: test_generate_dockerfile_python
+test_generate_dockerfile_python :-
+    declare_service(test_svc, [target(python), port(8080)]),
+    declare_docker_config(test_svc, [base_image('python:3.11-slim')]),
+    generate_dockerfile(test_svc, [], Dockerfile),
+    % These checks verify string content, NOT that it builds:
+    sub_atom(Dockerfile, _, _, _, 'FROM python:3.11-slim'),
+    sub_atom(Dockerfile, _, _, _, 'pip install'),
+    sub_atom(Dockerfile, _, _, _, 'EXPOSE 8080').
+```
+
+### What Would Be Needed for Full Testing
+
+1. **Docker Integration Tests**
+   ```bash
+   # Verify Dockerfile builds
+   generate_dockerfile(svc, [], DF),
+   write_to_file('Dockerfile', DF),
+   docker build -t test:latest .
+
+   # Verify image runs
+   docker run --rm test:latest --version
+   ```
+
+2. **Kubernetes Integration Tests**
+   ```bash
+   # Verify manifests are valid
+   generate_k8s_deployment(svc, [], Manifest),
+   kubectl apply --dry-run=client -f - <<< "$Manifest"
+
+   # Full deployment test (requires cluster)
+   kubectl apply -f - <<< "$Manifest"
+   kubectl rollout status deployment/svc
+   ```
+
+3. **Registry Integration Tests**
+   ```bash
+   # Verify login works
+   login_registry(reg, login_command(_, Cmd)),
+   eval "$Cmd"  # Actually execute login
+
+   # Verify push works
+   docker push $IMAGE_TAG
+   ```
+
+### Recommended Validation Before Production
+
+Before using Phase 7a in production:
+
+1. **Manual Dockerfile validation:**
+   ```bash
+   # Generate and build
+   swipl -g "generate_dockerfile(my_svc, [], DF), write(DF)" -t halt > Dockerfile
+   docker build -t test .
+   ```
+
+2. **Kubernetes dry-run:**
+   ```bash
+   # Generate and validate
+   swipl -g "generate_k8s_deployment(my_svc, [], M), write(M)" -t halt | \
+     kubectl apply --dry-run=client -f -
+   ```
+
+3. **Compose validation:**
+   ```bash
+   # Generate and check
+   swipl -g "generate_docker_compose(proj, [], C), write(C)" -t halt > docker-compose.yml
+   docker-compose config  # Validates syntax
+   ```
+
+---
+
+## Future Test Improvements
+
+### Short Term
+- [ ] Add `--dry-run` validation for K8s manifests
+- [ ] Add Dockerfile syntax validation
+- [ ] Add YAML schema validation for Compose files
+
+### Medium Term
+- [ ] CI/CD pipeline with Docker-in-Docker for build tests
+- [ ] Kind/minikube cluster for K8s integration tests
+- [ ] Mock registry for push tests
+
+### Long Term
+- [ ] Full end-to-end deployment tests
+- [ ] Performance/load testing
+- [ ] Security scanning of generated containers
+
+---
+
+## Running Tests
+
+```bash
+# All deployment glue tests (83 tests)
+swipl tests/glue/test_deployment_glue.pl
+
+# Expected output includes:
+# - Phase 6a-d: 62 tests (production ready)
+# - Phase 7a: 21 tests (experimental, code generation only)
+```
+
+## Contributing
+
+When adding new features:
+
+1. **Always add unit tests** for configuration and code generation
+2. **Document integration test requirements** in this file
+3. **Mark experimental features** with `[EXPERIMENTAL]` in code comments
+4. **Update this file** with coverage information

--- a/src/unifyweaver/glue/deployment_glue.pl
+++ b/src/unifyweaver/glue/deployment_glue.pl
@@ -10,6 +10,21 @@
  * - Change detection and automatic redeployment
  * - Security validation (encryption requirements)
  * - Generated deployment scripts
+ *
+ * EXPERIMENTAL FEATURES (Phase 7a):
+ * The following features are experimental and have only been tested for
+ * code generation correctness, NOT actual deployment functionality:
+ * - Docker configuration and Dockerfile generation
+ * - Docker Compose generation
+ * - Kubernetes manifest generation (Deployment, Service, Ingress, ConfigMap)
+ * - Container registry authentication
+ * - Helm chart generation
+ *
+ * These predicates generate shell commands and YAML/Dockerfile content but
+ * do NOT execute them. Integration testing with actual Docker/Kubernetes
+ * environments is required before production use.
+ *
+ * See TEST_COVERAGE.md for detailed test coverage information.
  */
 
 :- module(deployment_glue, [
@@ -2507,11 +2522,26 @@ filter_alert_history(Options, AlertName, Timestamp) :-
     ).
 
 %% ============================================
-%% Phase 7a: Container Deployment
+%% Phase 7a: Container Deployment [EXPERIMENTAL]
+%% ============================================
+%%
+%% WARNING: All Phase 7a predicates are EXPERIMENTAL.
+%%
+%% Current test coverage:
+%% - Unit tests verify code generation (string/structure output)
+%% - NO integration tests with actual Docker/Kubernetes
+%% - Generated commands are NOT executed, only returned
+%%
+%% Before production use, verify:
+%% - Generated Dockerfiles build successfully
+%% - Generated K8s manifests pass: kubectl apply --dry-run=client
+%% - Registry authentication works in your environment
+%% - Commands execute correctly on your target systems
+%%
 %% ============================================
 
 %% --------------------------------------------
-%% Docker Configuration
+%% Docker Configuration [EXPERIMENTAL]
 %% --------------------------------------------
 
 %% declare_docker_config(+Service, +Config)


### PR DESCRIPTION
## Summary

Implements Phase 7a of the Cloud & Enterprise feature set: container deployment support for Docker, Docker Compose, and Kubernetes.

## ⚠️ Experimental Status

**This feature is marked EXPERIMENTAL.**

### What's Tested
- ✅ Configuration storage and retrieval
- ✅ Code generation (Dockerfiles, YAML manifests, shell commands)
- ✅ Output string structure and content

### What's NOT Tested
- ❌ Generated Dockerfiles actually build
- ❌ Generated K8s manifests apply successfully
- ❌ Registry authentication works
- ❌ Docker/kubectl commands execute correctly
- ❌ End-to-end deployment workflows

### Before Production Use

1. **Validate Dockerfiles:**
   ```bash
   docker build -t test .
   ```

2. **Validate K8s manifests:**
   ```bash
   kubectl apply --dry-run=client -f manifest.yaml
   ```

3. **Test registry auth:**
   ```bash
   # Execute generated login command
   docker login ...
   ```

See `docs/TEST_COVERAGE.md` for detailed coverage information.

---

## New Features

### Docker Configuration

```prolog
% Configure Docker for a service
:- declare_docker_config(ml_predictor, [
    base_image('python:3.11-slim'),
    registry(docker_hub),
    tag('v1.0.0'),
    env(['APP_ENV'-production]),
    healthcheck(http('/health')),
    user(nonroot)
]).
```

### Dockerfile Generation

Generate target-specific, optimized Dockerfiles:

```prolog
% Python service
generate_dockerfile(ml_predictor, [], Dockerfile).
% → Multi-stage not needed, pip install, slim image

% Go service (multi-stage by default)
generate_dockerfile(api_service, [], Dockerfile).
% → Build stage with golang, runtime stage with alpine

% Rust service (multi-stage)
generate_dockerfile(data_processor, [], Dockerfile).
% → Cargo build with dependency caching, debian runtime
```

**Supported targets:** Python, Go, Rust, Node.js, C#/.NET

### Docker Compose

```prolog
% Configure multi-service project
:- declare_compose_config(my_project, [
    services([api, worker, redis]),
    networks([backend, frontend]),
    volumes([data_volume])
]).

% Generate docker-compose.yml
generate_docker_compose(my_project, [], ComposeYaml).
```

### Kubernetes Deployment

```prolog
% Configure K8s deployment
:- declare_k8s_config(api_service, [
    namespace(production),
    replicas(3),
    resources(resources([memory-'256Mi', cpu-'100m'], [memory-'512Mi', cpu-'500m'])),
    liveness_probe(http('/health')),
    readiness_probe(http('/ready')),
    service_type('LoadBalancer')
]).

% Generate manifests
generate_k8s_deployment(api_service, [], DeploymentYaml).
generate_k8s_service(api_service, [], ServiceYaml).
generate_k8s_ingress(api_service, [], IngressYaml).
```

### Container Registry

```prolog
% Configure registry with authentication
:- declare_registry(docker_hub, [
    url('docker.io'),
    username(myuser),
    password_env('DOCKER_PASSWORD'),
    auth_method(basic)
]).

% AWS ECR
:- declare_registry(aws_ecr, [
    url('123456789.dkr.ecr.us-east-1.amazonaws.com'),
    auth_method(aws_ecr)
]).

% Generate login command
login_registry(aws_ecr, Result).
% → aws ecr get-login-password | docker login --username AWS --password-stdin ...
```

### Kubernetes Operations

```prolog
% Deploy to cluster
deploy_to_k8s(api_service, [namespace(staging), wait(true)], Result).

% Scale deployment
scale_k8s_deployment(api_service, 5, [namespace(production)], Result).

% Check rollout status
rollout_status(api_service, [], Status).
```

## Implementation Details

### Dockerfile Templates

| Target | Base Image | Build Strategy |
|--------|-----------|----------------|
| Python | python:3.11-slim | Single stage, pip install |
| Go | golang:1.21-alpine | Multi-stage, alpine runtime |
| Rust | rust:1.73-slim | Multi-stage, debian runtime |
| Node.js | node:20-alpine | Single stage, npm ci |
| C#/.NET | dotnet/sdk:8.0 | Multi-stage, aspnet runtime |

### Kubernetes Resources Generated

- **Deployment**: Pods, replicas, resources, probes, env vars
- **Service**: ClusterIP, NodePort, LoadBalancer
- **ConfigMap**: Key-value configuration data
- **Ingress**: Host routing, TLS, path-based routing
- **Helm Chart**: Chart.yaml, values.yaml structure

## Files Changed

| File | Changes |
|------|---------|
| `src/unifyweaver/glue/deployment_glue.pl` | +1,275 lines |
| `tests/glue/test_deployment_glue.pl` | +297 lines |
| `docs/TEST_COVERAGE.md` | +200 lines (new) |

**Total: ~1,770 insertions(+)**

## Tests

21 new tests (83 total):

| Group | Tests | Coverage Type |
|-------|-------|---------------|
| Docker Configuration | 2 | Unit (config storage) |
| Dockerfile Generation | 4 | Unit (string output) |
| Docker Operations | 4 | Unit (command generation) |
| Docker Compose | 2 | Unit (YAML structure) |
| Kubernetes Deployment | 4 | Unit (manifest structure) |
| Container Registry | 3 | Unit (command generation) |
| Kubernetes Operations | 2 | Unit (command generation) |

**Note:** All Phase 7a tests are unit tests verifying code generation, NOT integration tests.

## Test Plan

```bash
# Run all tests
swipl tests/glue/test_deployment_glue.pl

# Manual validation (recommended before use)
# 1. Generate a Dockerfile and try to build it
# 2. Generate K8s manifests and run: kubectl apply --dry-run=client -f -
# 3. Test registry login in your environment
```

## Phase 7 Progress

- [x] **Phase 7a**: Container Deployment (this PR) - **EXPERIMENTAL**
  - Docker/Compose support
  - Kubernetes manifests
  - Registry authentication
- [ ] **Phase 7b**: Secrets Management
  - HashiCorp Vault
  - AWS/Azure/GCP secrets
- [ ] **Phase 7c**: Multi-Region & Cloud Functions
  - Geo-failover
  - Lambda/Cloud Functions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
