### PR TITLE
perf(csharp-query): cache generated QueryPlan graphs

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -2156,20 +2156,22 @@ namespace UnifyWeaver.Generated
 {
 ~w    public static class ~w
     {
-        public static (InMemoryRelationProvider Provider, QueryPlan Plan) Build()
-        {
-            var provider = new InMemoryRelationProvider();
-~w            var plan = new QueryPlan(
+        private static readonly Lazy<QueryPlan> CachedPlan = new Lazy<QueryPlan>(() =>
+            new QueryPlan(
                 new PredicateId("~w", ~w),
                 ~w,
                 ~w,
                 ~w
-            );
-            return (provider, plan);
+            ));
+
+        public static (InMemoryRelationProvider Provider, QueryPlan Plan) Build()
+        {
+            var provider = new InMemoryRelationProvider();
+~w            return (provider, CachedPlan.Value);
         }
     }
  }
-', [DynamicUsing, SchemaDeclarations, ModuleClass, ProviderSection, PredStr, Arity, PlanExpr, RecLiteral, InputPosLiteral]).
+', [DynamicUsing, SchemaDeclarations, ModuleClass, PredStr, Arity, PlanExpr, RecLiteral, InputPosLiteral, ProviderSection]).
 
 render_plans_to_csharp(Plans, Code) :-
     Plans = [FirstPlan|_],
@@ -2344,20 +2346,23 @@ plan_method_block(Plan, PredStr, Arity, MethodName, Block) :-
         format(atom(InputPosLiteral), 'new int[]{ ~w }', [InputPosStr])
     ;   InputPosLiteral = 'null'
     ),
+    format(atom(PlanField), '_plan~w', [MethodName]),
     format(atom(Block),
-'        public static (InMemoryRelationProvider Provider, QueryPlan Plan) ~w()
-        {
-            var provider = BuildProvider();
-            var plan = new QueryPlan(
+'        private static readonly Lazy<QueryPlan> ~w = new Lazy<QueryPlan>(() =>
+            new QueryPlan(
                 new PredicateId("~w", ~w),
                 ~w,
                 ~w,
                 ~w
-            );
-            return (provider, plan);
+            ));
+
+        public static (InMemoryRelationProvider Provider, QueryPlan Plan) ~w()
+        {
+            var provider = BuildProvider();
+            return (provider, ~w.Value);
         }
 
-', [MethodName, PredStr, Arity, PlanExpr, RecLiteral, InputPosLiteral]).
+', [PlanField, PredStr, Arity, PlanExpr, RecLiteral, InputPosLiteral, MethodName, PlanField]).
 
 emit_plan_expression(Node, Expr) :-
     is_dict(Node, param_seed), !,

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -490,6 +490,7 @@ verify_fact_plan :-
     get_dict(relations, Plan, [relation{predicate:predicate{name:test_fact, arity:2}, facts:Facts}]),
     Facts == [[alice, bob], [bob, charlie]],
     csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'Lazy<QueryPlan>'),
     sub_string(Source, _, _, _, 'RelationScanNode').
 
 verify_join_plan :-
@@ -1100,6 +1101,7 @@ verify_multi_mode_codegen_plan :-
     csharp_target:compile_predicate_to_csharp(test_multi_mode/2, [mode(query)], Code),
     sub_string(Code, _, _, _, 'BuildIn0'),
     sub_string(Code, _, _, _, 'BuildIn1'),
+    sub_string(Code, _, _, _, 'Lazy<QueryPlan>'),
     sub_string(Code, _, _, _, 'BuildForInputs').
 
 verify_multi_mode_plan_selection_api :-


### PR DESCRIPTION
  - Cache generated QueryPlan graphs in the emitted C# modules using Lazy<QueryPlan> (single-plan CachedPlan + per-mode cached plans) to
    avoid rebuilding node trees on repeated executions/parameter runs.
  - Keeps provider creation unchanged; only plan construction is reused.
  - Adds assertions in test_csharp_query_target to ensure caching code is emitted.