### PR TITLE
feat: Add rate limiting pipeline stages (rate_limit/throttle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_timeout_stage.sh` — Integration tests (12 tests)
   - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
 
+- **Pipeline Rate Limiting Stages** - Throughput control for pipeline processing
+  - `rate_limit(N, Per)` — Limit throughput to N records per time unit
+    - Time units: `second`, `minute`, `hour`, `ms(X)`
+    - Uses interval-based timing for precise rate control
+  - `throttle(Ms)` — Add fixed delay of Ms milliseconds between records
+  - Combines with other stages: `try_catch(rate_limit(...), handler)`, `timeout(rate_limit(...), ms)`
+  - Supported targets: Python, Go, Rust
+  - `tests/integration/test_rate_limiting_stages.sh` — Integration tests (16 tests)
+  - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
+
 - **XML Data Source Playbook** - A new playbook for processing XML data.
   - `playbooks/xml_data_source_playbook.md` - The playbook itself.
   - `playbooks/examples_library/xml_examples.md` - The implementation of the playbook.

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -1840,6 +1840,45 @@ where
     }
     result
 }
+
+/// Rate limit: Limit throughput to count records per interval.
+fn rate_limit_stage(records: &[Record], count: usize, interval_ms: u64) -> Vec<Record> {
+    use std::time::{Duration, Instant};
+    use std::thread;
+
+    let mut result = Vec::new();
+    let interval = Duration::from_millis(interval_ms) / count as u32;
+    let mut last_time: Option<Instant> = None;
+
+    for record in records {
+        if let Some(last) = last_time {
+            let elapsed = last.elapsed();
+            if elapsed < interval {
+                thread::sleep(interval - elapsed);
+            }
+        }
+        last_time = Some(Instant::now());
+        result.push(record.clone());
+    }
+    result
+}
+
+/// Throttle: Add fixed delay between records.
+fn throttle_stage(records: &[Record], delay_ms: u64) -> Vec<Record> {
+    use std::time::Duration;
+    use std::thread;
+
+    let mut result = Vec::new();
+    let delay = Duration::from_millis(delay_ms);
+
+    for (i, record) in records.iter().enumerate() {
+        if i > 0 {
+            thread::sleep(delay);
+        }
+        result.push(record.clone());
+    }
+    result
+}
 ".
 
 %% rust_parallel_helper(+ParallelMode, -Code)
@@ -2038,6 +2077,8 @@ generate_rust_single_enhanced_stage(timeout(Stage, _, Fallback), Code) :-
     generate_rust_single_enhanced_stage(Stage, StageCode),
     generate_rust_single_enhanced_stage(Fallback, FallbackCode),
     format(string(Code), "~w~w", [StageCode, FallbackCode]).
+generate_rust_single_enhanced_stage(rate_limit(_, _), "") :- !.
+generate_rust_single_enhanced_stage(throttle(_), "") :- !.
 generate_rust_single_enhanced_stage(Pred/Arity, Code) :-
     !,
     format(string(Code),
@@ -2321,6 +2362,23 @@ generate_rust_stage_flow(timeout(Stage, Ms, Fallback), InVar, OutVar, Code) :-
 "    // Timeout: ~w with ~wms limit, fallback to ~w
     let ~w = timeout_stage_with_fallback(&~w, ~w, ~w, ~w);", [StageName, Ms, FallbackName, OutVar, InVar, StageName, Ms, FallbackName]).
 
+% Rate limit stage: limit throughput to N records per time unit
+generate_rust_stage_flow(rate_limit(N, Per), InVar, OutVar, Code) :-
+    !,
+    rust_time_unit_to_ms(Per, IntervalMs),
+    OutVar = "rate_limited",
+    format(string(Code),
+"    // Rate limit: ~w records per ~w
+    let ~w = rate_limit_stage(&~w, ~w, ~w);", [N, Per, OutVar, InVar, N, IntervalMs]).
+
+% Throttle stage: add fixed delay between records
+generate_rust_stage_flow(throttle(Ms), InVar, OutVar, Code) :-
+    !,
+    OutVar = "throttled",
+    format(string(Code),
+"    // Throttle: ~wms delay between records
+    let ~w = throttle_stage(&~w, ~w);", [Ms, OutVar, InVar, Ms]).
+
 % Standard predicate stage
 generate_rust_stage_flow(Pred/Arity, InVar, OutVar, Code) :-
     !,
@@ -2354,6 +2412,15 @@ extract_rust_stage_name(_, unknown_stage).
 extract_rust_retry_options(Options, DelayMs, Backoff) :-
     ( member(delay(D), Options) -> DelayMs = D ; DelayMs = 0 ),
     ( member(backoff(B), Options) -> Backoff = B ; Backoff = none ).
+
+%% rust_time_unit_to_ms(+Unit, -Ms)
+%  Convert time unit to milliseconds for Rust rate limiting.
+rust_time_unit_to_ms(second, 1000) :- !.
+rust_time_unit_to_ms(minute, 60000) :- !.
+rust_time_unit_to_ms(hour, 3600000) :- !.
+rust_time_unit_to_ms(ms(X), X) :- !.
+rust_time_unit_to_ms(X, X) :- integer(X), !.
+rust_time_unit_to_ms(_, 1000).
 
 %% format_rust_stage_list(+Names, -ListStr)
 %  Format stage names as Rust function references.

--- a/tests/integration/test_rate_limiting_stages.sh
+++ b/tests/integration/test_rate_limiting_stages.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+# test_rate_limiting_stages.sh - Integration tests for pipeline rate limiting stages
+# Tests rate_limit(N, Per) and throttle(Ms)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# Test 1: Validation accepts rate_limit(N, second)
+test_validation_rate_limit_second() {
+    log_info "Test 1: Validation accepts rate_limit(N, second)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, rate_limit(10, second), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "rate_limit(10, second) validation accepted"
+    else
+        log_fail "rate_limit(10, second) validation failed: $output"
+    fi
+}
+
+# Test 2: Validation accepts rate_limit(N, minute)
+test_validation_rate_limit_minute() {
+    log_info "Test 2: Validation accepts rate_limit(N, minute)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, rate_limit(100, minute), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "rate_limit(100, minute) validation accepted"
+    else
+        log_fail "rate_limit(100, minute) validation failed: $output"
+    fi
+}
+
+# Test 3: Validation accepts rate_limit(N, hour)
+test_validation_rate_limit_hour() {
+    log_info "Test 3: Validation accepts rate_limit(N, hour)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, rate_limit(1000, hour), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "rate_limit(1000, hour) validation accepted"
+    else
+        log_fail "rate_limit(1000, hour) validation failed: $output"
+    fi
+}
+
+# Test 4: Validation accepts rate_limit(N, ms(X))
+test_validation_rate_limit_ms() {
+    log_info "Test 4: Validation accepts rate_limit(N, ms(X))"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, rate_limit(5, ms(500)), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "rate_limit(5, ms(500)) validation accepted"
+    else
+        log_fail "rate_limit(5, ms(500)) validation failed: $output"
+    fi
+}
+
+# Test 5: Validation accepts throttle(Ms)
+test_validation_throttle() {
+    log_info "Test 5: Validation accepts throttle(Ms)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, throttle(100), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "throttle(100) validation accepted"
+    else
+        log_fail "throttle(100) validation failed: $output"
+    fi
+}
+
+# Test 6: Validation rejects rate_limit with invalid N
+test_validation_rate_limit_invalid_n() {
+    log_info "Test 6: Validation rejects rate_limit with invalid N"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, rate_limit(0, second), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -qv "Errors: \[\]"; then
+        log_pass "rate_limit(0, second) correctly rejected"
+    else
+        log_fail "rate_limit(0, second) should have been rejected"
+    fi
+}
+
+# Test 7: Validation rejects throttle with invalid ms
+test_validation_throttle_invalid_ms() {
+    log_info "Test 7: Validation rejects throttle with invalid ms"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, throttle(-10), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -qv "Errors: \[\]"; then
+        log_pass "throttle(-10) correctly rejected"
+    else
+        log_fail "throttle(-10) should have been rejected"
+    fi
+}
+
+# Test 8: Python rate_limit compilation
+test_python_rate_limit() {
+    log_info "Test 8: Python rate_limit stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, rate_limit(10, second), output/1], [pipeline_name(rate_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "rate_limit_stage"; then
+        log_pass "Python rate_limit compiles correctly"
+    else
+        log_fail "Python rate_limit compilation failed"
+    fi
+}
+
+# Test 9: Python throttle compilation
+test_python_throttle() {
+    log_info "Test 9: Python throttle stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, throttle(100), output/1], [pipeline_name(throttle_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "throttle_stage" && \
+       echo "$output" | grep -q "100"; then
+        log_pass "Python throttle compiles correctly"
+    else
+        log_fail "Python throttle compilation failed"
+    fi
+}
+
+# Test 10: Go rate_limit compilation
+test_go_rate_limit() {
+    log_info "Test 10: Go rate_limit stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, rate_limit(10, second), output/1], [pipeline_name(rateTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "rateLimitStage"; then
+        log_pass "Go rate_limit compiles correctly"
+    else
+        log_fail "Go rate_limit compilation failed"
+    fi
+}
+
+# Test 11: Go throttle compilation
+test_go_throttle() {
+    log_info "Test 11: Go throttle stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, throttle(100), output/1], [pipeline_name(throttleTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "throttleStage" && \
+       echo "$output" | grep -q "100"; then
+        log_pass "Go throttle compiles correctly"
+    else
+        log_fail "Go throttle compilation failed"
+    fi
+}
+
+# Test 12: Rust rate_limit compilation
+test_rust_rate_limit() {
+    log_info "Test 12: Rust rate_limit stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, rate_limit(10, second), output/1], [pipeline_name(rate_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "rate_limit_stage"; then
+        log_pass "Rust rate_limit compiles correctly"
+    else
+        log_fail "Rust rate_limit compilation failed"
+    fi
+}
+
+# Test 13: Rust throttle compilation
+test_rust_throttle() {
+    log_info "Test 13: Rust throttle stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, throttle(100), output/1], [pipeline_name(throttle_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "throttle_stage" && \
+       echo "$output" | grep -q "100"; then
+        log_pass "Rust throttle compiles correctly"
+    else
+        log_fail "Rust throttle compilation failed"
+    fi
+}
+
+# Test 14: Combined rate limiting with other stages
+test_combined_rate_limiting() {
+    log_info "Test 14: Combined rate limiting with other stages"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, rate_limit(10, second), filter_by(active), throttle(50), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "Combined rate_limit and throttle validation accepted"
+    else
+        log_fail "Combined rate limiting validation failed: $output"
+    fi
+}
+
+# Test 15: Rate limiting with error handling
+test_rate_limit_with_try_catch() {
+    log_info "Test 15: Rate limiting with error handling"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, try_catch(rate_limit(5, second), error_handler/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "try_catch(rate_limit(...), handler) validation accepted"
+    else
+        log_fail "try_catch with rate_limit validation failed: $output"
+    fi
+}
+
+# Test 16: Rate limiting with timeout
+test_rate_limit_with_timeout() {
+    log_info "Test 16: Rate limiting with timeout"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, timeout(rate_limit(10, second), 5000), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "timeout(rate_limit(...), ms) validation accepted"
+    else
+        log_fail "timeout with rate_limit validation failed: $output"
+    fi
+}
+
+# Main test runner
+main() {
+    echo "=========================================="
+    echo "  Pipeline Rate Limiting Stage Tests"
+    echo "=========================================="
+    echo ""
+
+    test_validation_rate_limit_second
+    test_validation_rate_limit_minute
+    test_validation_rate_limit_hour
+    test_validation_rate_limit_ms
+    test_validation_throttle
+    test_validation_rate_limit_invalid_n
+    test_validation_throttle_invalid_ms
+    test_python_rate_limit
+    test_python_throttle
+    test_go_rate_limit
+    test_go_throttle
+    test_rust_rate_limit
+    test_rust_throttle
+    test_combined_rate_limiting
+    test_rate_limit_with_try_catch
+    test_rate_limit_with_timeout
+
+    echo ""
+    echo "=========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "=========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary

- Adds `rate_limit(N, Per)` stage to limit throughput to N records per time unit
- Adds `throttle(Ms)` stage to add fixed delay between records
- Supports time units: `second`, `minute`, `hour`, `ms(X)`
- Implemented for Python, Go, and Rust targets

## Test plan

- [x] Validation accepts valid rate_limit with all time units
- [x] Validation accepts valid throttle
- [x] Validation rejects invalid rate_limit (N=0, negative)
- [x] Validation rejects invalid throttle (negative ms)
- [x] Python compilation generates rate_limit_stage/throttle_stage
- [x] Go compilation generates rateLimitStage/throttleStage
- [x] Rust compilation generates rate_limit_stage/throttle_stage
- [x] Combined with other stages (try_catch, timeout)
- [x] All 16 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
