### PR TITLE
feat: Add debounce pipeline stage for rate-limiting noisy streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_flatten_stage.sh` — Integration tests (16 tests)
   - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
 
+- **Pipeline Debounce Stage** - Rate-limit noisy streams by emitting only after silence
+  - Debounce variants:
+    - `debounce(Ms)` — Emit record only after Ms milliseconds of silence
+    - `debounce(Ms, Field)` — Use specified timestamp field for timing
+  - Behavior:
+    - Groups records by time windows
+    - Emits only the last record when silence period is reached
+    - Useful for suppressing rapid successive updates
+  - Use cases:
+    - Rate-limiting sensor data
+    - Suppressing duplicate events
+    - Coalescing rapid updates
+    - Smoothing noisy time-series data
+  - Supported targets: Python, Go, Rust
+  - `tests/integration/test_debounce_stage.sh` — Integration tests (16 tests)
+  - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
+
 - **XML Data Source Playbook** - A new playbook for processing XML data.
   - `playbooks/xml_data_source_playbook.md` - The playbook itself.
   - `playbooks/examples_library/xml_examples.md` - The implementation of the playbook.

--- a/src/unifyweaver/core/pipeline_validation.pl
+++ b/src/unifyweaver/core/pipeline_validation.pl
@@ -318,6 +318,15 @@ is_valid_stage(flatten).
 is_valid_stage(flatten(Field)) :-
     atom(Field).
 
+% Debounce stage - emit only after silence period
+is_valid_stage(debounce(Ms)) :-
+    integer(Ms),
+    Ms > 0.
+is_valid_stage(debounce(Ms, Field)) :-
+    integer(Ms),
+    Ms > 0,
+    atom(Field).
+
 %% is_valid_time_unit(+Unit) is semidet.
 %  Validates time unit for rate limiting.
 is_valid_time_unit(second).
@@ -411,6 +420,8 @@ stage_type(merge_sorted(_, _, _), merge_sorted) :- !.
 stage_type(tap(_), tap) :- !.
 stage_type(flatten, flatten) :- !.
 stage_type(flatten(_), flatten) :- !.
+stage_type(debounce(_), debounce) :- !.
+stage_type(debounce(_, _), debounce) :- !.
 stage_type(_, unknown).
 
 %% validate_stage_type(+Stage, -Type) is det.
@@ -695,6 +706,20 @@ validate_stage_specific(flatten(Field), Errors) :-
         Errors = []
     ;
         Errors = [error(invalid_flatten, 'flatten(Field) requires a field atom')]
+    ).
+validate_stage_specific(debounce(Ms), Errors) :-
+    !,
+    ( integer(Ms), Ms > 0 ->
+        Errors = []
+    ;
+        Errors = [error(invalid_debounce, 'debounce(Ms) requires a positive integer milliseconds')]
+    ).
+validate_stage_specific(debounce(Ms, Field), Errors) :-
+    !,
+    ( integer(Ms), Ms > 0, atom(Field) ->
+        Errors = []
+    ;
+        Errors = [error(invalid_debounce, 'debounce(Ms, Field) requires positive integer ms and field atom')]
     ).
 validate_stage_specific(_, []).
 

--- a/tests/integration/test_debounce_stage.sh
+++ b/tests/integration/test_debounce_stage.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+# test_debounce_stage.sh - Integration tests for debounce pipeline stage
+# Tests: debounce(Ms), debounce(Ms, Field) - Emit only after silence period
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# ============================================
+# VALIDATION TESTS
+# ============================================
+
+# Test 1: Validation accepts debounce(Ms)
+test_validation_debounce() {
+    log_info "Test 1: Validation accepts debounce(Ms)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(100), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce(Ms) validation accepted"
+    else
+        log_fail "debounce(Ms) validation failed: $output"
+    fi
+}
+
+# Test 2: Validation accepts debounce(Ms, Field)
+test_validation_debounce_field() {
+    log_info "Test 2: Validation accepts debounce(Ms, Field)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(500, timestamp), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce(Ms, Field) validation accepted"
+    else
+        log_fail "debounce(Ms, Field) validation failed: $output"
+    fi
+}
+
+# Test 3: Validation rejects invalid debounce (zero ms)
+test_validation_debounce_zero() {
+    log_info "Test 3: Validation rejects invalid debounce (zero ms)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(0), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "invalid_debounce\|invalid_stage\|error"; then
+        log_pass "Invalid debounce(0) correctly rejected"
+    else
+        log_fail "Invalid debounce(0) should be rejected: $output"
+    fi
+}
+
+# Test 4: Validation rejects invalid debounce (negative ms)
+test_validation_debounce_negative() {
+    log_info "Test 4: Validation rejects invalid debounce (negative ms)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(-100), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "invalid_debounce\|invalid_stage\|error"; then
+        log_pass "Invalid debounce(-100) correctly rejected"
+    else
+        log_fail "Invalid debounce(-100) should be rejected: $output"
+    fi
+}
+
+# Test 5: Stage type detection for debounce
+test_stage_type_debounce() {
+    log_info "Test 5: Stage type detection for debounce"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        stage_type(debounce(100), Type1),
+        stage_type(debounce(100, ts), Type2),
+        format('Type1: ~w, Type2: ~w~n', [Type1, Type2])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Type1: debounce, Type2: debounce"; then
+        log_pass "debounce stage type correctly detected"
+    else
+        log_fail "debounce stage type detection failed: $output"
+    fi
+}
+
+# ============================================
+# PYTHON COMPILATION TESTS
+# ============================================
+
+# Test 6: Python debounce stage compilation
+test_python_debounce() {
+    log_info "Test 6: Python debounce stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, debounce(100), output/1], [pipeline_name(debounce_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "debounce_stage"; then
+        log_pass "Python debounce compiles correctly"
+    else
+        log_fail "Python debounce compilation failed"
+    fi
+}
+
+# Test 7: Python debounce(Ms, Field) compilation
+test_python_debounce_field() {
+    log_info "Test 7: Python debounce(Ms, Field) stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, debounce(500, timestamp), output/1], [pipeline_name(debounce_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "debounce_stage.*timestamp"; then
+        log_pass "Python debounce(Ms, Field) compiles correctly"
+    else
+        log_fail "Python debounce(Ms, Field) compilation failed"
+    fi
+}
+
+# ============================================
+# GO COMPILATION TESTS
+# ============================================
+
+# Test 8: Go debounce stage compilation
+test_go_debounce() {
+    log_info "Test 8: Go debounce stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, debounce(100), output/1], [pipeline_name(debounceTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "debounceStage"; then
+        log_pass "Go debounce compiles correctly"
+    else
+        log_fail "Go debounce compilation failed"
+    fi
+}
+
+# Test 9: Go debounce(Ms, Field) compilation
+test_go_debounce_field() {
+    log_info "Test 9: Go debounce(Ms, Field) stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, debounce(500, timestamp), output/1], [pipeline_name(debounceTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "debounceStage.*timestamp"; then
+        log_pass "Go debounce(Ms, Field) compiles correctly"
+    else
+        log_fail "Go debounce(Ms, Field) compilation failed"
+    fi
+}
+
+# ============================================
+# RUST COMPILATION TESTS
+# ============================================
+
+# Test 10: Rust debounce stage compilation
+test_rust_debounce() {
+    log_info "Test 10: Rust debounce stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, debounce(100), output/1], [pipeline_name(debounce_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "debounce_stage"; then
+        log_pass "Rust debounce compiles correctly"
+    else
+        log_fail "Rust debounce compilation failed"
+    fi
+}
+
+# Test 11: Rust debounce(Ms, Field) compilation
+test_rust_debounce_field() {
+    log_info "Test 11: Rust debounce(Ms, Field) stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, debounce(500, timestamp), output/1], [pipeline_name(debounce_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "debounce_stage.*timestamp"; then
+        log_pass "Rust debounce(Ms, Field) compiles correctly"
+    else
+        log_fail "Rust debounce(Ms, Field) compilation failed"
+    fi
+}
+
+# ============================================
+# COMBINED STAGE TESTS
+# ============================================
+
+# Test 12: debounce combined with filter_by
+test_debounce_with_filter() {
+    log_info "Test 12: debounce combined with filter_by"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(100), filter_by(is_valid), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce + filter_by validation accepted"
+    else
+        log_fail "debounce + filter_by validation failed: $output"
+    fi
+}
+
+# Test 13: debounce combined with distinct
+test_debounce_with_distinct() {
+    log_info "Test 13: debounce combined with distinct"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(100), distinct, output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce + distinct validation accepted"
+    else
+        log_fail "debounce + distinct validation failed: $output"
+    fi
+}
+
+# Test 14: debounce combined with tap
+test_debounce_with_tap() {
+    log_info "Test 14: debounce combined with tap"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, tap(log_input), debounce(100), tap(log_debounced), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce + tap validation accepted"
+    else
+        log_fail "debounce + tap validation failed: $output"
+    fi
+}
+
+# Test 15: debounce with try_catch
+test_debounce_with_try_catch() {
+    log_info "Test 15: debounce with try_catch error handling"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, try_catch(debounce(100), error_handler/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "try_catch(debounce, handler) validation accepted"
+    else
+        log_fail "try_catch with debounce validation failed: $output"
+    fi
+}
+
+# Test 16: debounce with flatten
+test_debounce_with_flatten() {
+    log_info "Test 16: debounce combined with flatten"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, flatten(items), debounce(100, timestamp), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce + flatten validation accepted"
+    else
+        log_fail "debounce + flatten validation failed: $output"
+    fi
+}
+
+# ============================================
+# MAIN TEST RUNNER
+# ============================================
+
+main() {
+    echo "==========================================="
+    echo "  Pipeline Debounce Stage Tests"
+    echo "==========================================="
+    echo ""
+
+    # Validation tests
+    test_validation_debounce
+    test_validation_debounce_field
+    test_validation_debounce_zero
+    test_validation_debounce_negative
+    test_stage_type_debounce
+
+    # Python compilation tests
+    test_python_debounce
+    test_python_debounce_field
+
+    # Go compilation tests
+    test_go_debounce
+    test_go_debounce_field
+
+    # Rust compilation tests
+    test_rust_debounce
+    test_rust_debounce_field
+
+    # Combined stage tests
+    test_debounce_with_filter
+    test_debounce_with_distinct
+    test_debounce_with_tap
+    test_debounce_with_try_catch
+    test_debounce_with_flatten
+
+    echo ""
+    echo "==========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "==========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary

Implements the **debounce pipeline stage** for rate-limiting noisy streams by emitting records only after a silence period. This is useful for suppressing rapid successive updates and coalescing events.

- `debounce(Ms)` — Emit record only after Ms milliseconds of silence
- `debounce(Ms, Field)` — Use specified timestamp field for timing

## Implementation

### Validation (`pipeline_validation.pl`)
- `is_valid_stage(debounce(Ms))` — Ms must be positive integer
- `is_valid_stage(debounce(Ms, Field))` — Ms positive integer, Field atom
- `stage_type(debounce(_), debounce)` / `stage_type(debounce(_, _), debounce)` — Type detection
- `validate_stage_specific` — Validates milliseconds > 0

### Python (`python_target.pl`)
```python
def debounce_stage(stream, ms, timestamp_field=None):
    '''
    Debounce: Emit records only after a silence period.
    Groups records by time windows and emits the last record in each window.
    '''
    import time
    buffer = []
    last_time = None
    threshold_sec = ms / 1000.0

    for record in stream:
        current_time = time.time()
        if timestamp_field and isinstance(record, dict) and timestamp_field in record:
            try:
                current_time = float(record[timestamp_field])
            except (ValueError, TypeError):
                pass

        if last_time is None:
            buffer = [record]
            last_time = current_time
        elif current_time - last_time < threshold_sec:
            # Within debounce window, replace buffer
            buffer = [record]
            last_time = current_time
        else:
            # Silence period exceeded, emit buffered and start new
            if buffer:
                yield buffer[-1]
            buffer = [record]
            last_time = current_time

    # Emit final buffered record
    if buffer:
        yield buffer[-1]
