### PR TITLE
feat: Add flatten pipeline stage for nested collection expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_tap_stage.sh` — Integration tests (16 tests)
   - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
 
+- **Pipeline Flatten Stage** - Flatten nested collections into individual records
+  - Collection flattening:
+    - `flatten` — Flatten nested lists/arrays into individual records
+    - `flatten(Field)` — Flatten a specific field within each record, expanding arrays
+  - Behavior:
+    - Simple flatten: Records containing `__items__` arrays are expanded
+    - Field flatten: Records where field contains an array become multiple records
+  - Use cases:
+    - Expanding nested JSON arrays
+    - Normalizing denormalized data
+    - Processing hierarchical structures
+    - Exploding array fields for analysis
+  - Supported targets: Python, Go, Rust
+  - `tests/integration/test_flatten_stage.sh` — Integration tests (16 tests)
+  - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
+
 - **XML Data Source Playbook** - A new playbook for processing XML data.
   - `playbooks/xml_data_source_playbook.md` - The playbook itself.
   - `playbooks/examples_library/xml_examples.md` - The implementation of the playbook.

--- a/src/unifyweaver/core/pipeline_validation.pl
+++ b/src/unifyweaver/core/pipeline_validation.pl
@@ -313,6 +313,11 @@ is_valid_stage(tap(Pred/Arity)) :-
     integer(Arity),
     Arity >= 0.
 
+% Flatten stage - flatten nested collections into individual records
+is_valid_stage(flatten).
+is_valid_stage(flatten(Field)) :-
+    atom(Field).
+
 %% is_valid_time_unit(+Unit) is semidet.
 %  Validates time unit for rate limiting.
 is_valid_time_unit(second).
@@ -404,6 +409,8 @@ stage_type(concat(_), concat) :- !.
 stage_type(merge_sorted(_, _), merge_sorted) :- !.
 stage_type(merge_sorted(_, _, _), merge_sorted) :- !.
 stage_type(tap(_), tap) :- !.
+stage_type(flatten, flatten) :- !.
+stage_type(flatten(_), flatten) :- !.
 stage_type(_, unknown).
 
 %% validate_stage_type(+Stage, -Type) is det.
@@ -680,6 +687,14 @@ validate_stage_specific(tap(Pred), Errors) :-
         Errors = []
     ;
         Errors = [error(invalid_tap, 'tap requires a predicate atom or predicate/arity')]
+    ).
+validate_stage_specific(flatten, []) :- !.
+validate_stage_specific(flatten(Field), Errors) :-
+    !,
+    ( atom(Field) ->
+        Errors = []
+    ;
+        Errors = [error(invalid_flatten, 'flatten(Field) requires a field atom')]
     ).
 validate_stage_specific(_, []).
 

--- a/tests/integration/test_flatten_stage.sh
+++ b/tests/integration/test_flatten_stage.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+# test_flatten_stage.sh - Integration tests for flatten pipeline stage
+# Tests: flatten, flatten(Field) - Flatten nested collections into individual records
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# ============================================
+# VALIDATION TESTS
+# ============================================
+
+# Test 1: Validation accepts flatten (simple)
+test_validation_flatten() {
+    log_info "Test 1: Validation accepts flatten (simple)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten, output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "flatten validation accepted"
+    else
+        log_fail "flatten validation failed: $output"
+    fi
+}
+
+# Test 2: Validation accepts flatten(Field)
+test_validation_flatten_field() {
+    log_info "Test 2: Validation accepts flatten(Field)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten(items), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "flatten(Field) validation accepted"
+    else
+        log_fail "flatten(Field) validation failed: $output"
+    fi
+}
+
+# Test 3: Validation rejects invalid flatten(Field)
+test_validation_flatten_invalid() {
+    log_info "Test 3: Validation rejects invalid flatten(Field)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten(123), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "invalid_flatten\|invalid_stage\|error"; then
+        log_pass "Invalid flatten(Field) correctly rejected"
+    else
+        log_fail "Invalid flatten(Field) should be rejected: $output"
+    fi
+}
+
+# Test 4: Stage type detection for flatten
+test_stage_type_flatten() {
+    log_info "Test 4: Stage type detection for flatten"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        stage_type(flatten, Type1),
+        stage_type(flatten(items), Type2),
+        format('Type1: ~w, Type2: ~w~n', [Type1, Type2])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Type1: flatten, Type2: flatten"; then
+        log_pass "flatten stage type correctly detected"
+    else
+        log_fail "flatten stage type detection failed: $output"
+    fi
+}
+
+# ============================================
+# PYTHON COMPILATION TESTS
+# ============================================
+
+# Test 5: Python flatten stage compilation
+test_python_flatten() {
+    log_info "Test 5: Python flatten stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, flatten, output/1], [pipeline_name(flatten_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "flatten_stage"; then
+        log_pass "Python flatten compiles correctly"
+    else
+        log_fail "Python flatten compilation failed"
+    fi
+}
+
+# Test 6: Python flatten(Field) compilation
+test_python_flatten_field() {
+    log_info "Test 6: Python flatten(Field) stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, flatten(items), output/1], [pipeline_name(flatten_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "flatten_field_stage.*items"; then
+        log_pass "Python flatten(Field) compiles correctly"
+    else
+        log_fail "Python flatten(Field) compilation failed"
+    fi
+}
+
+# ============================================
+# GO COMPILATION TESTS
+# ============================================
+
+# Test 7: Go flatten stage compilation
+test_go_flatten() {
+    log_info "Test 7: Go flatten stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, flatten, output/1], [pipeline_name(flattenTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "flattenStage"; then
+        log_pass "Go flatten compiles correctly"
+    else
+        log_fail "Go flatten compilation failed"
+    fi
+}
+
+# Test 8: Go flatten(Field) compilation
+test_go_flatten_field() {
+    log_info "Test 8: Go flatten(Field) stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, flatten(items), output/1], [pipeline_name(flattenTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "flattenFieldStage.*items"; then
+        log_pass "Go flatten(Field) compiles correctly"
+    else
+        log_fail "Go flatten(Field) compilation failed"
+    fi
+}
+
+# ============================================
+# RUST COMPILATION TESTS
+# ============================================
+
+# Test 9: Rust flatten stage compilation
+test_rust_flatten() {
+    log_info "Test 9: Rust flatten stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, flatten, output/1], [pipeline_name(flatten_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "flatten_stage"; then
+        log_pass "Rust flatten compiles correctly"
+    else
+        log_fail "Rust flatten compilation failed"
+    fi
+}
+
+# Test 10: Rust flatten(Field) compilation
+test_rust_flatten_field() {
+    log_info "Test 10: Rust flatten(Field) stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, flatten(items), output/1], [pipeline_name(flatten_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "flatten_field_stage.*items"; then
+        log_pass "Rust flatten(Field) compiles correctly"
+    else
+        log_fail "Rust flatten(Field) compilation failed"
+    fi
+}
+
+# ============================================
+# COMBINED STAGE TESTS
+# ============================================
+
+# Test 11: Multiple flatten stages in pipeline
+test_multiple_flattens() {
+    log_info "Test 11: Multiple flatten stages in pipeline"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten(outer), flatten(inner), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "Multiple flattens validation accepted"
+    else
+        log_fail "Multiple flattens validation failed: $output"
+    fi
+}
+
+# Test 12: flatten combined with filter_by
+test_flatten_with_filter() {
+    log_info "Test 12: flatten combined with filter_by"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten(items), filter_by(is_valid), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "flatten + filter_by validation accepted"
+    else
+        log_fail "flatten + filter_by validation failed: $output"
+    fi
+}
+
+# Test 13: flatten combined with distinct
+test_flatten_with_distinct() {
+    log_info "Test 13: flatten combined with distinct"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten, distinct, output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "flatten + distinct validation accepted"
+    else
+        log_fail "flatten + distinct validation failed: $output"
+    fi
+}
+
+# Test 14: flatten with parallel
+test_flatten_with_parallel() {
+    log_info "Test 14: flatten within parallel"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, parallel([flatten(items), flatten(tags)]), merge, output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "parallel([flatten, flatten]) validation accepted"
+    else
+        log_fail "parallel with flatten validation failed: $output"
+    fi
+}
+
+# Test 15: flatten with try_catch
+test_flatten_with_try_catch() {
+    log_info "Test 15: flatten with try_catch error handling"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, try_catch(flatten(items), error_handler/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "try_catch(flatten, handler) validation accepted"
+    else
+        log_fail "try_catch with flatten validation failed: $output"
+    fi
+}
+
+# Test 16: flatten with tap
+test_flatten_with_tap() {
+    log_info "Test 16: flatten combined with tap"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, tap(log_nested), flatten(items), tap(log_flattened), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "flatten + tap validation accepted"
+    else
+        log_fail "flatten + tap validation failed: $output"
+    fi
+}
+
+# ============================================
+# MAIN TEST RUNNER
+# ============================================
+
+main() {
+    echo "==========================================="
+    echo "  Pipeline Flatten Stage Tests"
+    echo "==========================================="
+    echo ""
+
+    # Validation tests
+    test_validation_flatten
+    test_validation_flatten_field
+    test_validation_flatten_invalid
+    test_stage_type_flatten
+
+    # Python compilation tests
+    test_python_flatten
+    test_python_flatten_field
+
+    # Go compilation tests
+    test_go_flatten
+    test_go_flatten_field
+
+    # Rust compilation tests
+    test_rust_flatten
+    test_rust_flatten_field
+
+    # Combined stage tests
+    test_multiple_flattens
+    test_flatten_with_filter
+    test_flatten_with_distinct
+    test_flatten_with_parallel
+    test_flatten_with_try_catch
+    test_flatten_with_tap
+
+    echo ""
+    echo "==========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "==========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary

Implements the **flatten pipeline stage** for expanding nested collections into individual records. This enables processing of hierarchical data structures by flattening arrays at the pipeline level.

- `flatten` — Flatten nested lists/arrays into individual records
- `flatten(Field)` — Flatten a specific field within each record, expanding arrays

## Implementation

### Validation (`pipeline_validation.pl`)
- `is_valid_stage(flatten)` — Simple flatten
- `is_valid_stage(flatten(Field))` — Field-specific flatten
- `stage_type(flatten, flatten)` / `stage_type(flatten(_), flatten)` — Type detection
- `validate_stage_specific(flatten(Field), Errors)` — Validates field is an atom

### Python (`python_target.pl`)
```python
def flatten_stage(stream):
    '''Flatten nested collections into individual records.'''
    for record in stream:
        if isinstance(record, (list, tuple)):
            for item in record:
                yield item
        elif isinstance(record, dict) and '__items__' in record:
            for item in record['__items__']:
                yield item
        else:
            yield record

