### PR TITLE
feat: Add Client-Server Phase 4 Service Mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Client-Server Phase 4: Service Mesh** - Load balancing, circuit breakers, and retry with backoff
+  - Load balancing strategies: `round_robin`, `random`, `least_connections`, `weighted`, `ip_hash`
+  - Circuit breaker pattern with `threshold`, `timeout`, `half_open_requests`, `success_threshold`
+  - Retry with backoff: `fixed`, `linear`, `exponential` strategies
+  - Retry options: `delay(Ms)`, `max_delay(Ms)`, `jitter(Bool)`
+  - Service discovery configuration: `static`, `dns`, `consul`, `etcd`
+  - Backend pool configuration for load balancing targets
+  - Service mesh validation in `service_validation.pl`
+  - Helper predicates: `get_load_balance_strategy/2`, `get_circuit_breaker_config/2`, `get_retry_config/2`, `has_load_balancing/1`, `has_circuit_breaker/1`, `has_retry/1`, `is_service_mesh_service/1`
+  - Service mesh compilation for Python, Go, and Rust targets
+  - Thread-safe implementations: Python threading.Lock, Go atomic operations, Rust RwLock/AtomicI32
+  - 61 integration tests in `tests/integration/test_service_mesh.sh`
+  - Documentation updated in `docs/CLIENT_SERVER_DESIGN.md`
+
+- **Client-Server Phase 3: Network Services** - TCP and HTTP transport support
+  - TCP transport for network socket communication (`transport(tcp(Host, Port))`)
+  - HTTP/REST transport for web API endpoints (`transport(http(Endpoint))`)
+  - JSONL protocol for TCP services (streaming JSON lines)
+  - JSON protocol for HTTP services (REST API style)
+  - Transport categorization: `is_network_service/1` predicate
+  - Full REST method support: GET, POST, PUT, DELETE, PATCH
+  - Stateful and stateless service variants for both TCP and HTTP
+  - Service compilation for Python, Go, and Rust targets
+  - Client generation for all three targets
+  - 26 integration tests in `tests/integration/test_network_services.sh`
+  - Documentation updated in `docs/CLIENT_SERVER_DESIGN.md`
+
 - **Enhanced Pipeline Chaining** - Complex data flow patterns across all targets (#296-#300)
   - `fan_out(Stages)` — Broadcast records to stages (sequential execution)
   - `parallel(Stages)` — Execute stages concurrently using target-native parallelism

--- a/src/unifyweaver/core/service_validation.pl
+++ b/src/unifyweaver/core/service_validation.pl
@@ -9,6 +9,7 @@
     is_valid_service/1,
     is_valid_handler_spec/1,
     is_valid_service_operation/1,
+    is_valid_service_option/1,
     validate_service_options/2,
     service_type/2,
     % Phase 2: Transport helpers
@@ -16,7 +17,16 @@
     get_service_protocol/2,
     get_service_timeout/2,
     is_cross_process_service/1,
-    is_network_service/1
+    is_network_service/1,
+    % Phase 4: Service mesh helpers
+    get_load_balance_strategy/2,
+    get_circuit_breaker_config/2,
+    get_retry_config/2,
+    get_backends/2,
+    has_load_balancing/1,
+    has_circuit_breaker/1,
+    has_retry/1,
+    is_service_mesh_service/1
 ]).
 
 :- use_module(library(lists)).
@@ -191,6 +201,115 @@ is_valid_service_option(max_concurrent(N)) :-
 is_valid_service_option(on_error(Handler)) :-
     ( atom(Handler) ; Handler = _/_ ).
 
