### PR TITLE
Implement Phase 3 Distributed Network with Kleinberg routing

### DIFF
--- a/docs/guides/KG_DISTRIBUTED_SETUP.md
+++ b/docs/guides/KG_DISTRIBUTED_SETUP.md
@@ -1,0 +1,276 @@
+# KG Distributed Setup Guide
+
+This guide covers setting up a distributed KG topology network using Kleinberg routing.
+
+## Prerequisites
+
+- Python 3.8+ with numpy
+- UnifyWeaver core installed
+- (Optional) Consul for production service discovery
+
+## Quick Start
+
+### 1. Single Node Setup
+
+```python
+from kg_topology_api import DistributedKGTopologyAPI
+
+# Create a distributed KG node
+api = DistributedKGTopologyAPI(
+    db_path='my_kg.db',
+    node_id='csv-expert-node',
+    discovery_backend='local'  # Use 'consul' for production
+)
+
+# Create an interface and compute centroid
+interface_id = api.create_interface(
+    name='csv_expert',
+    description='Expert on CSV and delimited file formats'
+)
+
+# Add Q-A pairs and compute centroid
+# ... (see Phase 1-2 documentation)
+
+# Register with discovery
+api.register_node(
+    host='localhost',
+    port=8081,
+    tags=['kg_node', 'csv_expert']
+)
+```
+
+### 2. Multi-Node Simulation (Testing)
+
+```python
+from discovery_clients import LocalDiscoveryClient
+
+# Use shared registry for multi-node simulation
+LocalDiscoveryClient.clear_shared()
+
+# Node A: CSV expert
+api_a = DistributedKGTopologyAPI(
+    db_path='node_a.db',
+    node_id='node-a',
+    discovery_backend='local',
+    discovery_config={'use_shared': True}
+)
+api_a.register_node(host='localhost', port=8081, tags=['kg_node', 'csv'])
+
+# Node B: JSON expert
+api_b = DistributedKGTopologyAPI(
+    db_path='node_b.db',
+    node_id='node-b',
+    discovery_backend='local',
+    discovery_config={'use_shared': True}
+)
+api_b.register_node(host='localhost', port=8082, tags=['kg_node', 'json'])
+
+# Query from Node A (will route to Node B if needed)
+results = api_a.distributed_search(
+    query_text='How do I parse JSON files?',
+    max_hops=5
+)
+```
+
+### 3. Production Setup with Consul
+
+```python
+api = DistributedKGTopologyAPI(
+    db_path='production.db',
+    node_id='prod-node-1',
+    discovery_backend='consul',
+    discovery_config={
+        'host': 'consul.example.com',
+        'port': 8500,
+        'token': 'your-acl-token'  # Optional
+    }
+)
+
+api.register_node(
+    host='kg-node-1.example.com',
+    port=8080,
+    tags=['kg_node', 'production']
+)
+```
+
+## Configuration Options
+
+### Kleinberg Router Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `alpha` | 2.0 | Link distribution exponent (higher = more local routing) |
+| `max_hops` | 10 | Maximum routing hops (HTL) |
+| `parallel_paths` | 1 | Number of parallel query paths |
+| `similarity_threshold` | 0.5 | Minimum similarity for forwarding |
+| `path_folding` | true | Create shortcuts from successful paths |
+
+### Prolog Service Definition
+
+```prolog
+service(my_kg_node, [
+    transport(http('/kg', [host('0.0.0.0'), port(8080)])),
+    discovery_enabled(true),
+    discovery_backend(consul),
+    discovery_tags([kg_node, my_domain]),
+    discovery_metadata([
+        semantic_centroid("base64_encoded_vector..."),
+        embedding_model('all-MiniLM-L6-v2'),
+        interface_topics([topic1, topic2])
+    ]),
+    routing(kleinberg([
+        alpha(2.0),
+        max_hops(10),
+        parallel_paths(1),
+        similarity_threshold(0.5),
+        path_folding(true)
+    ]))
+], [
+    receive(Query),
+    handle_kg_query(Query, Response),
+    respond(Response)
+]).
+```
+
+## HTTP Endpoints
+
+Each KG node exposes three endpoints:
+
+### POST /kg/query
+
+Handle distributed queries from other nodes.
+
+**Request:**
+```json
+{
+    "__type": "kg_query",
+    "__id": "uuid-123",
+    "__routing": {
+        "origin_node": "node_a",
+        "htl": 8,
+        "visited": ["node_a"],
+        "path_folding_enabled": true
+    },
+    "__embedding": {
+        "model": "all-MiniLM-L6-v2",
+        "vector": [0.1, 0.2, ...]
+    },
+    "payload": {
+        "query_text": "How do I parse CSV?",
+        "top_k": 5
+    }
+}
+```
+
+**Response:**
+```json
+{
+    "__type": "kg_response",
+    "__id": "uuid-123",
+    "results": [...],
+    "source_node": "node_b"
+}
+```
+
+### POST /kg/register
+
+Register the node with discovery service.
+
+**Request:**
+```json
+{
+    "host": "localhost",
+    "port": 8080,
+    "tags": ["kg_node", "expert"]
+}
+```
+
+### GET /kg/health
+
+Health check endpoint.
+
+**Response:**
+```json
+{
+    "status": "healthy",
+    "node_id": "my-node",
+    "interfaces": 3,
+    "stats": {
+        "total_queries": 150,
+        "avg_hops": 1.5,
+        "shortcuts": {"count": 25, "total_hits": 180}
+    }
+}
+```
+
+## Monitoring
+
+### Query Statistics
+
+```python
+stats = api.get_query_stats()
+print(f"Total queries: {stats['total_queries']}")
+print(f"Average hops: {stats['avg_hops']}")
+print(f"Shortcuts: {stats['shortcuts']['count']}")
+```
+
+### Router Statistics
+
+```python
+router = api.get_router()
+router_stats = router.get_stats()
+print(f"Cached nodes: {router_stats['cached_nodes']}")
+print(f"Shortcuts: {router_stats['shortcuts']}")
+```
+
+## Maintenance
+
+### Prune Shortcuts
+
+Remove old or unused shortcuts:
+
+```python
+# Remove shortcuts older than 30 days with fewer than 2 hits
+removed = api.prune_shortcuts(max_age_days=30, min_hits=2)
+print(f"Pruned {removed} shortcuts")
+```
+
+### Deregister Node
+
+```python
+api.deregister_node()
+```
+
+## Testing
+
+Run the integration tests:
+
+```bash
+./tests/integration/test_kg_distributed.sh
+```
+
+Run unit tests:
+
+```bash
+python -m pytest tests/core/test_kg_distributed.py -v
+```
+
+## Troubleshooting
+
+### No nodes discovered
+
+1. Check that nodes are registered with the same discovery backend
+2. Verify tags match between registration and discovery
+3. Check heartbeat/TTL expiration
+
+### High hop counts
+
+1. Increase `alpha` for more local routing
+2. Enable path folding to create shortcuts
+3. Add more nodes with diverse interface centroids
+
+### Slow queries
+
+1. Enable parallel paths: `parallel_paths=3`
+2. Lower similarity threshold for faster forwarding
+3. Check network latency between nodes

--- a/src/unifyweaver/targets/python_runtime/discovery_clients.py
+++ b/src/unifyweaver/targets/python_runtime/discovery_clients.py
@@ -1,0 +1,562 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Discovery client implementations for distributed KG topology.
+
+"""
+Discovery client implementations for distributed KG topology (Phase 3).
+
+Provides abstract base class and implementations for service discovery:
+- LocalDiscoveryClient: In-memory for testing and single-machine deployments
+- ConsulDiscoveryClient: HashiCorp Consul integration
+- EtcdDiscoveryClient: CoreOS etcd integration (stub)
+- DNSDiscoveryClient: DNS-based discovery (stub)
+
+See: docs/proposals/ROADMAP_KG_TOPOLOGY.md (Phase 3)
+     docs/CLIENT_SERVER_DESIGN.md (Phase 7: Service Discovery)
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Optional
+from enum import Enum, auto
+import json
+import threading
+import time
+import urllib.request
+import urllib.error
+
+
+class HealthStatus(Enum):
+    """Health status of a service instance."""
+    HEALTHY = auto()
+    UNHEALTHY = auto()
+    UNKNOWN = auto()
+
+
+@dataclass
+class ServiceInstance:
+    """Represents a discovered service instance."""
+    service_id: str
+    service_name: str
+    host: str
+    port: int
+    tags: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    health_status: HealthStatus = HealthStatus.UNKNOWN
+    last_heartbeat: float = field(default_factory=time.time)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            'service_id': self.service_id,
+            'service_name': self.service_name,
+            'host': self.host,
+            'port': self.port,
+            'tags': self.tags,
+            'metadata': self.metadata,
+            'health_status': self.health_status.name,
+            'last_heartbeat': self.last_heartbeat
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'ServiceInstance':
+        """Create from dictionary."""
+        health_str = data.get('health_status', 'UNKNOWN')
+        health = HealthStatus[health_str] if isinstance(health_str, str) else HealthStatus.UNKNOWN
+        return cls(
+            service_id=data['service_id'],
+            service_name=data['service_name'],
+            host=data['host'],
+            port=data['port'],
+            tags=data.get('tags', []),
+            metadata=data.get('metadata', {}),
+            health_status=health,
+            last_heartbeat=data.get('last_heartbeat', time.time())
+        )
+
+
+class DiscoveryClient(ABC):
+    """
+    Abstract base class for service discovery clients.
+
+    Implementations must provide:
+    - register: Register a service instance
+    - deregister: Remove a service instance
+    - discover: Find service instances by name and tags
+    - heartbeat: Send heartbeat to maintain registration
+    """
+
+    @abstractmethod
+    def register(
+        self,
+        service_name: str,
+        service_id: str,
+        host: str,
+        port: int,
+        tags: List[str] = None,
+        metadata: Dict[str, Any] = None,
+        ttl: int = 60
+    ) -> bool:
+        """
+        Register a service instance.
+
+        Args:
+            service_name: Name of the service (e.g., 'kg_topology')
+            service_id: Unique ID for this instance
+            host: Host address
+            port: Port number
+            tags: List of tags for filtering
+            metadata: Additional metadata (including semantic_centroid)
+            ttl: Time-to-live in seconds for heartbeat
+
+        Returns:
+            True if registration succeeded
+        """
+        pass
+
+    @abstractmethod
+    def deregister(self, service_id: str) -> bool:
+        """
+        Deregister a service instance.
+
+        Args:
+            service_id: ID of instance to deregister
+
+        Returns:
+            True if deregistration succeeded
+        """
+        pass
+
+    @abstractmethod
+    def discover(
+        self,
+        service_name: str,
+        tags: List[str] = None,
+        healthy_only: bool = True
+    ) -> List[ServiceInstance]:
+        """
+        Discover service instances.
+
+        Args:
+            service_name: Name of service to find
+            tags: Filter by tags (all tags must match)
+            healthy_only: Only return healthy instances
+
+        Returns:
+            List of matching service instances
+        """
+        pass
+
+    @abstractmethod
+    def heartbeat(self, service_id: str) -> bool:
+        """
+        Send heartbeat for a registered service.
+
+        Args:
+            service_id: ID of instance to heartbeat
+
+        Returns:
+            True if heartbeat succeeded
+        """
+        pass
+
+
+class LocalDiscoveryClient(DiscoveryClient):
+    """
+    In-memory discovery client for testing and single-machine deployments.
+
+    Thread-safe implementation using a lock for concurrent access.
+    Supports TTL-based expiration of instances.
+    """
+
+    # Class-level shared registry (singleton pattern for testing)
+    _shared_instances: Dict[str, ServiceInstance] = {}
+    _shared_lock = threading.Lock()
+    _use_shared: bool = False
+
+    def __init__(self, use_shared: bool = False):
+        """
+        Initialize local discovery client.
+
+        Args:
+            use_shared: If True, use shared class-level registry
+                       (useful for multi-node simulation in tests)
+        """
+        self._use_shared = use_shared
+        if not use_shared:
+            self._instances: Dict[str, ServiceInstance] = {}
+            self._lock = threading.Lock()
+            self._ttls: Dict[str, int] = {}
+        else:
+            self._instances = LocalDiscoveryClient._shared_instances
+            self._lock = LocalDiscoveryClient._shared_lock
+            self._ttls: Dict[str, int] = {}
+
+    def register(
+        self,
+        service_name: str,
+        service_id: str,
+        host: str,
+        port: int,
+        tags: List[str] = None,
+        metadata: Dict[str, Any] = None,
+        ttl: int = 60
+    ) -> bool:
+        """Register a service instance in local registry."""
+        instance = ServiceInstance(
+            service_id=service_id,
+            service_name=service_name,
+            host=host,
+            port=port,
+            tags=tags or [],
+            metadata=metadata or {},
+            health_status=HealthStatus.HEALTHY,
+            last_heartbeat=time.time()
+        )
+
+        with self._lock:
+            self._instances[service_id] = instance
+            self._ttls[service_id] = ttl
+
+        return True
+
+    def deregister(self, service_id: str) -> bool:
+        """Remove a service instance from local registry."""
+        with self._lock:
+            if service_id in self._instances:
+                del self._instances[service_id]
+                self._ttls.pop(service_id, None)
+                return True
+        return False
+
+    def discover(
+        self,
+        service_name: str,
+        tags: List[str] = None,
+        healthy_only: bool = True
+    ) -> List[ServiceInstance]:
+        """Find service instances in local registry."""
+        results = []
+        current_time = time.time()
+
+        with self._lock:
+            for instance in self._instances.values():
+                # Filter by service name
+                if instance.service_name != service_name:
+                    continue
+
+                # Filter by health (check TTL expiration)
+                if healthy_only:
+                    ttl = self._ttls.get(instance.service_id, 60)
+                    if current_time - instance.last_heartbeat > ttl:
+                        instance.health_status = HealthStatus.UNHEALTHY
+                        continue
+
+                # Filter by tags (all specified tags must be present)
+                if tags:
+                    if not all(t in instance.tags for t in tags):
+                        continue
+
+                results.append(instance)
+
+        return results
+
+    def heartbeat(self, service_id: str) -> bool:
+        """Update heartbeat timestamp for a service."""
+        with self._lock:
+            if service_id in self._instances:
+                self._instances[service_id].last_heartbeat = time.time()
+                self._instances[service_id].health_status = HealthStatus.HEALTHY
+                return True
+        return False
+
+    def clear(self):
+        """Clear all registered instances (for testing)."""
+        with self._lock:
+            self._instances.clear()
+            self._ttls.clear()
+
+    @classmethod
+    def clear_shared(cls):
+        """Clear the shared registry (for testing)."""
+        with cls._shared_lock:
+            cls._shared_instances.clear()
+
+
+class ConsulDiscoveryClient(DiscoveryClient):
+    """
+    HashiCorp Consul-based service discovery client.
+
+    Uses Consul's HTTP API for service registration and discovery.
+    Supports health checks and TTL-based heartbeats.
+    """
+
+    def __init__(
+        self,
+        host: str = 'localhost',
+        port: int = 8500,
+        token: str = None,
+        datacenter: str = None
+    ):
+        """
+        Initialize Consul discovery client.
+
+        Args:
+            host: Consul agent host
+            port: Consul agent port
+            token: ACL token for authentication
+            datacenter: Datacenter to use
+        """
+        self.host = host
+        self.port = port
+        self.token = token
+        self.datacenter = datacenter
+        self.base_url = f'http://{host}:{port}/v1'
+
+    def _make_request(
+        self,
+        method: str,
+        path: str,
+        data: Any = None,
+        params: Dict[str, str] = None
+    ) -> Optional[Any]:
+        """Make HTTP request to Consul API."""
+        url = f'{self.base_url}{path}'
+
+        if params:
+            query = '&'.join(f'{k}={v}' for k, v in params.items())
+            url = f'{url}?{query}'
+
+        headers = {'Content-Type': 'application/json'}
+        if self.token:
+            headers['X-Consul-Token'] = self.token
+
+        body = json.dumps(data).encode() if data else None
+
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers=headers,
+                method=method
+            )
+            response = urllib.request.urlopen(req, timeout=10)
+
+            if response.status == 200:
+                content = response.read()
+                if content:
+                    return json.loads(content)
+                return True
+            return None
+
+        except urllib.error.URLError as e:
+            # Log error in production
+            return None
+        except json.JSONDecodeError:
+            return None
+
+    def register(
+        self,
+        service_name: str,
+        service_id: str,
+        host: str,
+        port: int,
+        tags: List[str] = None,
+        metadata: Dict[str, Any] = None,
+        ttl: int = 60
+    ) -> bool:
+        """Register service with Consul agent."""
+        payload = {
+            'ID': service_id,
+            'Name': service_name,
+            'Address': host,
+            'Port': port,
+            'Tags': tags or [],
+            'Meta': metadata or {},
+            'Check': {
+                'TTL': f'{ttl}s',
+                'DeregisterCriticalServiceAfter': f'{ttl * 3}s'
+            }
+        }
+
+        result = self._make_request('PUT', '/agent/service/register', data=payload)
+
+        if result is not None:
+            # Initial pass to mark healthy
+            self.heartbeat(service_id)
+            return True
+        return False
+
+    def deregister(self, service_id: str) -> bool:
+        """Deregister service from Consul agent."""
+        result = self._make_request('PUT', f'/agent/service/deregister/{service_id}')
+        return result is not None
+
+    def discover(
+        self,
+        service_name: str,
+        tags: List[str] = None,
+        healthy_only: bool = True
+    ) -> List[ServiceInstance]:
+        """Discover services from Consul catalog."""
+        params = {}
+        if healthy_only:
+            params['passing'] = 'true'
+        if self.datacenter:
+            params['dc'] = self.datacenter
+
+        # Build URL with optional tag filtering
+        path = f'/health/service/{service_name}'
+        if tags:
+            for tag in tags:
+                params[f'tag'] = tag  # Note: Consul uses repeated tag params
+
+        data = self._make_request('GET', path, params=params)
+
+        if not data:
+            return []
+
+        results = []
+        for entry in data:
+            service = entry.get('Service', {})
+            checks = entry.get('Checks', [])
+
+            # Determine health from checks
+            health = HealthStatus.HEALTHY
+            for check in checks:
+                if check.get('Status') != 'passing':
+                    health = HealthStatus.UNHEALTHY
+                    break
+
+            instance = ServiceInstance(
+                service_id=service.get('ID', ''),
+                service_name=service.get('Service', service_name),
+                host=service.get('Address', ''),
+                port=service.get('Port', 0),
+                tags=service.get('Tags', []),
+                metadata=service.get('Meta', {}),
+                health_status=health
+            )
+            results.append(instance)
+
+        return results
+
+    def heartbeat(self, service_id: str) -> bool:
+        """Send TTL check pass to Consul."""
+        result = self._make_request('PUT', f'/agent/check/pass/service:{service_id}')
+        return result is not None
+
+
+class EtcdDiscoveryClient(DiscoveryClient):
+    """
+    CoreOS etcd-based service discovery client (stub).
+
+    TODO: Implement etcd v3 API integration.
+    """
+
+    def __init__(self, hosts: List[str] = None):
+        """Initialize etcd client."""
+        self.hosts = hosts or ['localhost:2379']
+        # TODO: Initialize etcd client
+
+    def register(
+        self,
+        service_name: str,
+        service_id: str,
+        host: str,
+        port: int,
+        tags: List[str] = None,
+        metadata: Dict[str, Any] = None,
+        ttl: int = 60
+    ) -> bool:
+        """Register service with etcd."""
+        raise NotImplementedError("etcd discovery not yet implemented")
+
+    def deregister(self, service_id: str) -> bool:
+        """Deregister service from etcd."""
+        raise NotImplementedError("etcd discovery not yet implemented")
+
+    def discover(
+        self,
+        service_name: str,
+        tags: List[str] = None,
+        healthy_only: bool = True
+    ) -> List[ServiceInstance]:
+        """Discover services from etcd."""
+        raise NotImplementedError("etcd discovery not yet implemented")
+
+    def heartbeat(self, service_id: str) -> bool:
+        """Send heartbeat to etcd."""
+        raise NotImplementedError("etcd discovery not yet implemented")
+
+
+class DNSDiscoveryClient(DiscoveryClient):
+    """
+    DNS-based service discovery client (stub).
+
+    TODO: Implement DNS SRV record queries.
+    """
+
+    def __init__(self, domain: str = 'service.consul'):
+        """Initialize DNS client."""
+        self.domain = domain
+        # TODO: Initialize DNS resolver
+
+    def register(
+        self,
+        service_name: str,
+        service_id: str,
+        host: str,
+        port: int,
+        tags: List[str] = None,
+        metadata: Dict[str, Any] = None,
+        ttl: int = 60
+    ) -> bool:
+        """DNS-based discovery typically doesn't support dynamic registration."""
+        raise NotImplementedError("DNS discovery is read-only")
+
+    def deregister(self, service_id: str) -> bool:
+        """DNS-based discovery typically doesn't support deregistration."""
+        raise NotImplementedError("DNS discovery is read-only")
+
+    def discover(
+        self,
+        service_name: str,
+        tags: List[str] = None,
+        healthy_only: bool = True
+    ) -> List[ServiceInstance]:
+        """Discover services via DNS SRV records."""
+        raise NotImplementedError("DNS discovery not yet implemented")
+
+    def heartbeat(self, service_id: str) -> bool:
+        """DNS-based discovery doesn't use heartbeats."""
+        return True  # No-op
+
+
+def create_discovery_client(backend: str, **kwargs) -> DiscoveryClient:
+    """
+    Factory function to create discovery client by backend name.
+
+    Args:
+        backend: Backend type ('local', 'consul', 'etcd', 'dns')
+        **kwargs: Backend-specific configuration
+
+    Returns:
+        Configured discovery client
+
+    Raises:
+        ValueError: If backend is unknown
+    """
+    backends = {
+        'local': LocalDiscoveryClient,
+        'consul': ConsulDiscoveryClient,
+        'etcd': EtcdDiscoveryClient,
+        'dns': DNSDiscoveryClient,
+    }
+
+    if backend not in backends:
+        raise ValueError(f"Unknown discovery backend: {backend}. "
+                        f"Available: {list(backends.keys())}")
+
+    return backends[backend](**kwargs)

