### PR TITLE
feat(glue): Add transport-aware pipeline compilation

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,58 @@
+# feat(glue): Add meta-interpreter for automatic pipeline step inference
+
+## Summary
+
+Adds a meta-interpreter that automatically derives pipeline `step/4` terms from high-level Prolog goals with `declare_target/3` declarations. This enables users to write declarative logic and have the compiler infer the concrete pipeline orchestration.
+
+## Changes
+
+### New Module
+- **`src/unifyweaver/glue/goal_inference.pl`**: Core meta-interpreter
+  - `infer_steps_from_goal/2,3` - Analyze goal body to derive steps
+  - `body_to_list/2` - Convert comma-body to list
+  - `subgoal_to_step/3` - Map subgoal to step/4 via target declarations
+  - `compile_goal_to_pipeline/3` - High-level goal → script API
+
+### Modified Modules
+- **`src/unifyweaver/core/compiler_driver.pl`**
+  - Re-exports `compile_goal_to_pipeline/3`
+  - Adds `compile_goal_to_pipeline/4` (also returns inferred steps)
+
+- **`src/unifyweaver/core/target_mapping.pl`**
+  - Added `target_options/2` convenience wrapper
+
+- **`src/unifyweaver/glue/shell_glue.pl`**
+  - Re-exports `infer_steps_from_goal/2,3`
+
+### Example
+- **`examples/glue/my_pipeline_example.pl`** - Updated to use actual modules
+
+## Usage
+
+```prolog
+% Define high-level logic
+process_data(Input, Output) :-
+    fetch(Input, Raw),
+    transform(Raw, Processed),
+    store(Processed, Output).
+
+% Declare targets for each step
+:- declare_target(fetch/2, bash, [file('fetch.sh'), name(fetch_stage)]).
+:- declare_target(transform/2, python, [file('transform.py'), name(transform_stage)]).
+:- declare_target(store/2, awk, [file('store.awk'), name(store_stage)]).
+
+% Compile to pipeline script
+?- compile_goal_to_pipeline(
+       process_data(_, _),
+       [input('data.csv'), output('result.txt')],
+       Script
+   ).
+```
+
+## Future Work
+
+The compiler currently uses shell pipes for all orchestration. A TODO is documented for future enhancement to use `resolve_transport/3` to choose optimal transport based on target families (in-process for .NET, pipes for shell, sockets for distributed).
+
+## Related Documentation
+- `docs/proposals/meta_interpreter_inference.md`
+- `education/book-07-cross-target-glue/01_introduction.md` (updated with three-tier approach)

--- a/src/unifyweaver/core/compiler_driver.pl
+++ b/src/unifyweaver/core/compiler_driver.pl
@@ -25,7 +25,9 @@
 :- use_module('../glue/goal_inference', [
     infer_steps_from_goal/2,
     infer_steps_from_goal/3,
-    compile_goal_to_pipeline/3  % Re-exported
+    compile_goal_to_pipeline/3,  % Re-exported
+    group_steps_by_transport/2,
+    generate_pipeline_for_groups/3
 ]).
 
 :- dynamic compiled/1.
@@ -230,29 +232,27 @@ is_linear_recursive(Pred, RecClauses) :-
 %% compile_goal_to_pipeline/3 is re-exported from goal_inference.
 %% This extension adds compile_goal_to_pipeline/4 which also returns steps.
 %%
-%% Current implementation uses shell pipes (via shell_glue).
-%% Future: Will use resolve_transport/3 to choose optimal transport
+%% Now uses resolve_transport/3 to choose optimal transport
 %% based on target families (in-process for .NET, pipes for shell, etc.)
 %%
 %% See: docs/proposals/meta_interpreter_inference.md
 %% See: education/book-07-cross-target-glue/01_introduction.md
 
 %% compile_goal_to_pipeline(+Goal, +Options, -Script, -Steps)
-%  Compile goal to pipeline, also returning the inferred steps.
-%  Useful for debugging or further processing.
+%  Compile goal to pipeline with transport-aware grouping.
+%  Returns both the script and the inferred steps.
+%
+%  Transport selection:
+%    - direct: Same runtime family (.NET targets in-process)
+%    - pipe: Different families (shell ↔ python ↔ native)
+%    - http: Remote hosts
 %
 compile_goal_to_pipeline(Goal, Options, Script, Steps) :-
     % Infer steps from goal body and target declarations
     infer_steps_from_goal(Goal, Steps),
     
