### PR TITLE
Implement Go Target Grouped Aggregations (Phase 9b)

### DIFF
--- a/tests/test_go_group_by.pl
+++ b/tests/test_go_group_by.pl
@@ -1,0 +1,77 @@
+:- use_module(library(filesex)).
+:- use_module('../src/unifyweaver/targets/go_target').
+
+% Define predicates with grouped aggregation
+
+% 1. Count users by role (using simple key)
+% Data: {"name": "A", "role": "admin"}, {"name": "B", "role": "user"}, ...
+count_by_role(Key, Count) :-
+    group_by(run_count_by_role, json_record([role-Key]), count, Count).
+
+% 2. Sum salary by department
+% Data: {"dept": "eng", "salary": 100}, {"dept": "sales", "salary": 200}, ...
+sum_salary_by_dept(Dept, TotalSalary) :-
+    group_by(run_sum_by_dept, json_record([dept-Dept, salary-Salary]), sum(Salary), TotalSalary).
+
+% Test runner
+run_test :-
+    shell('mkdir -p output'),
+    
+    % Create input data for roles
+    open('output/users_roles.jsonl', write, Stream1),
+    format(Stream1, '{"name": "Alice", "role": "admin"}~n', []),
+    format(Stream1, '{"name": "Bob", "role": "user"}~n', []),
+    format(Stream1, '{"name": "Charlie", "role": "user"}~n', []),
+    format(Stream1, '{"name": "Dave", "role": "admin"}~n', []),
+    format(Stream1, '{"name": "Eve", "role": "user"}~n', []),
+    close(Stream1),
+    
+    % Create input data for salaries
+    open('output/salaries.jsonl', write, Stream2),
+    format(Stream2, '{"dept": "eng", "salary": 1000}~n', []),
+    format(Stream2, '{"dept": "sales", "salary": 2000}~n', []),
+    format(Stream2, '{"dept": "eng", "salary": 1500}~n', []),
+    format(Stream2, '{"dept": "hr", "salary": 1000}~n', []),
+    format(Stream2, '{"dept": "eng", "salary": 2000}~n', []),
+    close(Stream2),
+    
+    test_group_by(count_by_role/2, 'users_roles.jsonl', 'count_role.go', 
+                  ['admin: 2', 'user: 3']),
+                  
+    test_group_by(sum_salary_by_dept/2, 'salaries.jsonl', 'sum_dept.go', 
+                  ['eng: 4500', 'sales: 2000', 'hr: 1000']).
+
+test_group_by(Pred/Arity, InputFile, ProgName, ExpectedLines) :-
+    format('Testing ~w...~n', [Pred]),
+    
+    % Compile (using json_input(true) for streams)
+    compile_predicate_to_go(Pred/Arity, [json_input(true)], GoCode),
+    atom_concat('output/', ProgName, ProgPath),
+    write_go_program(GoCode, ProgPath),
+    
+    % Run
+    format(atom(Cmd), 'go run ~w < output/~w > output/result_~w.txt', [ProgPath, InputFile, ProgName]),
+    shell(Cmd, ExitCode),
+    
+    (   ExitCode =:= 0
+    ->  true
+    ;   format('FAILURE: Go program failed~n'), fail
+    ),
+    
+    % Verify output contains expected lines
+    atom_concat('output/result_', ProgName, ResultPath),
+    atom_concat(ResultPath, '.txt', FullResultPath),
+    read_file_to_string(FullResultPath, OutputStr, []),
+    
+    check_contains_lines(OutputStr, ExpectedLines).
+
+check_contains_lines(_, []).
+check_contains_lines(Output, [Line|Rest]) :-
+    (   sub_string(Output, _, _, _, Line)
+    ->  format('  Found expected: ~w~n', [Line])
+    ;   format('FAILURE: Missing expected output: ~w~n', [Line]),
+        fail
+    ),
+    check_contains_lines(Output, Rest).
+
+:- run_test, halt.


### PR DESCRIPTION
## Description
This PR implements **Phase 9b** of the Go target roadmap, extending the aggregation support to handle SQL-like `GROUP BY` operations on JSON streams. It allows users to categorize data and perform aggregations (count, sum) per category using the `group_by(Goal, Key, Op, Result)` syntax.

## Key Changes
-   **JSONL Stream Support**: Added `generate_group_by_code_jsonl/6` to generate Go code for grouped aggregations when reading from `stdin` (JSONL).
    -   Uses in-memory `map[KeyType]State` for accumulation.
    -   Supports `count` and `sum(Field)` operations.
    -   Handles string keys (auto-formatted).
-   **Code Cleanup**: Refactored `src/unifyweaver/targets/go_target.pl` to remove accidental code duplication introduced in previous merges.
-   **Helper Predicates**: Restored and consolidated helper predicates (`find_field_for_var/3`, `format_import/2`).

## Example Usage
```prolog
% Count users by role
count_by_role(Role, Count) :-
    group_by(run_count, json_record([role-Role]), count, Count).
```

## Verification
New test file `tests/test_go_group_by.pl` verifies:
-   `count` aggregation by a string key (Role).
-   `sum` aggregation by a string key (Department).
-   Correct Go code generation and execution output.

Run verification with:
```bash
swipl tests/test_go_group_by.pl
```