### PR TITLE
at(lda): Add SQLite database for embeddings, projections, and Q-A mappings

### DIFF
--- a/docs/proposals/LDA_DATABASE_SCHEMA.md
+++ b/docs/proposals/LDA_DATABASE_SCHEMA.md
@@ -1,0 +1,350 @@
+# Proposal: LDA Projection Database Schema
+
+## Overview
+
+Store embeddings, transformations, and Q-A mappings in a database to enable agents to find useful playbook examples via semantic search with learned projections.
+
+## Use Case
+
+1. Agent receives a task description
+2. System embeds the task as a query (input model)
+3. Projects query using learned W matrix
+4. Compares to answer embeddings (output model)
+5. Returns most similar playbook examples
+
+## Asymmetric Embeddings
+
+Different models can be used for queries vs answers:
+
+| Role | Typical Length | Example Model | Dimension |
+|------|----------------|---------------|-----------|
+| Input (queries) | Short (2-50 words) | all-MiniLM-L6-v2 | 384 |
+| Output (answers) | Long (100-1000+ words) | ModernBERT | 1024 |
+
+The projection W transforms from input space to output space:
+```
+W: ℝ^(input_dim) → ℝ^(output_dim)
+W shape: (output_dim, input_dim)
+
+projected_query = W @ query_embedding  # (output_dim,)
+similarity = projected_query · answer_embedding
+```
+
+This allows:
+- Fast, lightweight model for queries
+- High-capacity model for long documents
+- W learns the cross-space mapping
+
+## Schema
+
+### Core Tables
+
+```sql
+-- Answer documents (playbook examples)
+-- Supports hierarchy: chunks reference parent documents
+CREATE TABLE answers (
+    answer_id INTEGER PRIMARY KEY,
+    parent_id INTEGER REFERENCES answers(answer_id),  -- NULL for root documents
+    source_file TEXT NOT NULL,           -- e.g., "playbooks/examples_library/csv_examples.md"
+    record_id TEXT,                       -- e.g., "unifyweaver.execution.csv_data_source"
+    text TEXT NOT NULL,                   -- answer text (may vary by model)
+    text_variant TEXT DEFAULT 'default',  -- 'default', 'short', 'long', or model name
+    chunk_index INTEGER,                  -- position within parent (NULL for root)
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Answer relationships (graph structure)
+CREATE TABLE answer_relations (
+    relation_id INTEGER PRIMARY KEY,
+    from_answer_id INTEGER REFERENCES answers(answer_id),
+    to_answer_id INTEGER REFERENCES answers(answer_id),
+    relation_type TEXT NOT NULL,
+    metadata TEXT,                        -- JSON for extra info
+    UNIQUE(from_answer_id, to_answer_id, relation_type)
+);
+
+-- Relation types:
+--
+-- Hierarchy:
+--   'chunk_of'     - this is a chunk of the target (chunk → full doc)
+--   'summarizes'   - this summarizes the target (summary → full doc)
+--   'abbreviates'  - abbreviated version (short → long)
+--
+-- Sequence:
+--   'next_chunk'   - next chunk in sequence (chunk N → chunk N+1)
+--   'prev_chunk'   - previous chunk (chunk N → chunk N-1)
+--
+-- Variants:
+--   'variant_of'   - same content, different text (model-specific)
+--   'translates'   - language translation (EN → FR, etc.)
+--                    metadata: {"from_lang": "en", "to_lang": "fr"}
+--
+-- Semantic:
+--   'related_to'   - semantically related but distinct
+--   'see_also'     - cross-reference
+--   'supersedes'   - newer version replaces older
+--
+-- Examples:
+--   (2, 1, 'chunk_of')      - answer 2 is a chunk of answer 1
+--   (3, 2, 'next_chunk')    - answer 3 follows answer 2 in sequence
+--   (4, 1, 'summarizes')    - answer 4 is a summary of answer 1
+--   (5, 1, 'translates', {"from_lang": "en", "to_lang": "es"})
+--   (6, 1, 'variant_of')    - answer 6 is a ModernBERT-optimized variant
+
+CREATE INDEX idx_relations_from ON answer_relations(from_answer_id);
+CREATE INDEX idx_relations_to ON answer_relations(to_answer_id);
+CREATE INDEX idx_relations_type ON answer_relations(relation_type);
+
+-- Query questions
+CREATE TABLE questions (
+    question_id INTEGER PRIMARY KEY,
+    text TEXT NOT NULL,
+    length_type TEXT CHECK(length_type IN ('short', 'medium', 'long')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Q-A cluster mappings
+CREATE TABLE qa_clusters (
+    cluster_id INTEGER PRIMARY KEY,
+    name TEXT,                            -- e.g., "csv_data_source"
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE cluster_answers (
+    cluster_id INTEGER REFERENCES qa_clusters(cluster_id),
+    answer_id INTEGER REFERENCES answers(answer_id),
+    PRIMARY KEY (cluster_id, answer_id)
+);
+
+CREATE TABLE cluster_questions (
+    cluster_id INTEGER REFERENCES qa_clusters(cluster_id),
+    question_id INTEGER REFERENCES questions(question_id),
+    PRIMARY KEY (cluster_id, question_id)
+);
+```
+
+### Embedding Tables
+
+```sql
+-- Embedding models
+CREATE TABLE embedding_models (
+    model_id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,            -- e.g., "all-MiniLM-L6-v2"
+    dimension INTEGER NOT NULL,           -- e.g., 384
+    backend TEXT,                         -- 'python', 'rust', 'go'
+    max_tokens INTEGER,
+    notes TEXT
+);
+
+-- Stored embeddings
+CREATE TABLE embeddings (
+    embedding_id INTEGER PRIMARY KEY,
+    model_id INTEGER REFERENCES embedding_models(model_id),
+    entity_type TEXT CHECK(entity_type IN ('answer', 'question')),
+    entity_id INTEGER,                    -- references answers or questions
+    vector BLOB NOT NULL,                 -- numpy array serialized
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(model_id, entity_type, entity_id)
+);
+
+-- Index for fast lookup
+CREATE INDEX idx_embeddings_entity ON embeddings(model_id, entity_type, entity_id);
+```
+
+### Projection Tables
+
+```sql
+-- Trained W matrices
+-- W transforms from input embedding space to output embedding space
+-- Shape: (output_dim, input_dim)
+CREATE TABLE projections (
+    projection_id INTEGER PRIMARY KEY,
+    input_model_id INTEGER REFERENCES embedding_models(model_id),   -- for questions
+    output_model_id INTEGER REFERENCES embedding_models(model_id),  -- for answers
+    name TEXT,                            -- e.g., "v1_playbook_examples"
+    W_matrix BLOB NOT NULL,               -- numpy array (output_dim × input_dim)
+    lambda_reg REAL,
+    ridge REAL,
+    num_clusters INTEGER,
+    num_queries INTEGER,
+    -- Evaluation metrics
+    recall_at_1 REAL,
+    mrr REAL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Note: When input_model_id == output_model_id, W is square (d × d)
+-- When different, W is rectangular (d_out × d_in)
+-- Example: input=all-MiniLM-L6-v2 (384), output=ModernBERT (1024)
+--          W shape = (1024, 384)
+
+-- Track which clusters were used for training
+CREATE TABLE projection_clusters (
+    projection_id INTEGER REFERENCES projections(projection_id),
+    cluster_id INTEGER REFERENCES qa_clusters(cluster_id),
+    PRIMARY KEY (projection_id, cluster_id)
+);
+```
+
+### Query Log (for continuous improvement)
+
+```sql
+-- Log queries for future training data
+CREATE TABLE query_log (
+    log_id INTEGER PRIMARY KEY,
+    query_text TEXT NOT NULL,
+    model_id INTEGER REFERENCES embedding_models(model_id),
+    projection_id INTEGER REFERENCES projections(projection_id),
+    results TEXT,                         -- JSON array of answer_ids
+    selected_answer_id INTEGER,           -- which one the agent used
+    was_helpful BOOLEAN,                  -- feedback
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## Storage Options
+
+### Option 1: SQLite + numpy files
+
+Simple, portable:
+- SQLite for metadata and mappings
+- `.npy` files for large vectors/matrices
+- `vector BLOB` stores path to file
+
+### Option 2: SQLite with sqlite-vss
+
+Vector similarity search built-in:
+- Uses sqlite-vss extension
+- Can do `SELECT * FROM embeddings WHERE vss_search(vector, ?)`
+- More complex setup
+
+### Option 3: DuckDB
+
+Analytical queries, good numpy integration:
+- Native array types
+- Fast aggregations
+- Parquet export
+
+**Recommendation**: Start with Option 1 (SQLite + numpy), migrate to Option 2 if vector search becomes a bottleneck.
+
+## API Design
+
+```python
+class LDAProjectionDB:
+    def __init__(self, db_path: str, embeddings_dir: str):
+        ...
+
+    # Answers
+    def add_answer(self, source_file: str, text: str, record_id: str = None) -> int:
+        ...
+
+    # Questions
+    def add_question(self, text: str, length_type: str = 'medium') -> int:
+        ...
+
+    # Clusters
+    def create_cluster(self, name: str, answer_ids: List[int], question_ids: List[int]) -> int:
+        ...
+
+    # Embeddings
+    def embed_and_store(self, model_name: str, entity_type: str, entity_id: int) -> np.ndarray:
+        ...
+
+    def get_embedding(self, model_name: str, entity_type: str, entity_id: int) -> np.ndarray:
+        ...
+
+    # Projections
+    def train_projection(self, model_name: str, cluster_ids: List[int], name: str = None) -> int:
+        ...
+
+    def get_projection(self, projection_id: int) -> Tuple[np.ndarray, dict]:
+        ...
+
+    # Search
+    def search(self, query_text: str, projection_id: int, top_k: int = 5) -> List[dict]:
+        """
+        1. Get projection (includes input_model, output_model, W)
+        2. Embed query with input_model
+        3. Apply projection: projected = W @ query_embedding
+        4. Compare to answer embeddings (already stored with output_model)
+        5. Return top-k with metadata
+        """
+        ...
+
+    # Graph traversal
+    def get_related(self, answer_id: int, relation_type: str = None) -> List[dict]:
+        """Get answers related to this one (optionally filter by type)."""
+        ...
+
+    def get_full_version(self, answer_id: int) -> Optional[dict]:
+        """Follow 'chunk_of', 'summarizes', 'abbreviates' to find full doc."""
+        ...
+
+    def get_variants(self, answer_id: int) -> List[dict]:
+        """Get all variants (different text representations)."""
+        ...
+
+    def add_relation(self, from_id: int, to_id: int, relation_type: str, metadata: dict = None):
+        """Create a relation between answers."""
+        ...
+
+    # Feedback
+    def log_query(self, query_text: str, results: List[int], selected: int = None, helpful: bool = None):
+        ...
+```
+
+## Example Usage
+
+```python
+db = LDAProjectionDB("playbooks/lda-training-data/lda.db", "playbooks/lda-training-data/embeddings")
+
+# Add training data
+a1 = db.add_answer("playbooks/examples_library/csv_examples.md", "CSV source: source(csv, ...")
+q1 = db.add_question("How do I read CSV files?", "medium")
+q2 = db.add_question("csv data loading", "short")
+
+c1 = db.create_cluster("csv_data_source", [a1], [q1, q2])
+
+# Train
+proj_id = db.train_projection("all-MiniLM-L6-v2", [c1], name="v1")
+
+# Search
+results = db.search(
+    "I need to load tabular data from a file",
+    model_name="all-MiniLM-L6-v2",
+    projection_id=proj_id,
+    top_k=3
+)
+# Returns: [{"answer_id": 1, "source_file": "...", "score": 0.95, ...}, ...]
+```
+
+## Migration Path
+
+1. **Phase 1**: Create schema and basic CRUD
+2. **Phase 2**: Import existing `qa_pairs_v1.json` into database
+3. **Phase 3**: Update training script to use database
+4. **Phase 4**: Add search API for agents
+5. **Phase 5**: Add query logging for continuous learning
+
+## Integration with Agents
+
+```prolog
+% Prolog interface
+find_examples(TaskDescription, TopK, Examples) :-
+    invoke_component(runtime, lda_search,
+        search(TaskDescription, TopK),
+        results(Examples)).
+```
+
+Or via MCP tool for Claude:
+```json
+{
+  "name": "find_playbook_examples",
+  "description": "Find relevant playbook examples for a task",
+  "parameters": {
+    "task_description": "string",
+    "top_k": "integer"
+  }
+}
+```

--- a/scripts/migrate_to_lda_db.py
+++ b/scripts/migrate_to_lda_db.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Migration script: Import qa_pairs_v1.json into LDA database
+
+"""
+Migrate existing Q-A pairs to SQLite database.
+
+This script:
+1. Creates the database schema
+2. Imports answers and questions from qa_pairs_v1.json
+3. Creates clusters linking them
+4. Embeds everything with sentence-transformers
+5. Trains and stores the projection matrix
+"""
+
+import sys
+import json
+from pathlib import Path
+import argparse
+
+import numpy as np
+
+# Add paths
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src" / "unifyweaver" / "targets" / "python_runtime"))
+
+from lda_database import LDAProjectionDB
+from projection import compute_W
+
+
+def load_qa_pairs(path: str) -> dict:
+    """Load Q-A pairs from JSON file."""
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def import_to_database(db: LDAProjectionDB, qa_data: dict, model_name: str = "all-MiniLM-L6-v2"):
+    """Import Q-A pairs into database.
+
+    Returns:
+        List of (cluster_id, answer_ids, question_ids) tuples
+    """
+    clusters_info = []
+
+    for cluster_data in qa_data['clusters']:
+        cluster_id_name = cluster_data['id']
+        source_file = cluster_data.get('answer_source', 'unknown')
+
+        print(f"\n  Importing cluster: {cluster_id_name}")
+
+        # Add answers (one per model variant)
+        answer_ids = []
+        answers_dict = cluster_data['answers']
+
+        # First add the default answer
+        default_text = answers_dict.get('default', '')
+        if default_text:
+            aid = db.add_answer(
+                source_file=source_file,
+                text=default_text,
+                record_id=cluster_id_name,
+                text_variant='default'
+            )
+            answer_ids.append(aid)
+            print(f"    Added default answer: id={aid}")
+
+        # Add model-specific variants as related answers
+        for model, text in answers_dict.items():
+            if model != 'default' and model == model_name:
+                # This is the primary answer for our target model
+                aid = db.add_answer(
+                    source_file=source_file,
+                    text=text,
+                    record_id=cluster_id_name,
+                    text_variant=model
+                )
+                # Link as variant of default
+                if answer_ids:
+                    db.add_relation(aid, answer_ids[0], 'variant_of')
+                answer_ids.append(aid)
+                print(f"    Added {model} variant: id={aid}")
+
+        # Add questions
+        question_ids = []
+        queries = cluster_data['queries']
+
+        for length_type, query_list in queries.items():
+            for query_text in query_list:
+                qid = db.add_question(
+                    text=query_text,
+                    length_type=length_type
+                )
+                question_ids.append(qid)
+
+        print(f"    Added {len(question_ids)} questions")
+
+        # Create cluster
+        cluster_id = db.create_cluster(
+            name=cluster_id_name,
+            answer_ids=answer_ids,
+            question_ids=question_ids,
+            description=f"Q-A cluster for {cluster_id_name}"
+        )
+
+        clusters_info.append((cluster_id, answer_ids, question_ids))
+        print(f"    Created cluster: id={cluster_id}")
+
+    return clusters_info
+
+
+def embed_all(db: LDAProjectionDB, model_name: str, clusters_info: list):
+    """Embed all answers and questions."""
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        print("ERROR: sentence-transformers not installed")
+        print("  pip install sentence-transformers")
+        return None
+
+    print(f"\nLoading embedding model: {model_name}")
+    embedder = SentenceTransformer(model_name)
+    dimension = embedder.get_sentence_embedding_dimension()
+
+    # Register model
+    model_id = db.add_model(
+        name=model_name,
+        dimension=dimension,
+        backend='python',
+        max_tokens=256,
+        notes='sentence-transformers'
+    )
+    print(f"  Registered model: id={model_id}, dim={dimension}")
+
+    # Embed answers
+    print("\nEmbedding answers...")
+    all_answers = set()
+    for cluster_id, answer_ids, question_ids in clusters_info:
+        all_answers.update(answer_ids)
+
+    for aid in all_answers:
+        answer = db.get_answer(aid)
+        if answer:
+            emb = embedder.encode(answer['text'], convert_to_numpy=True)
+            db.store_embedding(model_id, 'answer', aid, emb)
+    print(f"  Embedded {len(all_answers)} answers")
+
+    # Embed questions
+    print("Embedding questions...")
+    all_questions = set()
+    for cluster_id, answer_ids, question_ids in clusters_info:
+        all_questions.update(question_ids)
+
+    for qid in all_questions:
+        question = db.get_question(qid)
+        if question:
+            emb = embedder.encode(question['text'], convert_to_numpy=True)
+            db.store_embedding(model_id, 'question', qid, emb)
+    print(f"  Embedded {len(all_questions)} questions")
+
+    return model_id, embedder
+
+
+def train_projection(db: LDAProjectionDB, model_id: int, clusters_info: list, lambda_reg: float = 1.0, ridge: float = 1e-6):
+    """Train and store projection matrix."""
+    print("\nTraining projection matrix...")
+
+    # Build clusters in format expected by compute_W
+    # Format: List of (answer_embedding, question_embeddings_matrix)
+    training_clusters = []
+    cluster_ids = []
+
+    for cluster_id, answer_ids, question_ids in clusters_info:
+        # Get answer embeddings (use first one for the cluster)
+        answer_emb = None
+        for aid in answer_ids:
+            emb = db.get_embedding(model_id, 'answer', aid)
+            if emb is not None:
+                answer_emb = emb
+                break
+
+        if answer_emb is None:
+            print(f"  Warning: No answer embedding for cluster {cluster_id}")
+            continue
+
+        # Get question embeddings
+        q_embs = []
+        for qid in question_ids:
+            emb = db.get_embedding(model_id, 'question', qid)
+            if emb is not None:
+                q_embs.append(emb)
+
+        if not q_embs:
+            print(f"  Warning: No question embeddings for cluster {cluster_id}")
+            continue
+
+        training_clusters.append((answer_emb, np.array(q_embs)))
+        cluster_ids.append(cluster_id)
+
+    if not training_clusters:
+        print("  ERROR: No valid training clusters")
+        return None
+
+    print(f"  Training with {len(training_clusters)} clusters")
+
+    # Compute W matrix
+    W = compute_W(training_clusters, lambda_reg=lambda_reg, ridge=ridge)
+    print(f"  W shape: {W.shape}")
+
+    # Calculate metrics
+    total_queries = sum(len(q_embs) for _, q_embs in training_clusters)
+    correct = 0
+    ranks = []
+
+    answer_embs = np.array([a for a, _ in training_clusters])
+    answer_norms = np.linalg.norm(answer_embs, axis=1, keepdims=True)
+    answer_embs_normed = answer_embs / answer_norms
+
+    for i, (_, q_embs) in enumerate(training_clusters):
+        for q in q_embs:
+            projected = W @ q
+            proj_norm = np.linalg.norm(projected)
+            if proj_norm > 0:
+                projected = projected / proj_norm
+
+            sims = answer_embs_normed @ projected
+            ranking = np.argsort(-sims)
+            rank = np.where(ranking == i)[0][0] + 1
+
+            if rank == 1:
+                correct += 1
+            ranks.append(1.0 / rank)
+
+    recall_at_1 = correct / total_queries
+    mrr = np.mean(ranks)
+
+    print(f"  Recall@1: {recall_at_1:.2%}")
+    print(f"  MRR: {mrr:.4f}")
+
+    # Store projection (symmetric: same model for input and output)
+    projection_id = db.store_projection(
+        input_model_id=model_id,
+        output_model_id=model_id,
+        W=W,
+        name="v1_from_migration",
+        cluster_ids=cluster_ids,
+        lambda_reg=lambda_reg,
+        ridge=ridge,
+        metrics={
+            'num_clusters': len(training_clusters),
+            'total_queries': total_queries,
+            'recall_at_1': recall_at_1,
+            'mrr': mrr
+        }
+    )
+
+    print(f"  Stored projection: id={projection_id}")
+    return projection_id
+
+
+def test_search(db: LDAProjectionDB, projection_id: int, embedder):
+    """Test the search API with a novel query."""
+    print("\nTesting search API...")
+
+    test_queries = [
+        "How do I load data from a CSV file?",
+        "mutual recursion predicates",
+        "component registration system"
+    ]
+
+    for query in test_queries:
+        print(f"\n  Query: \"{query}\"")
+        results = db.search_with_embedder(
+            query_text=query,
+            projection_id=projection_id,
+            embedder=embedder,
+            top_k=3,
+            log=True
+        )
+
+        for i, r in enumerate(results):
+            print(f"    {i+1}. [{r['score']:.3f}] {r['record_id']}: {r['text'][:60]}...")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate Q-A pairs to LDA database")
+    parser.add_argument('--input', default='playbooks/lda-training-data/raw/qa_pairs_v1.json',
+                        help='Path to Q-A pairs JSON file')
+    parser.add_argument('--db', default='playbooks/lda-training-data/lda.db',
+                        help='Output database path')
+    parser.add_argument('--model', default='all-MiniLM-L6-v2',
+                        help='Embedding model name')
+    parser.add_argument('--lambda-reg', type=float, default=1.0,
+                        help='Lambda regularization')
+    parser.add_argument('--ridge', type=float, default=1e-6,
+                        help='Ridge regularization')
+    parser.add_argument('--skip-train', action='store_true',
+                        help='Skip projection training')
+    parser.add_argument('--skip-test', action='store_true',
+                        help='Skip search test')
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("LDA Database Migration")
+    print("=" * 60)
+
+    # Load Q-A pairs
+    print(f"\nLoading Q-A pairs from: {args.input}")
+    qa_data = load_qa_pairs(args.input)
+    print(f"  Found {len(qa_data['clusters'])} clusters")
+
+    # Create database
+    print(f"\nCreating database: {args.db}")
+    db = LDAProjectionDB(args.db)
+
+    # Import data
+    print("\nImporting data...")
+    clusters_info = import_to_database(db, qa_data, args.model)
+
+    # Embed
+    result = embed_all(db, args.model, clusters_info)
+    if result is None:
+        return 1
+    model_id, embedder = result
+
+    # Train projection
+    projection_id = None
+    if not args.skip_train:
+        projection_id = train_projection(
+            db, model_id, clusters_info,
+            lambda_reg=args.lambda_reg,
+            ridge=args.ridge
+        )
+
+    # Test search
+    if not args.skip_test and projection_id is not None:
+        test_search(db, projection_id, embedder)
+
+    # Print stats
+    print("\n" + "=" * 60)
+    print("Database Statistics")
+    print("=" * 60)
+    stats = db.get_stats()
+    for key, value in stats.items():
+        print(f"  {key}: {value}")
+
+    # Print query log
+    print("\nQuery Log:")
+    for log in db.get_query_log(limit=5):
+        print(f"  [{log['log_id']}] \"{log['query_text'][:50]}...\"")
+
+    db.close()
+    print("\nMigration complete!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/unifyweaver/targets/python_runtime/lda_database.py
+++ b/src/unifyweaver/targets/python_runtime/lda_database.py
@@ -1,0 +1,910 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# LDA Projection Database Layer
+
+"""
+SQLite database for storing embeddings, projections, and Q-A mappings.
+
+Supports:
+- Asymmetric embeddings (different models for input/output)
+- Hierarchical answers with graph relations
+- Multiple projection matrices per model pair
+- Query logging for continuous learning
+"""
+
+import sqlite3
+import json
+import os
+from pathlib import Path
+from typing import List, Dict, Any, Optional, Tuple
+from datetime import datetime
+
+import numpy as np
+
+
+class LDAProjectionDB:
+    """Database layer for LDA projection system."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, db_path: str, embeddings_dir: str = None):
+        """Initialize database connection.
+
+        Args:
+            db_path: Path to SQLite database file
+            embeddings_dir: Directory for storing large numpy arrays
+                           (defaults to same directory as db)
+        """
+        self.db_path = db_path
+        self.embeddings_dir = embeddings_dir or str(Path(db_path).parent / "embeddings")
+
+        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        os.makedirs(self.embeddings_dir, exist_ok=True)
+
+        self.conn = sqlite3.connect(db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self):
+        """Create tables if they don't exist."""
+        cursor = self.conn.cursor()
+
+        # Answers table
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS answers (
+                answer_id INTEGER PRIMARY KEY,
+                parent_id INTEGER REFERENCES answers(answer_id),
+                source_file TEXT NOT NULL,
+                record_id TEXT,
+                text TEXT NOT NULL,
+                text_variant TEXT DEFAULT 'default',
+                chunk_index INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Answer relations (graph)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS answer_relations (
+                relation_id INTEGER PRIMARY KEY,
+                from_answer_id INTEGER REFERENCES answers(answer_id),
+                to_answer_id INTEGER REFERENCES answers(answer_id),
+                relation_type TEXT NOT NULL,
+                metadata TEXT,
+                UNIQUE(from_answer_id, to_answer_id, relation_type)
+            )
+        """)
+
+        # Questions table
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS questions (
+                question_id INTEGER PRIMARY KEY,
+                text TEXT NOT NULL,
+                length_type TEXT CHECK(length_type IN ('short', 'medium', 'long')),
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Clusters
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS qa_clusters (
+                cluster_id INTEGER PRIMARY KEY,
+                name TEXT,
+                description TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS cluster_answers (
+                cluster_id INTEGER REFERENCES qa_clusters(cluster_id),
+                answer_id INTEGER REFERENCES answers(answer_id),
+                PRIMARY KEY (cluster_id, answer_id)
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS cluster_questions (
+                cluster_id INTEGER REFERENCES qa_clusters(cluster_id),
+                question_id INTEGER REFERENCES questions(question_id),
+                PRIMARY KEY (cluster_id, question_id)
+            )
+        """)
+
+        # Embedding models
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS embedding_models (
+                model_id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                dimension INTEGER NOT NULL,
+                backend TEXT,
+                max_tokens INTEGER,
+                notes TEXT
+            )
+        """)
+
+        # Embeddings
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS embeddings (
+                embedding_id INTEGER PRIMARY KEY,
+                model_id INTEGER REFERENCES embedding_models(model_id),
+                entity_type TEXT CHECK(entity_type IN ('answer', 'question')),
+                entity_id INTEGER,
+                vector_path TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(model_id, entity_type, entity_id)
+            )
+        """)
+
+        # Projections
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS projections (
+                projection_id INTEGER PRIMARY KEY,
+                input_model_id INTEGER REFERENCES embedding_models(model_id),
+                output_model_id INTEGER REFERENCES embedding_models(model_id),
+                name TEXT,
+                W_path TEXT NOT NULL,
+                lambda_reg REAL,
+                ridge REAL,
+                num_clusters INTEGER,
+                num_queries INTEGER,
+                recall_at_1 REAL,
+                mrr REAL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS projection_clusters (
+                projection_id INTEGER REFERENCES projections(projection_id),
+                cluster_id INTEGER REFERENCES qa_clusters(cluster_id),
+                PRIMARY KEY (projection_id, cluster_id)
+            )
+        """)
+
+        # Query log
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS query_log (
+                log_id INTEGER PRIMARY KEY,
+                query_text TEXT NOT NULL,
+                model_id INTEGER REFERENCES embedding_models(model_id),
+                projection_id INTEGER REFERENCES projections(projection_id),
+                results TEXT,
+                selected_answer_id INTEGER,
+                was_helpful BOOLEAN,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Indexes
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_embeddings_entity ON embeddings(model_id, entity_type, entity_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_relations_from ON answer_relations(from_answer_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_relations_to ON answer_relations(to_answer_id)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_relations_type ON answer_relations(relation_type)")
+
+        self.conn.commit()
+
+    def close(self):
+        """Close database connection."""
+        self.conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    # =========================================================================
+    # Answers
+    # =========================================================================
+
+    def add_answer(
+        self,
+        source_file: str,
+        text: str,
+        record_id: str = None,
+        text_variant: str = "default",
+        parent_id: int = None,
+        chunk_index: int = None
+    ) -> int:
+        """Add an answer document."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT INTO answers (source_file, text, record_id, text_variant, parent_id, chunk_index)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """, (source_file, text, record_id, text_variant, parent_id, chunk_index))
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def get_answer(self, answer_id: int) -> Optional[Dict]:
+        """Get answer by ID."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM answers WHERE answer_id = ?", (answer_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def find_answers(self, source_file: str = None, record_id: str = None) -> List[Dict]:
+        """Find answers matching criteria."""
+        cursor = self.conn.cursor()
+        conditions = []
+        params = []
+
+        if source_file:
+            conditions.append("source_file = ?")
+            params.append(source_file)
+        if record_id:
+            conditions.append("record_id = ?")
+            params.append(record_id)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        cursor.execute(f"SELECT * FROM answers WHERE {where}", params)
+        return [dict(row) for row in cursor.fetchall()]
+
+    # =========================================================================
+    # Relations
+    # =========================================================================
+
+    def add_relation(
+        self,
+        from_id: int,
+        to_id: int,
+        relation_type: str,
+        metadata: Dict = None
+    ) -> int:
+        """Create a relation between answers."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT OR REPLACE INTO answer_relations (from_answer_id, to_answer_id, relation_type, metadata)
+            VALUES (?, ?, ?, ?)
+        """, (from_id, to_id, relation_type, json.dumps(metadata) if metadata else None))
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def get_related(
+        self,
+        answer_id: int,
+        relation_type: str = None,
+        direction: str = "from"
+    ) -> List[Dict]:
+        """Get related answers.
+
+        Args:
+            answer_id: The answer to find relations for
+            relation_type: Filter by type (optional)
+            direction: 'from' (outgoing) or 'to' (incoming)
+        """
+        cursor = self.conn.cursor()
+
+        if direction == "from":
+            col = "from_answer_id"
+            other_col = "to_answer_id"
+        else:
+            col = "to_answer_id"
+            other_col = "from_answer_id"
+
+        if relation_type:
+            cursor.execute(f"""
+                SELECT ar.*, a.* FROM answer_relations ar
+                JOIN answers a ON ar.{other_col} = a.answer_id
+                WHERE ar.{col} = ? AND ar.relation_type = ?
+            """, (answer_id, relation_type))
+        else:
+            cursor.execute(f"""
+                SELECT ar.*, a.* FROM answer_relations ar
+                JOIN answers a ON ar.{other_col} = a.answer_id
+                WHERE ar.{col} = ?
+            """, (answer_id,))
+
+        return [dict(row) for row in cursor.fetchall()]
+
+    def get_full_version(self, answer_id: int) -> Optional[Dict]:
+        """Follow hierarchy relations to find the full document."""
+        current = self.get_answer(answer_id)
+        if not current:
+            return None
+
+        # Follow chunk_of, summarizes, abbreviates relations
+        hierarchy_types = ('chunk_of', 'summarizes', 'abbreviates')
+
+        visited = {answer_id}
+        while True:
+            related = self.get_related(answer_id, direction="from")
+            parent = None
+            for r in related:
+                if r['relation_type'] in hierarchy_types and r['answer_id'] not in visited:
+                    parent = r
+                    break
+
+            if not parent:
+                return current
+
+            answer_id = parent['answer_id']
+            visited.add(answer_id)
+            current = self.get_answer(answer_id)
+
+    # =========================================================================
+    # Questions
+    # =========================================================================
+
+    def add_question(self, text: str, length_type: str = "medium") -> int:
+        """Add a question."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT INTO questions (text, length_type)
+            VALUES (?, ?)
+        """, (text, length_type))
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def get_question(self, question_id: int) -> Optional[Dict]:
+        """Get question by ID."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM questions WHERE question_id = ?", (question_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    # =========================================================================
+    # Clusters
+    # =========================================================================
+
+    def create_cluster(
+        self,
+        name: str,
+        answer_ids: List[int],
+        question_ids: List[int],
+        description: str = None
+    ) -> int:
+        """Create a Q-A cluster."""
+        cursor = self.conn.cursor()
+
+        cursor.execute("""
+            INSERT INTO qa_clusters (name, description)
+            VALUES (?, ?)
+        """, (name, description))
+        cluster_id = cursor.lastrowid
+
+        for aid in answer_ids:
+            cursor.execute("""
+                INSERT INTO cluster_answers (cluster_id, answer_id)
+                VALUES (?, ?)
+            """, (cluster_id, aid))
+
+        for qid in question_ids:
+            cursor.execute("""
+                INSERT INTO cluster_questions (cluster_id, question_id)
+                VALUES (?, ?)
+            """, (cluster_id, qid))
+
+        self.conn.commit()
+        return cluster_id
+
+    def get_cluster(self, cluster_id: int) -> Optional[Dict]:
+        """Get cluster with its answers and questions."""
+        cursor = self.conn.cursor()
+
+        cursor.execute("SELECT * FROM qa_clusters WHERE cluster_id = ?", (cluster_id,))
+        cluster = cursor.fetchone()
+        if not cluster:
+            return None
+
+        result = dict(cluster)
+
+        cursor.execute("""
+            SELECT a.* FROM answers a
+            JOIN cluster_answers ca ON a.answer_id = ca.answer_id
+            WHERE ca.cluster_id = ?
+        """, (cluster_id,))
+        result['answers'] = [dict(row) for row in cursor.fetchall()]
+
+        cursor.execute("""
+            SELECT q.* FROM questions q
+            JOIN cluster_questions cq ON q.question_id = cq.question_id
+            WHERE cq.cluster_id = ?
+        """, (cluster_id,))
+        result['questions'] = [dict(row) for row in cursor.fetchall()]
+
+        return result
+
+    def list_clusters(self) -> List[Dict]:
+        """List all clusters."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM qa_clusters")
+        return [dict(row) for row in cursor.fetchall()]
+
+    # =========================================================================
+    # Embedding Models
+    # =========================================================================
+
+    def add_model(
+        self,
+        name: str,
+        dimension: int,
+        backend: str = None,
+        max_tokens: int = None,
+        notes: str = None
+    ) -> int:
+        """Register an embedding model."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT OR IGNORE INTO embedding_models (name, dimension, backend, max_tokens, notes)
+            VALUES (?, ?, ?, ?, ?)
+        """, (name, dimension, backend, max_tokens, notes))
+        self.conn.commit()
+
+        cursor.execute("SELECT model_id FROM embedding_models WHERE name = ?", (name,))
+        return cursor.fetchone()[0]
+
+    def get_model(self, name: str) -> Optional[Dict]:
+        """Get model by name."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM embedding_models WHERE name = ?", (name,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def get_model_by_id(self, model_id: int) -> Optional[Dict]:
+        """Get model by ID."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM embedding_models WHERE model_id = ?", (model_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    # =========================================================================
+    # Embeddings
+    # =========================================================================
+
+    def _embedding_path(self, model_id: int, entity_type: str, entity_id: int) -> str:
+        """Generate path for embedding numpy file."""
+        return os.path.join(
+            self.embeddings_dir,
+            f"{entity_type}_{entity_id}_model_{model_id}.npy"
+        )
+
+    def store_embedding(
+        self,
+        model_id: int,
+        entity_type: str,
+        entity_id: int,
+        vector: np.ndarray
+    ) -> int:
+        """Store an embedding vector."""
+        path = self._embedding_path(model_id, entity_type, entity_id)
+        np.save(path, vector)
+
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT OR REPLACE INTO embeddings (model_id, entity_type, entity_id, vector_path)
+            VALUES (?, ?, ?, ?)
+        """, (model_id, entity_type, entity_id, path))
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def get_embedding(
+        self,
+        model_id: int,
+        entity_type: str,
+        entity_id: int
+    ) -> Optional[np.ndarray]:
+        """Load an embedding vector."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT vector_path FROM embeddings
+            WHERE model_id = ? AND entity_type = ? AND entity_id = ?
+        """, (model_id, entity_type, entity_id))
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        return np.load(row['vector_path'])
+
+    def get_all_answer_embeddings(self, model_id: int) -> Tuple[List[int], np.ndarray]:
+        """Get all answer embeddings for a model.
+
+        Returns:
+            Tuple of (answer_ids, embedding_matrix)
+        """
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT entity_id, vector_path FROM embeddings
+            WHERE model_id = ? AND entity_type = 'answer'
+            ORDER BY entity_id
+        """, (model_id,))
+
+        ids = []
+        vectors = []
+        for row in cursor.fetchall():
+            ids.append(row['entity_id'])
+            vectors.append(np.load(row['vector_path']))
+
+        if not vectors:
+            return [], np.array([])
+
+        return ids, np.stack(vectors)
+
+    # =========================================================================
+    # Projections
+    # =========================================================================
+
+    def _projection_path(self, projection_id: int) -> str:
+        """Generate path for projection W matrix."""
+        return os.path.join(self.embeddings_dir, f"W_projection_{projection_id}.npy")
+
+    def store_projection(
+        self,
+        input_model_id: int,
+        output_model_id: int,
+        W: np.ndarray,
+        name: str = None,
+        cluster_ids: List[int] = None,
+        lambda_reg: float = None,
+        ridge: float = None,
+        metrics: Dict = None
+    ) -> int:
+        """Store a trained projection matrix."""
+        cursor = self.conn.cursor()
+
+        # Insert projection record (without path first to get ID)
+        cursor.execute("""
+            INSERT INTO projections (
+                input_model_id, output_model_id, name, W_path,
+                lambda_reg, ridge, num_clusters, num_queries,
+                recall_at_1, mrr
+            ) VALUES (?, ?, ?, '', ?, ?, ?, ?, ?, ?)
+        """, (
+            input_model_id, output_model_id, name,
+            lambda_reg, ridge,
+            metrics.get('num_clusters') if metrics else None,
+            metrics.get('total_queries') if metrics else None,
+            metrics.get('recall_at_1') if metrics else None,
+            metrics.get('mrr') if metrics else None
+        ))
+        projection_id = cursor.lastrowid
+
+        # Save W matrix
+        path = self._projection_path(projection_id)
+        np.save(path, W)
+
+        # Update with path
+        cursor.execute("""
+            UPDATE projections SET W_path = ? WHERE projection_id = ?
+        """, (path, projection_id))
+
+        # Link clusters
+        if cluster_ids:
+            for cid in cluster_ids:
+                cursor.execute("""
+                    INSERT INTO projection_clusters (projection_id, cluster_id)
+                    VALUES (?, ?)
+                """, (projection_id, cid))
+
+        self.conn.commit()
+        return projection_id
+
+    def get_projection(self, projection_id: int) -> Optional[Tuple[np.ndarray, Dict]]:
+        """Load a projection matrix and its metadata."""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM projections WHERE projection_id = ?", (projection_id,))
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        metadata = dict(row)
+        W = np.load(row['W_path'])
+
+        return W, metadata
+
+    def list_projections(self, input_model: str = None, output_model: str = None) -> List[Dict]:
+        """List projections, optionally filtered by model names."""
+        cursor = self.conn.cursor()
+
+        query = """
+            SELECT p.*, im.name as input_model_name, om.name as output_model_name
+            FROM projections p
+            JOIN embedding_models im ON p.input_model_id = im.model_id
+            JOIN embedding_models om ON p.output_model_id = om.model_id
+        """
+        conditions = []
+        params = []
+
+        if input_model:
+            conditions.append("im.name = ?")
+            params.append(input_model)
+        if output_model:
+            conditions.append("om.name = ?")
+            params.append(output_model)
+
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+
+        cursor.execute(query, params)
+        return [dict(row) for row in cursor.fetchall()]
+
+    # =========================================================================
+    # Query Logging
+    # =========================================================================
+
+    def log_query(
+        self,
+        query_text: str,
+        projection_id: int,
+        results: List[int],
+        selected_id: int = None,
+        was_helpful: bool = None
+    ):
+        """Log a query for continuous learning."""
+        cursor = self.conn.cursor()
+
+        # Get model_id from projection
+        cursor.execute("SELECT input_model_id FROM projections WHERE projection_id = ?", (projection_id,))
+        row = cursor.fetchone()
+        model_id = row['input_model_id'] if row else None
+
+        cursor.execute("""
+            INSERT INTO query_log (query_text, model_id, projection_id, results, selected_answer_id, was_helpful)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """, (query_text, model_id, projection_id, json.dumps(results), selected_id, was_helpful))
+        self.conn.commit()
+
+    def get_query_log(self, limit: int = 100) -> List[Dict]:
+        """Get recent query logs."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT * FROM query_log ORDER BY created_at DESC LIMIT ?
+        """, (limit,))
+        return [dict(row) for row in cursor.fetchall()]
+
+    def update_query_feedback(self, log_id: int, selected_id: int = None, was_helpful: bool = None):
+        """Update feedback on a logged query."""
+        cursor = self.conn.cursor()
+        updates = []
+        params = []
+
+        if selected_id is not None:
+            updates.append("selected_answer_id = ?")
+            params.append(selected_id)
+        if was_helpful is not None:
+            updates.append("was_helpful = ?")
+            params.append(was_helpful)
+
+        if updates:
+            params.append(log_id)
+            cursor.execute(f"""
+                UPDATE query_log SET {', '.join(updates)} WHERE log_id = ?
+            """, params)
+            self.conn.commit()
+
+    # =========================================================================
+    # Search API
+    # =========================================================================
+
+    def search(
+        self,
+        query_embedding: np.ndarray,
+        projection_id: int,
+        top_k: int = 5,
+        log: bool = True,
+        query_text: str = None
+    ) -> List[Dict]:
+        """Search for similar answers using LDA projection.
+
+        Args:
+            query_embedding: The embedded query vector (input model space)
+            projection_id: Which projection to use
+            top_k: Number of results to return
+            log: Whether to log this query
+            query_text: Original query text (for logging)
+
+        Returns:
+            List of dicts with answer_id, score, and answer metadata
+        """
+        # Load projection
+        result = self.get_projection(projection_id)
+        if not result:
+            raise ValueError(f"Projection {projection_id} not found")
+
+        W, metadata = result
+        output_model_id = metadata['output_model_id']
+
+        # Project query: projected = W @ query
+        projected = W @ query_embedding
+
+        # Normalize projected query
+        proj_norm = np.linalg.norm(projected)
+        if proj_norm > 0:
+            projected = projected / proj_norm
+
+        # Get all answer embeddings
+        answer_ids, answer_matrix = self.get_all_answer_embeddings(output_model_id)
+
+        if len(answer_ids) == 0:
+            return []
+
+        # Normalize answer embeddings
+        answer_norms = np.linalg.norm(answer_matrix, axis=1, keepdims=True)
+        answer_norms = np.where(answer_norms > 0, answer_norms, 1)  # Avoid division by zero
+        answer_matrix_normed = answer_matrix / answer_norms
+
+        # Compute similarities
+        similarities = answer_matrix_normed @ projected
+
+        # Get top-k indices
+        top_indices = np.argsort(-similarities)[:top_k]
+
+        # Build results
+        results = []
+        for idx in top_indices:
+            answer_id = answer_ids[idx]
+            answer = self.get_answer(answer_id)
+            results.append({
+                'answer_id': answer_id,
+                'score': float(similarities[idx]),
+                **answer
+            })
+
+        # Log query
+        if log and query_text:
+            self.log_query(
+                query_text=query_text,
+                projection_id=projection_id,
+                results=[r['answer_id'] for r in results]
+            )
+
+        return results
+
+    def search_with_embedder(
+        self,
+        query_text: str,
+        projection_id: int,
+        embedder,
+        top_k: int = 5,
+        log: bool = True
+    ) -> List[Dict]:
+        """Search using a provided embedder function/object.
+
+        Args:
+            query_text: The query string
+            projection_id: Which projection to use
+            embedder: Object with .encode() method or callable
+            top_k: Number of results to return
+            log: Whether to log this query
+
+        Returns:
+            List of dicts with answer_id, score, and answer metadata
+        """
+        # Embed query
+        if hasattr(embedder, 'encode'):
+            query_emb = embedder.encode(query_text, convert_to_numpy=True)
+        else:
+            query_emb = embedder(query_text)
+
+        return self.search(
+            query_embedding=query_emb,
+            projection_id=projection_id,
+            top_k=top_k,
+            log=log,
+            query_text=query_text
+        )
+
+    # =========================================================================
+    # Graph Traversal
+    # =========================================================================
+
+    def get_variants(self, answer_id: int) -> List[Dict]:
+        """Get all variants of an answer (different text representations)."""
+        variants = []
+
+        # Get variant_of relations (outgoing)
+        variants.extend(self.get_related(answer_id, "variant_of", direction="from"))
+
+        # Get variant_of relations (incoming - this is a variant of others)
+        variants.extend(self.get_related(answer_id, "variant_of", direction="to"))
+
+        return variants
+
+    def get_chunks(self, answer_id: int) -> List[Dict]:
+        """Get all chunks of a document."""
+        return self.get_related(answer_id, "chunk_of", direction="to")
+
+    def get_next_chunk(self, answer_id: int) -> Optional[Dict]:
+        """Get the next chunk in sequence."""
+        related = self.get_related(answer_id, "next_chunk", direction="from")
+        return related[0] if related else None
+
+    def get_prev_chunk(self, answer_id: int) -> Optional[Dict]:
+        """Get the previous chunk in sequence."""
+        related = self.get_related(answer_id, "prev_chunk", direction="from")
+        return related[0] if related else None
+
+    def get_translations(self, answer_id: int) -> List[Dict]:
+        """Get translations of an answer."""
+        return self.get_related(answer_id, "translates", direction="to")
+
+    # =========================================================================
+    # Batch Operations
+    # =========================================================================
+
+    def embed_and_store_batch(
+        self,
+        model_id: int,
+        entity_type: str,
+        items: List[Tuple[int, np.ndarray]]
+    ) -> int:
+        """Store multiple embeddings efficiently.
+
+        Args:
+            model_id: The embedding model ID
+            entity_type: 'answer' or 'question'
+            items: List of (entity_id, vector) tuples
+
+        Returns:
+            Number of embeddings stored
+        """
+        for entity_id, vector in items:
+            self.store_embedding(model_id, entity_type, entity_id, vector)
+        return len(items)
+
+    def get_cluster_embeddings(
+        self,
+        cluster_id: int,
+        model_id: int
+    ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+        """Get all embeddings for a cluster.
+
+        Returns:
+            Tuple of (answer_embeddings, question_embeddings)
+        """
+        cluster = self.get_cluster(cluster_id)
+        if not cluster:
+            return [], []
+
+        answer_embs = []
+        for a in cluster['answers']:
+            emb = self.get_embedding(model_id, 'answer', a['answer_id'])
+            if emb is not None:
+                answer_embs.append(emb)
+
+        question_embs = []
+        for q in cluster['questions']:
+            emb = self.get_embedding(model_id, 'question', q['question_id'])
+            if emb is not None:
+                question_embs.append(emb)
+
+        return answer_embs, question_embs
+
+    # =========================================================================
+    # Statistics
+    # =========================================================================
+
+    def get_stats(self) -> Dict:
+        """Get database statistics."""
+        cursor = self.conn.cursor()
+
+        stats = {}
+
+        cursor.execute("SELECT COUNT(*) FROM answers")
+        stats['num_answers'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM questions")
+        stats['num_questions'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM qa_clusters")
+        stats['num_clusters'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM embeddings")
+        stats['num_embeddings'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM projections")
+        stats['num_projections'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM query_log")
+        stats['num_queries_logged'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM answer_relations")
+        stats['num_relations'] = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM embedding_models")
+        stats['num_models'] = cursor.fetchone()[0]
+
+        return stats

--- a/tests/core/test_lda_database.py
+++ b/tests/core/test_lda_database.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Unit tests for LDA projection database layer
+
+"""
+Tests for lda_database.py
+
+Tests:
+- Schema creation
+- CRUD operations for answers, questions, clusters
+- Embedding storage and retrieval
+- Projection storage and retrieval
+- Search API
+- Query logging
+- Graph traversal
+"""
+
+import sys
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+# Add paths
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root / "src" / "unifyweaver" / "targets" / "python_runtime"))
+
+from lda_database import LDAProjectionDB
+
+
+class TestLDADatabaseSchema(unittest.TestCase):
+    """Test database schema creation."""
+
+    def test_creates_database_file(self):
+        """Database file is created."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            db = LDAProjectionDB(db_path)
+            self.assertTrue(os.path.exists(db_path))
+            db.close()
+
+    def test_creates_embeddings_dir(self):
+        """Embeddings directory is created."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            db = LDAProjectionDB(db_path)
+            self.assertTrue(os.path.isdir(db.embeddings_dir))
+            db.close()
+
+    def test_context_manager(self):
+        """Database can be used as context manager."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            with LDAProjectionDB(db_path) as db:
+                self.assertIsNotNone(db.conn)
+
+
+class TestAnswers(unittest.TestCase):
+    """Test answer CRUD operations."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_add_answer(self):
+        """Can add an answer."""
+        aid = self.db.add_answer(
+            source_file="test.md",
+            text="Test answer",
+            record_id="test_001"
+        )
+        self.assertIsInstance(aid, int)
+        self.assertGreater(aid, 0)
+
+    def test_get_answer(self):
+        """Can retrieve an answer."""
+        aid = self.db.add_answer(
+            source_file="test.md",
+            text="Test answer text",
+            record_id="test_001"
+        )
+        answer = self.db.get_answer(aid)
+        self.assertEqual(answer['text'], "Test answer text")
+        self.assertEqual(answer['source_file'], "test.md")
+        self.assertEqual(answer['record_id'], "test_001")
+
+    def test_get_nonexistent_answer(self):
+        """Returns None for nonexistent answer."""
+        answer = self.db.get_answer(9999)
+        self.assertIsNone(answer)
+
+    def test_add_answer_with_parent(self):
+        """Can add hierarchical answers."""
+        parent_id = self.db.add_answer("doc.md", "Full document")
+        chunk_id = self.db.add_answer(
+            source_file="doc.md",
+            text="Chunk 1",
+            parent_id=parent_id,
+            chunk_index=0
+        )
+        chunk = self.db.get_answer(chunk_id)
+        self.assertEqual(chunk['parent_id'], parent_id)
+        self.assertEqual(chunk['chunk_index'], 0)
+
+    def test_find_answers_by_source(self):
+        """Can find answers by source file."""
+        self.db.add_answer("source1.md", "Answer 1")
+        self.db.add_answer("source1.md", "Answer 2")
+        self.db.add_answer("source2.md", "Answer 3")
+
+        results = self.db.find_answers(source_file="source1.md")
+        self.assertEqual(len(results), 2)
+
+    def test_find_answers_by_record_id(self):
+        """Can find answers by record ID."""
+        self.db.add_answer("s.md", "A1", record_id="rec001")
+        self.db.add_answer("s.md", "A2", record_id="rec002")
+
+        results = self.db.find_answers(record_id="rec001")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['text'], "A1")
+
+
+class TestRelations(unittest.TestCase):
+    """Test answer relations."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_add_relation(self):
+        """Can create relations between answers."""
+        a1 = self.db.add_answer("s.md", "Full doc")
+        a2 = self.db.add_answer("s.md", "Summary")
+
+        rid = self.db.add_relation(a2, a1, "summarizes")
+        self.assertIsInstance(rid, int)
+
+    def test_get_related_outgoing(self):
+        """Can get outgoing relations."""
+        a1 = self.db.add_answer("s.md", "Full doc")
+        a2 = self.db.add_answer("s.md", "Chunk")
+        self.db.add_relation(a2, a1, "chunk_of")
+
+        related = self.db.get_related(a2, direction="from")
+        self.assertEqual(len(related), 1)
+        self.assertEqual(related[0]['relation_type'], "chunk_of")
+
+    def test_get_related_incoming(self):
+        """Can get incoming relations."""
+        a1 = self.db.add_answer("s.md", "Full doc")
+        a2 = self.db.add_answer("s.md", "Chunk")
+        self.db.add_relation(a2, a1, "chunk_of")
+
+        related = self.db.get_related(a1, direction="to")
+        self.assertEqual(len(related), 1)
+
+    def test_get_full_version(self):
+        """Can traverse hierarchy to find full document."""
+        full = self.db.add_answer("s.md", "Full document")
+        summary = self.db.add_answer("s.md", "Summary")
+        self.db.add_relation(summary, full, "summarizes")
+
+        result = self.db.get_full_version(summary)
+        self.assertEqual(result['answer_id'], full)
+
+    def test_relation_with_metadata(self):
+        """Can store relation metadata."""
+        a1 = self.db.add_answer("s.md", "English")
+        a2 = self.db.add_answer("s.md", "Spanish")
+        self.db.add_relation(a2, a1, "translates", {"from_lang": "en", "to_lang": "es"})
+
+        related = self.db.get_related(a2, "translates", direction="from")
+        self.assertEqual(len(related), 1)
+
+
+class TestQuestions(unittest.TestCase):
+    """Test question operations."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_add_question(self):
+        """Can add a question."""
+        qid = self.db.add_question("How do I test?", "medium")
+        self.assertIsInstance(qid, int)
+
+    def test_get_question(self):
+        """Can retrieve a question."""
+        qid = self.db.add_question("Test question", "short")
+        question = self.db.get_question(qid)
+        self.assertEqual(question['text'], "Test question")
+        self.assertEqual(question['length_type'], "short")
+
+
+class TestClusters(unittest.TestCase):
+    """Test cluster operations."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_create_cluster(self):
+        """Can create a cluster."""
+        a1 = self.db.add_answer("s.md", "Answer")
+        q1 = self.db.add_question("Question 1", "short")
+        q2 = self.db.add_question("Question 2", "medium")
+
+        cid = self.db.create_cluster(
+            name="test_cluster",
+            answer_ids=[a1],
+            question_ids=[q1, q2],
+            description="Test cluster"
+        )
+        self.assertIsInstance(cid, int)
+
+    def test_get_cluster(self):
+        """Can retrieve cluster with answers and questions."""
+        a1 = self.db.add_answer("s.md", "Answer")
+        q1 = self.db.add_question("Question", "short")
+        cid = self.db.create_cluster("test", [a1], [q1])
+
+        cluster = self.db.get_cluster(cid)
+        self.assertEqual(cluster['name'], "test")
+        self.assertEqual(len(cluster['answers']), 1)
+        self.assertEqual(len(cluster['questions']), 1)
+
+    def test_list_clusters(self):
+        """Can list all clusters."""
+        a1 = self.db.add_answer("s.md", "A")
+        q1 = self.db.add_question("Q", "short")
+        self.db.create_cluster("c1", [a1], [q1])
+        self.db.create_cluster("c2", [a1], [q1])
+
+        clusters = self.db.list_clusters()
+        self.assertEqual(len(clusters), 2)
+
+
+class TestEmbeddings(unittest.TestCase):
+    """Test embedding storage and retrieval."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+        self.model_id = self.db.add_model("test-model", 384)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_add_model(self):
+        """Can register an embedding model."""
+        mid = self.db.add_model("another-model", 768, backend="python")
+        self.assertIsInstance(mid, int)
+
+    def test_get_model(self):
+        """Can retrieve model by name."""
+        model = self.db.get_model("test-model")
+        self.assertEqual(model['dimension'], 384)
+
+    def test_store_embedding(self):
+        """Can store an embedding vector."""
+        aid = self.db.add_answer("s.md", "Test")
+        vec = np.random.randn(384).astype(np.float32)
+
+        eid = self.db.store_embedding(self.model_id, "answer", aid, vec)
+        self.assertIsInstance(eid, int)
+
+    def test_get_embedding(self):
+        """Can retrieve an embedding vector."""
+        aid = self.db.add_answer("s.md", "Test")
+        vec = np.random.randn(384).astype(np.float32)
+        self.db.store_embedding(self.model_id, "answer", aid, vec)
+
+        retrieved = self.db.get_embedding(self.model_id, "answer", aid)
+        np.testing.assert_array_almost_equal(vec, retrieved, decimal=5)
+
+    def test_get_all_answer_embeddings(self):
+        """Can retrieve all answer embeddings at once."""
+        a1 = self.db.add_answer("s.md", "A1")
+        a2 = self.db.add_answer("s.md", "A2")
+        v1 = np.random.randn(384).astype(np.float32)
+        v2 = np.random.randn(384).astype(np.float32)
+        self.db.store_embedding(self.model_id, "answer", a1, v1)
+        self.db.store_embedding(self.model_id, "answer", a2, v2)
+
+        ids, matrix = self.db.get_all_answer_embeddings(self.model_id)
+        self.assertEqual(len(ids), 2)
+        self.assertEqual(matrix.shape, (2, 384))
+
+
+class TestProjections(unittest.TestCase):
+    """Test projection storage and retrieval."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+        self.input_model_id = self.db.add_model("input-model", 384)
+        self.output_model_id = self.db.add_model("output-model", 1024)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_store_projection_symmetric(self):
+        """Can store symmetric projection (same input/output model)."""
+        W = np.random.randn(384, 384).astype(np.float32)
+        pid = self.db.store_projection(
+            input_model_id=self.input_model_id,
+            output_model_id=self.input_model_id,
+            W=W,
+            name="test_proj"
+        )
+        self.assertIsInstance(pid, int)
+
+    def test_store_projection_asymmetric(self):
+        """Can store asymmetric projection (different input/output models)."""
+        W = np.random.randn(1024, 384).astype(np.float32)
+        pid = self.db.store_projection(
+            input_model_id=self.input_model_id,
+            output_model_id=self.output_model_id,
+            W=W,
+            name="asymmetric_proj"
+        )
+        self.assertIsInstance(pid, int)
+
+    def test_get_projection(self):
+        """Can retrieve projection matrix and metadata."""
+        W = np.random.randn(384, 384).astype(np.float32)
+        pid = self.db.store_projection(
+            input_model_id=self.input_model_id,
+            output_model_id=self.input_model_id,
+            W=W,
+            name="test",
+            lambda_reg=0.5,
+            ridge=1e-6
+        )
+
+        W_retrieved, metadata = self.db.get_projection(pid)
+        np.testing.assert_array_almost_equal(W, W_retrieved, decimal=5)
+        self.assertEqual(metadata['name'], "test")
+        self.assertAlmostEqual(metadata['lambda_reg'], 0.5)
+
+    def test_list_projections(self):
+        """Can list projections with filters."""
+        W1 = np.random.randn(384, 384).astype(np.float32)
+        W2 = np.random.randn(1024, 384).astype(np.float32)
+        self.db.store_projection(self.input_model_id, self.input_model_id, W1, "sym")
+        self.db.store_projection(self.input_model_id, self.output_model_id, W2, "asym")
+
+        all_proj = self.db.list_projections()
+        self.assertEqual(len(all_proj), 2)
+
+        filtered = self.db.list_projections(output_model="output-model")
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]['name'], "asym")
+
+
+class TestSearch(unittest.TestCase):
+    """Test search API."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+        self.model_id = self.db.add_model("test-model", 4)
+
+        # Create simple test data
+        # Answer 1: [1, 0, 0, 0]
+        # Answer 2: [0, 1, 0, 0]
+        self.a1 = self.db.add_answer("s.md", "Answer 1", record_id="a1")
+        self.a2 = self.db.add_answer("s.md", "Answer 2", record_id="a2")
+        self.db.store_embedding(self.model_id, "answer", self.a1, np.array([1, 0, 0, 0], dtype=np.float32))
+        self.db.store_embedding(self.model_id, "answer", self.a2, np.array([0, 1, 0, 0], dtype=np.float32))
+
+        # Identity projection
+        W = np.eye(4, dtype=np.float32)
+        self.proj_id = self.db.store_projection(self.model_id, self.model_id, W, "identity")
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_search_finds_closest(self):
+        """Search returns closest answer."""
+        query = np.array([0.9, 0.1, 0, 0], dtype=np.float32)
+        results = self.db.search(query, self.proj_id, top_k=2, log=False)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]['record_id'], "a1")  # Closer to [1,0,0,0]
+
+    def test_search_logs_query(self):
+        """Search logs queries when enabled."""
+        query = np.array([1, 0, 0, 0], dtype=np.float32)
+        self.db.search(query, self.proj_id, log=True, query_text="test query")
+
+        logs = self.db.get_query_log()
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0]['query_text'], "test query")
+
+
+class TestQueryLog(unittest.TestCase):
+    """Test query logging functionality."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "test.db")
+        self.db = LDAProjectionDB(self.db_path)
+        self.model_id = self.db.add_model("test", 4)
+        W = np.eye(4, dtype=np.float32)
+        self.proj_id = self.db.store_projection(self.model_id, self.model_id, W)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_log_query(self):
+        """Can log a query."""
+        self.db.log_query(
+            query_text="test query",
+            projection_id=self.proj_id,
+            results=[1, 2, 3]
+        )
+        logs = self.db.get_query_log()
+        self.assertEqual(len(logs), 1)
+
+    def test_update_feedback(self):
+        """Can update query feedback."""
+        self.db.log_query("test", self.proj_id, [1])
+        logs = self.db.get_query_log()
+        log_id = logs[0]['log_id']
+
+        self.db.update_query_feedback(log_id, selected_id=1, was_helpful=True)
+        updated = self.db.get_query_log()[0]
+        self.assertEqual(updated['selected_answer_id'], 1)
+        self.assertTrue(updated['was_helpful'])
+
+
+class TestStats(unittest.TestCase):
+    """Test statistics retrieval."""
+
+    def test_get_stats(self):
+        """Can get database statistics."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            with LDAProjectionDB(db_path) as db:
+                db.add_answer("s.md", "Answer")
+                db.add_question("Question", "short")
+
+                stats = db.get_stats()
+                self.assertEqual(stats['num_answers'], 1)
+                self.assertEqual(stats['num_questions'], 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary                                                                                                                                   
                                                                                                                                             
- Add database schema proposal supporting asymmetric embeddings (different models for queries vs answers)                                    
- Implement SQLite database layer with graph-based answer relations (chunks, summaries, translations)                                        
- Add migration script to import existing Q-A pairs and train projections                                                                    
- Add 33 unit tests for database layer                                                                                                       
                                                                                                                                             
## Key Features                                                                                                                              
                                                                                                                                             
- **Asymmetric embeddings**: Input model (e.g., MiniLM for short queries) can differ from output model (e.g., ModernBERT for long documents) 
- **Answer graph**: Relations like `chunk_of`, `summarizes`, `translates`, `next_chunk` enable hierarchical document structure               
- **Search API**: `search_with_embedder()` applies projection and returns ranked results with logging                                        
- **Cross-target ready**: Python runtime for training, compatible with Rust/Go embedding backends via cross-target glue                      
                                                                                                                                             
## Test plan                                                                                                                                 
                                                                                                                                             
- [x] Run `python3 tests/core/test_lda_database.py` - 33 tests pass                                                                          
- [x] Run `python3 scripts/migrate_to_lda_db.py` - migrates Q-A pairs, achieves 100% Recall@1                                                
                                                                                                                                             
� Generated with [Claude Code](https://claude.com/claude-code)                                                                               