-    % TODO: Future enhancement - use resolve_transport/3 to pick
-    % optimal transport for each step pair based on target families.
-    % For now, delegate to shell_glue for pipe-based orchestration.
+    % Group steps by transport type
+    group_steps_by_transport(Steps, Groups),
     
-    % Generate pipeline script
-    (   current_predicate(shell_glue:generate_pipeline/3)
-    ->  shell_glue:generate_pipeline(Steps, Options, Script)
-    ;   throw(error(shell_glue_not_loaded,
-                    context(compile_goal_to_pipeline/4,
-                            'Load shell_glue module for pipeline generation')))
-    ).
+    % Generate pipeline using appropriate glue for each transport
+    generate_pipeline_for_groups(Groups, Options, Script).

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder.go
@@ -1,0 +1,85 @@
+// Package embedder provides text embedding implementations for semantic search.
+//
+// # Backend Options
+//
+// The package supports multiple backends selected via build tags:
+//
+//   - Default (pure Go): No build tags needed
+//     go build ./...
+//
+//   - Candle (Go+Rust): Use -tags candle
+//     go build -tags candle ./...
+//
+//   - ORT (Go+C): Use -tags ort
+//     go build -tags ort ./...
+//
+//   - XLA (Go+C++): Use -tags xla
+//     go build -tags xla ./...
+//
+// # Portability Ranking (most to least portable)
+//
+//  1. Pure Go (default) - No external dependencies
+//  2. Candle (Rust) - Requires Rust toolchain
+//  3. ORT (C) - Requires ONNX Runtime + libtokenizers
+//  4. XLA (C++) - Requires PJRT libraries
+//
+// # GPU Support
+//
+//   - Pure Go: CPU only
+//   - Candle: CUDA support
+//   - ORT: CUDA support
+//   - XLA: CUDA, Metal, TPU support
+package embedder
+
+// Embedder is the common interface for all embedding backends.
+// All implementations must be safe for concurrent use.
+type Embedder interface {
+	// Embed generates a vector embedding for the given text.
+	// Returns nil, nil if the text is empty or cannot be embedded.
+	Embed(text string) ([]float32, error)
+
+	// Close releases any resources held by the embedder.
+	// Must be called when the embedder is no longer needed.
+	Close()
+}
+
+// EmbedderConfig holds configuration for creating embedders.
+type EmbedderConfig struct {
+	// ModelPath is the path to the model directory or file
+	ModelPath string
+
+	// ModelName is the name/identifier of the model
+	ModelName string
+
+	// Dimensions is the expected output dimension (0 = auto-detect)
+	Dimensions int
+
+	// UseGPU enables GPU acceleration if available
+	UseGPU bool
+
+	// MaxLength is the maximum token length (0 = model default)
+	MaxLength int
+}
+
+// Backend represents the embedding backend type
+type Backend string
+
+const (
+	BackendPureGo Backend = "purego"  // Pure Go (hugot NewGoSession)
+	BackendCandle Backend = "candle"  // Rust candle via FFI
+	BackendORT    Backend = "ort"     // ONNX Runtime (C)
+	BackendXLA    Backend = "xla"     // OpenXLA/PJRT (C++)
+	BackendStub   Backend = "stub"    // Stub for testing
+)
+
+// AvailableBackend returns the backend that will be used based on build tags.
+// This is determined at compile time.
+func AvailableBackend() Backend {
+	return availableBackend
+}
+
+// NewEmbedder creates an embedder using the available backend.
+// The backend is selected at compile time based on build tags.
+func NewEmbedder(config EmbedderConfig) (Embedder, error) {
+	return newEmbedder(config)
+}

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_candle.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_candle.go
@@ -1,0 +1,101 @@
+//go:build candle
+
+package embedder
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/../lib -lcandle_semantic_router
+#cgo linux LDFLAGS: -lm -ldl -lpthread
+#cgo darwin LDFLAGS: -framework Accelerate
+
+#include <stdlib.h>
+
+// FFI declarations for candle_semantic_router library
+// These match the Rust library's C API
+
+extern int candle_init_embedding_model(const char* model_path, int use_gpu);
+extern int candle_get_embedding(const char* text, float* output, int max_dim);
+extern int candle_get_embedding_dim();
+extern void candle_cleanup();
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+)
+
+// availableBackend indicates this is the Candle (Rust) backend
+var availableBackend = BackendCandle
+
+// candleEmbedder uses the Rust candle library via FFI
+type candleEmbedder struct {
+	dimensions int
+	mu         sync.Mutex
+}
+
+var (
+	candleOnce     sync.Once
+	candleInitErr  error
+	candleInstance *candleEmbedder
+)
+
+// newEmbedder creates a Candle embedder using Rust FFI
+func newEmbedder(config EmbedderConfig) (Embedder, error) {
+	candleOnce.Do(func() {
+		modelPath := C.CString(config.ModelPath)
+		defer C.free(unsafe.Pointer(modelPath))
+
+		useGPU := C.int(0)
+		if config.UseGPU {
+			useGPU = 1
+		}
+
+		ret := C.candle_init_embedding_model(modelPath, useGPU)
+		if ret != 0 {
+			candleInitErr = fmt.Errorf("candle init failed with code %d", ret)
+			return
+		}
+
+		dim := int(C.candle_get_embedding_dim())
+		if dim <= 0 {
+			dim = 384 // default for MiniLM
+		}
+
+		candleInstance = &candleEmbedder{
+			dimensions: dim,
+		}
+	})
+
+	if candleInitErr != nil {
+		return nil, candleInitErr
+	}
+
+	return candleInstance, nil
+}
+
+func (e *candleEmbedder) Embed(text string) ([]float32, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+
+	output := make([]float32, e.dimensions)
+	ret := C.candle_get_embedding(cText, (*C.float)(unsafe.Pointer(&output[0])), C.int(e.dimensions))
+	if ret != 0 {
+		return nil, fmt.Errorf("candle embedding failed with code %d", ret)
+	}
+
+	return output, nil
+}
+
+func (e *candleEmbedder) Close() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	C.candle_cleanup()
+}

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_ort.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_ort.go
@@ -1,0 +1,66 @@
+//go:build ort
+
+package embedder
+
+import (
+	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/pipelines"
+)
+
+// availableBackend indicates this is the ONNX Runtime backend
+var availableBackend = BackendORT
+
+// ortEmbedder uses hugot's ONNX Runtime backend (requires C dependencies)
+type ortEmbedder struct {
+	session  *hugot.Session
+	pipeline *pipelines.FeatureExtractionPipeline
+}
+
+// newEmbedder creates an ONNX Runtime embedder
+// Requires: onnxruntime.so and libtokenizers.a
+func newEmbedder(config EmbedderConfig) (Embedder, error) {
+	// Use ONNX Runtime session (requires C dependencies)
+	// This requires:
+	// 1. onnxruntime.so in /usr/lib/ or LD_LIBRARY_PATH
+	// 2. libtokenizers.a linked at build time (from daulet/tokenizers)
+	session, err := hugot.NewORTSession()
+	if err != nil {
+		return nil, err
+	}
+
+	hugotConfig := hugot.FeatureExtractionConfig{
+		ModelPath: config.ModelPath,
+		Name:      config.ModelName,
+	}
+
+	pipeline, err := hugot.NewPipeline(session, hugotConfig)
+	if err != nil {
+		session.Destroy()
+		return nil, err
+	}
+
+	return &ortEmbedder{session: session, pipeline: pipeline}, nil
+}
+
+func (e *ortEmbedder) Embed(text string) ([]float32, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	output, err := e.pipeline.RunPipeline([]string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Embeddings) == 0 {
+		return nil, nil
+	}
+
+	return output.Embeddings[0], nil
+}
+
+func (e *ortEmbedder) Close() {
+	if e.session != nil {
+		e.session.Destroy()
+	}
+}

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_purego.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_purego.go
@@ -1,0 +1,62 @@
+//go:build !candle && !ort && !xla
+
+package embedder
+
+import (
+	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/pipelines"
+)
+
+// availableBackend indicates this is the pure Go backend
+var availableBackend = BackendPureGo
+
+// pureGoEmbedder uses hugot's pure Go backend (no C dependencies)
+type pureGoEmbedder struct {
+	session  *hugot.Session
+	pipeline *pipelines.FeatureExtractionPipeline
+}
+
+// newEmbedder creates a pure Go embedder using hugot's GoSession
+func newEmbedder(config EmbedderConfig) (Embedder, error) {
+	// Use pure Go session (no C dependencies)
+	session, err := hugot.NewGoSession()
+	if err != nil {
+		return nil, err
+	}
+
+	hugotConfig := hugot.FeatureExtractionConfig{
+		ModelPath: config.ModelPath,
+		Name:      config.ModelName,
+	}
+
+	pipeline, err := hugot.NewPipeline(session, hugotConfig)
+	if err != nil {
+		session.Destroy()
+		return nil, err
+	}
+
+	return &pureGoEmbedder{session: session, pipeline: pipeline}, nil
+}
+
+func (e *pureGoEmbedder) Embed(text string) ([]float32, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	output, err := e.pipeline.RunPipeline([]string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Embeddings) == 0 {
+		return nil, nil
+	}
+
+	return output.Embeddings[0], nil
+}
+
+func (e *pureGoEmbedder) Close() {
+	if e.session != nil {
+		e.session.Destroy()
+	}
+}

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_xla.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_xla.go
@@ -1,0 +1,65 @@
+//go:build xla
+
+package embedder
+
+import (
+	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/pipelines"
+)
+
+// availableBackend indicates this is the XLA/PJRT backend
+var availableBackend = BackendXLA
+
+// xlaEmbedder uses hugot's XLA backend (requires C++ PJRT dependencies)
+type xlaEmbedder struct {
+	session  *hugot.Session
+	pipeline *pipelines.FeatureExtractionPipeline
+}
+
+// newEmbedder creates an XLA/PJRT embedder
+// Requires: PJRT plugin libraries from GoMLX
+// Install: curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_linux_amd64.sh | bash
+// For GPU: curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda_linux_amd64.sh | bash
+func newEmbedder(config EmbedderConfig) (Embedder, error) {
+	// Use XLA session (requires PJRT C++ libraries)
+	session, err := hugot.NewXLASession()
+	if err != nil {
+		return nil, err
+	}
+
+	hugotConfig := hugot.FeatureExtractionConfig{
+		ModelPath: config.ModelPath,
+		Name:      config.ModelName,
+	}
+
+	pipeline, err := hugot.NewPipeline(session, hugotConfig)
+	if err != nil {
+		session.Destroy()
+		return nil, err
+	}
+
+	return &xlaEmbedder{session: session, pipeline: pipeline}, nil
+}
+
+func (e *xlaEmbedder) Embed(text string) ([]float32, error) {
+	if text == "" {
+		return nil, nil
+	}
+
+	output, err := e.pipeline.RunPipeline([]string{text})
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.Embeddings) == 0 {
+		return nil, nil
+	}
+
+	return output.Embeddings[0], nil
+}
+
+func (e *xlaEmbedder) Close() {
+	if e.session != nil {
+		e.session.Destroy()
+	}
+}


