### PR TITLE
feat(go): Add ORT (ONNX Runtime) backend support and embedder documentation

### DIFF
--- a/docs/GO_EMBEDDER_BACKENDS.md
+++ b/docs/GO_EMBEDDER_BACKENDS.md
@@ -1,0 +1,418 @@
+# Go Embedder Backends - Semantic Search with Multiple Runtime Options
+
+The Go embedder package provides text embedding for semantic search with multiple backend options, ranked by ease of installation.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Backend Comparison](#backend-comparison)
+3. [Backend 1: Pure Go (Easiest)](#backend-1-pure-go-easiest)
+4. [Backend 2: Candle/Rust (Recommended)](#backend-2-candlerust-recommended)
+5. [Backend 3: ONNX Runtime (ORT)](#backend-3-onnx-runtime-ort)
+6. [Backend 4: XLA/PJRT (Most Complex)](#backend-4-xlapjrt-most-complex)
+7. [Model Setup](#model-setup)
+8. [Configuration](#configuration)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+The embedder package uses Go build tags to select backends at compile time:
+
+```bash
+# Pure Go (default - no build tag needed)
+go build ./...
+
+# Candle (Rust FFI)
+go build -tags candle ./...
+
+# ONNX Runtime
+go build -tags ORT ./...
+
+# XLA/PJRT
+go build -tags XLA ./...
+```
+
+All backends implement the same `Embedder` interface:
+
+```go
+type Embedder interface {
+    Embed(text string) ([]float32, error)
+    Close()
+}
+```
+
+---
+
+## Backend Comparison
+
+| Backend | Difficulty | Performance | GPU Support | Dependencies |
+|---------|------------|-------------|-------------|--------------|
+| Pure Go | Easy | Moderate | No | None (pure Go) |
+| Candle | Easy-Medium | Fast | CUDA | Rust toolchain, libcandle_semantic_router.so |
+| ORT | Medium | Fast | CUDA | ONNX Runtime 1.22+, libtokenizers.a |
+| XLA | Hard | Fastest | CUDA/TPU/Metal | PJRT libraries, C++ toolchain |
+
+**Recommendation:** Start with Pure Go for development, use Candle for production.
+
+---
+
+## Backend 1: Pure Go (Easiest)
+
+The pure Go backend uses the `hugot` library with its built-in Go ONNX runtime. No external dependencies required.
+
+### Installation
+
+```bash
+# No additional installation needed - just build
+go build ./...
+```
+
+### Pros
+- Zero external dependencies
+- Cross-platform (works everywhere Go works)
+- Simplest setup
+
+### Cons
+- CPU only (no GPU acceleration)
+- Slower than native backends for large batches
+
+### Usage
+
+```bash
+# Build (default, no tags)
+go build -o myapp ./examples/pearltrees_go
+
+# Run
+./myapp --search "quantum physics"
+```
+
+---
+
+## Backend 2: Candle/Rust (Recommended)
+
+The Candle backend uses the Rust `candle` ML library via FFI. It provides excellent performance with optional GPU support.
+
+### Prerequisites
+
+1. **Rust toolchain**
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   source ~/.cargo/env
+   ```
+
+2. **Clone and build semantic-router library**
+   ```bash
+   git clone https://github.com/vllm-project/semantic-router.git /tmp/semantic-router
+   cd /tmp/semantic-router/candle-binding
+   cargo build --release
+   ```
+
+3. **Install the shared library**
+   ```bash
+   sudo cp target/release/libcandle_semantic_router.so /usr/local/lib/
+   sudo ldconfig
+   ```
+
+### Build
+
+```bash
+go build -tags candle -o myapp ./examples/pearltrees_go
+```
+
+### GPU Support (CUDA)
+
+For GPU acceleration, build semantic-router with CUDA:
+
+```bash
+cd /tmp/semantic-router/candle-binding
+cargo build --release --features cuda
+sudo cp target/release/libcandle_semantic_router.so /usr/local/lib/
+sudo ldconfig
+```
+
+Then run with:
+```bash
+USE_GPU=1 ./myapp --search "machine learning"
+```
+
+### Model Path
+
+Candle can use HuggingFace model IDs directly:
+```bash
+# Uses HuggingFace Hub (downloads on first use)
+MODEL_PATH="sentence-transformers/all-MiniLM-L6-v2" ./myapp --search "test"
+
+# Or local safetensors path
+MODEL_PATH="/path/to/model" ./myapp --search "test"
+```
+
+### Pros
+- Fast inference (native Rust performance)
+- GPU support via CUDA
+- Can download models from HuggingFace automatically
+- Single library dependency
+
+### Cons
+- Requires Rust toolchain to build
+- Linux/macOS only (no Windows support yet)
+
+---
+
+## Backend 3: ONNX Runtime (ORT)
+
+The ORT backend uses Microsoft's ONNX Runtime for inference. Requires C dependencies but provides excellent performance.
+
+### Prerequisites
+
+#### 1. Install ONNX Runtime 1.22.0+
+
+**Important:** ONNX Runtime version must be 1.22.0 or newer (API version 22 required by hugot).
+
+```bash
+# Download ONNX Runtime
+cd /tmp
+wget https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz
+tar xzf onnxruntime-linux-x64-1.22.0.tgz
+
+# Install libraries
+sudo cp onnxruntime-linux-x64-1.22.0/lib/libonnxruntime.so.1.22.0 /usr/local/lib/
+
+# Create required symlinks (order matters!)
+cd /usr/local/lib
+sudo ln -sf libonnxruntime.so.1.22.0 libonnxruntime.so.1
+sudo ln -sf libonnxruntime.so.1 libonnxruntime.so
+sudo ln -sf libonnxruntime.so onnxruntime.so  # hugot looks for this name
+sudo ldconfig
+
+# Install headers (for building)
+sudo cp -r /tmp/onnxruntime-linux-x64-1.22.0/include/* /usr/local/include/
+```
+
+#### 2. Build libtokenizers.a
+
+The tokenizers library must be built from the daulet/tokenizers fork (not knights-analytics/tokenizers):
+
+```bash
+# Clone the correct repository
+git clone https://github.com/daulet/tokenizers.git /tmp/daulet-tokenizers
+cd /tmp/daulet-tokenizers
+
+# Build the Rust library
+cargo build --release
+
+# Install the static library
+sudo cp target/release/libtokenizers.a /usr/local/lib/
+```
+
+### Build
+
+```bash
+# Note: Use uppercase ORT (required by hugot library)
+go build -tags ORT -o myapp ./examples/pearltrees_go
+```
+
+### Usage
+
+```bash
+# Must set LD_LIBRARY_PATH for runtime
+LD_LIBRARY_PATH=/usr/local/lib ./myapp --search "quantum physics"
+```
+
+### Model Path
+
+ORT requires a local directory containing both `model.onnx` and `tokenizer.json`:
+
+```bash
+# Point to directory with both model.onnx and tokenizer.json
+MODEL_PATH="../../models/all-MiniLM-L6-v2" LD_LIBRARY_PATH=/usr/local/lib ./myapp --search "test"
+```
+
+### Common Issues
+
+1. **API version mismatch**: "requested ORT API version 22 is not available"
+   - Solution: Upgrade to ONNX Runtime 1.22.0+
+
+2. **Library not found**: "cannot open shared object file"
+   - Solution: Set `LD_LIBRARY_PATH=/usr/local/lib` or run `sudo ldconfig`
+
+3. **Multiple ONNX files**: "multiple .onnx file detected"
+   - Solution: The embedder now defaults to `model.onnx`. Ensure your model directory structure is correct.
+
+4. **Tokenizer not found**: "feature extraction pipeline requires a tokenizer"
+   - Solution: Ensure `tokenizer.json` is in the same directory as `model.onnx`
+
+### Pros
+- Fast inference
+- GPU support (with CUDA build)
+- Well-maintained by Microsoft
+
+### Cons
+- Complex installation (multiple dependencies)
+- Version sensitivity (API v22 requirement)
+- Requires runtime library path configuration
+
+---
+
+## Backend 4: XLA/PJRT (Most Complex)
+
+The XLA backend uses Google's XLA compiler via PJRT. Provides the best performance, especially on TPUs, but has the most complex setup.
+
+### Prerequisites
+
+```bash
+# Install PJRT libraries
+curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_linux_amd64.sh | bash
+
+# For CUDA support
+curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda_linux_amd64.sh | bash
+```
+
+### Build
+
+```bash
+go build -tags XLA -o myapp ./examples/pearltrees_go
+```
+
+### Status
+
+**Note:** XLA backend is implemented but not yet fully tested. Use Candle or ORT for production.
+
+### Pros
+- Best performance potential
+- Supports TPU, Metal (Apple Silicon)
+- Optimizing compiler
+
+### Cons
+- Most complex installation
+- Large dependencies
+- Less mature Go integration
+
+---
+
+## Model Setup
+
+### Download all-MiniLM-L6-v2
+
+The recommended model is `sentence-transformers/all-MiniLM-L6-v2` (384 dimensions).
+
+#### For Pure Go / ORT / XLA
+
+Download the full model with ONNX files:
+
+```bash
+# Using huggingface-cli
+pip install huggingface_hub
+huggingface-cli download sentence-transformers/all-MiniLM-L6-v2 --local-dir models/all-MiniLM-L6-v2
+
+# Or using git lfs
+git lfs install
+git clone https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2 models/all-MiniLM-L6-v2
+```
+
+Required files:
+- `model.onnx` (or in `onnx/` subdirectory)
+- `tokenizer.json`
+- `config.json`
+
+#### For Candle
+
+Candle can download models automatically from HuggingFace:
+
+```bash
+# Just set the model ID - downloads on first use
+MODEL_PATH="sentence-transformers/all-MiniLM-L6-v2" ./myapp
+```
+
+Or use a local safetensors model:
+```bash
+MODEL_PATH="/path/to/model/with/model.safetensors" ./myapp
+```
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MODEL_PATH` | Path to model directory or HuggingFace ID | Backend-specific default |
+| `USE_GPU` | Enable GPU (`1` or `true`) | `false` |
+
+### EmbedderConfig
+
+```go
+type EmbedderConfig struct {
+    ModelPath    string  // Path to model directory
+    ModelName    string  // Model identifier
+    OnnxFilename string  // Specific ONNX file (default: "model.onnx")
+    Dimensions   int     // Output dimensions (default: 384)
+    UseGPU       bool    // Enable GPU acceleration
+    MaxLength    int     // Max token length (default: 512)
+}
+```
+
+### Build Tags Reference
+
+| Tag | Backend | Session Type |
+|-----|---------|--------------|
+| (none) | Pure Go | `hugot.NewGoSession()` |
+| `candle` | Candle/Rust | FFI to libcandle_semantic_router |
+| `ORT` or `ort` | ONNX Runtime | `hugot.NewORTSession()` |
+| `XLA` or `xla` | XLA/PJRT | `hugot.NewXLASession()` |
+
+---
+
+## Troubleshooting
+
+### Check Which Backend is Active
+
+```go
+backend := embedder.AvailableBackend()
+fmt.Printf("Using backend: %s\n", backend)
+```
+
+Or at runtime:
+```bash
+./myapp --search "test" 2>&1 | grep Backend
+# Output: Backend: ort
+```
+
+### Fallback to Stub Embedder
+
+If the embedder fails to load, the system automatically falls back to a stub embedder that returns random vectors. This allows the application to run but with degraded search quality.
+
+```
+Warning: Could not load embedder (ort): ...
+Falling back to stub embedder...
+```
+
+### Library Path Issues
+
+```bash
+# Check if libraries are found
+ldd ./myapp | grep -E "onnx|candle|tokenizer"
+
+# Add to library path permanently
+echo '/usr/local/lib' | sudo tee /etc/ld.so.conf.d/local.conf
+sudo ldconfig
+```
+
+### Build Tag Verification
+
+```bash
+# Verify build tags are applied
+go build -tags ORT -v ./... 2>&1 | grep embedder
+
+# Should show embedder_ort.go being compiled, NOT embedder_purego.go
+```
+
+---
+
+## See Also
+
+- [GO_TARGET.md](GO_TARGET.md) - Go target compiler documentation
+- [hugot library](https://github.com/knights-analytics/hugot) - Underlying embedding library
+- [semantic-router](https://github.com/vllm-project/semantic-router) - Candle-based embedding library

--- a/docs/GO_TARGET.md
+++ b/docs/GO_TARGET.md
@@ -696,6 +696,7 @@ See `test_go_target.pl` and `test_go_target_comprehensive.pl` for examples.
 
 ## See Also
 
+- [Go Embedder Backends](GO_EMBEDDER_BACKENDS.md) - Semantic search with Pure Go, Candle, ORT, and XLA backends
 - [AWK Target](AWK_TARGET_STATUS.md) - Similar record/field processing in AWK
 - [Match Predicate](MATCH_PREDICATE.md) - Regex matching across targets
 - [Python Target](../src/unifyweaver/targets/python_target.pl) - Alternative target

--- a/examples/pearltrees_go/main.go
+++ b/examples/pearltrees_go/main.go
@@ -25,7 +25,8 @@ func createEmbedder() (embedder.Embedder, func()) {
 			modelPath = "sentence-transformers/all-MiniLM-L6-v2"
 		default:
 			// Pure Go/ORT/XLA use ONNX model path
-			modelPath = "../../models/all-MiniLM-L6-v2-onnx"
+			// Must contain model.onnx and tokenizer.json in same directory
+			modelPath = "../../models/all-MiniLM-L6-v2"
 		}
 	}
 

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder.go
@@ -51,6 +51,10 @@ type EmbedderConfig struct {
 	// ModelName is the name/identifier of the model
 	ModelName string
 
+	// OnnxFilename is the specific ONNX file to use (for ORT/XLA backends)
+	// Required when model directory contains multiple .onnx files
+	OnnxFilename string
+
 	// Dimensions is the expected output dimension (0 = auto-detect)
 	Dimensions int
 

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_ort.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_ort.go
@@ -1,4 +1,4 @@
-//go:build ort
+//go:build ort || ORT
 
 package embedder
 
@@ -28,9 +28,16 @@ func newEmbedder(config EmbedderConfig) (Embedder, error) {
 		return nil, err
 	}
 
+	// Default to model.onnx if no specific ONNX file is specified
+	onnxFile := config.OnnxFilename
+	if onnxFile == "" {
+		onnxFile = "model.onnx"
+	}
+
 	hugotConfig := hugot.FeatureExtractionConfig{
-		ModelPath: config.ModelPath,
-		Name:      config.ModelName,
+		ModelPath:    config.ModelPath,
+		Name:         config.ModelName,
+		OnnxFilename: onnxFile,
 	}
 
 	pipeline, err := hugot.NewPipeline(session, hugotConfig)

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_purego.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_purego.go
@@ -1,4 +1,4 @@
-//go:build !candle && !ort && !xla
+//go:build !candle && !ort && !ORT && !xla && !XLA
 
 package embedder
 
@@ -24,9 +24,16 @@ func newEmbedder(config EmbedderConfig) (Embedder, error) {
 		return nil, err
 	}
 
+	// Default to model.onnx if no specific ONNX file is specified
+	onnxFile := config.OnnxFilename
+	if onnxFile == "" {
+		onnxFile = "model.onnx"
+	}
+
 	hugotConfig := hugot.FeatureExtractionConfig{
-		ModelPath: config.ModelPath,
-		Name:      config.ModelName,
+		ModelPath:    config.ModelPath,
+		Name:         config.ModelName,
+		OnnxFilename: onnxFile,
 	}
 
 	pipeline, err := hugot.NewPipeline(session, hugotConfig)

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_xla.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_xla.go
@@ -1,4 +1,4 @@
-//go:build xla
+//go:build xla || XLA
 
 package embedder
 
@@ -27,9 +27,16 @@ func newEmbedder(config EmbedderConfig) (Embedder, error) {
 		return nil, err
 	}
 
+	// Default to model.onnx if no specific ONNX file is specified
+	onnxFile := config.OnnxFilename
+	if onnxFile == "" {
+		onnxFile = "model.onnx"
+	}
+
 	hugotConfig := hugot.FeatureExtractionConfig{
-		ModelPath: config.ModelPath,
-		Name:      config.ModelName,
+		ModelPath:    config.ModelPath,
+		Name:         config.ModelName,
+		OnnxFilename: onnxFile,
 	}
 
 	pipeline, err := hugot.NewPipeline(session, hugotConfig)


### PR DESCRIPTION
## Summary                                                                                                 
                                                                                                           
- Add ORT (ONNX Runtime) backend support for Go embeddings                                                 
- Add `OnnxFilename` field to `EmbedderConfig` for multi-file model directories                            
- Create comprehensive documentation for all 4 embedding backends                                          
                                                                                                           
## Changes                                                                                                 
                                                                                                           
### Code                                                                                                   
- **embedder.go**: Add `OnnxFilename` config field for specifying which ONNX model file to use             
- **embedder_ort.go**: Update to use `OnnxFilename` (defaults to "model.onnx")                             
- **embedder_xla.go**: Same update for consistency                                                         
- **embedder_purego.go**: Same update for consistency                                                      
- **main.go**: Fix default model path from `all-MiniLM-L6-v2-onnx` to `all-MiniLM-L6-v2`                   
                                                                                                           
### Documentation                                                                                          
- **GO_EMBEDDER_BACKENDS.md**: New comprehensive guide covering:                                           
  - Backend comparison table (difficulty, performance, GPU support)                                        
  - Installation instructions for all 4 backends                                                           
  - Troubleshooting common issues (ONNX Runtime 1.22+ requirement, library paths, symlinks)                
  - Model setup instructions                                                                               
  - Configuration reference                                                                                
                                                                                                           
## Backend Difficulty Ranking                                                                              
                                                                                                           
| Backend | Difficulty | Status |                                                                          
|---------|------------|--------|                                                                          
| Pure Go | Easiest | Working |                                                                            
| Candle (Rust) | Easy-Medium | Working (Recommended) |                                                    
| ORT (ONNX Runtime) | Medium | Working (NEW) |                                                            
| XLA/PJRT | Hard | Implemented, not tested |                                                              
                                                                                                           
## Test Plan                                                                                               
                                                                                                           
- [x] Build with `-tags ORT` succeeds                                                                      
- [x] ORT backend loads ONNX Runtime 1.22.0 correctly                                                      
- [x] Semantic search returns relevant results ("quantum physics" → "Quantum Mechanics" 0.902)             
- [x] Default model path works without `MODEL_PATH` env var                                                