### PR TITLE
feat: Add batch(N) and unbatch stages for enhanced pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `merge` — Combine results from fan_out or parallel stages
   - `route_by(Pred, Routes)` — Conditional routing based on predicate
   - `filter_by(Pred)` — Filter records by predicate condition
+  - `batch(N)` — Collect N records into batches for bulk processing
+  - `unbatch` — Flatten batches back to individual records
   - Supported targets: Python, Go, C#, Rust, PowerShell, AWK, Bash, IronPython
   - `docs/ENHANCED_PIPELINE_CHAINING.md` — Unified documentation
   - Integration tests for all targets
@@ -34,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Pipeline Validation** - Compile-time validation for enhanced pipeline stages
   - `src/unifyweaver/core/pipeline_validation.pl` — Validation module
-  - Error detection: empty pipeline, invalid stages, empty fan_out, empty parallel, empty routes, invalid route format
+  - Error detection: empty pipeline, invalid stages, empty fan_out, empty parallel, empty routes, invalid route format, invalid batch size
   - Warning detection: fan_out/parallel without merge, merge without fan_out/parallel
   - Options: `validate(Bool)` to enable/disable, `strict(Bool)` to treat warnings as errors
   - Integrated into all enhanced pipeline compilation predicates

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -4655,6 +4655,32 @@ def parallel_records(record, stages):
             results.extend(future.result())
     return results
 
+def batch_records(stream, batch_size):
+    '''
+    Batch: Collect records into batches of specified size.
+    Yields each batch as a list. Final batch may be smaller.
+    '''
+    batch = []
+    for record in stream:
+        batch.append(record)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:  # Flush remaining records
+        yield batch
+
+def unbatch_records(stream):
+    '''
+    Unbatch: Flatten batches back to individual records.
+    Each batch (list) is expanded to yield individual records.
+    '''
+    for batch in stream:
+        if isinstance(batch, list):
+            for record in batch:
+                yield record
+        else:
+            yield batch  # Pass through non-list items
+
 ".
 
 %% generate_enhanced_stage_functions(+Stages, -Code)
@@ -4682,6 +4708,8 @@ generate_single_enhanced_stage(route_by(_, Routes), Code) :-
     findall(Stage, member((_Cond, Stage), Routes), RouteStages),
     generate_enhanced_stage_functions(RouteStages, Code).
 generate_single_enhanced_stage(filter_by(_), "") :- !.