```

### Go (`go_target.pl`)
```go
func debounceStage(records []Record, ms int64, timestampField string) []Record {
    if len(records) == 0 {
        return records
    }

    var result []Record
    var buffer Record
    var lastTime float64 = -1
    thresholdSec := float64(ms) / 1000.0

    for _, record := range records {
        currentTime := float64(time.Now().UnixNano()) / 1e9
        if timestampField != "" {
            if ts, ok := record[timestampField]; ok {
                switch v := ts.(type) {
                case float64:
                    currentTime = v
                case int64:
                    currentTime = float64(v)
                case int:
                    currentTime = float64(v)
                }
            }
        }

        if lastTime < 0 {
            buffer = record
            lastTime = currentTime
        } else if currentTime-lastTime < thresholdSec {
            buffer = record
            lastTime = currentTime
        } else {
            result = append(result, buffer)
            buffer = record
            lastTime = currentTime
        }
    }

    result = append(result, buffer)
    return result
}
```

### Rust (`rust_target.pl`)
```rust
fn debounce_stage(records: &[Record], ms: u64, timestamp_field: Option<&str>) -> Vec<Record> {
    use std::time::{SystemTime, UNIX_EPOCH};

    if records.is_empty() {
        return Vec::new();
    }

    let mut result = Vec::new();
    let mut buffer: Option<Record> = None;
    let mut last_time: Option<f64> = None;
    let threshold_sec = ms as f64 / 1000.0;

    for record in records {
        let current_time = if let Some(field) = timestamp_field {
            // Use timestamp field if available
            if let Some(ts) = record.get(field) {
                match ts {
                    serde_json::Value::Number(n) => n.as_f64().unwrap_or_else(|| {
                        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs_f64()
                    }),
                    _ => SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs_f64(),
                }
            } else {
                SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs_f64()
            }
        } else {
            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs_f64()
        };

        match last_time {
            None => {
                buffer = Some(record.clone());
                last_time = Some(current_time);
            }
            Some(lt) if current_time - lt < threshold_sec => {
                buffer = Some(record.clone());
                last_time = Some(current_time);
            }
            Some(_) => {
                if let Some(buf) = buffer.take() {
                    result.push(buf);
                }
                buffer = Some(record.clone());
                last_time = Some(current_time);
            }
        }
    }

    if let Some(buf) = buffer {
        result.push(buf);
    }

    result
}
```

## Use Cases

- **Rate-limiting sensor data** — Suppress high-frequency sensor readings
- **Suppressing duplicate events** — Coalesce rapid button clicks or UI events
- **Coalescing rapid updates** — Batch database writes during burst activity
- **Smoothing noisy time-series** — Filter out noise from streaming data

## Example Usage

```prolog
% Simple debounce with 100ms window
pipeline([
    parse/1,
    debounce(100),
    output/1
]).