def flatten_field_stage(stream, field):
    '''Flatten a specific field within each record.'''
    for record in stream:
        if isinstance(record, dict) and field in record:
            field_value = record[field]
            if isinstance(field_value, (list, tuple)):
                for item in field_value:
                    new_record = record.copy()
                    new_record[field] = item
                    yield new_record
            else:
                yield record
        else:
            yield record
```

### Go (`go_target.pl`)
```go
func flattenStage(records []Record) []Record {
    var result []Record
    for _, record := range records {
        if items, ok := record["__items__"]; ok {
            if arr, ok := items.([]interface{}); ok {
                for _, item := range arr {
                    if rec, ok := item.(Record); ok {
                        result = append(result, rec)
                    } else if m, ok := item.(map[string]interface{}); ok {
                        result = append(result, Record(m))
                    }
                }
                continue
            }
        }
        result = append(result, record)
    }
    return result
}

func flattenFieldStage(records []Record, field string) []Record {
    var result []Record
    for _, record := range records {
        if fieldValue, ok := record[field]; ok {
            if arr, ok := fieldValue.([]interface{}); ok {
                for _, item := range arr {
                    newRecord := make(Record)
                    for k, v := range record {
                        newRecord[k] = v
                    }
                    newRecord[field] = item
                    result = append(result, newRecord)
                }
                continue
            }
        }
        result = append(result, record)
    }
    return result
}
```

### Rust (`rust_target.pl`)
```rust
fn flatten_stage(records: &[Record]) -> Vec<Record> {
    let mut result = Vec::new();
    for record in records {
        if let Some(serde_json::Value::Array(items)) = record.get("__items__") {
            for item in items {
                if let serde_json::Value::Object(map) = item {
                    result.push(map.clone());
                }
            }
        } else {
            result.push(record.clone());
        }
    }
    result
}

