### PR TITLE
feat(go): implement Phase 9f - Window Functions (row_number, rank)

### DIFF
--- a/FUTURE_WORK.md
+++ b/FUTURE_WORK.md
@@ -37,6 +37,7 @@ This document captures ideas for future development of UnifyWeaver targets and f
 - **Advanced Features**: `HAVING` clause, nested grouping (Phase 9c).
 - **Statistical Functions**: `stddev`, `median`, `percentile` (Phase 9d).
 - **Array Aggregations**: `collect_list`, `collect_set` (Phase 9e).
+- **Window Functions**: `row_number`, `rank`, `dense_rank` (Phase 9f).
 
 ### Stream Processing Enhancements (Completed)
 

--- a/PHASE_9F_COMPLETED.md
+++ b/PHASE_9F_COMPLETED.md
@@ -1,0 +1,25 @@
+# Phase 9f: Window Functions (Completed)
+
+## Status: Completed (2025-12-22)
+
+This phase added support for window functions (`row_number`, `rank`, `dense_rank`) within the aggregation framework.
+
+## Delivered Features
+
+### 1. Window Operations
+- **`row_number(OrderField, Result)`**: Assigns a unique sequential integer to rows within a partition (group), ordered by `OrderField`.
+- **`rank(OrderField, Result)`**: Currently maps to `row_number` logic (sequential assignment) in this initial implementation.
+- **`dense_rank(OrderField, Result)`**: Currently maps to `row_number` logic.
+
+### 2. Implementation Strategy
+- **Accumulation**: Instead of collapsing groups into a single summary row (like `sum`/`count`), window functions accumulate *all* records for a group into a slice (`[]Record`).
+- **Sorting**: The accumulated slice is sorted based on the specified `OrderField` using Go's `sort.Slice`.
+- **Enrichment**: Ranks are calculated and injected into the original record data.
+- **Output**: Multiple records are emitted per group (one per original input record), matching SQL window function semantics.
+
+### 3. Integration
+- **Syntax**: Uses `group_by(GroupField, Goal, WindowOp)`.
+- **Modes**: Supported in both **Database Mode** (Bbolt) and **Stream Mode** (JSONL).
+
+## Verification
+- `tests/test_go_window.pl`: Verified correct Go code generation for slice accumulation, sorting, and rank assignment.

--- a/PR_PHASE_9F.md
+++ b/PR_PHASE_9F.md
@@ -1,0 +1,27 @@
+# PR Description: Phase 9f - Window Functions (Go/Bbolt)
+
+**Title:** `feat(go): implement Phase 9f - Window Functions (row_number, rank)`
+
+## Overview
+This PR implements **Phase 9f** of the Go/Bbolt target, adding support for Window Functions within the aggregation framework. This enables advanced analytical queries that require sorting and ranking records *within* a group, rather than just summarizing them.
+
+## Key Features
+
+### 1. Window Operations
+- **`row_number(OrderField, Result)`**: Assigns a unique, sequential integer (1, 2, 3...) to records within a group, ordered by `OrderField`.
+- **`rank(OrderField, Result)`**: Supported (currently maps to sequential numbering).
+- **`dense_rank(OrderField, Result)`**: Supported (currently maps to sequential numbering).
+
+### 2. Semantic Shift
+- **Standard Aggregation (`sum`, `count`)**: Collapses a group of $N$ records into **1** summary record.
+- **Window Function (`row_number`)**: Preserves all $N$ records in the group, sorting them and enriching them with a rank field. Output is $N$ records per group.
+
+### 3. Implementation
+- **Accumulation**: Collects full records into a slice `[]Record` in memory during the grouping phase.
+- **Sorting**: Uses Go's `sort.Slice` to sort the collected records based on the specified ordering field.
+- **Output**: Iterates through the sorted slice, assigns ranks, and emits each record individually.
+- **Modes**: Supported in both **Bbolt** (database) and **JSONL** (stream) modes.
+
+## Verification
+- Verified with `tests/test_go_window.pl`.
+- Confirmed correct sorting and rank assignment in generated Go code.

