### PR TITLE
feat(go): implement Phase 9d - Statistical Aggregations (stddev, median, percentile)

### DIFF
--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -29,6 +29,14 @@ This document captures ideas for future development of UnifyWeaver targets and f
 - **Schema Composition**: Nested `object(Schema)` types with recursive deep validation.
 - **Variable Mapping**: robust typed compilation for arbitrary projection.
 
+### Database Aggregations (Completed)
+
+✅ **Implemented**: Comprehensive aggregation support (Phase 9).
+- **Simple Aggregations**: `count`, `sum`, `avg`, `max`, `min`.
+- **Grouped Aggregations**: `group_by` with single or multiple operations.
+- **Advanced Features**: `HAVING` clause, nested grouping (Phase 9c).
+- **Statistical Functions**: `stddev`, `median`, `percentile` (Phase 9d).
+
 ### Stream Processing Enhancements (Completed)
 
 ✅ **Implemented**: High-performance concurrency and observability.

--- a/PHASE_9D_COMPLETED.md
+++ b/PHASE_9D_COMPLETED.md
@@ -1,0 +1,31 @@
+# Phase 9d: Statistical Aggregations (Completed)
+
+## Status: Completed (2025-12-22)
+
+This phase added advanced statistical aggregation functions to the Go target, supporting both simple and grouped aggregation modes.
+
+## Delivered Features
+
+### 1. New Aggregation Operations
+- **`stddev(Field, Result)`**: Sample Standard Deviation.
+  - Implemented using **Welford's Online Algorithm** for single-pass efficiency and numerical stability.
+  - O(1) memory per group.
+- **`median(Field, Result)`**: Median value.
+  - Implemented with value collection and `sort.Float64s`.
+  - O(n) memory per group (required for median).
+- **`percentile(Field, P, Result)`**: P-th Percentile.
+  - Supports arbitrary percentiles (e.g., 90th, 95th, 99th).
+  - Uses linear interpolation between closest ranks.
+
+### 2. Full Integration
+- **Simple Aggregations**: Works with `aggregate(Op, Goal, Result)`.
+- **Grouped Aggregations**: Works with `group_by(Group, Goal, Op, Result)` and multi-aggregation lists.
+- **HAVING Clause**: Fully supported in post-aggregation filtering (e.g., `group_by(...), StdDev > 5.0`).
+- **Target Support**: Currently implemented for **Go** (Bbolt and JSONL modes).
+
+### 3. Smart Code Generation
+- **Conditional Imports**: Only imports `math` or `sort` if the operations require them.
+- **Helper Injection**: Automatically injects necessary Go helper functions for median and percentile calculations.
+
+## Verification
+- `tests/test_go_stats.pl`: Verified `stddev`, `median`, and `percentile` in both simple and grouped modes, including HAVING clause integration.

--- a/PR_PHASE_9D.md
+++ b/PR_PHASE_9D.md
@@ -1,0 +1,42 @@
+# PR Description: Phase 9d - Statistical Aggregations (Go/Bbolt)
+
+**Title:** `feat(go): implement Phase 9d - Statistical Aggregations (stddev, median, percentile)`
+
+## Overview
+This PR implements **Phase 9d** of the Go/Bbolt target, adding advanced statistical aggregation functions. These features enable powerful data analysis directly within UnifyWeaver pipelines and database queries, matching capabilities found in advanced SQL dialects and statistical packages.
+
+## Key Features
+
+### 1. New Aggregation Functions
+- **`stddev(Field, Result)`**: Calculates the sample standard deviation.
+  - Implementation: **Welford's Online Algorithm** for numerically stable, single-pass computation.
+  - Memory: O(1) constant space per group.
+- **`median(Field, Result)`**: Calculates the median value (50th percentile).
+  - Implementation: Collects values into a slice and uses `sort.Float64s`.
+  - Memory: O(N) space per group.
+- **`percentile(Field, P, Result)`**: Calculates the P-th percentile (0-100).
+  - Implementation: Linear interpolation between closest ranks after sorting.
+  - Memory: O(N) space per group.
+
+### 2. Deep Integration
+- **Simple Aggregations:** Works with `aggregate/3`.
+  ```prolog
+  aggregate(stddev(Age), json_record([age-Age]), Dev).
+  ```
+- **Grouped Aggregations:** Works with `group_by/4` and multiple-aggregation lists.
+  ```prolog
+  group_by(City, Goal, [count(N), median(Age, Med), stddev(Age, Dev)]).
+  ```
+- **HAVING Clause:** Full support for filtering groups by statistical results.
+  ```prolog
+  group_by(..., stddev(Price, Volatility)), Volatility > 100.0.
+  ```
+
+### 3. Optimized Code Generation
+- **Smart Imports:** Automatically detects if `math` or `sort` packages are needed and adds them to the Go imports.
+- **Helper Injection:** Dynamically appends `calculateMedian` and `calculatePercentile` helper functions to the Go output only when required.
+
+## Verification
+- Verified with `tests/test_go_stats.pl`.
+- Validated correctness of Welford's algorithm and sorting logic.
+- Checked integration with existing `count`, `sum`, `avg` operations.


### PR DESCRIPTION
## Overview
This PR implements **Phase 9d** of the Go/Bbolt target, adding advanced statistical aggregation functions. These features enable powerful data analysis directly within UnifyWeaver pipelines and database queries, matching capabilities found in advanced SQL dialects and statistical packages.

## Key Features

### 1. New Aggregation Functions
- **`stddev(Field, Result)`**: Calculates the sample standard deviation.
  - Implementation: **Welford's Online Algorithm** for numerically stable, single-pass computation.
  - Memory: O(1) constant space per group.
- **`median(Field, Result)`**: Calculates the median value (50th percentile).
  - Implementation: Collects values into a slice and uses `sort.Float64s`.
  - Memory: O(N) space per group.
- **`percentile(Field, P, Result)`**: Calculates the P-th percentile (0-100).
  - Implementation: Linear interpolation between closest ranks after sorting.
  - Memory: O(N) space per group.

### 2. Deep Integration
- **Simple Aggregations:** Works with `aggregate/3`.
  ```prolog
  aggregate(stddev(Age), json_record([age-Age]), Dev).
  ```
- **Grouped Aggregations:** Works with `group_by/4` and multiple-aggregation lists.
  ```prolog
  group_by(City, Goal, [count(N), median(Age, Med), stddev(Age, Dev)]).
  ```
- **HAVING Clause:** Full support for filtering groups by statistical results.
  ```prolog
  group_by(..., stddev(Price, Volatility)), Volatility > 100.0.
  ```

### 3. Optimized Code Generation
- **Smart Imports:** Automatically detects if `math` or `sort` packages are needed and adds them to the Go imports.
- **Helper Injection:** Dynamically appends `calculateMedian` and `calculatePercentile` helper functions to the Go output only when required.

## Verification
- Verified with `tests/test_go_stats.pl`.
- Validated correctness of Welford's algorithm and sorting logic.
- Checked integration with existing `count`, `sum`, `avg` operations.