+%% Phase 4: Service Mesh Options
+
+% Load balancing strategies
+is_valid_service_option(load_balance(Strategy)) :-
+    is_valid_load_balance_strategy(Strategy).
+
+is_valid_service_option(load_balance(Strategy, Options)) :-
+    is_valid_load_balance_strategy(Strategy),
+    is_list(Options),
+    maplist(is_valid_load_balance_option, Options).
+
+% Circuit breaker configuration
+is_valid_service_option(circuit_breaker(Threshold, Timeout)) :-
+    is_valid_circuit_breaker_threshold(Threshold),
+    is_valid_circuit_breaker_timeout(Timeout).
+
+is_valid_service_option(circuit_breaker(Threshold, Timeout, Option)) :-
+    is_valid_circuit_breaker_threshold(Threshold),
+    is_valid_circuit_breaker_timeout(Timeout),
+    is_valid_circuit_breaker_option(Option).
+
+is_valid_service_option(circuit_breaker(Threshold, Timeout, Option1, Option2)) :-
+    is_valid_circuit_breaker_threshold(Threshold),
+    is_valid_circuit_breaker_timeout(Timeout),
+    is_valid_circuit_breaker_option(Option1),
+    is_valid_circuit_breaker_option(Option2).
+
+is_valid_service_option(circuit_breaker(Options)) :-
+    is_list(Options),
+    maplist(is_valid_circuit_breaker_option, Options).
+
+% Retry with backoff
+is_valid_service_option(retry(N, Strategy)) :-
+    integer(N),
+    N > 0,
+    is_valid_retry_strategy(Strategy).
+
+is_valid_service_option(retry(N, Strategy, Option)) :-
+    integer(N),
+    N > 0,
+    is_valid_retry_strategy(Strategy),
+    is_valid_retry_option(Option).
+
+is_valid_service_option(retry(N, Strategy, Option1, Option2)) :-
+    integer(N),
+    N > 0,
+    is_valid_retry_strategy(Strategy),
+    is_valid_retry_option(Option1),
+    is_valid_retry_option(Option2).
+
+is_valid_service_option(retry(N, Strategy, Options)) :-
+    integer(N),
+    N > 0,
+    is_valid_retry_strategy(Strategy),
+    is_list(Options),
+    maplist(is_valid_retry_option, Options).
+
+% Service discovery
+is_valid_service_option(discovery(Method)) :-
+    is_valid_discovery_method(Method).
+
+% Backend pool for load balancing
+is_valid_service_option(backends(Backends)) :-
+    is_list(Backends),
+    maplist(is_valid_backend, Backends).
+
+%% Load balance validation
+is_valid_load_balance_strategy(round_robin).
+is_valid_load_balance_strategy(random).
+is_valid_load_balance_strategy(least_connections).
+is_valid_load_balance_strategy(weighted).
+is_valid_load_balance_strategy(ip_hash).
+
+is_valid_load_balance_option(sticky(Bool)) :- ( Bool = true ; Bool = false ).
+is_valid_load_balance_option(health_check(Interval)) :- integer(Interval), Interval > 0.
+
+%% Circuit breaker validation
+is_valid_circuit_breaker_threshold(threshold(N)) :- integer(N), N > 0.
+is_valid_circuit_breaker_timeout(timeout(Ms)) :- integer(Ms), Ms > 0.
+
+is_valid_circuit_breaker_option(threshold(N)) :- integer(N), N > 0.
+is_valid_circuit_breaker_option(timeout(Ms)) :- integer(Ms), Ms > 0.
+is_valid_circuit_breaker_option(half_open_requests(N)) :- integer(N), N > 0.
+is_valid_circuit_breaker_option(success_threshold(N)) :- integer(N), N > 0.
+
+%% Retry validation
+is_valid_retry_strategy(fixed).
+is_valid_retry_strategy(linear).
+is_valid_retry_strategy(exponential).
+
+is_valid_retry_option(delay(Ms)) :- integer(Ms), Ms >= 0.
+is_valid_retry_option(max_delay(Ms)) :- integer(Ms), Ms > 0.
+is_valid_retry_option(jitter(Bool)) :- ( Bool = true ; Bool = false ).
+
+%% Discovery validation
+is_valid_discovery_method(static).
+is_valid_discovery_method(dns).
+is_valid_discovery_method(consul).
+is_valid_discovery_method(etcd).
+
+%% Backend validation
+is_valid_backend(backend(Name, Transport)) :-
+    atom(Name),
+    is_valid_transport(Transport).
+is_valid_backend(backend(Name, Transport, Options)) :-
+    atom(Name),
+    is_valid_transport(Transport),
+    is_list(Options).
+
 %% Transport validation
 is_valid_transport(in_process).
 is_valid_transport(unix_socket(Path)) :- atom(Path).
@@ -298,3 +417,90 @@ is_cross_process_service(Service) :-
 is_network_service(Service) :-
     get_service_transport(Service, Transport),
     transport_category(Transport, network).
