### PR TITLE
feat: Add pipeline aggregation stages for deduplication and grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_pipeline_validation.sh` — Integration tests
   - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
 
+- **Pipeline Aggregation Stages** - Deduplication and grouping at pipeline level
+  - Deduplication stages:
+    - `unique(Field)` — Keep first occurrence of each unique field value
+    - `first(Field)` — Alias for unique, keep first occurrence
+    - `last(Field)` — Keep last occurrence of each unique field value
+  - Grouping stage:
+    - `group_by(Field, Aggregations)` — Group records by field with aggregations
+    - Built-in aggregations: `count`, `sum(F)`, `avg(F)`, `min(F)`, `max(F)`, `first(F)`, `last(F)`, `collect(F)`
+  - Sequential processing:
+    - `reduce(Pred, Init)` — Fold all records into single result with custom reducer
+    - `scan(Pred, Init)` — Like reduce but emits intermediate results
+  - Supported targets: Python, Go, Rust
+  - `tests/integration/test_aggregation_stages.sh` — Integration tests (12 tests)
+  - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
+
 - **XML Data Source Playbook** - A new playbook for processing XML data.
   - `playbooks/xml_data_source_playbook.md` - The playbook itself.
   - `playbooks/examples_library/xml_examples.md` - The implementation of the playbook.

--- a/src/unifyweaver/core/pipeline_validation.pl
+++ b/src/unifyweaver/core/pipeline_validation.pl
@@ -161,6 +161,39 @@ is_valid_stage(filter_by(Pred)) :-
 is_valid_stage(batch(N)) :-
     integer(N).
 is_valid_stage(unbatch).
+% Aggregation stages
+is_valid_stage(unique(Field)) :-
+    atom(Field).
+is_valid_stage(first(Field)) :-
+    atom(Field).
+is_valid_stage(last(Field)) :-
+    atom(Field).
+is_valid_stage(group_by(Field, Agg)) :-
+    atom(Field),
+    is_valid_aggregation(Agg).
+is_valid_stage(reduce(Pred)) :-
+    atom(Pred).
+is_valid_stage(reduce(Pred, _Init)) :-
+    atom(Pred).
+is_valid_stage(scan(Pred)) :-
+    atom(Pred).
+is_valid_stage(scan(Pred, _Init)) :-
+    atom(Pred).
+
+%% is_valid_aggregation(+Agg) is semidet.
+%  Validates aggregation specification for group_by.
+is_valid_aggregation(count).
+is_valid_aggregation(sum(F)) :- atom(F).
+is_valid_aggregation(avg(F)) :- atom(F).
+is_valid_aggregation(min(F)) :- atom(F).
+is_valid_aggregation(max(F)) :- atom(F).
+is_valid_aggregation(first(F)) :- atom(F).
+is_valid_aggregation(last(F)) :- atom(F).
+is_valid_aggregation(collect(F)) :- atom(F).
+is_valid_aggregation(Aggs) :-
+    is_list(Aggs),
+    Aggs \= [],
+    maplist(is_valid_aggregation, Aggs).
 
 %% stage_type(+Stage, -Type) is det.
 %
@@ -175,6 +208,14 @@ stage_type(route_by(_, _), route_by) :- !.
 stage_type(filter_by(_), filter_by) :- !.
 stage_type(batch(_), batch) :- !.
 stage_type(unbatch, unbatch) :- !.
+stage_type(unique(_), unique) :- !.
+stage_type(first(_), first) :- !.
+stage_type(last(_), last) :- !.
+stage_type(group_by(_, _), group_by) :- !.
+stage_type(reduce(_), reduce) :- !.
+stage_type(reduce(_, _), reduce) :- !.
+stage_type(scan(_), scan) :- !.
+stage_type(scan(_, _), scan) :- !.
 stage_type(_, unknown).
 
 %% validate_stage_type(+Stage, -Type) is det.
@@ -215,6 +256,15 @@ validate_stage_specific(batch(N), Errors) :-
     !,
     validate_batch(batch(N), Errors).
 validate_stage_specific(unbatch, []) :- !.
+% Aggregation stages
+validate_stage_specific(unique(_), []) :- !.
+validate_stage_specific(first(_), []) :- !.
+validate_stage_specific(last(_), []) :- !.
+validate_stage_specific(group_by(_, _), []) :- !.
+validate_stage_specific(reduce(_), []) :- !.
+validate_stage_specific(reduce(_, _), []) :- !.
+validate_stage_specific(scan(_), []) :- !.
+validate_stage_specific(scan(_, _), []) :- !.
 validate_stage_specific(_, []).
 
 %% validate_batch(+BatchStage, -Errors) is det.

--- a/tests/integration/test_aggregation_stages.sh
+++ b/tests/integration/test_aggregation_stages.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# test_aggregation_stages.sh - Integration tests for pipeline aggregation stages
+# Tests unique, first, last, group_by, reduce, scan stages
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# Test 1: Validation accepts unique(Field)
+test_validation_unique() {
+    log_info "Test 1: Validation accepts unique(field)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, unique(user_id), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "unique(field) validation accepted"
+    else
+        log_fail "unique(field) validation failed: $output"
+    fi
+}
+
+# Test 2: Validation accepts group_by(Field, Agg)
+test_validation_group_by() {
+    log_info "Test 2: Validation accepts group_by(field, aggregations)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, group_by(category, [count, sum(amount)]), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "group_by validation accepted"
+    else
+        log_fail "group_by validation failed: $output"
+    fi
+}
+
+# Test 3: Validation accepts reduce(Pred, Init)
+test_validation_reduce() {
+    log_info "Test 3: Validation accepts reduce(pred, init)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, reduce(running_total, 0), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "reduce validation accepted"
+    else
+        log_fail "reduce validation failed: $output"
+    fi
+}
+
+# Test 4: Python unique compilation
+test_python_unique() {
+    log_info "Test 4: Python unique stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, unique(user_id), output/1], [pipeline_name(unique_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "unique_by_field" && \
+       echo "$output" | grep -q "Unique: keep first record"; then
+        log_pass "Python unique compiles correctly"
+    else
+        log_fail "Python unique compilation failed"
+    fi
+}
+
+# Test 5: Python group_by compilation
+test_python_group_by() {
+    log_info "Test 5: Python group_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, group_by(category, [count, sum(amount)]), output/1], [pipeline_name(groupby_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "group_by_field" && \
+       echo "$output" | grep -q "'count', 'count'" && \
+       echo "$output" | grep -q "'sum', 'sum', 'amount'"; then
+        log_pass "Python group_by compiles correctly"
+    else
+        log_fail "Python group_by compilation failed"
+    fi
+}
+
+# Test 6: Python reduce compilation
+test_python_reduce() {
+    log_info "Test 6: Python reduce stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, reduce(running_total, 0), output/1], [pipeline_name(reduce_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "reduce_records" && \
+       echo "$output" | grep -q "running_total, 0"; then
+        log_pass "Python reduce compiles correctly"
+    else
+        log_fail "Python reduce compilation failed"
+    fi
+}
+
+# Test 7: Go unique compilation
+test_go_unique() {
+    log_info "Test 7: Go unique stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, unique(user_id), output/1], [pipeline_name(uniqueTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "uniqueByField" && \
+       echo "$output" | grep -q "Unique: keep first record"; then
+        log_pass "Go unique compiles correctly"
+    else
+        log_fail "Go unique compilation failed"
+    fi
+}
+
+# Test 8: Go group_by compilation
+test_go_group_by() {
+    log_info "Test 8: Go group_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, group_by(category, [count, sum(amount)]), output/1], [pipeline_name(groupbyTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "groupByField" && \
+       echo "$output" | grep -q "Aggregation"; then
+        log_pass "Go group_by compiles correctly"
+    else
+        log_fail "Go group_by compilation failed"
+    fi
+}
+
+# Test 9: Rust unique compilation
+test_rust_unique() {
+    log_info "Test 9: Rust unique stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, unique(user_id), output/1], [pipeline_name(unique_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "unique_by_field" && \
+       echo "$output" | grep -q "Unique: keep first record"; then
+        log_pass "Rust unique compiles correctly"
+    else
+        log_fail "Rust unique compilation failed"
+    fi
+}
+
+# Test 10: Rust group_by compilation
+test_rust_group_by() {
+    log_info "Test 10: Rust group_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, group_by(category, [count, sum(amount)]), output/1], [pipeline_name(groupby_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "group_by_field" && \
+       echo "$output" | grep -q "AggType::Count" && \
+       echo "$output" | grep -q "AggType::Sum"; then
+        log_pass "Rust group_by compiles correctly"
+    else
+        log_fail "Rust group_by compilation failed"
+    fi
+}
+
+# Test 11: Python last stage
+test_python_last() {
+    log_info "Test 11: Python last stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, last(user_id), output/1], [pipeline_name(last_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "last_by_field" && \
+       echo "$output" | grep -q "Last: keep last record"; then
+        log_pass "Python last compiles correctly"
+    else
+        log_fail "Python last compilation failed"
+    fi
+}
+
+# Test 12: Python scan stage
+test_python_scan() {
+    log_info "Test 12: Python scan stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, scan(running_sum, 0), output/1], [pipeline_name(scan_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "scan_records" && \
+       echo "$output" | grep -q "Scan: running fold"; then
+        log_pass "Python scan compiles correctly"
+    else
+        log_fail "Python scan compilation failed"
+    fi
+}
+
+# Main test runner
+main() {
+    echo "=========================================="
+    echo "  Pipeline Aggregation Stages Tests"
+    echo "=========================================="
+    echo ""
+
+    test_validation_unique
+    test_validation_group_by
+    test_validation_reduce
+    test_python_unique
+    test_python_group_by
+    test_python_reduce
+    test_go_unique
+    test_go_group_by
+    test_rust_unique
+    test_rust_group_by
+    test_python_last
+    test_python_scan
+
+    echo ""
+    echo "=========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "=========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Implements pipeline-level aggregation stages across Python, Go, and Rust targets. These stages enable deduplication, grouping with aggregations, and custom sequential processing at the pipeline orchestration level.

### Deduplication Stages

| Stage | Description |
|-------|-------------|
| `unique(Field)` | Keep first occurrence of each unique field value |
| `first(Field)` | Alias for unique, keep first occurrence |
| `last(Field)` | Keep last occurrence of each unique field value |

### Grouping Stage

`group_by(Field, Aggregations)` - Group records by field with built-in aggregations:

| Aggregation | Description |
|-------------|-------------|
| `count` | Count records in group |
| `sum(F)` | Sum values of field F |
| `avg(F)` | Average values of field F |
| `min(F)` | Minimum value of field F |
| `max(F)` | Maximum value of field F |
| `first(F)` | First value of field F |
| `last(F)` | Last value of field F |
| `collect(F)` | Collect all values of field F into list |

### Sequential Processing

| Stage | Description |
|-------|-------------|
| `reduce(Pred, Init)` | Fold all records into single result with custom reducer |
| `scan(Pred, Init)` | Like reduce but emits intermediate results |

### Key Distinction

- **group_by aggregations**: Partition data by key, aggregate within each group (stateless between groups)
- **reduce/scan**: See ALL records in sequence order, maintain running state across entire stream

## Files Changed

- `src/unifyweaver/targets/python_target.pl` - Python helper functions and stage generation
- `src/unifyweaver/targets/go_target.pl` - Go helper functions with Aggregation struct
- `src/unifyweaver/targets/rust_target.pl` - Rust helper functions with AggType enum
- `src/unifyweaver/core/pipeline_validation.pl` - Validation for new stage types
- `docs/ENHANCED_PIPELINE_CHAINING.md` - Documentation section
- `CHANGELOG.md` - Feature entry
- `tests/integration/test_aggregation_stages.sh` - Integration tests (new)

## Test Plan

```bash
./tests/integration/test_aggregation_stages.sh
```

Results: **12 passed, 0 failed**

Tests cover:
- Validation accepts unique, group_by, reduce stages
- Python compilation for unique, group_by, reduce, last, scan
- Go compilation for unique, group_by
- Rust compilation for unique, group_by

## Example Usage

```prolog
% Deduplicate by user_id
pipeline([
    parse/1,
    unique(user_id),
    output/1
])

% Group by category with aggregations
pipeline([
    parse/1,
    group_by(category, [count, sum(amount), avg(price)]),
    output/1
])

% Running total with reduce
pipeline([
    parse/1,
    reduce(running_total, 0),
    output/1
])
```
