### PR TITLE
feat(kg-topology): Phase 6e Cross-Model Federation

### DIFF
--- a/docs/proposals/CROSS_MODEL_FEDERATION.md
+++ b/docs/proposals/CROSS_MODEL_FEDERATION.md
@@ -1,8 +1,9 @@
 # Cross-Model Federation Proposal
 
-**Status:** Proposed
+**Status:** Implemented ✅
 **Date:** 2024-12-19
 **Prerequisites:** Phase 1-5 Complete, Phase 6a Complete
+**Implementation:** `src/unifyweaver/targets/python_runtime/cross_model_federation.py`
 **Related:** [KG_TOPOLOGY_FUTURE_WORK.md](KG_TOPOLOGY_FUTURE_WORK.md), [DENSITY_SCORING_PROPOSAL.md](DENSITY_SCORING_PROPOSAL.md)
 
 ## Problem Statement

--- a/docs/proposals/KG_TOPOLOGY_FUTURE_WORK.md
+++ b/docs/proposals/KG_TOPOLOGY_FUTURE_WORK.md
@@ -123,30 +123,35 @@ We have 200+ tests verifying correctness, but no performance data. Users need gu
 
 **Priority:** Low
 **Complexity:** High
-**Status:** Proposed
+**Status:** Complete ✅
 
 ### Problem
 
 Currently, all nodes must use the same embedding model. Real deployments might have legacy nodes with older models, or specialized nodes using domain-specific embeddings. Cosine similarity between vectors from different models is meaningless.
 
-### Approaches
+### Solution Implemented
 
-1. **Simple (Recommended First):** Reject cross-model queries, require model match in routing
-2. **Medium:** Group nodes by model, query each group separately, merge by raw scores
-3. **Complex:** Learn projection matrices between embedding spaces using shared anchor vocabulary
+Two-phase architecture that preserves density scoring within model pools:
+1. **Phase 1:** Query each model pool separately with full density/HDBSCAN support
+2. **Phase 2:** Fuse density-adjusted scores across pools (no embeddings needed)
 
-### Implementation Notes
+Key insight: After softmax normalization, scores become probabilities that ARE comparable across models.
 
-Nodes already advertise `embedding_model` in discovery metadata. The federation engine could:
-1. Filter nodes by model compatibility before routing
-2. Maintain model-specific aggregation pools
-3. Use score normalization rather than embedding comparison for cross-model merging
+### Deliverables
 
-### Open Questions (from DENSITY_SCORING_PROPOSAL.md)
+- [x] `cross_model_federation.py` - Core engine with 5 fusion methods
+- [x] `FusionMethod` enum: weighted_sum, rrf, consensus, geometric_mean, max
+- [x] `CrossModelFederatedEngine` with parallel pool querying
+- [x] `PoolRouter` - filters nodes by embedding_model metadata
+- [x] `AdaptiveModelWeights` - learns weights from feedback with persistence
+- [x] Prolog validation: 9 new predicates for cross_model options
+- [x] HTTP endpoints: /kg/cross-model, /kg/cross-model/pools, /kg/cross-model/weights, /kg/cross-model/feedback
+- [x] Python code generation: compile_cross_model_engine_python/2, compile_cross_model_service_python/2
+- [x] 39 unit tests passing
 
-- How to compare densities across incompatible embedding spaces?
-- Can we use dimensionality reduction (PCA/UMAP) to create compatible subspaces?
-- What's the quality loss from score-only aggregation?
+### See Also
+
+- `docs/proposals/CROSS_MODEL_FEDERATION.md` - Detailed design proposal
 
 ---
 
@@ -215,11 +220,11 @@ The `QA_KNOWLEDGE_GRAPH.md` proposal describes learning path generation that cou
 
 | Phase | Work Item | Priority | Complexity | Status |
 |-------|-----------|----------|------------|--------|
-| 6a | Production Deployment Guide | High | Medium | **Complete** |
+| 6a | Production Deployment Guide | High | Medium | **Complete** ✅ |
 | 6b | Performance Benchmarking | Medium | Medium | Pending |
 | 6c | Go Phase 5 | Medium | High | Pending |
 | 6d | Rust Phase 5 | Medium | High | Pending |
-| 6e | Cross-Model Federation | Low | High | Pending |
+| 6e | Cross-Model Federation | Low | High | **Complete** ✅ |
 | 6f | Adversarial Robustness | Low | High | Pending |
 
 ## References