+
+%% ============================================
+%% Phase 4: Service Mesh Helper Predicates
+%% ============================================
+
+%% get_load_balance_strategy(+Service, -Strategy)
+%  Extract load balancing strategy from service definition.
+get_load_balance_strategy(service(_, Options, _), Strategy) :-
+    is_list(Options),
+    ( member(load_balance(Strategy), Options) ->
+        true
+    ; member(load_balance(Strategy, _), Options) ->
+        true
+    ),
+    !.
+get_load_balance_strategy(_, none).
+
+%% get_circuit_breaker_config(+Service, -Config)
+%  Extract circuit breaker configuration from service definition.
+get_circuit_breaker_config(service(_, Options, _), config(Threshold, Timeout)) :-
+    is_list(Options),
+    member(circuit_breaker(threshold(Threshold), timeout(Timeout)), Options),
+    !.
+get_circuit_breaker_config(service(_, Options, _), config(Threshold, Timeout, HalfOpen, SuccessThresh)) :-
+    is_list(Options),
+    member(circuit_breaker(CBOptions), Options),
+    is_list(CBOptions),
+    ( member(threshold(Threshold), CBOptions) -> true ; Threshold = 5 ),
+    ( member(timeout(Timeout), CBOptions) -> true ; Timeout = 30000 ),
+    ( member(half_open_requests(HalfOpen), CBOptions) -> true ; HalfOpen = 1 ),
+    ( member(success_threshold(SuccessThresh), CBOptions) -> true ; SuccessThresh = 1 ),
+    !.
+get_circuit_breaker_config(_, none).
+
+%% get_retry_config(+Service, -Config)
+%  Extract retry configuration from service definition.
+get_retry_config(service(_, Options, _), config(N, Strategy, Delay, MaxDelay, Jitter)) :-
+    is_list(Options),
+    ( member(retry(N, Strategy, RetryOptions), Options) ->
+        ( member(delay(Delay), RetryOptions) -> true ; Delay = 100 ),
+        ( member(max_delay(MaxDelay), RetryOptions) -> true ; MaxDelay = 30000 ),
+        ( member(jitter(Jitter), RetryOptions) -> true ; Jitter = false )
+    ; member(retry(N, Strategy), Options) ->
+        Delay = 100,
+        MaxDelay = 30000,
+        Jitter = false
+    ),
+    !.
+get_retry_config(_, none).
+
+%% get_backends(+Service, -Backends)
+%  Extract backend pool from service definition.
+get_backends(service(_, Options, _), Backends) :-
+    is_list(Options),
+    member(backends(Backends), Options),
+    !.
+get_backends(_, []).
+
+%% has_load_balancing(+Service)
+%  Succeeds if service has load balancing configured.
+has_load_balancing(service(_, Options, _)) :-
+    is_list(Options),
+    ( member(load_balance(_), Options) ; member(load_balance(_, _), Options) ),
+    !.
+
+%% has_circuit_breaker(+Service)
+%  Succeeds if service has circuit breaker configured.
+has_circuit_breaker(service(_, Options, _)) :-
+    is_list(Options),
+    ( member(circuit_breaker(_, _), Options) ; member(circuit_breaker(_), Options) ),
+    !.
+
+%% has_retry(+Service)
+%  Succeeds if service has retry configured.
+has_retry(service(_, Options, _)) :-
+    is_list(Options),
+    ( member(retry(_, _), Options) ; member(retry(_, _, _), Options) ),
+    !.
+
+%% is_service_mesh_service(+Service)
+%  Succeeds if service has any service mesh features.
+is_service_mesh_service(Service) :-
+    ( has_load_balancing(Service)
+    ; has_circuit_breaker(Service)
+    ; has_retry(Service)
+    ),
+    !.

