### PR TITLE
docs: Add parallel validation rules to pipeline chaining docs

### DIFF
--- a/docs/ENHANCED_PIPELINE_CHAINING.md
+++ b/docs/ENHANCED_PIPELINE_CHAINING.md
@@ -363,12 +363,15 @@ Enhanced pipelines are validated at compile-time to catch errors early. Validati
 - Empty pipeline
 - Invalid stage types
 - Empty `fan_out` (no sub-stages)
+- Empty `parallel` (no sub-stages)
+- Single-stage `parallel` (use regular stage instead - need 2+ for parallelism benefit)
 - Empty `route_by` (no routes)
 - Invalid route format (must be `(Condition, Stage)`)
 
 **Warnings** (compilation succeeds with message):
 - `fan_out` without subsequent `merge` - parallel results may be nested
-- `merge` without preceding `fan_out` - results may be unexpected
+- `parallel` without subsequent `merge` - parallel results may be nested
+- `merge` without preceding `fan_out` or `parallel` - results may be unexpected
 
 ### Validation Options
 


### PR DESCRIPTION
Update Pipeline Validation section to document existing parallel-specific validation rules that were missing from documentation:

Errors:
- Empty `parallel` (no sub-stages)
- Single-stage `parallel` (need 2+ for parallelism benefit)

Warnings:
- `parallel` without subsequent `merge`
- Updated `merge` warning to mention both `fan_out` and `parallel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)