### PR TITLE
feat(csharp-query): add avg aggregate support

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -107,6 +107,8 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
 - Query modifiers:
   - `order_by(Index)`, `order_by(Index, asc|desc)`, `order_by([(Index, asc|desc), ...])` (0-based output column indices)
   - `limit(N)`, `offset(N)`
+- Aggregates:
+  - `count`, `sum(Var)`, `avg(Var)`, `min(Var)`, `max(Var)`, `set(Var)`, `bag(Var)` via `aggregate_all/3,4` and `aggregate/4`
 - The generic `target(csharp)` option will initially alias `csharp_query` for recursion-heavy workloads while allowing smart fallback (see comparison doc).
 
 ## Security & Isolation

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -49,6 +49,7 @@ namespace UnifyWeaver.QueryRuntime
     {
         Count,
         Sum,
+        Avg,
         Min,
         Max,
         Set,
@@ -1555,6 +1556,11 @@ namespace UnifyWeaver.QueryRuntime
                         hasAny = true;
                         break;
 
+                    case AggregateOperation.Avg:
+                        sum += ConvertToDecimal(row, aggregate.ValueIndex);
+                        hasAny = true;
+                        break;
+
                     case AggregateOperation.Min:
                     {
                         var value = ConvertToDecimal(row, aggregate.ValueIndex);
@@ -1605,6 +1611,7 @@ namespace UnifyWeaver.QueryRuntime
             return aggregate.Operation switch
             {
                 AggregateOperation.Sum => new List<object[]> { new object[] { sum } },
+                AggregateOperation.Avg => new List<object[]> { new object[] { sum / count } },
                 AggregateOperation.Min => new List<object[]> { new object[] { min! } },
                 AggregateOperation.Max => new List<object[]> { new object[] { max! } },
                 AggregateOperation.Set => new List<object[]> { new object[] { set!.ToList() } },
@@ -1639,6 +1646,11 @@ namespace UnifyWeaver.QueryRuntime
                         break;
 
                     case AggregateOperation.Sum:
+                        sum += ConvertToDecimal(fact, aggregate.ValueIndex);
+                        hasAny = true;
+                        break;
+
+                    case AggregateOperation.Avg:
                         sum += ConvertToDecimal(fact, aggregate.ValueIndex);
                         hasAny = true;
                         break;
@@ -1693,6 +1705,7 @@ namespace UnifyWeaver.QueryRuntime
             return aggregate.Operation switch
             {
                 AggregateOperation.Sum => new List<object[]> { new object[] { sum } },
+                AggregateOperation.Avg => new List<object[]> { new object[] { sum / count } },
                 AggregateOperation.Min => new List<object[]> { new object[] { min! } },
                 AggregateOperation.Max => new List<object[]> { new object[] { max! } },
                 AggregateOperation.Set => new List<object[]> { new object[] { set!.ToList() } },
@@ -1752,6 +1765,11 @@ namespace UnifyWeaver.QueryRuntime
                         state.HasAny = true;
                         break;
 
+                    case AggregateOperation.Avg:
+                        state.Sum += ConvertToDecimal(fact, aggregate.ValueIndex);
+                        state.HasAny = true;
+                        break;
+
                     case AggregateOperation.Min:
                     {
                         var value = ConvertToDecimal(fact, aggregate.ValueIndex);
@@ -1806,6 +1824,14 @@ namespace UnifyWeaver.QueryRuntime
                         if (state.HasAny)
                         {
                             extension[groupCount] = state.Sum;
+                            extensions.Add(extension);
+                        }
+                        break;
+
+                    case AggregateOperation.Avg:
+                        if (state.HasAny)
+                        {
+                            extension[groupCount] = state.Sum / state.Count;
                             extensions.Add(extension);
                         }
                         break;
@@ -1887,6 +1913,11 @@ namespace UnifyWeaver.QueryRuntime
                         state.HasAny = true;
                         break;
 
+                    case AggregateOperation.Avg:
+                        state.Sum += ConvertToDecimal(row, aggregate.ValueIndex);
+                        state.HasAny = true;
+                        break;
+
                     case AggregateOperation.Min:
                     {
                         var value = ConvertToDecimal(row, aggregate.ValueIndex);
@@ -1941,6 +1972,14 @@ namespace UnifyWeaver.QueryRuntime
                         if (state.HasAny)
                         {
                             extension[groupCount] = state.Sum;
+                            extensions.Add(extension);
+                        }
+                        break;
+
+                    case AggregateOperation.Avg:
+                        if (state.HasAny)
+                        {
+                            extension[groupCount] = state.Sum / state.Count;
                             extensions.Add(extension);
                         }
                         break;


### PR DESCRIPTION
  - Adds AggregateOperation.Avg and runtime execution support in src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs.
  - Extends the Prolog C# query compiler to accept avg(Var) aggregates and emit AggregateOperation.Avg in src/unifyweaver/targets/
    csharp_target.pl.
  - Adds avg coverage in tests/core/test_csharp_query_target.pl (global + grouped) and makes numeric output invariant-culture to stabilize
    decimals.
  - Documents avg under aggregates in docs/targets/csharp-query-runtime.md.