### PR TITLE
feat: Add in-process C# hosting integration (Chapter 6)

### DIFF
--- a/docs/POWERSHELL_PURE_IMPLEMENTATION.md
+++ b/docs/POWERSHELL_PURE_IMPLEMENTATION.md
@@ -1,7 +1,7 @@
 # Pure PowerShell Implementation
 
-**Status:** Implemented (Phase 1 + Phase 2 Recursion + Phase 5 Bindings + Phase 6 Automation)
-**Version:** 2.1.0
+**Status:** Implemented (Phases 1-8: Sources, Recursion, Bindings, Automation, Joins, C# Hosting)
+**Version:** 2.2.0
 **Date:** 2025-12-10
 **Branch:** main
 
@@ -557,7 +557,25 @@ pwsh -File test.ps1
 - [x] Process management (Get-Process, Start-Process, Stop-Process)
 - [x] .NET integration (System.Math, System.IO, System.Xml methods)
 
-### Phase 7: Firewall Mode & Security
+### Phase 7: Multi-Fact Join Optimizations ✅ Complete (v2.2.0)
+
+- [x] Hash-based joins for large datasets - O(n+m) instead of O(n*m)
+- [x] Support for N-way joins (3+ fact goals)
+- [x] Automatic join key detection from shared variables
+- [x] Combined variable maps for multi-fact bound goal code generation
+
+### Phase 8: In-Process C# Hosting (Chapter 6) ✅ Complete (v2.2.0)
+
+- [x] Integration with `dotnet_glue.pl` for .NET bridge generation
+- [x] `compile_with_csharp_host/4` - dual PowerShell/C# output
+- [x] `generate_csharp_bridge/3` - PowerShell, IronPython, CPython bridges
+- [x] `compile_cross_target_pipeline/3` - multi-language pipelines
+- [x] 16 new C# hosting bindings (68 total PowerShell bindings)
+- [x] Runtime detection (.NET, PowerShell, IronPython)
+- [x] PowerShell runspace management from C#
+- [x] Book 12 Chapter 6 documentation
+
+### Phase 9: Firewall Mode & Security
 
 - [ ] Firewall detection logic in compiler
 - [ ] Enforce pure mode when firewall detected
@@ -565,21 +583,15 @@ pwsh -File test.ps1
 
 ### Future Enhancements
 
-#### Multi-Fact Join Optimizations
-- [ ] Hash-based joins for large datasets (instead of nested loops)
-- [ ] Support for more than 2 fact goals in joins
-- [ ] Index-based lookups for frequently-joined predicates
-
 #### Additional Bindings
 - [ ] Scheduled tasks (Register-ScheduledTask, Get-ScheduledTask)
 - [ ] Date/time operations (Get-Date, AddDays, AddHours)
 - [ ] Active Directory cmdlets (Get-ADUser, Get-ADGroup)
 - [ ] Network cmdlets (Test-Connection, Resolve-DnsName)
 
-#### In-Process C# Hosting (Chapter 6)
-- [ ] Cross-target glue for C# ↔ PowerShell integration
-- [ ] In-process .NET assembly hosting
-- [ ] PowerShell runspace management
+#### Advanced Join Optimizations
+- [ ] Index-based lookups for frequently-joined predicates
+- [ ] Pipelined hash joins for N-way joins (currently nested loops)
 
 ---
 


### PR DESCRIPTION
## Summary

Implements in-process C# ↔ PowerShell communication by integrating the `dotnet_glue` module with the PowerShell compiler. This completes Chapter 6 of Book 12 (PowerShell Target).

The key features are:
- **Zero serialization overhead** - Objects pass directly between runtimes
- **Shared runspace** - Efficient PowerShell execution from C#
- **Cross-target pipelines** - Mix PowerShell, C#, and Python in one pipeline

## Changes

### New Predicates in `powershell_compiler.pl`

| Predicate | Description |
|-----------|-------------|
| `compile_with_csharp_host/4` | Compile predicates to PowerShell + C# host class |
| `generate_csharp_bridge/3` | Generate bridge for PowerShell/IronPython/CPython |
| `compile_cross_target_pipeline/3` | Compile multi-language pipelines |

### New C# Hosting Bindings (16 new, 68 total)

#### Inline C# Compilation
- `add_type/1` - `Add-Type -TypeDefinition`
- `load_assembly/1` - `Add-Type -AssemblyName`
- `load_dll/1` - `Add-Type -Path`

#### Object Creation
- `new_object/2` - `New-Object`
- `new_object/3` - `New-Object -TypeName` with arguments

#### Runspace Management
- `create_runspace/1` - `RunspaceFactory.CreateRunspace()`
- `open_runspace/1` - `.Open()`
- `create_powershell/1` - `PowerShell.Create()`

#### Script Execution
- `add_script/2` - `.AddScript`
- `add_command/2` - `.AddCommand`
- `add_parameter/3` - `.AddParameter`
- `invoke_powershell/2` - `.Invoke()`

#### Type Operations
- `cast_type/3` - `-as`
- `is_type/2` - `-is`
- `get_assembly_types/2` - `.GetTypes()`
- `get_type_assembly/2` - `.Assembly`

## Example Usage

```prolog
% Compile predicates with C# host
?- compile_with_csharp_host(
       [filter_users/2, transform_data/2],
       [namespace('MyApp.Generated')],
       PSCode,
       CSharpCode
   ).

% Generate specific bridge type
?- generate_csharp_bridge(powershell, [], BridgeCode).
?- generate_csharp_bridge(ironpython, [namespace('MyApp')], IPCode).

% Cross-target pipeline
?- compile_cross_target_pipeline([
       step(powershell, load_users/1, []),
       step(csharp, validate/2, [])
   ], [], Code).
```

## Generated C# Code

The `compile_with_csharp_host/4` predicate generates:

```csharp
public static class PowerShellBridge
{
    private static readonly Runspace SharedRunspace;

    public static IEnumerable<TOutput> Invoke<TInput, TOutput>(
        string script, TInput input);

    public static IEnumerable<TOutput> InvokeStream<TInput, TOutput>(
        string script, IEnumerable<TInput> inputStream);
}

public class PowerShellHost
{
    public PowerShellHost(string scriptBlock) { ... }

    public IEnumerable<dynamic> filter_users(string arg1, string arg2)
    {
        return PowerShellBridge.Invoke<object, dynamic>(
            "filter_users $arg1 $arg2", null);
    }
}
```

## Test Plan

```bash
swipl -g "
    use_module('src/unifyweaver/core/binding_registry'),
    use_module('src/unifyweaver/bindings/powershell_bindings'),
    use_module('src/unifyweaver/core/powershell_compiler'),
    binding_registry:test_binding_registry,
    powershell_bindings:test_powershell_bindings,
    powershell_compiler:test_bindings_integration,
    powershell_compiler:test_bound_rule_compilation,
    powershell_compiler:test_csharp_hosting,
    halt
" -t 'halt(1)'
```

**Results:** All 32 tests pass
- 8 binding registry tests
- 6 PowerShell bindings tests
- 4 binding integration tests
- 10 bound rule compilation tests
- 4 C# hosting tests

## Files Changed

| File | Changes |
|------|---------|
| `src/unifyweaver/core/powershell_compiler.pl` | +220 lines (C# hosting integration + tests) |
| `src/unifyweaver/bindings/powershell_bindings.pl` | +118 lines (16 new bindings) |
| `docs/POWERSHELL_PURE_IMPLEMENTATION.md` | +31 lines (v2.2.0 update) |

## Documentation

- Updated `POWERSHELL_PURE_IMPLEMENTATION.md` to v2.2.0
- Added Phase 7 (N-way joins) and Phase 8 (C# hosting) as complete
- Book 12 Chapter 6 (`06_csharp_hosting.md`) created in education directory

## Related

- Builds on PR #262: N-way joins and hash-based join optimization
- Uses `src/unifyweaver/glue/dotnet_glue.pl` for bridge generation
- Completes Book 12, Chapter 6: In-Process C# Hosting