--- a/tests/integration/test_network_services.sh
+++ b/tests/integration/test_network_services.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (@s243a)
+#
+# test_network_services.sh - Integration tests for Client-Server Phase 3
+# Tests TCP and HTTP network service compilation for Python, Go, and Rust targets
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+info() {
+    echo -e "${YELLOW}INFO${NC}: $1"
+}
+
+run_prolog() {
+    timeout 30 swipl -g "$1" -t "halt(1)" 2>&1
+    return $?
+}
+
+echo "==========================================="
+echo "Client-Server Phase 3: Network Services"
+echo "Integration Tests"
+echo "==========================================="
+echo ""
+
+# Test 1: is_network_service identifies TCP services
+info "Test 1: is_network_service identifies TCP services"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), is_network_service(service(test, [transport(tcp('0.0.0.0', 8080))], [])), halt(0)" >/dev/null; then
+    pass "is_network_service works for TCP"
+else
+    fail "is_network_service failed for TCP"
+fi
+
+# Test 2: is_network_service identifies HTTP services
+info "Test 2: is_network_service identifies HTTP services"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), is_network_service(service(test, [transport(http('/api'))], [])), halt(0)" >/dev/null; then
+    pass "is_network_service works for HTTP"
+else
+    fail "is_network_service failed for HTTP"
+fi
+
+# Test 3: TCP service is not cross-process (it's network)
+info "Test 3: TCP service is network, not cross-process"
+if run_prolog "use_module('src/unifyweaver/core/service_validation'), \\+ is_cross_process_service(service(test, [transport(tcp('0.0.0.0', 8080))], [])), halt(0)" >/dev/null; then
+    pass "TCP service correctly categorized as network"
+else
+    fail "TCP service incorrectly categorized"
+fi
+
+# Test 4: Python TCP service compilation
+info "Test 4: Python TCP service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_tcp_service_python(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'socket.AF_INET'), sub_string(Code, _, _, _, 'start_server'), halt(0)" >/dev/null; then
+    pass "Python TCP service compiles"
+else
+    fail "Python TCP service compilation failed"
+fi
+
+# Test 5: Python TCP service has JSONL protocol
+info "Test 5: Python TCP service has JSONL protocol"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_tcp_service_python(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_id'), sub_string(Code, _, _, _, '_payload'), halt(0)" >/dev/null; then
+    pass "Python TCP has JSONL protocol"
+else
+    fail "Python TCP JSONL protocol missing"
+fi
+
+# Test 6: Python HTTP service compilation
+info "Test 6: Python HTTP service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_http_service_python(service(rest, [transport(http('/api/v1'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'HTTPServer'), sub_string(Code, _, _, _, 'do_GET'), halt(0)" >/dev/null; then
+    pass "Python HTTP service compiles"
+else
+    fail "Python HTTP service compilation failed"
+fi
+
+# Test 7: Python HTTP service handles REST methods
+info "Test 7: Python HTTP service handles REST methods"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_http_service_python(service(rest, [transport(http('/api/v1'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'do_POST'), sub_string(Code, _, _, _, 'do_PUT'), sub_string(Code, _, _, _, 'do_DELETE'), halt(0)" >/dev/null; then
+    pass "Python HTTP handles REST methods"
+else
+    fail "Python HTTP REST methods missing"
+fi
+
+# Test 8: Go TCP service compilation
+info "Test 8: Go TCP service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_tcp_service_go(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'net.Listen'), sub_string(Code, _, _, _, 'StartServer'), halt(0)" >/dev/null; then
+    pass "Go TCP service compiles"
+else
+    fail "Go TCP service compilation failed"
+fi
+
+# Test 9: Go TCP service has JSONL protocol
+info "Test 9: Go TCP service has JSONL protocol"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_tcp_service_go(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_id'), sub_string(Code, _, _, _, 'json.Unmarshal'), halt(0)" >/dev/null; then
+    pass "Go TCP has JSONL protocol"
+else
+    fail "Go TCP JSONL protocol missing"
+fi
+
+# Test 10: Go HTTP service compilation
+info "Test 10: Go HTTP service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_http_service_go(service(rest, [transport(http('/api/v1'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'http.Server'), sub_string(Code, _, _, _, 'ServeHTTP'), halt(0)" >/dev/null; then
+    pass "Go HTTP service compiles"
+else
+    fail "Go HTTP service compilation failed"
+fi
+
+# Test 11: Go HTTP service handles REST methods
+info "Test 11: Go HTTP service handles REST methods"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_http_service_go(service(rest, [transport(http('/api/v1'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'Method'), sub_string(Code, _, _, _, 'POST'), halt(0)" >/dev/null; then
+    pass "Go HTTP handles REST methods"
+else
+    fail "Go HTTP REST methods missing"
+fi
+
+# Test 12: Rust TCP service compilation
+info "Test 12: Rust TCP service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_tcp_service_rust(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'TcpListener'), sub_string(Code, _, _, _, 'start_server'), halt(0)" >/dev/null; then
+    pass "Rust TCP service compiles"
+else
+    fail "Rust TCP service compilation failed"
+fi
+
+# Test 13: Rust TCP service has JSONL protocol
+info "Test 13: Rust TCP service has JSONL protocol"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_tcp_service_rust(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_id'), sub_string(Code, _, _, _, 'serde_json'), halt(0)" >/dev/null; then
+    pass "Rust TCP has JSONL protocol"
+else
+    fail "Rust TCP JSONL protocol missing"
+fi
+
+# Test 14: Rust HTTP service compilation
+info "Test 14: Rust HTTP service compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_http_service_rust(service(rest, [transport(http('/api/v1'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'tiny_http'), sub_string(Code, _, _, _, 'start_server'), halt(0)" >/dev/null; then
+    pass "Rust HTTP service compiles"
+else
+    fail "Rust HTTP service compilation failed"
+fi
+
+# Test 15: Rust HTTP service handles REST methods
+info "Test 15: Rust HTTP service handles REST methods"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_http_service_rust(service(rest, [transport(http('/api/v1'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'Method'), sub_string(Code, _, _, _, 'Post'), halt(0)" >/dev/null; then
+    pass "Rust HTTP handles REST methods"
+else
+    fail "Rust HTTP REST methods missing"
+fi
+
+# Test 16: TCP client compilation (Python)
+info "Test 16: Python TCP client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_tcp_client_python(api, '0.0.0.0', 8080, Code), sub_string(Code, _, _, _, 'ApiClient'), sub_string(Code, _, _, _, 'connect'), halt(0)" >/dev/null; then
+    pass "Python TCP client compiles"
+else
+    fail "Python TCP client compilation failed"
+fi
+
+# Test 17: HTTP client compilation (Python)
+info "Test 17: Python HTTP client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_http_client_python(rest, '/api/v1', Code), sub_string(Code, _, _, _, 'RestClient'), sub_string(Code, _, _, _, 'get'), halt(0)" >/dev/null; then
+    pass "Python HTTP client compiles"
+else
+    fail "Python HTTP client compilation failed"
+fi
+
+# Test 18: TCP client compilation (Go)
+info "Test 18: Go TCP client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_tcp_client_go(api, '0.0.0.0', 8080, Code), sub_string(Code, _, _, _, 'ApiClient'), sub_string(Code, _, _, _, 'Connect'), halt(0)" >/dev/null; then
+    pass "Go TCP client compiles"
+else
+    fail "Go TCP client compilation failed"
+fi
+
+# Test 19: HTTP client compilation (Go)
+info "Test 19: Go HTTP client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_http_client_go(rest, '/api/v1', Code), sub_string(Code, _, _, _, 'RestClient'), sub_string(Code, _, _, _, 'Get'), halt(0)" >/dev/null; then
+    pass "Go HTTP client compiles"
+else
+    fail "Go HTTP client compilation failed"
+fi
+
+# Test 20: TCP client compilation (Rust)
+info "Test 20: Rust TCP client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_tcp_client_rust(api, '0.0.0.0', 8080, Code), sub_string(Code, _, _, _, 'ApiClient'), sub_string(Code, _, _, _, 'TcpStream'), halt(0)" >/dev/null; then
+    pass "Rust TCP client compiles"
+else
+    fail "Rust TCP client compilation failed"
+fi
+
+# Test 21: HTTP client compilation (Rust)
+info "Test 21: Rust HTTP client compilation"
+if run_prolog "use_module('src/unifyweaver/targets/rust_target'), compile_http_client_rust(rest, '/api/v1', Code), sub_string(Code, _, _, _, 'RestClient'), sub_string(Code, _, _, _, 'reqwest'), halt(0)" >/dev/null; then
+    pass "Rust HTTP client compiles"
+else
+    fail "Rust HTTP client compilation failed"
+fi
+
+# Test 22: Stateful TCP service (Python)
+info "Test 22: Stateful TCP service (Python)"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_tcp_service_python(service(counter, [transport(tcp('0.0.0.0', 8080)), stateful(true)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'stateful=True'), halt(0)" >/dev/null; then
+    pass "Python stateful TCP service compiles"
+else
+    fail "Python stateful TCP service failed"
+fi
+
+# Test 23: Stateful HTTP service (Go)
+info "Test 23: Stateful HTTP service (Go)"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_http_service_go(service(counter, [transport(http('/api')), stateful(true)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'sync.RWMutex'), halt(0)" >/dev/null; then
+    pass "Go stateful HTTP service compiles"
+else
+    fail "Go stateful HTTP service failed"
+fi
+
+# Test 24: Service dispatch through compile_service_to_python (TCP)
+info "Test 24: Service dispatch through compile_service_to_python (TCP)"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(api, [transport(tcp('0.0.0.0', 8080))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'socket.AF_INET'), halt(0)" >/dev/null; then
+    pass "Python service dispatch works for TCP"
+else
+    fail "Python service dispatch failed for TCP"
+fi
+
+# Test 25: Service dispatch through compile_service_to_go (HTTP)
+info "Test 25: Service dispatch through compile_service_to_go (HTTP)"
+if run_prolog "use_module('src/unifyweaver/targets/go_target'), compile_service_to_go(service(rest, [transport(http('/api'))], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'http.Server'), halt(0)" >/dev/null; then
+    pass "Go service dispatch works for HTTP"
+else
+    fail "Go service dispatch failed for HTTP"
+fi
+
+# Test 26: In-process service still works (regression test)
+info "Test 26: In-process service still works (regression test)"
+if run_prolog "use_module('src/unifyweaver/targets/python_target'), compile_service_to_python(service(echo, [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'class EchoService'), \\+ sub_string(Code, _, _, _, 'socket.AF_INET'), halt(0)" >/dev/null; then
+    pass "In-process service compilation still works"
+else
+    fail "In-process service compilation broken"
+fi
+
+echo ""
+echo "==========================================="
+echo -e "Results: ${GREEN}$PASS_COUNT passed${NC}, ${RED}$FAIL_COUNT failed${NC}"
+echo "==========================================="
+
+if [ $FAIL_COUNT -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/integration/test_service_mesh.sh
+++ b/tests/integration/test_service_mesh.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# Phase 4: Service Mesh Integration Tests
+# Tests load balancing, circuit breaker, and retry with backoff
+
+# Don't exit on error - we handle test failures ourselves
+cd "$(dirname "$0")/../.."
+
+PASSED=0
+FAILED=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+pass() {
+    echo -e "${GREEN}✓ $1${NC}"
+    ((PASSED++))
+}
+
+fail() {
+    echo -e "${RED}✗ $1${NC}"
+    ((FAILED++))
+}
+
+run_test() {
+    local name="$1"
+    local cmd="$2"
+    if timeout 20 bash -c "$cmd" >/dev/null 2>&1; then
+        pass "$name"
+    else
+        fail "$name"
+    fi
+}
+
+echo "=============================================="
+echo "Phase 4: Service Mesh Integration Tests"
+echo "=============================================="
+echo ""
+
+# ==============================================================================
+# VALIDATION TESTS
+# ==============================================================================
+echo "--- Validation Tests ---"
+
+# Load balance strategy validation
+run_test "Valid load_balance round_robin" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(load_balance(round_robin)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid load_balance random" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(load_balance(random)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid load_balance least_connections" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(load_balance(least_connections)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid load_balance weighted" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(load_balance(weighted)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid load_balance ip_hash" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(load_balance(ip_hash)), halt(0)\" -t \"halt(1)\""
+
+# Circuit breaker validation
+run_test "Valid circuit_breaker basic" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(circuit_breaker(threshold(5), timeout(30000))), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid circuit_breaker with half_open" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(circuit_breaker(threshold(3), timeout(10000), half_open_requests(2))), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid circuit_breaker with success_threshold" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(circuit_breaker(threshold(5), timeout(30000), success_threshold(3))), halt(0)\" -t \"halt(1)\""
+
+# Retry validation
+run_test "Valid retry fixed" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(retry(3, fixed)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid retry linear" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(retry(5, linear)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid retry exponential" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(retry(3, exponential)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid retry with delay" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(retry(3, fixed, delay(1000))), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid retry with max_delay" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(retry(3, exponential, delay(100), max_delay(10000))), halt(0)\" -t \"halt(1)\""
+
+# Discovery validation
+run_test "Valid discovery static" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(discovery(static)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid discovery dns" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(discovery(dns)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid discovery consul" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(discovery(consul)), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid discovery etcd" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(discovery(etcd)), halt(0)\" -t \"halt(1)\""
+
+# Backends validation
+run_test "Valid backends single" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(backends([backend(server1, tcp(localhost, 8080))])), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid backends multiple" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(backends([backend(server1, tcp(localhost, 8080)), backend(server2, tcp(localhost, 8081))])), halt(0)\" -t \"halt(1)\""
+
+run_test "Valid backends with options" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_valid_service_option(backends([backend(server1, tcp(localhost, 8080), [weight(3)]), backend(server2, tcp(localhost, 8081), [weight(1)])])), halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# HELPER PREDICATE TESTS
+# ==============================================================================
+echo ""
+echo "--- Helper Predicate Tests ---"
+
+run_test "get_load_balance_strategy extracts strategy" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_load_balance_strategy(service(test, [load_balance(round_robin)], []), round_robin), halt(0)\" -t \"halt(1)\""
+
+run_test "get_load_balance_strategy defaults to none" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_load_balance_strategy(service(test, [], []), none), halt(0)\" -t \"halt(1)\""
+
+run_test "get_circuit_breaker_config extracts config" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_circuit_breaker_config(service(test, [circuit_breaker(threshold(5), timeout(30000))], []), config(5, 30000)), halt(0)\" -t \"halt(1)\""
+
+run_test "get_retry_config extracts config" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_retry_config(service(test, [retry(3, exponential)], []), config(3, exponential, 100, 30000, false)), halt(0)\" -t \"halt(1)\""
+
+run_test "get_retry_config with custom delay" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_retry_config(service(test, [retry(5, fixed, [delay(500)])], []), config(5, fixed, 500, 30000, false)), halt(0)\" -t \"halt(1)\""
+
+run_test "has_load_balancing detects option" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), has_load_balancing(service(test, [load_balance(random)], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "has_circuit_breaker detects option" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), has_circuit_breaker(service(test, [circuit_breaker(threshold(5), timeout(30000))], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "has_retry detects option" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), has_retry(service(test, [retry(3, fixed)], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "is_service_mesh_service detects mesh service" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_service_mesh_service(service(test, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000))], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "is_service_mesh_service with retry only" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_service_mesh_service(service(test, [retry(3, exponential)], [])), halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# PYTHON SERVICE MESH COMPILATION TESTS
+# ==============================================================================
+echo ""
+echo "--- Python Service Mesh Compilation Tests ---"
+
+run_test "Python service mesh with round_robin" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'GatewayService'), sub_string(Code, _, _, _, 'CircuitState'), halt(0)\" -t \"halt(1)\""
+
+run_test "Python service mesh with random" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(loadbalancer, [load_balance(random), circuit_breaker(threshold(3), timeout(10000)), retry(5, fixed)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'LoadbalancerService'), halt(0)\" -t \"halt(1)\""
+
+run_test "Python service mesh with least_connections" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(proxy, [load_balance(least_connections), circuit_breaker(threshold(10), timeout(60000)), retry(2, linear)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'ProxyService'), halt(0)\" -t \"halt(1)\""
+
+run_test "Python service mesh has _select_backend method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_select_backend'), halt(0)\" -t \"halt(1)\""
+
+run_test "Python service mesh has _check_circuit method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_check_circuit'), halt(0)\" -t \"halt(1)\""
+
+run_test "Python service mesh has _calculate_delay method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, '_calculate_delay'), halt(0)\" -t \"halt(1)\""
+
+run_test "Python service mesh has register_service call" \
+    "swipl -g \"use_module('src/unifyweaver/targets/python_target'), compile_service_mesh_python(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'register_service'), halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# GO SERVICE MESH COMPILATION TESTS
+# ==============================================================================
+echo ""
+echo "--- Go Service Mesh Compilation Tests ---"
+
+run_test "Go service mesh with round_robin" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'GatewayService'), sub_string(Code, _, _, _, 'CircuitState'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh with random" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(loadbalancer, [load_balance(random), circuit_breaker(threshold(3), timeout(10000)), retry(5, fixed)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'LoadbalancerService'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh with least_connections" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(proxy, [load_balance(least_connections), circuit_breaker(threshold(10), timeout(60000)), retry(2, linear)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'ProxyService'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh has selectBackend method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'selectBackend'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh has checkCircuit method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'checkCircuit'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh has calculateDelay method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'calculateDelay'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh has atomic operations" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'atomic'), halt(0)\" -t \"halt(1)\""
+
+run_test "Go service mesh registers with RegisterService" \
+    "swipl -g \"use_module('src/unifyweaver/targets/go_target'), compile_service_mesh_go(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'RegisterService'), halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# RUST SERVICE MESH COMPILATION TESTS
+# ==============================================================================
+echo ""
+echo "--- Rust Service Mesh Compilation Tests ---"
+
+run_test "Rust service mesh with round_robin" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'GatewayService'), sub_string(Code, _, _, _, 'CircuitState'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh with random" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(loadbalancer, [load_balance(random), circuit_breaker(threshold(3), timeout(10000)), retry(5, fixed)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'LoadbalancerService'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh with least_connections" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(proxy, [load_balance(least_connections), circuit_breaker(threshold(10), timeout(60000)), retry(2, linear)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'ProxyService'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh has select_backend method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'select_backend'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh has check_circuit method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'check_circuit'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh has calculate_delay method" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'calculate_delay'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh has RwLock for circuit state" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'RwLock'), halt(0)\" -t \"halt(1)\""
+
+run_test "Rust service mesh has lazy_static registration" \
+    "swipl -g \"use_module('src/unifyweaver/targets/rust_target'), compile_service_mesh_rust(service(gateway, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]), Code), sub_string(Code, _, _, _, 'lazy_static'), halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# CROSS-TARGET CONSISTENCY TESTS
+# ==============================================================================
+echo ""
+echo "--- Cross-Target Consistency Tests ---"
+
+run_test "All targets produce CircuitState enum" \
+    "swipl -g \"
+        use_module('src/unifyweaver/targets/python_target'),
+        use_module('src/unifyweaver/targets/go_target'),
+        use_module('src/unifyweaver/targets/rust_target'),
+        Svc = service(test, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]),
+        compile_service_mesh_python(Svc, PyCode), sub_string(PyCode, _, _, _, 'CircuitState'),
+        compile_service_mesh_go(Svc, GoCode), sub_string(GoCode, _, _, _, 'CircuitState'),
+        compile_service_mesh_rust(Svc, RsCode), sub_string(RsCode, _, _, _, 'CircuitState'),
+        halt(0)\" -t \"halt(1)\""
+
+run_test "All targets have backends list" \
+    "swipl -g \"
+        use_module('src/unifyweaver/targets/python_target'),
+        use_module('src/unifyweaver/targets/go_target'),
+        use_module('src/unifyweaver/targets/rust_target'),
+        Svc = service(test, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]),
+        compile_service_mesh_python(Svc, PyCode), sub_string(PyCode, _, _, _, 'backends'),
+        compile_service_mesh_go(Svc, GoCode), sub_string(GoCode, _, _, _, 'backends'),
+        compile_service_mesh_rust(Svc, RsCode), sub_string(RsCode, _, _, _, 'backends'),
+        halt(0)\" -t \"halt(1)\""
+
+run_test "All targets have select_backend method" \
+    "swipl -g \"
+        use_module('src/unifyweaver/targets/python_target'),
+        use_module('src/unifyweaver/targets/go_target'),
+        use_module('src/unifyweaver/targets/rust_target'),
+        Svc = service(test, [load_balance(round_robin), circuit_breaker(threshold(5), timeout(30000)), retry(3, exponential)], [receive(X), respond(X)]),
+        compile_service_mesh_python(Svc, PyCode), sub_string(PyCode, _, _, _, 'select_backend'),
+        compile_service_mesh_go(Svc, GoCode), sub_string(GoCode, _, _, _, 'selectBackend'),
+        compile_service_mesh_rust(Svc, RsCode), sub_string(RsCode, _, _, _, 'select_backend'),
+        halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# EDGE CASE TESTS
+# ==============================================================================
+echo ""
+echo "--- Edge Case Tests ---"
+
+run_test "Service mesh with only load_balance" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_service_mesh_service(service(test, [load_balance(round_robin)], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "Service mesh with only circuit_breaker" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_service_mesh_service(service(test, [circuit_breaker(threshold(5), timeout(30000))], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "Service mesh with only retry" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), is_service_mesh_service(service(test, [retry(3, fixed)], [])), halt(0)\" -t \"halt(1)\""
+
+run_test "Default circuit breaker config when none specified" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_circuit_breaker_config(service(test, [], []), none), halt(0)\" -t \"halt(1)\""
+
+run_test "Default retry config when none specified" \
+    "swipl -g \"use_module('src/unifyweaver/core/service_validation'), get_retry_config(service(test, [], []), none), halt(0)\" -t \"halt(1)\""
+
+# ==============================================================================
+# SUMMARY
+# ==============================================================================
+echo ""
+echo "=============================================="
+echo "Test Summary"
+echo "=============================================="
+echo -e "Passed: ${GREEN}${PASSED}${NC}"
+echo -e "Failed: ${RED}${FAILED}${NC}"
+echo ""
+
+if [ $FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Implements service mesh capabilities:
- Load balancing: round_robin, random, least_connections, weighted, ip_hash
- Circuit breaker: threshold, timeout, half_open_requests, success_threshold
- Retry with backoff: fixed, linear, exponential strategies

Changes:
- service_validation.pl: Add is_valid_service_option export, validation for load_balance, circuit_breaker, retry, discovery, backends options
- python_target.pl: Add compile_service_mesh_python with threading.Lock
- go_target.pl: Add compile_service_mesh_go with sync/atomic
- rust_target.pl: Add compile_service_mesh_rust with RwLock/AtomicI32

Tests:
- test_service_mesh.sh: 61 tests for Phase 4
- test_network_services.sh: 26 tests for Phase 3

Documentation updated in CLIENT_SERVER_DESIGN.md and CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)