### PR TITLE
feat: Add binding system for PowerShell target (Book 12, Ch 3 & 5)

### DIFF
--- a/src/unifyweaver/bindings/binding_codegen.pl
+++ b/src/unifyweaver/bindings/binding_codegen.pl
@@ -1,0 +1,420 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% binding_codegen.pl - Code generation utilities using bindings
+%
+% This module provides utilities to generate code from binding declarations.
+% It bridges the binding registry with target code generators.
+%
+% See: docs/proposals/BINDING_PREDICATE_PROPOSAL.md
+
+:- module(binding_codegen, [
+    generate_binding_call/4,        % generate_binding_call(Target, Pred, Args, Code)
+    generate_function_from_binding/4, % generate_function_from_binding(Target, Pred, Options, Code)
+    generate_cmdlet_from_binding/4, % generate_cmdlet_from_binding(powershell, Pred, Options, Code)
+    test_binding_codegen/0
+]).
+
+:- use_module('../core/binding_registry').
+:- use_module('powershell_bindings').
+
+% ============================================================================
+% CODE GENERATION FROM BINDINGS
+% ============================================================================
+
+%% generate_binding_call(+Target, +Pred, +Args, -Code)
+%
+%  Generate a function call based on the binding for Pred in Target.
+%
+%  @param Target  atom - target language
+%  @param Pred    Name/Arity - predicate indicator
+%  @param Args    list - actual arguments for the call
+%  @param Code    string - generated code
+%
+generate_binding_call(Target, Pred, Args, Code) :-
+    (   binding(Target, Pred, TargetName, _Inputs, _Outputs, _Options)
+    ->  generate_call_code(Target, TargetName, Args, Code)
+    ;   format(string(Code), "# No binding found for ~w in ~w", [Pred, Target])
+    ).
+
+%% generate_call_code(+Target, +TargetName, +Args, -Code)
+%
+%  Target-specific call generation
+%
+generate_call_code(powershell, TargetName, Args, Code) :-
+    % Handle different PowerShell call patterns
+    (   sub_string(TargetName, 0, _, _, "[")
+    ->  % .NET static method call: [Class]::Method
+        format_dotnet_call(TargetName, Args, Code)
+    ;   sub_string(TargetName, 0, _, _, ".")
+    ->  % Instance method call: .Method
+        format_instance_call(TargetName, Args, Code)
+    ;   % Cmdlet call: Verb-Noun -Param Value
+        format_cmdlet_call(TargetName, Args, Code)
+    ).
+
+generate_call_code(bash, TargetName, Args, Code) :-
+    maplist(format_bash_arg, Args, FormattedArgs),
+    atomic_list_concat(FormattedArgs, ' ', ArgsStr),
+    format(string(Code), "~w ~w", [TargetName, ArgsStr]).
+
+generate_call_code(go, TargetName, Args, Code) :-
+    maplist(format_go_arg, Args, FormattedArgs),
+    atomic_list_concat(FormattedArgs, ', ', ArgsStr),
+    format(string(Code), "~w(~w)", [TargetName, ArgsStr]).
+
+% Helper: Format .NET static method call
+format_dotnet_call(TargetName, Args, Code) :-
+    maplist(format_ps_arg, Args, FormattedArgs),
+    atomic_list_concat(FormattedArgs, ', ', ArgsStr),
+    (   ArgsStr = ""
+    ->  format(string(Code), "~w", [TargetName])
+    ;   format(string(Code), "~w(~w)", [TargetName, ArgsStr])
+    ).
+
+% Helper: Format instance method call
+format_instance_call(TargetName, [Object|Args], Code) :-
+    format_ps_arg(Object, ObjStr),
+    maplist(format_ps_arg, Args, FormattedArgs),
+    atomic_list_concat(FormattedArgs, ', ', ArgsStr),
+    % Check if method name already ends with () - don't add extra parens
+    (   sub_string(TargetName, _, 2, 0, "()")
+    ->  % Already has () at end, like .Trim()
+        format(string(Code), "~w~w", [ObjStr, TargetName])
+    ;   ArgsStr = ""
+    ->  format(string(Code), "~w~w()", [ObjStr, TargetName])
+    ;   format(string(Code), "~w~w(~w)", [ObjStr, TargetName, ArgsStr])
+    ).
+
+% Helper: Format cmdlet call
+format_cmdlet_call(TargetName, Args, Code) :-
+    maplist(format_ps_arg, Args, FormattedArgs),
+    atomic_list_concat(FormattedArgs, ' ', ArgsStr),
+    (   ArgsStr = ""
+    ->  format(string(Code), "~w", [TargetName])
+    ;   format(string(Code), "~w ~w", [TargetName, ArgsStr])
+    ).
+
+% Argument formatters
+format_ps_arg(Arg, Str) :-
+    (   atom(Arg)
+    ->  format(string(Str), "'~w'", [Arg])
+    ;   number(Arg)
+    ->  format(string(Str), "~w", [Arg])
+    ;   string(Arg)
+    ->  format(string(Str), "'~w'", [Arg])
+    ;   is_list(Arg)
+    ->  maplist(format_ps_arg, Arg, Items),
+        atomic_list_concat(Items, ', ', ItemsStr),
+        format(string(Str), "@(~w)", [ItemsStr])
+    ;   format(string(Str), "~w", [Arg])
+    ).
+
+format_bash_arg(Arg, Str) :-
+    (   atom(Arg)
+    ->  format(string(Str), "'~w'", [Arg])
+    ;   format(string(Str), "~w", [Arg])
+    ).
+
+format_go_arg(Arg, Str) :-
+    (   atom(Arg)
+    ->  format(string(Str), "\"~w\"", [Arg])
+    ;   format(string(Str), "~w", [Arg])
+    ).
+
+% ============================================================================
+% FUNCTION GENERATION FROM BINDINGS
+% ============================================================================
+
+%% generate_function_from_binding(+Target, +Pred, +Options, -Code)
+%
+%  Generate a complete function wrapper based on binding information.
+%
+generate_function_from_binding(powershell, Pred, Options, Code) :-
+    generate_cmdlet_from_binding(powershell, Pred, Options, Code).
+
+generate_function_from_binding(Target, Pred, _Options, Code) :-
+    Target \= powershell,
+    (   binding(Target, Pred, TargetName, Inputs, Outputs, BindOpts)
+    ->  format(string(Code),
+"# Generated wrapper for ~w
+# Binding: ~w -> ~w
+# Inputs: ~w
+# Outputs: ~w
+# Options: ~w
+# (Target-specific generation not implemented yet)",
+               [Pred, Pred, TargetName, Inputs, Outputs, BindOpts])
+    ;   format(string(Code), "# No binding found for ~w in ~w", [Pred, Target])
+    ).
+
+% ============================================================================
+% POWERSHELL CMDLET GENERATION FROM BINDINGS
+% ============================================================================
+
+%% generate_cmdlet_from_binding(+powershell, +Pred, +Options, -Code)
+%
+%  Generate a PowerShell cmdlet wrapper using binding information.
+%  Incorporates features from Chapter 3 (cmdlet generation):
+%  - CmdletBinding attribute
+%  - Parameter attributes (Mandatory, Position, ValueFromPipeline)
+%  - Verbose/Debug output
+%  - Error handling
+%
+generate_cmdlet_from_binding(powershell, Pred, Options, Code) :-
+    Pred = Name/Arity,
+    (   binding(powershell, Pred, TargetName, Inputs, Outputs, BindOpts)
+    ->  % Extract binding properties
+        get_time(Timestamp),
+        format_time(string(DateStr), '%Y-%m-%d %H:%M:%S', Timestamp),
+
+        % Determine function name (PowerShell Verb-Noun convention)
+        generate_cmdlet_name(Name, CmdletName),
+
+        % Generate CmdletBinding attribute
+        generate_cmdlet_binding_attr(Options, BindOpts, CmdletBindingAttr),
+
+        % Generate parameters from inputs
+        generate_cmdlet_params(Inputs, Options, ParamsCode),
+
+        % Generate verbose output if requested
+        (   member(verbose_output(true), Options)
+        ->  format(string(VerboseCode), "    Write-Verbose \"[~w] Calling ~w\"", [CmdletName, TargetName])
+        ;   VerboseCode = ""
+        ),
+
+        % Generate the actual call
+        generate_cmdlet_body(TargetName, Inputs, Outputs, BindOpts, BodyCode),
+
+        % Generate output handling
+        generate_output_handling(Outputs, BindOpts, OutputCode),
+
+        format(string(Code),
+"# Generated PowerShell Cmdlet from Binding
+# Predicate: ~w/~w
+# Target: ~w
+# Generated: ~w
+# Generated by UnifyWeaver Binding Codegen
+
+function ~w {
+~w
+~w
+
+    begin {
+~w
+    }
+
+    process {
+~w
+~w
+    }
+
+    end {
+        Write-Verbose \"[~w] Complete\"
+    }
+}
+", [Name, Arity, TargetName, DateStr, CmdletName, CmdletBindingAttr, ParamsCode, VerboseCode, BodyCode, OutputCode, CmdletName])
+    ;   format(string(Code), "# No binding found for ~w in powershell", [Pred])
+    ).
+
+%% generate_cmdlet_name(+PredName, -CmdletName)
+%
+%  Generate PowerShell Verb-Noun name from predicate name.
+%
+generate_cmdlet_name(Name, CmdletName) :-
+    atom_string(Name, NameStr),
+    % Map common prefixes to PowerShell verbs
+    (   sub_string(NameStr, 0, 4, _, "get_")
+    ->  sub_string(NameStr, 4, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "Get-~w", [TitleRest])
+    ;   sub_string(NameStr, 0, 4, _, "set_")
+    ->  sub_string(NameStr, 4, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "Set-~w", [TitleRest])
+    ;   sub_string(NameStr, 0, 4, _, "new_")
+    ->  sub_string(NameStr, 4, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "New-~w", [TitleRest])
+    ;   sub_string(NameStr, 0, 7, _, "remove_")
+    ->  sub_string(NameStr, 7, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "Remove-~w", [TitleRest])
+    ;   sub_string(NameStr, 0, 5, _, "test_")
+    ->  sub_string(NameStr, 5, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "Test-~w", [TitleRest])
+    ;   sub_string(NameStr, 0, 6, _, "start_")
+    ->  sub_string(NameStr, 6, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "Start-~w", [TitleRest])
+    ;   sub_string(NameStr, 0, 5, _, "stop_")
+    ->  sub_string(NameStr, 5, _, 0, Rest),
+        string_to_title(Rest, TitleRest),
+        format(string(CmdletName), "Stop-~w", [TitleRest])
+    ;   % Default: Invoke-Name
+        string_to_title(NameStr, TitleName),
+        format(string(CmdletName), "Invoke-~w", [TitleName])
+    ).
+
+%% string_to_title(+Str, -TitleStr)
+%  Convert string to title case (first letter uppercase)
+string_to_title(Str, TitleStr) :-
+    string_chars(Str, [First|Rest]),
+    upcase_atom(First, Upper),
+    atom_chars(Upper, [UpperChar]),
+    string_chars(TitleStr, [UpperChar|Rest]).
+
+%% generate_cmdlet_binding_attr(+Options, +BindOpts, -Code)
+generate_cmdlet_binding_attr(Options, BindOpts, Code) :-
+    findall(Attr, (
+        (member(supports_should_process(true), Options) -> Attr = "SupportsShouldProcess=$true" ; fail)
+    ;   (member(effect(state), BindOpts) -> Attr = "SupportsShouldProcess=$true" ; fail)
+    ), Attrs),
+    (   Attrs = []
+    ->  Code = "    [CmdletBinding()]"
+    ;   atomic_list_concat(Attrs, ', ', AttrsStr),
+        format(string(Code), "    [CmdletBinding(~w)]", [AttrsStr])
+    ).
+
+%% generate_cmdlet_params(+Inputs, +Options, -Code)
+generate_cmdlet_params(Inputs, _Options, Code) :-
+    length(Inputs, NumInputs),
+    (   NumInputs = 0
+    ->  Code = "    param()"
+    ;   generate_param_list(Inputs, 0, ParamList),
+        atomic_list_concat(ParamList, ',\n', ParamsStr),
+        format(string(Code), "    param(\n~w\n    )", [ParamsStr])
+    ).
+
+generate_param_list([], _, []).
+generate_param_list([Input|Rest], Pos, [ParamCode|RestCodes]) :-
+    generate_single_param(Input, Pos, ParamCode),
+    Pos1 is Pos + 1,
+    generate_param_list(Rest, Pos1, RestCodes).
+
+generate_single_param(type(Type), Pos, Code) :-
+    format(string(Code),
+"        [Parameter(Position=~w)]
+        [~w]$Param~w", [Pos, Type, Pos]).
+generate_single_param(Input, Pos, Code) :-
+    Input \= type(_),
+    atom(Input),
+    ps_type_from_semantic(Input, PSType),
+    atom_string(Input, InputStr),
+    string_to_title(InputStr, ParamName),
+    (   Pos = 0
+    ->  Mandatory = ", Mandatory=$true"
+    ;   Mandatory = ""
+    ),
+    format(string(Code),
+"        [Parameter(Position=~w~w)]
+        [~w]$~w", [Pos, Mandatory, PSType, ParamName]).
+
+%% ps_type_from_semantic(+Semantic, -PSType)
+ps_type_from_semantic(string, "string").
+ps_type_from_semantic(int, "int").
+ps_type_from_semantic(path, "string").
+ps_type_from_semantic(any, "object").
+ps_type_from_semantic(list(_), "array").
+ps_type_from_semantic(hashtable, "hashtable").
+ps_type_from_semantic(object, "PSObject").
+ps_type_from_semantic(_, "object").
+
+%% generate_cmdlet_body(+TargetName, +Inputs, +Outputs, +BindOpts, -Code)
+generate_cmdlet_body(TargetName, Inputs, _Outputs, BindOpts, Code) :-
+    % Generate parameter passing
+    length(Inputs, NumInputs),
+    (   NumInputs = 0
+    ->  ArgsCode = ""
+    ;   generate_args_code(Inputs, 0, ArgsList),
+        atomic_list_concat(ArgsList, ' ', ArgsCode)
+    ),
+
+    % Check for ShouldProcess
+    (   member(effect(state), BindOpts)
+    ->  format(string(Code),
+"        if ($PSCmdlet.ShouldProcess($Param0, '~w')) {
+            $result = ~w ~w
+        }", [TargetName, TargetName, ArgsCode])
+    ;   format(string(Code), "        $result = ~w ~w", [TargetName, ArgsCode])
+    ).
+
+generate_args_code([], _, []).
+generate_args_code([Input|Rest], Pos, [ArgCode|RestCodes]) :-
+    (   Input = type(_)
+    ->  format(string(ArgCode), "$Param~w", [Pos])
+    ;   atom(Input),
+        atom_string(Input, InputStr),
+        string_to_title(InputStr, ParamName),
+        format(string(ArgCode), "$~w", [ParamName])
+    ),
+    Pos1 is Pos + 1,
+    generate_args_code(Rest, Pos1, RestCodes).
+
+%% generate_output_handling(+Outputs, +BindOpts, -Code)
+generate_output_handling([], _, "        # No output").
+generate_output_handling([_|_], BindOpts, Code) :-
+    (   member(pattern(object_pipeline), BindOpts)
+    ->  Code = "        $result"
+    ;   member(pattern(cmdlet_output), BindOpts)
+    ->  Code = "        $result"
+    ;   Code = "        Write-Output $result"
+    ).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_binding_codegen :-
+    format('~n=== Testing Binding Code Generation ===~n~n'),
+
+    % Initialize bindings
+    format('[Setup] Initializing PowerShell bindings...~n'),
+    init_powershell_bindings,
+
+    % Test 1: Generate call from binding
+    format('[Test 1] Generate binding call~n'),
+    generate_binding_call(powershell, sqrt/2, [16], Call1),
+    format('  sqrt(16) -> ~w~n', [Call1]),
+    (   sub_string(Call1, _, _, _, "[Math]::Sqrt")
+    ->  format('  [PASS] Correct .NET call generated~n')
+    ;   format('  [FAIL] Expected [Math]::Sqrt~n')
+    ),
+
+    % Test 2: Generate cmdlet call
+    format('[Test 2] Generate cmdlet call~n'),
+    generate_binding_call(powershell, get_child_item/2, ['/tmp'], Call2),
+    format('  get_child_item("/tmp") -> ~w~n', [Call2]),
+    (   sub_string(Call2, _, _, _, "Get-ChildItem")
+    ->  format('  [PASS] Cmdlet call generated~n')
+    ;   format('  [FAIL] Expected Get-ChildItem~n')
+    ),
+
+    % Test 3: Generate full cmdlet from binding
+    format('[Test 3] Generate cmdlet from binding~n'),
+    generate_cmdlet_from_binding(powershell, test_path/1, [verbose_output(true)], CmdletCode),
+    (   sub_string(CmdletCode, _, _, _, "[CmdletBinding()]"),
+        sub_string(CmdletCode, _, _, _, "param("),
+        sub_string(CmdletCode, _, _, _, "Test-Path")
+    ->  format('  [PASS] Full cmdlet structure generated~n')
+    ;   format('  [FAIL] Missing cmdlet components~n')
+    ),
+
+    % Test 4: Cmdlet name generation
+    format('[Test 4] Cmdlet name generation~n'),
+    generate_cmdlet_name(get_service, Name1),
+    generate_cmdlet_name(test_path, Name2),
+    generate_cmdlet_name(custom_pred, Name3),
+    format('  get_service -> ~w~n', [Name1]),
+    format('  test_path -> ~w~n', [Name2]),
+    format('  custom_pred -> ~w~n', [Name3]),
+    (   Name1 = "Get-Service", Name2 = "Test-Path"
+    ->  format('  [PASS] Verb-Noun names generated correctly~n')
+    ;   format('  [FAIL] Name generation issue~n')
+    ),
+
+    format('~n=== Binding Code Generation Tests Complete ===~n').

--- a/src/unifyweaver/bindings/powershell_bindings.pl
+++ b/src/unifyweaver/bindings/powershell_bindings.pl
@@ -1,0 +1,439 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% powershell_bindings.pl - PowerShell-specific bindings
+%
+% This module defines bindings for PowerShell target language features.
+% Based on:
+%   - Book 12, Chapter 3: Cmdlet Generation
+%   - Book 12, Chapter 5: Windows Automation
+%
+% See: docs/proposals/BINDING_PREDICATE_PROPOSAL.md
+
+:- module(powershell_bindings, [
+    init_powershell_bindings/0,
+    ps_binding/5,               % Convenience: ps_binding(Pred, TargetName, Inputs, Outputs, Options)
+    test_powershell_bindings/0
+]).
+
+:- use_module('../core/binding_registry').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+%% init_powershell_bindings
+%
+%  Initialize all PowerShell bindings. Call this before using the compiler.
+%
+init_powershell_bindings :-
+    register_cmdlet_bindings,
+    register_automation_bindings,
+    register_dotnet_bindings.
+
+% ============================================================================
+% CONVENIENCE PREDICATE
+% ============================================================================
+
+%% ps_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
+%
+%  Query PowerShell bindings with reduced arity (Target=powershell implied).
+%
+ps_binding(Pred, TargetName, Inputs, Outputs, Options) :-
+    binding(powershell, Pred, TargetName, Inputs, Outputs, Options).
+
+% ============================================================================
+% CHAPTER 3: CMDLET GENERATION BINDINGS
+% ============================================================================
+
+register_cmdlet_bindings :-
+    % -------------------------------------------
+    % Core Output Cmdlets
+    % -------------------------------------------
+
+    % Write-Output - primary output mechanism
+    declare_binding(powershell, write_output/1, 'Write-Output',
+        [any], [],
+        [effect(io), pattern(object_pipeline), deterministic]),
+
+    % Write-Host - display text (not pipelined)
+    declare_binding(powershell, write_host/1, 'Write-Host',
+        [string], [],
+        [effect(io), pattern(stdout_return), deterministic]),
+
+    % Write-Verbose - diagnostic output with -Verbose
+    declare_binding(powershell, write_verbose/1, 'Write-Verbose',
+        [string], [],
+        [effect(io), deterministic]),
+
+    % Write-Debug - debug output with -Debug
+    declare_binding(powershell, write_debug/1, 'Write-Debug',
+        [string], [],
+        [effect(io), deterministic]),
+
+    % Write-Warning - warning messages
+    declare_binding(powershell, write_warning/1, 'Write-Warning',
+        [string], [],
+        [effect(io), deterministic]),
+
+    % Write-Error - non-terminating errors
+    declare_binding(powershell, write_error/1, 'Write-Error',
+        [string], [],
+        [effect(io), effect(throws), deterministic]),
+
+    % -------------------------------------------
+    % Object Creation
+    % -------------------------------------------
+
+    % PSCustomObject - create structured output
+    declare_binding(powershell, ps_object/2, '[PSCustomObject]@{}',
+        [hashtable], [object],
+        [pure, deterministic, pattern(cmdlet_output)]),
+
+    % Select-Object - project specific properties
+    declare_binding(powershell, select_object/2, 'Select-Object',
+        [object, list(property)], [object],
+        [pure, deterministic, pattern(pipe_transform)]),
+
+    % -------------------------------------------
+    % Pipeline Operations
+    % -------------------------------------------
+
+    % ForEach-Object - iterate over pipeline
+    declare_binding(powershell, foreach_object/2, 'ForEach-Object',
+        [object, scriptblock], [object],
+        [nondeterministic, pattern(pipe_transform)]),
+
+    % Where-Object - filter pipeline
+    declare_binding(powershell, where_object/2, 'Where-Object',
+        [object, scriptblock], [object],
+        [pure, nondeterministic, pattern(pipe_transform)]),
+
+    % Sort-Object - sort pipeline output
+    declare_binding(powershell, sort_object/2, 'Sort-Object',
+        [object, property], [object],
+        [pure, nondeterministic, pattern(pipe_transform)]),
+
+    % Group-Object - group pipeline items
+    declare_binding(powershell, group_object/2, 'Group-Object',
+        [object, property], [group],
+        [pure, nondeterministic, pattern(pipe_transform)]),
+
+    % Measure-Object - compute statistics
+    declare_binding(powershell, measure_object/2, 'Measure-Object',
+        [object, list(property)], [measurement],
+        [pure, deterministic, pattern(pipe_transform)]),
+
+    % -------------------------------------------
+    % Type Conversions
+    % -------------------------------------------
+
+    % String casting
+    declare_binding(powershell, to_string/2, '[string]',
+        [any], [string],
+        [pure, deterministic, total]),
+
+    % Integer casting
+    declare_binding(powershell, to_int/2, '[int]',
+        [any], [int],
+        [pure, deterministic, partial, effect(throws)]),
+
+    % Array casting
+    declare_binding(powershell, to_array/2, '@()',
+        [any], [array],
+        [pure, deterministic, total]),
+
+    % Hashtable creation
+    declare_binding(powershell, to_hashtable/2, '@{}',
+        [list(pair)], [hashtable],
+        [pure, deterministic, total]).
+
+% ============================================================================
+% CHAPTER 5: WINDOWS AUTOMATION BINDINGS
+% ============================================================================
+
+register_automation_bindings :-
+    % -------------------------------------------
+    % File System Operations
+    % -------------------------------------------
+
+    % Get-ChildItem - list files/directories
+    declare_binding(powershell, get_child_item/2, 'Get-ChildItem',
+        [path], [list(file_info)],
+        [effect(io), nondeterministic, import('Microsoft.PowerShell.Management')]),
+
+    % Test-Path - check if path exists
+    declare_binding(powershell, test_path/1, 'Test-Path',
+        [path], [],
+        [effect(io), deterministic, pattern(cmdlet_output),
+         exit_status(true=exists, false=not_exists)]),
+
+    % Get-Content - read file content
+    declare_binding(powershell, get_content/2, 'Get-Content',
+        [path], [list(string)],
+        [effect(io), nondeterministic, partial]),
+
+    % Set-Content - write file content
+    declare_binding(powershell, set_content/2, 'Set-Content',
+        [path, content], [],
+        [effect(io), effect(state), deterministic]),
+
+    % Remove-Item - delete file/directory
+    declare_binding(powershell, remove_item/1, 'Remove-Item',
+        [path], [],
+        [effect(io), effect(state), deterministic]),
+
+    % New-Item - create file/directory
+    declare_binding(powershell, new_item/2, 'New-Item',
+        [path, item_type], [file_info],
+        [effect(io), effect(state), deterministic]),
+
+    % -------------------------------------------
+    % Windows Services
+    % -------------------------------------------
+
+    % Get-Service - get service information
+    declare_binding(powershell, get_service/1, 'Get-Service',
+        [], [list(service)],
+        [effect(io), nondeterministic, import('Microsoft.PowerShell.Management')]),
+
+    % Get-Service with name
+    declare_binding(powershell, get_service/2, 'Get-Service -Name',
+        [service_name], [service],
+        [effect(io), deterministic, partial]),
+
+    % Start-Service
+    declare_binding(powershell, start_service/1, 'Start-Service',
+        [service_name], [],
+        [effect(io), effect(state), deterministic]),
+
+    % Stop-Service
+    declare_binding(powershell, stop_service/1, 'Stop-Service',
+        [service_name], [],
+        [effect(io), effect(state), deterministic]),
+
+    % Restart-Service
+    declare_binding(powershell, restart_service/1, 'Restart-Service',
+        [service_name], [],
+        [effect(io), effect(state), deterministic]),
+
+    % -------------------------------------------
+    % Registry Operations
+    % -------------------------------------------
+
+    % Get-ItemProperty - read registry value
+    declare_binding(powershell, get_item_property/3, 'Get-ItemProperty',
+        [registry_path, property_name], [value],
+        [effect(io), deterministic, partial]),
+
+    % Set-ItemProperty - write registry value
+    declare_binding(powershell, set_item_property/3, 'Set-ItemProperty',
+        [registry_path, property_name, value], [],
+        [effect(io), effect(state), deterministic]),
+
+    % New-Item (registry)
+    declare_binding(powershell, new_registry_key/1, 'New-Item -Path',
+        [registry_path], [registry_key],
+        [effect(io), effect(state), deterministic]),
+
+    % -------------------------------------------
+    % Event Log Operations
+    % -------------------------------------------
+
+    % Get-WinEvent - query event logs
+    declare_binding(powershell, get_win_event/2, 'Get-WinEvent -FilterHashtable',
+        [hashtable], [list(event)],
+        [effect(io), nondeterministic, import('Microsoft.PowerShell.Diagnostics')]),
+
+    % Write-EventLog - write to event log
+    declare_binding(powershell, write_event_log/4, 'Write-EventLog',
+        [log_name, source, event_id, message], [],
+        [effect(io), effect(state), deterministic]),
+
+    % -------------------------------------------
+    % WMI/CIM Operations
+    % -------------------------------------------
+
+    % Get-CimInstance - query WMI/CIM
+    declare_binding(powershell, get_cim_instance/2, 'Get-CimInstance',
+        [class_name], [list(cim_object)],
+        [effect(io), nondeterministic, import('CimCmdlets')]),
+
+    % Invoke-CimMethod - call WMI method
+    declare_binding(powershell, invoke_cim_method/4, 'Invoke-CimMethod',
+        [class_name, method_name, arguments], [result],
+        [effect(io), effect(state), deterministic]),
+
+    % -------------------------------------------
+    % Process Operations
+    % -------------------------------------------
+
+    % Get-Process
+    declare_binding(powershell, get_process/1, 'Get-Process',
+        [], [list(process)],
+        [effect(io), nondeterministic]),
+
+    % Get-Process with name
+    declare_binding(powershell, get_process/2, 'Get-Process -Name',
+        [process_name], [list(process)],
+        [effect(io), nondeterministic, partial]),
+
+    % Stop-Process
+    declare_binding(powershell, stop_process/1, 'Stop-Process',
+        [process_id], [],
+        [effect(io), effect(state), deterministic]),
+
+    % Start-Process
+    declare_binding(powershell, start_process/2, 'Start-Process',
+        [path, list(argument)], [process],
+        [effect(io), effect(state), deterministic]).
+
+% ============================================================================
+% .NET INTEGRATION BINDINGS (Chapter 4 related)
+% ============================================================================
+
+register_dotnet_bindings :-
+    % -------------------------------------------
+    % System.IO
+    % -------------------------------------------
+
+    % File.Exists
+    declare_binding(powershell, file_exists/1, '[System.IO.File]::Exists',
+        [type(string)], [],
+        [effect(io), deterministic, total, pattern(exit_code_bool)]),
+
+    % File.ReadAllText
+    declare_binding(powershell, file_read_all_text/2, '[System.IO.File]::ReadAllText',
+        [type(string)], [type(string)],
+        [effect(io), deterministic, partial, effect(throws)]),
+
+    % File.WriteAllText
+    declare_binding(powershell, file_write_all_text/2, '[System.IO.File]::WriteAllText',
+        [type(string), type(string)], [],
+        [effect(io), effect(state), deterministic]),
+
+    % Path.GetFullPath
+    declare_binding(powershell, path_get_full/2, '[System.IO.Path]::GetFullPath',
+        [type(string)], [type(string)],
+        [pure, deterministic, total]),
+
+    % Path.Combine
+    declare_binding(powershell, path_combine/3, '[System.IO.Path]::Combine',
+        [type(string), type(string)], [type(string)],
+        [pure, deterministic, total]),
+
+    % -------------------------------------------
+    % System.Xml
+    % -------------------------------------------
+
+    % XmlReader.Create
+    declare_binding(powershell, xml_reader_create/2, '[System.Xml.XmlReader]::Create',
+        [type(string)], [type('System.Xml.XmlReader')],
+        [effect(io), deterministic, partial, effect(throws)]),
+
+    % XmlDocument.Load
+    declare_binding(powershell, xml_document_load/2, '[System.Xml.XmlDocument]::new().Load',
+        [type('System.Xml.XmlReader')], [type('System.Xml.XmlDocument')],
+        [effect(io), deterministic]),
+
+    % -------------------------------------------
+    % System.Math
+    % -------------------------------------------
+
+    % Math.Sqrt
+    declare_binding(powershell, sqrt/2, '[Math]::Sqrt',
+        [type(double)], [type(double)],
+        [pure, deterministic, total]),
+
+    % Math.Round
+    declare_binding(powershell, round/2, '[Math]::Round',
+        [type(double)], [type(double)],
+        [pure, deterministic, total]),
+
+    % Math.Abs
+    declare_binding(powershell, abs/2, '[Math]::Abs',
+        [type(double)], [type(double)],
+        [pure, deterministic, total]),
+
+    % -------------------------------------------
+    % String Operations
+    % -------------------------------------------
+
+    % String.Split
+    declare_binding(powershell, string_split/3, '.Split',
+        [type(string), type(char)], [type('string[]')],
+        [pure, deterministic, total]),
+
+    % String.Trim
+    declare_binding(powershell, string_trim/2, '.Trim()',
+        [type(string)], [type(string)],
+        [pure, deterministic, total]),
+
+    % String.Replace
+    declare_binding(powershell, string_replace/4, '.Replace',
+        [type(string), type(string), type(string)], [type(string)],
+        [pure, deterministic, total]).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_powershell_bindings :-
+    format('~n=== Testing PowerShell Bindings ===~n~n'),
+
+    % Initialize bindings
+    format('[Setup] Initializing PowerShell bindings...~n'),
+    init_powershell_bindings,
+
+    % Test 1: Check cmdlet bindings exist
+    format('[Test 1] Cmdlet bindings~n'),
+    (   ps_binding(write_output/1, _, _, _, _)
+    ->  format('  [PASS] write_output/1 binding exists~n')
+    ;   format('  [FAIL] write_output/1 binding missing~n')
+    ),
+    (   ps_binding(foreach_object/2, _, _, _, Opts1),
+        member(pattern(pipe_transform), Opts1)
+    ->  format('  [PASS] foreach_object/2 has pipe_transform pattern~n')
+    ;   format('  [FAIL] foreach_object/2 pattern missing~n')
+    ),
+
+    % Test 2: Check automation bindings
+    format('[Test 2] Automation bindings~n'),
+    (   ps_binding(get_service/1, _, _, _, _)
+    ->  format('  [PASS] get_service/1 binding exists~n')
+    ;   format('  [FAIL] get_service/1 binding missing~n')
+    ),
+    (   ps_binding(get_cim_instance/2, _, _, _, Opts2),
+        member(import(_), Opts2)
+    ->  format('  [PASS] get_cim_instance/2 has import declaration~n')
+    ;   format('  [FAIL] get_cim_instance/2 import missing~n')
+    ),
+
+    % Test 3: Check .NET bindings
+    format('[Test 3] .NET bindings~n'),
+    (   ps_binding(sqrt/2, Name, _, _, Opts3),
+        member(pure, Opts3)
+    ->  format('  [PASS] sqrt/2 is pure: ~w~n', [Name])
+    ;   format('  [FAIL] sqrt/2 binding issue~n')
+    ),
+
+    % Test 4: Count total bindings
+    format('[Test 4] Total binding count~n'),
+    bindings_for_target(powershell, AllBindings),
+    length(AllBindings, Total),
+    format('  Total PowerShell bindings: ~w~n', [Total]),
+    (   Total >= 40
+    ->  format('  [PASS] Sufficient bindings registered~n')
+    ;   format('  [WARN] Expected more bindings (got ~w)~n', [Total])
+    ),
+
+    % Test 5: Check imports
+    format('[Test 5] Import declarations~n'),
+    binding_imports(powershell, Imports),
+    format('  Required imports: ~w~n', [Imports]),
+
+    format('~n=== PowerShell Bindings Tests Complete ===~n').

--- a/src/unifyweaver/core/binding_registry.pl
+++ b/src/unifyweaver/core/binding_registry.pl
@@ -1,0 +1,391 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% binding_registry.pl - Foreign Function Binding Registry
+%
+% This module manages bindings that map Prolog predicates to target language
+% functions. Bindings preserve semantic information about effects, types,
+% and execution characteristics needed for correct code generation.
+%
+% See: docs/proposals/BINDING_PREDICATE_PROPOSAL.md
+
+:- module(binding_registry, [
+    % Core binding API
+    binding/6,                      % binding(Target, Pred, TargetName, Inputs, Outputs, Options)
+    declare_binding/6,              % declare_binding(Target, Pred, TargetName, Inputs, Outputs, Options)
+    clear_binding/2,                % clear_binding(Target, Pred)
+    clear_all_bindings/0,           % clear_all_bindings
+    clear_all_bindings/1,           % clear_all_bindings(Target)
+
+    % Effect annotations
+    effect/2,                       % effect(Pred, Effects)
+    declare_effect/2,               % declare_effect(Pred, Effects)
+    clear_effect/1,                 % clear_effect(Pred)
+
+    % Design patterns
+    pattern/2,                      % pattern(PatternName, Description)
+    declare_pattern/2,              % declare_pattern(PatternName, Description)
+
+    % Bidirectional predicates
+    bidirectional/2,                % bidirectional(Pred, Modes)
+    declare_bidirectional/2,        % declare_bidirectional(Pred, Modes)
+    binding_mode/5,                 % binding_mode(Target, Pred, Mode, TargetName, Options)
+    declare_binding_mode/5,         % declare_binding_mode(Target, Pred, Mode, TargetName, Options)
+
+    % Query API
+    bindings_for_target/2,          % bindings_for_target(Target, Bindings)
+    bindings_for_predicate/2,       % bindings_for_predicate(Pred, Bindings)
+    resolve_binding/4,              % resolve_binding(Preferences, Pred, Target, Binding)
+    binding_imports/2,              % binding_imports(Target, Imports)
+    binding_has_effect/3,           % binding_has_effect(Target, Pred, Effect)
+
+    % Utility
+    is_pure_binding/2,              % is_pure_binding(Target, Pred)
+    is_total_binding/2,             % is_total_binding(Target, Pred)
+    is_deterministic_binding/2,     % is_deterministic_binding(Target, Pred)
+
+    % Testing
+    test_binding_registry/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% DYNAMIC STORAGE
+% ============================================================================
+
+:- dynamic stored_binding/6.        % stored_binding(Target, Pred, TargetName, Inputs, Outputs, Options)
+:- dynamic stored_effect/2.         % stored_effect(Pred, Effects)
+:- dynamic stored_pattern/2.        % stored_pattern(PatternName, Description)
+:- dynamic stored_bidirectional/2.  % stored_bidirectional(Pred, Modes)
+:- dynamic stored_binding_mode/5.   % stored_binding_mode(Target, Pred, Mode, TargetName, Options)
+
+% ============================================================================
+% CORE BINDING API
+% ============================================================================
+
+%% binding(?Target, ?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
+%
+%  Query bindings from the registry. All arguments can be unbound for queries.
+%
+%  @param Target      atom - target language (go, bash, python, powershell, etc.)
+%  @param Pred        Name/Arity - the Prolog predicate being mapped
+%  @param TargetName  string/atom - the target language function/command
+%  @param Inputs      list - input argument specifications
+%  @param Outputs     list - output argument specifications
+%  @param Options     list - options/effects/annotations
+%
+binding(Target, Pred, TargetName, Inputs, Outputs, Options) :-
+    stored_binding(Target, Pred, TargetName, Inputs, Outputs, Options).
+
+%% declare_binding(+Target, +Pred, +TargetName, +Inputs, +Outputs, +Options)
+%
+%  Declare a new binding. Replaces any existing binding for the same Target/Pred.
+%
+declare_binding(Target, Pred, TargetName, Inputs, Outputs, Options) :-
+    atom(Target),
+    validate_pred_indicator(Pred),
+    is_list(Inputs),
+    is_list(Outputs),
+    is_list(Options),
+    retractall(stored_binding(Target, Pred, _, _, _, _)),
+    assertz(stored_binding(Target, Pred, TargetName, Inputs, Outputs, Options)).
+
+%% clear_binding(+Target, +Pred)
+%
+%  Remove a specific binding.
+%
+clear_binding(Target, Pred) :-
+    retractall(stored_binding(Target, Pred, _, _, _, _)).
+
+%% clear_all_bindings
+%
+%  Remove all bindings from the registry.
+%
+clear_all_bindings :-
+    retractall(stored_binding(_, _, _, _, _, _)).
+
+%% clear_all_bindings(+Target)
+%
+%  Remove all bindings for a specific target.
+%
+clear_all_bindings(Target) :-
+    retractall(stored_binding(Target, _, _, _, _, _)).
+
+% ============================================================================
+% EFFECT ANNOTATIONS
+% ============================================================================
+
+%% effect(?Pred, ?Effects)
+%
+%  Query effect annotations for a predicate.
+%
+effect(Pred, Effects) :-
+    stored_effect(Pred, Effects).
+
+%% declare_effect(+Pred, +Effects)
+%
+%  Declare effects for a predicate (target-independent).
+%
+declare_effect(Pred, Effects) :-
+    validate_pred_indicator(Pred),
+    is_list(Effects),
+    retractall(stored_effect(Pred, _)),
+    assertz(stored_effect(Pred, Effects)).
+
+%% clear_effect(+Pred)
+%
+%  Remove effect annotations for a predicate.
+%
+clear_effect(Pred) :-
+    retractall(stored_effect(Pred, _)).
+
+% ============================================================================
+% DESIGN PATTERNS
+% ============================================================================
+
+%% pattern(?PatternName, ?Description)
+%
+%  Query or list design patterns for non-standard function usage.
+%
+pattern(PatternName, Description) :-
+    stored_pattern(PatternName, Description).
+
+%% declare_pattern(+PatternName, +Description)
+%
+%  Declare a new design pattern.
+%
+declare_pattern(PatternName, Description) :-
+    atom(PatternName),
+    retractall(stored_pattern(PatternName, _)),
+    assertz(stored_pattern(PatternName, Description)).
+
+% Initialize standard patterns
+:- declare_pattern(stdout_return, "Return value via stdout (shell idiom)").
+:- declare_pattern(variable_return, "Return value via variable assignment").
+:- declare_pattern(exit_code_bool, "Boolean result via exit code").
+:- declare_pattern(pipe_transform, "Transform data through pipe").
+:- declare_pattern(accumulator, "Build result via accumulator parameter").
+:- declare_pattern(object_pipeline, "PowerShell object pipeline pattern").
+:- declare_pattern(cmdlet_output, "PowerShell cmdlet structured output").
+
+% ============================================================================
+% BIDIRECTIONAL PREDICATES
+% ============================================================================
+
+%% bidirectional(?Pred, ?Modes)
+%
+%  Query bidirectional predicate declarations.
+%
+bidirectional(Pred, Modes) :-
+    stored_bidirectional(Pred, Modes).
+
+%% declare_bidirectional(+Pred, +Modes)
+%
+%  Declare that a predicate supports multiple argument modes.
+%
+declare_bidirectional(Pred, Modes) :-
+    validate_pred_indicator(Pred),
+    is_list(Modes),
+    retractall(stored_bidirectional(Pred, _)),
+    assertz(stored_bidirectional(Pred, Modes)).
+
+%% binding_mode(?Target, ?Pred, ?Mode, ?TargetName, ?Options)
+%
+%  Query mode-specific bindings for bidirectional predicates.
+%
+binding_mode(Target, Pred, Mode, TargetName, Options) :-
+    stored_binding_mode(Target, Pred, Mode, TargetName, Options).
+
+%% declare_binding_mode(+Target, +Pred, +Mode, +TargetName, +Options)
+%
+%  Declare a binding for a specific mode of a bidirectional predicate.
+%
+declare_binding_mode(Target, Pred, Mode, TargetName, Options) :-
+    atom(Target),
+    validate_pred_indicator(Pred),
+    is_list(Options),
+    retractall(stored_binding_mode(Target, Pred, Mode, _, _)),
+    assertz(stored_binding_mode(Target, Pred, Mode, TargetName, Options)).
+
+% ============================================================================
+% QUERY API
+% ============================================================================
+
+%% bindings_for_target(+Target, -Bindings)
+%
+%  Get all bindings for a specific target.
+%
+bindings_for_target(Target, Bindings) :-
+    findall(
+        binding(Target, P, N, I, O, Opts),
+        stored_binding(Target, P, N, I, O, Opts),
+        Bindings
+    ).
+
+%% bindings_for_predicate(+Pred, -Bindings)
+%
+%  Get all bindings (across targets) for a specific predicate.
+%
+bindings_for_predicate(Pred, Bindings) :-
+    findall(
+        binding(T, Pred, N, I, O, Opts),
+        stored_binding(T, Pred, N, I, O, Opts),
+        Bindings
+    ).
+
+%% resolve_binding(+Preferences, +Pred, -Target, -Binding)
+%
+%  Resolve a binding given a list of preferred targets.
+%  Falls back through the list until a binding is found.
+%
+resolve_binding([Target|_], Pred, Target, Binding) :-
+    stored_binding(Target, Pred, Name, In, Out, Opts),
+    !,
+    Binding = binding(Target, Pred, Name, In, Out, Opts).
+resolve_binding([_|Rest], Pred, Target, Binding) :-
+    resolve_binding(Rest, Pred, Target, Binding).
+
+%% binding_imports(+Target, -Imports)
+%
+%  Get all imports required by bindings for a target.
+%
+binding_imports(Target, Imports) :-
+    findall(
+        Module,
+        (stored_binding(Target, _, _, _, _, Opts),
+         member(import(Module), Opts)),
+        ImportsRaw
+    ),
+    sort(ImportsRaw, Imports).
+
+%% binding_has_effect(+Target, +Pred, +Effect)
+%
+%  Check if a binding has a specific effect.
+%
+binding_has_effect(Target, Pred, Effect) :-
+    stored_binding(Target, Pred, _, _, _, Opts),
+    (   member(effect(Effect), Opts)
+    ;   member(Effect, Opts)
+    ).
+
+% ============================================================================
+% UTILITY PREDICATES
+% ============================================================================
+
+%% is_pure_binding(+Target, +Pred)
+%
+%  True if the binding is declared as pure (no side effects).
+%
+is_pure_binding(Target, Pred) :-
+    stored_binding(Target, Pred, _, _, _, Opts),
+    member(pure, Opts).
+
+%% is_total_binding(+Target, +Pred)
+%
+%  True if the binding is declared as total (always succeeds).
+%
+is_total_binding(Target, Pred) :-
+    stored_binding(Target, Pred, _, _, _, Opts),
+    member(total, Opts).
+
+%% is_deterministic_binding(+Target, +Pred)
+%
+%  True if the binding is declared as deterministic (single result).
+%
+is_deterministic_binding(Target, Pred) :-
+    stored_binding(Target, Pred, _, _, _, Opts),
+    member(deterministic, Opts).
+
+% ============================================================================
+% VALIDATION HELPERS
+% ============================================================================
+
+validate_pred_indicator(Name/Arity) :-
+    atom(Name),
+    integer(Arity),
+    Arity >= 0,
+    !.
+validate_pred_indicator(Pred) :-
+    throw(error(invalid_predicate_indicator(Pred), context(binding_registry, _))).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_binding_registry :-
+    format('~n=== Testing Binding Registry ===~n~n'),
+
+    % Clean up
+    clear_all_bindings,
+
+    % Test 1: Declare and query bindings
+    format('[Test 1] Declare and query bindings~n'),
+    declare_binding(powershell, length/2, 'Measure-Object -Character',
+                    [string], [int], [pure, deterministic]),
+    declare_binding(powershell, file_exists/1, 'Test-Path',
+                    [path], [], [effect(io), pattern(cmdlet_output)]),
+    (   binding(powershell, length/2, _, _, _, _)
+    ->  format('  [PASS] length/2 binding found~n')
+    ;   format('  [FAIL] length/2 binding not found~n')
+    ),
+
+    % Test 2: Query by target
+    format('[Test 2] Query bindings by target~n'),
+    bindings_for_target(powershell, PSBindings),
+    length(PSBindings, NumBindings),
+    format('  Found ~w PowerShell bindings~n', [NumBindings]),
+    (   NumBindings >= 2
+    ->  format('  [PASS] Expected bindings found~n')
+    ;   format('  [FAIL] Expected at least 2 bindings~n')
+    ),
+
+    % Test 3: Check pure binding
+    format('[Test 3] Check pure binding~n'),
+    (   is_pure_binding(powershell, length/2)
+    ->  format('  [PASS] length/2 is pure~n')
+    ;   format('  [FAIL] length/2 should be pure~n')
+    ),
+    (   \+ is_pure_binding(powershell, file_exists/1)
+    ->  format('  [PASS] file_exists/1 is not pure~n')
+    ;   format('  [FAIL] file_exists/1 should not be pure~n')
+    ),
+
+    % Test 4: Effects
+    format('[Test 4] Effect annotations~n'),
+    declare_effect(my_io_pred/2, [effect(io), nondeterministic]),
+    (   effect(my_io_pred/2, Effects), member(effect(io), Effects)
+    ->  format('  [PASS] Effect annotation stored~n')
+    ;   format('  [FAIL] Effect annotation not found~n')
+    ),
+
+    % Test 5: Patterns
+    format('[Test 5] Design patterns~n'),
+    (   pattern(stdout_return, _)
+    ->  format('  [PASS] stdout_return pattern exists~n')
+    ;   format('  [FAIL] stdout_return pattern not found~n')
+    ),
+    (   pattern(cmdlet_output, _)
+    ->  format('  [PASS] cmdlet_output pattern exists~n')
+    ;   format('  [FAIL] cmdlet_output pattern not found~n')
+    ),
+
+    % Test 6: Resolve binding with fallback
+    format('[Test 6] Resolve binding with fallback~n'),
+    declare_binding(python, length/2, 'len', [list], [int], [pure]),
+    (   resolve_binding([rust, powershell, python], length/2, Target, _)
+    ->  format('  Resolved to: ~w~n', [Target]),
+        (   Target == powershell
+        ->  format('  [PASS] Correctly resolved to powershell~n')
+        ;   format('  [FAIL] Should resolve to powershell first~n')
+        )
+    ;   format('  [FAIL] Resolution failed~n')
+    ),
+
+    % Cleanup
+    clear_all_bindings,
+    format('~n=== All Binding Registry Tests Complete ===~n').


### PR DESCRIPTION
## Summary

Implements the `binding/6` predicate system for mapping Prolog predicates to target language functions, with full PowerShell support covering Chapters 3 (Cmdlet Generation) and 5 (Windows Automation) from book-12-powershell-target.

- Adds core binding registry with effect annotations, design patterns, and fallback resolution
- Registers 52 PowerShell bindings for cmdlets, .NET methods, and Windows automation
- Integrates binding-based code generation with the PowerShell compiler
- All 20 tests pass; verified with PowerShell 7.5.4 in proot Debian

## Changes

### Core Binding System (`src/unifyweaver/core/binding_registry.pl`)
- `binding/6` - Query predicate-to-function mappings
- `effect/2` - Target-independent effect annotations (io, state, throws)
- `pattern/2` - Design patterns (stdout_return, pipe_transform, object_pipeline, etc.)
- `bidirectional/2`, `binding_mode/5` - Multi-mode predicate support
- `resolve_binding/4` - Fallback chains across targets
- Utility predicates: `is_pure_binding/2`, `is_total_binding/2`, `is_deterministic_binding/2`

### PowerShell Bindings (`src/unifyweaver/bindings/powershell_bindings.pl`)
**52 bindings** covering:

| Category | Examples |
|----------|----------|
| **Chapter 3 - Cmdlets** | Write-Output, ForEach-Object, Where-Object, Sort-Object, Group-Object, Measure-Object, PSCustomObject |
| **Chapter 5 - Automation** | Get-ChildItem, Test-Path, Get/Set-Content, Get/Start/Stop-Service, Registry ops, Get-WinEvent, Get-CimInstance |
| **.NET Integration** | [System.IO.File], [System.IO.Path], [Math]::Sqrt/Abs/Round, String.Split/Trim/Replace |

### Code Generation (`src/unifyweaver/bindings/binding_codegen.pl`)
- `generate_binding_call/4` - Generate inline calls from bindings
- `generate_cmdlet_from_binding/4` - Full cmdlet wrappers with CmdletBinding, params, begin/process/end
- Pattern-aware generation for .NET static methods, instance methods, and cmdlets

### Compiler Integration (`src/unifyweaver/core/powershell_compiler.pl`)
- `init_powershell_compiler/0` - Initialize with all registered bindings
- `compile_bound_predicate/3` - Compile using bindings with fallback
- `generate_cmdlet_wrapper/3` - Generate full cmdlet functions
- `has_powershell_binding/1` - Check binding existence
- `test_bindings_integration/0` - Integration tests

## Example Usage

```prolog
% Query a binding
?- binding(powershell, sqrt/2, Name, Inputs, Outputs, Options).
Name = '[Math]::Sqrt',
Inputs = [type(double)],
Outputs = [type(double)],
Options = [pure, deterministic, total].

% Generate a call
?- generate_binding_call(powershell, sqrt/2, [25], Code).
Code = "[Math]::Sqrt(25)".

% Generate full cmdlet wrapper
?- generate_cmdlet_wrapper(test_path/1, [verbose_output(true)], Code).
% Returns complete PowerShell function with CmdletBinding, params, etc.
```

## Test Plan

```bash
# Run all binding system tests
swipl -g "
    use_module('src/unifyweaver/core/binding_registry'), test_binding_registry,
    use_module('src/unifyweaver/bindings/powershell_bindings'), test_powershell_bindings,
    use_module('src/unifyweaver/bindings/binding_codegen'), test_binding_codegen,
    use_module('src/unifyweaver/core/powershell_compiler'), powershell_compiler:test_bindings_integration,
    halt
" -t 'halt(1)'

# Test in proot Debian with PowerShell
proot-distro login debian -- pwsh -File output/test_bindings.ps1
```

**Results:** All 20 tests pass ✓

## Related

- Implements design from `docs/proposals/BINDING_PREDICATE_PROPOSAL.md`
- References book-12-powershell-target chapters 3 and 5
- Context doc: `context/PROOT_DEBIAN_CLAUDE_CODE.md`
