### PR TITLE
perf: speed up parameterized fact scans and key joins

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -2249,11 +2249,11 @@ namespace UnifyWeaver.QueryRuntime
                     {
                         if (TryAddRow(totalSet, tuple))
                         {
-                            totalRows.Add(tuple);
                             nextDelta.Add(tuple);
                         }
                     }
                 }
+                totalRows.AddRange(nextDelta);
                 context.Deltas[predicate] = nextDelta;
             }
 
@@ -2308,11 +2308,12 @@ namespace UnifyWeaver.QueryRuntime
                         {
                             if (TryAddRow(totalSet, tuple))
                             {
-                                totalList.Add(tuple);
                                 memberNext.Add(tuple);
                             }
                         }
                     }
+
+                    totalList.AddRange(memberNext);
                 }
 
                 foreach (var pair in nextDeltas)


### PR DESCRIPTION
  - Improves C# query runtime performance for parameterized workloads.
  - Uses cached fact/join indexes to avoid full scans when QueryPlan.InputPositions is present (especially when the plan root is a
    RelationScanNode).
  - Optimizes single-key KeyJoinNode execution to avoid per-row key-array allocations and selects a better build/probe side via a simple
    heuristic (favoring ParamSeedNode/small nodes).
  - Note: enumeration order may differ from full-scan paths; ordering is not guaranteed by this runtime.
  - Tests: dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release (CI should also cover
    runtime smoke + core tests).