### PR TITLE
Feature/csharp query runtime ordering

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -60,7 +60,8 @@ The current implementation emits static C# builders that assemble the plan via n
 
 ## Current Limitations
 - Tail-recursive optimisation and memoised aggregates still fall back to iterative evaluation without specialised nodes.
-- Ordered outputs (`sort`, stable dedup) are not yet implemented; results follow hash-set semantics.
+- Ordering/paging are opt-in via query plan modifiers (`order_by/1`, `order_by/2`, `limit/1`, `offset/1`); default results follow hash-set semantics.
+- Stable ordered deduplication is not yet implemented.
 - Plans currently materialise relation facts inside the generated module; external fact providers will arrive in later releases.
 - Runtime assumes in-process execution (`dotnet run`); distributed execution and persistence hooks remain future work.
 
@@ -103,6 +104,9 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
   - `fixpoint(strategy(semi_naive|naive))`
   - `distinct(strategy(hash|ordered|none))`
   - `materialize(full|lazy)` to control when results are generated.
+- Query modifiers:
+  - `order_by(Index)`, `order_by(Index, asc|desc)`, `order_by([(Index, asc|desc), ...])` (0-based output column indices)
+  - `limit(N)`, `offset(N)`
 - The generic `target(csharp)` option will initially alias `csharp_query` for recursion-heavy workloads while allowing smart fallback (see comparison doc).
 
 ## Security & Isolation

--- a/scripts/testing/run_csharp_query_runtime_smoke.ps1
+++ b/scripts/testing/run_csharp_query_runtime_smoke.ps1
@@ -18,6 +18,9 @@ param(
     [string]$OutputDir = "tmp/csharp_query_smoke",
 
     [Parameter(Mandatory = $false)]
+    [string]$ProjectFilter = "csharp_query_*",
+
+    [Parameter(Mandatory = $false)]
     [switch]$KeepArtifacts,
 
     [Parameter(Mandatory = $false)]
@@ -135,7 +138,12 @@ function Invoke-NativeLogged {
 }
 
 $projectRoot = Resolve-ProjectRoot
-$outputPath = Join-Path $projectRoot $OutputDir
+
+$outputPath = if ([System.IO.Path]::IsPathRooted($OutputDir)) {
+    [System.IO.Path]::GetFullPath($OutputDir)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $projectRoot $OutputDir))
+}
 
 New-Item -ItemType Directory -Force -Path $outputPath | Out-Null
 
@@ -178,7 +186,7 @@ if (-not $SkipCodegen) {
 
 Assert-DotnetAvailable
 
-$projects = Get-ChildItem -Path $outputPath -Directory -Filter "csharp_query_*" | Where-Object {
+$projects = Get-ChildItem -Path $outputPath -Directory -Filter $ProjectFilter | Where-Object {
     Test-Path (Join-Path $_.FullName "expected_rows.txt")
 }
 


### PR DESCRIPTION
  - Adds new runtime plan nodes OrderByNode, LimitNode, OffsetNode and execution support in src/unifyweaver/targets/csharp_query_runtime/
    QueryRuntime.cs.
  - Extends the Prolog C# query plan compiler to accept order_by/1,2, limit/1, offset/1 options and render them into the corresponding
    runtime nodes in src/unifyweaver/targets/csharp_target.pl.
  - Applies query modifiers only at the final plan root (avoids altering fixpoint/recursion semantics).
  - Adds smoke-covered tests in tests/core/test_csharp_query_target.pl and documents modifiers in docs/targets/csharp-query-runtime.md.