### PR TITLE
docs(guides): Add HTTP transport examples to cross-target glue guide

### DIFF
--- a/docs/guides/cross-target-glue.md
+++ b/docs/guides/cross-target-glue.md
@@ -147,6 +147,42 @@ T = pipe.
 ?- group_steps_by_transport(Steps, Groups).
 ```
 
+### HTTP Transport for Remote Hosts
+
+When pipeline steps target remote services, use the `http` transport:
+
+```prolog
+% Define steps that call remote services
+Steps = [
+    step(ml_predict, python, 'http://ml-service:8080/predict', []),
+    step(enrich, go, 'http://enricher:9000/enrich', [timeout(60)])
+],
+
+% Generate pipeline with HTTP calls
+generate_pipeline_for_groups([group(http, Steps)], [language(python)], Code).
+```
+
+**Generated Python code:**
+```python
+def step_ml_predict(data):
+    response = requests.post(
+        "http://ml-service:8080/predict",
+        json={"data": data},
+        timeout=30
+    )
+    response.raise_for_status()
+    return response.json().get("data")
+
+def run_pipeline(input_data):
+    data = input_data
+    data = step_ml_predict(data)
+    data = step_enrich(data)
+    return data
+```
+
+> [!TIP]
+> Use `[language(go)]` for Go pipelines with `http.Client`, or `[language(bash)]` for Bash pipelines with `curl`.
+
 ---
 
 ## Module Reference


### PR DESCRIPTION
## Summary

Adds documentation for the HTTP transport in the Transport-Aware Compilation section.

## Changes

### [cross-target-glue.md](file:///home/s243a/Projects/UnifyWeaver/docs/guides/cross-target-glue.md)

Added "HTTP Transport for Remote Hosts" section with:
- Example step definitions targeting remote service URLs
- Generated Python code showing `requests.post` calls
- Tip about Go (`http.Client`) and Bash (`curl`) alternatives

## Example Added

```prolog
Steps = [
    step(ml_predict, python, 'http://ml-service:8080/predict', []),
    step(enrich, go, 'http://enricher:9000/enrich', [timeout(60)])
],
generate_pipeline_for_groups([group(http, Steps)], [language(python)], Code).
```

This completes the documentation for all three transport types: `pipe`, `direct`, and `http`.