### PR TITLE
CI: add C# query runtime smoke job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install SWI-Prolog
         run: |
@@ -88,3 +88,34 @@ jobs:
           echo "✓ Inference test runner generation"
           echo "✓ Generated bash script validation"
           echo "=========================================="
+
+  csharp_query_runtime_smoke:
+    name: C# Query Runtime Smoke
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install SWI-Prolog
+        run: |
+          sudo apt-add-repository ppa:swi-prolog/stable -y
+          sudo apt-get update -qq
+          sudo apt-get install -y swi-prolog
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Verify toolchain
+        run: |
+          swipl --version
+          dotnet --version
+          pwsh -v
+
+      - name: Run C# query runtime smoke runner
+        run: |
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -79,7 +79,7 @@ The core query runtime is intended to stay dependency-free (no LiteDB, ONNX, etc
 The Prolog test suite can generate per-plan C# console projects in codegen-only mode, and the PowerShell runner can then build/run them with dotnet and verify outputs.
 
 - Runner (recommended): `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1`
-  - Options: `-KeepArtifacts`, `-OutputDir tmp\\csharp_query_smoke`, `-SkipCodegen`
+  - Options: `-KeepArtifacts`, `-OutputDir tmp/csharp_query_smoke`, `-SkipCodegen`
 - Environment variables (used by the test harness):
   - `SKIP_CSHARP_EXECUTION=1` (generate C# projects but do not execute via Prolog)
   - `CSHARP_QUERY_OUTPUT_DIR=...` (where generated projects are written)


### PR DESCRIPTION
  This PR adds end-to-end CI coverage for the target(csharp_query) runtime by generating, building, and executing the per-plan C# console
  projects and comparing outputs.

  - Adds a new GitHub Actions job (C# Query Runtime Smoke) that runs on PRs and on main.
  - Updates scripts/testing/run_csharp_query_runtime_smoke.ps1 for better cross-platform behavior (portable path handling; run dotnet via
    Start-Process with captured logs instead of cmd /c).
  - Updates the docs example to use a portable -OutputDir path.

  Run locally

  - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci