### PR TITLE
Add meta-interpreter for automatic pipeline step inference

### DIFF
--- a/docs/guides/cross-target-glue.md
+++ b/docs/guides/cross-target-glue.md
@@ -2,6 +2,9 @@
 
 UnifyWeaver's cross-target glue system enables seamless communication between different programming languages and runtimes. This guide covers practical usage patterns.
 
+> [!TIP]
+> **New to cross-target glue?** Start with [Book 7, Chapter 1](file:///home/s243a/Projects/UnifyWeaver/education/book-07-cross-target-glue/01_introduction.md) which covers three approaches: high-level declarative, low-level explicit steps, and meta-interpreter inference.
+
 ## Quick Start
 
 ### Shell Pipeline (AWK + Python)

--- a/examples/glue/my_pipeline_example.pl
+++ b/examples/glue/my_pipeline_example.pl
@@ -7,6 +7,7 @@
 % Load necessary modules (using relative paths from examples/glue/)
 :- use_module('../../src/unifyweaver/glue/shell_glue').
 :- use_module('../../src/unifyweaver/core/target_mapping').
+:- use_module('../../src/unifyweaver/core/compiler_driver').
 
 % 1. High-level declarative Prolog for the data processing logic
 %    This defines the *what* and *flow*, without specifying *how* or *where*.
@@ -22,7 +23,7 @@ process_data(Input, Output) :-
 :- declare_target(store/2, awk, [file('store.awk'), name('store_stage')]).
 
 % 3. Predicate to generate the pipeline script using inferred steps.
-%    Now uses the built-in infer_steps_from_goal/2 from shell_glue.
+%    Uses infer_steps_from_goal/2 from shell_glue + generate_pipeline/3.
 generate_process_data_pipeline_inferred(Script) :-
     % Infer the steps from the high-level process_data/2 goal
     infer_steps_from_goal(my_pipeline_example:process_data(_, _), Steps),
@@ -32,7 +33,7 @@ generate_process_data_pipeline_inferred(Script) :-
     ],
     generate_pipeline(Steps, Options, Script).
 
-% Alternative: Use compile_goal_to_pipeline/3 for a one-step approach
+% Alternative: Use compile_goal_to_pipeline/3 from compiler_driver for a one-step approach
 generate_pipeline_onestep(Script) :-
     compile_goal_to_pipeline(
         my_pipeline_example:process_data(_, _),

--- a/examples/glue/my_pipeline_example.pl
+++ b/examples/glue/my_pipeline_example.pl
@@ -1,10 +1,12 @@
 % my_pipeline_example.pl
 % This file demonstrates how UnifyWeaver unifies a high-level declarative Prolog
 % pipeline definition with a concrete shell pipeline generation, by inferring steps.
+%
+% Updated to use the actual UnifyWeaver modules.
 
-% Load necessary modules
-:- use_module(library(shell_glue)).
-:- use_module(library(target_mapping)).
+% Load necessary modules (using relative paths from examples/glue/)
+:- use_module('../../src/unifyweaver/glue/shell_glue').
+:- use_module('../../src/unifyweaver/core/target_mapping').
 
 % 1. High-level declarative Prolog for the data processing logic
 %    This defines the *what* and *flow*, without specifying *how* or *where*.
@@ -19,52 +21,8 @@ process_data(Input, Output) :-
 :- declare_target(transform/2, python, [file('transform.py'), name('transform_stage')]).
 :- declare_target(store/2, awk, [file('store.awk'), name('store_stage')]).
 
-% Helper predicate to infer steps from a high-level goal's body
-% This simulates UnifyWeaver's internal compiler logic
-infer_steps_from_goal(Goal, Steps) :-
-    % Get the module of the goal
-    (   strip_module(Goal, Module, _CleanGoal)
-    ->  true
-    ;   Module = user % Default to user if no explicit module
-    ),
-    % Get the body of the goal (e.g., fetch(I,R),transform(R,P),store(P,O))
-    clause(Module:Goal, Body),
-    % Convert the comma-separated body into a list of subgoals
-    body_to_list(Body, SubGoals),
-    % Map each subgoal to a step/4 term using declared targets
-    maplist(subgoal_to_step(Module), SubGoals, Steps).
-
-% Convert comma-separated body to list of goals
-body_to_list((A,B), [A|Rest]) :-
-    !,
-    body_to_list(B, Rest).
-body_to_list(A, [A]).
-
-% Resolve a subgoal to a step/4 term
-subgoal_to_step(Module, SubGoal, step(StepName, Target, File, StepOptions)) :-
-    % Extract predicate name and arity
-    functor(SubGoal, PredName, Arity),
-    % Query the target mapping for this predicate
-    (   Module:predicate_target(PredName/Arity, Target)
-    ->  true
-    ;   throw(error(no_target_declared(PredName/Arity), _))
-    ),
-    % Get options (including file and step name)
-    Module:target_options(PredName/Arity, Options),
-    (   member(file(File), Options)
-    ->  true
-    ;   throw(error(missing_file_option(PredName/Arity), _))
-    ),
-    (   member(name(StepName), Options)
-    ->  true
-    ;   % Default step name if not provided
-        atom_concat(PredName, '_step', StepName)
-    ),
-    % Filter out file and name from StepOptions to avoid duplication
-    subtract(Options, [file(File), name(StepName)], StepOptions).
-
-
 % 3. Predicate to generate the pipeline script using inferred steps.
+%    Now uses the built-in infer_steps_from_goal/2 from shell_glue.
 generate_process_data_pipeline_inferred(Script) :-
     % Infer the steps from the high-level process_data/2 goal
     infer_steps_from_goal(my_pipeline_example:process_data(_, _), Steps),
@@ -74,10 +32,21 @@ generate_process_data_pipeline_inferred(Script) :-
     ],
     generate_pipeline(Steps, Options, Script).
 
+% Alternative: Use compile_goal_to_pipeline/3 for a one-step approach
+generate_pipeline_onestep(Script) :-
+    compile_goal_to_pipeline(
+        my_pipeline_example:process_data(_, _),
+        [input('access.log'), output('metrics.txt')],
+        Script
+    ).
 
 % To run this:
-% 1. Save the above code as 'my_pipeline_example.pl'.
-% 2. In a Prolog interpreter (like SWI-Prolog):
-%    ?- consult('my_pipeline_example.pl').
+% 1. From the UnifyWeaver root directory:
+%    $ swipl -l examples/glue/my_pipeline_example.pl
+%
+% 2. In the Prolog interpreter:
 %    ?- generate_process_data_pipeline_inferred(Script), writeln(Script).
+%    OR
+%    ?- generate_pipeline_onestep(Script), writeln(Script).
+%
 %    Script will be unified with the generated Bash script, with Steps inferred.

--- a/src/unifyweaver/core/compiler_driver.pl
+++ b/src/unifyweaver/core/compiler_driver.pl
@@ -7,7 +7,11 @@
 :- module(compiler_driver, [
     compile/1,
     compile/2,
-    compile/3
+    compile/3,
+    
+    % Pipeline compilation from high-level goals (re-exported from goal_inference)
+    compile_goal_to_pipeline/3,     % compile_goal_to_pipeline(+Goal, +Options, -Script)
+    compile_goal_to_pipeline/4      % compile_goal_to_pipeline(+Goal, +Options, -Script, -Steps)
 ]).
 
 :- use_module(library(lists)).
@@ -18,6 +22,11 @@
 :- use_module(dynamic_source_compiler). % Support for dynamic data sources
 :- use_module('advanced/advanced_recursive_compiler'). % Added for mutual recursion classification
 :- use_module('advanced/call_graph'). % Added for mutual recursion classification
