### PR TITLE
Complete Self-Join Pattern for PowerShell Generator Mode

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,67 @@
+# Add Recursion and Fixpoint Mode Support to PowerShell Compiler
+
+## Summary
+
+Implements both procedural recursion and fixpoint (generator) mode for pure PowerShell.
+
+## Features
+
+### 1. Procedural Recursion
+- Detects recursive predicates automatically
+- Generates PowerShell recursive functions
+- Handles factorial-like patterns
+
+### 2. Generator/Fixpoint Mode
+- `mode(generator)` option for fixpoint iteration
+- PowerShell `Fact` class with `Key()` method
+- Delta/total pattern for efficient iteration
+
+## Usage
+
+```prolog
+% Procedural recursion
+compile_to_powershell(factorial/2, [powershell_mode(pure)], Code)
+
+% Fixpoint/generator mode
+compile_to_powershell(ancestor/2, [powershell_mode(pure), mode(generator)], Code)
+```
+
+## Generated Code (Fixpoint Mode)
+
+```powershell
+class Fact {
+    [string]$Pred
+    [object[]]$Args
+    
+    [string] Key() {
+        return "$($this.Pred):$($this.Args -join ':')"
+    }
+}
+
+$script:total = @{}
+$script:delta = @{}
+
+function Solve-ancestor {
+    Initialize-Facts
+    
+    do {
+        $iteration++
+        $script:delta = @{}
+        Apply-ancestorRule $script:total
+        
+        foreach ($key in $script:delta.Keys) {
+            $script:total[$key] = $script:delta[$key]
+        }
+    } while ($script:delta.Count -gt 0)
+}
+```
+
+## New Predicates
+
+| Predicate | Purpose |
+|-----------|---------|
+| `is_recursive_predicate_ps/2` | Detect recursive predicates |
+| `compile_recursive_to_powershell/5` | Procedural recursion |
+| `compile_generator_mode_powershell/5` | Fixpoint mode |
+| `gather_dependencies_ps/3` | Find dependency predicates |
+| `generate_fixpoint_loop_ps/2` | Generate Solve-* function |


### PR DESCRIPTION
## Summary

Fixes generator mode to properly handle transitive closure patterns like `ancestor/2`.

## Supported Patterns

| Pattern | Example | Status |
|---------|---------|--------|
| Two-base join | `grandparent(X,Z) :- parent(X,Y), parent(Y,Z)` | ✅ |
| Self-join | `ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z)` | ✅ |
| Copy rule | `ancestor(X,Y) :- parent(X,Y)` | ✅ |

## Usage

```prolog
ancestor(X, Y) :- parent(X, Y).
ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).

compile_to_powershell(ancestor/2, [powershell_mode(pure), mode(generator)], Code)
```

## Generated Functions

```powershell
# Base case: copy parent to ancestor
function Apply-ancestorBaseRule {
    $base = $facts.Values | Where-Object { $_.Pred -eq 'parent' }
    foreach ($b in $base) {
        $newFact = [Fact]::new('ancestor', @($b.Args[0], $b.Args[1]))
        ...
    }
}

# Recursive case: self-join
function Apply-ancestorRule {
    $base = $facts.Values | Where-Object { $_.Pred -eq 'parent' }
    $derived = $facts.Values | Where-Object { $_.Pred -eq 'ancestor' }
    
    foreach ($b in $base) {
        foreach ($d in $derived) {
            if ($b.Args[1] -eq $d.Args[0]) {
                $newFact = [Fact]::new('ancestor', @($b.Args[0], $d.Args[1]))
                ...
            }
        }
    }
}

# Fixpoint loop
function Solve-ancestor {
    Apply-ancestorBaseRule $script:total   # Copy base facts
    do {
        Apply-ancestorRule $script:total   # Self-join
    } while ($script:delta.Count -gt 0)
}
```

## Changes

- Added `generate_two_base_join_ps/4`
- Added `generate_self_join_ps/3`
- Added `generate_copy_rule_ps/3`
- Updated `generate_rule_functions_ps` to handle all clauses
- Updated `generate_fixpoint_loop_ps` to call both rules