--- a/src/unifyweaver/targets/python_runtime/cross_model_federation.py
+++ b/src/unifyweaver/targets/python_runtime/cross_model_federation.py
@@ -1,0 +1,1036 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# Cross-Model Federation for KG Topology Phase 6e.
+
+"""
+Cross-Model Federation Engine for KG Topology.
+
+Enables federation across nodes using different embedding models by:
+1. Grouping nodes into model pools (same embedding space)
+2. Running density-based federation within each pool
+3. Fusing results across pools using score/rank-based methods
+
+Key insight: While embeddings are incompatible across models, normalized
+probabilities (softmax outputs) are comparable.
+
+See: docs/proposals/CROSS_MODEL_FEDERATION.md
+"""
+
+import math
+import time
+import uuid
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import reduce
+from typing import List, Dict, Any, Optional, Callable, Tuple
+
+import numpy as np
+
+try:
+    from .federated_query import (
+        FederatedQueryEngine,
+        AggregationConfig,
+        AggregationStrategy,
+        AggregatedResult,
+        AggregatedResponse,
+        NodeResult,
+        NodeResponse,
+        ResultProvenance
+    )
+    from .kleinberg_router import KleinbergRouter, KGNode
+    from .discovery_clients import DiscoveryClient
+except ImportError:
+    from federated_query import (
+        FederatedQueryEngine,
+        AggregationConfig,
+        AggregationStrategy,
+        AggregatedResult,
+        AggregatedResponse,
+        NodeResult,
+        NodeResponse,
+        ResultProvenance
+    )
+    from kleinberg_router import KleinbergRouter, KGNode
+    from discovery_clients import DiscoveryClient
+
+
+# =============================================================================
+# FUSION METHODS
+# =============================================================================
+
+class FusionMethod(Enum):
+    """Methods for combining results across model pools."""
+    WEIGHTED_SUM = "weighted_sum"      # Σ w_m * P(answer|model_m)
+    RECIPROCAL_RANK = "rrf"            # Σ 1/(k + rank_m)
+    CONSENSUS = "consensus"            # Boost multi-pool agreement
+    GEOMETRIC_MEAN = "geometric_mean"  # (Π score_m)^(1/n)
+    MAX = "max"                        # max(score_m)
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+@dataclass
+class ModelPoolConfig:
+    """Configuration for a single model pool."""
+    model_name: str
+    weight: float = 1.0
+
+    # Intra-pool federation settings
+    federation_k: int = 5
+    aggregation_strategy: AggregationStrategy = AggregationStrategy.DENSITY_FLUX
+    use_adaptive_k: bool = False
+    use_hierarchical: bool = False
+
+    # Optional node filter
+    node_filter: Optional[Callable[[KGNode], bool]] = None
+
+
+@dataclass
+class CrossModelConfig:
+    """Configuration for cross-model federation."""
+    pools: List[ModelPoolConfig] = field(default_factory=list)
+
+    # Fusion settings
+    fusion_method: FusionMethod = FusionMethod.WEIGHTED_SUM
+
+    # RRF parameters
+    rrf_k: int = 60  # Smoothing constant for reciprocal rank
+
+    # Consensus parameters
+    consensus_threshold: float = 0.1   # Min probability for consideration
+    min_pools_for_consensus: int = 2   # Pools needed for boost
+    consensus_boost_factor: float = 1.5  # Multiplier for consensus
+
+    # Query settings
+    pool_timeout_ms: int = 30000
+    max_workers: int = 10
+
+    # Weight learning (Phase 6e-iv)
+    learn_weights: bool = False
+    weight_learning_rate: float = 0.01
+
+
+# =============================================================================
+# DATA STRUCTURES
+# =============================================================================
+
+@dataclass
+class PoolResult:
+    """Result from a single model pool with density information."""
+    answer_id: str
+    answer_text: str
+    answer_hash: str
+
+    # Scores
+    raw_score: float
+    exp_score: float
+    density_adjusted_score: float
+
+    # Density information (computed within pool)
+    density_score: float = 0.0
+    cluster_id: int = -1
+    cluster_size: int = 0
+    cluster_confidence: float = 0.0
+
+    # Provenance
+    source_nodes: List[str] = field(default_factory=list)
+    model_name: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'answer_id': self.answer_id,
+            'answer_text': self.answer_text,
+            'answer_hash': self.answer_hash,
+            'raw_score': self.raw_score,
+            'exp_score': self.exp_score,
+            'density_adjusted_score': self.density_adjusted_score,
+            'density_score': self.density_score,
+            'cluster_id': self.cluster_id,
+            'cluster_size': self.cluster_size,
+            'cluster_confidence': self.cluster_confidence,
+            'source_nodes': self.source_nodes,
+            'model_name': self.model_name
+        }
+
+
+@dataclass
+class PoolResponse:
+    """Aggregated response from a model pool."""
+    model_name: str
+    results: List[PoolResult]
+
+    # Pool-level statistics
+    total_results: int = 0
+    num_clusters: int = 0
+    avg_density: float = 0.0
+    partition_sum: float = 0.0
+
+    # Timing
+    query_time_ms: float = 0.0
+    nodes_queried: int = 0
+    nodes_responded: int = 0
+
+    # Error handling
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'model_name': self.model_name,
+            'results': [r.to_dict() for r in self.results],
+            'total_results': self.total_results,
+            'num_clusters': self.num_clusters,
+            'avg_density': self.avg_density,
+            'partition_sum': self.partition_sum,
+            'query_time_ms': self.query_time_ms,
+            'nodes_queried': self.nodes_queried,
+            'nodes_responded': self.nodes_responded,
+            'error': self.error
+        }
+
+
+@dataclass
+class PoolContribution:
+    """A pool's contribution to a fused result."""
+    model_name: str
+    probability: float
+    density: float
+    cluster_size: int
+    rank: int
+
+
+@dataclass
+class FusedResult:
+    """Result after cross-model fusion."""
+    answer_id: str
+    answer_text: str
+    answer_hash: str
+    fused_score: float
+
+    # Cross-pool information
+    num_pools: int = 0
+    consensus_strength: float = 0.0  # num_pools / total_pools
+    pool_contributions: Dict[str, PoolContribution] = field(default_factory=dict)
+
+    # For RRF
+    ranks_by_pool: Dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'answer_id': self.answer_id,
+            'answer_text': self.answer_text,
+            'answer_hash': self.answer_hash,
+            'fused_score': self.fused_score,
+            'num_pools': self.num_pools,
+            'consensus_strength': self.consensus_strength,
+            'pool_contributions': {
+                k: {
+                    'model_name': v.model_name,
+                    'probability': v.probability,
+                    'density': v.density,
+                    'cluster_size': v.cluster_size,
+                    'rank': v.rank
+                }
+                for k, v in self.pool_contributions.items()
+            },
+            'ranks_by_pool': self.ranks_by_pool
+        }
+
+
+@dataclass
+class CrossModelResponse:
+    """Final response from cross-model federated query."""
+    query_id: str
+    results: List[FusedResult]
+    pools_queried: List[str]
+    pools_responded: int
+    total_time_ms: float
+    fusion_method: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            '__type': 'kg_cross_model_response',
+            '__id': self.query_id,
+            'results': [r.to_dict() for r in self.results],
+            'pools_queried': self.pools_queried,
+            'pools_responded': self.pools_responded,
+            'total_time_ms': self.total_time_ms,
+            'fusion_method': self.fusion_method
+        }
+
+
+# =============================================================================
+# FUSION ALGORITHMS
+# =============================================================================
+
+def geometric_mean(values: List[float]) -> float:
+    """Geometric mean - rewards consistency across pools."""
+    if not values:
+        return 0.0
+    product = 1.0
+    for v in values:
+        product *= max(v, 1e-10)  # Avoid zero
+    return product ** (1.0 / len(values))
+
+
+def weighted_sum_fusion(
+    pool_responses: Dict[str, PoolResponse],
+    config: CrossModelConfig,
+    top_k: int
+) -> List[FusedResult]:
+    """Weighted sum of density-adjusted probabilities."""
+
+    # Build weight map from config
+    weight_map = {p.model_name: p.weight for p in config.pools}
+
+    answer_scores = defaultdict(float)
+    answer_metadata: Dict[str, Dict] = {}
+
+    for model, response in pool_responses.items():
+        if response.error or not response.results:
+            continue
+
+        weight = weight_map.get(model, 1.0)
+
+        # Normalize to probabilities within pool
+        total = sum(r.density_adjusted_score for r in response.results)
+
+        for rank, r in enumerate(sorted(
+            response.results, key=lambda x: -x.density_adjusted_score
+        ), start=1):
+            prob = r.density_adjusted_score / total if total > 0 else 0
+            answer_scores[r.answer_hash] += weight * prob
+
+            # Track metadata
+            if r.answer_hash not in answer_metadata:
+                answer_metadata[r.answer_hash] = {
+                    'answer_id': r.answer_id,
+                    'answer_text': r.answer_text,
+                    'pool_contributions': {}
+                }
+
+            answer_metadata[r.answer_hash]['pool_contributions'][model] = PoolContribution(
+                model_name=model,
+                probability=prob,
+                density=r.density_score,
+                cluster_size=r.cluster_size,
+                rank=rank
+            )
+
+    # Build final results
+    ranked = sorted(answer_scores.items(), key=lambda x: -x[1])
+    total_pools = len(pool_responses)
+
+    return [
+        FusedResult(
+            answer_id=answer_metadata[ahash]['answer_id'],
+            answer_text=answer_metadata[ahash]['answer_text'],
+            answer_hash=ahash,
+            fused_score=score,
+            num_pools=len(answer_metadata[ahash]['pool_contributions']),
+            consensus_strength=len(answer_metadata[ahash]['pool_contributions']) / total_pools,
+            pool_contributions=answer_metadata[ahash]['pool_contributions']
+        )
+        for ahash, score in ranked[:top_k]
+    ]
+
+
+def rrf_fusion(
+    pool_responses: Dict[str, PoolResponse],
+    config: CrossModelConfig,
+    top_k: int
+) -> List[FusedResult]:
+    """Reciprocal Rank Fusion - combines rankings, not scores."""
+
+    answer_rrf_scores = defaultdict(float)
+    answer_ranks: Dict[str, Dict[str, int]] = defaultdict(dict)
+    answer_metadata: Dict[str, Dict] = {}
+
+    for model, response in pool_responses.items():
+        if response.error or not response.results:
+            continue
+
+        # Sort by density-adjusted score to get ranks
+        sorted_results = sorted(
+            response.results,
+            key=lambda r: -r.density_adjusted_score
+        )
+
+        for rank, r in enumerate(sorted_results, start=1):
+            rrf_contribution = 1.0 / (config.rrf_k + rank)
+            answer_rrf_scores[r.answer_hash] += rrf_contribution
+            answer_ranks[r.answer_hash][model] = rank
+
+            if r.answer_hash not in answer_metadata:
+                answer_metadata[r.answer_hash] = {
+                    'answer_id': r.answer_id,
+                    'answer_text': r.answer_text
+                }
+
+    ranked = sorted(answer_rrf_scores.items(), key=lambda x: -x[1])
+    total_pools = len(pool_responses)
+
+    return [
+        FusedResult(
+            answer_id=answer_metadata[ahash]['answer_id'],
+            answer_text=answer_metadata[ahash]['answer_text'],
+            answer_hash=ahash,
+            fused_score=score,
+            num_pools=len(answer_ranks[ahash]),
+            consensus_strength=len(answer_ranks[ahash]) / total_pools,
+            ranks_by_pool=answer_ranks[ahash]
+        )
+        for ahash, score in ranked[:top_k]
+    ]
+
+
+def consensus_fusion(
+    pool_responses: Dict[str, PoolResponse],
+    config: CrossModelConfig,
+    top_k: int
+) -> List[FusedResult]:
+    """Boost answers with high density across multiple pools."""
+
+    # Build weight map from config
+    weight_map = {p.model_name: p.weight for p in config.pools}
+
+    answer_evidence: Dict[str, List[Dict]] = defaultdict(list)
+    answer_metadata: Dict[str, Dict] = {}
+
+    # Collect evidence from each pool
+    for model, response in pool_responses.items():
+        if response.error or not response.results:
+            continue
+
+        weight = weight_map.get(model, 1.0)
+
+        # Normalize probabilities
+        total = sum(r.density_adjusted_score for r in response.results)
+
+        for rank, r in enumerate(sorted(
+            response.results, key=lambda x: -x.density_adjusted_score
+        ), start=1):
+            prob = r.density_adjusted_score / total if total > 0 else 0
+
+            if prob >= config.consensus_threshold:
+                answer_evidence[r.answer_hash].append({
+                    'model': model,
+                    'probability': prob,
+                    'density': r.density_score,
+                    'cluster_size': r.cluster_size,
+                    'cluster_confidence': r.cluster_confidence,
+                    'weight': weight,
+                    'rank': rank
+                })
+
+                if r.answer_hash not in answer_metadata:
+                    answer_metadata[r.answer_hash] = {
+                        'answer_id': r.answer_id,
+                        'answer_text': r.answer_text
+                    }
+
+    # Compute fused scores with consensus boost
+    final_scores: Dict[str, Dict] = {}
+    total_pools = len(pool_responses)
+
+    for answer_hash, evidences in answer_evidence.items():
+        # Base score: weighted sum of probabilities
+        base_score = sum(e['probability'] * e['weight'] for e in evidences)
+
+        # Consensus boost: reward multi-pool agreement
+        num_pools = len(evidences)
+
+        if num_pools >= config.min_pools_for_consensus:
+            # Geometric mean of densities (rewards consistent high density)
+            densities = [e['density'] for e in evidences if e['density'] > 0]
+            if densities:
+                density_agreement = geometric_mean(densities)
+                # Boost proportional to agreement strength
+                boost = 1 + (config.consensus_boost_factor - 1) * density_agreement
+                base_score *= boost
+
+            # Additional boost for cluster size agreement
+            cluster_sizes = [e['cluster_size'] for e in evidences]
+            if min(cluster_sizes) >= 3:  # All pools have substantial clusters
+                base_score *= 1.1
+
+        # Build pool contributions
+        pool_contributions = {}
+        for e in evidences:
+            pool_contributions[e['model']] = PoolContribution(
+                model_name=e['model'],
+                probability=e['probability'],
+                density=e['density'],
+                cluster_size=e['cluster_size'],
+                rank=e['rank']
+            )
+
+        final_scores[answer_hash] = {
+            'score': base_score,
+            'num_pools': num_pools,
+            'pool_contributions': pool_contributions
+        }
+
+    ranked = sorted(final_scores.items(), key=lambda x: -x[1]['score'])
+
+    return [
+        FusedResult(
+            answer_id=answer_metadata[ahash]['answer_id'],
+            answer_text=answer_metadata[ahash]['answer_text'],
+            answer_hash=ahash,
+            fused_score=data['score'],
+            num_pools=data['num_pools'],
+            consensus_strength=data['num_pools'] / total_pools,
+            pool_contributions=data['pool_contributions']
+        )
+        for ahash, data in ranked[:top_k]
+        if ahash in answer_metadata
+    ]
+
+
+def geometric_mean_fusion(
+    pool_responses: Dict[str, PoolResponse],
+    config: CrossModelConfig,
+    top_k: int
+) -> List[FusedResult]:
+    """Geometric mean of probabilities across pools."""
+
+    answer_probs: Dict[str, List[float]] = defaultdict(list)
+    answer_metadata: Dict[str, Dict] = {}
+    answer_contributions: Dict[str, Dict[str, PoolContribution]] = defaultdict(dict)
+
+    for model, response in pool_responses.items():
+        if response.error or not response.results:
+            continue
+
+        # Normalize to probabilities within pool
+        total = sum(r.density_adjusted_score for r in response.results)
+
+        for rank, r in enumerate(sorted(
+            response.results, key=lambda x: -x.density_adjusted_score
+        ), start=1):
+            prob = r.density_adjusted_score / total if total > 0 else 0
+            answer_probs[r.answer_hash].append(prob)
+
+            if r.answer_hash not in answer_metadata:
+                answer_metadata[r.answer_hash] = {
+                    'answer_id': r.answer_id,
+                    'answer_text': r.answer_text
+                }
+
+            answer_contributions[r.answer_hash][model] = PoolContribution(
+                model_name=model,
+                probability=prob,
+                density=r.density_score,
+                cluster_size=r.cluster_size,
+                rank=rank
+            )
+
+    # Compute geometric mean for each answer
+    answer_scores = {
+        ahash: geometric_mean(probs)
+        for ahash, probs in answer_probs.items()
+    }
+
+    ranked = sorted(answer_scores.items(), key=lambda x: -x[1])
+    total_pools = len(pool_responses)
+
+    return [
+        FusedResult(
+            answer_id=answer_metadata[ahash]['answer_id'],
+            answer_text=answer_metadata[ahash]['answer_text'],
+            answer_hash=ahash,
+            fused_score=score,
+            num_pools=len(answer_probs[ahash]),
+            consensus_strength=len(answer_probs[ahash]) / total_pools,
+            pool_contributions=answer_contributions[ahash]
+        )
+        for ahash, score in ranked[:top_k]
+    ]
+
+
+def max_fusion(
+    pool_responses: Dict[str, PoolResponse],
+    config: CrossModelConfig,
+    top_k: int
+) -> List[FusedResult]:
+    """Take maximum probability across pools."""
+
+    answer_max: Dict[str, Tuple[float, str]] = {}  # hash -> (max_prob, best_model)
+    answer_metadata: Dict[str, Dict] = {}
+    answer_contributions: Dict[str, Dict[str, PoolContribution]] = defaultdict(dict)
+
+    for model, response in pool_responses.items():
+        if response.error or not response.results:
+            continue
+
+        # Normalize to probabilities within pool
+        total = sum(r.density_adjusted_score for r in response.results)
+
+        for rank, r in enumerate(sorted(
+            response.results, key=lambda x: -x.density_adjusted_score
+        ), start=1):
+            prob = r.density_adjusted_score / total if total > 0 else 0
+
+            if r.answer_hash not in answer_max or prob > answer_max[r.answer_hash][0]:
+                answer_max[r.answer_hash] = (prob, model)
+
+            if r.answer_hash not in answer_metadata:
+                answer_metadata[r.answer_hash] = {
+                    'answer_id': r.answer_id,
+                    'answer_text': r.answer_text
+                }
+
+            answer_contributions[r.answer_hash][model] = PoolContribution(
+                model_name=model,
+                probability=prob,
+                density=r.density_score,
+                cluster_size=r.cluster_size,
+                rank=rank
+            )
+
+    ranked = sorted(answer_max.items(), key=lambda x: -x[1][0])
+    total_pools = len(pool_responses)
+
+    return [
+        FusedResult(
+            answer_id=answer_metadata[ahash]['answer_id'],
+            answer_text=answer_metadata[ahash]['answer_text'],
+            answer_hash=ahash,
+            fused_score=max_prob,
+            num_pools=len(answer_contributions[ahash]),
+            consensus_strength=len(answer_contributions[ahash]) / total_pools,
+            pool_contributions=answer_contributions[ahash]
+        )
+        for ahash, (max_prob, _) in ranked[:top_k]
+    ]
+
+
+# =============================================================================
+# POOL ROUTER (filters nodes by model)
+# =============================================================================
+
+class PoolRouter:
+    """A router that only sees nodes for a specific embedding model."""
+
+    def __init__(
+        self,
+        base_router: KleinbergRouter,
+        model_name: str,
+        node_filter: Optional[Callable[[KGNode], bool]] = None
+    ):
+        self.base_router = base_router
+        self.model_name = model_name
+        self.node_filter = node_filter
+        self._filtered_nodes: Optional[List[KGNode]] = None
+
+    def discover_nodes(self, tags: Optional[List[str]] = None) -> List[KGNode]:
+        """Discover nodes filtered by embedding model."""
+        if self._filtered_nodes is None:
+            all_nodes = self.base_router.discover_nodes(tags)
+            self._filtered_nodes = [
+                n for n in all_nodes
+                if n.metadata.get('embedding_model') == self.model_name
+                and (self.node_filter is None or self.node_filter(n))
+            ]
+        return self._filtered_nodes
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get pool-specific stats."""
+        base_stats = self.base_router.get_stats()
+        return {
+            **base_stats,
+            'model_name': self.model_name,
+            'pool_size': len(self._filtered_nodes) if self._filtered_nodes else 0
+        }
+
+    # Delegate other methods to base router
+    def __getattr__(self, name):
+        return getattr(self.base_router, name)
+
+
+# =============================================================================
+# CROSS-MODEL FEDERATED ENGINE
+# =============================================================================
+
+class CrossModelFederatedEngine:
+    """
+    Federate queries across nodes with different embedding models.
+
+    Two-phase architecture:
+    1. Query each model pool in parallel (density scoring works within pool)
+    2. Fuse results across pools using score/rank-based methods
+    """
+
+    def __init__(
+        self,
+        router: KleinbergRouter,
+        config: CrossModelConfig,
+        embedding_fn: Optional[Callable[[str, str], np.ndarray]] = None
+    ):
+        """
+        Initialize cross-model engine.
+
+        Args:
+            router: Base router for node discovery
+            config: Cross-model configuration
+            embedding_fn: Function(text, model_name) -> embedding vector
+        """
+        self.router = router
+        self.config = config
+        self.embedding_fn = embedding_fn
+
+        # Pool engines (initialized lazily)
+        self.pool_engines: Dict[str, FederatedQueryEngine] = {}
+        self.pool_routers: Dict[str, PoolRouter] = {}
+
+        # Statistics
+        self.queries_executed = 0
+        self.total_latency_ms = 0.0
+
+    def discover_pools(self) -> Dict[str, List[str]]:
+        """
+        Discover and group nodes by embedding model.
+
+        Returns:
+            Dict mapping model_name -> list of node_ids
+        """
+        all_nodes = self.router.discover_nodes()
+        pools: Dict[str, List[str]] = defaultdict(list)
+
+        for node in all_nodes:
+            model = node.metadata.get('embedding_model', 'unknown')
+            pools[model].append(node.node_id)
+
+        return pools
+
+    def _init_pool_engine(self, pool_config: ModelPoolConfig) -> Optional[FederatedQueryEngine]:
+        """Initialize a FederatedQueryEngine for a model pool."""
+        model = pool_config.model_name
+
+        # Create pool-specific router
+        pool_router = PoolRouter(
+            base_router=self.router,
+            model_name=model,
+            node_filter=pool_config.node_filter
+        )
+
+        # Check if pool has any nodes
+        nodes = pool_router.discover_nodes()
+        if not nodes:
+            return None
+
+        self.pool_routers[model] = pool_router
+
+        # Create aggregation config
+        agg_config = AggregationConfig(
+            strategy=pool_config.aggregation_strategy,
+            dedup_key='answer_hash'
+        )
+
+        # Create engine (could use Adaptive/Hierarchical based on config)
+        engine = FederatedQueryEngine(
+            router=pool_router,
+            aggregation_config=agg_config,
+            timeout_ms=self.config.pool_timeout_ms
+        )
+
+        return engine
+
+    def _ensure_pool_engines(self):
+        """Lazily initialize pool engines."""
+        if self.pool_engines:
+            return
+
+        for pool_config in self.config.pools:
+            engine = self._init_pool_engine(pool_config)
+            if engine:
+                self.pool_engines[pool_config.model_name] = engine
+
+    def _get_embedding(self, text: str, model: str) -> Optional[np.ndarray]:
+        """Get embedding for text using specified model."""
+        if self.embedding_fn:
+            return self.embedding_fn(text, model)
+        return None
+
+    def _query_pool(
+        self,
+        model: str,
+        engine: FederatedQueryEngine,
+        query_text: str,
+        embedding: Optional[np.ndarray],
+        top_k: int,
+        federation_k: int
+    ) -> PoolResponse:
+        """Query a single model pool."""
+        start_time = time.time()
+
+        try:
+            # Execute federated query within pool
+            response = engine.federated_query(
+                query_text=query_text,
+                embedding=embedding,
+                top_k=top_k,
+                federation_k=federation_k
+            )
+
+            elapsed_ms = (time.time() - start_time) * 1000
+
+            # Convert to PoolResult format
+            pool_results = []
+            for r in response.results:
+                # r is a dict from AggregatedResult.to_dict()
+                pool_results.append(PoolResult(
+                    answer_id=str(r.get('answer_hash', '')),  # Use hash as ID for cross-model
+                    answer_text=r.get('answer_text', ''),
+                    answer_hash=r.get('answer_hash', ''),
+                    raw_score=r.get('combined_score', 0.0),
+                    exp_score=r.get('combined_score', 0.0),
+                    density_adjusted_score=r.get('combined_score', 0.0),
+                    density_score=r.get('density_score', 0.0),
+                    cluster_id=r.get('cluster_id', -1) or -1,
+                    cluster_size=r.get('node_count', 0),
+                    cluster_confidence=r.get('cluster_confidence', 0.0),
+                    source_nodes=r.get('source_nodes', []),
+                    model_name=model
+                ))
+
+            # Compute pool statistics
+            densities = [r.density_score for r in pool_results if r.density_score > 0]
+            cluster_ids = set(r.cluster_id for r in pool_results if r.cluster_id >= 0)
+
+            return PoolResponse(
+                model_name=model,
+                results=pool_results,
+                total_results=len(pool_results),
+                num_clusters=len(cluster_ids),
+                avg_density=sum(densities) / len(densities) if densities else 0.0,
+                partition_sum=response.total_partition_sum,
+                query_time_ms=elapsed_ms,
+                nodes_queried=response.nodes_queried,
+                nodes_responded=response.nodes_responded
+            )
+
+        except Exception as e:
+            elapsed_ms = (time.time() - start_time) * 1000
+            return PoolResponse(
+                model_name=model,
+                results=[],
+                query_time_ms=elapsed_ms,
+                error=str(e)
+            )
+
+    def federated_query(
+        self,
+        query_text: str,
+        top_k: int = 10,
+        federation_k: Optional[int] = None,
+        timeout_ms: Optional[int] = None
+    ) -> CrossModelResponse:
+        """
+        Execute cross-model federated query.
+
+        Args:
+            query_text: The query string
+            top_k: Number of results to return
+            federation_k: Nodes to query per pool (default from pool config)
+            timeout_ms: Total timeout (default from config)
+
+        Returns:
+            CrossModelResponse with fused results
+        """
+        query_id = str(uuid.uuid4())
+        start_time = time.time()
+        timeout_ms = timeout_ms or self.config.pool_timeout_ms
+
+        # Ensure pool engines are initialized
+        self._ensure_pool_engines()
+
+        if not self.pool_engines:
+            return CrossModelResponse(
+                query_id=query_id,
+                results=[],
+                pools_queried=[],
+                pools_responded=0,
+                total_time_ms=0.0,
+                fusion_method=self.config.fusion_method.value
+            )
+
+        # Phase 1: Query each pool in parallel
+        pool_responses: Dict[str, PoolResponse] = {}
+
+        with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
+            futures = {}
+
+            for pool_config in self.config.pools:
+                model = pool_config.model_name
+                engine = self.pool_engines.get(model)
+
+                if not engine:
+                    continue
+
+                # Get embedding for this model
+                embedding = self._get_embedding(query_text, model)
+
+                # Use pool-specific federation_k or default
+                pool_federation_k = federation_k or pool_config.federation_k
+
+                future = executor.submit(
+                    self._query_pool,
+                    model, engine, query_text, embedding, top_k, pool_federation_k
+                )
+                futures[future] = model
+
+            # Collect results
+            for future in as_completed(futures, timeout=timeout_ms / 1000):
+                model = futures[future]
+                try:
+                    pool_responses[model] = future.result()
+                except Exception as e:
+                    pool_responses[model] = PoolResponse(
+                        model_name=model,
+                        results=[],
+                        error=str(e)
+                    )
+
+        # Phase 2: Fuse results
+        if self.config.fusion_method == FusionMethod.WEIGHTED_SUM:
+            fused = weighted_sum_fusion(pool_responses, self.config, top_k)
+        elif self.config.fusion_method == FusionMethod.RECIPROCAL_RANK:
+            fused = rrf_fusion(pool_responses, self.config, top_k)
+        elif self.config.fusion_method == FusionMethod.CONSENSUS:
+            fused = consensus_fusion(pool_responses, self.config, top_k)
+        elif self.config.fusion_method == FusionMethod.GEOMETRIC_MEAN:
+            fused = geometric_mean_fusion(pool_responses, self.config, top_k)
+        elif self.config.fusion_method == FusionMethod.MAX:
+            fused = max_fusion(pool_responses, self.config, top_k)
+        else:
+            fused = weighted_sum_fusion(pool_responses, self.config, top_k)
+
+        elapsed_ms = (time.time() - start_time) * 1000
+
+        # Update statistics
+        self.queries_executed += 1
+        self.total_latency_ms += elapsed_ms
+
+        pools_responded = sum(
+            1 for r in pool_responses.values()
+            if r.error is None and r.results
+        )
+
+        return CrossModelResponse(
+            query_id=query_id,
+            results=fused,
+            pools_queried=list(pool_responses.keys()),
+            pools_responded=pools_responded,
+            total_time_ms=elapsed_ms,
+            fusion_method=self.config.fusion_method.value
+        )
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get engine statistics."""
+        return {
+            'queries_executed': self.queries_executed,
+            'avg_latency_ms': (
+                self.total_latency_ms / self.queries_executed
+                if self.queries_executed > 0 else 0.0
+            ),
+            'pools_configured': len(self.config.pools),
+            'pools_active': len(self.pool_engines),
+            'pool_stats': {
+                model: router.get_stats()
+                for model, router in self.pool_routers.items()
+            }
+        }
+
+
+# =============================================================================
+# WEIGHT LEARNING (Phase 6e-iv)
+# =============================================================================
+
+class AdaptiveModelWeights:
+    """Learn optimal model weights from user feedback."""
+
+    def __init__(
+        self,
+        models: List[str],
+        learning_rate: float = 0.01,
+        initial_weights: Optional[Dict[str, float]] = None
+    ):
+        if initial_weights:
+            self.weights = initial_weights.copy()
+        else:
+            # Start with uniform weights
+            n = len(models)
+            self.weights = {m: 1.0 / n for m in models}
+
+        self.learning_rate = learning_rate
+        self.feedback_count = 0
+        self.models = models
+
+    def update(
+        self,
+        chosen_answer: str,
+        pool_rankings: Dict[str, List[str]]  # model -> [answer_hashes in rank order]
+    ):
+        """
+        Update weights based on which models ranked chosen answer highest.
+
+        Args:
+            chosen_answer: Hash of the answer the user selected
+            pool_rankings: Rankings from each model pool
+        """
+        rewards = {}
+
+        for model, ranking in pool_rankings.items():
+            if chosen_answer in ranking:
+                rank = ranking.index(chosen_answer) + 1
+                # Higher reward for better rank (inverse rank)
+                rewards[model] = 1.0 / rank
+            else:
+                rewards[model] = 0.0
+
+        # Normalize rewards
+        total_reward = sum(rewards.values())
+        if total_reward > 0:
+            rewards = {m: r / total_reward for m, r in rewards.items()}
+
+        # Gradient update toward rewarded models
+        for model in self.weights:
+            target = rewards.get(model, 0.0)
+            current = self.weights[model]
+            self.weights[model] += self.learning_rate * (target - current)
+
+        # Renormalize weights to sum to 1
+        total = sum(self.weights.values())
+        if total > 0:
+            self.weights = {m: w / total for m, w in self.weights.items()}
+
+        self.feedback_count += 1
+
+    def get_weights(self) -> Dict[str, float]:
+        """Get current model weights."""
+        return self.weights.copy()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            'weights': self.weights,
+            'feedback_count': self.feedback_count,
+            'learning_rate': self.learning_rate
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'AdaptiveModelWeights':
+        """Deserialize from dictionary."""
+        obj = cls(
+            models=list(d['weights'].keys()),
+            learning_rate=d.get('learning_rate', 0.01),
+            initial_weights=d['weights']
+        )
+        obj.feedback_count = d.get('feedback_count', 0)
+        return obj