+:- use_module('../glue/goal_inference', [
+    infer_steps_from_goal/2,
+    infer_steps_from_goal/3,
+    compile_goal_to_pipeline/3  % Re-exported
+]).
 
 :- dynamic compiled/1.
 
@@ -213,3 +222,37 @@ is_linear_recursive(Pred, RecClauses) :-
     findall(G, contains_goal(Body, G), Goals),
     findall(G, (member(G, Goals), functor(G, Pred, _)), RecGoals),
     length(RecGoals, 1).  % Exactly one recursive call
+
+%% ============================================
+%% Pipeline Compilation Extension
+%% ============================================
+%%
+%% compile_goal_to_pipeline/3 is re-exported from goal_inference.
+%% This extension adds compile_goal_to_pipeline/4 which also returns steps.
+%%
+%% Current implementation uses shell pipes (via shell_glue).
+%% Future: Will use resolve_transport/3 to choose optimal transport
+%% based on target families (in-process for .NET, pipes for shell, etc.)
+%%
+%% See: docs/proposals/meta_interpreter_inference.md
+%% See: education/book-07-cross-target-glue/01_introduction.md
+
+%% compile_goal_to_pipeline(+Goal, +Options, -Script, -Steps)
+%  Compile goal to pipeline, also returning the inferred steps.
+%  Useful for debugging or further processing.
+%
+compile_goal_to_pipeline(Goal, Options, Script, Steps) :-
+    % Infer steps from goal body and target declarations
+    infer_steps_from_goal(Goal, Steps),
+    
+    % TODO: Future enhancement - use resolve_transport/3 to pick
+    % optimal transport for each step pair based on target families.
+    % For now, delegate to shell_glue for pipe-based orchestration.
+    
+    % Generate pipeline script
+    (   current_predicate(shell_glue:generate_pipeline/3)
+    ->  shell_glue:generate_pipeline(Steps, Options, Script)
+    ;   throw(error(shell_glue_not_loaded,
+                    context(compile_goal_to_pipeline/4,
+                            'Load shell_glue module for pipeline generation')))
+    ).

--- a/src/unifyweaver/core/target_mapping.pl
+++ b/src/unifyweaver/core/target_mapping.pl
@@ -26,6 +26,7 @@
     % Queries
     predicate_target/2,         % predicate_target(Pred/Arity, Target)
     predicate_target_options/3, % predicate_target_options(Pred/Arity, Target, Options)
+    target_options/2,           % target_options(Pred/Arity, Options) - convenience wrapper
     predicate_location/2,       % predicate_location(Pred/Arity, Location)
     connection_transport/3,     % connection_transport(Pred1, Pred2, Transport)
     connection_options/3,       % connection_options(Pred1, Pred2, Options)
@@ -176,6 +177,13 @@ predicate_target(Pred/Arity, Target) :-
 %
 predicate_target_options(Pred/Arity, Target, Options) :-
     user_target(Pred/Arity, Target, Options).
+
+%% target_options(?Pred/Arity, ?Options)
+%  Convenience wrapper: query options without caring about target.
+%  Useful for goal inference when you just need the file/name options.
+%
+target_options(Pred/Arity, Options) :-
+    predicate_target_options(Pred/Arity, _, Options).
 
 %% predicate_location(?Pred/Arity, ?Location)
 %  Query explicit location options for a predicate.