+generate_single_enhanced_stage(batch(_), "") :- !.
+generate_single_enhanced_stage(unbatch, "") :- !.
 generate_single_enhanced_stage(Pred/Arity, Code) :-
     !,
     format(string(Code),
@@ -4770,6 +4798,20 @@ generate_stage_flow(filter_by(Pred), InVar, OutVar, Code) :-
     format(string(Code),
 "    # Filter by ~w
     ~w = filter_records(~w, ~w)", [Pred, OutVar, InVar, Pred]).
+
+% Batch stage: collect N records into batches
+generate_stage_flow(batch(N), InVar, OutVar, Code) :-
+    format(atom(OutVar), "batched_~w_result", [N]),
+    format(string(Code),
+"    # Batch records into groups of ~w
+    ~w = batch_records(~w, ~w)", [N, OutVar, InVar, N]).
+
+% Unbatch stage: flatten batches back to individual records
+generate_stage_flow(unbatch, InVar, OutVar, Code) :-
+    OutVar = "unbatched_result",
+    format(string(Code),
+"    # Unbatch: flatten batches to individual records
+    ~w = unbatch_records(~w)", [OutVar, InVar]).
 
 % Standard predicate stage
 generate_stage_flow(Pred/Arity, InVar, OutVar, Code) :-

--- a/tests/integration/test_batch_stage.sh
+++ b/tests/integration/test_batch_stage.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# test_batch_stage.sh - Integration tests for batch(N) and unbatch stages
+# Tests batch stage compilation across multiple targets
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+log_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+log_info() {
+    echo -e "${YELLOW}[INFO]${NC} $1"
+}
+
+# Test 1: Pipeline validation recognizes batch(N) and unbatch
+test_validation() {
+    log_info "Test 1: Pipeline validation recognizes batch(N) and unbatch"
+
+    cd "$PROJECT_ROOT"
+    if swipl -g "use_module(src/unifyweaver/core/pipeline_validation), test_pipeline_validation" -t halt 2>&1 | grep -q "All Pipeline Validation Tests Passed"; then
+        log_pass "Pipeline validation tests pass (includes batch tests)"
+    else
+        log_fail "Pipeline validation tests failed"
+    fi
+}
+
+# Test 2: Python batch stage compilation
+test_python_batch() {
+    log_info "Test 2: Python batch stage compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([
+            extract/1,
+            batch(100),
+            process_batch/1,
+            unbatch,
+            output/1
+        ], [pipeline_name(batch_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "batch_records" && \
+       echo "$output" | grep -q "unbatch_records" && \
+       echo "$output" | grep -q "Batch records into groups of 100"; then
+        log_pass "Python batch stage compiles correctly"
+    else
+        log_fail "Python batch stage compilation failed"
+    fi
+}
+
+# Test 3: Go batch stage compilation
+test_go_batch() {
+    log_info "Test 3: Go batch stage compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([
+            extract/1,
+            batch(50),
+            process/1,
+            unbatch,
+            output/1
+        ], [pipeline_name(batchPipe)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "batchRecords" && \
+       echo "$output" | grep -q "unbatchRecords" && \
+       echo "$output" | grep -q "Batch records into groups of 50"; then
+        log_pass "Go batch stage compiles correctly"
+    else
+        log_fail "Go batch stage compilation failed"
+    fi
+}
+
+# Test 4: Rust batch stage compilation
+test_rust_batch() {
+    log_info "Test 4: Rust batch stage compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([
+            extract/1,
+            batch(200),
+            bulk_process/1,
+            unbatch,
+            output/1
+        ], [pipeline_name(batch_pipe)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "batch_records" && \
+       echo "$output" | grep -q "unbatch_records" && \
+       echo "$output" | grep -q "Batch records into groups of 200"; then
+        log_pass "Rust batch stage compiles correctly"
+    else
+        log_fail "Rust batch stage compilation failed"
+    fi
+}
+
+# Test 5: Bash batch stage compilation
+test_bash_batch() {
+    log_info "Test 5: Bash batch stage compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/bash_target),
+        compile_bash_enhanced_pipeline([
+            extract/1,
+            batch(10),
+            process/1,
+            unbatch,
+            output/1
+        ], [pipeline_name(batch_pipe)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "batch_records" && \
+       echo "$output" | grep -q "unbatch_records" && \
+       echo "$output" | grep -q "Batch records into groups of 10"; then
+        log_pass "Bash batch stage compiles correctly"
+    else
+        log_fail "Bash batch stage compilation failed"
+    fi
+}
+
+# Test 6: Invalid batch size validation
+test_invalid_batch_size() {
+    log_info "Test 6: Invalid batch size validation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, batch(0), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "invalid_batch_size"; then
+        log_pass "Invalid batch size is detected"
+    else
+        log_fail "Invalid batch size not detected"
+    fi
+}
+
+# Test 7: Negative batch size validation
+test_negative_batch_size() {
+    log_info "Test 7: Negative batch size validation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, batch(-5), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "invalid_batch_size"; then
+        log_pass "Negative batch size is detected"
+    else
+        log_fail "Negative batch size not detected"
+    fi
+}
+
+# Main test runner
+main() {
+    echo "=========================================="
+    echo "  Batch Stage Integration Tests"
+    echo "=========================================="
+    echo ""
+
+    test_validation
+    test_python_batch
+    test_go_batch
+    test_rust_batch
+    test_bash_batch
+    test_invalid_batch_size
+    test_negative_batch_size
+
+    echo ""
+    echo "=========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "=========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Adds new stage types for batch processing in enhanced pipelines, enabling efficient bulk operations.

### New Stages

| Stage | Description |
|-------|-------------|
| `batch(N)` | Collect N records into batches for bulk processing |
| `unbatch` | Flatten batches back to individual records |

### Use Cases

- Bulk database inserts
- Batch API calls with rate limits
- Efficient I/O operations
- Memory-efficient processing of large datasets

### Example

```prolog
compile_enhanced_pipeline([
    extract/1,
    filter_by(is_valid),
    batch(100),           % Collect 100 records
    bulk_insert/1,        % Process batch
    unbatch,              % Flatten back to records
    output/1
], [pipeline_name(batch_pipe)], Code).
```

### Implementation

**Python:**
```python
def batch_records(stream, batch_size):
    batch = []
    for record in stream:
        batch.append(record)
        if len(batch) >= batch_size:
            yield batch
            batch = []
    if batch:
        yield batch

def unbatch_records(stream):
    for batch in stream:
        if isinstance(batch, list):
            for record in batch:
                yield record
        else:
            yield batch
```

**Go:**
```go
func batchRecords(records []Record, batchSize int) [][]Record {
    var batches [][]Record
    for i := 0; i < len(records); i += batchSize {
        end := i + batchSize
        if end > len(records) {
            end = len(records)
        }
        batches = append(batches, records[i:end])
    }
    return batches
}

func unbatchRecords(batches [][]Record) []Record {
    var records []Record
    for _, batch := range batches {
        records = append(records, batch...)
    }
    return records
}
```

**Rust:**
```rust
fn batch_records(records: &[Record], batch_size: usize) -> Vec<Vec<Record>> {
    records.chunks(batch_size)
        .map(|chunk| chunk.to_vec())
        .collect()
}

fn unbatch_records(batches: &[Vec<Record>]) -> Vec<Record> {
    batches.iter()
        .flat_map(|batch| batch.clone())
        .collect()
}
```

### Targets Implemented

- ✅ Python (CPython)
- ✅ Go
- ✅ Rust
- ✅ Bash

### Validation

Added to `pipeline_validation.pl`:
- `batch(N)` requires N to be a positive integer
- `unbatch` is always valid
- Error: `invalid_batch_size` when N ≤ 0

### Test Results

```
==========================================
  Batch Stage Integration Tests
==========================================

[PASS] Pipeline validation tests pass (includes batch tests)
[PASS] Python batch stage compiles correctly
[PASS] Go batch stage compiles correctly
[PASS] Rust batch stage compiles correctly
[PASS] Bash batch stage compiles correctly
[PASS] Invalid batch size is detected
[PASS] Negative batch size is detected

==========================================
  Results: 7 passed, 0 failed
==========================================
```

### Relationship to Existing Partitioning

This feature is **complementary to** (not replacing) the existing partitioning system:

| System | Level | Purpose |
|--------|-------|---------|
| `batch(N)` | Stream/pipeline | Collect records during processing |
| Partitioning | File | Split data before parallel workers |

### Files Changed

- `src/unifyweaver/targets/python_target.pl` - 42 lines added
- `src/unifyweaver/targets/go_target.pl` - 40 lines added
- `src/unifyweaver/targets/rust_target.pl` - 32 lines added
- `src/unifyweaver/targets/bash_target.pl` - 67 lines added
- `src/unifyweaver/core/pipeline_validation.pl` - 79 lines added
- `docs/ENHANCED_PIPELINE_CHAINING.md` - 84 lines added
- `CHANGELOG.md` - 4 lines added
- `tests/integration/test_batch_stage.sh` - 207 lines added (new file)

**Total: 551 insertions(+), 4 deletions(-)**

### Breaking Changes

None. This is a pure feature addition that's backwards compatible with existing pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
