### PR TITLE
docs: Update Go generator mode documentation

### DIFF
--- a/docs/design/GO_GENERATOR_MODE.md
+++ b/docs/design/GO_GENERATOR_MODE.md
@@ -2,308 +2,244 @@
 
 ## Overview
 
-This document describes the design for adding `mode(generator)` to the Go target in UnifyWeaver. Generator mode enables fixpoint-based Datalog evaluation, bringing Go to feature parity with C# and Python generator modes for recursive closure, joins, and stratified negation.
+This document describes the Go generator mode (`mode(generator)`) in UnifyWeaver. Generator mode enables fixpoint-based Datalog evaluation with recursive closure, joins, stratified negation, aggregation, and more.
 
-## Motivation
+## Status: ✅ Complete
 
-The current Go target excels at streaming operations (JSONL processing, aggregation, GROUP BY) but lacks support for recursive Datalog evaluation. Many use cases require computing transitive closures or derived facts that depend on previously derived facts—this requires a fixpoint iteration loop.
+All planned features have been implemented:
 
-### Example Use Case
+| Feature | PR | Description |
+|---------|-----|-------------|
+| Core (joins, negation, fixpoint) | #233 | Base generator mode with fixpoint loop |
+| Aggregation | #234 | `aggregate_all/3,4` with count, sum, min, max, avg |
+| Indexing | #235 | O(1) joins via hash-based index |
+| JSON Input | #236 | Load initial facts from stdin JSONL |
+| Parallel Execution | #237 | `workers(N)` for concurrent fixpoint |
+| Database Persistence | #238 | `db_backend(bbolt)` for incremental computation |
+| HAVING Clause | #239 | Post-aggregation filtering |
+
+---
+
+## Quick Start
+
+### Basic Usage
 
 ```prolog
-% Transitive closure - requires fixpoint
+% Define rules
+parent(john, mary).
+parent(mary, sue).
 ancestor(X, Y) :- parent(X, Y).
 ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).
 
-% Compile with generator mode
+% Compile to Go
 ?- compile_predicate_to_go(ancestor/2, [mode(generator)], Code).
 ```
 
-Without generator mode, Go cannot evaluate this. With generator mode, it produces a self-contained Go program with a fixpoint loop.
+### Running the Generated Code
 
----
-
-## Architecture
-
-### Execution Model Comparison
-
-| Target | Streaming Mode | Generator Mode |
-|--------|----------------|----------------|
-| **C#** | LINQ pipeline | ✅ Fixpoint with `HashSet<Fact>` |
-| **Python** | Iterator pipeline | ✅ Fixpoint with `Set[FrozenDict]` |
-| **Go** | stdin→stdout | 🆕 Fixpoint with `map[string]Fact` |
-
-### High-Level Flow
-
-```
-compile_predicate_to_go(Pred/Arity, [mode(generator)], Code)
-    │
-    ├─ compute_generator_dependency_closure/2  (find all related predicates)
-    ├─ guard_stratified_negation_go/3          (validate negation is stratified)
-    ├─ compile_go_generator_facts/3            (emit GetInitialFacts())
-    ├─ compile_go_generator_rules/5            (emit ApplyRule_N functions)
-    └─ compile_go_generator_execution/4        (emit Solve() fixpoint loop)
-```
-
-### Integration with Existing Go Target
-
-Generator mode is **additive**—existing streaming functionality is preserved:
-
-```prolog
-compile_predicate_to_go(PredIndicator, Options, GoCode) :-
-    ...
-    % NEW: Generator mode (check first)
-    (   option(mode(generator), Options)
-    ->  compile_generator_mode_go(Pred, Arity, Options, GoCode)
-    % Existing modes unchanged...
-    ;   is_aggregation_predicate(Body)
-    ->  compile_aggregation_mode(...)
-    ;   is_group_by_predicate(Body)
-    ->  compile_group_by_mode(...)
-    ...
+```bash
+go run ancestor.go
+# Output (JSONL):
+# {"relation":"parent","args":{"arg0":"john","arg1":"mary"}}
+# {"relation":"ancestor","args":{"arg0":"john","arg1":"sue"}}
+# ...
 ```
 
 ---
 
-## Design Details
+## Options Reference
 
-### Shared Infrastructure via `common_generator.pl`
+| Option | Default | Description |
+|--------|---------|-------------|
+| `mode(generator)` | - | **Required.** Enable generator mode |
+| `json_input(true)` | false | Load additional facts from stdin JSONL |
+| `workers(N)` | 1 | Parallel execution with N goroutines |
+| `db_backend(bbolt)` | - | Enable database persistence |
+| `db_file(Path)` | `'facts.db'` | Database file path |
+| `db_bucket(Name)` | `'facts'` | Database bucket name |
 
-Generator mode uses shared predicates for language-agnostic logic:
-
-| Predicate | Purpose |
-|-----------|---------|
-| `build_variable_map/2` | Map Prolog variables → accessor tokens |
-| `translate_expr_common/4` | Translate expressions using target config |
-| `translate_builtin_common/4` | Translate builtins (comparisons, arithmetic) |
-| `prepare_negation_data/4` | Build key-value pairs for negation checks |
-
-Each target provides a config block:
+### Examples
 
 ```prolog
