### PR TITLE
feat: Integrate binding system into PowerShell compilation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ Compiles predicates to SQL queries for database execution.
 
 **Docs:** [SQL Target Design](SQL_TARGET_DESIGN.md)
 
-### PowerShell Target (v0.1)
+### PowerShell Target (v0.2)
 Windows automation and .NET orchestration.
 - Dual-mode: pure PowerShell or Bash-as-a-Service via WSL
 - Cross-platform (PowerShell 7+)
+- **Binding system**: 52 bindings for cmdlets, .NET methods, Windows automation
+- **Auto-transpilation**: Rules like `sqrt(X, Y)` compile directly to `[Math]::Sqrt($X)`
 - Ideal for orchestrating .NET targets (C#, IronPython)
 
 **Docs:** [PowerShell Target Guide](docs/POWERSHELL_TARGET.md)


### PR DESCRIPTION
## Summary

Enables automatic transpilation of Prolog rules with bindings to PowerShell code. Rules like `sqrt(X, Y)` now compile directly to `$Y = [Math]::Sqrt($X)` without requiring explicit fact definitions.

This builds on the binding system from PR #258 to integrate bindings into the main compilation flow, making Chapter 5 (Windows Automation) features functional rather than design-only.

## Changes

### Core Variable Lookup Fix (`lookup_var_eq/3`)
- Fixed critical bug where `member/2` was used for variable lookup in VarMap
- `member/2` uses unification, causing different Prolog variables to accidentally unify
- New `lookup_var_eq/3` uses strict equality (`==`) for correct variable mapping
- Updated all code generators to use the new lookup

### Module-Qualified Goal Handling
- When rules are asserted from within a module context, Prolog adds prefixes like `powershell_compiler:sqrt(X,Y)`
- Updated `goal_has_binding/2` to strip module qualifiers
- Updated `is_builtin_goal_ps/1` with `is_builtin_goal_ps_inner/1` helper
- Updated `generate_bound_goal_code/6` to handle qualified goals

### Binding-Aware Rule Compilation
- Modified `compile_to_powershell` to try binding-aware compilation first
- Added `classify_body_goals/4` to categorize goals as bound, fact-based, or builtin
- Added `compile_rule_with_bindings/6` as main entry point
- Added `compile_pure_bound_rule/8` for rules where all goals have bindings
- Added `compile_mixed_bound_rule/9` for mixed bound/fact rules

### Code Generation Updates
Updated all generators to use strict variable lookup:
- `generate_cmdlet_call_code/6`
- `generate_dotnet_static_call/6`
- `generate_dotnet_instance_call/6`
- `generate_pipeline_call/6`
- `generate_bool_call/6`

## Example

**Before (would fail or generate error):**
```prolog
compute_sqrt(X, Y) :- sqrt(X, Y).
```

**After (automatic binding transpilation):**
```powershell
function compute_sqrt {
    param([string]$X, [string]$Y)

$Y = [Math]::Sqrt($X)
}
```

**Multiple bound goals:**
```prolog
math_ops(X, Y, Z) :- sqrt(X, Y), abs(Y, Z).
```

Compiles to:
```powershell
function math_ops {
    param([string]$X, [string]$Y, [string]$Z)

$Y = [Math]::Sqrt($X)
$Z = [Math]::Abs($Y)
}
```

## Test Plan

```bash
swipl -g "
    use_module('src/unifyweaver/core/binding_registry'),
    use_module('src/unifyweaver/bindings/powershell_bindings'),
    use_module('src/unifyweaver/core/powershell_compiler'),
    binding_registry:test_binding_registry,
    powershell_bindings:test_powershell_bindings,
    powershell_compiler:test_bindings_integration,
    powershell_compiler:test_bound_rule_compilation,
    halt
" -t 'halt(1)'
```

**Results:** All 24 tests pass
- 8 binding registry tests
- 6 PowerShell bindings tests
- 4 binding system integration tests
- 4 bound rule compilation tests (new)

## Files Changed

| File | Changes |
|------|---------|
| `src/unifyweaver/core/powershell_compiler.pl` | +595 lines (binding integration, variable lookup fix, tests) |
| `README.md` | Updated PowerShell Target to v0.2, added binding features |

## Related

- Builds on PR #258: Add binding system for PowerShell target
- Implements Book 12, Chapter 5: Windows Automation (auto-generation)
- References `docs/proposals/BINDING_PREDICATE_PROPOSAL.md`
