### PR TITLE
feat(lda): Add training batch tracking with file hash detection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,27 @@ This applies to:
 - **[playbooks/xml_data_source_playbook.md](../playbooks/xml_data_source_playbook.md)** - XML Data Source Playbook
   - Processing XML data using Python.
 
+### Semantic Search and LDA Projection
+
+- **[proposals/SEMANTIC_PROJECTION_LDA.md](proposals/SEMANTIC_PROJECTION_LDA.md)** - LDA Projection Theory
+  - Mathematical foundation for query-to-answer projection
+  - Weighted centroid computation
+  - Training from Q-A clusters
+
+- **[proposals/LDA_DATABASE_SCHEMA.md](proposals/LDA_DATABASE_SCHEMA.md)** - Database Schema
+  - Asymmetric embeddings (different models for queries vs answers)
+  - Answer relations graph (chunks, summaries, translations)
+  - Training batch tracking with file hash detection
+
+- **[proposals/COMPONENT_REGISTRY.md](proposals/COMPONENT_REGISTRY.md)** - Component Registry
+  - Unified component registration system
+  - Runtime, source, and binding categories
+  - Lazy/eager initialization
+
+- **[TODO_LDA_PROJECTION.md](TODO_LDA_PROJECTION.md)** - LDA Feature Progress
+  - Implementation status and next steps
+  - Quick test commands
+
 ### Testing
 
 - **[TESTING_GUIDE.md](TESTING_GUIDE.md)** - Testing infrastructure

--- a/docs/TODO_LDA_PROJECTION.md
+++ b/docs/TODO_LDA_PROJECTION.md
@@ -22,9 +22,9 @@ See: `docs/proposals/SEMANTIC_PROJECTION_LDA.md` and `docs/proposals/COMPONENT_R
 
 ## Documentation
 
-- [ ] Update main README with component registry section
-- [ ] Add usage examples for LDA projection
-- [ ] Document how to train W matrix from Q-A pairs
+- [x] Update docs/README.md with LDA section
+- [x] Update scripts/README.md with training scripts
+- [x] Update proposals/README.md with new proposals
 - [ ] Add architecture diagram showing component registry flow
 
 ## Testing & Validation
@@ -58,12 +58,34 @@ See: `docs/proposals/SEMANTIC_PROJECTION_LDA.md` and `docs/proposals/COMPONENT_R
 - [x] Implement answer relations graph (chunk_of, summarizes, translates, etc.)
 - [x] SQLite + numpy files for vector storage
 - [x] Search API with projection and logging
+- [x] Training batch tracking with file hash detection
 - [ ] Prolog interface for `find_examples/3`:
   ```prolog
   find_examples(TaskDescription, TopK, Examples) :-
       invoke_component(runtime, lda_search, search(TaskDescription, TopK), results(Examples)).
   ```
-- [ ] MCP tool for Claude integration
+
+### Training Batch Tracking (Implemented)
+
+Tracks which Q-A data files have been trained on with SHA256 file hashes:
+
+```bash
+# Scan for new/modified files
+python3 scripts/migrate_to_lda_db.py --scan --input playbooks/lda-training-data/raw/
+
+# Process all pending batches
+python3 scripts/migrate_to_lda_db.py --process-pending
+
+# Retry failed batches
+python3 scripts/migrate_to_lda_db.py --retry-failed
+
+# List all batches
+python3 scripts/migrate_to_lda_db.py --list-batches
+```
+
+Status history is tracked with timestamps for each transition:
+- pending → importing → embedding → training → completed
+- Failed batches record error messages for debugging
 
 ## Integration
 
