### PR TITLE
Add output_format(object) Option to PowerShell Compiler

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,65 @@
+# Add PowerShell Data Partitioning Target
+
+## Summary
+
+Ports `bash_partitioning_target.pl` functionality to pure PowerShell, completing Phase 3 of the PowerShell pure implementation roadmap.
+
+## New File
+
+`src/unifyweaver/targets/powershell_partitioning_target.pl` (466 lines)
+
+## Strategies Implemented
+
+| Strategy | Bash Equivalent | PowerShell Approach |
+|----------|-----------------|---------------------|
+| `fixed_size(rows(N))` | `split -l` | `Get-Content` + array slicing |
+| `fixed_size(bytes(N))` | `split -b` | `ReadAllBytes` + `Array.Copy` |
+| `hash_based([...])` | AWK hash function | Character code sum % N |
+| `key_based([...])` | AWK GROUP BY | Hashtable key tracking |
+
+## Usage
+
+```prolog
+% Fixed-size by rows
+generate_powershell_partitioner(fixed_size(rows(1000)), [], Code)
+
+% Hash-based on column 1 into 8 partitions
+generate_powershell_partitioner(hash_based([column(1), num_partitions(8)]), [], Code)
+
+% Key-based (GROUP BY) on column 0
+generate_powershell_partitioner(key_based([column(0)]), [], Code)
+```
+
+## Generated Functions
+
+Each strategy generates:
+- `Split-Data` - Main partitioning function
+- `Get-Partitions` - List partition files
+- `Get-PartitionCount` - Get count
+- `metadata.json` - Partition metadata
+
+## Example Output (fixed_size)
+
+```powershell
+function Split-Data {
+    param(
+        [string]$InputFile,
+        [string]$OutputDir,
+        [int]$RowsPerPartition = 1000
+    )
+    
+    $lines = Get-Content -Path $InputFile
+    for ($i = 0; $i -lt $partitionCount; $i++) {
+        $lines[$start..$end] | Out-File -FilePath $partitionFile
+    }
+    
+    $metadata | ConvertTo-Json | Out-File 'metadata.json'
+}
+```
+
+## Roadmap Progress
+
+- Phase 1: CSV/JSON/HTTP ✅
+- Phase 2: Recursion patterns ✅
+- **Phase 3: Data partitioning ✅**
+- Phase 4: PowerShell object pipeline (pending)


### PR DESCRIPTION
## Summary

Enables returning native `PSCustomObject` instead of colon-separated strings for better PowerShell pipeline integration.

## Usage

```prolog
% Object mode - returns PSCustomObject array
compile_prolog_to_pure_powershell(person/2, [output_format(object)], Code)

% Text mode (default) - returns colon-separated strings
compile_prolog_to_pure_powershell(person/2, [], Code)
```

## Generated Code Difference

### Text Mode (default)
```powershell
} else {
    $facts | ForEach-Object { "$($_.X):$($_.Y)" }
}
```

### Object Mode
```powershell
} else {
    $facts
}
```

## New Predicates

- `generate_filter_logic_ps/3` - Generates filter logic based on arity and output format

## Benefits

- Native PowerShell pipeline integration
- Works with `Where-Object`, `Select-Object`, `Sort-Object`
- Better PowerShell IntelliSense support
- Pipeline-friendly: `.\script.ps1 | Where-Object { $_.X -eq 'alice' }`

## Phase 4 Complete

This completes Phase 4 of the PowerShell pure implementation:

- Phase 1: CSV/JSON/HTTP ✅
- Phase 2: Recursion patterns ✅
- Phase 3: Data partitioning ✅
- **Phase 4: Object pipeline ✅**
- Phase 5: Firewall mode (pending)
