### PR TITLE
feat: Add branch pipeline stage for conditional routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_debounce_stage.sh` — Integration tests (16 tests)
   - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
 
+- **Pipeline Branch Stage** - Conditional routing within pipeline
+  - Branch syntax:
+    - `branch(Cond, TrueStage, FalseStage)` — Route records based on condition
+    - `branch(Cond/Arity, TrueStage, FalseStage)` — With explicit arity
+  - Behavior:
+    - Records matching condition go through TrueStage
+    - Records not matching go through FalseStage
+    - Results from both branches are combined in output
+    - Supports nested branches and complex sub-stages
+  - Use cases:
+    - A/B processing paths
+    - Conditional transformations
+    - Error vs success routing
+    - Type-based record handling
+  - Supported targets: Python, Go, Rust
+  - `tests/integration/test_branch_stage.sh` — Integration tests (16 tests)
+  - Documentation in `docs/ENHANCED_PIPELINE_CHAINING.md`
+
 - **XML Data Source Playbook** - A new playbook for processing XML data.
   - `playbooks/xml_data_source_playbook.md` - The playbook itself.
   - `playbooks/examples_library/xml_examples.md` - The implementation of the playbook.

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -9669,6 +9669,29 @@ func debounceStage(records []Record, ms int64, timestampField string) []Record {
 \treturn result
 }
 
+// branchStage routes records through different stages based on condition
+// Records matching condition go through trueStage, others through falseStage
+func branchStage(records []Record, condFn func(Record) bool, trueFn func([]Record) []Record, falseFn func([]Record) []Record) []Record {
+\tvar trueRecords, falseRecords []Record
+
+\tfor _, record := range records {
+\t\tif condFn(record) {
+\t\t\ttrueRecords = append(trueRecords, record)
+\t\t} else {
+\t\t\tfalseRecords = append(falseRecords, record)
+\t\t}
+\t}
+
+\tvar result []Record
+\tif len(trueRecords) > 0 {
+\t\tresult = append(result, trueFn(trueRecords)...)
+\t}
+\tif len(falseRecords) > 0 {
+\t\tresult = append(result, falseFn(falseRecords)...)
+\t}
+\treturn result
+}
+
 '.
 
 %% generate_go_enhanced_stage_functions(+Stages, -Code)
@@ -9769,6 +9792,11 @@ generate_go_single_enhanced_stage(flatten, "") :- !.
 generate_go_single_enhanced_stage(flatten(_), "") :- !.
 generate_go_single_enhanced_stage(debounce(_), "") :- !.
 generate_go_single_enhanced_stage(debounce(_, _), "") :- !.
+generate_go_single_enhanced_stage(branch(_Cond, TrueStage, FalseStage), Code) :-
+    !,
+    generate_go_single_enhanced_stage(TrueStage, TrueCode),
+    generate_go_single_enhanced_stage(FalseStage, FalseCode),
+    format(string(Code), "~w~w", [TrueCode, FalseCode]).
 generate_go_single_enhanced_stage(Pred/Arity, Code) :-
     !,
     format(string(Code),
@@ -10311,6 +10339,23 @@ generate_go_stage_flow(debounce(Ms, Field), InVar, OutVar, Code) :-
     format(string(Code),
 "\t// Debounce: emit after ~wms silence (using '~w' timestamp field)
 \t~w := debounceStage(~w, ~w, \"~w\")", [Ms, Field, OutVar, InVar, Ms, Field]).
+
+% Branch stage: conditional routing
+generate_go_stage_flow(branch(Cond, TrueStage, FalseStage), InVar, OutVar, Code) :-
+    !,
+    OutVar = "branchResult",
+    % Extract condition predicate name
+    ( Cond = CondName/_ -> true ; CondName = Cond ),
+    % Extract true/false stage names
+    ( TrueStage = TrueName/_ -> true ; TrueName = TrueStage ),
+    ( FalseStage = FalseName/_ -> true ; FalseName = FalseStage ),
+    format(string(Code),
+"\t// Branch: if ~w then ~w else ~w
+\t~w := branchStage(~w,
+\t\tfunc(r Record) bool { return ~w(r) },
+\t\tfunc(rs []Record) []Record { return ~w(rs) },
+\t\tfunc(rs []Record) []Record { return ~w(rs) })",
+    [CondName, TrueName, FalseName, OutVar, InVar, CondName, TrueName, FalseName]).
 
 % Standard predicate stage
 generate_go_stage_flow(Pred/Arity, InVar, OutVar, Code) :-

--- a/tests/integration/test_branch_stage.sh
+++ b/tests/integration/test_branch_stage.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+# test_branch_stage.sh - Integration tests for branch pipeline stage
+# Tests: branch(Cond, TrueStage, FalseStage) - Conditional routing
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# ============================================
+# VALIDATION TESTS
+# ============================================
+
+# Test 1: Validation accepts branch(Cond, TrueStage, FalseStage)
+test_validation_branch() {
+    log_info "Test 1: Validation accepts branch(Cond, TrueStage, FalseStage)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "branch(Cond, TrueStage, FalseStage) validation accepted"
+    else
+        log_fail "branch validation failed: $output"
+    fi
+}
+
+# Test 2: Validation accepts branch(Cond/Arity, TrueStage, FalseStage)
+test_validation_branch_arity() {
+    log_info "Test 2: Validation accepts branch(Cond/Arity, TrueStage, FalseStage)"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, branch(is_active/1, transform/1, skip/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "branch(Cond/Arity, TrueStage, FalseStage) validation accepted"
+    else
+        log_fail "branch with arity validation failed: $output"
+    fi
+}
+
+# Test 3: Stage type detection for branch
+test_stage_type_branch() {
+    log_info "Test 3: Stage type detection for branch"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        stage_type(branch(is_active, transform/1, skip/1), Type),
+        format('Type: ~w~n', [Type])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Type: branch"; then
+        log_pass "branch stage type correctly detected"
+    else
+        log_fail "branch stage type detection failed: $output"
+    fi
+}
+
+# Test 4: Validation validates nested stages
+test_validation_branch_nested() {
+    log_info "Test 4: Validation validates nested branch stages"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, branch(cond/1, filter_by(pred), distinct), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "branch with nested stages validation accepted"
+    else
+        log_fail "branch with nested stages validation failed: $output"
+    fi
+}
+
+# Test 5: Validation validates nested branch in branch
+test_validation_branch_recursive() {
+    log_info "Test 5: Validation validates nested branch in branch"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, branch(cond1/1, branch(cond2/1, a/1, b/1), c/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "nested branch in branch validation accepted"
+    else
+        log_fail "nested branch validation failed: $output"
+    fi
+}
+
+# ============================================
+# PYTHON COMPILATION TESTS
+# ============================================
+
+# Test 6: Python branch stage compilation
+test_python_branch() {
+    log_info "Test 6: Python branch stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], [pipeline_name(branch_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "branch_stage"; then
+        log_pass "Python branch compiles correctly"
+    else
+        log_fail "Python branch compilation failed"
+    fi
+}
+
+# Test 7: Python branch generates condition function
+test_python_branch_cond() {
+    log_info "Test 7: Python branch generates condition function"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/python_target),
+        compile_enhanced_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], [pipeline_name(branch_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "_branch_cond" && echo "$output" | grep -q "is_active"; then
+        log_pass "Python branch generates condition function"
+    else
+        log_fail "Python branch condition function not generated"
+    fi
+}
+
+# ============================================
+# GO COMPILATION TESTS
+# ============================================
+
+# Test 8: Go branch stage compilation
+test_go_branch() {
+    log_info "Test 8: Go branch stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], [pipeline_name(branchTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "branchStage"; then
+        log_pass "Go branch compiles correctly"
+    else
+        log_fail "Go branch compilation failed"
+    fi
+}
+
+# Test 9: Go branch generates function parameters
+test_go_branch_params() {
+    log_info "Test 9: Go branch generates function parameters"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/go_target),
+        compile_go_enhanced_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], [pipeline_name(branchTest)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "func(r Record) bool"; then
+        log_pass "Go branch generates function parameters"
+    else
+        log_fail "Go branch function parameters not generated"
+    fi
+}
+
+# ============================================
+# RUST COMPILATION TESTS
+# ============================================
+
+# Test 10: Rust branch stage compilation
+test_rust_branch() {
+    log_info "Test 10: Rust branch stage compilation"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], [pipeline_name(branch_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "branch_stage"; then
+        log_pass "Rust branch compiles correctly"
+    else
+        log_fail "Rust branch compilation failed"
+    fi
+}
+
+# Test 11: Rust branch generates closures
+test_rust_branch_closures() {
+    log_info "Test 11: Rust branch generates closures"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/targets/rust_target),
+        compile_rust_enhanced_pipeline([parse/1, branch(is_active, transform/1, skip/1), output/1], [pipeline_name(branch_test)], Code),
+        format('~w', [Code])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "|r| is_active(r)"; then
+        log_pass "Rust branch generates closures"
+    else
+        log_fail "Rust branch closures not generated"
+    fi
+}
+
+# ============================================
+# COMBINED STAGE TESTS
+# ============================================
+
+# Test 12: branch combined with filter_by
+test_branch_with_filter() {
+    log_info "Test 12: branch combined with filter_by"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, filter_by(active), branch(cond/1, a/1, b/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "filter_by + branch validation accepted"
+    else
+        log_fail "filter_by + branch validation failed: $output"
+    fi
+}
+
+# Test 13: branch combined with distinct
+test_branch_with_distinct() {
+    log_info "Test 13: branch combined with distinct"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, branch(cond/1, distinct, dedup), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "branch with distinct/dedup stages validation accepted"
+    else
+        log_fail "branch with distinct/dedup validation failed: $output"
+    fi
+}
+
+# Test 14: branch combined with tap
+test_branch_with_tap() {
+    log_info "Test 14: branch combined with tap"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, tap(log_input), branch(cond/1, a/1, b/1), tap(log_output), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "tap + branch + tap validation accepted"
+    else
+        log_fail "tap + branch + tap validation failed: $output"
+    fi
+}
+
+# Test 15: branch with try_catch
+test_branch_with_try_catch() {
+    log_info "Test 15: branch with try_catch error handling"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, try_catch(branch(cond/1, a/1, b/1), error_handler/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "try_catch(branch, handler) validation accepted"
+    else
+        log_fail "try_catch with branch validation failed: $output"
+    fi
+}
+
+# Test 16: branch with debounce
+test_branch_with_debounce() {
+    log_info "Test 16: branch combined with debounce"
+    cd "$PROJECT_ROOT"
+    local output=$(swipl -g "
+        use_module(src/unifyweaver/core/pipeline_validation),
+        validate_pipeline([parse/1, debounce(100), branch(cond/1, a/1, b/1), output/1], Errors),
+        format('Errors: ~w~n', [Errors])
+    " -t halt 2>&1)
+    if echo "$output" | grep -q "Errors: \[\]"; then
+        log_pass "debounce + branch validation accepted"
+    else
+        log_fail "debounce + branch validation failed: $output"
+    fi
+}
+
+# ============================================
+# MAIN TEST RUNNER
+# ============================================
+
+main() {
+    echo "==========================================="
+    echo "  Pipeline Branch Stage Tests"
+    echo "==========================================="
+    echo ""
+
+    # Validation tests
+    test_validation_branch
+    test_validation_branch_arity
+    test_stage_type_branch
+    test_validation_branch_nested
+    test_validation_branch_recursive
+
+    # Python compilation tests
+    test_python_branch
+    test_python_branch_cond
+
+    # Go compilation tests
+    test_go_branch
+    test_go_branch_params
+
+    # Rust compilation tests
+    test_rust_branch
+    test_rust_branch_closures
+
+    # Combined stage tests
+    test_branch_with_filter
+    test_branch_with_distinct
+    test_branch_with_tap
+    test_branch_with_try_catch
+    test_branch_with_debounce
+
+    echo ""
+    echo "==========================================="
+    echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "==========================================="
+
+    if [ $FAIL_COUNT -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main


### PR DESCRIPTION
## Summary

Implements the **branch pipeline stage** for conditional routing within pipelines. Records matching a condition go through one stage, while non-matching records go through another stage.

- `branch(Cond, TrueStage, FalseStage)` — Route records based on condition predicate
- `branch(Cond/Arity, TrueStage, FalseStage)` — With explicit arity

## Implementation

### Validation (`pipeline_validation.pl`)
- `is_valid_stage(branch(Cond, TrueStage, FalseStage))` — Validates condition atom and sub-stages
- `is_valid_stage(branch(Cond/Arity, TrueStage, FalseStage))` — With explicit arity
- `stage_type(branch(_, _, _), branch)` — Type detection
- `validate_stage_specific(branch(...))` — Recursive sub-stage validation

### Python (`python_target.pl`)
```python
def branch_stage(stream, condition_fn, true_fn, false_fn):
    '''
    Branch: Conditional routing within pipeline.
    Records matching condition go through true_fn, others through false_fn.
    Results from both branches are combined in the output.
    '''
    for record in stream:
        try:
            if condition_fn(record):
                result = true_fn(iter([record]))
                for item in result:
                    yield item
            else:
                result = false_fn(iter([record]))
                for item in result:
                    yield item
        except Exception:
            # On condition error, pass through unchanged
            yield record