@@ -81,6 +103,7 @@ See: `docs/proposals/SEMANTIC_PROJECTION_LDA.md` and `docs/proposals/COMPONENT_R
 
 - [ ] Go backend for LDA projection (avoid Python subprocess overhead)
 - [ ] Rust backend for LDA projection
+- [ ] MCP tool for Claude integration (useful for server-based deployments)
 - [ ] Hot-reload support for W matrix updates
 - [ ] Per-domain projection matrices
 - [ ] Multiple attention heads (separate input/output projections)

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -43,6 +43,10 @@ Proposals serve several purposes:
 | Proposal | Status | Target Version | Priority |
 |----------|--------|----------------|----------|
 | [Parallel Architecture](parallel_architecture.md) | Draft | v0.0.4+ | High (Phase 4) |
+| [Component Registry](COMPONENT_REGISTRY.md) | Implemented | v0.0.3 | Medium |
+| [Semantic Projection LDA](SEMANTIC_PROJECTION_LDA.md) | Implemented | v0.0.3 | Medium |
+| [LDA Database Schema](LDA_DATABASE_SCHEMA.md) | Implemented | v0.0.3 | Medium |
+| [LDA Training Approach](LDA_TRAINING_APPROACH.md) | Implemented | v0.0.3 | Medium |
 
 ## Proposal Template
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -231,6 +231,72 @@ See `legacy/conemu_logiforge.bat` for the original LogiForge ConEmu integration 
 
 ---
 
+## LDA Training Scripts
+
+Scripts for training and managing the LDA semantic projection system used by agents to find relevant playbook examples.
+
+### `train_lda_projection.py`
+**Train a W matrix from Q-A pairs**
+
+Computes the projection matrix that maps query embeddings to answer space for improved semantic search.
+
+```bash
+python3 scripts/train_lda_projection.py \
+    --input playbooks/lda-training-data/raw/qa_pairs_v1.json \
+    --model all-MiniLM-L6-v2 \
+    --output playbooks/lda-training-data/trained/all-MiniLM-L6-v2/W_matrix.npy
+```
+
+### `validate_lda_projection.py`
+**Validate projection with novel queries**
+
+Tests the trained W matrix with queries not in the training data, comparing projected vs direct cosine similarity.
+
+```bash
+python3 scripts/validate_lda_projection.py
+```
+
+### `migrate_to_lda_db.py`
+**Database migration and batch training**
+
+Manages Q-A training data in a SQLite database with batch tracking.
+
+**Single file import:**
+```bash
+python3 scripts/migrate_to_lda_db.py \
+    --input playbooks/lda-training-data/raw/qa_pairs_v1.json \
+    --db playbooks/lda-training-data/lda.db
+```
+
+**Batch operations:**
+```bash
+# Scan for new/modified JSON files
+python3 scripts/migrate_to_lda_db.py --scan --input playbooks/lda-training-data/raw/
+
+# Process all pending batches
+python3 scripts/migrate_to_lda_db.py --process-pending
+
+# Retry failed batches
+python3 scripts/migrate_to_lda_db.py --retry-failed
+
+# List batch status
+python3 scripts/migrate_to_lda_db.py --list-batches
+```
+
+**Features:**
+- SHA256 file hash detection (skips unchanged files)
+- Status tracking: pending → importing → embedding → training → completed
+- Failed batch retry with error logging
+- Full status history with timestamps
+
+**Requirements:**
+- `sentence-transformers` package: `pip install sentence-transformers`
+- NumPy
+
+See `docs/proposals/LDA_DATABASE_SCHEMA.md` for database schema details.
+
+---
+
 ## Legacy Scripts (LogiForge)
 
 The following scripts are from the LogiForge project and kept in `legacy/` for reference:


### PR DESCRIPTION
## Summary                                                                                                                   
                                                                                                                             
- Add `training_batches` and `batch_status_history` tables with SHA256 file hash detection                                   
- Update migrate script with batch processing modes (--scan, --process-pending, --retry-failed, --list-batches)              
- Add 11 new tests for batch tracking (44 total)                                                                             
- Update documentation across scripts/README.md, docs/README.md, and proposals/README.md                                     
                                                                                                                             
## Features                                                                                                                  
                                                                                                                             
- **File hash detection**: SHA256 hash tracks file changes - unchanged files are skipped, modified files create new batches  
- **Status tracking**: pending → importing → embedding → training → completed (with full history and timestamps)             
- **Batch modes**:                                                                                                           
  - `--scan`: Register new/modified JSON files in a directory                                                                
  - `--process-pending`: Train all pending batches                                                                           
  - `--retry-failed`: Retry failed batches with error logging                                                                
  - `--list-batches`: Show batch status table                                                                                
                                                                                                                             
## Test plan                                                                                                                 
                                                                                                                             
- [x] Run `python3 tests/core/test_lda_database.py` - 44 tests pass                                                          
- [x] Test unchanged file detection (skips already-processed files)                                                          
- [x] Test modified file detection (creates new batch)                                                                       
- [x] Verify status history with timestamps                                                                                  
                                                                                                                             
� Generated with [Claude Code](https://claude.com/claude-code)                                                               