### PR TITLE
feat(go): Add GPU support for ORT and XLA backends

### DIFF
--- a/docs/GO_EMBEDDER_BACKENDS.md
+++ b/docs/GO_EMBEDDER_BACKENDS.md
@@ -4,15 +4,47 @@ The Go embedder package provides text embedding for semantic search with multipl
 
 ## Table of Contents
 
-1. [Overview](#overview)
-2. [Backend Comparison](#backend-comparison)
-3. [Backend 1: Pure Go (Easiest)](#backend-1-pure-go-easiest)
-4. [Backend 2: Candle/Rust (Recommended)](#backend-2-candlerust-recommended)
-5. [Backend 3: ONNX Runtime (ORT)](#backend-3-onnx-runtime-ort)
-6. [Backend 4: XLA/PJRT (Most Complex)](#backend-4-xlapjrt-most-complex)
-7. [Model Setup](#model-setup)
-8. [Configuration](#configuration)
-9. [Troubleshooting](#troubleshooting)
+1. [Quick Start](#quick-start)
+2. [Overview](#overview)
+3. [Backend Comparison](#backend-comparison)
+4. [Backend 1: Pure Go (Easiest)](#backend-1-pure-go-easiest)
+5. [Backend 2: Candle/Rust (Recommended)](#backend-2-candlerust-recommended)
+6. [Backend 3: ONNX Runtime (ORT)](#backend-3-onnx-runtime-ort)
+7. [Backend 4: XLA/PJRT (Most Complex)](#backend-4-xlapjrt-most-complex)
+8. [Model Setup](#model-setup)
+9. [Configuration](#configuration)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## Quick Start
+
+**Just want it working? Use Pure Go (no dependencies):**
+
+```bash
+# Download the model
+pip install huggingface_hub
+huggingface-cli download sentence-transformers/all-MiniLM-L6-v2 --local-dir models/all-MiniLM-L6-v2
+
+# Build and run
+go build -o myapp ./examples/pearltrees_go
+MODEL_PATH="models/all-MiniLM-L6-v2" ./myapp --search "your query"
+```
+
+**Want best performance? Use Candle:**
+
+```bash
+# Install Rust and build the library
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+git clone https://github.com/vllm-project/semantic-router.git /tmp/semantic-router
+cd /tmp/semantic-router/candle-binding && cargo build --release
+sudo cp target/release/libcandle_semantic_router.so /usr/local/lib/ && sudo ldconfig
+
+# Build and run
+go build -tags candle -o myapp ./examples/pearltrees_go
+MODEL_PATH="sentence-transformers/all-MiniLM-L6-v2" LD_LIBRARY_PATH=/usr/local/lib ./myapp --search "your query"
+```
 
 ---
 
@@ -58,16 +90,16 @@ type Embedder interface {
 
 ### Performance Benchmarks
 
-Tested on GTX 1660 Ti, all-MiniLM-L6-v2 model, 5 queries x 5 runs averaged:
+Tested on GTX 1660 Ti, all-MiniLM-L6-v2 model, 5 queries x 3 runs averaged:
 
-| Backend | Avg/Query (CPU) | Binary Size | Notes |
-|---------|-----------------|-------------|-------|
-| **Candle** | **0.21s** | 17MB | Fastest on CPU |
-| Pure Go | 0.36s | 20MB | Good balance |
-| ORT | 0.44s | 38MB | More overhead |
-| XLA | 0.67s | 40MB | Optimized for TPU/GPU batches |
+| Backend | CPU Time | GPU Time | Notes |
+|---------|----------|----------|-------|
+| **Candle** | **0.21s** | 0.36s | Fastest on CPU |
+| Pure Go | 0.34s | N/A | No GPU support |
+| ORT | 0.45s | 0.44s | Marginal GPU gain |
+| XLA | 0.70s | ~0.72s | WSL2 may fall back to CPU |
 
-**GPU Note:** For single-query workloads, CPU is often faster due to GPU transfer overhead. GPU acceleration benefits appear with batch processing (multiple embeddings at once).
+**GPU Note:** For single-query workloads, CPU is often faster due to GPU transfer overhead. The embedding model is small enough that CPU inference completes before GPU data transfer finishes. GPU acceleration benefits appear with batch processing (multiple embeddings at once) or larger models.
 
 ---
 
@@ -256,6 +288,31 @@ MODEL_PATH="../../models/all-MiniLM-L6-v2" LD_LIBRARY_PATH=/usr/local/lib ./myap
 4. **Tokenizer not found**: "feature extraction pipeline requires a tokenizer"
    - Solution: Ensure `tokenizer.json` is in the same directory as `model.onnx`
 
+### GPU Support (CUDA)
+
+For GPU acceleration with ORT:
+
+```bash
+# Download GPU version of ONNX Runtime
+cd /tmp
+wget https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-gpu-1.22.0.tgz
+tar xzf onnxruntime-linux-x64-gpu-1.22.0.tgz
+
+# Install GPU libraries
+sudo cp onnxruntime-linux-x64-gpu-1.22.0/lib/libonnxruntime_providers_cuda.so /usr/local/lib/
+sudo cp onnxruntime-linux-x64-gpu-1.22.0/lib/libonnxruntime_providers_shared.so /usr/local/lib/
+
+# Install cuDNN 9 (required for CUDA provider)
+sudo apt install libcudnn9-cuda-12
+
+sudo ldconfig
+```
+
+Then run with:
+```bash
+USE_GPU=1 LD_LIBRARY_PATH=/usr/local/lib ./myapp --search "machine learning"
+```
+
 ### Pros
 - Fast inference
 - GPU support (with CUDA build)
@@ -265,6 +322,7 @@ MODEL_PATH="../../models/all-MiniLM-L6-v2" LD_LIBRARY_PATH=/usr/local/lib ./myap
 - Complex installation (multiple dependencies)
 - Version sensitivity (API v22 requirement)
 - Requires runtime library path configuration
+- GPU requires cuDNN 9
 
 ---
 
@@ -274,18 +332,50 @@ The XLA backend uses Google's XLA compiler via PJRT. Optimized for hardware acce
 
 ### Prerequisites
 
+#### CPU-only Install
+
 ```bash
-# Install PJRT libraries (CPU)
 # Option 1: System-wide (requires sudo)
 curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_linux_amd64.sh | bash
 
-# Option 2: Local install (no sudo)
+# Option 2: Local install (no sudo) - RECOMMENDED
 GOPJRT_INSTALL_DIR=$HOME/.local GOPJRT_NOSUDO=1 \
   bash -c 'curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_linux_amd64.sh | bash'
+```
 
-# For CUDA support (requires python3-venv)
+The local install places libraries in `~/.local/lib/` (~250MB PJRT plugin).
+
+#### GPU/CUDA Install (Complex)
+
+XLA CUDA support requires Python and JAX. This is significantly more complex than other backends:
+
+**Option 1: Official install script** (requires python3-venv):
+```bash
+sudo apt install python3-venv python3-dev
 curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda.sh | bash
 ```
+
+**Option 2: Manual install with Python 3.9+** (if python3-venv not available):
+```bash
+# Create venv with newer Python
+python3.9 -m venv /tmp/jax_cuda_venv
+source /tmp/jax_cuda_venv/bin/activate
+pip install --upgrade pip
+pip install "jax[cuda12]"
+
+# Copy CUDA PJRT plugin
+mkdir -p ~/.local/lib/gomlx/pjrt
+cp /tmp/jax_cuda_venv/lib/python3.9/site-packages/jax_plugins/xla_cuda12/xla_cuda_plugin.so \
+   ~/.local/lib/gomlx/pjrt/pjrt_c_api_cuda_plugin.so
+
+# Copy nvidia libraries
+cp -r /tmp/jax_cuda_venv/lib/python3.9/site-packages/nvidia/* ~/.local/lib/gomlx/nvidia/
+
+# Cleanup
+rm -rf /tmp/jax_cuda_venv
+```
+
+**Note:** XLA GPU may not work properly in WSL2 due to `/dev/nvidia*` device detection issues. For GPU acceleration in WSL2, **Candle or ORT are better alternatives**.
 
 ### Build
 
@@ -429,11 +519,17 @@ Falling back to stub embedder...
 
 ```bash
 # Check if libraries are found
-ldd ./myapp | grep -E "onnx|candle|tokenizer"
+ldd ./myapp | grep -E "onnx|candle|tokenizer|pjrt"
+
+# Check for missing libraries
+ldd ./myapp | grep "not found"
 
 # Add to library path permanently
 echo '/usr/local/lib' | sudo tee /etc/ld.so.conf.d/local.conf
 sudo ldconfig
+
+# For XLA local install
+export LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH
 ```
 
 ### Build Tag Verification
@@ -444,6 +540,60 @@ go build -tags ORT -v ./... 2>&1 | grep embedder
 
 # Should show embedder_ort.go being compiled, NOT embedder_purego.go
 ```
+
+### Common Errors by Backend
+
+#### Candle
+- **"libcandle_semantic_router.so: cannot open"**: Library not installed or not in LD_LIBRARY_PATH
+  ```bash
+  sudo ldconfig
+  # or
+  LD_LIBRARY_PATH=/usr/local/lib ./myapp
+  ```
+
+#### ORT
+- **"ORT API version 22 is not available"**: Wrong ONNX Runtime version
+  ```bash
+  # Must use v1.22.0+
+  wget https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz
+  ```
+
+- **"libcudnn.so.9: cannot open"**: Missing cuDNN for GPU
+  ```bash
+  sudo apt install libcudnn9-cuda-12
+  sudo ldconfig
+  ```
+
+- **"multiple .onnx file detected"**: Model directory has multiple ONNX files
+  - The embedder defaults to `model.onnx`. Ensure only one exists or it's named correctly.
+
+#### XLA
+- **"libpjrt_c_api_cpu_plugin.so: cannot open"**: PJRT not installed
+  ```bash
+  # Local install
+  GOPJRT_INSTALL_DIR=$HOME/.local GOPJRT_NOSUDO=1 \
+    bash -c 'curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_linux_amd64.sh | bash'
+  ```
+
+- **"ml-dtypes build failed"**: Missing Python headers for CUDA install
+  ```bash
+  sudo apt install python3-dev
+  ```
+
+### Verify GPU is Being Used
+
+```bash
+# Check GPU memory before/after running
+nvidia-smi --query-gpu=memory.used --format=csv,noheader
+
+# Run with GPU enabled
+USE_GPU=1 LD_LIBRARY_PATH=/usr/local/lib ./myapp --search "test"
+
+# Check GPU memory again - should increase if GPU is active
+nvidia-smi --query-gpu=memory.used --format=csv,noheader
+```
+
+**Note:** For small models like all-MiniLM-L6-v2, CPU may be faster than GPU for single queries due to data transfer overhead.
 
 ---
 

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_ort.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_ort.go
@@ -4,6 +4,7 @@ package embedder
 
 import (
 	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/options"
 	"github.com/knights-analytics/hugot/pipelines"
 )
 
@@ -18,12 +19,22 @@ type ortEmbedder struct {
 
 // newEmbedder creates an ONNX Runtime embedder
 // Requires: onnxruntime.so and libtokenizers.a
+// For GPU: libonnxruntime_providers_cuda.so and libonnxruntime_providers_shared.so
 func newEmbedder(config EmbedderConfig) (Embedder, error) {
 	// Use ONNX Runtime session (requires C dependencies)
 	// This requires:
 	// 1. onnxruntime.so in /usr/lib/ or LD_LIBRARY_PATH
 	// 2. libtokenizers.a linked at build time (from daulet/tokenizers)
-	session, err := hugot.NewORTSession()
+	// 3. For GPU: libonnxruntime_providers_cuda.so
+
+	// Build session options
+	var sessionOpts []options.WithOption
+	if config.UseGPU {
+		// Enable CUDA provider for GPU acceleration
+		sessionOpts = append(sessionOpts, options.WithCuda(nil))
+	}
+
+	session, err := hugot.NewORTSession(sessionOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/src/unifyweaver/targets/go_runtime/embedder/embedder_xla.go
+++ b/src/unifyweaver/targets/go_runtime/embedder/embedder_xla.go
@@ -4,6 +4,7 @@ package embedder
 
 import (
 	"github.com/knights-analytics/hugot"
+	"github.com/knights-analytics/hugot/options"
 	"github.com/knights-analytics/hugot/pipelines"
 )
 
@@ -19,10 +20,17 @@ type xlaEmbedder struct {
 // newEmbedder creates an XLA/PJRT embedder
 // Requires: PJRT plugin libraries from GoMLX
 // Install: curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_linux_amd64.sh | bash
-// For GPU: curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda_linux_amd64.sh | bash
+// For GPU: curl -sSf https://raw.githubusercontent.com/gomlx/gopjrt/main/cmd/install_cuda.sh | bash
 func newEmbedder(config EmbedderConfig) (Embedder, error) {
+	// Build session options
+	var sessionOpts []options.WithOption
+	if config.UseGPU {
+		// Enable CUDA for GPU acceleration
+		sessionOpts = append(sessionOpts, options.WithCuda(nil))
+	}
+
 	// Use XLA session (requires PJRT C++ libraries)
-	session, err := hugot.NewXLASession()
+	session, err := hugot.NewXLASession(sessionOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary                                                                                               
- Add `options.WithCuda()` GPU acceleration support for ORT and XLA embedder backends                    
- Update documentation with comprehensive GPU setup instructions and benchmarks                          
- Add Quick Start section and expanded troubleshooting guide                                             
                                                                                                         
## Changes                                                                                               
- **embedder_ort.go**: Enable CUDA provider when `UseGPU` config is true                                 
- **embedder_xla.go**: Enable CUDA when `UseGPU` config is true                                          
- **GO_EMBEDDER_BACKENDS.md**:                                                                           
  - Add Quick Start section for easy onboarding                                                          
  - Update benchmark table with CPU vs GPU comparison                                                    
  - Document ORT GPU setup (CUDA provider + cuDNN 9)                                                     
  - Add manual XLA CUDA install method using Python 3.9 venv                                             
  - Expand troubleshooting with common errors by backend                                                 
  - Add GPU verification steps                                                                           
                                                                                                         
## Benchmarks (GTX 1660 Ti, all-MiniLM-L6-v2)                                                            
                                                                                                         
| Backend | CPU | GPU | Notes |                                                                          
|---------|-----|-----|-------|                                                                          
| Candle | 0.21s | 0.36s | Fastest on CPU |                                                              
| Pure Go | 0.34s | N/A | No GPU support |                                                               
| ORT | 0.45s | 0.44s | Marginal GPU gain |                                                              
| XLA | 0.70s | ~0.72s | WSL2 may fall back to CPU |                                                     
                                                                                                         
**Note:** For single-query workloads with small models, CPU is often faster due to GPU transfer overhead.
                                                                                                         
## Test plan                                                                                             
- [x] ORT GPU tested with cuDNN 9                                                                        
- [x] XLA CUDA PJRT plugin installed and tested                                                          
- [x] All backends benchmarked on CPU and GPU                                                            
                                                                                                         
� Generated with [Claude Code](https://claude.com/claude-code)                                           