### PR TITLE
feat: Add pipeline sorting stages (order_by, sort_by)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_aggregation_stages.sh` — Integration tests (12 tests)
   - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
 
+- **Pipeline Sorting Stages** - Ordering records at pipeline level
+  - Field-based ordering:
+    - `order_by(Field)` — Sort by field ascending
+    - `order_by(Field, Dir)` — Sort by field with direction (asc/desc)
+    - `order_by(FieldSpecs)` — Sort by multiple fields with individual directions
+  - Custom comparator:
+    - `sort_by(ComparePred)` — Sort using user-defined comparison function
+  - Key distinction: `order_by` is declarative (fields), `sort_by` is programmatic (comparator)
+  - Supported targets: Python, Go, Rust
+  - `tests/integration/test_sorting_stages.sh` — Integration tests (12 tests)
+  - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
+
 - **XML Data Source Playbook** - A new playbook for processing XML data.
   - `playbooks/xml_data_source_playbook.md` - The playbook itself.
   - `playbooks/examples_library/xml_examples.md` - The implementation of the playbook.

--- a/src/unifyweaver/core/pipeline_validation.pl
+++ b/src/unifyweaver/core/pipeline_validation.pl
@@ -179,6 +179,28 @@ is_valid_stage(scan(Pred)) :-
     atom(Pred).
 is_valid_stage(scan(Pred, _Init)) :-
     atom(Pred).
+% Sorting stages
+is_valid_stage(order_by(Field)) :-
+    atom(Field).
+is_valid_stage(order_by(Field, Dir)) :-
+    atom(Field),
+    is_valid_direction(Dir).
+is_valid_stage(order_by(FieldSpecs)) :-
+    is_list(FieldSpecs),
+    FieldSpecs \= [],
+    maplist(is_valid_field_spec, FieldSpecs).
+is_valid_stage(sort_by(ComparePred)) :-
+    atom(ComparePred).
+
+%% is_valid_direction(+Dir) is semidet.
+%  Validates sort direction.
+is_valid_direction(asc).
+is_valid_direction(desc).
+
+%% is_valid_field_spec(+Spec) is semidet.
+%  Validates field specification for multi-field ordering.
+is_valid_field_spec(Field) :- atom(Field), !.
+is_valid_field_spec((Field, Dir)) :- atom(Field), is_valid_direction(Dir).
 
 %% is_valid_aggregation(+Agg) is semidet.
 %  Validates aggregation specification for group_by.
@@ -216,6 +238,9 @@ stage_type(reduce(_), reduce) :- !.
 stage_type(reduce(_, _), reduce) :- !.
 stage_type(scan(_), scan) :- !.
 stage_type(scan(_, _), scan) :- !.
+stage_type(order_by(_), order_by) :- !.
+stage_type(order_by(_, _), order_by) :- !.
+stage_type(sort_by(_), sort_by) :- !.
 stage_type(_, unknown).
 
 %% validate_stage_type(+Stage, -Type) is det.
@@ -265,6 +290,10 @@ validate_stage_specific(reduce(_), []) :- !.
 validate_stage_specific(reduce(_, _), []) :- !.
 validate_stage_specific(scan(_), []) :- !.
 validate_stage_specific(scan(_, _), []) :- !.
+% Sorting stages
+validate_stage_specific(order_by(_), []) :- !.
+validate_stage_specific(order_by(_, _), []) :- !.
+validate_stage_specific(sort_by(_), []) :- !.
 validate_stage_specific(_, []).
 
 %% validate_batch(+BatchStage, -Errors) is det.

--- a/tests/integration/test_sorting_stages.sh
+++ b/tests/integration/test_sorting_stages.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# test_sorting_stages.sh - Integration tests for pipeline sorting stages
+# Tests order_by and sort_by stages
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# Test 1: Validation accepts order_by(field)
+test_validation_order_by_simple() {
+    log_info "Test 1: Validation accepts order_by(field)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, order_by(timestamp), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "order_by(field) validation accepted"
+    else
+        log_fail "order_by(field) validation failed: $output"
+    fi
+}
+
+# Test 2: Validation accepts order_by(field, direction)
+test_validation_order_by_direction() {
+    log_info "Test 2: Validation accepts order_by(field, direction)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, order_by(timestamp, desc), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "order_by(field, direction) validation accepted"
+    else
+        log_fail "order_by(field, direction) validation failed: $output"
+    fi
+}
+
+# Test 3: Validation accepts order_by(list)
+test_validation_order_by_list() {
+    log_info "Test 3: Validation accepts order_by(field_list)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, order_by([(timestamp, desc), (user_id, asc)]), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "order_by(field_list) validation accepted"
+    else
+        log_fail "order_by(field_list) validation failed: $output"
+    fi
+}
+
+# Test 4: Validation accepts sort_by(pred)
+test_validation_sort_by() {
+    log_info "Test 4: Validation accepts sort_by(comparator)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, sort_by(compare_priority), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "sort_by(comparator) validation accepted"
+    else
+        log_fail "sort_by(comparator) validation failed: $output"
+    fi
+}
+
+# Test 5: Python order_by compilation
+test_python_order_by() {
+    log_info "Test 5: Python order_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, order_by(timestamp), output/1], [pipeline_name(order_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "order_by_field" && \
+       echo "$output" | grep -q "Order by"; then
+        log_pass "Python order_by compiles correctly"
+    else
+        log_fail "Python order_by compilation failed"
+    fi
+}
+
+# Test 6: Python order_by with direction compilation
+test_python_order_by_direction() {
+    log_info "Test 6: Python order_by with direction compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, order_by(timestamp, desc), output/1], [pipeline_name(order_desc_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "order_by_field" && \
+       echo "$output" | grep -q "desc"; then
+        log_pass "Python order_by with direction compiles correctly"
+    else
+        log_fail "Python order_by with direction compilation failed"
+    fi
+}
+
+# Test 7: Python sort_by compilation
+test_python_sort_by() {
+    log_info "Test 7: Python sort_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, sort_by(compare_priority), output/1], [pipeline_name(sort_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "sort_by_comparator" && \
+       echo "$output" | grep -q "compare_priority"; then
+        log_pass "Python sort_by compiles correctly"
+    else
+        log_fail "Python sort_by compilation failed"
+    fi
+}
+
+# Test 8: Go order_by compilation
+test_go_order_by() {
+    log_info "Test 8: Go order_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, order_by(timestamp), output/1], [pipeline_name(orderTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "orderByField" && \
+       echo "$output" | grep -q "Order by"; then
+        log_pass "Go order_by compiles correctly"
+    else
+        log_fail "Go order_by compilation failed"
+    fi
+}
+
+# Test 9: Go sort_by compilation
+test_go_sort_by() {
+    log_info "Test 9: Go sort_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, sort_by(comparePriority), output/1], [pipeline_name(sortTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "sortByComparator" && \
+       echo "$output" | grep -q "comparePriority"; then
+        log_pass "Go sort_by compiles correctly"
+    else
+        log_fail "Go sort_by compilation failed"
+    fi
+}
+
+# Test 10: Rust order_by compilation
+test_rust_order_by() {
+    log_info "Test 10: Rust order_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, order_by(timestamp), output/1], [pipeline_name(order_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "order_by_field" && \
+       echo "$output" | grep -q "Order by"; then
+        log_pass "Rust order_by compiles correctly"
+    else
+        log_fail "Rust order_by compilation failed"
+    fi
+}
+
+# Test 11: Rust sort_by compilation
+test_rust_sort_by() {
+    log_info "Test 11: Rust sort_by stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, sort_by(compare_priority), output/1], [pipeline_name(sort_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "sort_by_comparator" && \
+       echo "$output" | grep -q "compare_priority"; then
+        log_pass "Rust sort_by compiles correctly"
+    else
+        log_fail "Rust sort_by compilation failed"
+    fi
+}
+
+# Test 12: Python multi-field order_by compilation
+test_python_order_by_multi() {
+    log_info "Test 12: Python multi-field order_by compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, order_by([(timestamp, desc), (user_id, asc)]), output/1], [pipeline_name(multi_order_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "order_by_fields" && \
+       echo "$output" | grep -q "timestamp" && \
+       echo "$output" | grep -q "user_id"; then
+        log_pass "Python multi-field order_by compiles correctly"
+    else
+        log_fail "Python multi-field order_by compilation failed"
+    fi
+}
+
+# Main test runner
+main() {
+    echo "=========================================="
+    echo "  Pipeline Sorting Stages Tests"
+    echo "=========================================="
+    echo ""
+
+    test_validation_order_by_simple
+    test_validation_order_by_direction
+    test_validation_order_by_list
+    test_validation_sort_by
+    test_python_order_by
+    test_python_order_by_direction
+    test_python_sort_by
+    test_go_order_by
+    test_go_sort_by
+    test_rust_order_by
+    test_rust_sort_by
+    test_python_order_by_multi
+
+    echo ""
+    echo "=========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "=========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Implements pipeline-level sorting stages across Python, Go, and Rust targets. These stages enable ordering records by field values or custom comparison logic at the pipeline orchestration level.

### Field-Based Ordering

| Stage | Description |
|-------|-------------|
| `order_by(Field)` | Sort by field ascending (default) |
| `order_by(Field, Dir)` | Sort by field with direction (asc/desc) |
| `order_by(FieldSpecs)` | Sort by multiple fields with individual directions |

```prolog
% Single field
order_by(timestamp)
order_by(timestamp, desc)

