### PR TITLE
feat: add C# query runtime diagnostics (explain/trace + cache reuse)

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -10,7 +10,7 @@ Roadmap: `docs/targets/csharp-query-runtime-roadmap.md`
 - **Recursive predicates** – semi-naive fixpoint driver supports single-predicate recursion (e.g., reachability, factorial).
 - **Mutual recursion** – strongly connected predicate groups emit `mutual_fixpoint` plans composed of `cross_ref` nodes, enabling even/odd style dependencies.
 - **Deduplication** – per-predicate `HashSet<object[]>` mirrors Bash distinct semantics.
-- **Diagnostics** – generated modules build a `QueryPlan` tree that is easy to inspect and trace during execution.
+- **Diagnostics** – `QueryPlanExplainer.Explain(plan)` and `QueryExecutionTrace` provide plan inspection and basic per-node execution stats.
 
 ## Objectives
 - Declarative IR: Represent clause bodies as structured query plans instead of hard-coded C# statements.
@@ -86,6 +86,13 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
   - `SKIP_CSHARP_EXECUTION=1` (generate C# projects but do not execute via Prolog)
   - `CSHARP_QUERY_OUTPUT_DIR=...` (where generated projects are written)
   - `CSHARP_QUERY_KEEP_ARTIFACTS=1` (keep generated projects instead of auto-deleting)
+
+## Diagnostics
+- Plan inspection: `Console.WriteLine(QueryPlanExplainer.Explain(plan));`
+- Execution stats (rows/time per node):
+  - `var trace = new QueryExecutionTrace();`
+  - `foreach (var row in executor.Execute(plan, parameters, trace)) { ... }`
+  - `Console.WriteLine(trace.ToString());`
 
 ## Configuration
 - New preference atom: `target(csharp_query)`.

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -93,6 +93,9 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
   - `var trace = new QueryExecutionTrace();`
   - `foreach (var row in executor.Execute(plan, parameters, trace)) { ... }`
   - `Console.WriteLine(trace.ToString());`
+- Prepared-style cache reuse (useful for repeated parameterized calls):
+  - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));`
+  - `executor.ClearCaches();` (if underlying facts change)
 
 ## Configuration
 - New preference atom: `target(csharp_query)`.

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -2030,7 +2030,7 @@ harness_source(ModuleClass, Params, Source) :-
  using System.Text.Json.Nodes;
 
 var result = UnifyWeaver.Generated.~w.Build();
-var executor = new QueryExecutor(result.Provider);
+var executor = new QueryExecutor(result.Provider, new QueryExecutorOptions(ReuseCaches: true));
 ~wvar jsonOptions = new JsonSerializerOptions { WriteIndented = false };
 
  string FormatValue(object? value) => value switch
@@ -2075,7 +2075,7 @@ var jsonOptions = new JsonSerializerOptions { WriteIndented = false };
 
  void PrintRows((InMemoryRelationProvider Provider, QueryPlan Plan) result, object[][] parameters)
  {
-     var executor = new QueryExecutor(result.Provider);
+     var executor = new QueryExecutor(result.Provider, new QueryExecutorOptions(ReuseCaches: true));
      var _planText = QueryPlanExplainer.Explain(result.Plan);
      var trace = new QueryExecutionTrace();
      foreach (var row in executor.Execute(result.Plan, parameters, trace))

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -2016,18 +2016,18 @@ harness_source(ModuleClass, Source) :-
 
 harness_source(ModuleClass, Params, Source) :-
     (   Params == []
-    ->  ParamDecl = '',
-        ExecCall = 'executor.Execute(result.Plan)'
+    ->  ParamDecl = 'var _planText = QueryPlanExplainer.Explain(result.Plan);\nvar trace = new QueryExecutionTrace();\n',
+        ExecCall = 'executor.Execute(result.Plan, null, trace)'
     ;   csharp_params_literal(Params, ParamsLiteral),
-        format(atom(ParamDecl), 'var parameters = ~w;~n', [ParamsLiteral]),
-        ExecCall = 'executor.Execute(result.Plan, parameters)'
+        format(atom(ParamDecl), 'var parameters = ~w;~nvar _planText = QueryPlanExplainer.Explain(result.Plan);~nvar trace = new QueryExecutionTrace();~n', [ParamsLiteral]),
+        ExecCall = 'executor.Execute(result.Plan, parameters, trace)'
     ),
     format(atom(Source),
-'using System;
-using System.Linq;
-using UnifyWeaver.QueryRuntime;
-using System.Text.Json;
-using System.Text.Json.Nodes;
+ 'using System;
+ using System.Linq;
+ using UnifyWeaver.QueryRuntime;
+ using System.Text.Json;
+ using System.Text.Json.Nodes;
 
 var result = UnifyWeaver.Generated.~w.Build();
 var executor = new QueryExecutor(result.Provider);
@@ -2051,9 +2051,9 @@ var executor = new QueryExecutor(result.Provider);
         continue;
     }
 
-    Console.WriteLine(string.Join(\",\", projected));
- }
- ', [ModuleClass, ParamDecl, ExecCall]).
+     Console.WriteLine(string.Join(\",\", projected));
+  }
+  ', [ModuleClass, ParamDecl, ExecCall]).
 
 harness_source_multi_mode_dispatch(ModuleClass, Source) :-
     format(atom(Source),
@@ -2074,22 +2074,24 @@ var jsonOptions = new JsonSerializerOptions { WriteIndented = false };
  };
 
  void PrintRows((InMemoryRelationProvider Provider, QueryPlan Plan) result, object[][] parameters)
-{
-    var executor = new QueryExecutor(result.Provider);
-    foreach (var row in executor.Execute(result.Plan, parameters))
-    {
-        var projected = row.Take(result.Plan.Head.Arity)
-                           .Select(FormatValue)
-                           .ToArray();
+ {
+     var executor = new QueryExecutor(result.Provider);
+     var _planText = QueryPlanExplainer.Explain(result.Plan);
+     var trace = new QueryExecutionTrace();
+     foreach (var row in executor.Execute(result.Plan, parameters, trace))
+     {
+         var projected = row.Take(result.Plan.Head.Arity)
+                            .Select(FormatValue)
+                            .ToArray();
 
         if (projected.Length == 0)
         {
             continue;
         }
 
-        Console.WriteLine(string.Join(\",\", projected));
-    }
-}
+         Console.WriteLine(string.Join(\",\", projected));
+     }
+ }
 
 var result0 = UnifyWeaver.Generated.~w.BuildForInputs(0);
 PrintRows(result0, new object[][] { new object[]{ \"alice\" } });


### PR DESCRIPTION
  Adds first-class diagnostics and “prepared query” ergonomics for target(csharp_query).

  - QueryPlanExplainer.Explain(plan) prints a readable plan tree (with node IDs and key metadata).
  - QueryExecutionTrace collects per-node invocation/enumeration counts, row counts, and elapsed time; plumbed through
    QueryExecutor.Execute(..., trace).
  - QueryExecutorOptions(ReuseCaches: true) enables cache reuse across repeated executions; QueryExecutor.ClearCaches() clears cached
    fact/index state if facts change.
  - Updates docs and the generated C# harness (tests/core/test_csharp_query_target.pl) to exercise the new APIs.

  No change to query semantics; adds opt-in diagnostics/caching support.