### PR TITLE
feat: Implement Client-Server Phases 7-8 (Service Discovery & Tracing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Client-Server Phase 8: Service Tracing** - OpenTelemetry-compatible distributed tracing
+  - `tracing(Bool)` option to enable distributed tracing
+  - Trace exporters: `otlp`, `jaeger`, `zipkin`, `datadog`, `console`, `none`
+  - Trace propagation formats: `w3c`, `b3`, `b3_multi`, `jaeger`, `xray`, `datadog`
+  - `trace_sampling(Rate)` for sampling rate (0.0-1.0)
+  - `trace_service_name(Name)` for custom service name in traces
+  - `trace_propagation(Format)` for context propagation format
+  - `trace_attributes(List)` for default span attributes
+  - `trace_batch_size(N)` and `trace_export_interval(Ms)` for batch export
+  - SpanContext with W3C traceparent header generation/parsing
+  - Span management with SpanKind (Server/Client/Producer/Consumer/Internal)
+  - SpanEvent support for span events with timestamps
+  - Tracer with sampling decision, context extraction/injection, batch export
+  - SpanExporter interface with OTLP, Jaeger, Zipkin, Console implementations
+  - Helper predicates: `is_tracing_enabled/1`, `get_trace_sampling/2`, `get_trace_exporter/2`, `get_trace_service_name/2`, `get_trace_propagation/2`, `get_trace_attributes/2`
+  - Tracing service compilation for Python, Go, and Rust targets
+  - 20 integration tests in `tests/integration/test_service_tracing.sh`
+  - Documentation updated in `docs/CLIENT_SERVER_DESIGN.md`
+
+- **Client-Server Phase 7: Service Discovery** - Automatic service registration and health checks
+  - `discovery_enabled(Bool)` option to enable service discovery
+  - Discovery backends: `consul`, `etcd`, `dns`, `kubernetes`, `zookeeper`, `eureka`
+  - `health_check(Config)` for health check configuration: `http(Path, IntervalMs)`, `tcp(Port, IntervalMs)`
+  - `discovery_ttl(Seconds)` for service TTL in heartbeat
+  - `discovery_tags(List)` for service filtering tags
+  - ServiceRegistry interface with ConsulRegistry and LocalRegistry implementations
+  - HealthChecker with HTTP/TCP health check support
+  - ServiceInstance with metadata, health status, and last heartbeat
+  - Automatic heartbeat mechanism with TTL-based renewal
+  - Graceful deregistration on shutdown
+  - Helper predicates: `is_discovery_enabled/1`, `get_health_check_config/2`, `get_discovery_ttl/2`, `get_discovery_backend/2`, `get_discovery_tags/2`
+  - Discovery service compilation for Python, Go, and Rust targets
+  - 20 integration tests in `tests/integration/test_service_discovery.sh`
+  - Documentation updated in `docs/CLIENT_SERVER_DESIGN.md`
+
 - **Client-Server Phase 6: Distributed Services** - Cluster-aware services with sharding and replication
   - Sharding strategies: `hash`, `range`, `consistent_hash`, `geographic`
   - Consistency levels: `eventual`, `strong`, `quorum`, `read_your_writes`, `causal`

--- a/tests/integration/test_service_discovery.sh
+++ b/tests/integration/test_service_discovery.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+# Test suite for Phase 7: Service Discovery
+# Tests service discovery compilation for Python, Go, and Rust
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test function with timeout
+run_test() {
+    local test_name="$1"
+    local test_file="$2"
+
+    echo -n "  Testing $test_name... "
+    if timeout 30 swipl -s "$test_file" > /dev/null 2>&1; then
+        echo -e "${GREEN}PASSED${NC}"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}FAILED${NC}"
+        ((TESTS_FAILED++))
+    fi
+}
+
+# Create temp directory for test files
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+echo "=========================================="
+echo "Phase 7: Service Discovery Test Suite"
+echo "=========================================="
+echo ""
+
+# ==========================================
+# TEST GROUP 1: Validation Tests
+# ==========================================
+echo -e "${YELLOW}[1/4] Validation Tests${NC}"
+
+# Test 1.1: Valid discovery backend
+cat > "$TMPDIR/test_1_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    ( is_valid_discovery_backend(consul),
+      is_valid_discovery_backend(etcd),
+      is_valid_discovery_backend(dns),
+      is_valid_discovery_backend(kubernetes) -> halt(0) ; halt(1) ).
+EOF
+run_test "valid discovery backends" "$TMPDIR/test_1_1.pl"
+
+# Test 1.2: Valid health check config
+cat > "$TMPDIR/test_1_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    ( is_valid_health_check_config(http('/health', 30000)),
+      is_valid_health_check_config(tcp(8080, 10000)) -> halt(0) ; halt(1) ).
+EOF
+run_test "valid health check config" "$TMPDIR/test_1_2.pl"
+
+# Test 1.3: Discovery service options
+cat > "$TMPDIR/test_1_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    Options = [
+        discovery_enabled(true),
+        discovery_backend(consul),
+        health_check(http('/health', 30000)),
+        discovery_ttl(60)
+    ],
+    ( maplist(is_valid_service_option, Options) -> halt(0) ; halt(1) ).
+EOF
+run_test "discovery service options" "$TMPDIR/test_1_3.pl"
+
+# Test 1.4: is_discovery_enabled helper
+cat > "$TMPDIR/test_1_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( is_discovery_enabled(Service) -> halt(0) ; halt(1) ).
+EOF
+run_test "is_discovery_enabled helper" "$TMPDIR/test_1_4.pl"
+
+# Test 1.5: get_health_check_config helper
+cat > "$TMPDIR/test_1_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    Service = service(test, [health_check(http('/status', 5000))], [receive(_X), respond(_X)]),
+    ( get_health_check_config(Service, http('/status', 5000)) -> halt(0) ; halt(1) ).
+EOF
+run_test "get_health_check_config helper" "$TMPDIR/test_1_5.pl"
+
+echo ""
+
+# ==========================================
+# TEST GROUP 2: Python Discovery Compilation
+# ==========================================
+echo -e "${YELLOW}[2/4] Python Discovery Compilation Tests${NC}"
+
+# Test 2.1: Basic discovery service
+cat > "$TMPDIR/test_2_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "ServiceRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python discovery basic" "$TMPDIR/test_2_1.pl"
+
+# Test 2.2: Discovery with health check
+cat > "$TMPDIR/test_2_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [
+        discovery_enabled(true),
+        health_check(http('/health', 30000))
+    ], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "HealthChecker") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python discovery health check" "$TMPDIR/test_2_2.pl"
+
+# Test 2.3: Discovery with consul backend
+cat > "$TMPDIR/test_2_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [
+        discovery_backend(consul)
+    ], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "ConsulRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python consul backend" "$TMPDIR/test_2_3.pl"
+
+# Test 2.4: Discovery with tags
+cat > "$TMPDIR/test_2_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [
+        discovery_enabled(true),
+        discovery_tags([production, v1])
+    ], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "tags") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python discovery tags" "$TMPDIR/test_2_4.pl"
+
+# Test 2.5: LocalRegistry class
+cat > "$TMPDIR/test_2_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "LocalRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python LocalRegistry class" "$TMPDIR/test_2_5.pl"
+
+echo ""
+
+# ==========================================
+# TEST GROUP 3: Go Discovery Compilation
+# ==========================================
+echo -e "${YELLOW}[3/4] Go Discovery Compilation Tests${NC}"
+
+# Test 3.1: Basic Go discovery service
+cat > "$TMPDIR/test_3_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "ServiceRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go discovery basic" "$TMPDIR/test_3_1.pl"
+
+# Test 3.2: Go health checker
+cat > "$TMPDIR/test_3_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [
+        discovery_enabled(true),
+        health_check(http('/health', 30000))
+    ], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "HealthChecker") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go health checker" "$TMPDIR/test_3_2.pl"
+
+# Test 3.3: Go consul registry
+cat > "$TMPDIR/test_3_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [discovery_backend(consul)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "ConsulRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go consul registry" "$TMPDIR/test_3_3.pl"
+
+# Test 3.4: Go local registry
+cat > "$TMPDIR/test_3_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "LocalRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go local registry" "$TMPDIR/test_3_4.pl"
+
+# Test 3.5: Go heartbeat
+cat > "$TMPDIR/test_3_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "startHeartbeat") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go heartbeat" "$TMPDIR/test_3_5.pl"
+
+echo ""
+
+# ==========================================
+# TEST GROUP 4: Rust Discovery Compilation
+# ==========================================
+echo -e "${YELLOW}[4/4] Rust Discovery Compilation Tests${NC}"
+
+# Test 4.1: Basic Rust discovery service
+cat > "$TMPDIR/test_4_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "ServiceRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust discovery basic" "$TMPDIR/test_4_1.pl"
+
+# Test 4.2: Rust health status enum
+cat > "$TMPDIR/test_4_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "HealthStatus") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust health status" "$TMPDIR/test_4_2.pl"
+
+# Test 4.3: Rust local registry
+cat > "$TMPDIR/test_4_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "LocalRegistry") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust local registry" "$TMPDIR/test_4_3.pl"
+
+# Test 4.4: Rust service instance
+cat > "$TMPDIR/test_4_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "ServiceInstance") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust service instance" "$TMPDIR/test_4_4.pl"
+
+# Test 4.5: Rust lazy_static
+cat > "$TMPDIR/test_4_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(test, [discovery_enabled(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "lazy_static") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust lazy_static" "$TMPDIR/test_4_5.pl"
+
+echo ""
+
+# ==========================================
+# Summary
+# ==========================================
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "Passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Failed: ${RED}${TESTS_FAILED}${NC}"
+echo "Total:  $((TESTS_PASSED + TESTS_FAILED))"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi

--- a/tests/integration/test_service_tracing.sh
+++ b/tests/integration/test_service_tracing.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+# Test suite for Phase 8: Service Tracing
+# Tests distributed tracing compilation for Python, Go, and Rust
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test function with timeout
+run_test() {
+    local test_name="$1"
+    local test_file="$2"
+
+    echo -n "  Testing $test_name... "
+    if timeout 30 swipl -s "$test_file" > /dev/null 2>&1; then
+        echo -e "${GREEN}PASSED${NC}"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}FAILED${NC}"
+        ((TESTS_FAILED++))
+    fi
+}
+
+# Create temp directory for test files
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+echo "=========================================="
+echo "Phase 8: Service Tracing Test Suite"
+echo "=========================================="
+echo ""
+
+# ==========================================
+# TEST GROUP 1: Validation Tests
+# ==========================================
+echo -e "${YELLOW}[1/4] Validation Tests${NC}"
+
+# Test 1.1: Valid trace exporters
+cat > "$TMPDIR/test_1_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    ( is_valid_trace_exporter(otlp),
+      is_valid_trace_exporter(jaeger),
+      is_valid_trace_exporter(zipkin),
+      is_valid_trace_exporter(console) -> halt(0) ; halt(1) ).
+EOF
+run_test "valid trace exporters" "$TMPDIR/test_1_1.pl"
+
+# Test 1.2: Valid trace propagation formats
+cat > "$TMPDIR/test_1_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    ( is_valid_trace_propagation(w3c),
+      is_valid_trace_propagation(b3),
+      is_valid_trace_propagation(jaeger) -> halt(0) ; halt(1) ).
+EOF
+run_test "valid trace propagation" "$TMPDIR/test_1_2.pl"
+
+# Test 1.3: Tracing service options
+cat > "$TMPDIR/test_1_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    Options = [
+        tracing(true),
+        trace_exporter(otlp),
+        trace_sampling(0.1),
+        trace_propagation(w3c)
+    ],
+    ( maplist(is_valid_service_option, Options) -> halt(0) ; halt(1) ).
+EOF
+run_test "tracing service options" "$TMPDIR/test_1_3.pl"
+
+# Test 1.4: is_tracing_enabled helper
+cat > "$TMPDIR/test_1_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    Service = service(test, [tracing(true)], [receive(_X), respond(_X)]),
+    ( is_tracing_enabled(Service) -> halt(0) ; halt(1) ).
+EOF
+run_test "is_tracing_enabled helper" "$TMPDIR/test_1_4.pl"
+
+# Test 1.5: get_trace_exporter helper
+cat > "$TMPDIR/test_1_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/core/service_validation').
+:- initialization(main, main).
+main :-
+    Service = service(test, [trace_exporter(jaeger)], [receive(_X), respond(_X)]),
+    ( get_trace_exporter(Service, jaeger) -> halt(0) ; halt(1) ).
+EOF
+run_test "get_trace_exporter helper" "$TMPDIR/test_1_5.pl"
+
+echo ""
+
+# ==========================================
+# TEST GROUP 2: Python Tracing Compilation
+# ==========================================
+echo -e "${YELLOW}[2/4] Python Tracing Compilation Tests${NC}"
+
+# Test 2.1: Basic tracing service
+cat > "$TMPDIR/test_2_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "Tracer") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python tracing basic" "$TMPDIR/test_2_1.pl"
+
+# Test 2.2: SpanContext class
+cat > "$TMPDIR/test_2_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "SpanContext") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python SpanContext class" "$TMPDIR/test_2_2.pl"
+
+# Test 2.3: Span class
+cat > "$TMPDIR/test_2_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "class Span") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python Span class" "$TMPDIR/test_2_3.pl"
+
+# Test 2.4: Trace exporter
+cat > "$TMPDIR/test_2_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [trace_exporter(otlp)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "SpanExporter") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python SpanExporter" "$TMPDIR/test_2_4.pl"
+
+# Test 2.5: Sampling rate
+cat > "$TMPDIR/test_2_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/python_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true), trace_sampling(0.5)], [receive(_X), respond(_X)]),
+    ( compile_service_to_python(Service, Code),
+      sub_string(Code, _, _, _, "sampling_rate") -> halt(0) ; halt(1) ).
+EOF
+run_test "Python sampling rate" "$TMPDIR/test_2_5.pl"
+
+echo ""
+
+# ==========================================
+# TEST GROUP 3: Go Tracing Compilation
+# ==========================================
+echo -e "${YELLOW}[3/4] Go Tracing Compilation Tests${NC}"
+
+# Test 3.1: Basic Go tracing service
+cat > "$TMPDIR/test_3_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "Tracer") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go tracing basic" "$TMPDIR/test_3_1.pl"
+
+# Test 3.2: Go SpanContext
+cat > "$TMPDIR/test_3_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "SpanContext") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go SpanContext" "$TMPDIR/test_3_2.pl"
+
+# Test 3.3: Go Span struct
+cat > "$TMPDIR/test_3_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "type Span struct") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go Span struct" "$TMPDIR/test_3_3.pl"
+
+# Test 3.4: Go SpanExporter interface
+cat > "$TMPDIR/test_3_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [trace_exporter(jaeger)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "SpanExporter") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go SpanExporter interface" "$TMPDIR/test_3_4.pl"
+
+# Test 3.5: Go context propagation
+cat > "$TMPDIR/test_3_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/go_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_go(Service, Code),
+      sub_string(Code, _, _, _, "context.Context") -> halt(0) ; halt(1) ).
+EOF
+run_test "Go context propagation" "$TMPDIR/test_3_5.pl"
+
+echo ""
+
+# ==========================================
+# TEST GROUP 4: Rust Tracing Compilation
+# ==========================================
+echo -e "${YELLOW}[4/4] Rust Tracing Compilation Tests${NC}"
+
+# Test 4.1: Basic Rust tracing service
+cat > "$TMPDIR/test_4_1.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "Tracer") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust tracing basic" "$TMPDIR/test_4_1.pl"
+
+# Test 4.2: Rust SpanContext
+cat > "$TMPDIR/test_4_2.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "SpanContext") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust SpanContext" "$TMPDIR/test_4_2.pl"
+
+# Test 4.3: Rust Span struct
+cat > "$TMPDIR/test_4_3.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "struct Span") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust Span struct" "$TMPDIR/test_4_3.pl"
+
+# Test 4.4: Rust SpanExporter trait
+cat > "$TMPDIR/test_4_4.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [trace_exporter(zipkin)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "trait SpanExporter") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust SpanExporter trait" "$TMPDIR/test_4_4.pl"
+
+# Test 4.5: Rust SpanKind enum
+cat > "$TMPDIR/test_4_5.pl" << 'EOF'
+:- use_module('src/unifyweaver/targets/rust_target').
+:- initialization(main, main).
+main :-
+    Service = service(api, [tracing(true)], [receive(_X), respond(_X)]),
+    ( compile_service_to_rust(Service, Code),
+      sub_string(Code, _, _, _, "SpanKind") -> halt(0) ; halt(1) ).
+EOF
+run_test "Rust SpanKind enum" "$TMPDIR/test_4_5.pl"
+
+echo ""
+
+# ==========================================
+# Summary
+# ==========================================
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "Passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Failed: ${RED}${TESTS_FAILED}${NC}"
+echo "Total:  $((TESTS_PASSED + TESTS_FAILED))"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