```

### Go (`go_target.pl`)
```go
func branchStage(records []Record, condFn func(Record) bool, trueFn func([]Record) []Record, falseFn func([]Record) []Record) []Record {
    var trueRecords, falseRecords []Record

    for _, record := range records {
        if condFn(record) {
            trueRecords = append(trueRecords, record)
        } else {
            falseRecords = append(falseRecords, record)
        }
    }

    var result []Record
    if len(trueRecords) > 0 {
        result = append(result, trueFn(trueRecords)...)
    }
    if len(falseRecords) > 0 {
        result = append(result, falseFn(falseRecords)...)
    }
    return result
}
```

### Rust (`rust_target.pl`)
```rust
fn branch_stage<F, T, E>(
    records: &[Record],
    cond_fn: F,
    true_fn: T,
    false_fn: E,
) -> Vec<Record>
where
    F: Fn(&Record) -> bool,
    T: Fn(&[Record]) -> Vec<Record>,
    E: Fn(&[Record]) -> Vec<Record>,
{
    let (true_records, false_records): (Vec<_>, Vec<_>) =
        records.iter().cloned().partition(|r| cond_fn(r));

    let mut result = Vec::new();
    if !true_records.is_empty() {
        result.extend(true_fn(&true_records));
    }
    if !false_records.is_empty() {
        result.extend(false_fn(&false_records));
    }
    result
}
```

## Use Cases

- **A/B processing paths** — Route records through different transformations based on criteria
- **Conditional transformations** — Apply different logic to subsets of data
- **Error vs success routing** — Handle valid and invalid records differently
- **Type-based record handling** — Process different record types with appropriate handlers

## Example Usage

```prolog
% Simple conditional routing
pipeline([
    parse/1,
    branch(is_active, process_active/1, archive/1),
    output/1
]).