--- a/src/unifyweaver/targets/python_runtime/cross_model_federation.py
+++ b/src/unifyweaver/targets/python_runtime/cross_model_federation.py
@@ -1034,3 +1034,51 @@ class AdaptiveModelWeights:
         )
         obj.feedback_count = d.get('feedback_count', 0)
         return obj
+
+    def save_to_file(self, filepath: str) -> None:
+        """
+        Persist weights to a JSON file.
+
+        Args:
+            filepath: Path to save weights to
+        """
+        import json
+        with open(filepath, 'w') as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    def load_from_file(cls, filepath: str) -> 'AdaptiveModelWeights':
+        """
+        Load weights from a JSON file.
+
+        Args:
+            filepath: Path to load weights from
+
+        Returns:
+            AdaptiveModelWeights instance
+        """
+        import json
+        with open(filepath, 'r') as f:
+            return cls.from_dict(json.load(f))
+
+    def reset_weights(self) -> None:
+        """Reset weights to uniform distribution."""
+        n = len(self.weights)
+        self.weights = {m: 1.0 / n for m in self.weights}
+        self.feedback_count = 0
+
+    def set_weights(self, new_weights: Dict[str, float]) -> None:
+        """
+        Manually set model weights.
+
+        Args:
+            new_weights: Dict mapping model -> weight (will be normalized)
+        """
+        for model, weight in new_weights.items():
+            if model in self.weights:
+                self.weights[model] = weight
+
+        # Renormalize
+        total = sum(self.weights.values())
+        if total > 0:
+            self.weights = {m: w / total for m, w in self.weights.items()}