This PR completes the Client-Server Architecture by implementing the final two phases:

- **Phase 7: Service Discovery** - Automatic service registration with health checks and multiple backend support
- **Phase 8: Service Tracing** - OpenTelemetry-compatible distributed tracing

Both phases include full implementations for Python, Go, and Rust targets with 40 passing integration tests.

## Phase 7: Service Discovery

### Features

| Option | Description | Default |
|--------|-------------|---------|
| `discovery_enabled(Bool)` | Enable service discovery | false |
| `discovery_backend(Backend)` | Discovery backend | consul |
| `discovery_ttl(Seconds)` | Service TTL for heartbeat | 60 |
| `discovery_tags(List)` | Tags for filtering | [] |
| `health_check(Config)` | Health check configuration | http('/health', 30000) |

### Supported Discovery Backends

- `consul` - HashiCorp Consul
- `etcd` - CoreOS etcd
- `dns` - DNS-based discovery
- `kubernetes` - Kubernetes Service Discovery
- `zookeeper` - Apache ZooKeeper
- `eureka` - Netflix Eureka

### Example

```prolog
service(api_gateway, [
    discovery_enabled(true),
    discovery_backend(consul),
    health_check(http('/health', 30000)),
    discovery_tags([production, v2])
], [
    receive(Request),
    route_by(path, Routes),
    respond(Response)
]).
```

