### PR TITLE
feat(go): Integrate Candle (Rust) backend with semantic-router library

### DIFF
--- a/examples/pearltrees_go/main.go
+++ b/examples/pearltrees_go/main.go
@@ -10,6 +10,51 @@ import (
 	"unifyweaver/targets/go_runtime/storage"
 )
 
+// createEmbedder initializes the embedder based on compile-time backend selection.
+// Uses MODEL_PATH environment variable or defaults to all-MiniLM-L6-v2.
+// Returns the embedder and an optional close function.
+func createEmbedder() (embedder.Embedder, func()) {
+	// Get model path from environment or use default
+	modelPath := os.Getenv("MODEL_PATH")
+	if modelPath == "" {
+		// Default paths based on backend
+		backend := embedder.AvailableBackend()
+		switch backend {
+		case embedder.BackendCandle:
+			// Candle uses HuggingFace model ID or local safetensors path
+			modelPath = "sentence-transformers/all-MiniLM-L6-v2"
+		default:
+			// Pure Go/ORT/XLA use ONNX model path
+			modelPath = "../../models/all-MiniLM-L6-v2-onnx"
+		}
+	}
+
+	backend := embedder.AvailableBackend()
+	fmt.Fprintf(os.Stderr, "Backend: %s\n", backend)
+	fmt.Fprintf(os.Stderr, "Model: %s\n", modelPath)
+
+	// Check for GPU environment variable
+	useGPU := os.Getenv("USE_GPU") == "1" || os.Getenv("USE_GPU") == "true"
+
+	config := embedder.EmbedderConfig{
+		ModelPath:  modelPath,
+		ModelName:  "all-MiniLM-L6-v2",
+		Dimensions: 384,
+		UseGPU:     useGPU,
+		MaxLength:  512,
+	}
+
+	emb, err := embedder.NewEmbedder(config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Could not load embedder (%s): %v\n", backend, err)
+		fmt.Fprintf(os.Stderr, "Falling back to stub embedder...\n")
+		return embedder.NewStubEmbedder(384), nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Embedding model loaded successfully\n")
+	return emb, func() { emb.Close() }
+}
+
 func main() {
 	dbPath := "pearltrees.bolt"
 
@@ -40,18 +85,10 @@ func runIngest(dbPath string) {
 	defer store.Close()
 	fmt.Fprintf(os.Stderr, "Database: %s\n", dbPath)
 
-	// Initialize embedder - try HugotEmbedder first, fall back to stub
-	modelPath := "../../models/all-MiniLM-L6-v2-onnx"
-	var emb crawler.Embedder
-	hugotEmb, err := embedder.NewHugotEmbedder(modelPath, "all-MiniLM-L6-v2")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Could not load HugotEmbedder: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Falling back to stub embedder...\n")
-		emb = embedder.NewStubEmbedder(384)
-	} else {
-		fmt.Fprintf(os.Stderr, "Embedding model: all-MiniLM-L6-v2 (hugot)\n")
-		emb = hugotEmb
-		defer hugotEmb.Close()
+	// Initialize embedder using backend selected at compile time
+	emb, closeFunc := createEmbedder()
+	if closeFunc != nil {
+		defer closeFunc()
 	}
 
 	// Initialize crawler
@@ -85,18 +122,10 @@ func runSearch(dbPath, query string) {
 	}
 	defer store.Close()
 
-	// Initialize embedder - try HugotEmbedder first, fall back to stub
-	modelPath := "../../models/all-MiniLM-L6-v2-onnx"
-	var emb search.Embedder
-	hugotEmb, err := embedder.NewHugotEmbedder(modelPath, "all-MiniLM-L6-v2")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Could not load HugotEmbedder: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Falling back to stub embedder...\n")
-		emb = embedder.NewStubEmbedder(384)
-	} else {
-		fmt.Fprintf(os.Stderr, "Embedding model: all-MiniLM-L6-v2 (hugot)\n")
-		emb = hugotEmb
-		defer hugotEmb.Close()
+	// Initialize embedder using backend selected at compile time
+	emb, closeFunc := createEmbedder()
+	if closeFunc != nil {
+		defer closeFunc()
 	}
 
 	// Initialize bookmark filer

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_candle.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_candle.go
@@ -3,19 +3,45 @@
 package embedder
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../lib -lcandle_semantic_router
+#cgo LDFLAGS: -L/usr/local/lib -lcandle_semantic_router
 #cgo linux LDFLAGS: -lm -ldl -lpthread
 #cgo darwin LDFLAGS: -framework Accelerate
 
 #include <stdlib.h>
+#include <stdbool.h>
+
+// EmbeddingResult matches the Rust FFI struct
+// Note: Field order must match Rust exactly
+typedef struct {
+    float* data;
+    int length;
+    bool error;
+    int model_type;
+    int sequence_length;
+    float processing_time_ms;
+} EmbeddingResult;
 
 // FFI declarations for candle_semantic_router library
-// These match the Rust library's C API
+// These match the Rust library's C API (from src/ffi/init.rs and src/ffi/similarity.rs)
 
-extern int candle_init_embedding_model(const char* model_path, int use_gpu);
-extern int candle_get_embedding(const char* text, float* output, int max_dim);
-extern int candle_get_embedding_dim();
-extern void candle_cleanup();
+// Initialize BERT similarity model for sentence embeddings
+// model_id: HuggingFace model ID (e.g., "sentence-transformers/all-MiniLM-L6-v2")
+//           or local path to model directory
+// use_cpu: true for CPU, false for GPU (CUDA)
+// Returns: true on success, false on failure
+extern bool init_similarity_model(const char* model_id, bool use_cpu);
+
+// Check if similarity model is initialized
+extern bool is_similarity_model_initialized();
+
+// Get text embedding from initialized model
+// text: Input text (null-terminated C string)
+// max_length: Maximum sequence length (0 for default)
+// Returns: EmbeddingResult struct (caller must free data with free_embedding)
+extern EmbeddingResult get_text_embedding(const char* text, int max_length);
+
+// Free embedding data allocated by Rust
+extern void free_embedding(float* data, int length);
 */
 import "C"
 
@@ -31,6 +57,7 @@ var availableBackend = BackendCandle
 // candleEmbedder uses the Rust candle library via FFI
 type candleEmbedder struct {
 	dimensions int
+	maxLength  int
 	mu         sync.Mutex
 }
 
@@ -41,29 +68,36 @@ var (
 )
 
 // newEmbedder creates a Candle embedder using Rust FFI
+// Uses the semantic-router library's BERT similarity model
 func newEmbedder(config EmbedderConfig) (Embedder, error) {
 	candleOnce.Do(func() {
 		modelPath := C.CString(config.ModelPath)
 		defer C.free(unsafe.Pointer(modelPath))
 
-		useGPU := C.int(0)
-		if config.UseGPU {
-			useGPU = 1
-		}
+		// use_cpu is inverted from UseGPU
+		useCPU := C.bool(!config.UseGPU)
 
-		ret := C.candle_init_embedding_model(modelPath, useGPU)
-		if ret != 0 {
-			candleInitErr = fmt.Errorf("candle init failed with code %d", ret)
+		// Initialize the BERT similarity model
+		success := C.init_similarity_model(modelPath, useCPU)
+		if !success {
+			candleInitErr = fmt.Errorf("candle init_similarity_model failed for model: %s", config.ModelPath)
 			return
 		}
 
-		dim := int(C.candle_get_embedding_dim())
+		// Default dimensions for common models
+		dim := config.Dimensions
 		if dim <= 0 {
-			dim = 384 // default for MiniLM
+			dim = 384 // default for all-MiniLM-L6-v2
+		}
+
+		maxLen := config.MaxLength
+		if maxLen <= 0 {
+			maxLen = 512 // default max sequence length
 		}
 
 		candleInstance = &candleEmbedder{
 			dimensions: dim,
+			maxLength:  maxLen,
 		}
 	})
 
@@ -82,20 +116,41 @@ func (e *candleEmbedder) Embed(text string) ([]float32, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	// Check model is initialized
+	if !C.is_similarity_model_initialized() {
+		return nil, fmt.Errorf("candle similarity model not initialized")
+	}
+
 	cText := C.CString(text)
 	defer C.free(unsafe.Pointer(cText))
 
-	output := make([]float32, e.dimensions)
-	ret := C.candle_get_embedding(cText, (*C.float)(unsafe.Pointer(&output[0])), C.int(e.dimensions))
-	if ret != 0 {
-		return nil, fmt.Errorf("candle embedding failed with code %d", ret)
+	// Get embedding from Rust library
+	result := C.get_text_embedding(cText, C.int(e.maxLength))
+
+	// Check for errors
+	if result.error {
+		return nil, fmt.Errorf("candle get_text_embedding failed")
 	}
+
+	if result.data == nil || result.length <= 0 {
+		return nil, fmt.Errorf("candle returned empty embedding")
+	}
+
+	// Copy data to Go slice before freeing Rust memory
+	length := int(result.length)
+	output := make([]float32, length)
+
+	// Convert C float* to Go slice
+	cSlice := unsafe.Slice((*float32)(unsafe.Pointer(result.data)), length)
+	copy(output, cSlice)
+
+	// Free Rust-allocated memory
+	C.free_embedding(result.data, result.length)
 
 	return output, nil
 }
 
 func (e *candleEmbedder) Close() {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	C.candle_cleanup()
+	// The Rust library handles cleanup internally via OnceLock
+	// No explicit cleanup needed - the model lives for the process lifetime
 }


### PR DESCRIPTION
PR Description:                                                                                                        
## Summary                                                                                                             
- Integrate vllm-project/semantic-router Rust library for Candle backend                                               
- Update `embedder_candle.go` to use correct FFI API (`init_similarity_model`, `get_text_embedding`, `free_embedding`) 
- Refactor `main.go` with unified `createEmbedder()` function that auto-selects backend                                
                                                                                                                       
## Changes                                                                                                             
- **embedder_candle.go**: Use semantic-router FFI with proper EmbeddingResult struct and memory management             
- **main.go**: Add `createEmbedder()` supporting `MODEL_PATH` and `USE_GPU` environment variables                      
                                                                                                                       
## Usage                                                                                                               
```bash                                                                                                                
# Build with Candle backend                                                                                            
go build -tags candle -o pearltrees_go ./...                                                                           
                                                                                                                       
# Run with GPU                                                                                                         
USE_GPU=1 ./pearltrees_go --search "query"                                                                             
                                                                                                                       
Test plan                                                                                                              
                                                                                                                       
- Build with -tags candle links to libcandle_semantic_router.so                                                        
- Semantic search returns relevant results with Candle backend                                                         
- GPU acceleration works with USE_GPU=1                                                                                
                                                                                                                       
� Generated with https://claude.com/claude-code                                                                        