--- a/src/unifyweaver/glue/goal_inference.pl
+++ b/src/unifyweaver/glue/goal_inference.pl
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 John William Creighton (s243a)
+ *
+ * Goal Inference - Meta-interpreter for deriving pipeline steps from goals
+ *
+ * This module analyzes high-level Prolog goals and automatically constructs
+ * pipeline step/4 terms by consulting target_mapping declarations.
+ *
+ * Key predicates:
+ *   - infer_steps_from_goal/2: Infer steps from a goal's body
+ *   - compile_goal_to_pipeline/3: High-level API for goal → script
+ *
+ * See: docs/proposals/meta_interpreter_inference.md
+ */
+
+:- module(goal_inference, [
+    % Core inference
+    infer_steps_from_goal/2,        % infer_steps_from_goal(+Goal, -Steps)
+    infer_steps_from_goal/3,        % infer_steps_from_goal(+Goal, +Options, -Steps)
+    
+    % Helper predicates (exported for testing)
+    body_to_list/2,                 % body_to_list(+Body, -Goals)
+    subgoal_to_step/3,              % subgoal_to_step(+Module, +SubGoal, -Step)
+    
+    % High-level API
+    compile_goal_to_pipeline/3      % compile_goal_to_pipeline(+Goal, +Options, -Script)
+]).
+
+:- use_module(library(lists)).
+:- use_module('../core/target_mapping').
+
+%% ============================================
+%% Core Inference Predicates
+%% ============================================
+
+%% infer_steps_from_goal(+Goal, -Steps)
+%  Infer pipeline step/4 terms from a high-level goal's body.
+%
+%  The goal must be a defined predicate with target declarations for
+%  each subgoal in its body.
+%
+%  Example:
+%    % Given:
+%    %   process_data(I,O) :- fetch(I,R), transform(R,P), store(P,O).
+%    %   :- declare_target(fetch/2, bash, [file('fetch.sh'), name(fetch_stage)]).
+%    %   :- declare_target(transform/2, python, [file('t.py'), name(transform_stage)]).
+%    %   :- declare_target(store/2, awk, [file('s.awk'), name(store_stage)]).
+%    
+%    ?- infer_steps_from_goal(process_data(_, _), Steps).
+%    Steps = [step(fetch_stage, bash, 'fetch.sh', []),
+%             step(transform_stage, python, 't.py', []),
+%             step(store_stage, awk, 's.awk', [])].
+%
+infer_steps_from_goal(Goal, Steps) :-
+    infer_steps_from_goal(Goal, [], Steps).
+
+%% infer_steps_from_goal(+Goal, +Options, -Steps)
+%  Infer steps with additional options.
+%
+%  Options:
+%    - module(M): Use module M instead of auto-detecting
+%    - skip_missing(true): Skip subgoals without target declarations
+%
+infer_steps_from_goal(Goal, Options, Steps) :-
+    % Determine the module
+    goal_module(Goal, Options, Module, CleanGoal),
+    
+    % Get the clause body
+    (   clause(Module:CleanGoal, Body)
+    ->  true
+    ;   throw(error(no_clause_found(Module:CleanGoal), 
+                    context(infer_steps_from_goal/3, 'Goal has no clause')))
+    ),
+    
+    % Convert body to list of subgoals
+    body_to_list(Body, SubGoals),
+    
+    % Map each subgoal to a step
+    (   member(skip_missing(true), Options)
+    ->  findall(Step, 
+            (member(SG, SubGoals), subgoal_to_step(Module, SG, Step)),
+            Steps)
+    ;   maplist(subgoal_to_step(Module), SubGoals, Steps)
+    ).
+
+%% goal_module(+Goal, +Options, -Module, -CleanGoal)
+%  Determine the module for a goal.
+%
+goal_module(Goal, Options, Module, CleanGoal) :-
+    % Check if module specified in options
+    (   member(module(M), Options)
+    ->  Module = M,
+        (   Goal = _:G -> CleanGoal = G ; CleanGoal = Goal)
+    ;   % Try to extract from goal itself
+        (   strip_module(Goal, ExtractedModule, CleanGoal)
+        ->  Module = ExtractedModule
+        ;   Module = user,
+            CleanGoal = Goal
+        )
+    ).
+
+%% ============================================
+%% Body Processing
+%% ============================================
+
+%% body_to_list(+Body, -Goals)
+%  Convert a comma-separated clause body into a list of goals.
+%
+%  Example:
+%    ?- body_to_list((a, b, c), Goals).
+%    Goals = [a, b, c].
+%
+body_to_list((A, B), [A|Rest]) :-
+    !,
+    body_to_list(B, Rest).
+body_to_list(true, []) :- !.
+body_to_list(A, [A]).
+
+%% ============================================
+%% Subgoal to Step Conversion
+%% ============================================
+
+%% subgoal_to_step(+Module, +SubGoal, -Step)
+%  Convert a subgoal to a step/4 term using target declarations.
+%
+%  Throws an error if no target is declared for the predicate.
+%
+subgoal_to_step(Module, SubGoal, step(StepName, Target, File, StepOptions)) :-
+    % Extract predicate name and arity
+    functor(SubGoal, PredName, Arity),
+    PredIndicator = PredName/Arity,
+    
+    % Query the target mapping
+    (   target_mapping:predicate_target(PredIndicator, Target)
+    ->  true
+    ;   % Try module-qualified lookup
+        Module:predicate_target(PredIndicator, Target)
+    ->  true
+    ;   throw(error(no_target_declared(PredIndicator),
+                    context(subgoal_to_step/3, 'No declare_target for predicate')))
+    ),
+    
+    % Get options from target mapping
+    (   target_mapping:predicate_target_options(PredIndicator, Target, Options)
+    ->  true
+    ;   Module:predicate_target_options(PredIndicator, Target, Options)
+    ->  true
+    ;   Options = []
+    ),
+    
+    % Extract file from options
+    (   member(file(File), Options)
+    ->  true
+    ;   throw(error(missing_file_option(PredIndicator),
+                    context(subgoal_to_step/3, 'No file() in target options')))
+    ),
+    
+    % Extract or generate step name
+    (   member(name(StepName), Options)
+    ->  true
+    ;   atom_concat(PredName, '_step', StepName)
+    ),
+    
+    % Filter out file and name from StepOptions
+    subtract(Options, [file(File), name(StepName)], StepOptions).
+
+%% ============================================
+%% High-Level API
+%% ============================================
+
+%% compile_goal_to_pipeline(+Goal, +Options, -Script)
+%  Compile a high-level goal directly to a pipeline script.
+%
+%  This is the ultimate convenience predicate that:
+%  1. Infers steps from the goal
+%  2. Generates the pipeline script
+%
+%  Options can include both inference options and pipeline options.
+%
+%  Example:
+%    ?- compile_goal_to_pipeline(
+%           process_data(_, _),
+%           [input('data.csv'), output('result.txt')],
+%           Script
+%       ).
+%
+compile_goal_to_pipeline(Goal, Options, Script) :-
+    % Separate inference options from pipeline options
+    partition(is_inference_option, Options, InferenceOpts, PipelineOpts),
+    
+    % Infer steps
+    infer_steps_from_goal(Goal, InferenceOpts, Steps),
+    
+    % Generate pipeline (requires shell_glue loaded)
+    (   current_predicate(shell_glue:generate_pipeline/3)
+    ->  shell_glue:generate_pipeline(Steps, PipelineOpts, Script)
+    ;   throw(error(shell_glue_not_loaded,
+                    context(compile_goal_to_pipeline/3, 
+                            'Load shell_glue module first')))
+    ).
+
+%% is_inference_option(+Option)
+%  True if Option is an inference-specific option.
+%
+is_inference_option(module(_)).
+is_inference_option(skip_missing(_)).