### Generated Components

- `ServiceRegistry` interface with `ConsulRegistry` and `LocalRegistry` implementations
- `HealthChecker` with HTTP/TCP health check support
- `ServiceInstance` with metadata, health status, and heartbeat tracking
- Automatic TTL-based heartbeat mechanism
- Graceful deregistration on shutdown

## Phase 8: Service Tracing

### Features

| Option | Description | Default |
|--------|-------------|---------|
| `tracing(Bool)` | Enable distributed tracing | false |
| `trace_exporter(Exporter)` | Trace exporter backend | otlp |
| `trace_sampling(Rate)` | Sampling rate (0.0-1.0) | 1.0 |
| `trace_service_name(Name)` | Service name in traces | service name |
| `trace_propagation(Format)` | Context propagation format | w3c |
| `trace_attributes(List)` | Default span attributes | [] |

### Supported Exporters

- `otlp` / `otlp(Endpoint)` - OpenTelemetry Protocol
- `jaeger` / `jaeger(Endpoint)` - Jaeger
- `zipkin` / `zipkin(Endpoint)` - Zipkin
- `datadog` / `datadog(AgentHost)` - Datadog APM
- `console` - Console output (debugging)
- `none` - Disabled

### Propagation Formats

- `w3c` - W3C Trace Context (default)
- `b3` / `b3_multi` - B3 headers
- `jaeger` - Jaeger native format
- `xray` - AWS X-Ray format
- `datadog` - Datadog format