-go_generator_config(Config) :-
-    Config = [
-        access_fmt-"fact[\"arg~w\"]",      % fact["arg0"]
-        atom_fmt-"\"~w\"",                  % "value"
-        null_val-"nil",
-        ops-[
-            + - "+", - - "-", * - "*", / - "/",
-            > - ">", < - "<", >= - ">=", =< - "<=", 
-            =:= - "==", =\= - "!="
-        ]
-    ].
+% Basic
+compile_predicate_to_go(ancestor/2, [mode(generator)], Code).
+
+% With JSON input from stdin
+compile_predicate_to_go(ancestor/2, [mode(generator), json_input(true)], Code).
+
+% With 4 parallel workers
+compile_predicate_to_go(ancestor/2, [mode(generator), workers(4)], Code).
+
+% With database persistence
+compile_predicate_to_go(ancestor/2, [mode(generator), db_backend(bbolt), 
+                                      db_file('my.db')], Code).
+
+% Combined: parallel + database + json input
+compile_predicate_to_go(ancestor/2, [mode(generator), workers(4), 
+                                      db_backend(bbolt), json_input(true)], Code).
 ```
 
-### Fact Representation
+---
+
+## Features
+
+### Fixpoint Evaluation
+
+The core loop iterates until no new facts are derived:
 
 ```go