--- a/src/unifyweaver/targets/python_runtime/kleinberg_router.py
+++ b/src/unifyweaver/targets/python_runtime/kleinberg_router.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Kleinberg small-world routing for distributed KG topology.
+
+"""
+Kleinberg small-world routing for distributed KG topology (Phase 3).
+
+Implements greedy forwarding based on semantic distance (embedding similarity)
+with HTL limits and path folding for shortcut creation.
+
+Key concepts:
+- Greedy forwarding: Route to node with closest interface centroid
+- HTL (Hops-To-Live): Limit query propagation depth
+- Path folding: Create shortcuts based on successful query paths
+- Parallel paths: Query multiple nodes concurrently (optional)
+
+See: docs/proposals/ROADMAP_KG_TOPOLOGY.md (Phase 3)
+     docs/proposals/SMALL_WORLD_ROUTING.md
+"""
+
+import base64
+import hashlib
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Optional, Set, Tuple
+import urllib.request
+import urllib.error
+import json
+
+import numpy as np
+
+from .discovery_clients import DiscoveryClient, ServiceInstance
+
+
+@dataclass
+class KGNode:
+    """Represents a discovered KG node in the network."""
+    node_id: str
+    endpoint: str
+    centroid: np.ndarray
+    topics: List[str]
+    embedding_model: str
+    similarity: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            'node_id': self.node_id,
+            'endpoint': self.endpoint,
+            'centroid': self.centroid.tolist() if self.centroid is not None else None,
+            'topics': self.topics,
+            'embedding_model': self.embedding_model,
+            'similarity': self.similarity
+        }
+
+
+@dataclass
+class RoutingEnvelope:
+    """
+    Routing information for inter-node queries.
+
+    Tracks the query path through the network and enforces HTL limits.
+    """
+    origin_node: str
+    htl: int
+    visited: Set[str] = field(default_factory=set)
+    path_folding_enabled: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            'origin_node': self.origin_node,
+            'htl': self.htl,
+            'visited': list(self.visited),
+            'path_folding_enabled': self.path_folding_enabled
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'RoutingEnvelope':
+        """Create from dictionary."""
+        return cls(
+            origin_node=data.get('origin_node', 'unknown'),
+            htl=data.get('htl', 0),
+            visited=set(data.get('visited', [])),
+            path_folding_enabled=data.get('path_folding_enabled', True)
+        )
+
+
+@dataclass
+class QueryResult:
+    """Result from a distributed query."""
+    answer_id: int
+    score: float
+    text: str
+    source_node: str
+    interface_similarity: float = 0.0
+    record_id: str = ''
+    source_file: str = ''
+    hops: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            'answer_id': self.answer_id,
+            'score': self.score,
+            'text': self.text,
+            'source_node': self.source_node,
+            'interface_similarity': self.interface_similarity,
+            'record_id': self.record_id,
+            'source_file': self.source_file,
+            'hops': self.hops
+        }
+
+
+class KleinbergRouter:
+    """
+    Kleinberg small-world routing for distributed KG topology.
+
+    Implements greedy forwarding to semantically closest interface centroids
+    with HTL limits and optional path folding.
+
+    Attributes:
+        local_node_id: ID of the local node
+        discovery_client: Service discovery client
+        alpha: Link distribution exponent (default 2.0)
+        max_hops: Maximum routing hops (HTL, default 10)
+        parallel_paths: Number of parallel query paths (default 1)
+        similarity_threshold: Minimum similarity for forwarding (default 0.5)
+        path_folding_enabled: Whether to create shortcuts (default True)
+    """
+
+    def __init__(
+        self,
+        local_node_id: str,
+        discovery_client: DiscoveryClient,
+        alpha: float = 2.0,
+        max_hops: int = 10,
+        parallel_paths: int = 1,
+        similarity_threshold: float = 0.5,
+        path_folding_enabled: bool = True,
+        request_timeout: float = 30.0
+    ):
+        """
+        Initialize Kleinberg router.
+
+        Args:
+            local_node_id: Unique ID for this node
+            discovery_client: Discovery client for finding nodes
+            alpha: Kleinberg exponent (higher = more local routing)
+            max_hops: Maximum hops before query termination
+            parallel_paths: Number of parallel query paths
+            similarity_threshold: Minimum similarity to forward
+            path_folding_enabled: Create shortcuts from successful paths
+            request_timeout: HTTP request timeout in seconds
+        """
+        self.local_node_id = local_node_id
+        self.discovery_client = discovery_client
+        self.alpha = alpha
+        self.max_hops = max_hops
+        self.parallel_paths = parallel_paths
+        self.similarity_threshold = similarity_threshold
+        self.path_folding_enabled = path_folding_enabled
+        self.request_timeout = request_timeout
+
+        # Cache of discovered nodes
+        self._node_cache: Dict[str, KGNode] = {}
+        self._cache_timestamp: float = 0.0
+        self._cache_ttl: float = 60.0  # Refresh cache every 60 seconds
+
+        # Shortcut links from path folding
+        self._shortcuts: Dict[str, str] = {}  # query_hash -> node_id
+
+    def discover_nodes(
+        self,
+        tags: List[str] = None,
+        force_refresh: bool = False
+    ) -> List[KGNode]:
+        """
+        Discover KG nodes from service registry.
+
+        Args:
+            tags: Filter tags (default: ['kg_node'])
+            force_refresh: Force cache refresh
+
+        Returns:
+            List of discovered KG nodes with centroids
+        """
+        # Check cache
+        current_time = time.time()
+        if not force_refresh and (current_time - self._cache_timestamp) < self._cache_ttl:
+            return list(self._node_cache.values())
+
+        tags = tags or ['kg_node']
+        instances = self.discovery_client.discover('kg_topology', tags)
+
+        nodes = []
+        for instance in instances:
+            metadata = instance.metadata or {}
+
+            # Decode centroid from base64
+            centroid_b64 = metadata.get('semantic_centroid')
+            if not centroid_b64:
+                continue
+
+            try:
+                if isinstance(centroid_b64, str):
+                    centroid_bytes = base64.b64decode(centroid_b64)
+                    centroid = np.frombuffer(centroid_bytes, dtype=np.float32).copy()
+                elif isinstance(centroid_b64, list):
+                    centroid = np.array(centroid_b64, dtype=np.float32)
+                else:
+                    continue
+            except Exception:
+                continue
+
+            # Extract topics
+            topics = metadata.get('interface_topics', [])
+            if isinstance(topics, str):
+                try:
+                    topics = json.loads(topics)
+                except json.JSONDecodeError:
+                    topics = [topics]
+
+            node = KGNode(
+                node_id=instance.service_id,
+                endpoint=f"http://{instance.host}:{instance.port}",
+                centroid=centroid,
+                topics=topics,
+                embedding_model=metadata.get('embedding_model', 'unknown')
+            )
+            nodes.append(node)
+            self._node_cache[node.node_id] = node
+
+        self._cache_timestamp = current_time
+        return nodes
+
+    def route_query(
+        self,
+        query_embedding: np.ndarray,
+        query_text: str,
+        envelope: RoutingEnvelope = None,
+        top_k: int = 5
+    ) -> List[Dict[str, Any]]:
+        """
+        Route a query through the small-world network.
+
+        Uses greedy forwarding to the closest interface centroid,
+        with backtracking on failure.
+
+        Args:
+            query_embedding: Query embedding vector
+            query_text: Original query text
+            envelope: Routing envelope (created if None)
+            top_k: Number of results to return
+
+        Returns:
+            List of query results from network
+        """
+        # Initialize envelope
+        if envelope is None:
+            envelope = RoutingEnvelope(
+                origin_node=self.local_node_id,
+                htl=self.max_hops,
+                path_folding_enabled=self.path_folding_enabled
+            )
+
+        # Check HTL
+        if envelope.htl <= 0:
+            return []
+
+        envelope.visited.add(self.local_node_id)
+
+        # Check for shortcut
+        shortcut_node = self.check_shortcut(query_text)
+        if shortcut_node and shortcut_node not in envelope.visited:
+            # Try shortcut first
+            if shortcut_node in self._node_cache:
+                node = self._node_cache[shortcut_node]
+                shortcut_results = self._forward_to_node(
+                    node, query_embedding, query_text, envelope, top_k
+                )
+                if shortcut_results:
+                    return shortcut_results
+
+        # Get available nodes (excluding visited)
+        nodes = self.discover_nodes()
+        candidates = [n for n in nodes if n.node_id not in envelope.visited]
+
+        if not candidates:
+            return []
+
+        # Compute similarities to all candidate centroids
+        query_norm = query_embedding / (np.linalg.norm(query_embedding) + 1e-9)
+
+        for node in candidates:
+            centroid_norm = node.centroid / (np.linalg.norm(node.centroid) + 1e-9)
+            node.similarity = float(np.dot(query_norm, centroid_norm))
+
+        # Sort by similarity (greedy)
+        candidates.sort(key=lambda n: n.similarity, reverse=True)
+
+        # Select paths
+        selected = candidates[:self.parallel_paths]
+
+        results = []
+        if self.parallel_paths > 1:
+            # Parallel query execution
+            with ThreadPoolExecutor(max_workers=self.parallel_paths) as executor:
+                futures = {
+                    executor.submit(
+                        self._forward_to_node,
+                        node, query_embedding, query_text, envelope, top_k
+                    ): node for node in selected
+                }
+                for future in as_completed(futures):
+                    try:
+                        node_results = future.result()
+                        results.extend(node_results)
+                    except Exception:
+                        pass  # Node failed, try others
+        else:
+            # Sequential greedy with backtracking
+            for node in selected:
+                if node.similarity >= self.similarity_threshold:
+                    node_results = self._forward_to_node(
+                        node, query_embedding, query_text, envelope, top_k
+                    )
+                    if node_results:
+                        results.extend(node_results)
+                        break  # Greedy: stop on first success
+
+        # Path folding: create shortcut if successful
+        if results and envelope.path_folding_enabled:
+            source_node = results[0].get('source_node', selected[0].node_id if selected else None)
+            if source_node:
+                self.create_shortcut(query_text, source_node)
+
+        return results
+
+    def _forward_to_node(
+        self,
+        node: KGNode,
+        query_embedding: np.ndarray,
+        query_text: str,
+        envelope: RoutingEnvelope,
+        top_k: int
+    ) -> List[Dict[str, Any]]:
+        """
+        Forward query to a remote node via HTTP.
+
+        Args:
+            node: Target node
+            query_embedding: Query embedding vector
+            query_text: Original query text
+            envelope: Current routing envelope
+            top_k: Number of results
+
+        Returns:
+            List of results from remote node
+        """
+        # Prepare routing envelope for next hop
+        next_envelope = RoutingEnvelope(
+            origin_node=envelope.origin_node,
+            htl=envelope.htl - 1,
+            visited=envelope.visited.copy(),
+            path_folding_enabled=envelope.path_folding_enabled
+        )
+
+        request_body = {
+            '__type': 'kg_query',
+            '__id': hashlib.sha256(f'{query_text}{time.time()}'.encode()).hexdigest()[:16],
+            '__routing': next_envelope.to_dict(),
+            '__embedding': {
+                'model': node.embedding_model,
+                'vector': query_embedding.tolist()
+            },
+            'payload': {
+                'query_text': query_text,
+                'top_k': top_k
+            }
+        }
+
+        try:
+            req = urllib.request.Request(
+                f"{node.endpoint}/kg/query",
+                data=json.dumps(request_body).encode(),
+                headers={'Content-Type': 'application/json'},
+                method='POST'
+            )
+
+            response = urllib.request.urlopen(req, timeout=self.request_timeout)
+
+            if response.status == 200:
+                result = json.loads(response.read())
+                results = result.get('results', [])
+
+                # Add source node info and increment hop count
+                for r in results:
+                    if 'source_node' not in r:
+                        r['source_node'] = node.node_id
+                    r['hops'] = r.get('hops', 0) + 1
+
+                return results
+
+        except urllib.error.URLError:
+            pass  # Node unreachable
+        except json.JSONDecodeError:
+            pass  # Invalid response
+        except Exception:
+            pass  # Other errors
+
+        return []
+
+    def check_shortcut(self, query_text: str) -> Optional[str]:
+        """
+        Check if a shortcut exists for this query.
+
+        Args:
+            query_text: Query to check
+
+        Returns:
+            Node ID if shortcut exists, None otherwise
+        """
+        query_hash = self._hash_query(query_text)
+        return self._shortcuts.get(query_hash)
+
+    def create_shortcut(self, query_text: str, target_node_id: str):
+        """
+        Create a path-folded shortcut.
+
+        Args:
+            query_text: Query that was successful
+            target_node_id: Node that provided good results
+        """
+        query_hash = self._hash_query(query_text)
+        self._shortcuts[query_hash] = target_node_id
+
+    def remove_shortcut(self, query_text: str):
+        """Remove a shortcut."""
+        query_hash = self._hash_query(query_text)
+        self._shortcuts.pop(query_hash, None)
+
+    def clear_shortcuts(self):
+        """Clear all shortcuts."""
+        self._shortcuts.clear()
+
+    def get_shortcuts(self) -> Dict[str, str]:
+        """Get all shortcuts (for persistence)."""
+        return dict(self._shortcuts)
+
+    def load_shortcuts(self, shortcuts: Dict[str, str]):
+        """Load shortcuts from persistence."""
+        self._shortcuts.update(shortcuts)
+
+    def _hash_query(self, query_text: str) -> str:
+        """Hash query for shortcut lookup."""
+        return hashlib.sha256(query_text.encode()).hexdigest()[:16]
+
+    def compute_routing_probability(
+        self,
+        nodes: List[KGNode],
+        query_embedding: np.ndarray,
+        temperature: float = 1.0
+    ) -> List[Tuple[KGNode, float]]:
+        """
+        Compute routing probabilities using softmax over similarities.
+
+        This is similar to the local map_query_to_interface() but for
+        distributed routing decisions.
+
+        Args:
+            nodes: List of candidate nodes
+            query_embedding: Query embedding vector
+            temperature: Softmax temperature (lower = sharper)
+
+        Returns:
+            List of (node, probability) tuples, sorted by probability
+        """
+        if not nodes:
+            return []
+
+        query_norm = query_embedding / (np.linalg.norm(query_embedding) + 1e-9)
+
+        similarities = []
+        for node in nodes:
+            centroid_norm = node.centroid / (np.linalg.norm(node.centroid) + 1e-9)
+            sim = float(np.dot(query_norm, centroid_norm))
+            node.similarity = sim
+            similarities.append(sim)
+
+        # Softmax
+        similarities = np.array(similarities)
+        exp_sims = np.exp(similarities / temperature)
+        probs = exp_sims / exp_sims.sum()
+
+        # Create sorted list
+        result = [(nodes[i], float(probs[i])) for i in range(len(nodes))]
+        result.sort(key=lambda x: x[1], reverse=True)
+
+        return result
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get router statistics."""
+        return {
+            'local_node_id': self.local_node_id,
+            'cached_nodes': len(self._node_cache),
+            'shortcuts': len(self._shortcuts),
+            'config': {
+                'alpha': self.alpha,
+                'max_hops': self.max_hops,
+                'parallel_paths': self.parallel_paths,
+                'similarity_threshold': self.similarity_threshold,
+                'path_folding_enabled': self.path_folding_enabled
+            }
+        }

--- a/tests/core/test_kg_distributed.py
+++ b/tests/core/test_kg_distributed.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Unit tests for KG Topology Phase 3: Distributed Network
+
+"""
+Unit tests for distributed KG topology components.
+
+Tests:
+- LocalDiscoveryClient: In-memory service discovery
+- ConsulDiscoveryClient: Consul API (mocked)
+- KleinbergRouter: Routing logic and shortcuts
+- DistributedKGTopologyAPI: Schema and methods
+"""
+
+import unittest
+import tempfile
+import os
+import sys
+import json
+import time
+import base64
+
+import numpy as np
+
+# Add source directories to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'unifyweaver', 'targets', 'python_runtime'))
+
+from discovery_clients import (
+    DiscoveryClient, LocalDiscoveryClient, ConsulDiscoveryClient,
+    ServiceInstance, HealthStatus, create_discovery_client
+)
+from kleinberg_router import (
+    KleinbergRouter, KGNode, RoutingEnvelope, QueryResult
+)
+
+
+class TestServiceInstance(unittest.TestCase):
+    """Tests for ServiceInstance dataclass."""
+
+    def test_to_dict(self):
+        """Test ServiceInstance serialization."""
+        instance = ServiceInstance(
+            service_id='test-123',
+            service_name='kg_topology',
+            host='localhost',
+            port=8080,
+            tags=['kg_node', 'expert'],
+            metadata={'key': 'value'},
+            health_status=HealthStatus.HEALTHY
+        )
+
+        d = instance.to_dict()
+        self.assertEqual(d['service_id'], 'test-123')
+        self.assertEqual(d['service_name'], 'kg_topology')
+        self.assertEqual(d['host'], 'localhost')
+        self.assertEqual(d['port'], 8080)
+        self.assertEqual(d['tags'], ['kg_node', 'expert'])
+        self.assertEqual(d['metadata'], {'key': 'value'})
+        self.assertEqual(d['health_status'], 'HEALTHY')
+
+    def test_from_dict(self):
+        """Test ServiceInstance deserialization."""
+        d = {
+            'service_id': 'test-456',
+            'service_name': 'kg_topology',
+            'host': '192.168.1.1',
+            'port': 9090,
+            'tags': ['tag1'],
+            'metadata': {'foo': 'bar'},
+            'health_status': 'UNHEALTHY'
+        }
+
+        instance = ServiceInstance.from_dict(d)
+        self.assertEqual(instance.service_id, 'test-456')
+        self.assertEqual(instance.health_status, HealthStatus.UNHEALTHY)
+
+
+class TestLocalDiscoveryClient(unittest.TestCase):
+    """Tests for LocalDiscoveryClient."""
+
+    def setUp(self):
+        """Set up test client."""
+        self.client = LocalDiscoveryClient()
+        self.client.clear()
+
+    def tearDown(self):
+        """Clean up."""
+        self.client.clear()
+
+    def test_register_and_discover(self):
+        """Test basic registration and discovery."""
+        # Register a service
+        success = self.client.register(
+            service_name='kg_topology',
+            service_id='node-a',
+            host='localhost',
+            port=8081,
+            tags=['kg_node'],
+            metadata={'semantic_centroid': 'abc123'}
+        )
+        self.assertTrue(success)
+
+        # Discover it
+        instances = self.client.discover('kg_topology')
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].service_id, 'node-a')
+        self.assertEqual(instances[0].metadata['semantic_centroid'], 'abc123')
+
+    def test_discover_with_tags(self):
+        """Test discovery filtering by tags."""
+        # Register services with different tags
+        self.client.register('kg_topology', 'node-a', 'localhost', 8081,
+                            tags=['kg_node', 'csv_expert'])
+        self.client.register('kg_topology', 'node-b', 'localhost', 8082,
+                            tags=['kg_node', 'json_expert'])
+        self.client.register('kg_topology', 'node-c', 'localhost', 8083,
+                            tags=['kg_node', 'csv_expert', 'json_expert'])
+
+        # Filter by single tag
+        csv_nodes = self.client.discover('kg_topology', tags=['csv_expert'])
+        self.assertEqual(len(csv_nodes), 2)
+
+        # Filter by multiple tags (AND)
+        both_nodes = self.client.discover('kg_topology',
+                                         tags=['csv_expert', 'json_expert'])
+        self.assertEqual(len(both_nodes), 1)
+        self.assertEqual(both_nodes[0].service_id, 'node-c')
+
+    def test_deregister(self):
+        """Test service deregistration."""
+        self.client.register('kg_topology', 'node-a', 'localhost', 8081)
+
+        # Verify registered
+        self.assertEqual(len(self.client.discover('kg_topology')), 1)
+
+        # Deregister
+        success = self.client.deregister('node-a')
+        self.assertTrue(success)
+
+        # Verify gone
+        self.assertEqual(len(self.client.discover('kg_topology')), 0)
+
+        # Deregister non-existent
+        success = self.client.deregister('node-x')
+        self.assertFalse(success)
+
+    def test_heartbeat(self):
+        """Test heartbeat updates."""
+        self.client.register('kg_topology', 'node-a', 'localhost', 8081)
+
+        # Get initial heartbeat
+        instances = self.client.discover('kg_topology')
+        initial_hb = instances[0].last_heartbeat
+
+        # Small delay
+        time.sleep(0.01)
+
+        # Send heartbeat
+        success = self.client.heartbeat('node-a')
+        self.assertTrue(success)
+
+        # Check updated
+        instances = self.client.discover('kg_topology')
+        self.assertGreater(instances[0].last_heartbeat, initial_hb)
+
+    def test_ttl_expiration(self):
+        """Test TTL-based expiration."""
+        # Register with very short TTL
+        self.client.register('kg_topology', 'node-a', 'localhost', 8081, ttl=0)
+
+        # Small delay to exceed TTL
+        time.sleep(0.01)
+
+        # Should be filtered out by healthy_only
+        instances = self.client.discover('kg_topology', healthy_only=True)
+        self.assertEqual(len(instances), 0)
+
+        # But still exists if healthy_only=False
+        instances = self.client.discover('kg_topology', healthy_only=False)
+        self.assertEqual(len(instances), 1)
+
+    def test_shared_registry(self):
+        """Test shared registry mode."""
+        LocalDiscoveryClient.clear_shared()
+
+        client1 = LocalDiscoveryClient(use_shared=True)
+        client2 = LocalDiscoveryClient(use_shared=True)
+
+        # Register via client1
+        client1.register('kg_topology', 'node-a', 'localhost', 8081)
+
+        # Discover via client2
+        instances = client2.discover('kg_topology')
+        self.assertEqual(len(instances), 1)
+
+        LocalDiscoveryClient.clear_shared()
+
+
+class TestCreateDiscoveryClient(unittest.TestCase):
+    """Tests for discovery client factory."""
+
+    def test_create_local(self):
+        """Test creating local client."""
+        client = create_discovery_client('local')
+        self.assertIsInstance(client, LocalDiscoveryClient)
+
+    def test_create_consul(self):
+        """Test creating Consul client."""
+        client = create_discovery_client('consul', host='127.0.0.1', port=8500)
+        self.assertIsInstance(client, ConsulDiscoveryClient)
+
+    def test_create_unknown(self):
+        """Test error on unknown backend."""
+        with self.assertRaises(ValueError):
+            create_discovery_client('unknown_backend')
+
+
+class TestKGNode(unittest.TestCase):
+    """Tests for KGNode dataclass."""
+
+    def test_to_dict(self):
+        """Test KGNode serialization."""
+        centroid = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        node = KGNode(
+            node_id='node-1',
+            endpoint='http://localhost:8080',
+            centroid=centroid,
+            topics=['csv', 'data'],
+            embedding_model='all-MiniLM-L6-v2',
+            similarity=0.85
+        )
+
+        d = node.to_dict()
+        self.assertEqual(d['node_id'], 'node-1')
+        self.assertEqual(d['endpoint'], 'http://localhost:8080')
+        self.assertAlmostEqual(d['centroid'][0], 0.1, places=5)
+        self.assertEqual(d['topics'], ['csv', 'data'])
+
+
+class TestRoutingEnvelope(unittest.TestCase):
+    """Tests for RoutingEnvelope dataclass."""
+
+    def test_to_dict(self):
+        """Test serialization."""
+        envelope = RoutingEnvelope(
+            origin_node='node-a',
+            htl=8,
+            visited={'node-a', 'node-b'},
+            path_folding_enabled=True
+        )
+
+        d = envelope.to_dict()
+        self.assertEqual(d['origin_node'], 'node-a')
+        self.assertEqual(d['htl'], 8)
+        self.assertIn('node-a', d['visited'])
+        self.assertIn('node-b', d['visited'])
+        self.assertTrue(d['path_folding_enabled'])
+
+    def test_from_dict(self):
+        """Test deserialization."""
+        d = {
+            'origin_node': 'node-x',
+            'htl': 5,
+            'visited': ['node-x', 'node-y'],
+            'path_folding_enabled': False
+        }
+
+        envelope = RoutingEnvelope.from_dict(d)
+        self.assertEqual(envelope.origin_node, 'node-x')
+        self.assertEqual(envelope.htl, 5)
+        self.assertIn('node-y', envelope.visited)
+        self.assertFalse(envelope.path_folding_enabled)
+
+
+class TestKleinbergRouter(unittest.TestCase):
+    """Tests for KleinbergRouter."""
+
+    def setUp(self):
+        """Set up test router with mock discovery."""
+        self.discovery = LocalDiscoveryClient()
+        self.discovery.clear()
+
+        # Register some mock nodes
+        self._register_mock_nodes()
+
+        self.router = KleinbergRouter(
+            local_node_id='local-node',
+            discovery_client=self.discovery,
+            alpha=2.0,
+            max_hops=5,
+            parallel_paths=1,
+            similarity_threshold=0.3,
+            path_folding_enabled=True
+        )
+
+    def _register_mock_nodes(self):
+        """Register mock KG nodes."""
+        # Node A: CSV expert
+        csv_centroid = np.array([0.8, 0.2, 0.1], dtype=np.float32)
+        self.discovery.register(
+            'kg_topology', 'node-a', 'localhost', 8081,
+            tags=['kg_node'],
+            metadata={
+                'semantic_centroid': base64.b64encode(csv_centroid.tobytes()).decode(),
+                'interface_topics': ['csv', 'data'],
+                'embedding_model': 'all-MiniLM-L6-v2'
+            }
+        )
+
+        # Node B: JSON expert
+        json_centroid = np.array([0.1, 0.8, 0.2], dtype=np.float32)
+        self.discovery.register(
+            'kg_topology', 'node-b', 'localhost', 8082,
+            tags=['kg_node'],
+            metadata={
+                'semantic_centroid': base64.b64encode(json_centroid.tobytes()).decode(),
+                'interface_topics': ['json', 'api'],
+                'embedding_model': 'all-MiniLM-L6-v2'
+            }
+        )
+
+    def tearDown(self):
+        """Clean up."""
+        self.discovery.clear()
+
+    def test_discover_nodes(self):
+        """Test node discovery."""
+        nodes = self.router.discover_nodes()
+        self.assertEqual(len(nodes), 2)
+
+        node_ids = {n.node_id for n in nodes}
+        self.assertIn('node-a', node_ids)
+        self.assertIn('node-b', node_ids)
+
+    def test_discover_nodes_decodes_centroid(self):
+        """Test centroid decoding from base64."""
+        nodes = self.router.discover_nodes()
+
+        for node in nodes:
+            self.assertIsInstance(node.centroid, np.ndarray)
+            self.assertEqual(node.centroid.dtype, np.float32)
+            self.assertEqual(len(node.centroid), 3)
+
+    def test_shortcut_management(self):
+        """Test shortcut creation and lookup."""
+        # No shortcut initially
+        self.assertIsNone(self.router.check_shortcut('test query'))
+
+        # Create shortcut
+        self.router.create_shortcut('test query', 'node-a')
+
+        # Check exists
+        self.assertEqual(self.router.check_shortcut('test query'), 'node-a')
+
+        # Remove shortcut
+        self.router.remove_shortcut('test query')
+        self.assertIsNone(self.router.check_shortcut('test query'))
+
+    def test_clear_shortcuts(self):
+        """Test clearing all shortcuts."""
+        self.router.create_shortcut('query1', 'node-a')
+        self.router.create_shortcut('query2', 'node-b')
+
+        self.router.clear_shortcuts()
+
+        self.assertIsNone(self.router.check_shortcut('query1'))
+        self.assertIsNone(self.router.check_shortcut('query2'))
+
+    def test_compute_routing_probability(self):
+        """Test softmax routing probability computation."""
+        nodes = self.router.discover_nodes()
+
+        # Query closer to CSV node
+        csv_query = np.array([0.9, 0.1, 0.0], dtype=np.float32)
+
+        probs = self.router.compute_routing_probability(nodes, csv_query)
+
+        # Should have probabilities summing to 1
+        total_prob = sum(p for _, p in probs)
+        self.assertAlmostEqual(total_prob, 1.0, places=5)
+
+        # First node should have highest probability (CSV expert)
+        self.assertGreater(probs[0][1], probs[1][1])
+
+    def test_get_stats(self):
+        """Test router statistics."""
+        # Create some shortcuts
+        self.router.create_shortcut('q1', 'node-a')
+        self.router.create_shortcut('q2', 'node-b')
+
+        stats = self.router.get_stats()
+
+        self.assertEqual(stats['local_node_id'], 'local-node')
+        self.assertEqual(stats['shortcuts'], 2)
+        self.assertEqual(stats['config']['alpha'], 2.0)
+        self.assertEqual(stats['config']['max_hops'], 5)
+
+
+class TestDistributedKGTopologyAPI(unittest.TestCase):
+    """Tests for DistributedKGTopologyAPI."""
+
+    def setUp(self):
+        """Set up test database."""
+        self.temp_db = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.temp_db.close()
+        self.db_path = self.temp_db.name
+
+        # Import here to avoid circular imports
+        from kg_topology_api import DistributedKGTopologyAPI
+        self.api = DistributedKGTopologyAPI(
+            db_path=self.db_path,
+            node_id='test-node',
+            discovery_backend='local'
+        )
+
+    def tearDown(self):
+        """Clean up."""
+        self.api.conn.close()
+        os.unlink(self.db_path)
+
+    def test_schema_creation(self):
+        """Test distributed schema tables are created."""
+        cursor = self.api.conn.cursor()
+
+        # Check query_shortcuts table
+        cursor.execute("""
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name='query_shortcuts'
+        """)
+        self.assertIsNotNone(cursor.fetchone())
+
+        # Check remote_nodes table
+        cursor.execute("""
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name='remote_nodes'
+        """)
+        self.assertIsNotNone(cursor.fetchone())
+
+        # Check distributed_query_log table
+        cursor.execute("""
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name='distributed_query_log'
+        """)
+        self.assertIsNotNone(cursor.fetchone())
+
+    def test_node_id_generation(self):
+        """Test node ID is generated correctly."""
+        self.assertEqual(self.api.node_id, 'test-node')
+
+        # Auto-generate from db path
+        from kg_topology_api import DistributedKGTopologyAPI
+        temp_db2 = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        temp_db2.close()
+        try:
+            api2 = DistributedKGTopologyAPI(db_path=temp_db2.name)
+            self.assertTrue(api2.node_id.startswith('node_'))
+            api2.conn.close()
+        finally:
+            os.unlink(temp_db2.name)
+
+    def test_create_shortcut(self):
+        """Test shortcut creation."""
+        self.api.create_shortcut('test query', 'target-node', 42)
+
+        shortcut = self.api._get_shortcut(
+            __import__('hashlib').sha256('test query'.encode()).hexdigest()[:16]
+        )
+        self.assertIsNotNone(shortcut)
+        self.assertEqual(shortcut['target_node_id'], 'target-node')
+        self.assertEqual(shortcut['target_interface_id'], 42)
+
+    def test_shortcut_usage_tracking(self):
+        """Test shortcut hit count updates."""
+        query_hash = __import__('hashlib').sha256('test query'.encode()).hexdigest()[:16]
+
+        self.api.create_shortcut('test query', 'target-node')
+
+        # Get initial hit count
+        cursor = self.api.conn.cursor()
+        cursor.execute("SELECT hit_count FROM query_shortcuts WHERE query_hash = ?",
+                      (query_hash,))
+        initial_count = cursor.fetchone()[0]
+        self.assertEqual(initial_count, 1)
+
+        # Update usage
+        self.api._update_shortcut_usage(query_hash)
+
+        cursor.execute("SELECT hit_count FROM query_shortcuts WHERE query_hash = ?",
+                      (query_hash,))
+        new_count = cursor.fetchone()[0]
+        self.assertEqual(new_count, 2)
+
+    def test_query_stats(self):
+        """Test query statistics."""
+        stats = self.api.get_query_stats()
+
+        self.assertEqual(stats['total_queries'], 0)
+        self.assertEqual(stats['avg_hops'], 0)
+        self.assertEqual(stats['shortcuts']['count'], 0)
+        self.assertEqual(stats['node_id'], 'test-node')
+
+    def test_prune_shortcuts(self):
+        """Test shortcut pruning."""
+        # Create shortcuts
+        self.api.create_shortcut('query1', 'node-a')
+        self.api.create_shortcut('query2', 'node-b')
+
+        # Prune with high min_hits (removes everything)
+        removed = self.api.prune_shortcuts(max_age_days=0, min_hits=100)
+        self.assertEqual(removed, 2)
+
+        # Verify gone
+        stats = self.api.get_query_stats()
+        self.assertEqual(stats['shortcuts']['count'], 0)
+
+    def test_get_router(self):
+        """Test router creation."""
+        router = self.api.get_router()
+        self.assertIsNotNone(router)
+        self.assertEqual(router.local_node_id, 'test-node')
+
+        # Same instance on second call
+        router2 = self.api.get_router()
+        self.assertIs(router, router2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_kg_distributed.sh
+++ b/tests/integration/test_kg_distributed.sh
@@ -1,0 +1,635 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Integration tests for KG Topology Phase 3: Distributed Network
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+# Helper function for test results
+pass() {
+    echo -e "  ${GREEN}[PASS]${NC} $1"
+    ((TESTS_PASSED++))
+}
+
+fail() {
+    echo -e "  ${RED}[FAIL]${NC} $1"
+    ((TESTS_FAILED++))
+}
+
+skip() {
+    echo -e "  ${YELLOW}[SKIP]${NC} $1"
+    ((TESTS_SKIPPED++))
+}
+
+echo "=========================================="
+echo "KG Topology Phase 3: Distributed Network"
+echo "Integration Tests"
+echo "=========================================="
+echo ""
+
+# =============================================================================
+# Group 1: Prolog Validation Tests
+# =============================================================================
+
+echo -e "${BLUE}[Group 1] Prolog Validation Tests${NC}"
+
+# Test 1.1: Valid routing strategies
+echo -n "  Testing valid routing strategies... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/core/service_validation'),
+    (   is_valid_routing_strategy(direct),
+        is_valid_routing_strategy(round_robin),
+        is_valid_routing_strategy(kleinberg),
+        is_valid_routing_strategy(kleinberg([alpha(2.0), max_hops(10)]))
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Valid routing strategies"
+else
+    fail "Valid routing strategies"
+fi
+
+# Test 1.2: Invalid routing strategies rejected
+echo -n "  Testing invalid strategies rejected... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/core/service_validation'),
+    (   \+ is_valid_routing_strategy(invalid_strategy),
+        \+ is_valid_routing_strategy(kleinberg([invalid_option(123)]))
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Invalid strategies rejected"
+else
+    fail "Invalid strategies rejected"
+fi
+
+# Test 1.3: Kleinberg options validation
+echo -n "  Testing Kleinberg options validation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/core/service_validation'),
+    (   is_valid_kleinberg_option(alpha(2.5)),
+        is_valid_kleinberg_option(max_hops(15)),
+        is_valid_kleinberg_option(parallel_paths(3)),
+        is_valid_kleinberg_option(similarity_threshold(0.7)),
+        is_valid_kleinberg_option(path_folding(true)),
+        \+ is_valid_kleinberg_option(alpha(-1)),
+        \+ is_valid_kleinberg_option(max_hops(0)),
+        \+ is_valid_kleinberg_option(similarity_threshold(1.5))
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Kleinberg options validation"
+else
+    fail "Kleinberg options validation"
+fi
+
+# Test 1.4: Discovery metadata validation
+echo -n "  Testing discovery metadata validation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/core/service_validation'),
+    (   is_valid_discovery_metadata_entry(semantic_centroid([0.1, 0.2, 0.3])),
+        is_valid_discovery_metadata_entry(semantic_centroid('base64string')),
+        is_valid_discovery_metadata_entry(interface_topics([csv, json, xml])),
+        is_valid_discovery_metadata_entry(embedding_model('all-MiniLM-L6-v2'))
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Discovery metadata validation"
+else
+    fail "Discovery metadata validation"
+fi
+
+# Test 1.5: is_kleinberg_routed helper
+echo -n "  Testing is_kleinberg_routed helper... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/core/service_validation'),
+    Service1 = service(test, [routing(kleinberg)], handler),
+    Service2 = service(test, [routing(kleinberg([alpha(2.0)]))], handler),
+    Service3 = service(test, [routing(direct)], handler),
+    (   is_kleinberg_routed(Service1),
+        is_kleinberg_routed(Service2),
+        \+ is_kleinberg_routed(Service3)
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "is_kleinberg_routed helper"
+else
+    fail "is_kleinberg_routed helper"
+fi
+
+# Test 1.6: Kleinberg option extraction
+echo -n "  Testing Kleinberg option extraction... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/core/service_validation'),
+    Service = service(test, [routing(kleinberg([alpha(3.0), max_hops(5)]))], handler),
+    (   get_kleinberg_alpha(Service, 3.0),
+        get_kleinberg_max_hops(Service, 5),
+        get_kleinberg_parallel_paths(Service, 1),  % default
+        get_kleinberg_similarity_threshold(Service, 0.5)  % default
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Kleinberg option extraction"
+else
+    fail "Kleinberg option extraction"
+fi
+
+echo ""
+
+# =============================================================================
+# Group 2: Python Discovery Client Tests
+# =============================================================================
+
+echo -e "${BLUE}[Group 2] Python Discovery Client Tests${NC}"
+
+# Test 2.1: LocalDiscoveryClient
+echo -n "  Testing LocalDiscoveryClient... "
+RESULT=$(python3 -c "
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from discovery_clients import LocalDiscoveryClient
+
+client = LocalDiscoveryClient()
+client.clear()
+
+# Register
+success = client.register('kg_topology', 'node-a', 'localhost', 8081,
+                         tags=['kg_node'], metadata={'key': 'value'})
+assert success, 'Registration failed'
+
+# Discover
+instances = client.discover('kg_topology')
+assert len(instances) == 1, f'Expected 1 instance, got {len(instances)}'
+assert instances[0].service_id == 'node-a', 'Wrong service_id'
+
+# Deregister
+success = client.deregister('node-a')
+assert success, 'Deregistration failed'
+
+instances = client.discover('kg_topology')
+assert len(instances) == 0, 'Instance still present after deregister'
+
+print('SUCCESS')
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "LocalDiscoveryClient"
+else
+    fail "LocalDiscoveryClient: $RESULT"
+fi
+
+# Test 2.2: Tag filtering
+echo -n "  Testing tag filtering... "
+RESULT=$(python3 -c "
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from discovery_clients import LocalDiscoveryClient
+
+client = LocalDiscoveryClient()
+client.clear()
+
+client.register('kg_topology', 'csv-node', 'localhost', 8081, tags=['kg_node', 'csv'])
+client.register('kg_topology', 'json-node', 'localhost', 8082, tags=['kg_node', 'json'])
+client.register('kg_topology', 'both-node', 'localhost', 8083, tags=['kg_node', 'csv', 'json'])
+
+# Filter by single tag
+csv_nodes = client.discover('kg_topology', tags=['csv'])
+assert len(csv_nodes) == 2, f'Expected 2 CSV nodes, got {len(csv_nodes)}'
+
+# Filter by multiple tags (AND)
+both = client.discover('kg_topology', tags=['csv', 'json'])
+assert len(both) == 1, f'Expected 1 both node, got {len(both)}'
+
+print('SUCCESS')
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Tag filtering"
+else
+    fail "Tag filtering: $RESULT"
+fi
+
+# Test 2.3: create_discovery_client factory
+echo -n "  Testing discovery client factory... "
+RESULT=$(python3 -c "
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from discovery_clients import create_discovery_client, LocalDiscoveryClient, ConsulDiscoveryClient
+
+local = create_discovery_client('local')
+assert isinstance(local, LocalDiscoveryClient)
+
+consul = create_discovery_client('consul', host='127.0.0.1', port=8500)
+assert isinstance(consul, ConsulDiscoveryClient)
+
+try:
+    create_discovery_client('unknown')
+    assert False, 'Should have raised ValueError'
+except ValueError:
+    pass
+
+print('SUCCESS')
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Discovery client factory"
+else
+    fail "Discovery client factory: $RESULT"
+fi
+
+echo ""
+
+# =============================================================================
+# Group 3: Kleinberg Router Tests
+# =============================================================================
+
+echo -e "${BLUE}[Group 3] Kleinberg Router Tests${NC}"
+
+# Test 3.1: Router initialization
+echo -n "  Testing router initialization... "
+RESULT=$(python3 -c "
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from kleinberg_router import KleinbergRouter
+from discovery_clients import LocalDiscoveryClient
+
+discovery = LocalDiscoveryClient()
+router = KleinbergRouter(
+    local_node_id='test-node',
+    discovery_client=discovery,
+    alpha=2.5,
+    max_hops=8
+)
+
+assert router.local_node_id == 'test-node'
+assert router.alpha == 2.5
+assert router.max_hops == 8
+
+print('SUCCESS')
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Router initialization"
+else
+    fail "Router initialization: $RESULT"
+fi
+
+# Test 3.2: Shortcut management
+echo -n "  Testing shortcut management... "
+RESULT=$(python3 -c "
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from kleinberg_router import KleinbergRouter
+from discovery_clients import LocalDiscoveryClient
+
+discovery = LocalDiscoveryClient()
+router = KleinbergRouter('test-node', discovery)
+
+# No shortcut initially
+assert router.check_shortcut('test query') is None
+
+# Create shortcut
+router.create_shortcut('test query', 'target-node')
+assert router.check_shortcut('test query') == 'target-node'
+
+# Remove shortcut
+router.remove_shortcut('test query')
+assert router.check_shortcut('test query') is None
+
+# Clear all
+router.create_shortcut('q1', 'n1')
+router.create_shortcut('q2', 'n2')
+router.clear_shortcuts()
+assert len(router.get_shortcuts()) == 0
+
+print('SUCCESS')
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Shortcut management"
+else
+    fail "Shortcut management: $RESULT"
+fi
+
+# Test 3.3: RoutingEnvelope serialization
+echo -n "  Testing RoutingEnvelope serialization... "
+RESULT=$(python3 -c "
+import sys
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from kleinberg_router import RoutingEnvelope
+
+envelope = RoutingEnvelope(
+    origin_node='node-a',
+    htl=8,
+    visited={'node-a', 'node-b'},
+    path_folding_enabled=True
+)
+
+d = envelope.to_dict()
+assert d['origin_node'] == 'node-a'
+assert d['htl'] == 8
+assert 'node-a' in d['visited']
+assert 'node-b' in d['visited']
+assert d['path_folding_enabled'] == True
+
+# Deserialize
+envelope2 = RoutingEnvelope.from_dict(d)
+assert envelope2.origin_node == 'node-a'
+assert envelope2.htl == 8
+assert 'node-b' in envelope2.visited
+
+print('SUCCESS')
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "RoutingEnvelope serialization"
+else
+    fail "RoutingEnvelope serialization: $RESULT"
+fi
+
+echo ""
+
+# =============================================================================
+# Group 4: DistributedKGTopologyAPI Tests
+# =============================================================================
+
+echo -e "${BLUE}[Group 4] DistributedKGTopologyAPI Tests${NC}"
+
+# Test 4.1: Schema creation
+echo -n "  Testing distributed schema creation... "
+RESULT=$(python3 -c "
+import sys
+import tempfile
+import os
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from kg_topology_api import DistributedKGTopologyAPI
+
+with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+    db_path = f.name
+
+try:
+    api = DistributedKGTopologyAPI(db_path, node_id='test-node')
+
+    # Check tables exist
+    cursor = api.conn.cursor()
+
+    cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='query_shortcuts'\")
+    assert cursor.fetchone() is not None, 'query_shortcuts table missing'
+
+    cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='remote_nodes'\")
+    assert cursor.fetchone() is not None, 'remote_nodes table missing'
+
+    cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='distributed_query_log'\")
+    assert cursor.fetchone() is not None, 'distributed_query_log table missing'
+
+    api.conn.close()
+    print('SUCCESS')
+finally:
+    os.unlink(db_path)
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Distributed schema creation"
+else
+    fail "Distributed schema creation: $RESULT"
+fi
+
+# Test 4.2: Shortcut persistence
+echo -n "  Testing shortcut persistence... "
+RESULT=$(python3 -c "
+import sys
+import tempfile
+import os
+import hashlib
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from kg_topology_api import DistributedKGTopologyAPI
+
+with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+    db_path = f.name
+
+try:
+    api = DistributedKGTopologyAPI(db_path, node_id='test-node')
+
+    # Create shortcut
+    api.create_shortcut('test query', 'target-node', 42)
+
+    # Verify in database
+    query_hash = hashlib.sha256('test query'.encode()).hexdigest()[:16]
+    shortcut = api._get_shortcut(query_hash)
+    assert shortcut is not None
+    assert shortcut['target_node_id'] == 'target-node'
+    assert shortcut['target_interface_id'] == 42
+
+    api.conn.close()
+    print('SUCCESS')
+finally:
+    os.unlink(db_path)
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Shortcut persistence"
+else
+    fail "Shortcut persistence: $RESULT"
+fi
+
+# Test 4.3: Query statistics
+echo -n "  Testing query statistics... "
+RESULT=$(python3 -c "
+import sys
+import tempfile
+import os
+sys.path.insert(0, '$PROJECT_ROOT/src/unifyweaver/targets/python_runtime')
+from kg_topology_api import DistributedKGTopologyAPI
+
+with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+    db_path = f.name
+
+try:
+    api = DistributedKGTopologyAPI(db_path, node_id='test-node')
+
+    stats = api.get_query_stats()
+    assert stats['total_queries'] == 0
+    assert stats['avg_hops'] == 0
+    assert stats['shortcuts']['count'] == 0
+    assert stats['node_id'] == 'test-node'
+
+    api.conn.close()
+    print('SUCCESS')
+finally:
+    os.unlink(db_path)
+" 2>&1)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Query statistics"
+else
+    fail "Query statistics: $RESULT"
+fi
+
+echo ""
+
+# =============================================================================
+# Group 5: Code Generation Tests
+# =============================================================================
+
+echo -e "${BLUE}[Group 5] Code Generation Tests${NC}"
+
+# Test 5.1: Python Kleinberg router generation
+echo -n "  Testing Python router code generation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/targets/python_target'),
+    compile_kleinberg_router_python([alpha(3.0), max_hops(8)], Code),
+    (   sub_string(Code, _, _, _, 'alpha=3.0'),
+        sub_string(Code, _, _, _, 'max_hops=8'),
+        sub_string(Code, _, _, _, 'KleinbergRouter')
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Python router code generation"
+else
+    fail "Python router code generation"
+fi
+
+# Test 5.2: Go Kleinberg router generation
+echo -n "  Testing Go router code generation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/targets/go_target'),
+    compile_kleinberg_router_go([alpha(2.5), parallel_paths(3)], Code),
+    (   sub_string(Code, _, _, _, 'Alpha'),
+        sub_string(Code, _, _, _, 'KleinbergRouter'),
+        sub_string(Code, _, _, _, 'sync.RWMutex')
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Go router code generation"
+else
+    fail "Go router code generation"
+fi
+
+# Test 5.3: Rust Kleinberg router generation
+echo -n "  Testing Rust router code generation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/targets/rust_target'),
+    compile_kleinberg_router_rust([similarity_threshold(0.6)], Code),
+    (   sub_string(Code, _, _, _, 'KleinbergRouter'),
+        sub_string(Code, _, _, _, 'RwLock'),
+        sub_string(Code, _, _, _, 'cosine_similarity')
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Rust router code generation"
+else
+    fail "Rust router code generation"
+fi
+
+# Test 5.4: KG endpoint generation (Python)
+echo -n "  Testing Python KG endpoint generation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/glue/network_glue'),
+    generate_kg_query_endpoint(python, [], Code),
+    (   sub_string(Code, _, _, _, '/kg/query'),
+        sub_string(Code, _, _, _, '/kg/register'),
+        sub_string(Code, _, _, _, '/kg/health'),
+        sub_string(Code, _, _, _, 'handle_remote_query')
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Python KG endpoint generation"
+else
+    fail "Python KG endpoint generation"
+fi
+
+# Test 5.5: KG endpoint generation (Go)
+echo -n "  Testing Go KG endpoint generation... "
+RESULT=$(swipl -g "
+    use_module('$PROJECT_ROOT/src/unifyweaver/glue/network_glue'),
+    generate_kg_query_endpoint(go, [], Code),
+    (   sub_string(Code, _, _, _, 'handleKGQuery'),
+        sub_string(Code, _, _, _, 'handleKGHealth'),
+        sub_string(Code, _, _, _, 'RegisterKGRoutes')
+    ->  writeln('SUCCESS')
+    ;   writeln('FAILED')
+    ),
+    halt.
+" 2>/dev/null)
+
+if [[ "$RESULT" == *"SUCCESS"* ]]; then
+    pass "Go KG endpoint generation"
+else
+    fail "Go KG endpoint generation"
+fi
+
+echo ""
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "  ${GREEN}Passed:${NC}  $TESTS_PASSED"
+echo -e "  ${RED}Failed:${NC}  $TESTS_FAILED"
+echo -e "  ${YELLOW}Skipped:${NC} $TESTS_SKIPPED"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

  - Implement KG Topology Phase 3: Distributed small-world network with Kleinberg routing
  - Add service discovery integration (Local, Consul, etcd stub, DNS stub)
  - Add inter-node query routing with HTL limits and path folding
  - Generate HTTP endpoints and router code for Python, Go, and Rust targets

  ## Changes

  ### Core Implementation
  - **service_validation.pl**: Add `routing(kleinberg)` validation with options (alpha, max_hops, parallel_paths, similarity_threshold, path_folding)
  - **discovery_clients.py**: Discovery client ABC with LocalDiscoveryClient, ConsulDiscoveryClient implementations
  - **kleinberg_router.py**: Greedy forwarding router with node caching, shortcuts, and softmax probability computation
  - **kg_topology_api.py**: Add `DistributedKGTopologyAPI` class with `distributed_search()`, `handle_remote_query()`, shortcut persistence

  ### Code Generation
  - **network_glue.pl**: Generate `/kg/query`, `/kg/register`, `/kg/health` endpoints for Python/Go/Rust
  - **python_target.pl**: Add `compile_kleinberg_router_python/2`
  - **go_target.pl**: Add `compile_kleinberg_router_go/2`
  - **rust_target.pl**: Add `compile_kleinberg_router_rust/2`

  ### Documentation & Tests
  - **KG_DISTRIBUTED_SETUP.md**: Setup guide for multi-node deployment
  - **ROADMAP_KG_TOPOLOGY.md**: Mark Phase 3 components as complete
  - **test_kg_distributed.py**: Unit tests for discovery clients, router, distributed API
  - **test_kg_distributed.sh**: Integration tests for Prolog validation and code generation

  ## Test plan

  - [ ] Run `./tests/integration/test_kg_distributed.sh`
  - [ ] Run `python -m pytest tests/core/test_kg_distributed.py -v`
  - [ ] Verify Prolog validation with `swipl -g "use_module('src/unifyweaver/core/service_validation'), is_valid_routing_strategy(kleinberg)."`

  � Generated with [Claude Code](https://claude.com/claude-code)