### PR TITLE
PR: Client-Server Architecture (Phases 1-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tests/integration/test_in_process_services.sh` — Integration tests (13 tests)
   - Documentation in `docs/CLIENT_SERVER_DESIGN.md`
 
+- **Client-Server Architecture Phase 2: Cross-Process Services** - Unix socket transport for inter-process communication
+  - Unix Socket Server:
+    - `transport(unix_socket(Path))` — Service option for Unix socket transport
+    - Multi-threaded connection handling
+    - JSONL request/response protocol with `_id`, `_payload`, `_status` fields
+    - Graceful shutdown with signal handling (SIGINT, SIGTERM)
+    - Configurable timeout per connection
+  - Unix Socket Client:
+    - Connection pooling with automatic reconnect
+    - Request/response correlation via `_id`
+    - Error propagation with structured error responses
+    - Convenience functions for one-shot calls
+  - Service Helpers:
+    - `get_service_transport/2` — Extract transport from service definition
+    - `get_service_protocol/2` — Extract protocol from service definition
+    - `get_service_timeout/2` — Extract timeout from service definition
+    - `is_cross_process_service/1` — Check if service uses Unix sockets
+    - `is_network_service/1` — Check if service uses network transport
+  - Multi-Target Support:
+    - Python: `socket.AF_UNIX`, threading, JSONL via `json` module
+    - Go: `net.Listen("unix", ...)`, goroutines, `encoding/json`
+    - Rust: `std::os::unix::net::UnixListener`, threads, `serde_json`
+  - Stateful Services:
+    - Thread-safe state with locks (Python: `threading.Lock`, Go: `sync.Mutex`, Rust: `RwLock`)
+    - State persists across connections for stateful services
+  - `tests/integration/test_unix_socket_services.sh` — Integration tests (18 tests)
+  - Documentation in `docs/CLIENT_SERVER_DESIGN.md`
+
 ## [0.1] - 2025-11-15
 
 ### 🎉 Milestone Release: Initial Vision Achieved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `docs/development/testing/playbooks/xml_data_source_playbook__reference.md` - The reference document for reviewers.
   - Updated `docs/EXTENDED_README.md` to include the new playbook.
 
+- **Client-Server Architecture Phase 1: In-Process Services** - Foundation for service-oriented pipeline composition
+  - Service Definition DSL:
+    - `service(Name, HandlerSpec)` — Define a stateless service with operations
+    - `service(Name, Options, HandlerSpec)` — Define service with options (stateful, transport, timeout)
+  - Service Operations:
+    - `receive(Var)` — Bind incoming request to variable
+    - `respond(Value)` — Send response to caller
+    - `respond_error(Error)` — Send error response
+    - `state_get(Key, Value)` — Get state value (stateful services)
+    - `state_put(Key, Value)` — Set state value (stateful services)
+    - `call_service(Name, Request, Response)` — Call another service
+    - `transform(In, Out, Goal)` — Transform data with predicate
+    - `branch(Cond, TrueOps, FalseOps)` — Conditional execution
+    - `route_by(Field, Routes)` — Route by field value
+  - Service Options:
+    - `stateful(Bool)` — Enable/disable state management
+    - `transport(Type)` — Transport type (in_process, unix_socket, tcp, http)
+    - `protocol(Format)` — Wire format (jsonl, json, messagepack, protobuf)
+    - `timeout(Ms)` — Request timeout in milliseconds
+    - `max_concurrent(N)` — Maximum concurrent requests
+    - `on_error(Handler)` — Error handler predicate
+  - Pipeline Integration:
+    - `call_service(Name, RequestExpr, ResponseVar)` — Pipeline stage for service calls
+    - `call_service(Name, Request, Response, Options)` — With options (timeout, retry, fallback)
+    - Call service options: `timeout(Ms)`, `retry(N)`, `retry_delay(Ms)`, `fallback(Value)`
+  - Multi-Target Compilation:
+    - Python: Service classes with `_services` registry
+    - Go: Service interfaces with struct implementations
+    - Rust: Service trait with lazy_static registration
+  - Validation:
+    - `src/unifyweaver/core/service_validation.pl` — Service definition validation
+    - Extended `src/unifyweaver/core/pipeline_validation.pl` — call_service stage validation
+  - `tests/integration/test_in_process_services.sh` — Integration tests (13 tests)
+  - Documentation in `docs/CLIENT_SERVER_DESIGN.md`
+
 ## [0.1] - 2025-11-15
 
 ### 🎉 Milestone Release: Initial Vision Achieved

--- a/docs/CLIENT_SERVER_DESIGN.md
+++ b/docs/CLIENT_SERVER_DESIGN.md
@@ -1,0 +1,335 @@
+# Client-Server Architecture Design
+
+UnifyWeaver's client-server architecture enables service-oriented pipeline composition with transport independence.
+
+## Overview
+
+The core insight: **client-server communication is fundamentally two pipelines going in opposite directions**:
+- **Request Pipeline**: Client → Server (carries request data)
+- **Response Pipeline**: Server → Client (carries response data)
+
+This allows the same Prolog DSL to define services, and the same compilation infrastructure to generate service implementations across all target languages.
+
+## Architecture Layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Application Layer                        │
+│  service(Name, [receive(X), transform(X, Y), respond(Y)])  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Service Layer                            │
+│  - Service Registry (in-process lookup)                     │
+│  - Request/Response handling                                │
+│  - State management (for stateful services)                 │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   Transport Layer                           │
+│  - in_process: Direct function calls                        │
+│  - unix_socket: Unix domain sockets                         │
+│  - tcp: TCP sockets                                         │
+│  - http: HTTP/REST endpoints                                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   Protocol Layer                            │
+│  - jsonl: JSON Lines (streaming)                            │
+│  - json: Standard JSON                                      │
+│  - messagepack: Binary MessagePack                          │
+│  - protobuf: Protocol Buffers                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Phase 1: In-Process Services (Current)
+
+Phase 1 establishes the foundation with in-process service calls.
+
+### Service Definition
+
+```prolog
+% Simple stateless service
+service(echo, [
+    receive(X),
+    respond(X)
+]).
+
+% Service with options
+service(counter, [stateful(true), timeout(5000)], [
+    receive(Cmd),
+    state_get(count, Current),
+    ( Cmd = increment ->
+        NewCount is Current + 1,
+        state_put(count, NewCount),
+        respond(NewCount)
+    ;
+        respond(Current)
+    )
+]).
+
+% Service with transformation
+service(user_enricher, [
+    receive(UserId),
+    lookup_user(UserId, UserData),
+    enrich_user(UserData, Enriched),
+    respond(Enriched)
+]).
+```
+
+### Service Operations
+
+| Operation | Description |
+|-----------|-------------|
+| `receive(Var)` | Bind incoming request to variable |
+| `respond(Value)` | Send response to caller |
+| `respond_error(Error)` | Send error response |
+| `state_get(Key, Value)` | Get state value (stateful services) |
+| `state_put(Key, Value)` | Set state value (stateful services) |
+| `state_modify(Key, Func)` | Modify state with function |
+| `state_delete(Key)` | Delete state key |
+| `call_service(Name, Req, Resp)` | Call another service |
+| `transform(In, Out, Goal)` | Transform data with predicate |
+| `branch(Cond, True, False)` | Conditional execution |
+| `route_by(Field, Routes)` | Route by field value |
+
+### Service Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `stateful(Bool)` | Enable state management | `false` |
+| `transport(Type)` | Transport mechanism | `in_process` |
+| `protocol(Format)` | Wire format | `jsonl` |
+| `timeout(Ms)` | Request timeout | None |
+| `max_concurrent(N)` | Max concurrent requests | Unlimited |
+| `on_error(Handler)` | Error handler predicate | None |
+
+### Pipeline Integration
+
+Services can be called from pipelines using the `call_service` stage:
+
+```prolog
+% Simple service call
+pipeline([
+    read_json,
+    call_service(enricher, record, enriched_record),
+    write_json
+]).
+
+% With options
+pipeline([
+    read_json,
+    call_service(enricher, record, enriched_record, [
+        timeout(5000),
+        retry(3),
+        retry_delay(100),
+        fallback(default_value)
+    ]),
+    write_json
+]).
+```
+
+### Generated Code
+
+#### Python
+
+```python
+class EchoService(Service):
+    def __init__(self):
+        self.name = "echo"
+
+    def call(self, request):
+        return request
+
+_services["echo"] = EchoService()
+```
+
+#### Go
+
+```go
+type EchoService struct {
+    name string
+}
+
+func NewEchoService() *EchoService {
+    return &EchoService{name: "echo"}
+}
+
+func (s *EchoService) Name() string {
+    return s.name
+}
+
+func (s *EchoService) Call(request interface{}) (interface{}, error) {
+    return request, nil
+}
+
+func init() {
+    RegisterService("echo", NewEchoService())
+}
+```
+
+#### Rust
+
+```rust
+pub struct EchoService;
+
+impl EchoService {
+    pub fn new() -> Self {
+        EchoService
+    }
+}
+
+impl Service for EchoService {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    fn call(&self, request: serde_json::Value) -> Result<serde_json::Value, ServiceError> {
+        Ok(request)
+    }
+}
+
+lazy_static::lazy_static! {
+    static ref ECHO_SERVICE: std::sync::Arc<EchoService> = {
+        let service = std::sync::Arc::new(EchoService::new());
+        register_service("echo", service.clone());
+        service
+    };
+}
+```
+
+## Future Phases
+
+### Phase 2: Cross-Process Services (Planned)
+
+Unix domain sockets for inter-process communication:
+
+```prolog
+service(worker, [transport(unix_socket('/tmp/worker.sock'))], [
+    receive(Task),
+    process_task(Task, Result),
+    respond(Result)
+]).
+```
+
+### Phase 3: Network Services (Planned)
+
+TCP and HTTP transports:
+
+```prolog
+service(api, [transport(tcp('0.0.0.0', 8080)), protocol(jsonl)], [
+    receive(Request),
+    handle_request(Request, Response),
+    respond(Response)
+]).
+
+service(rest, [transport(http('/api/v1')), protocol(json)], [
+    receive(Request),
+    route_by(method, [
+        (get, handle_get),
+        (post, handle_post)
+    ])
+]).
+```
+
+### Phase 4: Service Mesh (Planned)
+
+Load balancing, circuit breakers, service discovery:
+
+```prolog
+service(gateway, [
+    load_balance(round_robin),
+    circuit_breaker(threshold(5), timeout(30000)),
+    retry(3, exponential)
+], [
+    receive(Request),
+    route_to_backend(Request, Response),
+    respond(Response)
+]).
+```
+
+### Phase 5: Multi-Language Polyglot Services (Planned)
+
+Seamless calls between services written in different languages:
+
+```prolog
+% Prolog service definition
+service(coordinator, [
+    receive(Job),
+    call_service(python_ml_model, Job, Prediction),    % Python ML service
+    call_service(go_validator, Prediction, Validated), % Go validation service
+    call_service(rust_db, Validated, Stored),          % Rust database service
+    respond(Stored)
+]).
+```
+
+### Phase 6: Distributed Services (Planned)
+
+Cluster-aware services with automatic routing:
+
+```prolog
+service(distributed_cache, [
+    distributed(true),
+    replication(3),
+    consistency(eventual)
+], [
+    receive(Op),
+    route_to_shard(Op, Node),
+    execute_on_node(Node, Op, Result),
+    respond(Result)
+]).
+```
+
+## Validation
+
+The system validates service definitions at compile time:
+
+### Service Validation (`service_validation.pl`)
+
+- Service name must be an atom
+- Handler spec must be a list
+- All operations must be valid
+- Options must be valid
+
+### Pipeline Validation (`pipeline_validation.pl`)
+
+- `call_service` stage requires atom service name
+- Options must be valid (timeout, retry, retry_delay, fallback)
+
+## Testing
+
+Integration tests verify the implementation:
+
+```bash
+./tests/integration/test_in_process_services.sh
+```
+
+Tests cover:
+1. Service validation module loads
+2. Valid service definitions accepted
+3. Service with options validates
+4. Service operations validated
+5. call_service stage validates in pipeline
+6. call_service options validated
+7. Python service compilation
+8. Go service compilation
+9. Rust service compilation
+10. Python infrastructure included
+11. Go infrastructure included
+12. Rust infrastructure included
+13. Invalid services rejected
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `src/unifyweaver/core/service_validation.pl` | Service definition validation |
+| `src/unifyweaver/core/pipeline_validation.pl` | Extended with call_service validation |
+| `src/unifyweaver/targets/python_target.pl` | Python service compilation |
+| `src/unifyweaver/targets/go_target.pl` | Go service compilation |
+| `src/unifyweaver/targets/rust_target.pl` | Rust service compilation |
+| `tests/integration/test_in_process_services.sh` | Integration tests |
+| `docs/CLIENT_SERVER_DESIGN.md` | This document |

--- a/docs/design/CLIENT_SERVER_IMPLEMENTATION.md
+++ b/docs/design/CLIENT_SERVER_IMPLEMENTATION.md
@@ -1,0 +1,606 @@
+# Client-Server Architecture: Implementation Plan
+
+## Overview
+
+This document outlines the phased implementation approach for adding client-server capabilities to UnifyWeaver.
+
+## Implementation Principles
+
+1. **Incremental**: Each phase delivers working functionality
+2. **Backward Compatible**: Existing pipelines continue to work
+3. **Test-Driven**: Each feature has integration tests
+4. **Multi-Target**: Features work across Python, Go, Rust
+
+## Phase Overview
+
+| Phase | Focus | Deliverables |
+|-------|-------|--------------|
+| **Phase 1** | In-Process Services | Service definition, basic call_service |
+| **Phase 2** | Stateful Services | State operations, service lifecycle |
+| **Phase 3** | Cross-Process | Unix socket transport |
+| **Phase 4** | Error Handling | Timeouts, retries, fallbacks |
+| **Phase 5** | Network Transport | HTTP/TCP services |
+| **Phase 6** | Advanced Features | Streaming, async, discovery |
+
+---
+
+## Phase 1: In-Process Services
+
+### Goal
+Enable defining and calling services within a single process.
+
+### Deliverables
+
+#### 1.1 Service Definition Syntax
+
+```prolog
+% New directive: service/2
+service(echo, [
+    receive(Message),
+    respond(Message)
+]).
+
+service(double, [
+    receive(N),
+    transform(N, Result, Result is N * 2),
+    respond(Result)
+]).
+```
+
+#### 1.2 Service Validation
+
+**File: `src/unifyweaver/core/service_validation.pl`** (new)
+
+```prolog
+:- module(service_validation, [
+    validate_service/2,
+    is_valid_service/1,
+    is_valid_handler_spec/1
+]).
+
+validate_service(service(Name, HandlerSpec), Errors) :-
+    ( atom(Name) -> E1 = [] ; E1 = [error(invalid_service_name, Name)] ),
+    ( is_valid_handler_spec(HandlerSpec) -> E2 = [] ; E2 = [error(invalid_handler)] ),
+    append(E1, E2, Errors).
+```
+
+#### 1.3 Pipeline Integration: call_service Stage
+
+**File: `src/unifyweaver/core/pipeline_validation.pl`** (modify)
+
+```prolog
+% Add validation for call_service stage
+is_valid_stage(call_service(ServiceName, _RequestExpr, _ResponseVar)) :-
+    atom(ServiceName).
+```
+
+#### 1.4 Python Target: Service Compilation
+
+**File: `src/unifyweaver/targets/python_target.pl`** (modify)
+
+```prolog
+% Generate service class
+compile_service_to_python(service(Name, HandlerSpec), PythonCode) :-
+    generate_service_handler(HandlerSpec, HandlerCode),
+    format(string(PythonCode), "
+class ~wService:
+    def __init__(self):
+        self.state = {}
+
+    def call(self, request):
+~w
+        return response
+
+_services['~w'] = ~wService()
+", [Name, HandlerCode, Name, Name]).
+
+% Generate call_service stage
+generate_stage_flow(call_service(ServiceName, RequestExpr, ResponseVar), InVar, OutVar, Code) :-
+    format(string(Code), "
+    # Call service: ~w
+    def _call_~w(record):
+        request = record.get('~w')
+        response = _services['~w'].call(request)
+        record['~w'] = response
+        return record
+    ~w = map(_call_~w, ~w)
+", [ServiceName, ServiceName, RequestExpr, ServiceName, ResponseVar, OutVar, ServiceName, InVar]).
+```
+
+#### 1.5 Go Target: Service Compilation
+
+**File: `src/unifyweaver/targets/go_target.pl`** (modify)
+
+```go
+// Generated service structure
+type EchoService struct {
+    state map[string]interface{}
+}
+
+func (s *EchoService) Call(request Record) Record {
+    // Handler implementation
+    return request
+}
+
+var services = map[string]Service{
+    "echo": &EchoService{state: make(map[string]interface{})},
+}
+```
+
+#### 1.6 Integration Tests
+
+**File: `tests/integration/test_in_process_services.sh`** (new)
+
+```bash
+# Test 1: Service definition validation
+# Test 2: Service compilation to Python
+# Test 3: Service compilation to Go
+# Test 4: call_service in pipeline
+# Test 5: Service with transformation
+# Test 6: Multiple services in pipeline
+```
+
+### Files Changed (Phase 1)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/unifyweaver/core/service_validation.pl` | Create | Service validation module |
+| `src/unifyweaver/core/pipeline_validation.pl` | Modify | Add call_service validation |
+| `src/unifyweaver/targets/python_target.pl` | Modify | Service compilation, call_service stage |
+| `src/unifyweaver/targets/go_target.pl` | Modify | Service compilation, call_service stage |
+| `src/unifyweaver/targets/rust_target.pl` | Modify | Service compilation, call_service stage |
+| `tests/integration/test_in_process_services.sh` | Create | Integration tests |
+| `CHANGELOG.md` | Modify | Document new feature |
+
+---
+
+## Phase 2: Stateful Services
+
+### Goal
+Enable services that maintain state between requests.
+
+### Deliverables
+
+#### 2.1 State Operations
+
+```prolog
+service(counter, [stateful(true)], [
+    receive(Op),
+    route_by(Op, [
+        (increment, [
+            state_modify(count, succ),
+            state_get(count, Value),
+            respond(Value)
+        ]),
+        (get, [
+            state_get(count, Value),
+            respond(Value)
+        ])
+    ])
+]).
+```
+
+#### 2.2 State Management
+
+**File: `src/unifyweaver/core/service_state.pl`** (new)
+
+```prolog
+:- module(service_state, [
+    init_service_state/2,
+    state_get/3,
+    state_put/3,
+    state_modify/3
+]).
+```
+
+#### 2.3 Python State Implementation
+
+```python
+class StatefulService:
+    def __init__(self, initial_state=None):
+        self.state = initial_state or {}
+
+    def state_get(self, key, default=None):
+        return self.state.get(key, default)
+
+    def state_put(self, key, value):
+        self.state[key] = value
+
+    def state_modify(self, key, func):
+        self.state[key] = func(self.state.get(key))
+```
+
+### Files Changed (Phase 2)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/unifyweaver/core/service_state.pl` | Create | State management |
+| `src/unifyweaver/core/service_validation.pl` | Modify | Validate state operations |
+| `src/unifyweaver/targets/python_target.pl` | Modify | Stateful service generation |
+| `tests/integration/test_stateful_services.sh` | Create | State tests |
+
+---
+
+## Phase 3: Cross-Process Communication
+
+### Goal
+Enable services to run in separate processes, communicating via Unix sockets.
+
+### Deliverables
+
+#### 3.1 Transport Configuration
+
+```prolog
+service(user_lookup, [
+    transport(unix_socket('/tmp/user_service.sock'))
+], [
+    receive(UserId),
+    lookup_user/1,
+    respond(UserRecord)
+]).
+```
+
+#### 3.2 Socket Server Generation
+
+```python
+# Generated server code
+import socket
+import json
+
+def run_user_lookup_server(socket_path):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(socket_path)
+    sock.listen(5)
+
+    service = UserLookupService()
+
+    while True:
+        conn, _ = sock.accept()
+        try:
+            for line in conn.makefile():
+                request = json.loads(line)
+                response = service.call(request['payload'])
+                conn.sendall(json.dumps({
+                    '__type': 'response',
+                    '__id': request['__id'],
+                    '__status': 'ok',
+                    'payload': response
+                }).encode() + b'\n')
+        finally:
+            conn.close()
+```
+
+#### 3.3 Socket Client Generation
+
+```python
+# Generated client code
+import socket
+import json
+import uuid
+
+class UnixSocketClient:
+    def __init__(self, socket_path):
+        self.socket_path = socket_path
+
+    def call(self, request):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(self.socket_path)
+        try:
+            request_id = str(uuid.uuid4())
+            sock.sendall(json.dumps({
+                '__type': 'request',
+                '__id': request_id,
+                'payload': request
+            }).encode() + b'\n')
+
+            response = json.loads(sock.makefile().readline())
+            if response['__status'] == 'error':
+                raise ServiceError(response['error'])
+            return response['payload']
+        finally:
+            sock.close()
+```
+
+### Files Changed (Phase 3)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/unifyweaver/core/transport.pl` | Create | Transport abstraction |
+| `src/unifyweaver/transports/unix_socket.pl` | Create | Unix socket implementation |
+| `src/unifyweaver/targets/python_target.pl` | Modify | Socket client/server generation |
+| `tests/integration/test_socket_services.sh` | Create | Cross-process tests |
+
+---
+
+## Phase 4: Error Handling
+
+### Goal
+Add robust error handling: timeouts, retries, fallbacks, circuit breakers.
+
+### Deliverables
+
+#### 4.1 Client Options
+
+```prolog
+pipeline([
+    parse/1,
+    call_service(slow_service, request, response, [
+        timeout(5000),           % 5 second timeout
+        retry(3),                % Retry up to 3 times
+        retry_delay(100),        % 100ms between retries
+        fallback(default_value), % Use fallback on failure
+        circuit_breaker(5, 60)   % Open after 5 failures, reset after 60s
+    ]),
+    output/1
+]).
+```
+
+#### 4.2 Error Types
+
+```python
+class ServiceError(Exception):
+    pass
+
+class TimeoutError(ServiceError):
+    pass
+
+class ConnectionError(ServiceError):
+    pass
+
+class CircuitOpenError(ServiceError):
+    pass
+```
+
+#### 4.3 Retry Logic
+
+```python
+def call_with_retry(client, request, options):
+    max_retries = options.get('retry', 0)
+    timeout = options.get('timeout')
+    fallback = options.get('fallback')
+
+    last_error = None
+    for attempt in range(max_retries + 1):
+        try:
+            return client.call(request, timeout=timeout)
+        except ServiceError as e:
+            last_error = e
+            if attempt < max_retries:
+                time.sleep(options.get('retry_delay', 0) / 1000)
+
+    if fallback is not None:
+        return fallback
+    raise last_error
+```
+
+### Files Changed (Phase 4)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/unifyweaver/core/service_validation.pl` | Modify | Validate client options |
+| `src/unifyweaver/core/error_handling.pl` | Create | Error types and handling |
+| `src/unifyweaver/targets/python_target.pl` | Modify | Retry/timeout generation |
+| `tests/integration/test_service_errors.sh` | Create | Error handling tests |
+
+---
+
+## Phase 5: Network Transport
+
+### Goal
+Enable services over HTTP and TCP.
+
+### Deliverables
+
+#### 5.1 HTTP Transport
+
+```prolog
+service(api_service, [
+    transport(http('/api/service', [port(8080)]))
+], [
+    receive(Request),
+    process/1,
+    respond(Response)
+]).
+```
+
+#### 5.2 HTTP Server (Flask/Gin/Actix)
+
+```python
+# Python: Flask
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route('/api/<service_name>', methods=['POST'])
+def handle_request(service_name):
+    service = _services.get(service_name)
+    req = request.json
+    response = service.call(req['payload'])
+    return jsonify({
+        '__type': 'response',
+        '__id': req['__id'],
+        '__status': 'ok',
+        'payload': response
+    })
+```
+
+```go
+// Go: Standard library
+func handleService(w http.ResponseWriter, r *http.Request) {
+    serviceName := mux.Vars(r)["service"]
+    service := services[serviceName]
+
+    var req Request
+    json.NewDecoder(r.Body).Decode(&req)
+
+    response := service.Call(req.Payload)
+
+    json.NewEncoder(w).Encode(Response{
+        Type:    "response",
+        ID:      req.ID,
+        Status:  "ok",
+        Payload: response,
+    })
+}
+```
+
+### Files Changed (Phase 5)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/unifyweaver/transports/http.pl` | Create | HTTP transport |
+| `src/unifyweaver/transports/tcp.pl` | Create | TCP transport |
+| `src/unifyweaver/targets/python_target.pl` | Modify | HTTP client/server |
+| `src/unifyweaver/targets/go_target.pl` | Modify | HTTP client/server |
+| `tests/integration/test_http_services.sh` | Create | Network tests |
+
+---
+
+## Phase 6: Advanced Features
+
+### Goal
+Add streaming responses, async calls, service discovery.
+
+### Deliverables
+
+#### 6.1 Streaming Responses
+
+```prolog
+service(data_stream, [streaming(true)], [
+    receive(Query),
+    stream_results/1,  % Yields multiple responses
+    end_stream
+]).
+```
+
+#### 6.2 Async Calls
+
+```prolog
+pipeline([
+    parse/1,
+    call_service_async(slow_service, request, future),
+    do_other_work/1,
+    await_service(future, response),
+    output/1
+]).
+```
+
+#### 6.3 Service Discovery
+
+```prolog
+% Register with discovery service
+service(user_service, [
+    register(consul, [
+        name('user-service'),
+        tags(['v1', 'production']),
+        health_check('/health')
+    ])
+], [...]).
+
+% Discover service at runtime
+pipeline([
+    call_service(discover(consul, 'user-service'), request, response),
+    output/1
+]).
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+Each module has unit tests for:
+- Validation logic
+- Code generation
+- State management
+
+### Integration Tests
+
+Each phase includes integration tests:
+
+```bash
+tests/integration/
+├── test_in_process_services.sh     # Phase 1
+├── test_stateful_services.sh       # Phase 2
+├── test_socket_services.sh         # Phase 3
+├── test_service_errors.sh          # Phase 4
+├── test_http_services.sh           # Phase 5
+└── test_advanced_services.sh       # Phase 6
+```
+
+### End-to-End Tests
+
+Real-world scenarios:
+- Pipeline calling multiple services
+- Service calling other services
+- Error recovery scenarios
+- Performance benchmarks
+
+---
+
+## Migration Guide
+
+### For Existing Pipelines
+
+Existing pipelines work unchanged. The `call_service` stage is additive.
+
+### Adopting Services
+
+```prolog
+% Before: Inline lookup
+pipeline([
+    parse/1,
+    lookup_user/1,  % Inline predicate
+    output/1
+]).
+
+% After: Service-based lookup
+service(user_lookup, [
+    receive(UserId),
+    query_database/1,
+    respond(UserRecord)
+]).
+
+pipeline([
+    parse/1,
+    call_service(user_lookup, user_id, user_data),
+    output/1
+]).
+```
+
+Benefits of migration:
+- Reusable across pipelines
+- Can be deployed separately
+- Easier to test in isolation
+- Can add caching, retries, etc.
+
+---
+
+## Timeline Estimates
+
+| Phase | Complexity | Estimate |
+|-------|------------|----------|
+| Phase 1 | Medium | Foundation work |
+| Phase 2 | Medium | Builds on Phase 1 |
+| Phase 3 | High | New transport layer |
+| Phase 4 | Medium | Applies existing patterns |
+| Phase 5 | High | Network complexity |
+| Phase 6 | High | Advanced patterns |
+
+**Recommended approach**: Complete Phase 1-2 first, which provides immediate value. Phases 3-6 can be implemented based on user needs.
+
+---
+
+## Success Metrics
+
+1. **Phase 1 Complete**: Can define and call in-process services
+2. **Phase 2 Complete**: Services can maintain state
+3. **Phase 3 Complete**: Services can run in separate processes
+4. **Phase 4 Complete**: Robust error handling
+5. **Phase 5 Complete**: Network-accessible services
+6. **Phase 6 Complete**: Production-ready service infrastructure
+
+---
+
+*This implementation plan is a living document. Adjust phases based on user feedback and priorities.*

--- a/docs/design/CLIENT_SERVER_PHILOSOPHY.md
+++ b/docs/design/CLIENT_SERVER_PHILOSOPHY.md
@@ -1,0 +1,291 @@
+# Client-Server Architecture: Philosophy & Vision
+
+## Overview
+
+This document describes the philosophical foundation for extending UnifyWeaver beyond unidirectional pipelines to bidirectional client-server communication patterns.
+
+## The Journey So Far
+
+UnifyWeaver began with a simple but powerful abstraction: **pipelines**.
+
+```
+Input → Stage1 → Stage2 → Stage3 → Output
+```
+
+Pipelines model data flowing in one direction through a series of transformations. This is powerful for:
+- ETL (Extract, Transform, Load)
+- Stream processing
+- Data validation and enrichment
+- Record-by-record transformations
+
+But pipelines have a fundamental limitation: **data flows one way**.
+
+## The Limitation of Unidirectional Flow
+
+Consider these scenarios that pipelines struggle with:
+
+1. **Lookup enrichment**: For each record, query a database and merge results
+2. **Validation services**: Send record to validator, receive pass/fail with errors
+3. **Stateful computation**: Accumulate state, query it later
+4. **Interactive processing**: Request clarification, wait for response
+5. **Caching with invalidation**: Check cache, populate on miss, invalidate on update
+
+These patterns require **bidirectional communication** - the ability to send a request and receive a response.
+
+## The Insight: Two Opposing Pipes
+
+A client-server interaction can be modeled as **two pipes flowing in opposite directions**:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                 Client-Server Model                  │
+│                                                      │
+│    ┌────────┐                      ┌────────┐       │
+│    │ Client │ ──── Request ────→  │ Server │       │
+│    │        │ ←─── Response ────  │        │       │
+│    └────────┘                      └────────┘       │
+│                                                      │
+│    Request Pipe:   Client → Server                  │
+│    Response Pipe:  Server → Client                  │
+│                                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+This preserves the pipeline mental model while enabling bidirectional patterns.
+
+## Generalization: Transport Independence
+
+Just as pipelines can operate at different levels:
+
+| Pipeline Level | Mechanism |
+|----------------|-----------|
+| In-process | Generator/iterator chains |
+| Cross-process | Unix pipes, stdin/stdout |
+| Cross-runtime | JSONL serialization |
+| Cross-machine | (not yet implemented) |
+
+Client-server should follow the same pattern:
+
+| Client-Server Level | Mechanism |
+|---------------------|-----------|
+| In-process | Function calls with return values |
+| Cross-process | Unix sockets, named pipes |
+| Cross-runtime | Protocol-based (JSONL, MessagePack) |
+| Network | HTTP, gRPC, WebSocket, TCP |
+
+The key insight: **the same service definition should work at any level**.
+
+## Design Principles
+
+### 1. Composition Over Configuration
+
+Services should compose like pipeline stages:
+
+```prolog
+% A service is just a bidirectional pipeline
+service(user_enrichment, [
+    receive(user_id),
+    lookup_in_database/1,
+    format_response/1,
+    respond(user_record)
+]).
+
+% Services can call other services
+service(full_enrichment, [
+    receive(record),
+    call_service(user_enrichment, user_id, user_data),
+    call_service(org_enrichment, org_id, org_data),
+    merge_enrichments/1,
+    respond(enriched_record)
+]).
+```
+
+### 2. Location Transparency
+
+The caller shouldn't need to know if the service is:
+- A local function
+- A separate process
+- A remote server
+
+```prolog
+% Same syntax regardless of where service runs
+pipeline([
+    parse/1,
+    call_service(validator, record, validation_result),
+    handle_validation/1,
+    output/1
+]).
+```
+
+### 3. Protocol Consistency
+
+Request and response should use the same serialization as pipelines:
+- JSONL for simplicity and debugging
+- Optional binary protocols for performance
+
+### 4. Graceful Degradation
+
+When a service is unavailable:
+- Configurable fallback behavior
+- Retry with backoff
+- Circuit breaker patterns
+- Timeout handling
+
+These patterns already exist in pipeline stages (`try_catch`, `retry`, `timeout`).
+
+### 5. Stateful by Design
+
+Unlike stateless pipelines, servers can maintain state:
+- Connection state
+- Cached computations
+- Accumulated data
+- Session context
+
+This is where patterns like caching naturally belong - as **server-side concerns**, not pipeline stages.
+
+## Relationship to Existing Features
+
+### Pipelines Are Still Primary
+
+Client-server doesn't replace pipelines - it extends them:
+
+```prolog
+% Pipeline that uses services
+pipeline([
+    parse/1,
+    call_service(cache, lookup, cached_result),
+    branch(cache_hit,
+        use_cached/1,
+        call_service(compute, transform, fresh_result)
+    ),
+    output/1
+]).
+```
+
+### Services Can Contain Pipelines
+
+A service handler can be a full pipeline:
+
+```prolog
+service(batch_processor, [
+    receive(batch),
+    % Internal pipeline for processing
+    pipeline([
+        unbatch,
+        validate/1,
+        transform/1,
+        filter_by(valid),
+        batch(100)
+    ]),
+    respond(processed_batch)
+]).
+```
+
+### Existing Stages Apply
+
+Error handling, branching, and observation stages work in services:
+
+```prolog
+service(robust_lookup, [
+    receive(query),
+    try_catch(
+        database_query/1,
+        respond_error/1
+    ),
+    tap(log_query),
+    respond(result)
+]).
+```
+
+## Use Cases Enabled
+
+### 1. Lookup Services
+```prolog
+service(user_service, [
+    receive(user_id),
+    query_user_db/1,
+    respond(user_record)
+]).
+```
+
+### 2. Validation Services
+```prolog
+service(schema_validator, [
+    receive(record),
+    validate_against_schema/1,
+    respond(validation_result)
+]).
+```
+
+### 3. Caching Services
+```prolog
+service(cache_service, [
+    receive(cache_request),
+    route_by(operation, [
+        (get, cache_get/1),
+        (set, cache_set/1),
+        (invalidate, cache_invalidate/1)
+    ]),
+    respond(cache_response)
+]).
+```
+
+### 4. Aggregation Services
+```prolog
+service(stats_collector, [
+    receive(data_point),
+    update_running_stats/1,  % Stateful
+    respond(current_stats)
+]).
+```
+
+### 5. Orchestration Services
+```prolog
+service(workflow_orchestrator, [
+    receive(workflow_request),
+    call_service(step1_service, input1, result1),
+    call_service(step2_service, result1, result2),
+    call_service(step3_service, result2, result3),
+    respond(workflow_result)
+]).
+```
+
+## What This Is NOT
+
+### Not a Full RPC Framework
+We're not building gRPC or Thrift. The focus is on:
+- Simple request/response patterns
+- Composition with pipelines
+- Multi-target code generation
+
+### Not a Distributed Systems Framework
+We're not solving:
+- Consensus
+- Distributed transactions
+- Service mesh
+- Container orchestration
+
+### Not Replacing Pipelines
+Pipelines remain the primary abstraction for data flow. Services extend the model for bidirectional needs.
+
+## Success Criteria
+
+The client-server architecture is successful if:
+
+1. **Natural Extension**: Feels like a logical extension of pipelines, not a separate system
+2. **Simple Cases Are Simple**: In-process services require minimal boilerplate
+3. **Complex Cases Are Possible**: Network services with retries, timeouts work
+4. **Multi-Target**: Generates correct code for Python, Go, Rust
+5. **Composable**: Services compose with each other and with pipelines
+6. **Testable**: Services can be unit tested in isolation
+
+## Next Steps
+
+1. **Specification**: Define exact syntax and semantics
+2. **Protocol Design**: Request/response format
+3. **Implementation Plan**: Phased approach starting with in-process
+4. **Proof of Concept**: Simple service in Python target
+
+---
+
+*This document establishes the philosophical foundation. See `CLIENT_SERVER_SPECIFICATION.md` for technical details.*

--- a/docs/design/CLIENT_SERVER_SPECIFICATION.md
+++ b/docs/design/CLIENT_SERVER_SPECIFICATION.md
@@ -1,0 +1,531 @@
+# Client-Server Architecture: Technical Specification
+
+## Overview
+
+This document specifies the syntax, semantics, and protocols for UnifyWeaver's client-server architecture.
+
+## 1. Core Concepts
+
+### 1.1 Service
+
+A **service** is a named, reusable unit that:
+- Receives requests
+- Performs computation (possibly stateful)
+- Returns responses
+
+```prolog
+service(ServiceName, HandlerSpec).
+service(ServiceName, Options, HandlerSpec).
+```
+
+### 1.2 Client
+
+A **client** is code that:
+- Sends requests to services
+- Receives responses
+- Handles errors/timeouts
+
+Clients can be:
+- Pipeline stages (`call_service/4`)
+- Standalone programs
+- Other services
+
+### 1.3 Channel
+
+A **channel** is the communication path between client and server:
+- In-process: Direct function calls
+- Cross-process: Pipes, sockets
+- Network: HTTP, WebSocket, TCP
+
+## 2. Service Definition Syntax
+
+### 2.1 Basic Service
+
+```prolog
+% Minimal service definition
+service(echo, [
+    receive(Message),
+    respond(Message)
+]).
+
+% Service with handler predicate
+service(user_lookup, [
+    receive(user_id),
+    lookup_user/1,
+    respond(user_record)
+]).
+
+% Service with inline transformation
+service(double, [
+    receive(Number),
+    transform(N, N * 2),
+    respond(Result)
+]).
+```
+
+### 2.2 Service Options
+
+```prolog
+service(ServiceName, Options, HandlerSpec).
+
+% Available options:
+Options = [
+    % Transport configuration
+    transport(in_process),          % Default: direct function call
+    transport(unix_socket(Path)),   % Unix domain socket
+    transport(tcp(Host, Port)),     % TCP socket
+    transport(http(Endpoint)),      % HTTP endpoint
+
+    % Protocol configuration
+    protocol(jsonl),                % Default: JSON Lines
+    protocol(messagepack),          % Binary MessagePack
+    protocol(protobuf(Schema)),     % Protocol Buffers
+
+    % Behavior configuration
+    stateful(true),                 % Service maintains state between requests
+    timeout(Ms),                    % Default timeout for requests
+    max_concurrent(N),              % Max concurrent requests
+
+    % Error handling
+    on_error(respond_error),        % Default error behavior
+    on_error(log_and_continue),
+    on_error(crash)
+].
+```
+
+### 2.3 Handler Specification
+
+The handler spec is a list of operations:
+
+```prolog
+HandlerSpec = [Operation1, Operation2, ...].
+
+% Operations:
+receive(Variable)              % Bind request to Variable
+respond(Value)                 % Send response
+respond_error(Error)           % Send error response
+
+Predicate/Arity                % Execute predicate (pipeline stage)
+transform(In, Out)             % Inline transformation
+state_get(Key, Value)          % Read from service state
+state_put(Key, Value)          % Write to service state
+state_modify(Key, Func)        % Modify service state
+
+call_service(Name, Req, Resp)  % Call another service
+```
+
+### 2.4 Stateful Services
+
+```prolog
+% Counter service with state
+service(counter, [stateful(true)], [
+    receive(Operation),
+    route_by(operation, [
+        (increment, [
+            state_modify(count, succ),
+            state_get(count, Value),
+            respond(Value)
+        ]),
+        (decrement, [
+            state_modify(count, pred),
+            state_get(count, Value),
+            respond(Value)
+        ]),
+        (get, [
+            state_get(count, Value),
+            respond(Value)
+        ]),
+        (reset, [
+            state_put(count, 0),
+            respond(ok)
+        ])
+    ])
+]).
+
+% Cache service with state
+service(cache, [stateful(true)], [
+    receive(Request),
+    route_by(op, [
+        (get, [
+            state_get(Request.key, Value),
+            respond(Value)
+        ]),
+        (set, [
+            state_put(Request.key, Request.value),
+            respond(ok)
+        ]),
+        (delete, [
+            state_delete(Request.key),
+            respond(ok)
+        ])
+    ])
+]).
+```
+
+## 3. Client Syntax
+
+### 3.1 Pipeline Integration
+
+```prolog
+% call_service(ServiceName, RequestExpr, ResponseVar)
+pipeline([
+    parse/1,
+    call_service(user_lookup, record.user_id, user_data),
+    merge_user_data/1,
+    output/1
+]).
+
+% With options
+pipeline([
+    parse/1,
+    call_service(slow_service, request, response, [
+        timeout(5000),
+        retry(3),
+        fallback(default_value)
+    ]),
+    output/1
+]).
+```
+
+### 3.2 Standalone Client
+
+```prolog
+% Define a client for a service
+client(user_client, user_lookup, [
+    transport(http('http://localhost:8080/users'))
+]).
+
+% Use client in code
+query_user(UserId, UserData) :-
+    client_call(user_client, UserId, UserData).
+```
+
+### 3.3 Async Client
+
+```prolog
+% Non-blocking service call
+pipeline([
+    parse/1,
+    call_service_async(slow_service, request, FutureRef),
+    % ... do other work ...
+    await_service(FutureRef, response),
+    output/1
+]).
+```
+
+## 4. Protocol Specification
+
+### 4.1 Request Format (JSONL)
+
+```json
+{"__type": "request", "__id": "uuid-123", "__service": "user_lookup", "payload": {"user_id": 42}}
+```
+
+Fields:
+- `__type`: Always "request"
+- `__id`: Unique request identifier (for correlation)
+- `__service`: Target service name
+- `payload`: Request data
+
+### 4.2 Response Format (JSONL)
+
+Success:
+```json
+{"__type": "response", "__id": "uuid-123", "__status": "ok", "payload": {"user_id": 42, "name": "Alice"}}
+```
+
+Error:
+```json
+{"__type": "response", "__id": "uuid-123", "__status": "error", "error": {"code": "NOT_FOUND", "message": "User not found"}}
+```
+
+Fields:
+- `__type`: Always "response"
+- `__id`: Matching request ID
+- `__status`: "ok" or "error"
+- `payload`: Response data (on success)
+- `error`: Error details (on failure)
+
+### 4.3 Streaming Protocol
+
+For services that return multiple responses:
+
+```json
+{"__type": "response", "__id": "uuid-123", "__status": "streaming", "__seq": 1, "payload": {...}}
+{"__type": "response", "__id": "uuid-123", "__status": "streaming", "__seq": 2, "payload": {...}}
+{"__type": "response", "__id": "uuid-123", "__status": "end", "__seq": 3}
+```
+
+## 5. Transport Specifications
+
+### 5.1 In-Process Transport
+
+```python
+# Python implementation
+class InProcessService:
+    def __init__(self, handler_fn, stateful=False):
+        self.handler = handler_fn
+        self.state = {} if stateful else None
+
+    def call(self, request):
+        return self.handler(request, self.state)
+
+# Generated code for call_service
+def call_user_lookup(request):
+    return _services['user_lookup'].call(request)
+```
+
+```go
+// Go implementation
+type InProcessService struct {
+    handler func(request Record, state *State) Record
+    state   *State
+}
+
+func (s *InProcessService) Call(request Record) Record {
+    return s.handler(request, s.state)
+}
+```
+
+### 5.2 Unix Socket Transport
+
+```python
+# Server side
+import socket
+
+def run_service(service_name, handler, socket_path):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(socket_path)
+    sock.listen(1)
+
+    while True:
+        conn, _ = sock.accept()
+        for line in conn.makefile():
+            request = json.loads(line)
+            response = handler(request['payload'])
+            conn.send(json.dumps({
+                '__type': 'response',
+                '__id': request['__id'],
+                '__status': 'ok',
+                'payload': response
+            }).encode() + b'\n')
+```
+
+### 5.3 HTTP Transport
+
+```python
+# Using Flask
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route('/service/<name>', methods=['POST'])
+def handle_service(name):
+    handler = _services.get(name)
+    if not handler:
+        return jsonify({'error': 'Unknown service'}), 404
+
+    req = request.json
+    response = handler(req['payload'])
+    return jsonify({
+        '__type': 'response',
+        '__id': req['__id'],
+        '__status': 'ok',
+        'payload': response
+    })
+```
+
+## 6. Validation
+
+### 6.1 Service Validation
+
+```prolog
+% In pipeline_validation.pl
+
+% Service definition validation
+is_valid_service(service(Name, HandlerSpec)) :-
+    atom(Name),
+    is_valid_handler_spec(HandlerSpec).
+
+is_valid_service(service(Name, Options, HandlerSpec)) :-
+    atom(Name),
+    is_list(Options),
+    validate_service_options(Options),
+    is_valid_handler_spec(HandlerSpec).
+
+% Handler spec validation
+is_valid_handler_spec([]).
+is_valid_handler_spec([Op|Rest]) :-
+    is_valid_service_operation(Op),
+    is_valid_handler_spec(Rest).
+
+% Operation validation
+is_valid_service_operation(receive(Var)) :- var(Var).
+is_valid_service_operation(respond(_)).
+is_valid_service_operation(respond_error(_)).
+is_valid_service_operation(Pred/Arity) :- atom(Pred), integer(Arity).
+is_valid_service_operation(transform(_, _)).
+is_valid_service_operation(state_get(Key, _)) :- atom(Key).
+is_valid_service_operation(state_put(Key, _)) :- atom(Key).
+is_valid_service_operation(call_service(Name, _, _)) :- atom(Name).
+```
+
+### 6.2 Client Validation
+
+```prolog
+% call_service as pipeline stage
+is_valid_stage(call_service(Name, _, _)) :-
+    atom(Name).
+
+is_valid_stage(call_service(Name, _, _, Options)) :-
+    atom(Name),
+    is_list(Options),
+    validate_client_options(Options).
+
+% Client options
+validate_client_options([]).
+validate_client_options([Opt|Rest]) :-
+    is_valid_client_option(Opt),
+    validate_client_options(Rest).
+
+is_valid_client_option(timeout(Ms)) :- integer(Ms), Ms > 0.
+is_valid_client_option(retry(N)) :- integer(N), N >= 0.
+is_valid_client_option(fallback(_)).
+is_valid_client_option(transport(_)).
+```
+
+## 7. Error Handling
+
+### 7.1 Error Types
+
+```prolog
+% Service-side errors
+service_error(not_found, "Resource not found").
+service_error(invalid_request, "Invalid request format").
+service_error(internal_error, "Internal service error").
+service_error(unauthorized, "Authentication required").
+
+% Client-side errors
+client_error(timeout, "Request timed out").
+client_error(connection_failed, "Could not connect to service").
+client_error(service_unavailable, "Service is unavailable").
+```
+
+### 7.2 Error Handling in Services
+
+```prolog
+service(safe_lookup, [
+    receive(Request),
+    try_catch(
+        [
+            validate_request/1,
+            lookup_data/1,
+            respond(Result)
+        ],
+        respond_error(Error)
+    )
+]).
+```
+
+### 7.3 Error Handling in Clients
+
+```prolog
+pipeline([
+    parse/1,
+    try_catch(
+        call_service(risky_service, request, response),
+        [
+            on_error(timeout, use_cached/1),
+            on_error(not_found, create_default/1),
+            on_error(_, log_and_skip/1)
+        ]
+    ),
+    output/1
+]).
+```
+
+## 8. Service Discovery (Future)
+
+### 8.1 Local Registry
+
+```prolog
+% Register service at compile time
+:- register_service(user_lookup, [
+    transport(in_process)
+]).
+
+% Lookup service
+get_service(Name, ServiceRef) :-
+    service_registry(Name, ServiceRef).
+```
+
+### 8.2 External Registry (Future)
+
+```prolog
+% Connect to service registry
+:- service_registry(consul, 'http://consul:8500').
+
+% Services registered externally
+service(user_lookup, [
+    transport(discover(consul, 'user-service'))
+]).
+```
+
+## 9. Metrics and Observability
+
+### 9.1 Built-in Metrics
+
+Services automatically track:
+- Request count
+- Response time (p50, p95, p99)
+- Error rate
+- Active connections
+
+### 9.2 Integration with Audit
+
+```prolog
+service(audited_lookup, [
+    audit([include_timing(true)]),  % Track in audit log
+    receive(Request),
+    lookup/1,
+    respond(Result)
+]).
+```
+
+## 10. Type Definitions
+
+### 10.1 Request/Response Types
+
+```prolog
+% Optional type annotations for documentation and validation
+service(typed_lookup, [
+    types([
+        request: user_id(integer),
+        response: user_record([
+            id: integer,
+            name: string,
+            email: string
+        ])
+    ]),
+    receive(UserId),
+    lookup_user/1,
+    respond(UserRecord)
+]).
+```
+
+### 10.2 Schema Validation
+
+```prolog
+% Validate requests against schema
+service(validated_service, [
+    validate_schema(true),
+    types([...]),
+    receive(Request),
+    process/1,
+    respond(Response)
+]).
+```
+
+---
+
+*This document specifies the technical details. See `CLIENT_SERVER_IMPLEMENTATION.md` for the implementation roadmap.*

--- a/docs/design/PROPOSED_PIPELINE_FEATURES.md
+++ b/docs/design/PROPOSED_PIPELINE_FEATURES.md
@@ -1,0 +1,405 @@
+# Proposed Pipeline Features
+
+## Overview
+
+This document captures pipeline-related features that were proposed during design discussions. Some may be implemented as pipeline stages, others may be better suited as client-server services. This serves as a reference for future implementation decisions.
+
+## Feature Categories
+
+| Feature | Pipeline Stage? | Service? | Notes |
+|---------|----------------|----------|-------|
+| Cache | Maybe | Yes | Stateful, better as service |
+| Checkpoint | Yes | Maybe | Write-aside persistence |
+| Audit | Yes | Maybe | Metadata enrichment |
+| Coalesce | Yes | No | Field merging |
+| Profiling | Yes | Maybe | Metrics collection |
+| State Monad | Complex | Yes | State threading |
+| Pipeline Composition | Yes | No | Named sub-pipelines |
+| Lazy Evaluation | Built-in | N/A | Already implemented |
+
+---
+
+## 1. Cache
+
+### Original Proposal (Pipeline Stage)
+```prolog
+cache(expensive_api/1, id_field)        % Cache by key field
+cache(transform/1, id, 3600)            % With TTL (seconds)
+```
+
+### Recommendation: Implement as Service
+```prolog
+service(cache_service, [stateful(true)], [
+    receive(Request),
+    route_by(op, [
+        (get, [state_get(Request.key, Value), respond(Value)]),
+        (set, [state_put(Request.key, Request.value), respond(ok)]),
+        (get_or_compute, [
+            state_get(Request.key, Cached),
+            branch(is_cached,
+                respond(Cached),
+                [compute(Request), state_put(Request.key, Result), respond(Result)]
+            )
+        ])
+    ])
+]).
+
+% Usage in pipeline
+pipeline([
+    parse/1,
+    call_service(cache_service, {op: get_or_compute, key: id, compute: transform/1}, result),
+    output/1
+]).
+```
+
+### Why Service is Better
+- Cache state persists across pipeline executions
+- Can be shared across multiple pipelines
+- Natural fit for stateful service pattern
+- TTL, eviction policies are service concerns
+
+---
+
+## 2. Checkpoint
+
+### Original Proposal (Pipeline Stage)
+```prolog
+checkpoint(jsonl, 'output/checkpoint.jsonl')
+checkpoint(sqlite, 'data/state.db', [table(processed)])
+```
+
+### Recommendation: Keep as Pipeline Stage
+Similar to `tee` but with persistence. Records pass through unchanged while being written to storage.
+
+### Implementation Approach
+```prolog
+% Validation
+is_valid_stage(checkpoint(Format, Location)) :-
+    valid_checkpoint_format(Format),
+    atom(Location).
+
+valid_checkpoint_format(jsonl).
+valid_checkpoint_format(sqlite).
+valid_checkpoint_format(csv).
+
+% Python implementation
+def checkpoint_stage(stream, format, location):
+    '''Write records to persistent storage while passing through.'''
+    writer = get_checkpoint_writer(format, location)
+    try:
+        for record in stream:
+            writer.write(record)
+            yield record
+    finally:
+        writer.close()
+```
+
+### Resume Capability
+Could be implemented as compilation option:
+```prolog
+compile_pipeline(Stages, [resume_from('checkpoint.jsonl', last_id)], Code).
+```
+
+---
+
+## 3. Audit
+
+### Original Proposal (Pipeline Stage)
+```prolog
+audit                                    % Track stage journey
+audit([include_timing(true)])           % With performance data
+audit([checkpoint('audit.jsonl')])      % Persist audit trail
+```
+
+### Recommendation: Keep as Pipeline Stage
+Metadata enrichment that adds `_audit` field to records.
+
+### Implementation Approach
+```prolog
+% Validation
+is_valid_stage(audit).
+is_valid_stage(audit(Options)) :- is_list(Options).
+
+% Python implementation
+def audit_stage(stream, stage_name, options=None):
+    '''Enrich records with audit metadata.'''
+    for record in stream:
+        if '_audit' not in record:
+            record['_audit'] = {'journey': [], 'created_at': now()}
+
+        entry = {'stage': stage_name, 'timestamp': now()}
+        if options.get('include_timing'):
+            entry['duration_ms'] = measure_duration()
+
+        record['_audit']['journey'].append(entry)
+        yield record
+```
+
+### Integration with Checkpoint
+```prolog
+pipeline([
+    parse/1,
+    audit([include_timing(true)]),
+    transform/1,
+    audit,
+    checkpoint(jsonl, 'audit_trail.jsonl'),  % Persist audit data
+    output/1
+]).
+```
+
+---
+
+## 4. Coalesce
+
+### Original Proposal (Pipeline Stage)
+```prolog
+coalesce([
+    email/[primary_email, backup_email],  % First non-null wins
+    name/[full_name, first_name]
+])
+```
+
+### Recommendation: Keep as Pipeline Stage
+Pure transformation, no state needed.
+
+### Implementation Approach
+```prolog
+% Validation
+is_valid_stage(coalesce(Mappings)) :-
+    is_list(Mappings),
+    maplist(is_valid_coalesce_mapping, Mappings).
+
+is_valid_coalesce_mapping(Target/Sources) :-
+    atom(Target),
+    is_list(Sources),
+    maplist(atom, Sources).
+
+% Python implementation
+def coalesce_stage(stream, mappings):
+    '''Merge fields, keeping first non-null value.'''
+    for record in stream:
+        for target, sources in mappings.items():
+            for source in sources:
+                if source in record and record[source] is not None:
+                    record[target] = record[source]
+                    break
+        yield record
+```
+
+### Use Cases
+- Consolidating results from `fan_out`
+- Schema migration (old field names → new)
+- Default value handling
+
+---
+
+## 5. Profiling
+
+### Original Proposal (Pipeline Stage)
+```prolog
+profile([latency, throughput, memory])
+profile([latency], [sample_rate(0.1), checkpoint('metrics.jsonl')])
+```
+
+### Recommendation: Hybrid (Stage + Service)
+
+**As Stage**: Collect metrics inline
+```prolog
+pipeline([
+    parse/1,
+    profile([latency]),
+    transform/1,
+    profile([latency, memory]),
+    output/1
+]).
+```
+
+**As Service**: Aggregate and query metrics
+```prolog
+service(metrics_service, [stateful(true)], [
+    receive(MetricEvent),
+    route_by(op, [
+        (record, [update_aggregates/1, respond(ok)]),
+        (query, [get_aggregates/1, respond(Stats)])
+    ])
+]).
+```
+
+### Implementation Approach
+```python
+def profile_stage(stream, metrics, options=None):
+    '''Collect performance metrics.'''
+    sample_rate = options.get('sample_rate', 1.0)
+
+    for record in stream:
+        if random.random() > sample_rate:
+            yield record
+            continue
+
+        profile = {}
+        if 'latency' in metrics:
+            profile['latency_ms'] = measure_latency(record)
+        if 'memory' in metrics:
+            profile['memory_mb'] = get_memory_usage()
+        if 'throughput' in metrics:
+            profile['records_per_sec'] = calculate_throughput()
+
+        record['_profile'] = profile
+        yield record
+```
+
+---
+
+## 6. State Monad Pattern
+
+### Original Proposal
+```prolog
+with_state(InitialState, [
+    stage1/1,    % Can read/modify state
+    stage2/1,    % Receives state from stage1
+    stage3/1     % Receives state from stage2
+])
+```
+
+### Recommendation: Implement as Service Pattern
+State threading is complex for pipeline users. Services provide a simpler model.
+
+### Alternative: Explicit State Service
+```prolog
+service(pipeline_state, [stateful(true)], [
+    receive(Op),
+    route_by(Op.action, [
+        (get, [state_get(Op.key, Value), respond(Value)]),
+        (put, [state_put(Op.key, Op.value), respond(ok)]),
+        (modify, [state_modify(Op.key, Op.func), respond(ok)])
+    ])
+]).
+
+% Usage in pipeline
+pipeline([
+    parse/1,
+    call_service(pipeline_state, {action: put, key: count, value: 0}, _),
+    map(process_and_count/1),  % Calls state service internally
+    call_service(pipeline_state, {action: get, key: count}, final_count),
+    output/1
+]).
+```
+
+### Why Service is Better
+- Explicit state location (not hidden in pipeline)
+- Testable in isolation
+- Can persist state if needed
+- Avoids functional programming complexity
+
+---
+
+## 7. Pipeline Composition
+
+### Original Proposal
+```prolog
+% Named pipelines as reusable units
+define_pipeline(validate_and_enrich, [
+    validate/1,
+    enrich/1,
+    normalize/1
+]).
+
+% Use in other pipelines
+pipeline([
+    parse/1,
+    use_pipeline(validate_and_enrich),
+    output/1
+]).
+```
+
+### Recommendation: Keep as Pipeline Feature
+This is purely about code organization, not state.
+
+### Implementation Approach
+```prolog
+% Store named pipelines
+:- dynamic defined_pipeline/2.
+
+define_pipeline(Name, Stages) :-
+    assertz(defined_pipeline(Name, Stages)).
+
+% Expand use_pipeline during compilation
+expand_pipeline([]) --> [].
+expand_pipeline([use_pipeline(Name)|Rest]) -->
+    { defined_pipeline(Name, Stages) },
+    Stages,
+    expand_pipeline(Rest).
+expand_pipeline([Stage|Rest]) -->
+    [Stage],
+    expand_pipeline(Rest).
+```
+
+### Benefits
+- DRY (Don't Repeat Yourself)
+- Named, documented pipeline fragments
+- Easier testing of sub-pipelines
+
+---
+
+## 8. Lazy Evaluation
+
+### Status: Already Implemented
+
+UnifyWeaver pipelines are lazy by default:
+- Python: Generator-based (`yield`)
+- Go: Iterator pattern
+- Rust: Iterator trait
+
+### Potential Enhancement: Explicit Eager Stages
+```prolog
+% Force materialization at specific points
+pipeline([
+    parse/1,
+    transform/1,
+    materialize,      % Force all records into memory here
+    expensive_sort/1, % Needs all records
+    output/1
+]).
+```
+
+This is already implicit in stages like `order_by`, `group_by`.
+
+---
+
+## Implementation Priority
+
+Based on value and complexity:
+
+| Priority | Feature | Approach | Rationale |
+|----------|---------|----------|-----------|
+| 1 | Coalesce | Pipeline stage | Simple, useful for fan_out |
+| 2 | Audit | Pipeline stage | Debugging, compliance |
+| 3 | Checkpoint | Pipeline stage | Persistence, resume |
+| 4 | Pipeline Composition | Pipeline feature | Code organization |
+| 5 | Profiling | Pipeline stage | Performance analysis |
+| 6 | Cache | Service | Stateful, complex |
+| 7 | State Monad | Service | Complex, niche use |
+
+---
+
+## Relationship to Client-Server
+
+Many of these features benefit from or require client-server:
+
+| Feature | Client-Server Benefit |
+|---------|----------------------|
+| Cache | Shared state across pipelines, persistence |
+| Checkpoint | Resume from external process |
+| Audit | Centralized audit log service |
+| Profiling | Metrics aggregation service |
+| State | Explicit state service |
+
+The client-server architecture enables these features to be:
+- Shared across multiple pipelines
+- Persistent across executions
+- Deployed and scaled independently
+- Easier to test and monitor
+
+---
+
+*This document serves as a reference. Implementation decisions should consider the client-server architecture as the foundation for stateful features.*

--- a/src/unifyweaver/core/service_validation.pl
+++ b/src/unifyweaver/core/service_validation.pl
@@ -1,0 +1,248 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% service_validation.pl - Service Definition Validation
+% Validates service definitions for the client-server architecture.
+
+:- module(service_validation, [
+    validate_service/2,
+    is_valid_service/1,
+    is_valid_handler_spec/1,
+    is_valid_service_operation/1,
+    validate_service_options/2,
+    service_type/2
+]).
+
+:- use_module(library(lists)).
+
+%% validate_service(+Service, -Errors)
+%  Validates a service definition and returns list of errors.
+%  Empty list means valid service.
+validate_service(service(Name, HandlerSpec), Errors) :-
+    !,
+    validate_service_name(Name, NameErrors),
+    validate_handler_spec(HandlerSpec, HandlerErrors),
+    append(NameErrors, HandlerErrors, Errors).
+
+validate_service(service(Name, Options, HandlerSpec), Errors) :-
+    !,
+    validate_service_name(Name, NameErrors),
+    validate_service_options(Options, OptionErrors),
+    validate_handler_spec(HandlerSpec, HandlerErrors),
+    append([NameErrors, OptionErrors, HandlerErrors], Errors).
+
+validate_service(Invalid, [error(invalid_service_definition, Invalid)]).
+
+%% validate_service_name(+Name, -Errors)
+validate_service_name(Name, []) :-
+    atom(Name),
+    !.
+validate_service_name(Name, [error(invalid_service_name, Name)]).
+
+%% is_valid_service(+Service)
+%  Succeeds if Service is a valid service definition.
+is_valid_service(service(Name, HandlerSpec)) :-
+    atom(Name),
+    is_valid_handler_spec(HandlerSpec).
+
+is_valid_service(service(Name, Options, HandlerSpec)) :-
+    atom(Name),
+    is_list(Options),
+    maplist(is_valid_service_option, Options),
+    is_valid_handler_spec(HandlerSpec).
+
+%% is_valid_handler_spec(+HandlerSpec)
+%  Validates the handler specification (list of operations).
+is_valid_handler_spec([]).
+is_valid_handler_spec([Op|Rest]) :-
+    is_valid_service_operation(Op),
+    is_valid_handler_spec(Rest).
+
+%% validate_handler_spec(+HandlerSpec, -Errors)
+validate_handler_spec(HandlerSpec, Errors) :-
+    is_list(HandlerSpec),
+    !,
+    validate_operations(HandlerSpec, 1, Errors).
+validate_handler_spec(Invalid, [error(handler_spec_not_list, Invalid)]).
+
+validate_operations([], _, []).
+validate_operations([Op|Rest], N, Errors) :-
+    ( is_valid_service_operation(Op) ->
+        OpErrors = []
+    ;
+        OpErrors = [error(invalid_operation_at_position, N, Op)]
+    ),
+    N1 is N + 1,
+    validate_operations(Rest, N1, RestErrors),
+    append(OpErrors, RestErrors, Errors).
+
+%% is_valid_service_operation(+Operation)
+%  Validates individual service operations.
+
+% receive(Variable) - Bind request to variable
+is_valid_service_operation(receive(_Var)) :- !.
+
+% respond(Value) - Send response
+is_valid_service_operation(respond(_Value)) :- !.
+
+% respond_error(Error) - Send error response
+is_valid_service_operation(respond_error(_Error)) :- !.
+
+% Predicate/Arity - Execute predicate
+is_valid_service_operation(Pred/Arity) :-
+    atom(Pred),
+    integer(Arity),
+    Arity >= 0,
+    !.
+
+% Atom predicate (arity inferred)
+is_valid_service_operation(Pred) :-
+    atom(Pred),
+    Pred \= receive,
+    Pred \= respond,
+    Pred \= respond_error,
+    !.
+
+% transform(In, Out) or transform(In, Out, Goal)
+is_valid_service_operation(transform(_, _)) :- !.
+is_valid_service_operation(transform(_, _, _)) :- !.
+
+% State operations (for stateful services)
+is_valid_service_operation(state_get(Key, _Value)) :-
+    atom(Key),
+    !.
+is_valid_service_operation(state_put(Key, _Value)) :-
+    atom(Key),
+    !.
+is_valid_service_operation(state_modify(Key, _Func)) :-
+    atom(Key),
+    !.
+is_valid_service_operation(state_delete(Key)) :-
+    atom(Key),
+    !.
+
+% Call another service
+is_valid_service_operation(call_service(Name, _Request, _Response)) :-
+    atom(Name),
+    !.
+is_valid_service_operation(call_service(Name, _Request, _Response, Options)) :-
+    atom(Name),
+    is_list(Options),
+    !.
+
+% Route by field value
+is_valid_service_operation(route_by(Field, Routes)) :-
+    atom(Field),
+    is_list(Routes),
+    maplist(is_valid_route, Routes),
+    !.
+
+% Branch on condition
+is_valid_service_operation(branch(Cond, TrueOps, FalseOps)) :-
+    ( atom(Cond) ; Cond = _/_ ),
+    is_valid_handler_spec(TrueOps),
+    is_valid_handler_spec(FalseOps),
+    !.
+
+% Nested handler spec (for routing)
+is_valid_service_operation(Ops) :-
+    is_list(Ops),
+    is_valid_handler_spec(Ops),
+    !.
+
+%% is_valid_route(+Route)
+is_valid_route((Value, Handler)) :-
+    is_valid_handler_spec(Handler),
+    ( atom(Value) ; number(Value) ; Value = _ ).
+
+%% Service Options Validation
+
+validate_service_options(Options, Errors) :-
+    is_list(Options),
+    !,
+    findall(Error,
+        (member(Opt, Options), \+ is_valid_service_option(Opt), Error = error(invalid_option, Opt)),
+        Errors).
+validate_service_options(Invalid, [error(options_not_list, Invalid)]).
+
+is_valid_service_option(stateful(Bool)) :-
+    ( Bool = true ; Bool = false ).
+
+is_valid_service_option(transport(Transport)) :-
+    is_valid_transport(Transport).
+
+is_valid_service_option(protocol(Protocol)) :-
+    is_valid_protocol(Protocol).
+
+is_valid_service_option(timeout(Ms)) :-
+    integer(Ms),
+    Ms > 0.
+
+is_valid_service_option(max_concurrent(N)) :-
+    integer(N),
+    N > 0.
+
+is_valid_service_option(on_error(Handler)) :-
+    ( atom(Handler) ; Handler = _/_ ).
+
+%% Transport validation
+is_valid_transport(in_process).
+is_valid_transport(unix_socket(Path)) :- atom(Path).
+is_valid_transport(tcp(Host, Port)) :- atom(Host), integer(Port), Port > 0.
+is_valid_transport(http(Endpoint)) :- atom(Endpoint).
+is_valid_transport(http(Endpoint, Options)) :- atom(Endpoint), is_list(Options).
+
+%% Protocol validation
+is_valid_protocol(jsonl).
+is_valid_protocol(json).
+is_valid_protocol(messagepack).
+is_valid_protocol(protobuf(Schema)) :- atom(Schema).
+
+%% service_type(+Service, -Type)
+%  Determines the type of service (stateful/stateless, transport type).
+service_type(service(_, Options, _), Type) :-
+    !,
+    ( member(stateful(true), Options) ->
+        Stateful = stateful
+    ;
+        Stateful = stateless
+    ),
+    ( member(transport(Transport), Options) ->
+        transport_category(Transport, TransportCat)
+    ;
+        TransportCat = in_process
+    ),
+    Type = service_type(Stateful, TransportCat).
+
+service_type(service(_, _), service_type(stateless, in_process)).
+
+transport_category(in_process, in_process).
+transport_category(unix_socket(_), cross_process).
+transport_category(tcp(_, _), network).
+transport_category(http(_), network).
+transport_category(http(_, _), network).
+
+%% Utility predicates for querying services
+
+%% has_state_operations(+HandlerSpec)
+%  Succeeds if handler spec contains state operations.
+has_state_operations(HandlerSpec) :-
+    member(Op, HandlerSpec),
+    ( Op = state_get(_, _)
+    ; Op = state_put(_, _)
+    ; Op = state_modify(_, _)
+    ; Op = state_delete(_)
+    ),
+    !.
+
+%% extract_receive_var(+HandlerSpec, -Var)
+%  Extract the variable bound by receive operation.
+extract_receive_var([receive(Var)|_], Var) :- !.
+extract_receive_var([_|Rest], Var) :-
+    extract_receive_var(Rest, Var).
+
+%% extract_respond_value(+HandlerSpec, -Value)
+%  Extract the value from respond operation.
+extract_respond_value(HandlerSpec, Value) :-
+    member(respond(Value), HandlerSpec),
+    !.

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -31,7 +31,10 @@
     test_go_enhanced_chaining/0,    % Test enhanced pipeline chaining
     % Client-server architecture exports (Phase 9)
     compile_service_to_go/2,        % +Service, -GoCode
-    generate_service_handler_go/2   % +HandlerSpec, -GoCode
+    generate_service_handler_go/2,  % +HandlerSpec, -GoCode
+    % Phase 2: Cross-process services
+    compile_unix_socket_service_go/2,   % +Service, -GoCode
+    compile_unix_socket_client_go/3     % +ServiceName, +SocketPath, -GoCode
 ]).
 
 :- use_module(library(lists)).
@@ -44,6 +47,9 @@
 
 % Pipeline validation
 :- use_module('../core/pipeline_validation').
+
+% Service validation (Client-Server Phase 2)
+:- use_module('../core/service_validation').
 
 % Track required imports from bindings
 :- dynamic required_binding_import/1.
@@ -199,11 +205,20 @@ get_field_info(SchemaName, FieldName, any, []) :-
 
 %% compile_service_to_go(+Service, -GoCode)
 %  Compile a service definition to a Go struct and methods.
+%  Dispatches based on transport type: in_process, unix_socket, etc.
 compile_service_to_go(service(Name, HandlerSpec), GoCode) :-
     !,
     compile_service_to_go(service(Name, [], HandlerSpec), GoCode).
 
+compile_service_to_go(Service, GoCode) :-
+    Service = service(_Name, Options, _HandlerSpec),
+    member(transport(unix_socket(_Path)), Options),
+    !,
+    % Phase 2: Unix socket service
+    compile_unix_socket_service_go(Service, GoCode).
+
 compile_service_to_go(service(Name, Options, HandlerSpec), GoCode) :-
+    % Phase 1: In-process service (default)
     % Determine if service is stateful
     ( member(stateful(true), Options) -> Stateful = true ; Stateful = false ),
     % Generate handler code
@@ -349,6 +364,513 @@ generate_handler_op_go(Pred, Code) :-
     format(string(Code), "\t// Execute predicate: ~w", [Pred]).
 
 generate_handler_op_go(_, "\t// Unknown operation").
+
+%% ============================================
+%% PHASE 2: CROSS-PROCESS SERVICES (Unix Socket)
+%% ============================================
+
+%% compile_unix_socket_service_go(+Service, -GoCode)
+%  Generate Go code for a Unix socket service server.
+compile_unix_socket_service_go(service(Name, Options, HandlerSpec), GoCode) :-
+    % Extract socket path
+    member(transport(unix_socket(SocketPath)), Options),
+    % Determine if service is stateful
+    ( member(stateful(true), Options) -> Stateful = true ; Stateful = false ),
+    % Extract timeout (default 30000ms)
+    ( member(timeout(TimeoutMs), Options) -> Timeout = TimeoutMs ; Timeout = 30000 ),
+    % Generate handler code
+    generate_service_handler_go(HandlerSpec, HandlerCode),
+    % Format the struct name (capitalize first letter)
+    atom_codes(Name, [First|Rest]),
+    ( First >= 0'a, First =< 0'z ->
+        Upper is First - 32,
+        StructName = [Upper|Rest]
+    ;
+        StructName = [First|Rest]
+    ),
+    atom_codes(StructNameAtom, StructName),
+    % Generate upper case name for export
+    atom_codes(UpperName, StructName),
+    % Generate the Unix socket service
+    ( Stateful = true ->
+        format(string(GoCode),
+"package main
+
+import (
+\t\"bufio\"
+\t\"encoding/json\"
+\t\"fmt\"
+\t\"net\"
+\t\"os\"
+\t\"os/signal\"
+\t\"sync\"
+\t\"syscall\"
+\t\"time\"
+)
+
+// ~wService implements a Unix socket server for ~w
+type ~wService struct {
+\t*StatefulService
+\tsocketPath string
+\ttimeout    time.Duration
+\tlistener   net.Listener
+\trunning    bool
+\tmu         sync.Mutex
+}
+
+// New~wService creates a new ~w service instance
+func New~wService() *~wService {
+\treturn &~wService{
+\t\tStatefulService: NewStatefulService(\"~w\"),
+\t\tsocketPath:      \"~w\",
+\t\ttimeout:         ~w * time.Millisecond,
+\t}
+}
+
+// Name returns the service name
+func (s *~wService) Name() string {
+\treturn \"~w\"
+}
+
+// Call processes a request and returns a response
+func (s *~wService) Call(request interface{}) (interface{}, error) {
+~w
+}
+
+// StartServer starts the Unix socket server
+func (s *~wService) StartServer() error {
+\t// Remove existing socket file
+\tos.Remove(s.socketPath)
+
+\tlistener, err := net.Listen(\"unix\", s.socketPath)
+\tif err != nil {
+\t\treturn err
+\t}
+\ts.listener = listener
+\ts.running = true
+
+\tfmt.Fprintf(os.Stderr, \"[~w] Server listening on %%s\\n\", s.socketPath)
+
+\tfor s.running {
+\t\tconn, err := listener.Accept()
+\t\tif err != nil {
+\t\t\tif !s.running {
+\t\t\t\tbreak
+\t\t\t}
+\t\t\tcontinue
+\t\t}
+\t\tgo s.handleConnection(conn)
+\t}
+
+\ts.cleanup()
+\treturn nil
+}
+
+func (s *~wService) handleConnection(conn net.Conn) {
+\tdefer conn.Close()
+\tconn.SetDeadline(time.Now().Add(s.timeout))
+
+\treader := bufio.NewReader(conn)
+\tfor {
+\t\tline, err := reader.ReadBytes('\\n')
+\t\tif err != nil {
+\t\t\tbreak
+\t\t}
+\t\ts.processRequest(conn, line)
+\t}
+}
+
+func (s *~wService) processRequest(conn net.Conn, line []byte) {
+\tvar request map[string]interface{}
+\tif err := json.Unmarshal(line, &request); err != nil {
+\t\ts.sendError(conn, \"parse_error\", err.Error())
+\t\treturn
+\t}
+
+\trequestID, _ := request[\"_id\"].(string)
+\tpayload := request[\"_payload\"]
+\tif payload == nil {
+\t\tpayload = request
+\t}
+
+\ts.mu.Lock()
+\tresponse, err := s.Call(payload)
+\ts.mu.Unlock()
+
+\tif err != nil {
+\t\ts.sendError(conn, \"service_error\", err.Error())
+\t\treturn
+\t}
+
+\ts.sendResponse(conn, requestID, response)
+}
+
+func (s *~wService) sendResponse(conn net.Conn, requestID string, response interface{}) {
+\tmsg := map[string]interface{}{
+\t\t\"_id\":      requestID,
+\t\t\"_status\":  \"ok\",
+\t\t\"_payload\": response,
+\t}
+\tdata, _ := json.Marshal(msg)
+\tconn.Write(append(data, '\\n'))
+}
+
+func (s *~wService) sendError(conn net.Conn, errorType, message string) {
+\tmsg := map[string]interface{}{
+\t\t\"_status\":     \"error\",
+\t\t\"_error_type\": errorType,
+\t\t\"_message\":    message,
+\t}
+\tdata, _ := json.Marshal(msg)
+\tconn.Write(append(data, '\\n'))
+}
+
+// StopServer stops the Unix socket server
+func (s *~wService) StopServer() {
+\ts.running = false
+\tif s.listener != nil {
+\t\ts.listener.Close()
+\t}
+}
+
+func (s *~wService) cleanup() {
+\tos.Remove(s.socketPath)
+\tfmt.Fprintf(os.Stderr, \"[~w] Server stopped\\n\")
+}
+
+// Global service instance
+var _~wService = New~wService()
+
+func init() {
+\tRegisterService(\"~w\", _~wService)
+}
+
+func main() {
+\tsigChan := make(chan os.Signal, 1)
+\tsignal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+\tgo func() {
+\t\t<-sigChan
+\t\tfmt.Fprintf(os.Stderr, \"\\n[~w] Shutting down...\\n\")
+\t\t_~wService.StopServer()
+\t\tos.Exit(0)
+\t}()
+
+\t_~wService.StartServer()
+}
+", [StructNameAtom, Name, StructNameAtom, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom, Name, SocketPath, Timeout,
+    StructNameAtom, Name, HandlerCode, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom,
+    StructNameAtom, StructNameAtom, StructNameAtom, Name, StructNameAtom, StructNameAtom, Name, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom])
+    ;
+        % Non-stateful version
+        format(string(GoCode),
+"package main
+
+import (
+\t\"bufio\"
+\t\"encoding/json\"
+\t\"fmt\"
+\t\"net\"
+\t\"os\"
+\t\"os/signal\"
+\t\"sync\"
+\t\"syscall\"
+\t\"time\"
+)
+
+// ~wService implements a Unix socket server for ~w
+type ~wService struct {
+\tname       string
+\tsocketPath string
+\ttimeout    time.Duration
+\tlistener   net.Listener
+\trunning    bool
+\tmu         sync.Mutex
+}
+
+// New~wService creates a new ~w service instance
+func New~wService() *~wService {
+\treturn &~wService{
+\t\tname:       \"~w\",
+\t\tsocketPath: \"~w\",
+\t\ttimeout:    ~w * time.Millisecond,
+\t}
+}
+
+// Name returns the service name
+func (s *~wService) Name() string {
+\treturn s.name
+}
+
+// Call processes a request and returns a response
+func (s *~wService) Call(request interface{}) (interface{}, error) {
+~w
+}
+
+// StartServer starts the Unix socket server
+func (s *~wService) StartServer() error {
+\t// Remove existing socket file
+\tos.Remove(s.socketPath)
+
+\tlistener, err := net.Listen(\"unix\", s.socketPath)
+\tif err != nil {
+\t\treturn err
+\t}
+\ts.listener = listener
+\ts.running = true
+
+\tfmt.Fprintf(os.Stderr, \"[~w] Server listening on %%s\\n\", s.socketPath)
+
+\tfor s.running {
+\t\tconn, err := listener.Accept()
+\t\tif err != nil {
+\t\t\tif !s.running {
+\t\t\t\tbreak
+\t\t\t}
+\t\t\tcontinue
+\t\t}
+\t\tgo s.handleConnection(conn)
+\t}
+
+\ts.cleanup()
+\treturn nil
+}
+
+func (s *~wService) handleConnection(conn net.Conn) {
+\tdefer conn.Close()
+\tconn.SetDeadline(time.Now().Add(s.timeout))
+
+\treader := bufio.NewReader(conn)
+\tfor {
+\t\tline, err := reader.ReadBytes('\\n')
+\t\tif err != nil {
+\t\t\tbreak
+\t\t}
+\t\ts.processRequest(conn, line)
+\t}
+}
+
+func (s *~wService) processRequest(conn net.Conn, line []byte) {
+\tvar request map[string]interface{}
+\tif err := json.Unmarshal(line, &request); err != nil {
+\t\ts.sendError(conn, \"parse_error\", err.Error())
+\t\treturn
+\t}
+
+\trequestID, _ := request[\"_id\"].(string)
+\tpayload := request[\"_payload\"]
+\tif payload == nil {
+\t\tpayload = request
+\t}
+
+\ts.mu.Lock()
+\tresponse, err := s.Call(payload)
+\ts.mu.Unlock()
+
+\tif err != nil {
+\t\ts.sendError(conn, \"service_error\", err.Error())
+\t\treturn
+\t}
+
+\ts.sendResponse(conn, requestID, response)
+}
+
+func (s *~wService) sendResponse(conn net.Conn, requestID string, response interface{}) {
+\tmsg := map[string]interface{}{
+\t\t\"_id\":      requestID,
+\t\t\"_status\":  \"ok\",
+\t\t\"_payload\": response,
+\t}
+\tdata, _ := json.Marshal(msg)
+\tconn.Write(append(data, '\\n'))
+}
+
+func (s *~wService) sendError(conn net.Conn, errorType, message string) {
+\tmsg := map[string]interface{}{
+\t\t\"_status\":     \"error\",
+\t\t\"_error_type\": errorType,
+\t\t\"_message\":    message,
+\t}
+\tdata, _ := json.Marshal(msg)
+\tconn.Write(append(data, '\\n'))
+}
+
+// StopServer stops the Unix socket server
+func (s *~wService) StopServer() {
+\ts.running = false
+\tif s.listener != nil {
+\t\ts.listener.Close()
+\t}
+}
+
+func (s *~wService) cleanup() {
+\tos.Remove(s.socketPath)
+\tfmt.Fprintf(os.Stderr, \"[~w] Server stopped\\n\")
+}
+
+// Global service instance
+var _~wService = New~wService()
+
+func init() {
+\tRegisterService(\"~w\", _~wService)
+}
+
+func main() {
+\tsigChan := make(chan os.Signal, 1)
+\tsignal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+\tgo func() {
+\t\t<-sigChan
+\t\tfmt.Fprintf(os.Stderr, \"\\n[~w] Shutting down...\\n\")
+\t\t_~wService.StopServer()
+\t\tos.Exit(0)
+\t}()
+
+\t_~wService.StartServer()
+}
+", [StructNameAtom, Name, StructNameAtom, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom, Name, SocketPath, Timeout,
+    StructNameAtom, HandlerCode, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom,
+    StructNameAtom, StructNameAtom, StructNameAtom, Name, StructNameAtom, StructNameAtom, Name, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom])
+    ).
+
+%% compile_unix_socket_client_go(+ServiceName, +SocketPath, -GoCode)
+%  Generate Go code for a Unix socket service client.
+compile_unix_socket_client_go(Name, SocketPath, GoCode) :-
+    % Format the struct name (capitalize first letter)
+    atom_codes(Name, [First|Rest]),
+    ( First >= 0'a, First =< 0'z ->
+        Upper is First - 32,
+        StructName = [Upper|Rest]
+    ;
+        StructName = [First|Rest]
+    ),
+    atom_codes(StructNameAtom, StructName),
+    format(string(GoCode),
+"package main
+
+import (
+\t\"bufio\"
+\t\"encoding/json\"
+\t\"fmt\"
+\t\"net\"
+\t\"time\"
+
+\t\"github.com/google/uuid\"
+)
+
+// ~wClient is a client for the ~w Unix socket service
+type ~wClient struct {
+\tsocketPath string
+\ttimeout    time.Duration
+\tconn       net.Conn
+}
+
+// New~wClient creates a new client for ~w service
+func New~wClient(socketPath string, timeout time.Duration) *~wClient {
+\treturn &~wClient{
+\t\tsocketPath: socketPath,
+\t\ttimeout:    timeout,
+\t}
+}
+
+// Connect connects to the service
+func (c *~wClient) Connect() error {
+\tconn, err := net.DialTimeout(\"unix\", c.socketPath, c.timeout)
+\tif err != nil {
+\t\treturn err
+\t}
+\tc.conn = conn
+\treturn nil
+}
+
+// Disconnect disconnects from the service
+func (c *~wClient) Disconnect() {
+\tif c.conn != nil {
+\t\tc.conn.Close()
+\t\tc.conn = nil
+\t}
+}
+
+// Call sends a request and receives a response
+func (c *~wClient) Call(request interface{}) (interface{}, error) {
+\tif c.conn == nil {
+\t\tif err := c.Connect(); err != nil {
+\t\t\treturn nil, err
+\t\t}
+\t}
+
+\tc.conn.SetDeadline(time.Now().Add(c.timeout))
+
+\trequestID := uuid.New().String()
+\tmsg := map[string]interface{}{
+\t\t\"_id\":      requestID,
+\t\t\"_payload\": request,
+\t}
+\tdata, err := json.Marshal(msg)
+\tif err != nil {
+\t\treturn nil, err
+\t}
+\t_, err = c.conn.Write(append(data, '\\n'))
+\tif err != nil {
+\t\treturn nil, err
+\t}
+
+\treader := bufio.NewReader(c.conn)
+\tline, err := reader.ReadBytes('\\n')
+\tif err != nil {
+\t\treturn nil, err
+\t}
+
+\tvar response map[string]interface{}
+\tif err := json.Unmarshal(line, &response); err != nil {
+\t\treturn nil, err
+\t}
+
+\tif response[\"_status\"] == \"ok\" {
+\t\treturn response[\"_payload\"], nil
+\t}
+
+\treturn nil, &ServiceError{
+\t\tService: \"~w\",
+\t\tMessage: fmt.Sprintf(\"%%v\", response[\"_message\"]),
+\t}
+}
+
+// Call~w is a convenience function to call the ~w service
+func Call~w(request interface{}, socketPath string, timeout time.Duration) (interface{}, error) {
+\tclient := New~wClient(socketPath, timeout)
+\tdefer client.Disconnect()
+\treturn client.Call(request)
+}
+
+// Default client
+var Default~wClient = New~wClient(\"~w\", 30*time.Second)
+
+// ~wRemoteService wraps the client for use with call_service_impl
+type ~wRemoteService struct {
+\tclient *~wClient
+}
+
+// Name returns the service name
+func (s *~wRemoteService) Name() string {
+\treturn \"~w\"
+}
+
+// Call calls the remote service
+func (s *~wRemoteService) Call(request interface{}) (interface{}, error) {
+\treturn s.client.Call(request)
+}
+
+func init() {
+\t// Register remote service if local not available
+\tif _, ok := services[\"~w\"]; !ok {
+\t\tRegisterService(\"~w\", &~wRemoteService{client: Default~wClient})
+\t}
+}
+", [StructNameAtom, Name, StructNameAtom, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom,
+    StructNameAtom, StructNameAtom, StructNameAtom, StructNameAtom, StructNameAtom,
+    Name, StructNameAtom, Name, StructNameAtom, StructNameAtom, StructNameAtom, SocketPath,
+    StructNameAtom, StructNameAtom, StructNameAtom, Name, StructNameAtom, Name, Name, StructNameAtom, StructNameAtom]).
 
 %% ============================================
 %% PUBLIC API

--- a/tests/integration/test_in_process_services.sh
+++ b/tests/integration/test_in_process_services.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (@s243a)
+#
+# test_in_process_services.sh - Integration tests for Client-Server Phase 1
+# Tests in-process service definitions and call_service pipeline stage
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+info() {
+    echo -e "${YELLOW}INFO${NC}: $1"
+}
+
+run_prolog() {
+    timeout 30 swipl -g "$1" -t "halt(1)" 2>&1
+    return $?
+}
+
+echo "=========================================="
+echo "Client-Server Phase 1: In-Process Services"
+echo "Integration Tests"
+echo "=========================================="
+echo ""
+
+# Test 1: Service validation module loads correctly
+info "Test 1: Service validation module loads correctly"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), halt(0)" >/dev/null; then
+    pass "Service validation module loads"
+else
+    fail "Service validation module failed to load"
+fi
+
+# Test 2: Valid service definition is accepted
+info "Test 2: Valid service definition is accepted"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), is_valid_service(service(echo, [receive(X), respond(X)])), halt(0)" >/dev/null; then
+    pass "Valid simple service accepted"
+else
+    fail "Valid simple service rejected"
+fi
+
+# Test 3: Service with options validates correctly
+info "Test 3: Service with options validates correctly"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), is_valid_service(service(counter, [stateful(true), timeout(5000)], [receive(X), respond(X)])), halt(0)" >/dev/null; then
+    pass "Service with options validated"
+else
+    fail "Service with options validation failed"
+fi
+
+# Test 4: Service operations are validated
+info "Test 4: Service operations are validated"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), is_valid_service_operation(receive(X)), is_valid_service_operation(respond(Y)), is_valid_service_operation(respond_error(not_found)), is_valid_service_operation(state_get(count, V)), is_valid_service_operation(state_put(count, 0)), is_valid_service_operation(call_service(other_service, Req, Resp)), halt(0)" >/dev/null; then
+    pass "All service operations validated"
+else
+    fail "Service operation validation failed"
+fi
+
+# Test 5: call_service stage validates in pipeline
+info "Test 5: call_service stage validates in pipeline"
+if run_prolog "use_module('src/unifyweaver/core/pipeline_validation'), is_valid_stage(call_service(my_service, request_field, response_field)), is_valid_stage(call_service(my_service, request_field, response_field, [timeout(5000), retry(3)])), halt(0)" >/dev/null; then
+    pass "call_service stage validates"
+else
+    fail "call_service validation failed"
+fi
+
+# Test 6: call_service options are validated
+info "Test 6: call_service options are validated"
+if run_prolog "use_module('src/unifyweaver/core/pipeline_validation'), is_valid_call_service_option(timeout(5000)), is_valid_call_service_option(retry(3)), is_valid_call_service_option(retry_delay(100)), is_valid_call_service_option(fallback(default)), halt(0)" >/dev/null; then
+    pass "call_service options validated"
+else
+    fail "call_service options validation failed"
+fi
+
+# Test 7: Python service compilation
+info "Test 7: Python service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(echo, [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'class EchoService'), sub_string(Code, _, _, _, 'def call'), halt(0)" >/dev/null; then
+    pass "Python service compilation works"
+else
+    fail "Python service compilation failed"
+fi
+
+# Test 8: Go service compilation
+info "Test 8: Go service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_service_to_go(service(echo, [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'type EchoService struct'), sub_string(Code, _, _, _, 'func (s *EchoService) Call'), halt(0)" >/dev/null; then
+    pass "Go service compilation works"
+else
+    fail "Go service compilation failed"
+fi
+
+# Test 9: Rust service compilation
+info "Test 9: Rust service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_service_to_rust(service(echo, [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'pub struct EchoService'), sub_string(Code, _, _, _, 'impl Service for EchoService'), halt(0)" >/dev/null; then
+    pass "Rust service compilation works"
+else
+    fail "Rust service compilation failed"
+fi
+
+# Test 10: Python enhanced helpers include service infrastructure
+info "Test 10: Python enhanced helpers include service infrastructure"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), enhanced_pipeline_helpers(Code), sub_string(Code, _, _, _, '_services = {}'), sub_string(Code, _, _, _, 'class Service'), halt(0)" >/dev/null; then
+    pass "Python service infrastructure included"
+else
+    fail "Python service infrastructure missing"
+fi
+
+# Test 11: Go enhanced helpers include service infrastructure
+info "Test 11: Go enhanced helpers include service infrastructure"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), go_enhanced_helpers(Code), sub_string(Code, _, _, _, 'type Service interface'), sub_string(Code, _, _, _, 'var services'), halt(0)" >/dev/null; then
+    pass "Go service infrastructure included"
+else
+    fail "Go service infrastructure missing"
+fi
+
+# Test 12: Rust enhanced helpers include service infrastructure
+info "Test 12: Rust enhanced helpers include service infrastructure"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), rust_enhanced_helpers(std_thread, Code), sub_string(Code, _, _, _, 'pub trait Service'), sub_string(Code, _, _, _, 'SERVICES'), halt(0)" >/dev/null; then
+    pass "Rust service infrastructure included"
+else
+    fail "Rust service infrastructure missing"
+fi
+
+# Test 13: Invalid service rejected
+info "Test 13: Invalid service rejected"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), validate_service(service(123, []), Errors), Errors \\= [], halt(0)" >/dev/null; then
+    pass "Invalid service correctly rejected"
+else
+    fail "Invalid service should be rejected"
+fi
+
+echo ""
+echo "=========================================="
+echo -e "Results: ${GREEN}$PASS_COUNT passed${NC}, ${RED}$FAIL_COUNT failed${NC}"
+echo "=========================================="
+
+if [ $FAIL_COUNT -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/integration/test_unix_socket_services.sh
+++ b/tests/integration/test_unix_socket_services.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (@s243a)
+#
+# test_unix_socket_services.sh - Integration tests for Client-Server Phase 2
+# Tests Unix socket service compilation for Python, Go, and Rust targets
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+info() {
+    echo -e "${YELLOW}INFO${NC}: $1"
+}
+
+run_prolog() {
+    timeout 30 swipl -g "$1" -t "halt(1)" 2>&1
+    return $?
+}
+
+echo "==========================================="
+echo "Client-Server Phase 2: Unix Socket Services"
+echo "Integration Tests"
+echo "==========================================="
+echo ""
+
+# Test 1: Service validation helper predicates work
+info "Test 1: Service validation helper predicates work"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), get_service_transport(service(test, [transport(unix_socket('/tmp/test.sock'))], []), T), T = unix_socket('/tmp/test.sock'), halt(0)" >/dev/null; then
+    pass "get_service_transport extracts unix_socket"
+else
+    fail "get_service_transport failed"
+fi
+
+# Test 2: is_cross_process_service identifies unix socket services
+info "Test 2: is_cross_process_service identifies unix socket services"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), is_cross_process_service(service(test, [transport(unix_socket('/tmp/test.sock'))], [])), halt(0)" >/dev/null; then
+    pass "is_cross_process_service works for unix socket"
+else
+    fail "is_cross_process_service failed"
+fi
+
+# Test 3: In-process service is not cross-process
+info "Test 3: In-process service is not cross-process"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), \\+ is_cross_process_service(service(test, [], [])), halt(0)" >/dev/null; then
+    pass "In-process service correctly not cross-process"
+else
+    fail "In-process service incorrectly identified as cross-process"
+fi
+
+# Test 4: get_service_protocol extracts protocol
+info "Test 4: get_service_protocol extracts protocol"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), get_service_protocol(service(test, [protocol(jsonl)], []), P), P = jsonl, halt(0)" >/dev/null; then
+    pass "get_service_protocol works"
+else
+    fail "get_service_protocol failed"
+fi
+
+# Test 5: Python Unix socket service compilation
+info "Test 5: Python Unix socket service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(echo, [transport(unix_socket('/tmp/echo.sock'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'socket.AF_UNIX'), sub_string(Code, _, _, _, 'start_server'), halt(0)" >/dev/null; then
+    pass "Python Unix socket service compiles"
+else
+    fail "Python Unix socket service compilation failed"
+fi
+
+# Test 6: Python Unix socket service has JSONL protocol
+info "Test 6: Python Unix socket service has JSONL protocol"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(echo, [transport(unix_socket('/tmp/echo.sock'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_id'), sub_string(Code, _, _, _, '_payload'), sub_string(Code, _, _, _, 'json.loads'), halt(0)" >/dev/null; then
+    pass "Python Unix socket has JSONL protocol"
+else
+    fail "Python Unix socket JSONL protocol missing"
+fi
+
+# Test 7: Python Unix socket client compilation
+info "Test 7: Python Unix socket client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_unix_socket_client_python(echo, '/tmp/echo.sock', Code), sub_string(Code, _, _, _, 'EchoClient'), sub_string(Code, _, _, _, 'connect'), halt(0)" >/dev/null; then
+    pass "Python Unix socket client compiles"
+else
+    fail "Python Unix socket client compilation failed"
+fi
+
+# Test 8: Go Unix socket service compilation
+info "Test 8: Go Unix socket service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_service_to_go(service(echo, [transport(unix_socket('/tmp/echo.sock'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'net.Listen'), sub_string(Code, _, _, _, 'StartServer'), halt(0)" >/dev/null; then
+    pass "Go Unix socket service compiles"
+else
+    fail "Go Unix socket service compilation failed"
+fi
+
+# Test 9: Go Unix socket service has JSONL protocol
+info "Test 9: Go Unix socket service has JSONL protocol"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_service_to_go(service(echo, [transport(unix_socket('/tmp/echo.sock'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_id'), sub_string(Code, _, _, _, '_payload'), sub_string(Code, _, _, _, 'json.Unmarshal'), halt(0)" >/dev/null; then
+    pass "Go Unix socket has JSONL protocol"
+else
+    fail "Go Unix socket JSONL protocol missing"
+fi
+
+# Test 10: Go Unix socket client compilation
+info "Test 10: Go Unix socket client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_unix_socket_client_go(echo, '/tmp/echo.sock', Code), sub_string(Code, _, _, _, 'EchoClient'), sub_string(Code, _, _, _, 'Connect'), halt(0)" >/dev/null; then
+    pass "Go Unix socket client compiles"
+else
+    fail "Go Unix socket client compilation failed"
+fi
+
+# Test 11: Rust Unix socket service compilation
+info "Test 11: Rust Unix socket service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_service_to_rust(service(echo, [transport(unix_socket('/tmp/echo.sock'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'UnixListener'), sub_string(Code, _, _, _, 'start_server'), halt(0)" >/dev/null; then
+    pass "Rust Unix socket service compiles"
+else
+    fail "Rust Unix socket service compilation failed"
+fi
+
+# Test 12: Rust Unix socket service has JSONL protocol
+info "Test 12: Rust Unix socket service has JSONL protocol"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_service_to_rust(service(echo, [transport(unix_socket('/tmp/echo.sock'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_id'), sub_string(Code, _, _, _, '_payload'), sub_string(Code, _, _, _, 'serde_json'), halt(0)" >/dev/null; then
+    pass "Rust Unix socket has JSONL protocol"
+else
+    fail "Rust Unix socket JSONL protocol missing"
+fi
+
+# Test 13: Rust Unix socket client compilation
+info "Test 13: Rust Unix socket client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_unix_socket_client_rust(echo, '/tmp/echo.sock', Code), sub_string(Code, _, _, _, 'EchoClient'), sub_string(Code, _, _, _, 'connect'), halt(0)" >/dev/null; then
+    pass "Rust Unix socket client compiles"
+else
+    fail "Rust Unix socket client compilation failed"
+fi
+
+# Test 14: Stateful Unix socket service (Python)
+info "Test 14: Stateful Unix socket service (Python)"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(counter, [transport(unix_socket('/tmp/counter.sock')), stateful(true)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'stateful=True'), sub_string(Code, _, _, _, '_lock'), halt(0)" >/dev/null; then
+    pass "Python stateful Unix socket service compiles"
+else
+    fail "Python stateful Unix socket service failed"
+fi
+
+# Test 15: Stateful Unix socket service (Go)
+info "Test 15: Stateful Unix socket service (Go)"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_service_to_go(service(counter, [transport(unix_socket('/tmp/counter.sock')), stateful(true)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'StatefulService'), sub_string(Code, _, _, _, 'sync.Mutex'), halt(0)" >/dev/null; then
+    pass "Go stateful Unix socket service compiles"
+else
+    fail "Go stateful Unix socket service failed"
+fi
+
+# Test 16: Stateful Unix socket service (Rust)
+info "Test 16: Stateful Unix socket service (Rust)"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_service_to_rust(service(counter, [transport(unix_socket('/tmp/counter.sock')), stateful(true)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'RwLock'), sub_string(Code, _, _, _, 'state_get'), halt(0)" >/dev/null; then
+    pass "Rust stateful Unix socket service compiles"
+else
+    fail "Rust stateful Unix socket service failed"
+fi
+
+# Test 17: Service with custom timeout
+info "Test 17: Service with custom timeout"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(fast, [transport(unix_socket('/tmp/fast.sock')), timeout(5000)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '5000'), halt(0)" >/dev/null; then
+    pass "Custom timeout included in generated code"
+else
+    fail "Custom timeout not found in generated code"
+fi
+
+# Test 18: In-process service still works (regression test)
+info "Test 18: In-process service still works (regression test)"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(echo, [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'class EchoService'), \\+ sub_string(Code, _, _, _, 'socket.AF_UNIX'), halt(0)" >/dev/null; then
+    pass "In-process service compilation still works"
+else
+    fail "In-process service compilation broken"
+fi
+
+echo ""
+echo "==========================================="
+echo -e "Results: ${GREEN}$PASS_COUNT passed${NC}, ${RED}$FAIL_COUNT failed${NC}"
+echo "==========================================="
+
+if [ $FAIL_COUNT -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements a complete **client-server architecture** for UnifyWeaver, enabling service-oriented pipeline composition with transport independence. This PR includes four phases that take services from in-process calls to production-ready distributed systems with resilience patterns.

The core insight: client-server communication is fundamentally two pipelines going in opposite directions - request and response. This allows the same Prolog DSL to define services across all transport types and target languages.

## Phases Overview

| Phase | Feature | Tests |
|-------|---------|-------|
| 1 | In-Process Services | Core infrastructure |
| 2 | Cross-Process (Unix Sockets) | JSONL protocol |
| 3 | Network Services (TCP/HTTP) | 26 tests |
| 4 | Service Mesh | 61 tests |

## Phase 1: In-Process Services

Foundation for service definitions with stateful/stateless variants.

```prolog
% Simple stateless service
service(echo, [receive(X), respond(X)]).

% Stateful service with options
service(counter, [stateful(true), timeout(5000)], [
    receive(Cmd),
    state_get(count, Current),
    ( Cmd = increment -> NewCount is Current + 1, state_put(count, NewCount), respond(NewCount)
    ; respond(Current) )
]).
```

**Service Operations:**
- `receive(Var)` / `respond(Value)` / `respond_error(Error)`
- `state_get/put/modify/delete` for stateful services
- `call_service(Name, Req, Resp)` for service composition
- `transform`, `branch`, `route_by` for data flow

## Phase 2: Cross-Process Services (Unix Sockets)

Inter-process communication via Unix domain sockets with JSONL protocol.

```prolog
service(worker, [transport(unix_socket('/tmp/worker.sock'))], [
    receive(Task),
    process_task(Task, Result),
    respond(Result)
]).
```

**Features:**
- Unix socket transport for IPC
- JSONL (JSON Lines) streaming protocol
- Request/response with correlation IDs
- Server and client generation for Python, Go, Rust

## Phase 3: Network Services (TCP/HTTP)

Full network transport support for distributed systems.

```prolog
% TCP service
service(api, [transport(tcp('0.0.0.0', 8080))], [
    receive(X), process(X, Y), respond(Y)
]).

% HTTP/REST service
service(rest_api, [transport(http('/api/v1'))], [
    receive(Request), handle(Request, Response), respond(Response)
]).
```

**Features:**
- TCP transport with JSONL protocol
- HTTP/REST transport with JSON protocol
- Full REST method support: GET, POST, PUT, DELETE, PATCH
- Stateful and stateless variants
- Client generation for all targets

## Phase 4: Service Mesh

Production-ready resilience patterns for fault-tolerant systems.

```prolog
service(api_gateway, [
    load_balance(round_robin),
    circuit_breaker(threshold(5), timeout(30000)),
    retry(3, exponential, [delay(100), max_delay(5000)])
], [
    receive(Request),
    handle_request(Request, Response),
    respond(Response)
]).
```

### Load Balancing Strategies

| Strategy | Description |
|----------|-------------|
| `round_robin` | Distribute requests evenly |
| `random` | Random backend selection |
| `least_connections` | Fewest active connections |
| `weighted` | Weight-based distribution |
| `ip_hash` | Consistent hashing by client IP |

### Circuit Breaker

| Option | Description |
|--------|-------------|
| `threshold(N)` | Open after N failures |
| `timeout(Ms)` | Time before half-open |
| `half_open_requests(N)` | Requests in half-open state |
| `success_threshold(N)` | Successes to close |

### Retry with Backoff

| Strategy | Description |
|----------|-------------|
| `fixed` | Fixed delay between retries |
| `linear` | Linearly increasing delay |
| `exponential` | Exponentially increasing delay |

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    Application Layer                         │
│  service(Name, Options, [receive(X), ..., respond(Y)])      │
└─────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────┐
│                    Service Mesh Layer (Phase 4)             │
│  Load Balancing │ Circuit Breaker │ Retry with Backoff      │
└─────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────┐
│                    Service Layer                             │
│  Service Registry │ Request/Response │ State Management      │
└─────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────┐
│                    Transport Layer                           │
│  in_process │ unix_socket │ tcp │ http                      │
└─────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────┐
│                    Protocol Layer                            │
│  Direct calls │ JSONL │ JSON │ MessagePack │ Protobuf       │
└─────────────────────────────────────────────────────────────┘
```

## Files Changed

### Core
- `src/unifyweaver/core/service_validation.pl` - Service definition validation with Phase 2-4 helpers

### Targets
- `src/unifyweaver/targets/python_target.pl` - Python service/client generation
- `src/unifyweaver/targets/go_target.pl` - Go service/client generation
- `src/unifyweaver/targets/rust_target.pl` - Rust service/client generation

### Tests
- `tests/integration/test_network_services.sh` - Phase 3 tests (26 tests)
- `tests/integration/test_service_mesh.sh` - Phase 4 tests (61 tests)

### Documentation
- `docs/CLIENT_SERVER_DESIGN.md` - Complete architecture documentation
- `CHANGELOG.md` - Phase 3 and 4 entries

## Generated Code Highlights

### Thread-Safe Implementations

**Python:** `threading.Lock` for circuit state
**Go:** `sync/atomic` for counters and state
**Rust:** `RwLock<CircuitState>`, `AtomicI32`, `AtomicU32`

### Transport Abstraction

Same service definition compiles to:
- Direct function calls (in_process)
- Unix socket server/client (unix_socket)
- TCP server/client with JSONL (tcp)
- HTTP endpoints with JSON (http)

## Test Plan

```bash
# Run Phase 3 network services tests
./tests/integration/test_network_services.sh

# Run Phase 4 service mesh tests
./tests/integration/test_service_mesh.sh
```

- Phase 3: 26/26 tests pass
- Phase 4: 61/61 tests pass

## Future Phases

| Phase | Feature | Status |
|-------|---------|--------|
| 5 | Multi-Language Polyglot Services | Planned |
| 6 | Distributed Services | Planned |

## Breaking Changes

None. This is a pure feature addition that's backwards compatible with existing UnifyWeaver functionality.

---

Generated with [Claude Code](https://claude.com/claude-code)