-// Fact represents a relation tuple
-type Fact struct {
-    Relation string
-    Args     map[string]interface{}
+func Solve() map[string]Fact {
+    total := make(map[string]Fact)
+    for _, fact := range GetInitialFacts() {
+        total[fact.Key()] = fact
+    }
+    
+    idx := BuildIndex(total)
+    
+    changed := true
+    for changed {
+        changed = false
+        var newFacts []Fact
+        for _, fact := range total {
+            newFacts = append(newFacts, ApplyRule_1(fact, total, idx)...)
+        }
+        for _, nf := range newFacts {
+            if _, exists := total[nf.Key()]; !exists {
+                total[nf.Key()] = nf
+                idx.Add(&nf)
+                changed = true
+            }
+        }
+    }
+    return total
+}
+```
+
+### Indexed Joins
+
+Joins use O(1) hash lookups instead of O(n) linear scans:
+
+```go
+// Before (linear scan):
+for _, j1 := range total {
+    if j1.Relation == "ancestor" && j1.Args["arg0"] == fact.Args["arg1"] { ... }
 }
 
-// Key returns a canonical string for set membership
+// After (indexed):
+for _, j1Ptr := range idx.Lookup("ancestor", "arg0", fact.Args["arg1"]) {
+    j1 := *j1Ptr
+    ...
+}
+```
+
+### Stratified Negation
+
+Negation is validated at compile time and checked against the total set:
+
+```prolog
+path(X, Y) :- edge(X, Y), \+ blocked(X, Y).
+```
+
+```go
+negFact := Fact{Relation: "blocked", Args: map[string]interface{}{"arg0": x, "arg1": y}}
+if _, exists := total[negFact.Key()]; exists {
+    continue  // Skip if negated fact exists
+}
+```
+
+### Aggregation
+
+Supports `aggregate_all/3` (ungrouped) and `aggregate_all/4` (grouped):
+
+```prolog
+% Ungrouped: count all items
+item_count(N) :- aggregate_all(count, item(_, _), N).
+
+% Grouped: sum by department
+dept_total(Dept, Total) :- aggregate_all(sum(S), salary(Dept, S), Dept, Total).
+```
+
+**Supported operations:** `count`, `sum`, `min`, `max`, `avg`
+
+### HAVING Clause
+
+Builtins after aggregation filter results:
+
+```prolog
+% Only departments with total > 5000
+dept_high(Dept, Total) :- 
+    aggregate_all(sum(S), salary(Dept, S), Dept, Total),
+    Total > 5000.
+```
+
+```go
+if len(values) > 0 {
+    agg := 0.0; for _, v := range values { agg += v }
+    // HAVING clause filter
+    if !(agg > 5000) {
+        continue
+    }
+    results = append(results, ...)
+}
+```
+
+### JSON Input
+
+Load facts from stdin in JSONL format:
+
+```bash
+echo '{"relation":"parent","args":{"arg0":"alice","arg1":"bob"}}' | ./ancestor
+```
+
+### Parallel Execution
+
+Split fact processing across goroutines:
+
+```prolog
+compile_predicate_to_go(ancestor/2, [mode(generator), workers(4)], Code).
+```
+
+Workers process chunks of facts concurrently, with results collected via channel.
+
+### Database Persistence
+
+Enable incremental Datalog with bbolt:
+
+```prolog
+compile_predicate_to_go(ancestor/2, [mode(generator), db_backend(bbolt)], Code).
+```
+
+1. **Load:** Read existing facts from database at startup
+2. **Compute:** Run fixpoint including loaded facts
+3. **Save:** Persist all facts after fixpoint completes
+
+---
+
+## Fact Representation
+
+```go
+type Fact struct {
+    Relation string                 `json:"relation"`
+    Args     map[string]interface{} `json:"args"`
+}
+
 func (f Fact) Key() string {
     b, _ := json.Marshal(f)
     return string(b)
 }
 ```
 
-Using JSON marshaling for the key ensures structural equality matching regardless of map iteration order.
-
-### Fixpoint Loop
-
-```go
-func Solve() map[string]Fact {
-    total := make(map[string]Fact)
-    
-    // Initialize with base facts
-    for _, fact := range GetInitialFacts() {
-        total[fact.Key()] = fact
-    }
-    
-    // Iterate until no new facts
-    changed := true
-    for changed {
-        changed = false
-        var newFacts []Fact
-        
-        for _, fact := range total {
-            newFacts = append(newFacts, ApplyRule_1(fact, total)...)
-            newFacts = append(newFacts, ApplyRule_2(fact, total)...)
-            // ... more rules
-        }
-        
-        for _, nf := range newFacts {
-            key := nf.Key()
-            if _, exists := total[key]; !exists {
-                total[key] = nf
-                changed = true
-            }
-        }
-    }
-    
-    return total
-}
-```
-
-### Negation
-
-Stratified negation is validated at compile time (non-stratified negation is rejected). Generated code checks `total` set:
-
-```go
-// For rule: path(X,Y) :- edge(X,Y), \+ blocked(X,Y)
-negFact := Fact{Relation: "blocked", Args: map[string]interface{}{"arg0": x, "arg1": y}}
-if _, exists := total[negFact.Key()]; exists {
-    return results  // Skip if negated fact exists
-}
-```
-
-### Joins
-
-Multi-relation joins iterate over `total`:
-
-```go
-// For rule: grandparent(X,Z) :- parent(X,Y), parent(Y,Z)
-func ApplyRule_1(fact Fact, total map[string]Fact) []Fact {
-    var results []Fact
-    if fact.Relation != "parent" {
-        return results
-    }
-    x := fact.Args["arg0"]
-    y := fact.Args["arg1"]
-    
-    // Join with second parent relation
-    for _, f2 := range total {
-        if f2.Relation == "parent" && f2.Args["arg0"] == y {
-            z := f2.Args["arg1"]
-            results = append(results, Fact{
-                Relation: "grandparent",
-                Args: map[string]interface{}{"arg0": x, "arg1": z},
-            })
-        }
-    }
-    return results
-}
-```
-
 ---
 
-## Aggregation Support
+## Testing
 
-### Syntax Normalization
+```bash
+# Run generator tests
+swipl -g "run_tests" -t halt tests/core/test_go_generator.pl
 
-Both syntaxes are supported via aliasing:
-
-```prolog
-% Normalize aggregate/3 → aggregate_all/3 in generator mode
-normalize_aggregate_goal(aggregate(Op, Goal, R), aggregate_all(Op, Goal, R)) :- !.
-normalize_aggregate_goal(G, G).
+# Run aggregation tests  
+swipl -g "run_tests" -t halt tests/core/test_go_generator_aggregates.pl
 ```
-
-This ensures backward compatibility with existing code using `aggregate/3`.
-
-### Aggregation Over Derived Facts
-
-Unlike streaming mode (which aggregates input), generator mode aggregates over the computed `total` set:
-
-```prolog
-% Example: Sum salaries of reachable employees (derived via transitive closure)
-reachable_salary(Total) :- 
-    aggregate_all(sum(S), reachable_employee(_, _, S), Total).
-```
-
-### Supported Operations
-
-| Operation | Go Code |
-|-----------|---------|
-| `count` | `agg := float64(len(values))` |
-| `sum` | `for _, v := range values { agg += v }` |
-| `min` | `for _, v := range values { if v < agg { agg = v } }` |
-| `max` | `for _, v := range values { if v > agg { agg = v } }` |
-| `avg` | `agg = sum / float64(len(values))` |
-
-### Grouped Aggregation
-
-`aggregate_all/4` supports grouping:
-
-```prolog
-dept_total(Dept, Total) :- aggregate_all(sum(S), salary(Dept, S), Dept, Total).
-```
-
-Generates:
-
-```go
-groups := make(map[interface{}][]float64)
-for _, f := range total {
-    if f.Relation == "salary" {
-        key := f.Args["arg0"]  // Dept
-        val := f.Args["arg1"]  // S
-        groups[key] = append(groups[key], val)
-    }
-}
-for key, values := range groups {
-    agg := 0.0
-    for _, v := range values { agg += v }
-    results = append(results, Fact{...})
-}
-```
-
----
-
-## Implementation Phases
-
-| Phase | Description | Effort |
-|-------|-------------|--------|
-| **1** | Infrastructure: `common_generator` import, config block, mode dispatch | 1-2 days |
-| **2** | Fixpoint engine: `Solve()` function, `Fact` type, iteration loop | 2-3 days |
-| **3** | Rule compilation: joins, negation, builtins via shared abstractions | 2-3 days |
-| **4** | Testing: unit tests, cross-target comparison with C#/Python | 1-2 days |
-| **5** | Aggregation: `aggregate_all/3,4` with syntax aliasing | 2-3 days |
-
-**Total: ~2-3 weeks**
-
----
-
-## Testing Strategy
-
-### Unit Tests
-
-```prolog
-% tests/core/test_go_generator.pl
-
-test(transitive_closure) :-
-    % parent facts + ancestor rules → compile and run
-    compile_predicate_to_go(ancestor/2, [mode(generator)], Code),
-    % Write, compile, execute, verify output
-    ...
-
-test(stratified_negation) :-
-    % edge + blocked facts, path rule with negation
-    ...
-
-test(cross_target_comparison) :-
-    % Same program compiled to Go, C#, Python
-    % All outputs must match
-    ...
-```
-
-### Manual Verification
-
-1. Compile same Datalog program to all three targets
-2. Run on identical input
-3. Diff outputs (sorted, canonicalized JSON)
-
----
-
-## Future Work
-
-- **Indexing**: arg0/arg1 buckets (like C#) for faster joins
-- **Parallel evaluation**: Go's goroutines are well-suited for this
-- **I/O integration**: Use `json_input(true)` to load initial facts from stdin
-- **Database persistence**: Combine with `db_backend(bbolt)` for incremental computation
-- **HAVING clause**: Post-aggregation filtering
 
 ---
 

--- a/docs/tutorials/GO_GENERATOR_TUTORIAL.md
+++ b/docs/tutorials/GO_GENERATOR_TUTORIAL.md
@@ -1,0 +1,194 @@
+# Go Generator Mode Tutorial
+
+This tutorial walks through using Go generator mode for Datalog evaluation.
+
+## Prerequisites
+
+- Go installed (`go version`)
+- SWI-Prolog with UnifyWeaver loaded
+
+---
+
+## Example 1: Transitive Closure (Ancestor)
+
+The classic recursive Datalog example.
+
+### Define the Program
+
+```prolog
+% Load UnifyWeaver
+:- use_module('src/unifyweaver/targets/go_target').
+
+% Define facts
+parent(john, mary).
+parent(mary, sue).
+parent(sue, alice).
+
+% Define rules
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).
+
+% Compile to Go
+:- compile_predicate_to_go(ancestor/2, [mode(generator)], Code),
+   open('ancestor.go', write, S),
+   write(S, Code),
+   close(S).
+```
+
+### Run
+
+```bash
+go run ancestor.go
+```
+
+### Expected Output
+
+```json
+{"relation":"parent","args":{"arg0":"john","arg1":"mary"}}
+{"relation":"parent","args":{"arg0":"mary","arg1":"sue"}}
+{"relation":"parent","args":{"arg0":"sue","arg1":"alice"}}
+{"relation":"ancestor","args":{"arg0":"sue","arg1":"alice"}}
+{"relation":"ancestor","args":{"arg0":"mary","arg1":"sue"}}
+{"relation":"ancestor","args":{"arg0":"mary","arg1":"alice"}}
+{"relation":"ancestor","args":{"arg0":"john","arg1":"mary"}}
+{"relation":"ancestor","args":{"arg0":"john","arg1":"sue"}}
+{"relation":"ancestor","args":{"arg0":"john","arg1":"alice"}}
+```
+
+---
+
+## Example 2: Graph Reachability with Negation
+
+Find paths that aren't blocked.
+
+```prolog
+edge(a, b).
+edge(b, c).
+edge(c, d).
+blocked(b, c).
+
+path(X, Y) :- edge(X, Y), \+ blocked(X, Y).
+path(X, Z) :- edge(X, Y), \+ blocked(X, Y), path(Y, Z).
+
+:- compile_predicate_to_go(path/2, [mode(generator)], Code), ...
+```
+
+---
+
+## Example 3: Aggregation with HAVING
+
+Calculate department totals, filter high earners.
+
+```prolog
+salary(eng, 1000).
+salary(eng, 1500).
+salary(sales, 800).
+salary(sales, 1700).
+salary(hr, 600).
+
+% Sum by department, only where total > 1000
+dept_high(Dept, Total) :- 
+    aggregate_all(sum(S), salary(Dept, S), Dept, Total),
+    Total > 1000.
+
+:- compile_predicate_to_go(dept_high/2, [mode(generator)], Code), ...
+```
+
+### Output
+
+```json
+{"relation":"dept_high","args":{"arg0":"eng","arg1":2500}}
+{"relation":"dept_high","args":{"arg0":"sales","arg1":2500}}
+```
+
+(hr excluded because 600 < 1000)
+
+---
+
+## Example 4: Loading Data from Stdin
+
+Instead of hardcoding facts, pipe them in.
+
+```prolog
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).
+
+:- compile_predicate_to_go(ancestor/2, [mode(generator), json_input(true)], Code), ...
+```
+
+### Run with Piped Data
+
+```bash
+echo '{"relation":"parent","args":{"arg0":"john","arg1":"mary"}}
+{"relation":"parent","args":{"arg0":"mary","arg1":"sue"}}' | go run ancestor.go
+```
+
+---
+
+## Example 5: Parallel Execution
+
+Speed up large computations with goroutines.
+
+```prolog
+:- compile_predicate_to_go(ancestor/2, [mode(generator), workers(4)], Code), ...
+```
+
+The fixpoint loop distributes facts across 4 workers.
+
+---
+
+## Example 6: Incremental Computation with Database
+
+Persist results to bbolt database.
+
+```prolog
+:- compile_predicate_to_go(ancestor/2, [mode(generator), db_backend(bbolt), 
+                                         db_file('ancestry.db')], Code), ...
+```
+
+### Workflow
+
+```bash
+# First run - computes and saves to ancestry.db
+./ancestor
+
+# Add more facts via stdin, continue from saved state
+echo '{"relation":"parent","args":{"arg0":"alice","arg1":"bob"}}' | ./ancestor
+```
+
+---
+
+## Combining Options
+
+All options can be combined:
+
+```prolog
+:- compile_predicate_to_go(ancestor/2, [
+    mode(generator),
+    json_input(true),      % Load facts from stdin
+    workers(4),            % 4 parallel workers
+    db_backend(bbolt),     % Persist to database
+    db_file('data.db')
+], Code), ...
+```
+
+---
+
+## Tips
+
+1. **Filter output by relation**:
+   ```bash
+   go run ancestor.go | jq 'select(.relation == "ancestor")'
+   ```
+
+2. **Pretty print**:
+   ```bash
+   go run ancestor.go | jq .
+   ```
+
+3. **Count results**:
+   ```bash
+   go run ancestor.go | wc -l
+   ```
+
+4. **Performance**: For large datasets, use `workers(N)` where N = number of CPU cores.


### PR DESCRIPTION
## Summary

Complete rewrite of design documentation and new comprehensive tutorial for Go generator mode.

## Files Changed

### `docs/design/GO_GENERATOR_MODE.md` (rewritten)
- Added status table showing all 7 PRs merged
- Added Options Reference with all settings
- Documented all features: indexing, JSON input, parallel, database, HAVING
- Updated code examples for new features
- Removed "Future Work" section (all items implemented)

### `docs/tutorials/GO_GENERATOR_TUTORIAL.md` (new)
- Example 1: Transitive closure (ancestor)
- Example 2: Graph reachability with negation
- Example 3: Aggregation with HAVING clause
- Example 4: Loading data from stdin
- Example 5: Parallel execution with workers
- Example 6: Incremental computation with database
- Tips for jq filtering and performance

## What's Documented

| Feature | Documented |
|---------|-----------|
| Fixpoint evaluation | ✅ |
| Indexed O(1) joins | ✅ |
| Stratified negation | ✅ |
| Aggregation (count/sum/min/max/avg) | ✅ |
| HAVING clause | ✅ |
| JSON input from stdin | ✅ |
| Parallel execution | ✅ |
| Database persistence | ✅ |