--- a/tests/core/test_cross_model_federation.py
+++ b/tests/core/test_cross_model_federation.py
@@ -1,0 +1,659 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+
+"""
+Unit tests for Cross-Model Federation (Phase 6e).
+"""
+
+import unittest
+from unittest.mock import Mock, MagicMock, patch
+from dataclasses import dataclass
+from typing import List, Dict, Any, Optional
+
+import numpy as np
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../src/unifyweaver/targets/python_runtime'))
+
+from cross_model_federation import (
+    # Enums
+    FusionMethod,
+    # Config
+    ModelPoolConfig,
+    CrossModelConfig,
+    # Data structures
+    PoolResult,
+    PoolResponse,
+    PoolContribution,
+    FusedResult,
+    CrossModelResponse,
+    # Fusion functions
+    weighted_sum_fusion,
+    rrf_fusion,
+    consensus_fusion,
+    geometric_mean_fusion,
+    max_fusion,
+    geometric_mean,
+    # Engine
+    PoolRouter,
+    CrossModelFederatedEngine,
+    # Weight learning
+    AdaptiveModelWeights
+)
+from federated_query import AggregationStrategy
+
+
+class TestFusionMethod(unittest.TestCase):
+    """Test FusionMethod enum."""
+
+    def test_enum_values(self):
+        """All fusion methods have correct string values."""
+        self.assertEqual(FusionMethod.WEIGHTED_SUM.value, "weighted_sum")
+        self.assertEqual(FusionMethod.RECIPROCAL_RANK.value, "rrf")
+        self.assertEqual(FusionMethod.CONSENSUS.value, "consensus")
+        self.assertEqual(FusionMethod.GEOMETRIC_MEAN.value, "geometric_mean")
+        self.assertEqual(FusionMethod.MAX.value, "max")
+
+
+class TestModelPoolConfig(unittest.TestCase):
+    """Test ModelPoolConfig data class."""
+
+    def test_default_values(self):
+        """Default values are correct."""
+        config = ModelPoolConfig(model_name="test-model")
+        self.assertEqual(config.model_name, "test-model")
+        self.assertEqual(config.weight, 1.0)
+        self.assertEqual(config.federation_k, 5)
+        self.assertEqual(config.aggregation_strategy, AggregationStrategy.DENSITY_FLUX)
+        self.assertFalse(config.use_adaptive_k)
+        self.assertFalse(config.use_hierarchical)
+        self.assertIsNone(config.node_filter)
+
+    def test_custom_values(self):
+        """Custom values are stored correctly."""
+        config = ModelPoolConfig(
+            model_name="custom-model",
+            weight=0.5,
+            federation_k=10,
+            aggregation_strategy=AggregationStrategy.SUM
+        )
+        self.assertEqual(config.weight, 0.5)
+        self.assertEqual(config.federation_k, 10)
+        self.assertEqual(config.aggregation_strategy, AggregationStrategy.SUM)
+
+
+class TestCrossModelConfig(unittest.TestCase):
+    """Test CrossModelConfig data class."""
+
+    def test_default_values(self):
+        """Default values are correct."""
+        config = CrossModelConfig()
+        self.assertEqual(config.pools, [])
+        self.assertEqual(config.fusion_method, FusionMethod.WEIGHTED_SUM)
+        self.assertEqual(config.rrf_k, 60)
+        self.assertEqual(config.consensus_threshold, 0.1)
+        self.assertEqual(config.min_pools_for_consensus, 2)
+        self.assertEqual(config.consensus_boost_factor, 1.5)
+        self.assertEqual(config.pool_timeout_ms, 30000)
+
+    def test_with_pools(self):
+        """Configuration with pools."""
+        config = CrossModelConfig(
+            pools=[
+                ModelPoolConfig(model_name="model-a", weight=0.6),
+                ModelPoolConfig(model_name="model-b", weight=0.4)
+            ],
+            fusion_method=FusionMethod.CONSENSUS
+        )
+        self.assertEqual(len(config.pools), 2)
+        self.assertEqual(config.fusion_method, FusionMethod.CONSENSUS)
+
+
+class TestPoolResult(unittest.TestCase):
+    """Test PoolResult data class."""
+
+    def test_creation(self):
+        """PoolResult can be created with required fields."""
+        result = PoolResult(
+            answer_id="ans_1",
+            answer_text="Test answer",
+            answer_hash="hash123",
+            raw_score=0.8,
+            exp_score=2.23,
+            density_adjusted_score=1.89
+        )
+        self.assertEqual(result.answer_id, "ans_1")
+        self.assertEqual(result.density_score, 0.0)  # default
+        self.assertEqual(result.cluster_id, -1)  # default
+
+    def test_to_dict(self):
+        """to_dict serializes correctly."""
+        result = PoolResult(
+            answer_id="ans_1",
+            answer_text="Test answer",
+            answer_hash="hash123",
+            raw_score=0.8,
+            exp_score=2.23,
+            density_adjusted_score=1.89,
+            density_score=0.7,
+            cluster_id=2,
+            source_nodes=["node_a", "node_b"],
+            model_name="test-model"
+        )
+        d = result.to_dict()
+        self.assertEqual(d['answer_id'], "ans_1")
+        self.assertEqual(d['density_score'], 0.7)
+        self.assertEqual(d['cluster_id'], 2)
+        self.assertEqual(d['model_name'], "test-model")
+
+
+class TestPoolResponse(unittest.TestCase):
+    """Test PoolResponse data class."""
+
+    def test_creation(self):
+        """PoolResponse can be created."""
+        response = PoolResponse(
+            model_name="test-model",
+            results=[],
+            total_results=0
+        )
+        self.assertEqual(response.model_name, "test-model")
+        self.assertIsNone(response.error)
+
+    def test_with_error(self):
+        """PoolResponse can capture errors."""
+        response = PoolResponse(
+            model_name="test-model",
+            results=[],
+            error="Connection timeout"
+        )
+        self.assertEqual(response.error, "Connection timeout")
+
+
+class TestFusedResult(unittest.TestCase):
+    """Test FusedResult data class."""
+
+    def test_creation(self):
+        """FusedResult can be created."""
+        result = FusedResult(
+            answer_id="ans_1",
+            answer_text="Test answer",
+            answer_hash="hash123",
+            fused_score=0.85,
+            num_pools=3,
+            consensus_strength=1.0
+        )
+        self.assertEqual(result.fused_score, 0.85)
+        self.assertEqual(result.num_pools, 3)
+        self.assertEqual(result.consensus_strength, 1.0)
+
+    def test_to_dict(self):
+        """to_dict serializes correctly."""
+        result = FusedResult(
+            answer_id="ans_1",
+            answer_text="Test answer",
+            answer_hash="hash123",
+            fused_score=0.85,
+            num_pools=2,
+            consensus_strength=0.67,
+            pool_contributions={
+                "model-a": PoolContribution(
+                    model_name="model-a",
+                    probability=0.8,
+                    density=0.7,
+                    cluster_size=5,
+                    rank=1
+                )
+            }
+        )
+        d = result.to_dict()
+        self.assertEqual(d['fused_score'], 0.85)
+        self.assertIn('model-a', d['pool_contributions'])
+
+
+class TestGeometricMean(unittest.TestCase):
+    """Test geometric_mean helper function."""
+
+    def test_empty_list(self):
+        """Empty list returns 0."""
+        self.assertEqual(geometric_mean([]), 0.0)
+
+    def test_single_value(self):
+        """Single value returns itself."""
+        self.assertAlmostEqual(geometric_mean([0.5]), 0.5)
+
+    def test_multiple_values(self):
+        """Multiple values compute correctly."""
+        # geometric_mean([4, 9]) = sqrt(36) = 6
+        # But we're dealing with probabilities, so:
+        # geometric_mean([0.5, 0.5]) = 0.5
+        self.assertAlmostEqual(geometric_mean([0.5, 0.5]), 0.5)
+        # geometric_mean([0.25, 1.0]) = sqrt(0.25) = 0.5
+        self.assertAlmostEqual(geometric_mean([0.25, 1.0]), 0.5)
+
+    def test_handles_zero(self):
+        """Zero values are handled (clamped to small epsilon)."""
+        result = geometric_mean([0.0, 1.0])
+        self.assertGreater(result, 0)
+        self.assertLess(result, 0.1)  # Should be very small
+
+
+class TestWeightedSumFusion(unittest.TestCase):
+    """Test weighted_sum_fusion function."""
+
+    def _make_pool_responses(self) -> Dict[str, PoolResponse]:
+        """Create test pool responses."""
+        return {
+            "model-a": PoolResponse(
+                model_name="model-a",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="Answer 1", answer_hash="hash1",
+                        raw_score=0.8, exp_score=2.23, density_adjusted_score=0.8,
+                        density_score=0.7, cluster_size=5
+                    ),
+                    PoolResult(
+                        answer_id="2", answer_text="Answer 2", answer_hash="hash2",
+                        raw_score=0.6, exp_score=1.82, density_adjusted_score=0.6,
+                        density_score=0.5, cluster_size=3
+                    )
+                ]
+            ),
+            "model-b": PoolResponse(
+                model_name="model-b",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="Answer 1", answer_hash="hash1",
+                        raw_score=0.7, exp_score=2.01, density_adjusted_score=0.7,
+                        density_score=0.6, cluster_size=4
+                    ),
+                    PoolResult(
+                        answer_id="3", answer_text="Answer 3", answer_hash="hash3",
+                        raw_score=0.5, exp_score=1.65, density_adjusted_score=0.5,
+                        density_score=0.4, cluster_size=2
+                    )
+                ]
+            )
+        }
+
+    def test_basic_fusion(self):
+        """Basic weighted sum fusion works."""
+        config = CrossModelConfig(
+            pools=[
+                ModelPoolConfig(model_name="model-a", weight=0.5),
+                ModelPoolConfig(model_name="model-b", weight=0.5)
+            ]
+        )
+        pool_responses = self._make_pool_responses()
+
+        results = weighted_sum_fusion(pool_responses, config, top_k=5)
+
+        self.assertGreater(len(results), 0)
+        # hash1 appears in both pools, should have highest score
+        self.assertEqual(results[0].answer_hash, "hash1")
+        self.assertEqual(results[0].num_pools, 2)
+
+    def test_respects_weights(self):
+        """Fusion respects model weights."""
+        config = CrossModelConfig(
+            pools=[
+                ModelPoolConfig(model_name="model-a", weight=0.9),
+                ModelPoolConfig(model_name="model-b", weight=0.1)
+            ]
+        )
+        pool_responses = self._make_pool_responses()
+
+        results = weighted_sum_fusion(pool_responses, config, top_k=5)
+
+        # hash1 is in both, but model-a weighted higher
+        # Check that consensus_strength is correct
+        self.assertEqual(results[0].num_pools, 2)
+
+    def test_handles_empty_pool(self):
+        """Handles pools with no results."""
+        config = CrossModelConfig(
+            pools=[
+                ModelPoolConfig(model_name="model-a", weight=0.5),
+                ModelPoolConfig(model_name="model-b", weight=0.5)
+            ]
+        )
+        pool_responses = {
+            "model-a": PoolResponse(model_name="model-a", results=[]),
+            "model-b": self._make_pool_responses()["model-b"]
+        }
+
+        results = weighted_sum_fusion(pool_responses, config, top_k=5)
+        self.assertGreater(len(results), 0)
+
+
+class TestRRFFusion(unittest.TestCase):
+    """Test rrf_fusion function."""
+
+    def test_basic_rrf(self):
+        """Basic RRF fusion works."""
+        config = CrossModelConfig(rrf_k=60)
+        pool_responses = {
+            "model-a": PoolResponse(
+                model_name="model-a",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.8, exp_score=2.2, density_adjusted_score=0.8
+                    ),
+                    PoolResult(
+                        answer_id="2", answer_text="A2", answer_hash="h2",
+                        raw_score=0.6, exp_score=1.8, density_adjusted_score=0.6
+                    )
+                ]
+            ),
+            "model-b": PoolResponse(
+                model_name="model-b",
+                results=[
+                    PoolResult(
+                        answer_id="2", answer_text="A2", answer_hash="h2",
+                        raw_score=0.9, exp_score=2.5, density_adjusted_score=0.9
+                    ),
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.7, exp_score=2.0, density_adjusted_score=0.7
+                    )
+                ]
+            )
+        }
+
+        results = rrf_fusion(pool_responses, config, top_k=5)
+
+        # Both answers appear in both pools
+        self.assertEqual(len(results), 2)
+        # h2 is rank 1 in model-b, h1 is rank 1 in model-a
+        # RRF should give them similar scores since they trade top spots
+        for r in results:
+            self.assertEqual(r.num_pools, 2)
+
+    def test_rrf_rank_tracking(self):
+        """RRF tracks ranks by pool."""
+        config = CrossModelConfig(rrf_k=60)
+        pool_responses = {
+            "model-a": PoolResponse(
+                model_name="model-a",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.8, exp_score=2.2, density_adjusted_score=0.8
+                    )
+                ]
+            )
+        }
+
+        results = rrf_fusion(pool_responses, config, top_k=5)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].ranks_by_pool["model-a"], 1)
+
+
+class TestConsensusFusion(unittest.TestCase):
+    """Test consensus_fusion function."""
+
+    def test_consensus_boost(self):
+        """Answers in multiple pools get boosted."""
+        config = CrossModelConfig(
+            pools=[
+                ModelPoolConfig(model_name="model-a", weight=0.5),
+                ModelPoolConfig(model_name="model-b", weight=0.5)
+            ],
+            consensus_threshold=0.1,
+            min_pools_for_consensus=2,
+            consensus_boost_factor=1.5
+        )
+        pool_responses = {
+            "model-a": PoolResponse(
+                model_name="model-a",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.8, exp_score=2.2, density_adjusted_score=0.8,
+                        density_score=0.7, cluster_size=5
+                    )
+                ]
+            ),
+            "model-b": PoolResponse(
+                model_name="model-b",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.7, exp_score=2.0, density_adjusted_score=0.7,
+                        density_score=0.6, cluster_size=4
+                    )
+                ]
+            )
+        }
+
+        results = consensus_fusion(pool_responses, config, top_k=5)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].num_pools, 2)
+        # Score should be boosted (base * boost)
+        # Base = 0.5*1.0 + 0.5*1.0 = 1.0 (normalized within each pool)
+        # Boost = 1 + 0.5 * geom_mean([0.7, 0.6])
+        self.assertGreater(results[0].fused_score, 0)
+
+
+class TestMaxFusion(unittest.TestCase):
+    """Test max_fusion function."""
+
+    def test_takes_maximum(self):
+        """Max fusion takes highest probability."""
+        config = CrossModelConfig()
+        pool_responses = {
+            "model-a": PoolResponse(
+                model_name="model-a",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.3, exp_score=1.35, density_adjusted_score=0.3
+                    )
+                ]
+            ),
+            "model-b": PoolResponse(
+                model_name="model-b",
+                results=[
+                    PoolResult(
+                        answer_id="1", answer_text="A1", answer_hash="h1",
+                        raw_score=0.9, exp_score=2.46, density_adjusted_score=0.9
+                    )
+                ]
+            )
+        }
+
+        results = max_fusion(pool_responses, config, top_k=5)
+
+        self.assertEqual(len(results), 1)
+        # Should take the higher normalized probability (from model-b)
+        self.assertGreater(results[0].fused_score, 0.5)
+
+
+class TestAdaptiveModelWeights(unittest.TestCase):
+    """Test AdaptiveModelWeights class."""
+
+    def test_initial_uniform_weights(self):
+        """Weights start uniform."""
+        weights = AdaptiveModelWeights(["a", "b", "c"])
+        w = weights.get_weights()
+        self.assertAlmostEqual(w["a"], 1/3, places=5)
+        self.assertAlmostEqual(w["b"], 1/3, places=5)
+        self.assertAlmostEqual(w["c"], 1/3, places=5)
+
+    def test_custom_initial_weights(self):
+        """Custom initial weights are respected."""
+        weights = AdaptiveModelWeights(
+            ["a", "b"],
+            initial_weights={"a": 0.8, "b": 0.2}
+        )
+        w = weights.get_weights()
+        self.assertAlmostEqual(w["a"], 0.8)
+        self.assertAlmostEqual(w["b"], 0.2)
+
+    def test_update_increases_winner_weight(self):
+        """Update increases weight of model that ranked answer highest."""
+        weights = AdaptiveModelWeights(["a", "b"], learning_rate=0.1)
+
+        # Model 'a' ranked answer at position 1, model 'b' at position 5
+        weights.update(
+            chosen_answer="ans1",
+            pool_rankings={
+                "a": ["ans1", "ans2", "ans3"],
+                "b": ["ans2", "ans3", "ans4", "ans5", "ans1"]
+            }
+        )
+
+        w = weights.get_weights()
+        # Model 'a' should have higher weight now
+        self.assertGreater(w["a"], w["b"])
+
+    def test_update_increments_count(self):
+        """Feedback count is incremented."""
+        weights = AdaptiveModelWeights(["a", "b"])
+        self.assertEqual(weights.feedback_count, 0)
+
+        weights.update("ans1", {"a": ["ans1"], "b": ["ans2", "ans1"]})
+
+        self.assertEqual(weights.feedback_count, 1)
+
+    def test_serialization(self):
+        """Weights can be serialized and deserialized."""
+        weights = AdaptiveModelWeights(["a", "b"])
+        weights.update("ans1", {"a": ["ans1"], "b": ["ans2"]})
+
+        d = weights.to_dict()
+        restored = AdaptiveModelWeights.from_dict(d)
+
+        self.assertEqual(restored.get_weights(), weights.get_weights())
+        self.assertEqual(restored.feedback_count, weights.feedback_count)
+
+
+class TestCrossModelFederatedEngine(unittest.TestCase):
+    """Test CrossModelFederatedEngine class."""
+
+    def _create_mock_router(self, nodes: List[Dict]) -> Mock:
+        """Create a mock router with specified nodes."""
+        mock_router = Mock()
+
+        # Create mock KGNode objects
+        mock_nodes = []
+        for n in nodes:
+            node = Mock()
+            node.node_id = n['node_id']
+            node.metadata = n.get('metadata', {})
+            mock_nodes.append(node)
+
+        mock_router.discover_nodes.return_value = mock_nodes
+        mock_router.get_stats.return_value = {}
+        return mock_router
+
+    def test_discover_pools(self):
+        """discover_pools groups nodes by embedding_model."""
+        router = self._create_mock_router([
+            {'node_id': 'n1', 'metadata': {'embedding_model': 'model-a'}},
+            {'node_id': 'n2', 'metadata': {'embedding_model': 'model-a'}},
+            {'node_id': 'n3', 'metadata': {'embedding_model': 'model-b'}},
+            {'node_id': 'n4', 'metadata': {}},  # unknown model
+        ])
+
+        config = CrossModelConfig()
+        engine = CrossModelFederatedEngine(router, config)
+
+        pools = engine.discover_pools()
+
+        self.assertEqual(len(pools['model-a']), 2)
+        self.assertEqual(len(pools['model-b']), 1)
+        self.assertEqual(len(pools['unknown']), 1)
+
+    def test_get_stats(self):
+        """get_stats returns engine statistics."""
+        router = self._create_mock_router([])
+        config = CrossModelConfig()
+        engine = CrossModelFederatedEngine(router, config)
+
+        stats = engine.get_stats()
+
+        self.assertIn('queries_executed', stats)
+        self.assertIn('avg_latency_ms', stats)
+        self.assertIn('pools_configured', stats)
+
+    def test_empty_pools_returns_empty_response(self):
+        """Query with no pools returns empty response."""
+        router = self._create_mock_router([])
+        config = CrossModelConfig()
+        engine = CrossModelFederatedEngine(router, config)
+
+        response = engine.federated_query("test query")
+
+        self.assertEqual(len(response.results), 0)
+        self.assertEqual(response.pools_responded, 0)
+
+
+class TestPoolRouter(unittest.TestCase):
+    """Test PoolRouter class."""
+
+    def test_filters_by_model(self):
+        """PoolRouter only returns nodes with matching model."""
+        base_router = Mock()
+
+        node_a = Mock()
+        node_a.node_id = 'n1'
+        node_a.metadata = {'embedding_model': 'model-a'}
+
+        node_b = Mock()
+        node_b.node_id = 'n2'
+        node_b.metadata = {'embedding_model': 'model-b'}
+
+        base_router.discover_nodes.return_value = [node_a, node_b]
+
+        pool_router = PoolRouter(base_router, 'model-a')
+        nodes = pool_router.discover_nodes()
+
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].node_id, 'n1')
+
+    def test_caches_filtered_nodes(self):
+        """Filtered nodes are cached."""
+        base_router = Mock()
+        base_router.discover_nodes.return_value = []
+
+        pool_router = PoolRouter(base_router, 'model-a')
+
+        # Call twice
+        pool_router.discover_nodes()
+        pool_router.discover_nodes()
+
+        # Base router should only be called once
+        base_router.discover_nodes.assert_called_once()
+
+    def test_custom_node_filter(self):
+        """Custom node filter is applied."""
+        base_router = Mock()
+
+        node_1 = Mock()
+        node_1.node_id = 'n1'
+        node_1.metadata = {'embedding_model': 'model-a', 'region': 'us'}
+
+        node_2 = Mock()
+        node_2.node_id = 'n2'
+        node_2.metadata = {'embedding_model': 'model-a', 'region': 'eu'}
+
+        base_router.discover_nodes.return_value = [node_1, node_2]
+
+        # Filter to only 'us' region
+        pool_router = PoolRouter(
+            base_router, 'model-a',
+            node_filter=lambda n: n.metadata.get('region') == 'us'
+        )
+        nodes = pool_router.discover_nodes()
+
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].node_id, 'n1')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary                                                                                                          
                                                                                                                    