### PR DESCRIPTION
## Summary

Enhances the pipeline compiler to automatically choose optimal transport between steps based on target families:
- **direct**: In-process communication for same-family targets (.NET, JVM)
- **pipe**: Unix pipes for cross-family targets (shell ↔ python ↔ native)
- **http**: Network communication for remote hosts (future)

## Changes

### [goal_inference.pl](file:///home/s243a/Projects/UnifyWeaver/src/unifyweaver/glue/goal_inference.pl)
- `group_steps_by_transport/2` - Groups consecutive steps by transport type
- `step_pair_transport/3` - Determines transport between adjacent steps
- `infer_transport_from_targets/3` - Uses `target_family/2` for transport inference
- `generate_pipeline_for_groups/3` - Dispatches to appropriate glue generator

### [compiler_driver.pl](file:///home/s243a/Projects/UnifyWeaver/src/unifyweaver/core/compiler_driver.pl)
- `compile_goal_to_pipeline/4` now uses transport-aware grouping

## Example

```prolog
Steps = [step(s1, bash, ...), step(s2, awk, ...), step(s3, csharp, ...),
         step(s4, powershell, ...), step(s5, python, ...)]
```

**Grouping result:**
```
group(pipe, [bash, awk, csharp])
group(direct, [csharp, powershell])   % .NET in-process
group(pipe, [powershell, python])
```

Boundary nodes appear in both adjacent groups for proper handoff.

## Transport Selection Logic

| Source Family | Target Family | Transport |
|--------------|---------------|-----------|
| dotnet | dotnet | direct |
| jvm | jvm | direct |
| shell | python | pipe |
| any | remote | http |