--- a/src/unifyweaver/glue/shell_glue.pl
+++ b/src/unifyweaver/glue/shell_glue.pl
@@ -17,12 +17,22 @@
     % Pipeline generation
     generate_pipeline/3,        % generate_pipeline(Steps, Options, Script)
 
+    % Goal inference (re-exported from goal_inference)
+    infer_steps_from_goal/2,    % infer_steps_from_goal(+Goal, -Steps)
+    infer_steps_from_goal/3,    % infer_steps_from_goal(+Goal, +Options, -Steps)
+    compile_goal_to_pipeline/3, % compile_goal_to_pipeline(+Goal, +Options, -Script)
+
     % Format detection
     input_format/2,             % input_format(Options, Format)
     output_format/2             % output_format(Options, Format)
 ]).
 
 :- use_module(library(lists)).
+:- use_module(goal_inference, [
+    infer_steps_from_goal/2,
+    infer_steps_from_goal/3,
+    compile_goal_to_pipeline/3
+]).
 
 %% ============================================
 %% Format Detection

--- a/src/unifyweaver/glue/shell_glue.pl
+++ b/src/unifyweaver/glue/shell_glue.pl
@@ -20,7 +20,7 @@
     % Goal inference (re-exported from goal_inference)
     infer_steps_from_goal/2,    % infer_steps_from_goal(+Goal, -Steps)
     infer_steps_from_goal/3,    % infer_steps_from_goal(+Goal, +Options, -Steps)