- Implements cross-model federation for KG Topology, enabling queries across nodes using different embedding models 
- Two-phase architecture: density scoring within model pools, score fusion across pools                             
- Key insight: softmax-normalized scores are comparable probabilities across embedding spaces                       
                                                                                                                    
## Changes                                                                                                          
                                                                                                                    
| File | Lines | Description |                                                                                      
|------|-------|-------------|                                                                                      
| `cross_model_federation.py` | +1084 | Core engine, 5 fusion methods, weight learning |                            
| `test_cross_model_federation.py` | +776 | 39 unit tests |                                                         
| `service_validation.pl` | +115 | 9 Prolog validation predicates |                                                 
| `network_glue.pl` | +210 | HTTP endpoint generation (Python/Go/Rust) |                                            
| `python_target.pl` | +173 | Code generation predicates |                                                          
                                                                                                                    
## Features                                                                                                         
                                                                                                                    
**Fusion Methods:**                                                                                                 
- `weighted_sum` - Weighted probability aggregation                                                                 
- `rrf` - Reciprocal Rank Fusion (score-agnostic)                                                                   
- `consensus` - Boost multi-pool agreement via geometric mean of densities                                          
- `geometric_mean` - Rewards consistent scores across pools                                                         
- `max` - Take maximum probability                                                                                  
                                                                                                                    
**HTTP Endpoints:**                                                                                                 
- `POST /kg/cross-model` - Execute cross-model query                                                                
- `GET /kg/cross-model/pools` - List available model pools                                                          
- `GET/PUT /kg/cross-model/weights` - Get/set model weights                                                         
- `POST /kg/cross-model/feedback` - Relevance feedback for weight learning                                          
                                                                                                                    
**Weight Learning:**                                                                                                
- `AdaptiveModelWeights` with inverse rank rewards                                                                  
- File persistence via `save_to_file()` / `load_from_file()`                                                        
                                                                                                                    
## Test plan                                                                                                        
                                                                                                                    
- [x] 39 unit tests passing                                                                                         
- [x] Prolog validation predicates tested                                                                           
- [ ] Manual testing with multi-model cluster                                                                       
                                                                                                                    
� Generated with [Claude Code](https://claude.com/claude-code)                                                      