### PR TITLE
ci: run csharp_query target tests (codegen-only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           swipl -g "asserta(user:file_search_path(library, 'src/unifyweaver/core')), asserta(user:file_search_path(library, 'tests/core')), use_module(library(test_policy)), test_policy, halt."
 
+      - name: Run C# query target tests (codegen only)
+        run: |
+          SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g "test_csharp_query_target:test_csharp_query_target" -t halt
+
       - name: Generate and run inference test runner
         run: |
           swipl -g "use_module('src/unifyweaver/core/advanced/test_runner_inference'), generate_test_runner_inferred('output/advanced/inferred_test_runner.sh'), halt."


### PR DESCRIPTION
  - Adds a GitHub Actions step to run tests/core/test_csharp_query_target.pl with SKIP_CSHARP_EXECUTION=1, so query-mode planning/codegen
    stays covered on every push/PR without requiring dotnet.
  - Intended as lightweight regression protection for the newly merged query-mode engine work.