% Multiple fields
order_by([(category, asc), (price, desc)])
```

### Custom Comparator

| Stage | Description |
|-------|-------------|
| `sort_by(ComparePred)` | Sort using user-defined comparison function |

The comparator function receives two records and returns:
- `-1` (or negative) if first record comes before second
- `0` if records are equal
- `1` (or positive) if first record comes after second

```prolog
sort_by(compare_priority)
```

### Key Distinction

- **`order_by`**: Declarative - specify which fields to sort by
- **`sort_by`**: Programmatic - specify a comparison function

This mirrors the user's observation: a key extractor can be achieved with a view + order_by, but a custom comparator provides genuinely different capability.

## Files Changed

- `src/unifyweaver/targets/python_target.pl` - Python helpers and stage generation
- `src/unifyweaver/targets/go_target.pl` - Go helpers with FieldSpec struct
- `src/unifyweaver/targets/rust_target.pl` - Rust helpers with compare_values function
- `src/unifyweaver/core/pipeline_validation.pl` - Validation for new stage types
- `docs/ENHANCED_PIPELINE_CHAINING.md` - Sorting Stages documentation section
- `CHANGELOG.md` - Feature entry
- `tests/integration/test_sorting_stages.sh` - Integration tests (new)

## Test Plan

```bash
./tests/integration/test_sorting_stages.sh
```

Results: **12 passed, 0 failed**

Tests cover:
- Validation accepts order_by(field), order_by(field, dir), order_by(list), sort_by(pred)
- Python compilation for order_by, order_by with direction, sort_by, multi-field order_by
- Go compilation for order_by, sort_by
- Rust compilation for order_by, sort_by

## Example Usage

```prolog
% Sort by timestamp descending
compile_enhanced_pipeline([
    parse/1,
    order_by(timestamp, desc),
    output/1
], [pipeline_name(sorted_by_time)], Code).

% Multi-field sort: department asc, then salary desc
compile_enhanced_pipeline([
    parse/1,
    order_by([(department, asc), (salary, desc)]),
    output/1
], [pipeline_name(sorted_employees)], Code).

% Custom comparator for complex sorting logic
compile_enhanced_pipeline([
    parse/1,
    sort_by(compare_priority),
    output/1
], [pipeline_name(priority_sorted)], Code).
```

## Implementation Notes

- All sorting stages buffer records before sorting (necessary for comparison-based sorts)
- Null/None values sort to the end by default
- Multi-field ordering uses lexicographic comparison with per-field direction control
- Python uses `functools.cmp_to_key` for comparator support
- Go uses `sort.Slice` with custom less function
- Rust uses `Vec::sort_by` with `std::cmp::Ordering`