% Debounce using timestamp field from records
pipeline([
    parse/1,
    debounce(500, event_time),
    output/1
]).

% Combine with tap for monitoring
pipeline([
    parse/1,
    tap(log_raw),
    debounce(100),
    tap(log_debounced),
    output/1
]).

% Chain with other stages
pipeline([
    parse/1,
    flatten(events),
    debounce(200, timestamp),
    distinct,
    output/1
]).
```

## Files Changed

- `src/unifyweaver/core/pipeline_validation.pl` — Validation support
- `src/unifyweaver/targets/python_target.pl` — Python implementation
- `src/unifyweaver/targets/go_target.pl` — Go implementation
- `src/unifyweaver/targets/rust_target.pl` — Rust implementation
- `tests/integration/test_debounce_stage.sh` — Integration tests
- `CHANGELOG.md` — Documentation

## Test Plan

```bash
./tests/integration/test_debounce_stage.sh
```

**16 tests passing:**
- Validation tests (5): debounce(Ms), debounce(Ms, Field), zero rejection, negative rejection, stage type
- Python compilation tests (2): debounce, debounce with field
- Go compilation tests (2): debounce, debounce with field
- Rust compilation tests (2): debounce, debounce with field
- Combined stage tests (5): filter_by, distinct, tap, try_catch, flatten

## Breaking Changes

None. This is a pure feature addition that's backwards compatible.

---

Generated with [Claude Code](https://claude.com/claude-code)
