### PR TITLE
fix(glue): Remove unnecessary step format conversion for dotnet_glue

### DIFF
--- a/src/unifyweaver/glue/goal_inference.pl
+++ b/src/unifyweaver/glue/goal_inference.pl
@@ -314,9 +314,9 @@ generate_group_code(Options, group(pipe, Steps), Code) :-
 
 generate_group_code(Options, group(direct, Steps), Code) :-
     % Use dotnet_glue for in-process groups
+    % Note: dotnet_glue:generate_dotnet_pipeline/3 uses same step/4 format
     (   current_predicate(dotnet_glue:generate_dotnet_pipeline/3)
-    ->  steps_to_dotnet_steps(Steps, DotNetSteps),
-        dotnet_glue:generate_dotnet_pipeline(DotNetSteps, Options, Code)
+    ->  dotnet_glue:generate_dotnet_pipeline(Steps, Options, Code)
     ;   % Fallback to pipe if dotnet_glue not available
         generate_group_code(Options, group(pipe, Steps), Code)
     ).


### PR DESCRIPTION
## Summary

Fixes the integration between `goal_inference` and `dotnet_glue` for in-process .NET pipeline generation.

## Problem

The `steps_to_dotnet_steps/2` function was incorrectly converting steps:
- **From:** `step(Name, Target, File, Opts)` (4-arity)
- **To:** `step(Target, Name, File)` (3-arity)

But `dotnet_glue:generate_dotnet_pipeline/3` expects the original 4-arity format.

## Fix

Removed the conversion since both modules already use the same `step/4` format.

## Changes

### [goal_inference.pl](file:///home/s243a/Projects/UnifyWeaver/src/unifyweaver/glue/goal_inference.pl)
- Removed `steps_to_dotnet_steps` call in `generate_group_code/3`
- Direct call to `dotnet_glue:generate_dotnet_pipeline/3` with original steps

## Verification

```prolog
generate_pipeline_for_groups([group(direct, Steps)], [], Code)
```

**Result:** Generates C# code with in-process PowerShell via `PowerShellBridge.InvokeStream`.