-    compile_goal_to_pipeline/3, % compile_goal_to_pipeline(+Goal, +Options, -Script)
+    % Note: compile_goal_to_pipeline/3 is now in compiler_driver
 
     % Format detection
     input_format/2,             % input_format(Options, Format)
@@ -30,8 +30,7 @@
 :- use_module(library(lists)).
 :- use_module(goal_inference, [
     infer_steps_from_goal/2,
-    infer_steps_from_goal/3,
-    compile_goal_to_pipeline/3
+    infer_steps_from_goal/3
 ]).
 
 %% ============================================


### PR DESCRIPTION
## Summary

Adds a meta-interpreter that automatically derives pipeline `step/4` terms from high-level Prolog goals with `declare_target/3` declarations. This enables users to write declarative logic and have the compiler infer the concrete pipeline orchestration.

## Changes

### New Module
- **`src/unifyweaver/glue/goal_inference.pl`**: Core meta-interpreter
  - `infer_steps_from_goal/2,3` - Analyze goal body to derive steps
  - `body_to_list/2` - Convert comma-body to list
  - `subgoal_to_step/3` - Map subgoal to step/4 via target declarations
  - `compile_goal_to_pipeline/3` - High-level goal → script API

### Modified Modules
- **`src/unifyweaver/core/compiler_driver.pl`**
  - Re-exports `compile_goal_to_pipeline/3`
  - Adds `compile_goal_to_pipeline/4` (also returns inferred steps)

- **`src/unifyweaver/core/target_mapping.pl`**
  - Added `target_options/2` convenience wrapper

- **`src/unifyweaver/glue/shell_glue.pl`**
  - Re-exports `infer_steps_from_goal/2,3`

### Example
- **`examples/glue/my_pipeline_example.pl`** - Updated to use actual modules

## Usage

```prolog
% Define high-level logic
process_data(Input, Output) :-
    fetch(Input, Raw),
    transform(Raw, Processed),
    store(Processed, Output).

% Declare targets for each step
:- declare_target(fetch/2, bash, [file('fetch.sh'), name(fetch_stage)]).
:- declare_target(transform/2, python, [file('transform.py'), name(transform_stage)]).
:- declare_target(store/2, awk, [file('store.awk'), name(store_stage)]).

% Compile to pipeline script
?- compile_goal_to_pipeline(
       process_data(_, _),
       [input('data.csv'), output('result.txt')],
       Script
   ).
```

## Future Work

The compiler currently uses shell pipes for all orchestration. A TODO is documented for future enhancement to use `resolve_transport/3` to choose optimal transport based on target families (in-process for .NET, pipes for shell, sockets for distributed).

## Related Documentation
- `docs/proposals/meta_interpreter_inference.md`
- `education/book-07-cross-target-glue/01_introduction.md` (updated with three-tier approach)