### Example

```prolog
service(payment_processor, [
    tracing(true),
    trace_exporter(otlp('http://collector:4318')),
    trace_sampling(0.1),
    trace_propagation(w3c),
    trace_attributes([environment-production, team-payments])
], [
    receive(PaymentRequest),
    validate_payment(PaymentRequest, Validated),
    process_payment(Validated, Result),
    respond(Result)
]).
```

### Generated Components

- `SpanContext` with W3C traceparent header generation/parsing
- `Span` with `SpanKind`, `SpanStatus`, `SpanEvent`
- `Tracer` with sampling, context extraction/injection, batch export
- `SpanExporter` interface with OTLP, Jaeger, Zipkin, Console implementations

## Files Changed

| File | Changes |
|------|---------|
| `src/unifyweaver/core/service_validation.pl` | Phase 7-8 validation options and helper predicates |
| `src/unifyweaver/targets/python_target.pl` | Python discovery and tracing compilation |
| `src/unifyweaver/targets/go_target.pl` | Go discovery and tracing compilation |
| `src/unifyweaver/targets/rust_target.pl` | Rust discovery and tracing compilation |
| `tests/integration/test_service_discovery.sh` | 20 Phase 7 integration tests |
| `tests/integration/test_service_tracing.sh` | 20 Phase 8 integration tests |
| `docs/CLIENT_SERVER_DESIGN.md` | Updated documentation |
| `CHANGELOG.md` | Release notes |

## Test Plan

```bash
# Run Phase 7 tests
./tests/integration/test_service_discovery.sh

# Run Phase 8 tests
./tests/integration/test_service_tracing.sh
```

### Test Results

```
Phase 7: Service Discovery - 20/20 passed
  [1/4] Validation Tests - 5/5
  [2/4] Python Discovery Compilation - 5/5
  [3/4] Go Discovery Compilation - 5/5
  [4/4] Rust Discovery Compilation - 5/5

Phase 8: Service Tracing - 20/20 passed
  [1/4] Validation Tests - 5/5
  [2/4] Python Tracing Compilation - 5/5
  [3/4] Go Tracing Compilation - 5/5
  [4/4] Rust Tracing Compilation - 5/5
```

## Breaking Changes

None. This is a pure feature addition that is backwards compatible with existing client-server functionality.

## Architecture Complete

With Phases 7-8, the Client-Server Architecture is now complete:

| Phase | Feature | Status |
|-------|---------|--------|
| 1 | In-Process Services | ✅ |
| 2 | Unix Socket Services | ✅ |
| 3 | Network Services (TCP/HTTP) | ✅ |
| 4 | Service Mesh | ✅ |
| 5 | Polyglot Services | ✅ |
| 6 | Distributed Services | ✅ |
| 7 | Service Discovery | ✅ |
| 8 | Service Tracing | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