fn flatten_field_stage(records: &[Record], field: &str) -> Vec<Record> {
    let mut result = Vec::new();
    for record in records {
        if let Some(serde_json::Value::Array(items)) = record.get(field) {
            for item in items {
                let mut new_record = record.clone();
                new_record.insert(field.to_string(), item.clone());
                result.push(new_record);
            }
        } else {
            result.push(record.clone());
        }
    }
    result
}
```

## Use Cases

- **Expanding nested JSON arrays** — Flatten `{"users": [{"name": "A"}, {"name": "B"}]}` into individual user records
- **Normalizing denormalized data** — Convert nested structures to flat records
- **Processing hierarchical structures** — Flatten tree-like data for analysis
- **Exploding array fields** — Turn `{"id": 1, "tags": ["a", "b"]}` into `[{"id": 1, "tags": "a"}, {"id": 1, "tags": "b"}]`

## Example Usage

```prolog
% Simple flatten of nested records
pipeline([
    parse/1,
    flatten,
    output/1
]).

% Flatten a specific field
pipeline([
    parse/1,
    flatten(items),
    filter_by(is_valid),
    output/1
]).

% Multiple flatten operations for deeply nested data
pipeline([
    parse/1,
    flatten(orders),
    flatten(line_items),
    output/1
]).

% Combine with tap for debugging
pipeline([
    parse/1,
    tap(log_nested),
    flatten(items),
    tap(log_flattened),
    distinct,
    output/1
]).
```

## Files Changed

- `src/unifyweaver/core/pipeline_validation.pl` — Validation support
- `src/unifyweaver/targets/python_target.pl` — Python implementation
- `src/unifyweaver/targets/go_target.pl` — Go implementation
- `src/unifyweaver/targets/rust_target.pl` — Rust implementation
- `tests/integration/test_flatten_stage.sh` — Integration tests
- `CHANGELOG.md` — Documentation

## Test Plan

```bash
./tests/integration/test_flatten_stage.sh
```

**16 tests passing:**
- Validation tests (4): simple flatten, flatten(Field), invalid rejection, stage type
- Python compilation tests (2): flatten, flatten(Field)
- Go compilation tests (2): flatten, flatten(Field)
- Rust compilation tests (2): flatten, flatten(Field)
- Combined stage tests (6): multiple flattens, filter_by, distinct, parallel, try_catch, tap

## Breaking Changes

None. This is a pure feature addition that's backwards compatible.

---

Generated with [Claude Code](https://claude.com/claude-code)