% With explicit arity
pipeline([
    parse/1,
    branch(is_valid/1, transform/1, log_error/1),
    output/1
]).

% Nested branches
pipeline([
    parse/1,
    branch(is_premium,
        branch(is_vip, vip_handler/1, premium_handler/1),
        standard_handler/1),
    output/1
]).

% Combined with other stages
pipeline([
    parse/1,
    filter_by(active),
    branch(needs_update, update/1, passthrough/1),
    distinct,
    output/1
]).
```

## Files Changed

- `src/unifyweaver/core/pipeline_validation.pl` — Validation support
- `src/unifyweaver/targets/python_target.pl` — Python implementation
- `src/unifyweaver/targets/go_target.pl` — Go implementation
- `src/unifyweaver/targets/rust_target.pl` — Rust implementation
- `tests/integration/test_branch_stage.sh` — Integration tests
- `CHANGELOG.md` — Documentation

## Test Plan

```bash
./tests/integration/test_branch_stage.sh
```

**16 tests passing:**
- Validation tests (5): branch syntax, arity variant, stage type, nested stages, recursive branches
- Python compilation tests (2): branch stage, condition function generation
- Go compilation tests (2): branch stage, function parameters
- Rust compilation tests (2): branch stage, closure generation
- Combined stage tests (5): filter_by, distinct/dedup, tap, try_catch, debounce

## Breaking Changes

None. This is a pure feature addition that's backwards compatible.

---

Generated with [Claude Code](https://claude.com/claude-code)