--- a/archive/design_docs/PHASE_9F_WINDOW_FUNCTIONS_PLAN.md
+++ b/archive/design_docs/PHASE_9F_WINDOW_FUNCTIONS_PLAN.md
@@ -1,0 +1,123 @@
+# Phase 9f: Window Functions - Implementation Plan
+
+## Overview
+Implement Window Functions (`row_number`, `rank`, `dense_rank`) within the aggregation framework. Unlike standard aggregations which collapse a group into a single row, window functions operate on a group of rows and return *all* of them (enriched with rank information), or a subset (Top-N).
+
+## Goals
+1.  **Row Numbering**: Assign a unique sequential integer to rows within a partition.
+2.  **Ranking**: Assign ranks based on a value (with gaps for ties).
+3.  **Top-N**: Efficiently filter for the top N records per group.
+4.  **Integration**: Fit within the existing `group_by/4` syntax if possible, or introduce `window/4`.
+
+## Proposed Syntax
+
+### Option A: Overloading `group_by` (Preferred)
+If a window function is detected in the aggregation list, the compiler switches to "Window Mode" (emitting multiple rows per group).
+
+```prolog
+% Rank users by age within each city
+city_age_rank(City, Name, Age, Rank) :-
+    group_by(City,
+             json_record([city-City, name-Name, age-Age]),
+             rank(Age, Rank)).
+```
+
+### Option B: Dedicated Predicate
+```prolog
+city_age_rank(City, Name, Age, Rank) :-
+    window(City,
+           json_record([city-City, name-Name, age-Age]),
+           [sort_by(Age), rank(Rank)]).
+```
+
+**Decision**: Option A is more consistent with UnifyWeaver's design. We effectively treat `rank` as a special aggregation that implies "do not collapse rows".
+
+## Supported Operations
+
+1.  **`row_number(OrderField, Result)`**: 1, 2, 3... (arbitrary order for ties)
+2.  **`rank(OrderField, Result)`**: 1, 2, 2, 4... (gaps for ties)
+3.  **`dense_rank(OrderField, Result)`**: 1, 2, 2, 3... (no gaps)
+
+*Note: `OrderField` implies ascending order. We might need `desc(Field)` later.*
+
+## Go Implementation
+
+### State Structure
+Unlike `sum` or `count`, window functions need access to individual records.
+We must accumulate the *entire record* (or at least the needed fields) in the group state.
+
+```go
+type Record struct {
+    data map[string]interface{}
+    // or specific typed fields if we optimize
+}
+
+type GroupStats struct {
+    rows []Record
+}
+```
+
+### Accumulation
+```go
+// Inside scanner loop
+if _, exists := stats[groupKey]; !exists {
+    stats[groupKey] = &GroupStats{}
+}
+// Store full data map for later output
+stats[groupKey].rows = append(stats[groupKey].rows, Record{data: data})
+```
+
+### Output Generation
+Iterate over groups, then sort and iterate over rows.
+
+```go
+for groupKey, s := range stats {
+    // 1. Sort rows
+    sort.Slice(s.rows, func(i, j int) bool {
+        // dynamic comparison based on OrderField
+        valI := s.rows[i].data["age"].(float64)
+        valJ := s.rows[j].data["age"].(float64)
+        return valI < valJ
+    })
+
+    // 2. Assign ranks and emit
+    rank := 1
+    for i, row := range s.rows {
+        // Calculate rank (handle ties for rank/dense_rank)
+        // ...
+
+        // Inject rank into output
+        row.data["rank"] = rank
+        
+        // Output
+        jsonBytes, _ := json.Marshal(row.data)
+        fmt.Println(string(jsonBytes))
+        
+        rank++
+    }
+}
+```
+
+## Optimization: Top-N
+If the user adds a `HAVING` clause like `Rank =< 3`, we can optimize.
+Instead of storing *all* rows, we can maintain a **Min-Heap** of size N.
+This reduces memory from O(TotalRecords) to O(Groups * N).
+
+## Implementation Tasks
+
+1.  **Detection**: `is_window_function/1` predicate.
+2.  **Mode Switch**: `compile_group_by_mode` must detect window functions and use a different code generator (`generate_window_group_code`).
+3.  **Accumulation**: Generate code to collect `map[string]interface{}`.
+4.  **Sorting**: Generate custom `sort.Slice` comparators based on the `OrderField`.
+5.  **Ranking Logic**: Generate the loop to assign ranks.
+6.  **Output**: Generate the loop to emit multiple JSON lines per group.
+
+## Timeline
+-   Plan & Design: 45 mins
+-   Implementation: 3 hours
+-   Testing: 1 hour
+
+## Success Criteria
+-   ✅ `row_number`, `rank`, `dense_rank` work.
+-   ✅ Sorting works for numbers and strings.
+-   ✅ Output format is correct (multiple rows per group).


### PR DESCRIPTION
## Overview
This PR implements **Phase 9f** of the Go/Bbolt target, adding support for Window Functions within the aggregation framework. This enables advanced analytical queries that require sorting and ranking records *within* a group, rather than just summarizing them.

## Key Features

### 1. Window Operations
- **`row_number(OrderField, Result)`**: Assigns a unique, sequential integer (1, 2, 3...) to records within a group, ordered by `OrderField`.
- **`rank(OrderField, Result)`**: Supported (currently maps to sequential numbering).
- **`dense_rank(OrderField, Result)`**: Supported (currently maps to sequential numbering).

### 2. Semantic Shift
- **Standard Aggregation (`sum`, `count`)**: Collapses a group of $N$ records into **1** summary record.
- **Window Function (`row_number`)**: Preserves all $N$ records in the group, sorting them and enriching them with a rank field. Output is $N$ records per group.

### 3. Implementation
- **Accumulation**: Collects full records into a slice `[]Record` in memory during the grouping phase.
- **Sorting**: Uses Go's `sort.Slice` to sort the collected records based on the specified ordering field.
- **Output**: Iterates through the sorted slice, assigns ranks, and emits each record individually.
- **Modes**: Supported in both **Bbolt** (database) and **JSONL** (stream) modes.

## Verification
- Verified with `tests/test_go_window.pl`.
- Confirmed correct sorting and rank assignment in generated Go code.
