### PR TITLE
feat(pipeline): Add ordered(true) option to parallel stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Parallel Stage Execution** - True concurrent processing for performance-critical workloads
   - `parallel(Stages)` stage type for concurrent stage execution
+  - `parallel(Stages, Options)` with options support:
+    - `ordered(true)` — Preserve stage definition order in results (default: completion order)
   - Target-native parallelism mechanisms:
     - Python: `ThreadPoolExecutor`
     - Go: Goroutines with `sync.WaitGroup`
@@ -31,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Bash: Background processes with `wait`
     - IronPython: .NET `Task.Factory.StartNew` with `ConcurrentBag<T>`
     - AWK: Sequential by default, GNU Parallel with `parallel_mode(gnu_parallel)` option
-  - Validation support: empty parallel detection, single-stage parallel warning
+  - Validation support: empty parallel detection, single-stage parallel warning, invalid option detection
   - Clear distinction from `fan_out` (sequential) vs `parallel` (concurrent)
 
 - **Pipeline Validation** - Compile-time validation for enhanced pipeline stages

--- a/tests/integration/test_parallel_ordered.sh
+++ b/tests/integration/test_parallel_ordered.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# test_parallel_ordered.sh - Integration tests for parallel(Stages, [ordered(true)]) option
+# Tests ordered parallel compilation across multiple targets
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+log_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+log_info() {
+    echo -e "${YELLOW}[INFO]${NC} $1"
+}
+
+# Test 1: Pipeline validation recognizes parallel(Stages, Options)
+test_validation_valid() {
+    log_info "Test 1: Pipeline validation accepts parallel(Stages, [ordered(true)])"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, parallel([a/1, b/1], [ordered(true)]), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "Valid ordered parallel accepted"
+    else
+        log_fail "Valid ordered parallel rejected: $output"
+    fi
+}
+
+# Test 2: Pipeline validation detects invalid options
+test_validation_invalid_option() {
+    log_info "Test 2: Pipeline validation detects invalid parallel options"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, parallel([a/1, b/1], [invalid_option]), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "invalid_parallel_option"; then
+        log_pass "Invalid parallel option detected"
+    else
+        log_fail "Invalid parallel option not detected: $output"
+    fi
+}
+
+# Test 3: Python ordered parallel compilation
+test_python_ordered() {
+    log_info "Test 3: Python ordered parallel compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([
+            parse/1,
+            parallel([process_a/1, process_b/1], [ordered(true)]),
+            output/1
+        ], [pipeline_name(ordered_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "parallel_records_ordered" && \
+       echo "$output" | grep -q "indexed_results" && \
+       echo "$output" | grep -q "Parallel execution (ordered)"; then
+        log_pass "Python ordered parallel compiles correctly"
+    else
+        log_fail "Python ordered parallel compilation failed"
+    fi
+}
+
+# Test 4: Python unordered parallel (default) compilation
+test_python_unordered() {
+    log_info "Test 4: Python unordered parallel (default) compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([
+            parse/1,
+            parallel([process_a/1, process_b/1]),
+            output/1
+        ], [pipeline_name(unordered_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    # Should use parallel_records (not ordered version)
+    if echo "$output" | grep -q "parallel_records(record, \[process_a, process_b\])" && \
+       ! echo "$output" | grep -q "parallel_records_ordered(record, \[process_a, process_b\])"; then
+        log_pass "Python unordered parallel compiles correctly"
+    else
+        log_fail "Python unordered parallel compilation failed"
+    fi
+}
+
+# Test 5: Go ordered parallel compilation
+test_go_ordered() {
+    log_info "Test 5: Go ordered parallel compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([
+            parse/1,
+            parallel([process_a/1, process_b/1], [ordered(true)]),
+            output/1
+        ], [pipeline_name(orderedTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "parallelRecordsOrdered" && \
+       echo "$output" | grep -q "indexedResults" && \
+       echo "$output" | grep -q "Parallel execution (ordered)"; then
+        log_pass "Go ordered parallel compiles correctly"
+    else
+        log_fail "Go ordered parallel compilation failed"
+    fi
+}
+
+# Test 6: Rust ordered parallel compilation
+test_rust_ordered() {
+    log_info "Test 6: Rust ordered parallel compilation"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([
+            parse/1,
+            parallel([process_a/1, process_b/1], [ordered(true)]),
+            output/1
+        ], [pipeline_name(ordered_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    if echo "$output" | grep -q "parallel_records_ordered" && \
+       echo "$output" | grep -q "indexed_results" && \
+       echo "$output" | grep -q "Parallel execution (ordered)"; then
+        log_pass "Rust ordered parallel compiles correctly"
+    else
+        log_fail "Rust ordered parallel compilation failed"
+    fi
+}
+
+# Test 7: ordered(false) uses unordered version
+test_ordered_false() {
+    log_info "Test 7: ordered(false) uses unordered version"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([
+            parse/1,
+            parallel([process_a/1, process_b/1], [ordered(false)]),
+            output/1
+        ], [pipeline_name(explicit_unordered)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    # Should use parallel_records (not ordered version)
+    if echo "$output" | grep -q "parallel_records(record, \[process_a, process_b\])" && \
+       ! echo "$output" | grep -q "parallel_records_ordered(record, \[process_a, process_b\])"; then
+        log_pass "ordered(false) correctly uses unordered version"
+    else
+        log_fail "ordered(false) did not use unordered version"
+    fi
+}
+
+# Test 8: Empty options list uses default (unordered)
+test_empty_options() {
+    log_info "Test 8: Empty options list uses default (unordered)"
+
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([
+            parse/1,
+            parallel([process_a/1, process_b/1], []),
+            output/1
+        ], [pipeline_name(empty_options)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+
+    # Should use parallel_records (not ordered version)
+    if echo "$output" | grep -q "parallel_records(record, \[process_a, process_b\])" && \
+       ! echo "$output" | grep -q "parallel_records_ordered(record, \[process_a, process_b\])"; then
+        log_pass "Empty options uses default unordered"
+    else
+        log_fail "Empty options did not use default unordered"
+    fi
+}
+
+# Main test runner
+main() {
+    echo "=========================================="
+    echo "  Parallel Result Ordering Tests"
+    echo "=========================================="
+    echo ""
+
+    test_validation_valid
+    test_validation_invalid_option
+    test_python_ordered
+    test_python_unordered
+    test_go_ordered
+    test_rust_ordered
+    test_ordered_false
+    test_empty_options
+
+    echo ""
+    echo "=========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "=========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds support for preserving stage definition order in parallel stage results via the `ordered(true)` option.

**Default behavior:** Results returned in completion order (fastest stage first)
**With `ordered(true)`:** Results returned in stage definition order

## Syntax

```prolog
% Unordered (default) - results in completion order
parallel([slow_stage/1, fast_stage/1])

% Ordered - results in stage definition order
parallel([slow_stage/1, fast_stage/1], [ordered(true)])
```

## Use Cases

- Downstream processing depends on result order
- Stage outputs must maintain predictable ordering
- Combining results with zip-like operations

## Changes

### Core Implementation

| Target | Helper Function | Mechanism |
|--------|-----------------|-----------|
| Python | `parallel_records_ordered` | Indexed futures with `ThreadPoolExecutor` |
| Go | `parallelRecordsOrdered` | Indexed goroutine results with `sync.WaitGroup` |
| Rust | `parallel_records_ordered` | Indexed results for both `std_thread` and `rayon` modes |

### Pipeline Validation (`pipeline_validation.pl`)
- Added `is_valid_stage(parallel(Stages, Options))`
- Added `validate_parallel_options/2` for option validation
- Invalid options detected with clear error messages

### Documentation (`ENHANCED_PIPELINE_CHAINING.md`)
- New "Ordered Parallel" section with syntax and examples
- Data flow diagrams showing ordered vs unordered behavior
- Generated code examples for Python and Go

## Files Changed

- `src/unifyweaver/targets/python_target.pl` - Ordered helper and flow generation
- `src/unifyweaver/targets/go_target.pl` - Ordered helper and flow generation
- `src/unifyweaver/targets/rust_target.pl` - Ordered helpers for both parallel modes
- `src/unifyweaver/core/pipeline_validation.pl` - Options validation
- `docs/ENHANCED_PIPELINE_CHAINING.md` - Documentation
- `CHANGELOG.md` - Updated changelog
- `tests/integration/test_parallel_ordered.sh` - Integration tests

## Test Plan

```bash
# Run ordered parallel tests
./tests/integration/test_parallel_ordered.sh
```

**Results: 8 passed, 0 failed**

| Test | Description |
|------|-------------|
| 1 | Validation accepts `parallel(Stages, [ordered(true)])` |
| 2 | Validation detects invalid parallel options |
| 3 | Python ordered parallel compilation |
| 4 | Python unordered parallel (default) compilation |
| 5 | Go ordered parallel compilation |
| 6 | Rust ordered parallel compilation |
| 7 | `ordered(false)` uses unordered version |
| 8 | Empty options list uses default (unordered) |

## Breaking Changes

None. This is a pure feature addition that's backwards compatible with existing `parallel(Stages)` syntax.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
