### PR TITLE
Add GPU support with conservative device selection and fix vector normalization

### DIFF
--- a/examples/test_rust_vector.pl
+++ b/examples/test_rust_vector.pl
@@ -1,14 +1,29 @@
-:- module(test_rust_vector, [main/0]).
+:- module(test_rust_vector, [main/0, main_gpu/0, main_cpu/0]).
 :- use_module('../src/unifyweaver/targets/rust_target').
 
 % This predicate tests the full vector search capability
-test_vector_search(Query) :-
-    % 1. Index data (with embeddings)
+% Device can be: auto, cpu, cuda, gpu, metal
+test_vector_search(Query, Device) :-
+    % 1. Initialize with specified device
+    init_embeddings(Device),
+
+    % 2. Index data (with embeddings)
     crawler_run(["context/PT/pearltrees_export.rdf"], 1),
-    
-    % 2. Search
+
+    % 3. Search
     semantic_search(Query, 5, Results).
 
+% Default: conservative auto-detection (prefers CPU unless explicitly GPU-capable)
 main :-
-    compile_predicate_to_rust(test_rust_vector:test_vector_search/1, [], Code),
+    compile_predicate_to_rust(test_rust_vector:test_vector_search/2, [device(auto)], Code),
     write_rust_project(Code, 'output/rust_vector_test').
+
+% Force GPU mode
+main_gpu :-
+    compile_predicate_to_rust(test_rust_vector:test_vector_search/2, [device(cuda)], Code),
+    write_rust_project(Code, 'output/rust_vector_gpu').
+
+% Force CPU mode (for proot/termux)
+main_cpu :-
+    compile_predicate_to_rust(test_rust_vector:test_vector_search/2, [device(cpu)], Code),
+    write_rust_project(Code, 'output/rust_vector_cpu').


### PR DESCRIPTION
## Summary                                                                                                                                        
                                                                                                                                                  
This PR fixes critical bugs in the Rust vector search implementation and adds GPU support with conservative device selection that ensures         
compatibility across different environments (WSL2, proot, Termux, etc.).                                                                          
                                                                                                                                                  
## Changes                                                                                                                                        
                                                                                                                                                  
### � Bug Fixes                                                                                                                                   
                                                                                                                                                  
1. **Fixed L2 normalization in embedding generation** (`embedding.rs:134-135`)                                                                    
   - Changed from scalar division to `broadcast_div` for proper tensor operations                                                                 
   - Resolves "shape mismatch in div, lhs: [384], rhs: []" error during vector search                                                             
                                                                                                                                                  
2. **Fixed model configuration for all-MiniLM-L6-v2** (`embedding.rs:30-43`)                                                                      
   - Added custom `Config` with 384-dimensional embeddings (6 layers)                                                                             
   - Resolves "shape mismatch for embeddings.word_embeddings.weight, expected: [30522, 768], got: [30522, 384]" error                             
   - Properly supports the sentence transformer model architecture                                                                                
                                                                                                                                                  
### ✨ New Features                                                                                                                                
                                                                                                                                                  
3. **Conservative GPU/CPU device selection** (`embedding.rs:46-111`)                                                                              
   - **CONSERVATIVE DEFAULT**: Uses CPU if `CANDLE_DEVICE` environment variable is not set                                                        
   - Explicit GPU support via `CANDLE_DEVICE=cuda` or `CANDLE_DEVICE=metal`                                                                       
   - Auto-detection mode via `CANDLE_DEVICE=auto`                                                                                                 
   - Graceful fallback to CPU if GPU initialization fails                                                                                         
   - Detailed logging for device initialization and fallback behavior                                                                             
   - Ensures safe operation in constrained environments (proot, containers, Termux)                                                               
                                                                                                                                                  
4. **Enhanced test configuration** (`test_rust_vector.pl`)                                                                                        
   - Added `Device` parameter to `test_vector_search/2`                                                                                           
   - New test predicates: `main/0` (auto), `main_gpu/0` (cuda), `main_cpu/0` (cpu)`                                                               
   - Allows flexible testing across different device modes                                                                                        
                                                                                                                                                  
## Testing                                                                                                                                        
                                                                                                                                                  
✅ **CPU Mode**: Model loads and processes embeddings without errors                                                                               
✅ **GPU Mode**: CUDA device initializes successfully on NVIDIA GTX 1660                                                                           
- Device: `Cuda(CudaDevice(DeviceId(1)))`                                                                                                         
- Successfully generates embeddings using GPU acceleration                                                                                        
                                                                                                                                                  
## Benefits                                                                                                                                       
                                                                                                                                                  
- � GPU acceleration for faster embedding generation (when available)                                                                             
- �️ Conservative defaults ensure safety in unknown environments                                                                                  
- � User-controllable device selection via environment variable                                                                                   
- � Clear logging helps debug device selection issues                                                                                             
- � Ready for larger models with GPU support                                                                                                      
                                                                                                                                                  
## Device Selection Examples                                                                                                                      
                                                                                                                                                  
```bash                                                                                                                                           
# Default: Conservative CPU mode (safe for all environments)                                                                                      
./rust_vector_test                                                                                                                                
                                                                                                                                                  
# Explicit GPU mode (WSL2, native Linux with CUDA)                                                                                                
CANDLE_DEVICE=cuda ./rust_vector_test                                                                                                             
                                                                                                                                                  
# Auto-detection (tries GPU, falls back to CPU)                                                                                                   
CANDLE_DEVICE=auto ./rust_vector_test                                                                                                             
                                                                                                                                                  
# Force CPU mode (for proot/Termux)                                                                                                               
CANDLE_DEVICE=cpu ./rust_vector_test                                                                                                              
                                                                                                                                                  
Files Changed                                                                                                                                     
                                                                                                                                                  
- src/unifyweaver/targets/rust_runtime/embedding.rs - Fixed normalization, added model config, implemented device selection                       
- examples/test_rust_vector.pl - Enhanced with device configuration support                                                                       
                                                                                                                                                  
Related Issues                                                                                                                                    
                                                                                                                                                  
Closes the issue where Gemini 3.0 couldn't test this in proot Debian within Termux due to GPU assumptions. Now works safely in both GPU and       
CPU-only environments.                                                                                                                            