### PR TITLE
feat: add answer-level benchmark with metric explanations

### DIFF
--- a/docs/proposals/CROSS_CLUSTER_SMOOTHING.md
+++ b/docs/proposals/CROSS_CLUSTER_SMOOTHING.md
@@ -371,11 +371,41 @@ results = pipeline.search(query_embedding, k=10)
 
 ## Future Work
 
-1. **Learnable FFT filters**: Train filter shape instead of fixed cutoff
-2. **Cross-validation**: Automatic hyperparameter selection
-3. **Integration with HNSW**: Use Go/Rust federation infrastructure
-4. **Streaming updates**: Incremental smoothing for new clusters
-5. **Real embedding evaluation**: Run experiments with E5/ModernBERT embeddings
+### Priority 1: Deeper Benchmarking
+
+Current benchmarks measure cluster-level accuracy (P@1, P@3). We need answer-level metrics:
+
+| Metric | Description | Why It Matters |
+|--------|-------------|----------------|
+| **Cosine Similarity** | cos(projected_query, target_answer) | Measures projection quality directly |
+| **MSE** | ‖projected_query - target_answer‖² | Captures magnitude errors |
+| **Rank of Target** | Position of correct answer in results | End-to-end retrieval quality |
+| **Recall@k** | Is correct answer in top-k? | Practical retrieval threshold |
+
+**Tasks:**
+- [ ] Add per-query cosine similarity to target answer (not just cluster centroid)
+- [ ] Add MSE from projected query to ground-truth answer embedding
+- [ ] Compare metrics across smoothing methods (FFT vs Basis vs Baseline)
+- [ ] Measure variance across clusters (are some clusters harder?)
+- [ ] Test with real embeddings (E5-small, ModernBERT)
+
+### Priority 2: Hyperparameter Optimization
+
+- [ ] **Cross-validation**: Automatic selection of FFT cutoff, blend factor
+- [ ] **Learnable FFT filters**: Train filter shape instead of fixed cutoff
+- [ ] Sensitivity analysis: How robust are results to parameter changes?
+
+### Priority 3: Production Integration
+
+- [ ] **Integration with HNSW**: Use Go/Rust federation infrastructure
+- [ ] **Streaming updates**: Incremental smoothing for new clusters
+- [ ] Serialization format for cross-language compatibility
+
+### Priority 4: Advanced Features
+
+- [ ] Hierarchical FFT: Apply smoothing at multiple granularities
+- [ ] Adaptive cutoff per cluster based on local density
+- [ ] Online learning: Update W matrices from user feedback
 
 ## References
 

--- a/reports/answer_level_benchmark.json
+++ b/reports/answer_level_benchmark.json
@@ -1,0 +1,10693 @@
+{
+  "metric_legend": {
+    "cosine_to_target": {
+      "description": "Cosine similarity between projected query and target answer",
+      "good_value": "Higher is better (1.0 = perfect alignment)",
+      "range": "[-1.0, 1.0]"
+    },
+    "mse_to_target": {
+      "description": "Mean Squared Error between projected query and target answer",
+      "good_value": "Lower is better (0.0 = identical vectors)",
+      "range": "[0.0, inf)"
+    },
+    "target_rank": {
+      "description": "Position of correct answer when sorted by similarity (1-indexed)",
+      "good_value": "Lower is better (1 = correct answer is top result)",
+      "range": "[1, num_answers]"
+    },
+    "mrr": {
+      "description": "Mean Reciprocal Rank = average of 1/rank across all queries",
+      "good_value": "Higher is better (1.0 = always rank 1)",
+      "range": "(0.0, 1.0]"
+    },
+    "recall_at_k": {
+      "description": "Fraction of queries where correct answer is in top k results",
+      "good_value": "Higher is better (1.0 = always in top k)",
+      "range": "[0.0, 1.0]"
+    }
+  },
+  "winners": {
+    "highest_cosine": "FFT_c0.7",
+    "lowest_mse": "FFT_c0.7",
+    "lowest_rank": "AdaptiveFFT",
+    "highest_mrr": "FFT_c0.3",
+    "highest_recall_at_5": "FFT_c0.5"
+  },
+  "results": [
+    {
+      "method": "MultiHeadLDA",
+      "params": {
+        "type": "baseline"
+      },
+      "mean_cosine_to_target": 0.5184569208453473,
+      "std_cosine_to_target": 0.17778379235056904,
+      "mean_mse_to_target": 0.012191786134197882,
+      "std_mse_to_target": 0.00299481688536059,
+      "mean_target_rank": 12.251552795031056,
+      "median_target_rank": 2.0,
+      "recall_at_1": 0.32608695652173914,
+      "recall_at_5": 0.8633540372670807,
+      "recall_at_10": 0.906832298136646,
+      "mrr": 0.5497338823010277,
+      "train_time_ms": 4.682100028730929,
+      "inference_time_us": 1194.2125822530238,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4068402125658741,
+          "mean_mse": 0.01370454122850734,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.26681647300193256,
+          "mean_mse": 0.014312508459456417,
+          "mean_rank": 117.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.3715451822831357,
+          "mean_mse": 0.014058279936113822,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4741836244913379,
+          "mean_mse": 0.013839163989193642,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4598323248557479,
+          "mean_mse": 0.013529784022659908,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4585775739847799,
+          "mean_mse": 0.013909991892373904,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.2951247504366509,
+          "mean_mse": 0.014499687036022618,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.4584850465530265,
+          "mean_mse": 0.014017590295320976,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.22925553619866915,
+          "mean_mse": 0.014963299524116857,
+          "mean_rank": 120.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.43430661682238714,
+          "mean_mse": 0.013568030710616227,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4300399960831753,
+          "mean_mse": 0.01381690243578598,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.48636024896037755,
+          "mean_mse": 0.013428738851511142,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.4304123450382228,
+          "mean_mse": 0.013877117470544573,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.36840311681733795,
+          "mean_mse": 0.01448347899140362,
+          "mean_rank": 71.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.455694253343624,
+          "mean_mse": 0.014101908081633622,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.2819763287703281,
+          "mean_mse": 0.014687319802612335,
+          "mean_rank": 73.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.45104564820221893,
+          "mean_mse": 0.013817096978156397,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.44568835255118344,
+          "mean_mse": 0.013847705223686613,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.43627038985430266,
+          "mean_mse": 0.013832664095845802,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.3669617799000878,
+          "mean_mse": 0.014007537066801589,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.4644094618842274,
+          "mean_mse": 0.01359390805922698,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.3813159835811126,
+          "mean_mse": 0.014121005716268986,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.3559842859996925,
+          "mean_mse": 0.01424406703516446,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.4305192902546384,
+          "mean_mse": 0.013506902646039036,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.39157723398764743,
+          "mean_mse": 0.014217201549046215,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.38759484801099076,
+          "mean_mse": 0.014059996875609286,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.5011147766366301,
+          "mean_mse": 0.013289892491769826,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.36616804363828975,
+          "mean_mse": 0.013968209511230522,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.503397679048024,
+          "mean_mse": 0.012947861913327613,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.5719905745462157,
+          "mean_mse": 0.012578161481790421,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.46370739682147677,
+          "mean_mse": 0.013346159215117063,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.47481313526643676,
+          "mean_mse": 0.013544465701307998,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.4025785441932408,
+          "mean_mse": 0.014208874083363044,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.42838549092345835,
+          "mean_mse": 0.013961297381367779,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.45415566569903154,
+          "mean_mse": 0.013369310272057369,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.260202097851009,
+          "mean_mse": 0.014854845671107904,
+          "mean_rank": 81.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.27995120551485847,
+          "mean_mse": 0.014783591276660813,
+          "mean_rank": 78.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.43049991562160006,
+          "mean_mse": 0.013941651000950375,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.38107349470822766,
+          "mean_mse": 0.01402179778881001,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.5066077093036506,
+          "mean_mse": 0.012386603268551517,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.4819435497875564,
+          "mean_mse": 0.013496552097794302,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.3218181924367322,
+          "mean_mse": 0.014647487647083544,
+          "mean_rank": 80.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.45959298035203555,
+          "mean_mse": 0.013596224728355007,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.43117280449329776,
+          "mean_mse": 0.013942690303910146,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.5337801087436346,
+          "mean_mse": 0.013265091853694365,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.33730955005404606,
+          "mean_mse": 0.014326639541874823,
+          "mean_rank": 132.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.35627051292006784,
+          "mean_mse": 0.0142093818220663,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.4789034122902802,
+          "mean_mse": 0.013733723652620693,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.4514231809380034,
+          "mean_mse": 0.013426304805858217,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.3699103955524254,
+          "mean_mse": 0.014057416884441627,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.4842783155851748,
+          "mean_mse": 0.01333959583800682,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.41653419439363165,
+          "mean_mse": 0.013452225252788302,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.4427850571922426,
+          "mean_mse": 0.013735759119575761,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.5326690662919271,
+          "mean_mse": 0.012809384483227073,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.338796879791918,
+          "mean_mse": 0.014236320122162317,
+          "mean_rank": 34.25,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.4592910739847216,
+          "mean_mse": 0.01355747244362801,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.5344365219897487,
+          "mean_mse": 0.013367528723304743,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.4447983067662676,
+          "mean_mse": 0.013470143187166075,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.30705475907251223,
+          "mean_mse": 0.014638459780945823,
+          "mean_rank": 27.75,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.39819950665603165,
+          "mean_mse": 0.013155389989693282,
+          "mean_rank": 61.0,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.37783274961368607,
+          "mean_mse": 0.014327024832573898,
+          "mean_rank": 24.25,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.32817629031926776,
+          "mean_mse": 0.014262658301674652,
+          "mean_rank": 73.0,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.2309635109604362,
+          "mean_mse": 0.014894523223332845,
+          "mean_rank": 125.75,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.3988072176857849,
+          "mean_mse": 0.013967348314784293,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.4540763837827712,
+          "mean_mse": 0.013519141696003968,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.347962462955077,
+          "mean_mse": 0.014612834438328372,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.41408444145304046,
+          "mean_mse": 0.013710438046984807,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.4891665721350792,
+          "mean_mse": 0.013752966202582935,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.47584313032648495,
+          "mean_mse": 0.013570370541493789,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.5275987858947725,
+          "mean_mse": 0.012508483301626095,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.5302762801502197,
+          "mean_mse": 0.012875099672001076,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.527816085229651,
+          "mean_mse": 0.012875595068508959,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.5226222625600946,
+          "mean_mse": 0.01286623976514091,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.5059973680478457,
+          "mean_mse": 0.013374854362548113,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.5856871663918025,
+          "mean_mse": 0.011699550209518869,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.5393380705927583,
+          "mean_mse": 0.012883217537066198,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.5461390555835691,
+          "mean_mse": 0.012104918281818665,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.5917227258537949,
+          "mean_mse": 0.011773419141598873,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.47788471964990603,
+          "mean_mse": 0.013363909891001039,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.47145446648857775,
+          "mean_mse": 0.013366055980074261,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.5909975307506256,
+          "mean_mse": 0.011485093369335507,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.5285393778564824,
+          "mean_mse": 0.01265498634322404,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.45738832209955715,
+          "mean_mse": 0.013405247413439325,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.5649646171034816,
+          "mean_mse": 0.01176166703859021,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.47400602914657264,
+          "mean_mse": 0.013049695866501752,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.5293037492715328,
+          "mean_mse": 0.012487719582692477,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.5493965096414484,
+          "mean_mse": 0.012505156619994752,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.4916765085599253,
+          "mean_mse": 0.012897943548428171,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.5924667699573901,
+          "mean_mse": 0.012439965672147146,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.5991846154432777,
+          "mean_mse": 0.011740368549347681,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.5280920785294559,
+          "mean_mse": 0.012656124438738425,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.5232389446425153,
+          "mean_mse": 0.013293780550101206,
+          "mean_rank": 1.0,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.5090168240686976,
+          "mean_mse": 0.01302338066675511,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.6033231962267998,
+          "mean_mse": 0.011732643847411258,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.6530301507908464,
+          "mean_mse": 0.011531489162076684,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.563032206178867,
+          "mean_mse": 0.01259830315541617,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.6473182824343966,
+          "mean_mse": 0.010211910264406968,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5310074173215181,
+          "mean_mse": 0.01255926095713123,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.48310061770179785,
+          "mean_mse": 0.012929886996667805,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.5480616209071936,
+          "mean_mse": 0.012833573130718269,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.4731079050384344,
+          "mean_mse": 0.013221490066398575,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.5816992344074109,
+          "mean_mse": 0.011864856068125004,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.44711082352291465,
+          "mean_mse": 0.013467731045100295,
+          "mean_rank": 3.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.5842904992603314,
+          "mean_mse": 0.012091966117981337,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.5173341577762128,
+          "mean_mse": 0.01321202731484941,
+          "mean_rank": 1.0,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.5431270886539621,
+          "mean_mse": 0.01251742014075168,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.5636033036843296,
+          "mean_mse": 0.011910220475966448,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.5280239327413973,
+          "mean_mse": 0.012937123339128416,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.39563748551208205,
+          "mean_mse": 0.013843553231274409,
+          "mean_rank": 30.0,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.4361716257754558,
+          "mean_mse": 0.013609301876714934,
+          "mean_rank": 5.0,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.5304353818216733,
+          "mean_mse": 0.013119429487596724,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.48956740884320293,
+          "mean_mse": 0.012846163329539195,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.5719529208032053,
+          "mean_mse": 0.01166743756498836,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.5368847496073822,
+          "mean_mse": 0.012067670960668806,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.49859230149391515,
+          "mean_mse": 0.012990393161940965,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.5444392928798796,
+          "mean_mse": 0.012699635903346967,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.5945798327391415,
+          "mean_mse": 0.011794035505617743,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.5439342668833071,
+          "mean_mse": 0.011929309111817938,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.5530762476127243,
+          "mean_mse": 0.012548177451470474,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.5910898196761313,
+          "mean_mse": 0.012185599361968261,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.5181769555652312,
+          "mean_mse": 0.013050783678519843,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.5840579568461829,
+          "mean_mse": 0.012076606458828368,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.573739152543606,
+          "mean_mse": 0.012147259179047456,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.5493766558775853,
+          "mean_mse": 0.013035635068301252,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.5496661125923484,
+          "mean_mse": 0.012713645155665998,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.5260902926529741,
+          "mean_mse": 0.013329150883620001,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.49143457220509856,
+          "mean_mse": 0.012858309794723306,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.6733780986831679,
+          "mean_mse": 0.00924194767145175,
+          "mean_rank": 6.666666666666667,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.5938745948487885,
+          "mean_mse": 0.012322724258628154,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.5509457129354052,
+          "mean_mse": 0.012665936931267252,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.5874884133314523,
+          "mean_mse": 0.011775327809462015,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.5039051914472965,
+          "mean_mse": 0.012760977392019613,
+          "mean_rank": 5.0,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.5962156800169498,
+          "mean_mse": 0.011598150992300486,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.5621727519098437,
+          "mean_mse": 0.011555491508011564,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.5088558895270184,
+          "mean_mse": 0.013288694803060547,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.5595674530927659,
+          "mean_mse": 0.012143104524020815,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.5984728008873049,
+          "mean_mse": 0.010939014258644462,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.5326058430690893,
+          "mean_mse": 0.012910549564892515,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.5509445060924476,
+          "mean_mse": 0.012933511981582019,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.5527152153492616,
+          "mean_mse": 0.012595789933826138,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.5186225514943418,
+          "mean_mse": 0.012781929596394381,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5588936256510536,
+          "mean_mse": 0.011746009513712137,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.7355397682211077,
+          "mean_mse": 0.008940721715167004,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7471173885069509,
+          "mean_mse": 0.008363303702695862,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9999990963633296,
+          "mean_mse": 5.290504631367834e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7910417477426422,
+          "mean_mse": 0.006339776605851278,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.7256089507739598,
+          "mean_mse": 0.00791439463879507,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7679037505049572,
+          "mean_mse": 0.008118147572245712,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.6443381514284128,
+          "mean_mse": 0.009591409652102229,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.6326517753986232,
+          "mean_mse": 0.010811634043109825,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6784696674157504,
+          "mean_mse": 0.01006848813273178,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.684055182275116,
+          "mean_mse": 0.00923457600536631,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6963031149770179,
+          "mean_mse": 0.008224748422620744,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6696836564381591,
+          "mean_mse": 0.009498842922377144,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.6941675228965328,
+          "mean_mse": 0.008346287331774362,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9999985333653255,
+          "mean_mse": 5.948210428155885e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9999987420665468,
+          "mean_mse": 6.304572112853338e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.6256508584484333,
+          "mean_mse": 0.01003619905377355,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.6218766162232339,
+          "mean_mse": 0.009991443208460495,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6869887389808325,
+          "mean_mse": 0.009061095100978002,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.9999991847919892,
+          "mean_mse": 4.3428928461646895e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6864692322477036,
+          "mean_mse": 0.009099750036300513,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7541793472622944,
+          "mean_mse": 0.007071557878068079,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.6566422332174058,
+          "mean_mse": 0.01103917764006451,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9999989173604383,
+          "mean_mse": 6.097117345273394e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6650021196150291,
+          "mean_mse": 0.00897301203563092,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9999985925628881,
+          "mean_mse": 1.0261653626152049e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7958523752911375,
+          "mean_mse": 0.007934681259701596,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6228602877924276,
+          "mean_mse": 0.010573165040046711,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.7034145919395243,
+          "mean_mse": 0.008137321855485564,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9999992232723216,
+          "mean_mse": 5.303010288092201e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.7209658052934335,
+          "mean_mse": 0.008483430260137047,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.9999993799521669,
+          "mean_mse": 5.346167617723145e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7880911642637611,
+          "mean_mse": 0.006908642189888436,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9999981604903061,
+          "mean_mse": 8.226472398172294e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6521028330925702,
+          "mean_mse": 0.00964739647839977,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6588516590995614,
+          "mean_mse": 0.009051164223756184,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.7061996529302574,
+          "mean_mse": 0.008432673164035006,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6481474522677969,
+          "mean_mse": 0.009458166030274825,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9999966053776397,
+          "mean_mse": 8.707584171362682e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.6978536612476178,
+          "mean_mse": 0.008470049673878016,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7853297770436318,
+          "mean_mse": 0.006696554260806608,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.999998637095588,
+          "mean_mse": 6.270985888880193e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6906921162836832,
+          "mean_mse": 0.00842194916259707,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6906382999965459,
+          "mean_mse": 0.008440145919565628,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9999987923336894,
+          "mean_mse": 6.747819430491216e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9999990330157905,
+          "mean_mse": 5.279063164632553e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.7565218904387159,
+          "mean_mse": 0.007599503663081301,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6964053569652229,
+          "mean_mse": 0.008367634100547888,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.7452248079583921,
+          "mean_mse": 0.007471377223096318,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.999999183268903,
+          "mean_mse": 5.417621595798182e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.7128903019394527,
+          "mean_mse": 0.008341612556991682,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.7157460711284951,
+          "mean_mse": 0.008390143476050382,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9999991374159187,
+          "mean_mse": 7.894995094196907e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.7757404295664674,
+          "mean_mse": 0.007195705401460884,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.999998509666147,
+          "mean_mse": 6.2831211746256736e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7754658213056419,
+          "mean_mse": 0.006866375947867285,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.6256194889459986,
+          "mean_mse": 0.00980379605013762,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9999985422396201,
+          "mean_mse": 5.22294932038162e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9999989284954682,
+          "mean_mse": 7.022996862333899e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9999992759186866,
+          "mean_mse": 5.353085632349968e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.999999190119197,
+          "mean_mse": 5.5233419457417494e-06,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.6191217426535445,
+          "mean_mse": 0.010049336760432133,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.664552235375309,
+          "mean_mse": 0.009563824887632901,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6600801628739275,
+          "mean_mse": 0.009504716714195583,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.7399123513249446,
+          "mean_mse": 0.008954350775320015,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.597860065176143,
+          "mean_mse": 0.012287414853492912,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.763569851096249,
+          "mean_mse": 0.007290372314360159,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.48514669696424106,
+          "mean_mse": 0.01343897129121461,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.4161978643290236,
+          "mean_mse": 0.014298541823222917,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.6235222450887122,
+          "mean_mse": 0.011585971683990372,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.48402262118434347,
+          "mean_mse": 0.01376182563366809,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6881757601435299,
+          "mean_mse": 0.010463468598187926,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.5618124380163397,
+          "mean_mse": 0.011776406046482328,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.559858430299484,
+          "mean_mse": 0.011658127716336302,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.17811469781652428,
+          "mean_mse": 0.014981348583434367,
+          "mean_rank": 161.6,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.4282675390278512,
+          "mean_mse": 0.013340400068643218,
+          "mean_rank": 18.666666666666668,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.3947211620960246,
+          "mean_mse": 0.013843531090562734,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.3",
+      "params": {
+        "cutoff": 0.3,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.5429288083735159,
+      "std_cosine_to_target": 0.15503869378545207,
+      "mean_mse_to_target": 0.012744018564415165,
+      "std_mse_to_target": 0.0026873223069953283,
+      "mean_target_rank": 6.593167701863354,
+      "median_target_rank": 2.0,
+      "recall_at_1": 0.3338509316770186,
+      "recall_at_5": 0.9192546583850931,
+      "recall_at_10": 0.953416149068323,
+      "mrr": 0.5739620016981252,
+      "train_time_ms": 421.18950199801475,
+      "inference_time_us": 1857.2209705526345,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4617814136572845,
+          "mean_mse": 0.014017750104987027,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.3324915163840151,
+          "mean_mse": 0.014489700598009988,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.45464711259813295,
+          "mean_mse": 0.014330654740238041,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.5129453782055332,
+          "mean_mse": 0.014174635026827538,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.47752003152662237,
+          "mean_mse": 0.013897350226445122,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.48684370603469007,
+          "mean_mse": 0.014280975525855813,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3463276151717863,
+          "mean_mse": 0.014531772274627826,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.5055189672176454,
+          "mean_mse": 0.01440422726807818,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.31550776239528605,
+          "mean_mse": 0.015055622812000813,
+          "mean_rank": 95.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4782589284855078,
+          "mean_mse": 0.013897074904192508,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.43214085793550916,
+          "mean_mse": 0.01422598934303373,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.536118612050599,
+          "mean_mse": 0.013768961324695028,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.45558309556636245,
+          "mean_mse": 0.01418169230568699,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.4480105562947417,
+          "mean_mse": 0.01466255365307883,
+          "mean_rank": 21.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.5112250063108359,
+          "mean_mse": 0.014347166658329183,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.30404006414393625,
+          "mean_mse": 0.014854620599729033,
+          "mean_rank": 64.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.49624354920656677,
+          "mean_mse": 0.014099321398219145,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4745259224503421,
+          "mean_mse": 0.014272399975941461,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.48658963257408944,
+          "mean_mse": 0.014178427178782272,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.43087013611855457,
+          "mean_mse": 0.014297479165344785,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.463342468947815,
+          "mean_mse": 0.01402681320772774,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.4172241736910396,
+          "mean_mse": 0.014269115174620258,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.4212213244966526,
+          "mean_mse": 0.014442534299282137,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.460531009441985,
+          "mean_mse": 0.013903092867610833,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.4502120383792919,
+          "mean_mse": 0.01439079478450419,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.413029588751909,
+          "mean_mse": 0.014310177274129726,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.5049381372503263,
+          "mean_mse": 0.013792432755023478,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.3843006566726951,
+          "mean_mse": 0.01431089777858242,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.5135585399307604,
+          "mean_mse": 0.013495518555795508,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.5839510308518465,
+          "mean_mse": 0.013248446027995808,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.5150024600304229,
+          "mean_mse": 0.013730865984774117,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.49946082955209187,
+          "mean_mse": 0.013988588235423993,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.43311754108193057,
+          "mean_mse": 0.014521319599431686,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.4784217109597265,
+          "mean_mse": 0.014223545336677834,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.47663792341755845,
+          "mean_mse": 0.013760715528342862,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.3875891551442973,
+          "mean_mse": 0.014872710327289708,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.3614502472713423,
+          "mean_mse": 0.014833742636650042,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.4791798597044723,
+          "mean_mse": 0.014238866417841044,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.4321818271840434,
+          "mean_mse": 0.014301532295411047,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.5183441030998346,
+          "mean_mse": 0.01308614747664568,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.5228155892892606,
+          "mean_mse": 0.01387977857303739,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.3752621669537912,
+          "mean_mse": 0.01483109834861249,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.4978805523035049,
+          "mean_mse": 0.013870212049774506,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.47110410041165307,
+          "mean_mse": 0.014208339709826975,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.553808456980626,
+          "mean_mse": 0.013781128501998207,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.3709119707691399,
+          "mean_mse": 0.014499054678764306,
+          "mean_rank": 120.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.4116133565519202,
+          "mean_mse": 0.014476263879280696,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.5251461804750526,
+          "mean_mse": 0.014090643937752844,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.5314502248558125,
+          "mean_mse": 0.013739521912696645,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.41496042695841395,
+          "mean_mse": 0.014392133045770663,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.47891788223545023,
+          "mean_mse": 0.013824668996657918,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.47013081865275386,
+          "mean_mse": 0.013757894130140695,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.4951758590826328,
+          "mean_mse": 0.014081192292723031,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.5435384738222371,
+          "mean_mse": 0.013353629941368397,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.41758874586655537,
+          "mean_mse": 0.014491860563933603,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.49212813669309974,
+          "mean_mse": 0.01392751054401986,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.5453480856855923,
+          "mean_mse": 0.01393753223719255,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.4426991012133885,
+          "mean_mse": 0.013910098574727858,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.36509820795936054,
+          "mean_mse": 0.01478029053959976,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.42178062517001874,
+          "mean_mse": 0.01353398871784798,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.4272036862179684,
+          "mean_mse": 0.014562164131916262,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.3979411124301657,
+          "mean_mse": 0.014429201543354512,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.29064620506541516,
+          "mean_mse": 0.015016069016044624,
+          "mean_rank": 45.5,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.44271533064255086,
+          "mean_mse": 0.014325297386082937,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.5067778785980267,
+          "mean_mse": 0.013837961017427843,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.43044372110698464,
+          "mean_mse": 0.014814782276647462,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.4402835063334206,
+          "mean_mse": 0.014055967549557898,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.5268812005634561,
+          "mean_mse": 0.014183437952647973,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.5134547848649246,
+          "mean_mse": 0.014063696906339318,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.541831548422716,
+          "mean_mse": 0.013141354792694245,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.5365594144852489,
+          "mean_mse": 0.013462594623571389,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.5477100531879942,
+          "mean_mse": 0.01336037689396326,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.5523495307561546,
+          "mean_mse": 0.013400944489446407,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.5649205437803803,
+          "mean_mse": 0.013730722453474667,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.5879872866810754,
+          "mean_mse": 0.01239180595267335,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.5593922430312553,
+          "mean_mse": 0.013329073805315792,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.5484507364168308,
+          "mean_mse": 0.012790903731496916,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.6009133534961891,
+          "mean_mse": 0.012464477592033835,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.5058610732373852,
+          "mean_mse": 0.013768246421814824,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.5074299219414494,
+          "mean_mse": 0.01373363486985339,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.596110117366448,
+          "mean_mse": 0.012262775675722858,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.5256586757900229,
+          "mean_mse": 0.013245794429288539,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.4871628726062352,
+          "mean_mse": 0.013798073057716242,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.5649373494505987,
+          "mean_mse": 0.012458867111428568,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.5183576643210789,
+          "mean_mse": 0.01345377918996809,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.5432115414397102,
+          "mean_mse": 0.012996815067991134,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.5561067503783067,
+          "mean_mse": 0.013173616440024759,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.5405055773418413,
+          "mean_mse": 0.013325403876873676,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.5857788077119964,
+          "mean_mse": 0.013199518640393764,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.5921121590145426,
+          "mean_mse": 0.012538717389063777,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.5308784467365296,
+          "mean_mse": 0.013290481562007551,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.5195127379515978,
+          "mean_mse": 0.013788455578663839,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.5062419823466225,
+          "mean_mse": 0.013490890212854082,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.606944307585421,
+          "mean_mse": 0.012500815564422478,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.6589333570514463,
+          "mean_mse": 0.01242022884477829,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.5800441768206478,
+          "mean_mse": 0.013147765868706507,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.6490867179518885,
+          "mean_mse": 0.011073248142166944,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5440176737669812,
+          "mean_mse": 0.013155068614227728,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.47687236020816154,
+          "mean_mse": 0.013418740837983431,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.5772229548371531,
+          "mean_mse": 0.013347337176502848,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.5478179810422636,
+          "mean_mse": 0.013586343021735744,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.5991032396127753,
+          "mean_mse": 0.012525002353744,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.4852825315909557,
+          "mean_mse": 0.013819463308638244,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.5962204716561735,
+          "mean_mse": 0.012728892888160231,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.5396400451282027,
+          "mean_mse": 0.01377471628308235,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.5578315839602715,
+          "mean_mse": 0.013133129990647661,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.5447089107121744,
+          "mean_mse": 0.01267124103088172,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.5178409399928829,
+          "mean_mse": 0.013493247920833182,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.4627006711831738,
+          "mean_mse": 0.01419283491705031,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.500965869180143,
+          "mean_mse": 0.013931412418856946,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.5615508509748572,
+          "mean_mse": 0.013552975867439086,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.4935844816210346,
+          "mean_mse": 0.01336543508756287,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.5842866870589042,
+          "mean_mse": 0.012234579949091032,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.5490525799633367,
+          "mean_mse": 0.012648833335522093,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.5161146014339979,
+          "mean_mse": 0.013534284244575423,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.5702110624085406,
+          "mean_mse": 0.013163183437278748,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.6038337762050471,
+          "mean_mse": 0.012499179602371157,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.5464404005812479,
+          "mean_mse": 0.012589600358362726,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.5508516108667122,
+          "mean_mse": 0.013171508319789518,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.5962830050831215,
+          "mean_mse": 0.012818717965004436,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.5310469376634467,
+          "mean_mse": 0.013559242200643825,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.590519330992547,
+          "mean_mse": 0.012672280470426787,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.5787743995900995,
+          "mean_mse": 0.012773761628130076,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.6004432801001153,
+          "mean_mse": 0.013550820559560734,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.553908308279441,
+          "mean_mse": 0.01333497339160943,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.5450691667207382,
+          "mean_mse": 0.01381657068155921,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.5115326656830567,
+          "mean_mse": 0.013361287101622528,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.6762488261861318,
+          "mean_mse": 0.010228950462318033,
+          "mean_rank": 6.0,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.5985293584710499,
+          "mean_mse": 0.012966017957777576,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.5474560306648363,
+          "mean_mse": 0.01332527333980331,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.584141027543636,
+          "mean_mse": 0.012574525165637075,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.5318518060350444,
+          "mean_mse": 0.013281484417633611,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.5996227354473032,
+          "mean_mse": 0.012403767510712954,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.5559230606229363,
+          "mean_mse": 0.012287933996651063,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.5431609982922426,
+          "mean_mse": 0.013753440732786606,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.5541012786510744,
+          "mean_mse": 0.012861693111779508,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.5940636266551094,
+          "mean_mse": 0.011737607749687068,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.5510332522564302,
+          "mean_mse": 0.013404160852182087,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.5827566004450527,
+          "mean_mse": 0.013427335876783528,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.5658058711549868,
+          "mean_mse": 0.013256889270427152,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.5282120530021998,
+          "mean_mse": 0.013311526496559846,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5680207873051781,
+          "mean_mse": 0.012373812383933825,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.7438306864871496,
+          "mean_mse": 0.010104864449088298,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7348271252428942,
+          "mean_mse": 0.009779917396052221,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9963018065365933,
+          "mean_mse": 0.0011168920160739763,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7835029650260537,
+          "mean_mse": 0.007693849584186851,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.7115025387300389,
+          "mean_mse": 0.00914240482091429,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7659396932977707,
+          "mean_mse": 0.009457547340343988,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.6416146929575739,
+          "mean_mse": 0.010379573947453579,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.6368197233406419,
+          "mean_mse": 0.01167690996875612,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6788518240713544,
+          "mean_mse": 0.011010640517325934,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.6767929177356553,
+          "mean_mse": 0.010342369301166582,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6917186369865553,
+          "mean_mse": 0.009181364832773079,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6666010266686784,
+          "mean_mse": 0.010502789987698921,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.6905944193524738,
+          "mean_mse": 0.009292165215958508,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9984673739519874,
+          "mean_mse": 0.0012177639801093428,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9958301813305859,
+          "mean_mse": 0.0013230041093382743,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.6189401041078615,
+          "mean_mse": 0.010945734585365357,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.5973018122191127,
+          "mean_mse": 0.010996338743284189,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6812768540186249,
+          "mean_mse": 0.010230424539754986,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.9963231419207507,
+          "mean_mse": 0.0012155181382831207,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6839678944457995,
+          "mean_mse": 0.010130081407600714,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7468252193507096,
+          "mean_mse": 0.008209529131061506,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.6634422066658787,
+          "mean_mse": 0.011891946635554412,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.997847096297326,
+          "mean_mse": 0.0013287792605892685,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6664015222164406,
+          "mean_mse": 0.009779266301863815,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9970933735239895,
+          "mean_mse": 0.0012166891406392574,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7961652671497339,
+          "mean_mse": 0.00942336856637651,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6283060078932788,
+          "mean_mse": 0.01142642317161727,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.7010214619684223,
+          "mean_mse": 0.009088284506330974,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9961645797999185,
+          "mean_mse": 0.001170239263121784,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.7161363387359347,
+          "mean_mse": 0.009729768200986387,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.9983192814352478,
+          "mean_mse": 0.0011681077537822981,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7901754750298253,
+          "mean_mse": 0.008183189092317092,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9957221297390194,
+          "mean_mse": 0.0011917201360992506,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6421817996834636,
+          "mean_mse": 0.010588202978253802,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6360298330244192,
+          "mean_mse": 0.010212785463162026,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.6972813021751781,
+          "mean_mse": 0.009588077246349183,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6487461253270101,
+          "mean_mse": 0.010330798363052243,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9909859971550447,
+          "mean_mse": 0.0013060492717437361,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.6970789400543418,
+          "mean_mse": 0.00941423632458346,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7806708305558575,
+          "mean_mse": 0.008050688499113048,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9995969045659947,
+          "mean_mse": 0.0011716366072990903,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6879459589753163,
+          "mean_mse": 0.009253248459369912,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6836111936867588,
+          "mean_mse": 0.009379933607817751,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9942809717930797,
+          "mean_mse": 0.0013403399702944995,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9970078998277778,
+          "mean_mse": 0.0011142258054707408,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.753279304423933,
+          "mean_mse": 0.008850258149266916,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.690606560403165,
+          "mean_mse": 0.009379864457900592,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.7449787709877884,
+          "mean_mse": 0.008623498336605102,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.9941549093307313,
+          "mean_mse": 0.0012640998430768875,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.7025527219575807,
+          "mean_mse": 0.009458338686657328,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.7105153473741385,
+          "mean_mse": 0.0095296653605258,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9953890831596115,
+          "mean_mse": 0.0013162634566182053,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.7716871803272998,
+          "mean_mse": 0.008588082123516794,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.9927449875527349,
+          "mean_mse": 0.0012576107142009978,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.766660095314439,
+          "mean_mse": 0.008278208501816082,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.6201200795672374,
+          "mean_mse": 0.010640940965997516,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9959973548644125,
+          "mean_mse": 0.0013220912191794303,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9940935481037623,
+          "mean_mse": 0.0013189408262986439,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9962486815667739,
+          "mean_mse": 0.0011901379498672022,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.9993651946153023,
+          "mean_mse": 0.0011059791423306885,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.6158610792257502,
+          "mean_mse": 0.010921307077935608,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.652230748682777,
+          "mean_mse": 0.010730066055850748,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6609743481334951,
+          "mean_mse": 0.010412886193324434,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.7429378439871495,
+          "mean_mse": 0.01009445720104352,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.6059986545364284,
+          "mean_mse": 0.013021906732870523,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7559503561562595,
+          "mean_mse": 0.008625266337547568,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.5344438922255829,
+          "mean_mse": 0.013848365511643201,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.4939886553726135,
+          "mean_mse": 0.014438162667329616,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.646521622636912,
+          "mean_mse": 0.012210360475748716,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.5338615919021042,
+          "mean_mse": 0.014156470858039763,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6874500132566709,
+          "mean_mse": 0.011493735014106672,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.5664791990139145,
+          "mean_mse": 0.012422190040161476,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.5582039224924464,
+          "mean_mse": 0.012389553001797313,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.22038158730599106,
+          "mean_mse": 0.015008978802189998,
+          "mean_rank": 116.8,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.45681861224014275,
+          "mean_mse": 0.013750555351155963,
+          "mean_rank": 6.666666666666667,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.43663492275222915,
+          "mean_mse": 0.014134947352483385,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.5",
+      "params": {
+        "cutoff": 0.5,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.5486403819927397,
+      "std_cosine_to_target": 0.15396349775705687,
+      "mean_mse_to_target": 0.01218647614054812,
+      "std_mse_to_target": 0.0029657601863130405,
+      "mean_target_rank": 6.208074534161491,
+      "median_target_rank": 2.0,
+      "recall_at_1": 0.32608695652173914,
+      "recall_at_5": 0.9208074534161491,
+      "recall_at_10": 0.9503105590062112,
+      "mrr": 0.5703891295620386,
+      "train_time_ms": 135.3380000218749,
+      "inference_time_us": 1871.0793523473653,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4751364993505013,
+          "mean_mse": 0.013586956012800834,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.35254088149554363,
+          "mean_mse": 0.014175823151836783,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.45933689227620306,
+          "mean_mse": 0.014047472239864536,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.521808244932624,
+          "mean_mse": 0.013816866379482562,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.48379364606438,
+          "mean_mse": 0.013514976900767677,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4987870307512521,
+          "mean_mse": 0.013995798559001038,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.32564429064381856,
+          "mean_mse": 0.014447574904068117,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.5195690936589599,
+          "mean_mse": 0.01411385881447657,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.31117149439718816,
+          "mean_mse": 0.014904224340262015,
+          "mean_rank": 97.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4754448079973134,
+          "mean_mse": 0.01356624735199471,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4469126750804761,
+          "mean_mse": 0.01382241874456286,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5377798657194134,
+          "mean_mse": 0.013312538581185168,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.45943725706703686,
+          "mean_mse": 0.013819292421177132,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.4525516858595596,
+          "mean_mse": 0.014427784490194264,
+          "mean_rank": 18.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.5219465060029786,
+          "mean_mse": 0.014057210337056206,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.3145574512736723,
+          "mean_mse": 0.014678341572054002,
+          "mean_rank": 46.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.5019775671075735,
+          "mean_mse": 0.013815887775967232,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4819698362454783,
+          "mean_mse": 0.01390752053622223,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.48037975488803475,
+          "mean_mse": 0.013815811012488658,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.4514483655428171,
+          "mean_mse": 0.013903774234195828,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.4598730824774363,
+          "mean_mse": 0.01372268083213534,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.4163268474768004,
+          "mean_mse": 0.014037970854007013,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.4161101741386616,
+          "mean_mse": 0.014232265578765942,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.4819314004094682,
+          "mean_mse": 0.013472307020742797,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.4485596337493939,
+          "mean_mse": 0.014129632519089476,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.42261874639124947,
+          "mean_mse": 0.014081175983406066,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.5119495606762642,
+          "mean_mse": 0.013340710381562256,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.3964432521132313,
+          "mean_mse": 0.013972742407372495,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.5158220778652353,
+          "mean_mse": 0.012955020465969642,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.594262347753442,
+          "mean_mse": 0.012575195356022644,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.523367571421718,
+          "mean_mse": 0.01329217979080002,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.5105736868788923,
+          "mean_mse": 0.013526451278486624,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.4413188273397315,
+          "mean_mse": 0.01426392542394252,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.48257364004802006,
+          "mean_mse": 0.013910292538731321,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.4809353212242737,
+          "mean_mse": 0.013379781691453754,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.3970099281042756,
+          "mean_mse": 0.014670321103670936,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.3721237515931042,
+          "mean_mse": 0.014623513430687914,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.47875215162320617,
+          "mean_mse": 0.013905068302781022,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.44380309439593424,
+          "mean_mse": 0.0139666531690603,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.5347736161033327,
+          "mean_mse": 0.01241406868422728,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.5251879955959113,
+          "mean_mse": 0.013492940806442297,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.395853341776511,
+          "mean_mse": 0.01461711796738534,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.5003149354914189,
+          "mean_mse": 0.01353786264894401,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.4751950376543595,
+          "mean_mse": 0.013875031763943557,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.5530795347439055,
+          "mean_mse": 0.01330102850916965,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.3755348411327973,
+          "mean_mse": 0.014204091106654913,
+          "mean_rank": 119.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.4346797564496797,
+          "mean_mse": 0.014154936739984253,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.5345253428209924,
+          "mean_mse": 0.013724094288825013,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.5202361937774633,
+          "mean_mse": 0.013439218590040759,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.4302079640221132,
+          "mean_mse": 0.014052934775217518,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.4847619834155052,
+          "mean_mse": 0.013393220322935025,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.4781444485971764,
+          "mean_mse": 0.013266485151683802,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.5003220655230732,
+          "mean_mse": 0.013734618539919818,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.5445164828424385,
+          "mean_mse": 0.012835041811040643,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.4210708116001029,
+          "mean_mse": 0.014238028484706924,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.49236896734917046,
+          "mean_mse": 0.013532963583261195,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.5525925526907896,
+          "mean_mse": 0.013461980541385626,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.44929575901527846,
+          "mean_mse": 0.013504187090559235,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.3660058285069845,
+          "mean_mse": 0.014585973284674314,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.4290829981415141,
+          "mean_mse": 0.013065265913543005,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.42814567997880815,
+          "mean_mse": 0.014326658137042689,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.40180914495133524,
+          "mean_mse": 0.014151959850866773,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.3055178853355768,
+          "mean_mse": 0.014835920656683328,
+          "mean_rank": 32.75,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.4444773893635302,
+          "mean_mse": 0.013975815572645389,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.518012881992556,
+          "mean_mse": 0.013437205236467992,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.4410451423088055,
+          "mean_mse": 0.014595623798206038,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.44761533889346106,
+          "mean_mse": 0.013654709945345078,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.5380545180288882,
+          "mean_mse": 0.01379202118236482,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.5223136577192956,
+          "mean_mse": 0.013680321955336083,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.547526035542917,
+          "mean_mse": 0.012503784983032208,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.5433787702711315,
+          "mean_mse": 0.01290541031126712,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.5614130358578231,
+          "mean_mse": 0.012799554425566587,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.5513120830116104,
+          "mean_mse": 0.01292219376040152,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.5677408796863764,
+          "mean_mse": 0.0132452532183329,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.5957540647462923,
+          "mean_mse": 0.011716644096758511,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.5660479721673827,
+          "mean_mse": 0.012845746922426765,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.5540860335361948,
+          "mean_mse": 0.01208749527761988,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.6067973283598463,
+          "mean_mse": 0.011695505887360952,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.524959432780648,
+          "mean_mse": 0.013257726335685479,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.5070748853566213,
+          "mean_mse": 0.01330124250830752,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.5985526833610662,
+          "mean_mse": 0.011505451682509616,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.5334090498864841,
+          "mean_mse": 0.012770151038910717,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.5021793844974979,
+          "mean_mse": 0.013310948515711206,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.5690538779121627,
+          "mean_mse": 0.01180418986686651,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.5176017391809369,
+          "mean_mse": 0.012962862026690785,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.5542734418574727,
+          "mean_mse": 0.012421596415524113,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.5579148481988522,
+          "mean_mse": 0.012529789236087108,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.5457667080632014,
+          "mean_mse": 0.012801351206108794,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.5917439022801597,
+          "mean_mse": 0.01257097539839648,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.6033095160724814,
+          "mean_mse": 0.01177404451167631,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.5400019712985703,
+          "mean_mse": 0.012678282541628005,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.527628048795302,
+          "mean_mse": 0.013294721585746594,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.513890158732741,
+          "mean_mse": 0.013063996246208921,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.6163842639824001,
+          "mean_mse": 0.011699906382427822,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.6605325058264858,
+          "mean_mse": 0.01157273071443051,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.5758435222424553,
+          "mean_mse": 0.012577310731540052,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.6550206105207197,
+          "mean_mse": 0.010218841602051108,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5509066062455781,
+          "mean_mse": 0.012599916510446547,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.48364506269420754,
+          "mean_mse": 0.013004046538098585,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.5689300181239757,
+          "mean_mse": 0.012831055796141444,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.5528417283152234,
+          "mean_mse": 0.013198179728910804,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.6005543973648758,
+          "mean_mse": 0.011812208810808278,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.48946077339798105,
+          "mean_mse": 0.013446184422180534,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.598139156776498,
+          "mean_mse": 0.012065393491618268,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.5362566711146028,
+          "mean_mse": 0.013310336236845528,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.5563951047132473,
+          "mean_mse": 0.012569567443622127,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.5572969573145,
+          "mean_mse": 0.012017835698106466,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.5395406777452377,
+          "mean_mse": 0.012949467877296434,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.46361969145494203,
+          "mean_mse": 0.013834749958494813,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.49877817573497407,
+          "mean_mse": 0.013537832660148305,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.5698637996800023,
+          "mean_mse": 0.01305244486259452,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.5092982282701751,
+          "mean_mse": 0.01274775610252441,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.5826013305855359,
+          "mean_mse": 0.011662369935535419,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.5461730897024294,
+          "mean_mse": 0.01219757523531186,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.5254330817481434,
+          "mean_mse": 0.01299758591718758,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.5721359864971135,
+          "mean_mse": 0.012662169096545849,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.6132561897145009,
+          "mean_mse": 0.011727120301178248,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.5464851481902882,
+          "mean_mse": 0.011948206948234558,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.5582752031401347,
+          "mean_mse": 0.012577718924334236,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.6009241491953214,
+          "mean_mse": 0.012181952824694336,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.5392795976205723,
+          "mean_mse": 0.013049000230217498,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.5969877757758705,
+          "mean_mse": 0.012059159077390158,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.5850709789133587,
+          "mean_mse": 0.012108687158045079,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.6056142933310165,
+          "mean_mse": 0.013005929372907489,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.5559505346140897,
+          "mean_mse": 0.012758165120325219,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.5540770076122635,
+          "mean_mse": 0.013306182724762916,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.5161281663195142,
+          "mean_mse": 0.012818823501579915,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.6775444468120604,
+          "mean_mse": 0.00926379887202254,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.6052520518721249,
+          "mean_mse": 0.012279405665912778,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.5488851730645906,
+          "mean_mse": 0.012726977611899648,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.5925763960620966,
+          "mean_mse": 0.011840368047891042,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.5284132798338538,
+          "mean_mse": 0.01280909638356006,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.6027673401420746,
+          "mean_mse": 0.011645408325641524,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.5658365164206698,
+          "mean_mse": 0.011568024485469591,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.545984494219365,
+          "mean_mse": 0.013279588245721528,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.5658561792470589,
+          "mean_mse": 0.012158007601720701,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.5966370614261223,
+          "mean_mse": 0.011017119037461382,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.5527005586419749,
+          "mean_mse": 0.012967648885387534,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.5810489190330107,
+          "mean_mse": 0.01291333842003607,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.5686955903836869,
+          "mean_mse": 0.01267427903985724,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.5339927028308152,
+          "mean_mse": 0.012764695570786888,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5611531196106494,
+          "mean_mse": 0.011771398034292307,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.7413107556775175,
+          "mean_mse": 0.008976328694479162,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7515253481623899,
+          "mean_mse": 0.00836375197939995,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9999749744448627,
+          "mean_mse": 2.10177662429499e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7912338646309346,
+          "mean_mse": 0.006395799960524548,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.7260678941317182,
+          "mean_mse": 0.007965172045192273,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7664837398619195,
+          "mean_mse": 0.008229231883019031,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.645470717292977,
+          "mean_mse": 0.00961542904465162,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.6414134782319789,
+          "mean_mse": 0.010803007744038497,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6856946793044729,
+          "mean_mse": 0.010024542032983554,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.6850971434493416,
+          "mean_mse": 0.009293098609410164,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6966909081527659,
+          "mean_mse": 0.008250710619440216,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6736665560761562,
+          "mean_mse": 0.009517522175182525,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.6947964198595855,
+          "mean_mse": 0.008375987072822803,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9999711198335356,
+          "mean_mse": 2.2972555538457575e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9999832880659725,
+          "mean_mse": 2.38719097765118e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.6280063977867181,
+          "mean_mse": 0.010052624312578291,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.6229578398959214,
+          "mean_mse": 0.010017827903263709,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6888125803358787,
+          "mean_mse": 0.009093140477335473,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.9999616379257041,
+          "mean_mse": 2.135620722884337e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6878752752542154,
+          "mean_mse": 0.00916042682276142,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7549287756688035,
+          "mean_mse": 0.0071081575651465966,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.6642022843032209,
+          "mean_mse": 0.011080313806138872,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9999847239545454,
+          "mean_mse": 2.2795949407712506e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6640110273599347,
+          "mean_mse": 0.009019885686975157,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9999684616452955,
+          "mean_mse": 3.109561623889215e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7965580879613623,
+          "mean_mse": 0.008033855003748928,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6278222957730588,
+          "mean_mse": 0.01059610736268027,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.7018125620466894,
+          "mean_mse": 0.008202436755965183,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9999617025370844,
+          "mean_mse": 2.2913798899568375e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.7187353755898034,
+          "mean_mse": 0.008604982180294561,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.9999826037115437,
+          "mean_mse": 1.9381551440288e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7895802620244112,
+          "mean_mse": 0.006960058085101469,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9999565651559551,
+          "mean_mse": 2.4088795185843042e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6544671502611349,
+          "mean_mse": 0.009666699751374228,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6585802951718926,
+          "mean_mse": 0.009087111703422005,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.7062496972080547,
+          "mean_mse": 0.008497434009273348,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6475504643741454,
+          "mean_mse": 0.0095164867268091,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.999959126759911,
+          "mean_mse": 2.8158437666141153e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.6985108968865578,
+          "mean_mse": 0.008513057068096365,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7845707677566487,
+          "mean_mse": 0.006799825614082551,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9999805506483609,
+          "mean_mse": 2.294446229536493e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6914374998797077,
+          "mean_mse": 0.00844015514513827,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6918057025609836,
+          "mean_mse": 0.008464363410837403,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9999757783872437,
+          "mean_mse": 2.3784604996096882e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9999693230070867,
+          "mean_mse": 2.077017593144128e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.7545291834526289,
+          "mean_mse": 0.007684823859196894,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6973394985961372,
+          "mean_mse": 0.008403592478919825,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.7476353744477592,
+          "mean_mse": 0.007499705533644745,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.9999511552646329,
+          "mean_mse": 2.2559665460681404e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.7119106764701706,
+          "mean_mse": 0.008414303409564288,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.7170698553625169,
+          "mean_mse": 0.008388915583001116,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9999700874591287,
+          "mean_mse": 2.6582201393779624e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.7763208024155259,
+          "mean_mse": 0.007274342939351481,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.9999640733865606,
+          "mean_mse": 2.4270470527009008e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7752014377383589,
+          "mean_mse": 0.006926223870500894,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.6251586958476711,
+          "mean_mse": 0.009844654556933998,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9999796171399081,
+          "mean_mse": 2.20128842410088e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9999626298796245,
+          "mean_mse": 2.3978484805877822e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9999730637839007,
+          "mean_mse": 2.221887307680339e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.9999799917574471,
+          "mean_mse": 2.0082504760911584e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.6214445474578936,
+          "mean_mse": 0.01006610170493948,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.6657027832325396,
+          "mean_mse": 0.009621994847733645,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6621272088750649,
+          "mean_mse": 0.009515765576568644,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.7456537445741108,
+          "mean_mse": 0.008980410428584511,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.6169548795171091,
+          "mean_mse": 0.012286090378119762,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7654552266517949,
+          "mean_mse": 0.007328758589919568,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.5342514682801146,
+          "mean_mse": 0.013483705286510226,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.5070159037018803,
+          "mean_mse": 0.014113492447606582,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.6528236957933876,
+          "mean_mse": 0.01163518581673679,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.5434005042145026,
+          "mean_mse": 0.013761906025362461,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6889964709087546,
+          "mean_mse": 0.010515381845137037,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.5658995743716417,
+          "mean_mse": 0.011818634209952017,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.5643332219085824,
+          "mean_mse": 0.01168848688996707,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.2216013973405488,
+          "mean_mse": 0.014881271113230449,
+          "mean_rank": 121.2,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.4633079178084582,
+          "mean_mse": 0.013301013705353719,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.4391163983168013,
+          "mean_mse": 0.013773762608019255,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.7",
+      "params": {
+        "cutoff": 0.7,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.5487064442731847,
+      "std_cosine_to_target": 0.15406124122269824,
+      "mean_mse_to_target": 0.012181020315342544,
+      "std_mse_to_target": 0.0029674164880847263,
+      "mean_target_rank": 6.25,
+      "median_target_rank": 2.0,
+      "recall_at_1": 0.3245341614906832,
+      "recall_at_5": 0.9208074534161491,
+      "recall_at_10": 0.9518633540372671,
+      "mrr": 0.5697937073059868,
+      "train_time_ms": 118.20019991137087,
+      "inference_time_us": 1896.8889798885155,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4750385347582262,
+          "mean_mse": 0.013573824623016281,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.3554835344883382,
+          "mean_mse": 0.014165921870457433,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.45794662232407857,
+          "mean_mse": 0.01404349555614031,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.5225800016668296,
+          "mean_mse": 0.013807205426206188,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.48400747519302745,
+          "mean_mse": 0.013509561723308434,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4985004951234455,
+          "mean_mse": 0.013994222824649356,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.32648434870585774,
+          "mean_mse": 0.01444223998879994,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.5200366981040696,
+          "mean_mse": 0.014108940313665325,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.31038063487315426,
+          "mean_mse": 0.014905320356972512,
+          "mean_rank": 97.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4741375501594559,
+          "mean_mse": 0.013568153177189296,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4469010693486256,
+          "mean_mse": 0.013821343912331124,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5366062409442092,
+          "mean_mse": 0.013314681386006225,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.45943168511580534,
+          "mean_mse": 0.013813320333196502,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.45316665422751023,
+          "mean_mse": 0.014421857673415531,
+          "mean_rank": 18.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.5225360916907672,
+          "mean_mse": 0.014053151012079346,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.31316653475443135,
+          "mean_mse": 0.014681547994166187,
+          "mean_rank": 46.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.5022873355702442,
+          "mean_mse": 0.013814034082721117,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4811807725368351,
+          "mean_mse": 0.013905860483882685,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.48021402947718317,
+          "mean_mse": 0.013816757491305235,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.4506797057090944,
+          "mean_mse": 0.013904091567819644,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.4617330517577326,
+          "mean_mse": 0.013707986111577551,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.4160973208349498,
+          "mean_mse": 0.014039672299434848,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.41758902865666,
+          "mean_mse": 0.014227589652229849,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.4823309546319067,
+          "mean_mse": 0.01347243578599298,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.44767187935895536,
+          "mean_mse": 0.014135251850201858,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.42289091514464144,
+          "mean_mse": 0.014083347414114007,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.512681743380003,
+          "mean_mse": 0.013332508620490745,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.3969451529759473,
+          "mean_mse": 0.01396625046696229,
+          "mean_rank": 26.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.5153029854648143,
+          "mean_mse": 0.012950871994361462,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.5944571651393527,
+          "mean_mse": 0.01257255702288227,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.5233940486676774,
+          "mean_mse": 0.013287576971890492,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.5095630640023278,
+          "mean_mse": 0.01352246837762076,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.440874877652906,
+          "mean_mse": 0.014262345033097427,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.4819128048133647,
+          "mean_mse": 0.013919765465967585,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.48197201739372775,
+          "mean_mse": 0.013375593835655973,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.39723769231876754,
+          "mean_mse": 0.014664810991556127,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.37086739215344433,
+          "mean_mse": 0.014624422698405984,
+          "mean_rank": 29.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.4789003257324856,
+          "mean_mse": 0.013901340926271485,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.4419660022723221,
+          "mean_mse": 0.013973621077299398,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.5361202707563317,
+          "mean_mse": 0.012400528829598675,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.5254541374703458,
+          "mean_mse": 0.013483699892354706,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.394330350247978,
+          "mean_mse": 0.014617753893087136,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.5003468791192108,
+          "mean_mse": 0.013536038011084453,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.4761795293130133,
+          "mean_mse": 0.013866050064467311,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.5535839114628719,
+          "mean_mse": 0.013292526715458199,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.37451743845276,
+          "mean_mse": 0.014207563065929293,
+          "mean_rank": 119.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.43288268884934533,
+          "mean_mse": 0.01416256722826489,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.5347138225695175,
+          "mean_mse": 0.01372452235578855,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.5199699769230165,
+          "mean_mse": 0.013437609876585932,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.431939326820835,
+          "mean_mse": 0.014044395562035804,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.4839561840920143,
+          "mean_mse": 0.013395257477890263,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.4786109320287944,
+          "mean_mse": 0.013262084019661538,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.5007557652165187,
+          "mean_mse": 0.013733280266708956,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.5445195811215989,
+          "mean_mse": 0.012829171241751725,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.4213430375333596,
+          "mean_mse": 0.014238687309055451,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.49328668573417656,
+          "mean_mse": 0.01352181590037224,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.5522659694513788,
+          "mean_mse": 0.013459811992790558,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.4501617739387995,
+          "mean_mse": 0.013496747346250618,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.36387148402163955,
+          "mean_mse": 0.014592281460436587,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.42883933394311496,
+          "mean_mse": 0.013059277179584675,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.42904330839003973,
+          "mean_mse": 0.01432037869023839,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.40093472853001066,
+          "mean_mse": 0.014154705453928027,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.30608645971334836,
+          "mean_mse": 0.014834084171363338,
+          "mean_rank": 33.0,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.4444819089613313,
+          "mean_mse": 0.013971429558624977,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.5187259963092853,
+          "mean_mse": 0.013430765789845558,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.44083815756415107,
+          "mean_mse": 0.014592273153081033,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.449077623252852,
+          "mean_mse": 0.013641257158446983,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.5379903880751937,
+          "mean_mse": 0.013787540403339947,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.522577087591801,
+          "mean_mse": 0.013674147372674169,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.547990848976584,
+          "mean_mse": 0.012493852805065543,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.5445126270391385,
+          "mean_mse": 0.012894229222043016,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.5613959180750706,
+          "mean_mse": 0.012794237812045193,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.5509470193679706,
+          "mean_mse": 0.01291640443788801,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.5676086075677772,
+          "mean_mse": 0.013235072480284195,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.5952621355167587,
+          "mean_mse": 0.011710712490041348,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.5672805004634914,
+          "mean_mse": 0.01283324708842302,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.5549516117981949,
+          "mean_mse": 0.012071266612214401,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.6073581226928725,
+          "mean_mse": 0.011685856739627196,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.5261480691740444,
+          "mean_mse": 0.01324597560845036,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.5072600034593424,
+          "mean_mse": 0.01330105341172858,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.5989550100074839,
+          "mean_mse": 0.011495160918136571,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.5329767088267507,
+          "mean_mse": 0.012766821208574771,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.5010805040334408,
+          "mean_mse": 0.013310663685130392,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.5700087509870405,
+          "mean_mse": 0.011783028041999344,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.5194692304214458,
+          "mean_mse": 0.012952524494332441,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.5537874735664053,
+          "mean_mse": 0.012416572007723031,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.5583105550057664,
+          "mean_mse": 0.012524168272436178,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.5451063869069102,
+          "mean_mse": 0.012795284409956734,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.5902957759762594,
+          "mean_mse": 0.01257666056877932,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.6046006897566815,
+          "mean_mse": 0.011755296743898871,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.540000779542514,
+          "mean_mse": 0.012669981192714432,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.5291832307134694,
+          "mean_mse": 0.013279671883088193,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.5142371812781416,
+          "mean_mse": 0.01306259309458014,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.6161172177239175,
+          "mean_mse": 0.011692181725703401,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.6615860299682131,
+          "mean_mse": 0.011554710780045748,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.575697484028892,
+          "mean_mse": 0.012575110655483784,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.6534154386543682,
+          "mean_mse": 0.010226814810213885,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5499957133878002,
+          "mean_mse": 0.012607799003687891,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.48433879989381784,
+          "mean_mse": 0.012991898288880933,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.5686805136371342,
+          "mean_mse": 0.012822190762742769,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.5527711757073139,
+          "mean_mse": 0.013198215345019205,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.6010675217879652,
+          "mean_mse": 0.011799360955700505,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.4896463949381586,
+          "mean_mse": 0.013438849596618141,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.598388080491969,
+          "mean_mse": 0.012056471836709484,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.5370105791596425,
+          "mean_mse": 0.013294767831027171,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.5575818154753501,
+          "mean_mse": 0.012553813314981588,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.5580841868000074,
+          "mean_mse": 0.01201030464105772,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.5403766443972865,
+          "mean_mse": 0.012939442033755723,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.464258338084287,
+          "mean_mse": 0.013831934408992622,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.49988974896096217,
+          "mean_mse": 0.013524795878624216,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.5695917169806456,
+          "mean_mse": 0.013047786670197322,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.509530105057458,
+          "mean_mse": 0.012743149937299551,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.5825499844151399,
+          "mean_mse": 0.011655310041981072,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.545842816264523,
+          "mean_mse": 0.012192918965087757,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.5252340905723227,
+          "mean_mse": 0.012994974608878933,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.5717357153602712,
+          "mean_mse": 0.012651578061235735,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.6132069522090692,
+          "mean_mse": 0.0117178231958647,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.5456503333775601,
+          "mean_mse": 0.011946903549554832,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.5600767749833112,
+          "mean_mse": 0.01255764531059915,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.6011355519446956,
+          "mean_mse": 0.012170865633393249,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.5390530144504434,
+          "mean_mse": 0.013047789778289312,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.5970139174673413,
+          "mean_mse": 0.012061520103411017,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.5860349298195678,
+          "mean_mse": 0.012093394710843142,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.6066896728561028,
+          "mean_mse": 0.012994651356414153,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.5569955093684107,
+          "mean_mse": 0.012744102745337908,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.5535252127509535,
+          "mean_mse": 0.013300499346220579,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.517616748020168,
+          "mean_mse": 0.012806918105438173,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.67705586675361,
+          "mean_mse": 0.009256021977408812,
+          "mean_rank": 6.0,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.6062409600704558,
+          "mean_mse": 0.012263012754019476,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.5488358374339992,
+          "mean_mse": 0.012717250358297183,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.5933704388743134,
+          "mean_mse": 0.011825049127552757,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.5302199873233596,
+          "mean_mse": 0.012790710137530775,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.6035182946706491,
+          "mean_mse": 0.011637507891626523,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.5657161522118827,
+          "mean_mse": 0.011563815102119374,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.545795709417868,
+          "mean_mse": 0.013273370303197106,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.5652345782170413,
+          "mean_mse": 0.012158998331631879,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.5975036126549873,
+          "mean_mse": 0.011001108510602637,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.5521404760260471,
+          "mean_mse": 0.01296509768512947,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.5821611421243835,
+          "mean_mse": 0.012902048082583537,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.5692907828302282,
+          "mean_mse": 0.012660192898909605,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.5338575650257801,
+          "mean_mse": 0.01275962224391409,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5610938899413256,
+          "mean_mse": 0.011762287482597776,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.741402415764479,
+          "mean_mse": 0.00896037819879199,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7524106184329135,
+          "mean_mse": 0.008340716658104142,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9999932168571448,
+          "mean_mse": 1.674579197150265e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7920427833555592,
+          "mean_mse": 0.006373223300892625,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.7253698839311495,
+          "mean_mse": 0.007970744178544743,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7662903648441522,
+          "mean_mse": 0.008221100895406515,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.6453297947492456,
+          "mean_mse": 0.009615535719301247,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.6418495400874913,
+          "mean_mse": 0.010787441052031003,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6856865015583686,
+          "mean_mse": 0.010013511047814071,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.6839678659444045,
+          "mean_mse": 0.009302764779187584,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6969553255663964,
+          "mean_mse": 0.0082423636956543,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6742336854802202,
+          "mean_mse": 0.009502122808623531,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.6942227440292235,
+          "mean_mse": 0.00837430003405476,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9999903594648846,
+          "mean_mse": 1.852453562157036e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9999895712117589,
+          "mean_mse": 1.902593503569171e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.6285690002167732,
+          "mean_mse": 0.010041135663435003,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.6243629402702313,
+          "mean_mse": 0.009990764808835534,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6879934309022886,
+          "mean_mse": 0.00909503026767718,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.999986257580433,
+          "mean_mse": 1.6575360536035146e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6880562920372522,
+          "mean_mse": 0.009156679218132098,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7547648048366612,
+          "mean_mse": 0.007103761565615593,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.6639017926591355,
+          "mean_mse": 0.01107273653147512,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9999901866704629,
+          "mean_mse": 1.9861697034046698e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6637301230555577,
+          "mean_mse": 0.009020765099830548,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9999883061668529,
+          "mean_mse": 2.5737117661250034e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7961430791923754,
+          "mean_mse": 0.008018178816283835,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6275980680881175,
+          "mean_mse": 0.010594011368306764,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.7027132102875857,
+          "mean_mse": 0.00818010133863735,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9999882354585942,
+          "mean_mse": 1.751215902743175e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.7196248894761101,
+          "mean_mse": 0.008575395602099889,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.9999872958239927,
+          "mean_mse": 1.809372948962475e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7887169729005497,
+          "mean_mse": 0.006963971547093111,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9999896839461685,
+          "mean_mse": 2.216164409033382e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6539445931776442,
+          "mean_mse": 0.009670875661780223,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6593564670755436,
+          "mean_mse": 0.009071089963046466,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.7070586915112924,
+          "mean_mse": 0.008470216826030004,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6470154066736531,
+          "mean_mse": 0.009516136685103146,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9999868377783756,
+          "mean_mse": 2.344605686518849e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.6980944515399543,
+          "mean_mse": 0.008516142184867185,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7848208958670325,
+          "mean_mse": 0.00678271849596758,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9999928292064261,
+          "mean_mse": 1.9064486450913556e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6912275643367101,
+          "mean_mse": 0.008442652864401603,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6915171997347491,
+          "mean_mse": 0.008461483665424614,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9999905433871247,
+          "mean_mse": 2.0286486180590905e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9999894551449314,
+          "mean_mse": 1.7501487400377478e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.7534394763437768,
+          "mean_mse": 0.007694186858394959,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6979422729978155,
+          "mean_mse": 0.008386070224088677,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.748655153026534,
+          "mean_mse": 0.007469605051182857,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.9999915707357077,
+          "mean_mse": 1.7581260069089534e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.7128015645350751,
+          "mean_mse": 0.008391027811057062,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.717179514018087,
+          "mean_mse": 0.00838012080217778,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9999906546227428,
+          "mean_mse": 2.200558684442139e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.7760983684407425,
+          "mean_mse": 0.007271695462566032,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.9999898252639652,
+          "mean_mse": 1.9451986076118675e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7751610356491986,
+          "mean_mse": 0.006918502245728824,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.6245751649494766,
+          "mean_mse": 0.009846916815979632,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9999919737555821,
+          "mean_mse": 1.700782143050627e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.999979820622856,
+          "mean_mse": 2.118333167927505e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9999832931792728,
+          "mean_mse": 1.8964782296290447e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.9999877459562895,
+          "mean_mse": 1.889993811530685e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.6216732685600757,
+          "mean_mse": 0.01005912559936313,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.6649015576737327,
+          "mean_mse": 0.009619529685599159,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6618186904380852,
+          "mean_mse": 0.009512247579057118,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.7453471086945151,
+          "mean_mse": 0.00897480204743762,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.6158861393586963,
+          "mean_mse": 0.01228553367666801,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7653700565775636,
+          "mean_mse": 0.007316494633306658,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.533347923698962,
+          "mean_mse": 0.013486340539432996,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.508049026394052,
+          "mean_mse": 0.014106825573450069,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.6527046449045654,
+          "mean_mse": 0.011633208913765373,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.5422397416220857,
+          "mean_mse": 0.013767993485960852,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6877189710605289,
+          "mean_mse": 0.010514790725869744,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.566478124109494,
+          "mean_mse": 0.01180898226952337,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.5638779593042084,
+          "mean_mse": 0.01168529459512075,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.21921869188459406,
+          "mean_mse": 0.014889597474930063,
+          "mean_rank": 124.8,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.46385586545040836,
+          "mean_mse": 0.013294952500561126,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.43732181244178836,
+          "mean_mse": 0.01378271845706508,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveFFT",
+      "params": {
+        "min_cutoff": 0.2,
+        "max_cutoff": 0.7
+      },
+      "mean_cosine_to_target": 0.5477873310313185,
+      "std_cosine_to_target": 0.15393299469453492,
+      "mean_mse_to_target": 0.012346626208560512,
+      "std_mse_to_target": 0.0029137479102058737,
+      "mean_target_rank": 6.204968944099379,
+      "median_target_rank": 2.0,
+      "recall_at_1": 0.3245341614906832,
+      "recall_at_5": 0.9208074534161491,
+      "recall_at_10": 0.9518633540372671,
+      "mrr": 0.5705017094400666,
+      "train_time_ms": 356.9307009456679,
+      "inference_time_us": 2006.6624301592733,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.47125371919222453,
+          "mean_mse": 0.013725414645909276,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.35017174069118845,
+          "mean_mse": 0.014265128606857375,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.4585396673150198,
+          "mean_mse": 0.014139950850352119,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.5203677891655953,
+          "mean_mse": 0.013941451803260119,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.48287760432479654,
+          "mean_mse": 0.01360363060828465,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4913963396548512,
+          "mean_mse": 0.014159695011642149,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3323014728475103,
+          "mean_mse": 0.014480027993241799,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.5169129553673055,
+          "mean_mse": 0.01419640448555154,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3135961390080654,
+          "mean_mse": 0.014921972166612113,
+          "mean_rank": 96.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4790343097971054,
+          "mean_mse": 0.013629392978009212,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4430776945359983,
+          "mean_mse": 0.013972030757932598,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.537922831888844,
+          "mean_mse": 0.013398929114037332,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.459413030780218,
+          "mean_mse": 0.013899826465021688,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.45143532958566146,
+          "mean_mse": 0.014500191525641012,
+          "mean_rank": 19.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.5173357706860635,
+          "mean_mse": 0.01420671782569215,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.31182177697430746,
+          "mean_mse": 0.01474718613542526,
+          "mean_rank": 50.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.501140508371334,
+          "mean_mse": 0.013913171799003962,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.480695036364406,
+          "mean_mse": 0.014003998726612435,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.48290896009754847,
+          "mean_mse": 0.01387951178941917,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.45240446725152433,
+          "mean_mse": 0.013960425185852082,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.46536927571408726,
+          "mean_mse": 0.01384697294737528,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.41628512764260966,
+          "mean_mse": 0.014167536659012301,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.4180894410245452,
+          "mean_mse": 0.0142971261006241,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.46740960676928134,
+          "mean_mse": 0.013759341443611222,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.45030300148629365,
+          "mean_mse": 0.01418179629685019,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.42054139067327856,
+          "mean_mse": 0.014153972005203812,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.5103648448842374,
+          "mean_mse": 0.013526819997498052,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.39431664289359136,
+          "mean_mse": 0.014044937717483354,
+          "mean_rank": 27.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.5158532901497227,
+          "mean_mse": 0.013094926977218946,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.5915136668632044,
+          "mean_mse": 0.012770843457947609,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.5223173534776911,
+          "mean_mse": 0.0134312986176273,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.5076491091074171,
+          "mean_mse": 0.013658344777797113,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.43869359570571126,
+          "mean_mse": 0.01437714740887331,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.48083082927077647,
+          "mean_mse": 0.014023762101003,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.4802527257136572,
+          "mean_mse": 0.013491831752472549,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.39581048253890194,
+          "mean_mse": 0.014718198336008993,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.3683811894848211,
+          "mean_mse": 0.014705625378100634,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.4785027197957149,
+          "mean_mse": 0.01398700603808942,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.44057674307077677,
+          "mean_mse": 0.014093703587961708,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.5317469286784764,
+          "mean_mse": 0.012625878486723453,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.526267725933526,
+          "mean_mse": 0.013599610435511908,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.3937933617291416,
+          "mean_mse": 0.014692170057146226,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.49651415666037746,
+          "mean_mse": 0.013733818329610913,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.4739668416967467,
+          "mean_mse": 0.014069734982116472,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.5535802847906515,
+          "mean_mse": 0.013408664187850826,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.3765168519347344,
+          "mean_mse": 0.014268355322748623,
+          "mean_rank": 117.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.43078642024540903,
+          "mean_mse": 0.014221905056588767,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.5318303910035742,
+          "mean_mse": 0.013888181125476785,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.5214247913149579,
+          "mean_mse": 0.013557880269544376,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.43008951119119326,
+          "mean_mse": 0.014133563343971665,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.4838392307944871,
+          "mean_mse": 0.01349755358198454,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.4741921137191496,
+          "mean_mse": 0.013474591229891236,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.5032260931673489,
+          "mean_mse": 0.01382158908360167,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.5453451640819842,
+          "mean_mse": 0.012982963418441119,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.42723169085343593,
+          "mean_mse": 0.01427752189424749,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.4936962825976229,
+          "mean_mse": 0.01359925743523174,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.5522259260152516,
+          "mean_mse": 0.013633858577917081,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.44899455429082424,
+          "mean_mse": 0.013610198196479345,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.3626346441111694,
+          "mean_mse": 0.01465172265576098,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.4307900906945052,
+          "mean_mse": 0.013138192603360703,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.4244761169859081,
+          "mean_mse": 0.01445767946911337,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.3992624005485089,
+          "mean_mse": 0.014268606100213497,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.3034611585705343,
+          "mean_mse": 0.014896345304304646,
+          "mean_rank": 35.0,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.44646894268798687,
+          "mean_mse": 0.014075860747941139,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.5146030586994128,
+          "mean_mse": 0.01358902118533501,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.43980169677441794,
+          "mean_mse": 0.014648229109614915,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.4454261361393917,
+          "mean_mse": 0.013794957146572194,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.5366213818240875,
+          "mean_mse": 0.013895829251526916,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.5197816046663096,
+          "mean_mse": 0.013821913521367007,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.5436687732953233,
+          "mean_mse": 0.012797454090118995,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.5421092423649904,
+          "mean_mse": 0.01310030617778662,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.5574264187409425,
+          "mean_mse": 0.01304632629795196,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.5496698940656938,
+          "mean_mse": 0.01311953843547961,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.5665986226928778,
+          "mean_mse": 0.013412867839970033,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.593554517230675,
+          "mean_mse": 0.011978699862344686,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.5655823573765867,
+          "mean_mse": 0.013027102018249788,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.5519650546497649,
+          "mean_mse": 0.012378697352307998,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.6074363550682649,
+          "mean_mse": 0.011831665701417832,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.5230887302508281,
+          "mean_mse": 0.013367784885472855,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.5065811446567369,
+          "mean_mse": 0.013481696038007798,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.5985070484779271,
+          "mean_mse": 0.011680566333570945,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.5321051471821684,
+          "mean_mse": 0.012897316580717645,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.4986580956346531,
+          "mean_mse": 0.01351602197503519,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.5683844499278049,
+          "mean_mse": 0.011925163822952329,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.5178564667359673,
+          "mean_mse": 0.01308419134438931,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.5498531646833081,
+          "mean_mse": 0.01270880561522156,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.5592548659311237,
+          "mean_mse": 0.012754648941254344,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.5455540586529563,
+          "mean_mse": 0.01296051675332171,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.5909178171389566,
+          "mean_mse": 0.01271141763344666,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.6037303634465393,
+          "mean_mse": 0.011948415811746103,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.5393922926781652,
+          "mean_mse": 0.012915618153910978,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.5278670296412759,
+          "mean_mse": 0.013416507027515881,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.5104059144495311,
+          "mean_mse": 0.013381501531831486,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.6155516063248347,
+          "mean_mse": 0.011934088970205462,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.6603444798789853,
+          "mean_mse": 0.011759891918682657,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.5762328167571762,
+          "mean_mse": 0.012794340726129574,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.6538270625749019,
+          "mean_mse": 0.010423186036710275,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5499513608608032,
+          "mean_mse": 0.012701989919665745,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.48133665080965454,
+          "mean_mse": 0.013193029104000437,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.5700089206399082,
+          "mean_mse": 0.012957560270118925,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.544361499380387,
+          "mean_mse": 0.013440615721758682,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.6011630875055044,
+          "mean_mse": 0.012035525019757937,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.48733656609679565,
+          "mean_mse": 0.013585668270187043,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.5986397323801408,
+          "mean_mse": 0.012275370785399349,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.5393192769559202,
+          "mean_mse": 0.013475555106369936,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.5578083621630993,
+          "mean_mse": 0.012694926336011872,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.5554333885366431,
+          "mean_mse": 0.012210298188834573,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.5307416630612211,
+          "mean_mse": 0.013293292603747687,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.4667317120011067,
+          "mean_mse": 0.013899391481396807,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.5007429893049903,
+          "mean_mse": 0.013672082422565407,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.5686310473869648,
+          "mean_mse": 0.01323612878363063,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.5071514146551538,
+          "mean_mse": 0.012895200041922591,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.5819763452284361,
+          "mean_mse": 0.011792027370397064,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.5496570678280749,
+          "mean_mse": 0.012268148107334237,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.5234848252387421,
+          "mean_mse": 0.013141303861002854,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.5709934897388638,
+          "mean_mse": 0.012844817785180403,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.6101723817476826,
+          "mean_mse": 0.012050109375423121,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.5458827206984381,
+          "mean_mse": 0.01214270814054027,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.5578914410520296,
+          "mean_mse": 0.012862879767275619,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.600521306895153,
+          "mean_mse": 0.012303743792293034,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.5387413545357504,
+          "mean_mse": 0.013190521968805538,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.596541884167968,
+          "mean_mse": 0.012212293914483197,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.58431648440081,
+          "mean_mse": 0.0122704885450262,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.6039363919766125,
+          "mean_mse": 0.013191637832213478,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.5565825036245379,
+          "mean_mse": 0.012907883802546547,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.5528263318986656,
+          "mean_mse": 0.013422734014132359,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.5159377862845873,
+          "mean_mse": 0.012969727395935557,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.6773978445374585,
+          "mean_mse": 0.00951657785373027,
+          "mean_rank": 6.0,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.604914109651954,
+          "mean_mse": 0.012506152530574586,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.5485240978695424,
+          "mean_mse": 0.012834502942756043,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.5920444106780454,
+          "mean_mse": 0.011941263792158598,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.5316780100863291,
+          "mean_mse": 0.012899213417869801,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.6022045203792098,
+          "mean_mse": 0.011816199272113484,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.5631572181602356,
+          "mean_mse": 0.01191912675596895,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.5460396072514796,
+          "mean_mse": 0.013360860506904515,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.5643130627312775,
+          "mean_mse": 0.012309479985378147,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.5972676992429758,
+          "mean_mse": 0.011229902067992488,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.553160298654153,
+          "mean_mse": 0.013092003550608076,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.5826348488754556,
+          "mean_mse": 0.01304743403704467,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.5716698211959609,
+          "mean_mse": 0.012759773494848895,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.533743149944273,
+          "mean_mse": 0.012903306938731901,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5621706950305972,
+          "mean_mse": 0.011895134258407894,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.7422672429612123,
+          "mean_mse": 0.00937865716330815,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7477313962895611,
+          "mean_mse": 0.008747678902871524,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.999833111084754,
+          "mean_mse": 0.00012604135771556376,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7905752380474593,
+          "mean_mse": 0.006670202534754206,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.7236175808932452,
+          "mean_mse": 0.00828775764595279,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7656083446852482,
+          "mean_mse": 0.008695379365491899,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.6436655076828046,
+          "mean_mse": 0.009989385055232787,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.640190068012848,
+          "mean_mse": 0.0111042708171914,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6842739782533587,
+          "mean_mse": 0.010457821914955376,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.6836433127417529,
+          "mean_mse": 0.009563921444787517,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6958344895476457,
+          "mean_mse": 0.008385351557145607,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6719532199025642,
+          "mean_mse": 0.009869225683773518,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.693930613683871,
+          "mean_mse": 0.008617889571391854,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9999001903732384,
+          "mean_mse": 0.0001660916713899427,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9997277863951223,
+          "mean_mse": 0.00020599892469187387,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.6276730650297948,
+          "mean_mse": 0.01020585850024541,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.6203473013978221,
+          "mean_mse": 0.010160371737415566,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6876687831991134,
+          "mean_mse": 0.009554083718742527,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.9998255025299712,
+          "mean_mse": 0.0001331700560539997,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6855569644096919,
+          "mean_mse": 0.009602037862834882,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7543973248741059,
+          "mean_mse": 0.007418876790926964,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.665483707671136,
+          "mean_mse": 0.011220680348627797,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9999267859730786,
+          "mean_mse": 0.00013539345301347166,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6647350964146304,
+          "mean_mse": 0.009166193073546306,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9996600748563002,
+          "mean_mse": 0.00034513441645394347,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7971829974529405,
+          "mean_mse": 0.008485176891308474,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6289053134840762,
+          "mean_mse": 0.0107133082073145,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.7038077915060984,
+          "mean_mse": 0.008497360525576134,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9997541173963128,
+          "mean_mse": 0.00017356543505683613,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.7189792004588486,
+          "mean_mse": 0.008777598034179645,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.9999673483612062,
+          "mean_mse": 8.897633840434132e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7902797947616148,
+          "mean_mse": 0.007268212106319108,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9996146262846624,
+          "mean_mse": 0.00026943162271253636,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6528775812855416,
+          "mean_mse": 0.009822725191916935,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6524204878075786,
+          "mean_mse": 0.009498729970410404,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.7049006719291717,
+          "mean_mse": 0.008762591699411813,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6476537260043772,
+          "mean_mse": 0.009649254448665944,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9981616413841714,
+          "mean_mse": 0.00048401002530000796,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.6984236206508312,
+          "mean_mse": 0.008612626604924425,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7846273196684737,
+          "mean_mse": 0.007025665415630515,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9999801149101486,
+          "mean_mse": 0.0001196598772292538,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6915072084828696,
+          "mean_mse": 0.00859101988769094,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6900163163293823,
+          "mean_mse": 0.008775881282751913,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9996093707828069,
+          "mean_mse": 0.0002135463750555846,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9998326279281317,
+          "mean_mse": 0.00014213148361311243,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.7545562755263012,
+          "mean_mse": 0.00798443689915208,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6965585304369062,
+          "mean_mse": 0.008519261725218972,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.7475577416049776,
+          "mean_mse": 0.007630600481801497,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.999635608400724,
+          "mean_mse": 0.00017863906042580352,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.7114466095975518,
+          "mean_mse": 0.008732351970665204,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.7169752987385978,
+          "mean_mse": 0.008642034762895042,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9996561648840803,
+          "mean_mse": 0.0002061823671152324,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.7755575504005919,
+          "mean_mse": 0.007894780162508646,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.9992189748935378,
+          "mean_mse": 0.00029566099060106195,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7728638564982078,
+          "mean_mse": 0.007410264913987783,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.6239498858962571,
+          "mean_mse": 0.010006648321815914,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9998326168300548,
+          "mean_mse": 0.00012484391216747585,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9996737691582002,
+          "mean_mse": 0.00018794240325979678,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9998179303533067,
+          "mean_mse": 0.00014406590399593136,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.999962520540053,
+          "mean_mse": 0.0001364790390243877,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.6201796756794191,
+          "mean_mse": 0.010345267200296613,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.6625776923914857,
+          "mean_mse": 0.00994570044031615,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.662367410531293,
+          "mean_mse": 0.009649956332620113,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.7470196487810628,
+          "mean_mse": 0.009446583724091056,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.6172871737011505,
+          "mean_mse": 0.012462806219587544,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7640917127852396,
+          "mean_mse": 0.00777125835915884,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.5351378501842343,
+          "mean_mse": 0.013563146616971515,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.5059230291414931,
+          "mean_mse": 0.014194248433372095,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.6513100325091044,
+          "mean_mse": 0.01196022774145046,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.5431508582111104,
+          "mean_mse": 0.013836794294648368,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6881374716608426,
+          "mean_mse": 0.010681017583813887,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.5652128134123657,
+          "mean_mse": 0.011961244337677673,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.5638663979453229,
+          "mean_mse": 0.011825715817445705,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.22367875997548925,
+          "mean_mse": 0.01490838926074754,
+          "mean_rank": 118.8,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.4623699987027772,
+          "mean_mse": 0.013442644854254416,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.43841686148651277,
+          "mean_mse": 0.013934361242937005,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K4",
+      "params": {
+        "K": 4,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.28530728546587175,
+      "std_cosine_to_target": 0.2577889219568189,
+      "mean_mse_to_target": 0.013792392249105027,
+      "std_mse_to_target": 0.0030923751693210755,
+      "mean_target_rank": 103.03571428571429,
+      "median_target_rank": 21.0,
+      "recall_at_1": 0.16614906832298137,
+      "recall_at_5": 0.391304347826087,
+      "recall_at_10": 0.4440993788819876,
+      "mrr": 0.27599474751339603,
+      "train_time_ms": 2174.591101007536,
+      "inference_time_us": 6147.149846323633,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.3217220041879606,
+          "mean_mse": 0.014486339937002504,
+          "mean_rank": 29.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.2676222574920726,
+          "mean_mse": 0.01475575058149426,
+          "mean_rank": 55.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.20227487932849816,
+          "mean_mse": 0.014999504675700878,
+          "mean_rank": 149.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4073694544766417,
+          "mean_mse": 0.014206571763779662,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.062047342077030485,
+          "mean_mse": 0.015608013315695998,
+          "mean_rank": 243.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.06182057640058254,
+          "mean_mse": 0.015541240555488686,
+          "mean_rank": 225.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.022078082725495853,
+          "mean_mse": 0.015598565523669509,
+          "mean_rank": 280.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.08724461566765848,
+          "mean_mse": 0.015576252752072813,
+          "mean_rank": 212.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": -0.02622621091324399,
+          "mean_mse": 0.015714857249597886,
+          "mean_rank": 368.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": -0.07724431305152979,
+          "mean_mse": 0.015772074434850684,
+          "mean_rank": 446.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.08862374413993887,
+          "mean_mse": 0.015481451399998514,
+          "mean_rank": 191.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.028003680922121656,
+          "mean_mse": 0.0156322511125081,
+          "mean_rank": 280.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.2189518139976613,
+          "mean_mse": 0.015216568263287331,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.0032475147016881147,
+          "mean_mse": 0.015734838210551626,
+          "mean_rank": 321.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.0598640070492944,
+          "mean_mse": 0.015584562181483068,
+          "mean_rank": 233.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": -0.01587098416278126,
+          "mean_mse": 0.015706152479590927,
+          "mean_rank": 350.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.1016162984869985,
+          "mean_mse": 0.015470127366849565,
+          "mean_rank": 204.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.016711082193113194,
+          "mean_mse": 0.015663595732233818,
+          "mean_rank": 292.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.07499594757770936,
+          "mean_mse": 0.01548977485694552,
+          "mean_rank": 229.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": -0.020853735195151497,
+          "mean_mse": 0.015625125430726427,
+          "mean_rank": 307.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.12432016524887109,
+          "mean_mse": 0.015410469765587896,
+          "mean_rank": 120.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.17624707074739399,
+          "mean_mse": 0.015297546272822767,
+          "mean_rank": 55.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": -0.0772555766774648,
+          "mean_mse": 0.01577731933567042,
+          "mean_rank": 434.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.15595290335458648,
+          "mean_mse": 0.015285633641295957,
+          "mean_rank": 115.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.15383570240299174,
+          "mean_mse": 0.015277351090925543,
+          "mean_rank": 102.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.13031407283725427,
+          "mean_mse": 0.015450058735192302,
+          "mean_rank": 187.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.08330676884388022,
+          "mean_mse": 0.01551877575918704,
+          "mean_rank": 192.75,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.10131227198784364,
+          "mean_mse": 0.015533145730352839,
+          "mean_rank": 220.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.17396430275133623,
+          "mean_mse": 0.015330051010841445,
+          "mean_rank": 80.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.15734964717880207,
+          "mean_mse": 0.015377774962345367,
+          "mean_rank": 104.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.07483863597417688,
+          "mean_mse": 0.015525236046559181,
+          "mean_rank": 233.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.19157240678209825,
+          "mean_mse": 0.015348217051402553,
+          "mean_rank": 56.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": -0.05579024113671066,
+          "mean_mse": 0.015704073319076226,
+          "mean_rank": 385.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.10980326569532309,
+          "mean_mse": 0.015459200920431765,
+          "mean_rank": 172.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.211032583840626,
+          "mean_mse": 0.015091703625302752,
+          "mean_rank": 99.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.05579864034168672,
+          "mean_mse": 0.015672048570321232,
+          "mean_rank": 237.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.014992294442978789,
+          "mean_mse": 0.0156839790871185,
+          "mean_rank": 299.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.09518327500490695,
+          "mean_mse": 0.015484351528888215,
+          "mean_rank": 176.0,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": -0.0253108322872166,
+          "mean_mse": 0.01561052534644022,
+          "mean_rank": 356.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.21796493207025763,
+          "mean_mse": 0.014839496355800372,
+          "mean_rank": 66.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.1497836025776608,
+          "mean_mse": 0.015316843909098002,
+          "mean_rank": 99.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.024437718909025383,
+          "mean_mse": 0.01563481304119636,
+          "mean_rank": 277.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.08372493695606932,
+          "mean_mse": 0.015525818145580211,
+          "mean_rank": 194.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.1812720708489966,
+          "mean_mse": 0.015322921898200156,
+          "mean_rank": 68.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.22693370512761557,
+          "mean_mse": 0.015169600722574205,
+          "mean_rank": 37.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.025932648914581927,
+          "mean_mse": 0.015791794568770137,
+          "mean_rank": 246.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.059979092510824936,
+          "mean_mse": 0.015555824925021635,
+          "mean_rank": 235.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.13302474248091506,
+          "mean_mse": 0.015450431028315085,
+          "mean_rank": 175.0,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.08843516983900385,
+          "mean_mse": 0.01526790033142159,
+          "mean_rank": 287.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.0676303533907529,
+          "mean_mse": 0.015560830750473629,
+          "mean_rank": 219.75,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.3481402912212479,
+          "mean_mse": 0.014674716058154449,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": -0.004490037338473418,
+          "mean_mse": 0.0157165583362475,
+          "mean_rank": 320.5,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.22080979224632263,
+          "mean_mse": 0.015166438557844966,
+          "mean_rank": 59.0,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.2838306255090088,
+          "mean_mse": 0.01481244067936065,
+          "mean_rank": 41.25,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.07935252355005479,
+          "mean_mse": 0.015537159293085696,
+          "mean_rank": 203.25,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.11455509019006335,
+          "mean_mse": 0.01543058026095319,
+          "mean_rank": 219.5,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.14646101221933222,
+          "mean_mse": 0.015386134767909006,
+          "mean_rank": 107.5,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.12229752510967803,
+          "mean_mse": 0.015441856311731419,
+          "mean_rank": 127.0,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": -0.06300765419039261,
+          "mean_mse": 0.015721252447138095,
+          "mean_rank": 421.75,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.2875115985519074,
+          "mean_mse": 0.014694107022398574,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.0443324308432466,
+          "mean_mse": 0.01560776929209434,
+          "mean_rank": 255.75,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.08634769386333928,
+          "mean_mse": 0.015554529568567956,
+          "mean_rank": 183.25,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.13444441783609548,
+          "mean_mse": 0.015407404357848015,
+          "mean_rank": 126.75,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.15850151069740975,
+          "mean_mse": 0.015350901457152372,
+          "mean_rank": 117.25,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.1912932723540543,
+          "mean_mse": 0.015134718305485108,
+          "mean_rank": 94.75,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.03431102528118429,
+          "mean_mse": 0.015584860972921244,
+          "mean_rank": 273.0,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.03047103278258075,
+          "mean_mse": 0.015545196605625086,
+          "mean_rank": 294.75,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.21558407349243083,
+          "mean_mse": 0.01523580994767746,
+          "mean_rank": 63.5,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.12625538090126887,
+          "mean_mse": 0.015450334892603026,
+          "mean_rank": 172.0,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.20751989550353714,
+          "mean_mse": 0.014868221835413779,
+          "mean_rank": 73.0,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.3354410299435527,
+          "mean_mse": 0.014476957504683967,
+          "mean_rank": 7.333333333333333,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.3345065662583551,
+          "mean_mse": 0.014477202249205378,
+          "mean_rank": 8.333333333333334,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.3176038002411406,
+          "mean_mse": 0.014879238721892262,
+          "mean_rank": 29.0,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.37062994596914,
+          "mean_mse": 0.014313433057989535,
+          "mean_rank": 5.0,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.42143191701198246,
+          "mean_mse": 0.013254834054181694,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.30381976569487895,
+          "mean_mse": 0.014646809730219694,
+          "mean_rank": 20.666666666666668,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.366042794909053,
+          "mean_mse": 0.014152872589787526,
+          "mean_rank": 4.333333333333333,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.5149459387907848,
+          "mean_mse": 0.013099051148815955,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.17837389869588607,
+          "mean_mse": 0.01523504815589651,
+          "mean_rank": 55.333333333333336,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.1808856544298371,
+          "mean_mse": 0.015220190979174578,
+          "mean_rank": 52.0,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.4801730654566892,
+          "mean_mse": 0.01307178862100559,
+          "mean_rank": 6.666666666666667,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.386856232949862,
+          "mean_mse": 0.014179982797364986,
+          "mean_rank": 7.666666666666667,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.0897355034386289,
+          "mean_mse": 0.015407694197289087,
+          "mean_rank": 256.6666666666667,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.4539189165493432,
+          "mean_mse": 0.013321824948386287,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.35856414205694165,
+          "mean_mse": 0.014354992385315674,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.42239753418620624,
+          "mean_mse": 0.013793922235022562,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.2976044295353846,
+          "mean_mse": 0.014763350600292253,
+          "mean_rank": 10.666666666666666,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.21034338503672953,
+          "mean_mse": 0.014888997492933043,
+          "mean_rank": 97.66666666666667,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.2663810558555329,
+          "mean_mse": 0.01494076031572982,
+          "mean_rank": 29.666666666666668,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.45535742967444764,
+          "mean_mse": 0.013537873303796369,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.3379022530115446,
+          "mean_mse": 0.01437226413381311,
+          "mean_rank": 14.666666666666666,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.29246230912626575,
+          "mean_mse": 0.014814342470177521,
+          "mean_rank": 34.333333333333336,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.2336155835543885,
+          "mean_mse": 0.015013824384893683,
+          "mean_rank": 44.666666666666664,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.5245358142080737,
+          "mean_mse": 0.013026660025262168,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.46127417265824544,
+          "mean_mse": 0.01356057421572251,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.3548874472718508,
+          "mean_mse": 0.014341632242072763,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.5796540524189971,
+          "mean_mse": 0.011375400192319904,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.326627195299426,
+          "mean_mse": 0.01439698109356539,
+          "mean_rank": 9.0,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.25940866917213035,
+          "mean_mse": 0.014803066257848276,
+          "mean_rank": 29.0,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.3307851203707006,
+          "mean_mse": 0.01487697653733615,
+          "mean_rank": 8.666666666666666,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.2462146224894548,
+          "mean_mse": 0.01470383771928427,
+          "mean_rank": 48.0,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.4922662516735084,
+          "mean_mse": 0.01325162198574126,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.28800787347817297,
+          "mean_mse": 0.015041837667646085,
+          "mean_rank": 36.0,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.41746510541906806,
+          "mean_mse": 0.013873653932526408,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.35515037172830183,
+          "mean_mse": 0.014723548643943615,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.4024278701078019,
+          "mean_mse": 0.014115360290508994,
+          "mean_rank": 6.333333333333333,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.42465041124743114,
+          "mean_mse": 0.01345046539495068,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.29460361864293166,
+          "mean_mse": 0.014999911189778545,
+          "mean_rank": 15.666666666666666,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.229437065502942,
+          "mean_mse": 0.015132876415460026,
+          "mean_rank": 43.666666666666664,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.11794042073977197,
+          "mean_mse": 0.015262734497346225,
+          "mean_rank": 184.33333333333334,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.1323863925505496,
+          "mean_mse": 0.015412527339081203,
+          "mean_rank": 156.66666666666666,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.20460784650297628,
+          "mean_mse": 0.015058287921041717,
+          "mean_rank": 80.33333333333333,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.37761204600632564,
+          "mean_mse": 0.013665884611621272,
+          "mean_rank": 4.333333333333333,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.36314374919400455,
+          "mean_mse": 0.013818915305678641,
+          "mean_rank": 4.666666666666667,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.2208149279498115,
+          "mean_mse": 0.01499050293572012,
+          "mean_rank": 39.666666666666664,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.3213931484814101,
+          "mean_mse": 0.014330293692058039,
+          "mean_rank": 17.0,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.4680582611841981,
+          "mean_mse": 0.013865682570696704,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.35488171641838256,
+          "mean_mse": 0.014020709692474985,
+          "mean_rank": 5.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.1313658176575368,
+          "mean_mse": 0.015384379843875138,
+          "mean_rank": 153.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.3932092832996037,
+          "mean_mse": 0.013850602501409947,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.05704082077886186,
+          "mean_mse": 0.015582913466102757,
+          "mean_rank": 231.66666666666666,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.33487530405794635,
+          "mean_mse": 0.014468972837990693,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.41096524847352595,
+          "mean_mse": 0.013618679096930828,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.2111389487741017,
+          "mean_mse": 0.015124725940298428,
+          "mean_rank": 72.0,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.270640733531021,
+          "mean_mse": 0.014870008246374638,
+          "mean_rank": 38.666666666666664,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.06483552954760356,
+          "mean_mse": 0.015462194809473551,
+          "mean_rank": 248.0,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.21938358897050925,
+          "mean_mse": 0.015044123372301458,
+          "mean_rank": 71.33333333333333,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.5808696509750458,
+          "mean_mse": 0.010954054618935588,
+          "mean_rank": 6.333333333333333,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.36724079650771285,
+          "mean_mse": 0.014188912499796516,
+          "mean_rank": 4.333333333333333,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.34530371150285544,
+          "mean_mse": 0.01467043234112103,
+          "mean_rank": 6.666666666666667,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.23612431179616442,
+          "mean_mse": 0.014864727952989341,
+          "mean_rank": 59.0,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.17171943815088428,
+          "mean_mse": 0.015262073645301745,
+          "mean_rank": 74.66666666666667,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.345359565523258,
+          "mean_mse": 0.014473627484620484,
+          "mean_rank": 11.333333333333334,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.31466382200421905,
+          "mean_mse": 0.01420852952740749,
+          "mean_rank": 11.666666666666666,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.1868649540390331,
+          "mean_mse": 0.015155172253624718,
+          "mean_rank": 71.0,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.18416280805062613,
+          "mean_mse": 0.015232049827890901,
+          "mean_rank": 62.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.42678043279650285,
+          "mean_mse": 0.013028949537050078,
+          "mean_rank": 3.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.3902277535808025,
+          "mean_mse": 0.014198719266783755,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.11601711695829482,
+          "mean_mse": 0.015335361802601396,
+          "mean_rank": 175.66666666666666,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.17240040528185832,
+          "mean_mse": 0.015271796509493896,
+          "mean_rank": 71.66666666666667,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.31659078019474757,
+          "mean_mse": 0.014520897367663557,
+          "mean_rank": 35.666666666666664,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.3950170942452192,
+          "mean_mse": 0.013658177115071243,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.6633609507195763,
+          "mean_mse": 0.010274444307955474,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.6874287185786191,
+          "mean_mse": 0.009376939107610298,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9790045810366811,
+          "mean_mse": 0.0006527240079880405,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7480759199647817,
+          "mean_mse": 0.007320273260605286,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.5467763749147088,
+          "mean_mse": 0.011227539044729893,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.6939586890958906,
+          "mean_mse": 0.009464796400751721,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.5675279272278321,
+          "mean_mse": 0.010865378647010863,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.5736286530933957,
+          "mean_mse": 0.011756981666614735,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6169006737479197,
+          "mean_mse": 0.010946628631035342,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.5399120495154641,
+          "mean_mse": 0.011430002305450871,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6128703330054546,
+          "mean_mse": 0.009835097518859543,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6303682957415351,
+          "mean_mse": 0.010304307671088902,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.6386299837899545,
+          "mean_mse": 0.00943604281284014,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9809336673057264,
+          "mean_mse": 0.0005935721338230946,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.968250473860655,
+          "mean_mse": 0.0009794110722520445,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.5367222828148447,
+          "mean_mse": 0.011469354304894156,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.57207115242392,
+          "mean_mse": 0.010894400343928454,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6066421338480522,
+          "mean_mse": 0.01034298453528871,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.9813686555713532,
+          "mean_mse": 0.0005815661980955553,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.5360624957424678,
+          "mean_mse": 0.011821200389019319,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.6891661699964612,
+          "mean_mse": 0.008360024484487923,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.5365860064772722,
+          "mean_mse": 0.012338936783066932,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9842693090849698,
+          "mean_mse": 0.000491054278082908,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.642907047933355,
+          "mean_mse": 0.009493192407517104,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9811331472485612,
+          "mean_mse": 0.0005850686794643297,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.6787393134468531,
+          "mean_mse": 0.009719595384467893,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.493036186748744,
+          "mean_mse": 0.012222442222347668,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.6156765838437622,
+          "mean_mse": 0.009806512171917555,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9867501951903882,
+          "mean_mse": 0.00041405299200792105,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.6674094789335101,
+          "mean_mse": 0.009586229579173952,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.9857773090494557,
+          "mean_mse": 0.00044540010874856184,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7444909846285805,
+          "mean_mse": 0.0077616419502244665,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9854374288477648,
+          "mean_mse": 0.00045344572226179607,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.5916562475044733,
+          "mean_mse": 0.01057064264945598,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.5953164578769897,
+          "mean_mse": 0.010234344244151409,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.6250741584144471,
+          "mean_mse": 0.00980771960052803,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6107340574228797,
+          "mean_mse": 0.010285451112291549,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9777925591447861,
+          "mean_mse": 0.0006876201406922585,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.7065129845886562,
+          "mean_mse": 0.008414084559989795,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7410521722709904,
+          "mean_mse": 0.007645161271535577,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9832405570290828,
+          "mean_mse": 0.000522600967037169,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6039781871336757,
+          "mean_mse": 0.01004496172653551,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.5702774750736768,
+          "mean_mse": 0.010629441462436214,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9872066989610762,
+          "mean_mse": 0.00040089679356256785,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9875710557452977,
+          "mean_mse": 0.00038987177586841126,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.6860152919508706,
+          "mean_mse": 0.008859062018515163,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6246536836250263,
+          "mean_mse": 0.00970565016518345,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.7040563135930022,
+          "mean_mse": 0.008226640358210635,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.978470289532984,
+          "mean_mse": 0.000668833934696728,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.5778887539321982,
+          "mean_mse": 0.010648106174724191,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.6183984286758868,
+          "mean_mse": 0.010166599135623617,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9876943696334332,
+          "mean_mse": 0.000384113656833122,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.709748154146813,
+          "mean_mse": 0.008653902946711926,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.9864230918669349,
+          "mean_mse": 0.0004242236153530989,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7196193201077188,
+          "mean_mse": 0.008047809370416673,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.48581277113484056,
+          "mean_mse": 0.01217061373478575,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9869117033983096,
+          "mean_mse": 0.0004104450598878562,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9801622451444444,
+          "mean_mse": 0.0006168545709898047,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9830438676634368,
+          "mean_mse": 0.0005292264778192009,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.9897004508571038,
+          "mean_mse": 0.0003245277692615835,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.5181913769783979,
+          "mean_mse": 0.011544449460945756,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.6274885168498622,
+          "mean_mse": 0.010410345136931821,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6124614176969745,
+          "mean_mse": 0.010682877790593405,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.712316285797192,
+          "mean_mse": 0.009480469517151677,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.3345435716869367,
+          "mean_mse": 0.014516716836607187,
+          "mean_rank": 30.333333333333332,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7002215358862298,
+          "mean_mse": 0.008583676732310133,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.24379621461574222,
+          "mean_mse": 0.014852076300769254,
+          "mean_rank": 45.333333333333336,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": -0.07975463572776942,
+          "mean_mse": 0.015758347933898603,
+          "mean_rank": 447.75,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.4962927690692947,
+          "mean_mse": 0.01296801846776017,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.1501451866081147,
+          "mean_mse": 0.015345603981802054,
+          "mean_rank": 84.33333333333333,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6390914763489873,
+          "mean_mse": 0.010793735029851727,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.22082899380104068,
+          "mean_mse": 0.01508034729541747,
+          "mean_rank": 41.0,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.46940570577533614,
+          "mean_mse": 0.012818614064417214,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.001172123406623138,
+          "mean_mse": 0.015644661629264152,
+          "mean_rank": 315.0,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.20801163445202622,
+          "mean_mse": 0.015096248168347213,
+          "mean_rank": 38.0,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.17660063576096957,
+          "mean_mse": 0.015414707318786587,
+          "mean_rank": 54.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K8",
+      "params": {
+        "K": 8,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.39941272965022395,
+      "std_cosine_to_target": 0.2303647016823948,
+      "mean_mse_to_target": 0.01306292812662115,
+      "std_mse_to_target": 0.0031308179806939195,
+      "mean_target_rank": 44.06366459627329,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.281055900621118,
+      "recall_at_5": 0.6226708074534162,
+      "recall_at_10": 0.6816770186335404,
+      "mrr": 0.43419256945760776,
+      "train_time_ms": 2844.313301029615,
+      "inference_time_us": 9284.372055890062,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4015566099706247,
+          "mean_mse": 0.014006309887956682,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.29326381686474506,
+          "mean_mse": 0.014523943552091592,
+          "mean_rank": 32.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.22000720336968974,
+          "mean_mse": 0.01479513756601884,
+          "mean_rank": 113.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.49768159305418413,
+          "mean_mse": 0.01366884145401972,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.2814651314243915,
+          "mean_mse": 0.014568287258305532,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.36563660460296626,
+          "mean_mse": 0.014353961242257594,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.32069146309156366,
+          "mean_mse": 0.014652649893137408,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.3975502363690297,
+          "mean_mse": 0.01436919753434785,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.08408365374881493,
+          "mean_mse": 0.015602983872567085,
+          "mean_rank": 210.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.26067523154535943,
+          "mean_mse": 0.014790600510308342,
+          "mean_rank": 47.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.10544135600751228,
+          "mean_mse": 0.015468098621354332,
+          "mean_rank": 166.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.3722496510920734,
+          "mean_mse": 0.014366299192128786,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.3819398711583381,
+          "mean_mse": 0.014471236643658198,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.13042563909864496,
+          "mean_mse": 0.015406681290818226,
+          "mean_rank": 124.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.3515366064771799,
+          "mean_mse": 0.014650439876000301,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.05740185391680318,
+          "mean_mse": 0.015561046795356871,
+          "mean_rank": 245.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.22944911527662096,
+          "mean_mse": 0.0148624252999611,
+          "mean_rank": 57.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.20996262228629153,
+          "mean_mse": 0.015168224869216535,
+          "mean_rank": 55.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.2557881520805623,
+          "mean_mse": 0.01479746846543228,
+          "mean_rank": 75.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.09178945640212485,
+          "mean_mse": 0.015454717453720722,
+          "mean_rank": 197.5,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.2592967941613551,
+          "mean_mse": 0.014880545483022643,
+          "mean_rank": 28.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.22918453796658483,
+          "mean_mse": 0.015072316864160877,
+          "mean_rank": 30.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.08201572559380547,
+          "mean_mse": 0.015516216625103638,
+          "mean_rank": 219.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.3103394568723338,
+          "mean_mse": 0.014415707127661858,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.1595287173013391,
+          "mean_mse": 0.015219172616809714,
+          "mean_rank": 88.5,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.18576520936917512,
+          "mean_mse": 0.015147108580393356,
+          "mean_rank": 87.75,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.3810106065773412,
+          "mean_mse": 0.01438625053114993,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.1686105250207719,
+          "mean_mse": 0.01542723900045236,
+          "mean_rank": 174.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.36535731516478515,
+          "mean_mse": 0.014357047386687133,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.4887874711430702,
+          "mean_mse": 0.01353825848131053,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.2637954289370236,
+          "mean_mse": 0.014671094823415432,
+          "mean_rank": 142.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.2293226867435033,
+          "mean_mse": 0.0151653294486725,
+          "mean_rank": 55.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.21111955163055562,
+          "mean_mse": 0.015217975052346034,
+          "mean_rank": 119.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.2441608628438155,
+          "mean_mse": 0.014879407607352586,
+          "mean_rank": 69.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.261344329412771,
+          "mean_mse": 0.014717996219577895,
+          "mean_rank": 60.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.033872369788518694,
+          "mean_mse": 0.01564274645877645,
+          "mean_rank": 261.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.07860256824012359,
+          "mean_mse": 0.015556739372966682,
+          "mean_rank": 209.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.23054261791159703,
+          "mean_mse": 0.01497623959450367,
+          "mean_rank": 45.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.1876957777107238,
+          "mean_mse": 0.015249024026332589,
+          "mean_rank": 84.0,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.3280889053950733,
+          "mean_mse": 0.0139962768200683,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.2689054746468135,
+          "mean_mse": 0.014873750253110343,
+          "mean_rank": 29.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.0032538232159743524,
+          "mean_mse": 0.015732808787626125,
+          "mean_rank": 311.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.21839407188091153,
+          "mean_mse": 0.01506316338071473,
+          "mean_rank": 80.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.17572330175764578,
+          "mean_mse": 0.015252420707884174,
+          "mean_rank": 88.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.2814157773628776,
+          "mean_mse": 0.0149145897394949,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.07617605336937071,
+          "mean_mse": 0.015757417990074817,
+          "mean_rank": 229.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.18301943399672269,
+          "mean_mse": 0.015256482384245724,
+          "mean_rank": 74.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.16987273146599688,
+          "mean_mse": 0.015262287655786815,
+          "mean_rank": 152.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.20546264993578078,
+          "mean_mse": 0.0148579642142485,
+          "mean_rank": 92.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.1319735490769015,
+          "mean_mse": 0.015341787230007117,
+          "mean_rank": 137.0,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.3561213794404734,
+          "mean_mse": 0.014270268022137081,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.13769468315345734,
+          "mean_mse": 0.015261415200154178,
+          "mean_rank": 136.0,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.29525748504606303,
+          "mean_mse": 0.014740196217283168,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.3865423149601419,
+          "mean_mse": 0.013938702434028422,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.22038521913811032,
+          "mean_mse": 0.015156064854158904,
+          "mean_rank": 85.0,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.2503576512174749,
+          "mean_mse": 0.014846157710192123,
+          "mean_rank": 47.5,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.2736780723757282,
+          "mean_mse": 0.014989827813097961,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.2237601243684616,
+          "mean_mse": 0.015128448338325686,
+          "mean_rank": 73.75,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.14897927055794358,
+          "mean_mse": 0.015370202812273517,
+          "mean_rank": 156.0,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.3521379025070883,
+          "mean_mse": 0.014097125464902638,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.10682672189060476,
+          "mean_mse": 0.015487165108471486,
+          "mean_rank": 192.25,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.2003776060196558,
+          "mean_mse": 0.015119189240448888,
+          "mean_rank": 86.5,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.08723164934624622,
+          "mean_mse": 0.015510772052114867,
+          "mean_rank": 167.75,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.27278960638709576,
+          "mean_mse": 0.014885433433658765,
+          "mean_rank": 99.25,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.24001713111730621,
+          "mean_mse": 0.01474301128730893,
+          "mean_rank": 118.5,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.15342159351481793,
+          "mean_mse": 0.015359721492498406,
+          "mean_rank": 138.5,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.2757653311909436,
+          "mean_mse": 0.014627987428860085,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.3325943410319292,
+          "mean_mse": 0.014798220775225739,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.34849798259078196,
+          "mean_mse": 0.014290068663362437,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.47190490947631103,
+          "mean_mse": 0.013057650211589703,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.4590403477582963,
+          "mean_mse": 0.013450421748611547,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.4522278503875328,
+          "mean_mse": 0.01376804857004195,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.3982707827200466,
+          "mean_mse": 0.01421071806958228,
+          "mean_rank": 3.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.4361200830183236,
+          "mean_mse": 0.013851107259783854,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.5421168072559844,
+          "mean_mse": 0.012362856967032128,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.49896665660417344,
+          "mean_mse": 0.013313956370770923,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.48227156996283016,
+          "mean_mse": 0.01283661272664014,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.5067728594482521,
+          "mean_mse": 0.012796867980507517,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.3722287643149178,
+          "mean_mse": 0.014289150713250548,
+          "mean_rank": 4.0,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.3460827614680408,
+          "mean_mse": 0.014159555628490911,
+          "mean_rank": 7.0,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.5722923533198478,
+          "mean_mse": 0.01182637305405843,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.4892180218245599,
+          "mean_mse": 0.013241872266507379,
+          "mean_rank": 1.0,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.3664379210725251,
+          "mean_mse": 0.014144002965608853,
+          "mean_rank": 6.0,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.488066963106016,
+          "mean_mse": 0.012671425761719987,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.44736649705193954,
+          "mean_mse": 0.013208250311659646,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.4690270774815371,
+          "mean_mse": 0.013261305264719787,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.4485526923235257,
+          "mean_mse": 0.013280189398141573,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.34925207975913963,
+          "mean_mse": 0.013892691900275228,
+          "mean_rank": 21.333333333333332,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.48670054284017344,
+          "mean_mse": 0.013194089960998655,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.5369330635315778,
+          "mean_mse": 0.012453836807878862,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.4491517781307543,
+          "mean_mse": 0.013278382757344769,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.29162825851982294,
+          "mean_mse": 0.014778650494021599,
+          "mean_rank": 30.666666666666668,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.38388027723063445,
+          "mean_mse": 0.014224054745263883,
+          "mean_rank": 18.0,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.48258055283185475,
+          "mean_mse": 0.013047279464467265,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.5659791611699044,
+          "mean_mse": 0.012734165740618697,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.4765317428971115,
+          "mean_mse": 0.01327947561669652,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.5871823984665853,
+          "mean_mse": 0.01107127135001021,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5013906426498068,
+          "mean_mse": 0.012795190210007204,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.3963202048315055,
+          "mean_mse": 0.013776360502867289,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.41966711740187956,
+          "mean_mse": 0.01347688738096658,
+          "mean_rank": 18.0,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.34279369056049247,
+          "mean_mse": 0.014531985965751115,
+          "mean_rank": 6.0,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.5307162600325128,
+          "mean_mse": 0.012427979183176086,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.45319628163110265,
+          "mean_mse": 0.013768655120853701,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.5269802176899075,
+          "mean_mse": 0.012725515562335513,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.3970745260921267,
+          "mean_mse": 0.014217179174966491,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.46874478017413973,
+          "mean_mse": 0.013339337787316776,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.43494733219665166,
+          "mean_mse": 0.013161120060944068,
+          "mean_rank": 3.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.3424926293043869,
+          "mean_mse": 0.01426988590657584,
+          "mean_rank": 11.666666666666666,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.32909425980016677,
+          "mean_mse": 0.014666197798286316,
+          "mean_rank": 14.333333333333334,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.3753846071932465,
+          "mean_mse": 0.0140408615042618,
+          "mean_rank": 7.0,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.33800856744575486,
+          "mean_mse": 0.014430873053254897,
+          "mean_rank": 38.333333333333336,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.3975631878068859,
+          "mean_mse": 0.013517727524986374,
+          "mean_rank": 3.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.45708959837631974,
+          "mean_mse": 0.013024652356960294,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.41012906839061275,
+          "mean_mse": 0.013296092392412986,
+          "mean_rank": 4.333333333333333,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.3984354171209077,
+          "mean_mse": 0.0139607185013181,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.41057495938421024,
+          "mean_mse": 0.013424736311696814,
+          "mean_rank": 5.666666666666667,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.479016993583767,
+          "mean_mse": 0.013101950674446645,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.4809347501137268,
+          "mean_mse": 0.012627701001080372,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.400615474300386,
+          "mean_mse": 0.013806938188328103,
+          "mean_rank": 4.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.5504289148588019,
+          "mean_mse": 0.012519203886507823,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.34749968679378124,
+          "mean_mse": 0.014216563330337868,
+          "mean_rank": 15.333333333333334,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.5451220224293286,
+          "mean_mse": 0.012618853176939745,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.5204605886827932,
+          "mean_mse": 0.012648287926778698,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.43216016865953405,
+          "mean_mse": 0.013835547847457538,
+          "mean_rank": 10.0,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.491528896390081,
+          "mean_mse": 0.013301858911379994,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.29883768954643886,
+          "mean_mse": 0.01461723451709119,
+          "mean_rank": 61.666666666666664,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.4039746361824817,
+          "mean_mse": 0.013593276002414523,
+          "mean_rank": 4.0,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.6081024807592308,
+          "mean_mse": 0.010413859474421453,
+          "mean_rank": 8.0,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.5092709591085272,
+          "mean_mse": 0.012961563863238615,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.5027562070244761,
+          "mean_mse": 0.013309688048258876,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.4789723697572472,
+          "mean_mse": 0.013068757367294653,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.41650562237547745,
+          "mean_mse": 0.013660759971974861,
+          "mean_rank": 15.333333333333334,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.5607997777688278,
+          "mean_mse": 0.012165707628633601,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.40032695583707906,
+          "mean_mse": 0.013368089792760584,
+          "mean_rank": 6.333333333333333,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.33411302980016505,
+          "mean_mse": 0.01451546421075374,
+          "mean_rank": 6.333333333333333,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.4461081538883403,
+          "mean_mse": 0.013337124244577092,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.47934938487245815,
+          "mean_mse": 0.012420362293462403,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.4402875748944046,
+          "mean_mse": 0.013533903337117764,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.46920892290288485,
+          "mean_mse": 0.01360232460476967,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.39492086289251294,
+          "mean_mse": 0.014072014012675355,
+          "mean_rank": 5.333333333333333,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.39497029852524296,
+          "mean_mse": 0.013696063957719787,
+          "mean_rank": 6.333333333333333,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5279329780205194,
+          "mean_mse": 0.012286881765381239,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.7240371615130674,
+          "mean_mse": 0.009125048280657048,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7172637346467712,
+          "mean_mse": 0.008723969805040682,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9931424628556981,
+          "mean_mse": 0.0002163600282628794,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7535633345662827,
+          "mean_mse": 0.007060267206641062,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.6970260538100188,
+          "mean_mse": 0.008441129649226107,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7129236102914478,
+          "mean_mse": 0.008910644595112174,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.6250300198439105,
+          "mean_mse": 0.01005030852760942,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.641356641667334,
+          "mean_mse": 0.010936492998762528,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6566653888942218,
+          "mean_mse": 0.010393957967526492,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.6107653775724649,
+          "mean_mse": 0.010366741274322149,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6424419049653136,
+          "mean_mse": 0.009237246681200526,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6810495685309081,
+          "mean_mse": 0.009581746034455229,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.7127419046345763,
+          "mean_mse": 0.008096027424578399,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9910619806591836,
+          "mean_mse": 0.00027974513513587165,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9925665458908397,
+          "mean_mse": 0.00023289207036649093,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.5911350442043528,
+          "mean_mse": 0.010555280631057668,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.5943736239617308,
+          "mean_mse": 0.010452542572927576,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6626606438591072,
+          "mean_mse": 0.009467043215974528,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.9962620107716837,
+          "mean_mse": 0.00011953936747085073,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6465060835504026,
+          "mean_mse": 0.009716203476538482,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7373053167904084,
+          "mean_mse": 0.007387381231877604,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.6348936806504899,
+          "mean_mse": 0.01148885425660099,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9910370567089842,
+          "mean_mse": 0.00028022085779578847,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6495328827240394,
+          "mean_mse": 0.009261346330439046,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9920480724921865,
+          "mean_mse": 0.00024753344611830563,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7386817781103858,
+          "mean_mse": 0.00871467323441131,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6125947065660695,
+          "mean_mse": 0.010873818441412919,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.6176017203165416,
+          "mean_mse": 0.009681520085158137,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9923065105304094,
+          "mean_mse": 0.0002413613928903101,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.7001534064929651,
+          "mean_mse": 0.008870842225109032,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.992201221075891,
+          "mean_mse": 0.0002449398779908839,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7633492904643949,
+          "mean_mse": 0.007360737628567142,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9928526701973525,
+          "mean_mse": 0.00022356439280932558,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6178161370306547,
+          "mean_mse": 0.010183251393464099,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6210238322583621,
+          "mean_mse": 0.009696338759845234,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.6513811504182407,
+          "mean_mse": 0.009322108364032763,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6033795673824711,
+          "mean_mse": 0.010205326034294644,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9953298629490216,
+          "mean_mse": 0.00014611742563666152,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.7033494225892964,
+          "mean_mse": 0.00847859482146207,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7679866754388947,
+          "mean_mse": 0.007034201489530795,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9946058342407023,
+          "mean_mse": 0.0001692375955184784,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6525049407805938,
+          "mean_mse": 0.00915223756786529,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6625645846243036,
+          "mean_mse": 0.008950064905033552,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.9933419833560938,
+          "mean_mse": 0.0002090574453549335,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9918417074874136,
+          "mean_mse": 0.0002549848259092441,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.7361590662373291,
+          "mean_mse": 0.007888690739114865,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6826561943286718,
+          "mean_mse": 0.008633607688588734,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.6986789233419564,
+          "mean_mse": 0.008268287776306461,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.9948250038327522,
+          "mean_mse": 0.00016291988380917003,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.6533369884747426,
+          "mean_mse": 0.009343512516662825,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.7063820305725346,
+          "mean_mse": 0.008677979031705852,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9934491933325406,
+          "mean_mse": 0.0002049816920243563,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.719033311157705,
+          "mean_mse": 0.008226897935604369,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.9938202927969211,
+          "mean_mse": 0.00019446991313667604,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7391730828319748,
+          "mean_mse": 0.007460333779861803,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.5345955694707802,
+          "mean_mse": 0.011248866240470346,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9932462633653583,
+          "mean_mse": 0.00021096241306921957,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9906605190476178,
+          "mean_mse": 0.0002917461882115709,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9916785597978969,
+          "mean_mse": 0.00026103307335923387,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.9952320425579058,
+          "mean_mse": 0.00015147400511566957,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.5816453046553915,
+          "mean_mse": 0.010628858923447324,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.6577341185099784,
+          "mean_mse": 0.00972177594494375,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6285318173787835,
+          "mean_mse": 0.010067032503579335,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.7198097140490276,
+          "mean_mse": 0.009127727140264583,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.4841921350213851,
+          "mean_mse": 0.013416495398150706,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7427647490618969,
+          "mean_mse": 0.007767308177341159,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.4089106283943423,
+          "mean_mse": 0.013984145293534533,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.10619335077572117,
+          "mean_mse": 0.015435395281228989,
+          "mean_rank": 175.5,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.5736957881421105,
+          "mean_mse": 0.01223209494615773,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.41264973565533153,
+          "mean_mse": 0.014407135770307352,
+          "mean_rank": 7.666666666666667,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6823846983323059,
+          "mean_mse": 0.010363210155635207,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.4434983869504627,
+          "mean_mse": 0.013263135880108764,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.5219339443128067,
+          "mean_mse": 0.01214758921940996,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": -0.02598815289730954,
+          "mean_mse": 0.015775551529383643,
+          "mean_rank": 362.2,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.45158378059753274,
+          "mean_mse": 0.013697027049110006,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.2567669784706341,
+          "mean_mse": 0.014759714918242605,
+          "mean_rank": 133.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K16",
+      "params": {
+        "K": 16,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.4787092904224676,
+      "std_cosine_to_target": 0.19415701534747073,
+      "mean_mse_to_target": 0.012508680908970013,
+      "std_mse_to_target": 0.0030562210926889095,
+      "mean_target_rank": 17.65527950310559,
+      "median_target_rank": 2.0,
+      "recall_at_1": 0.327639751552795,
+      "recall_at_5": 0.7981366459627329,
+      "recall_at_10": 0.84472049689441,
+      "mrr": 0.5251288051361986,
+      "train_time_ms": 4390.106091042981,
+      "inference_time_us": 15035.318066648017,
+      "num_queries": 644,
+      "num_answers": 644,
+      "num_clusters": 218,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.38616349774058556,
+          "mean_mse": 0.013924124518146858,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.3207343213458443,
+          "mean_mse": 0.014301695444327151,
+          "mean_rank": 39.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.30767399149523195,
+          "mean_mse": 0.014431237654827851,
+          "mean_rank": 45.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.49295424030271484,
+          "mean_mse": 0.013762897201315977,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4515179286298134,
+          "mean_mse": 0.013649266147973592,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.44435169609712255,
+          "mean_mse": 0.013902512403226295,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.23345140319922505,
+          "mean_mse": 0.014876907039195801,
+          "mean_rank": 76.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.44520470618551633,
+          "mean_mse": 0.014259830047704819,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.10606120751701678,
+          "mean_mse": 0.015275206230543795,
+          "mean_rank": 242.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4573343791031645,
+          "mean_mse": 0.013449820207582924,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.38344328485824286,
+          "mean_mse": 0.014260011310188399,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.4654931143895757,
+          "mean_mse": 0.01362124229240061,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.3790861380533713,
+          "mean_mse": 0.014436486146775724,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.36488074563855954,
+          "mean_mse": 0.01461191155861411,
+          "mean_rank": 37.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.407549432302311,
+          "mean_mse": 0.01438692040576518,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.3051077010385749,
+          "mean_mse": 0.014635507323033689,
+          "mean_rank": 67.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.28030793560635525,
+          "mean_mse": 0.014646476705996605,
+          "mean_rank": 28.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.38337219865231287,
+          "mean_mse": 0.014407236291190582,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.3566958966195969,
+          "mean_mse": 0.01425702756847604,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.35518379261584393,
+          "mean_mse": 0.014447806000097003,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.38776076936633697,
+          "mean_mse": 0.014049893734115353,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.29804255594133117,
+          "mean_mse": 0.014721640948186987,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.3061201912853374,
+          "mean_mse": 0.01472212755424034,
+          "mean_rank": 62.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.33185544935501204,
+          "mean_mse": 0.014038091858458723,
+          "mean_rank": 59.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.31652661489080236,
+          "mean_mse": 0.01469678186493011,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.3487422359891361,
+          "mean_mse": 0.014441354381001177,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.43319626918734644,
+          "mean_mse": 0.013849630207947735,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.27024425342179714,
+          "mean_mse": 0.014651352560206088,
+          "mean_rank": 140.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.46235316638475044,
+          "mean_mse": 0.013423110040158254,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.49166047220073517,
+          "mean_mse": 0.013051424872653237,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.39778774819609153,
+          "mean_mse": 0.013819375851094521,
+          "mean_rank": 52.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.3619896795648522,
+          "mean_mse": 0.014058239106046276,
+          "mean_rank": 33.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.3126267517836347,
+          "mean_mse": 0.014816053503778898,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.3686525533112431,
+          "mean_mse": 0.01430655783064041,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.34271842790097035,
+          "mean_mse": 0.014071669264959516,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.2273628593102231,
+          "mean_mse": 0.015003887005146009,
+          "mean_rank": 116.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.2026131502990515,
+          "mean_mse": 0.01510767292929454,
+          "mean_rank": 72.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.4089492597141947,
+          "mean_mse": 0.014216204296093736,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.32385863348599914,
+          "mean_mse": 0.014534037698290581,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.41818228455299034,
+          "mean_mse": 0.013027817821166764,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.3658956817146806,
+          "mean_mse": 0.014051324538569642,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.2264106198279019,
+          "mean_mse": 0.015166803528403147,
+          "mean_rank": 84.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.3775812117956635,
+          "mean_mse": 0.014184838261846482,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.3153047551609108,
+          "mean_mse": 0.014698555763367935,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.4759809217723149,
+          "mean_mse": 0.013571673402339206,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.18292110465336553,
+          "mean_mse": 0.015327328654219142,
+          "mean_rank": 157.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.24688896225749332,
+          "mean_mse": 0.014723614187997346,
+          "mean_rank": 75.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.45324552784704014,
+          "mean_mse": 0.01380882916481213,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.403913379229306,
+          "mean_mse": 0.013677302333727137,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.2958821012551288,
+          "mean_mse": 0.014507176922962058,
+          "mean_rank": 24.25,
+          "num_queries": 4
+        },
+        "template-system": {
+          "mean_cosine": 0.43590322870575804,
+          "mean_mse": 0.013700888241958822,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "template-customization": {
+          "mean_cosine": 0.41015885494550913,
+          "mean_mse": 0.013816441518277722,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "test-runner-inference": {
+          "mean_cosine": 0.3807457585973686,
+          "mean_mse": 0.014274558634490914,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "test-inference-heuristics": {
+          "mean_cosine": 0.47909662013660903,
+          "mean_mse": 0.0132639868987834,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "runtime-architecture": {
+          "mean_cosine": 0.261465655290544,
+          "mean_mse": 0.014790014029462511,
+          "mean_rank": 64.25,
+          "num_queries": 4
+        },
+        "dotnet-deployment": {
+          "mean_cosine": 0.4400739267684496,
+          "mean_mse": 0.013867734579409194,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "csharp-testing": {
+          "mean_cosine": 0.4368948994122935,
+          "mean_mse": 0.014090020288280936,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "multi-target-overview": {
+          "mean_cosine": 0.3147407308465204,
+          "mean_mse": 0.014377279531599806,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "csharp-setup": {
+          "mean_cosine": 0.1900540922903877,
+          "mean_mse": 0.01513337181416736,
+          "mean_rank": 95.5,
+          "num_queries": 4
+        },
+        "query-runtime-overview": {
+          "mean_cosine": 0.3519588496967981,
+          "mean_mse": 0.013530825514036266,
+          "mean_rank": 85.0,
+          "num_queries": 4
+        },
+        "ir-components": {
+          "mean_cosine": 0.35784439432695225,
+          "mean_mse": 0.014478944231918374,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "fixpoint-iteration": {
+          "mean_cosine": 0.27048221723328536,
+          "mean_mse": 0.014753058842752645,
+          "mean_rank": 34.75,
+          "num_queries": 4
+        },
+        "mutual-recursion-csharp": {
+          "mean_cosine": 0.12260907368542186,
+          "mean_mse": 0.015396480566443625,
+          "mean_rank": 140.75,
+          "num_queries": 4
+        },
+        "semantic-crawling": {
+          "mean_cosine": 0.3462260308955837,
+          "mean_mse": 0.014271138996839239,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "vector-search": {
+          "mean_cosine": 0.4367236210216596,
+          "mean_mse": 0.013752614635368894,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "powershell-semantic": {
+          "mean_cosine": 0.20176178225027264,
+          "mean_mse": 0.01522652841165241,
+          "mean_rank": 59.75,
+          "num_queries": 4
+        },
+        "csharp-stream-target": {
+          "mean_cosine": 0.42075897920242256,
+          "mean_mse": 0.013723668008647522,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "csharp-stream-rules": {
+          "mean_cosine": 0.43365723176378257,
+          "mean_mse": 0.014083768601429028,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "stream-target-limitations": {
+          "mean_cosine": 0.4840540501180416,
+          "mean_mse": 0.013448251952052053,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "b4-c4-cost-speed-quality": {
+          "mean_cosine": 0.47654802876354746,
+          "mean_mse": 0.012928515707967042,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c4-decision-heuristics": {
+          "mean_cosine": 0.5304808362795476,
+          "mean_mse": 0.012818467267843359,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c4-resource-constraints": {
+          "mean_cosine": 0.50523977293714,
+          "mean_mse": 0.013290399909542555,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-enhanced-pipeline-stages": {
+          "mean_cosine": 0.49080907195914786,
+          "mean_mse": 0.013264481351651104,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-stream-combination": {
+          "mean_cosine": 0.5333363484599487,
+          "mean_mse": 0.013380145070020952,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c6-flow-control": {
+          "mean_cosine": 0.5751264368458059,
+          "mean_mse": 0.011795711414608417,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b4-c6-error-throughput": {
+          "mean_cosine": 0.5552554886407207,
+          "mean_mse": 0.0127308532717273,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b4-c5-example-libraries": {
+          "mean_cosine": 0.5160706420133948,
+          "mean_mse": 0.012512143116608684,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c5-example-record-format": {
+          "mean_cosine": 0.5493595179191503,
+          "mean_mse": 0.012440642793618535,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c5-cross-references": {
+          "mean_cosine": 0.4662420289043525,
+          "mean_mse": 0.013549495426910729,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b4-c3-multi-target-pipelines": {
+          "mean_cosine": 0.39019974358874765,
+          "mean_mse": 0.013857470075609743,
+          "mean_rank": 6.333333333333333,
+          "num_queries": 3
+        },
+        "b4-c3-target-selection": {
+          "mean_cosine": 0.5643321755044061,
+          "mean_mse": 0.01180903751770161,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c3-pipeline-composition": {
+          "mean_cosine": 0.45797963865637303,
+          "mean_mse": 0.013362866618667424,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b4-c1-workflows-vs-playbooks": {
+          "mean_cosine": 0.4303192333486315,
+          "mean_mse": 0.013655086544570655,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b4-c2-playbook-format": {
+          "mean_cosine": 0.5318829971943375,
+          "mean_mse": 0.012227333523731856,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b4-c2-callout-types": {
+          "mean_cosine": 0.4816929702226353,
+          "mean_mse": 0.013094500943875405,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b5-c3-generator-mode": {
+          "mean_cosine": 0.5206578356757722,
+          "mean_mse": 0.012748472526948823,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-frozendict": {
+          "mean_cosine": 0.5335828832856709,
+          "mean_mse": 0.012663406249044986,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c3-negation": {
+          "mean_cosine": 0.4695554023106146,
+          "mean_mse": 0.013074558011063981,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c1-python-overview": {
+          "mean_cosine": 0.5591992493059866,
+          "mean_mse": 0.012616440620613836,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c1-target-comparison": {
+          "mean_cosine": 0.5819140232546949,
+          "mean_mse": 0.012014332432186789,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-procedural-mode": {
+          "mean_cosine": 0.47537785841789254,
+          "mean_mse": 0.01303873759859262,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b5-c2-constraints-arithmetic": {
+          "mean_cosine": 0.47402815573983886,
+          "mean_mse": 0.0136275432864567,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c2-io-formats": {
+          "mean_cosine": 0.45959550062912724,
+          "mean_mse": 0.013491796558202226,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c4-recursion-overview": {
+          "mean_cosine": 0.5549389401488769,
+          "mean_mse": 0.012253196515827201,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c4-tail-recursion": {
+          "mean_cosine": 0.5927499976000679,
+          "mean_mse": 0.01217290928862857,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c4-memoization": {
+          "mean_cosine": 0.5617859767771692,
+          "mean_mse": 0.012829731878088784,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b5-c4-mutual-recursion": {
+          "mean_cosine": 0.628262653699911,
+          "mean_mse": 0.010448894979109882,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b5-c5-semantic-overview": {
+          "mean_cosine": 0.5066011101168856,
+          "mean_mse": 0.012729390922757051,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b5-c5-vector-search": {
+          "mean_cosine": 0.4374976156635652,
+          "mean_mse": 0.013235620845754062,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b5-c5-graph-rag": {
+          "mean_cosine": 0.44821145670686496,
+          "mean_mse": 0.01345966008237154,
+          "mean_rank": 5.333333333333333,
+          "num_queries": 3
+        },
+        "b5-c5-crawling-llm": {
+          "mean_cosine": 0.4546150507446743,
+          "mean_mse": 0.013672741110129434,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-c3-regex-constraints": {
+          "mean_cosine": 0.5666065021070279,
+          "mean_mse": 0.012111419319392804,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c4-json-processing": {
+          "mean_cosine": 0.43967867612115175,
+          "mean_mse": 0.013539930416235206,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a1-core-apis": {
+          "mean_cosine": 0.5674046352491366,
+          "mean_mse": 0.012279579757181384,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-a1-recursion-apis": {
+          "mean_cosine": 0.48438180455656354,
+          "mean_mse": 0.013611066372648415,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b6-a1-api-selection": {
+          "mean_cosine": 0.4925762010262334,
+          "mean_mse": 0.01285535035827661,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a2-mode-complexity": {
+          "mean_cosine": 0.5317702453039436,
+          "mean_mse": 0.01208641282685533,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-a2-recursion-complexity": {
+          "mean_cosine": 0.4894869671352307,
+          "mean_mse": 0.013177087387530095,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b6-a2-db-complexity": {
+          "mean_cosine": 0.36410270697908825,
+          "mean_mse": 0.014102190629553563,
+          "mean_rank": 37.666666666666664,
+          "num_queries": 3
+        },
+        "b6-a3-boltdb-schema": {
+          "mean_cosine": 0.40454150033776126,
+          "mean_mse": 0.013705203361670871,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b6-a3-key-strategies": {
+          "mean_cosine": 0.49284202602132715,
+          "mean_mse": 0.013268354382967862,
+          "mean_rank": 5.0,
+          "num_queries": 3
+        },
+        "b6-a3-query-outside": {
+          "mean_cosine": 0.40619099649785273,
+          "mean_mse": 0.013467462631597519,
+          "mean_rank": 3.6666666666666665,
+          "num_queries": 3
+        },
+        "b6-a3-incremental": {
+          "mean_cosine": 0.570927905101069,
+          "mean_mse": 0.011845145995870098,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-generator-mode": {
+          "mean_cosine": 0.42489983455161123,
+          "mean_mse": 0.012656256437312071,
+          "mean_rank": 16.0,
+          "num_queries": 3
+        },
+        "b6-c6-aggregation-negation": {
+          "mean_cosine": 0.4743231528435951,
+          "mean_mse": 0.013198602226875418,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c6-parallel-persistence": {
+          "mean_cosine": 0.487658859455725,
+          "mean_mse": 0.012893282636980974,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b6-c1-go-overview": {
+          "mean_cosine": 0.5891396659280072,
+          "mean_mse": 0.011912417530067465,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c2-basic-compilation": {
+          "mean_cosine": 0.5021382474253646,
+          "mean_mse": 0.012302143561525225,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursive-compilation": {
+          "mean_cosine": 0.4519970894123098,
+          "mean_mse": 0.013227239311348912,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b6-c7-recursion-patterns": {
+          "mean_cosine": 0.5917143707483377,
+          "mean_mse": 0.012154666869429407,
+          "mean_rank": 1.3333333333333333,
+          "num_queries": 3
+        },
+        "b6-c5-semantic-runtime": {
+          "mean_cosine": 0.4249804637510987,
+          "mean_mse": 0.013656196527773196,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c12a-service-mesh": {
+          "mean_cosine": 0.5604549377493971,
+          "mean_mse": 0.012198411650303631,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12b-polyglot": {
+          "mean_cosine": 0.546547245076493,
+          "mean_mse": 0.01243038224890227,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12c-discovery-tracing": {
+          "mean_cosine": 0.5450213990589883,
+          "mean_mse": 0.013144148622705186,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c12d-kg-topology": {
+          "mean_cosine": 0.5498076865352235,
+          "mean_mse": 0.0127884326558081,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c7-dotnet-bridges": {
+          "mean_cosine": 0.5135659165690173,
+          "mean_mse": 0.013387859033513147,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c8-ironpython-compat": {
+          "mean_cosine": 0.4554615902177641,
+          "mean_mse": 0.013128993596141761,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c1-cross-target-overview": {
+          "mean_cosine": 0.6349135143363914,
+          "mean_mse": 0.009795399130596604,
+          "mean_rank": 9.333333333333334,
+          "num_queries": 3
+        },
+        "b7-c1-runtime-families": {
+          "mean_cosine": 0.5604072954331233,
+          "mean_mse": 0.012567423371460995,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c2-design-principles": {
+          "mean_cosine": 0.4758139593937549,
+          "mean_mse": 0.013281051401768067,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c2-data-formats": {
+          "mean_cosine": 0.5170993139993899,
+          "mean_mse": 0.012549611640049904,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c9-native-code-gen": {
+          "mean_cosine": 0.5086163643611433,
+          "mean_mse": 0.012768439247535476,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "b7-c10-native-orchestration": {
+          "mean_cosine": 0.5865399891784819,
+          "mean_mse": 0.01190130081871083,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c11-http-services": {
+          "mean_cosine": 0.5227694827591208,
+          "mean_mse": 0.011987032533621628,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c12-distributed-pipelines": {
+          "mean_cosine": 0.4883519195412112,
+          "mean_mse": 0.013472394192309703,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c15-deployment": {
+          "mean_cosine": 0.49353167187312136,
+          "mean_mse": 0.012739284884374502,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c16-cloud-enterprise": {
+          "mean_cosine": 0.5470833033907962,
+          "mean_mse": 0.011661612587060765,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "b7-c14-case-studies": {
+          "mean_cosine": 0.4954698920437448,
+          "mean_mse": 0.013259551649762702,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c5-shell-glue": {
+          "mean_cosine": 0.5344241678149513,
+          "mean_mse": 0.012995789567229849,
+          "mean_rank": 1.6666666666666667,
+          "num_queries": 3
+        },
+        "b7-c6-pipeline-orchestration": {
+          "mean_cosine": 0.4916735029699719,
+          "mean_mse": 0.012963044563855636,
+          "mean_rank": 3.3333333333333335,
+          "num_queries": 3
+        },
+        "b7-c3-target-registry": {
+          "mean_cosine": 0.4605069165309392,
+          "mean_mse": 0.013238151325389731,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "b7-c3-location-resolution": {
+          "mean_cosine": 0.5782378074033702,
+          "mean_mse": 0.011753991715913431,
+          "mean_rank": 1.0,
+          "num_queries": 3
+        },
+        "firewall-001": {
+          "mean_cosine": 0.7352378755597411,
+          "mean_mse": 0.008707610625019057,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "firewall-002": {
+          "mean_cosine": 0.7422130895462118,
+          "mean_mse": 0.008382709874222122,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "firewall-003": {
+          "mean_cosine": 0.9979711813620293,
+          "mean_mse": 6.47635193729602e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "security-001": {
+          "mean_cosine": 0.7664800248054074,
+          "mean_mse": 0.0067818524376366835,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "security-002": {
+          "mean_cosine": 0.719750126542921,
+          "mean_mse": 0.007974450609628793,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "hooks-001": {
+          "mean_cosine": 0.7555390826414943,
+          "mean_mse": 0.008242559541981708,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "hooks-002": {
+          "mean_cosine": 0.6033923911365222,
+          "mean_mse": 0.010192024090392274,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-001": {
+          "mean_cosine": 0.6216803484788271,
+          "mean_mse": 0.010821505706175901,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "production-002": {
+          "mean_cosine": 0.6746560288732593,
+          "mean_mse": 0.010153846478642415,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "production-003": {
+          "mean_cosine": 0.6868981863241044,
+          "mean_mse": 0.009123300396201142,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "target-sec-001": {
+          "mean_cosine": 0.6653301694783429,
+          "mean_mse": 0.008784933992415148,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "target-sec-002": {
+          "mean_cosine": 0.6870378324249447,
+          "mean_mse": 0.009280565803601787,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "validation-001": {
+          "mean_cosine": 0.6820364506024923,
+          "mean_mse": 0.008555339968449913,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "validation-002": {
+          "mean_cosine": 0.9974970789810079,
+          "mean_mse": 7.862708207097299e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "validation-003": {
+          "mean_cosine": 0.9978114367423668,
+          "mean_mse": 6.892636382370079e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-compile-001": {
+          "mean_cosine": 0.6029234048913561,
+          "mean_mse": 0.010334857305742424,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-compile-002": {
+          "mean_cosine": 0.627680674352771,
+          "mean_mse": 0.009896172767831526,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-001": {
+          "mean_cosine": 0.6821238653376471,
+          "mean_mse": 0.009110249690004665,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-002": {
+          "mean_cosine": 0.998146770041372,
+          "mean_mse": 5.9391114302719234e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "rust-project-001": {
+          "mean_cosine": 0.6705888356548975,
+          "mean_mse": 0.009306596963914343,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "rust-advanced-001": {
+          "mean_cosine": 0.7540932540758287,
+          "mean_mse": 0.007036700694939868,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-001": {
+          "mean_cosine": 0.6419159196442371,
+          "mean_mse": 0.011118515568676265,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-basic-002": {
+          "mean_cosine": 0.9975997381684355,
+          "mean_mse": 7.567731040975098e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-case-001": {
+          "mean_cosine": 0.6524998472401697,
+          "mean_mse": 0.00919536455526833,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-case-002": {
+          "mean_cosine": 0.9977681498854928,
+          "mean_mse": 6.969780376345357e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-cte-001": {
+          "mean_cosine": 0.7796035863477067,
+          "mean_mse": 0.00823589955627579,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-cte-002": {
+          "mean_cosine": 0.6140144628630291,
+          "mean_mse": 0.010646242971985895,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-001": {
+          "mean_cosine": 0.6831576284012315,
+          "mean_mse": 0.008482370994141739,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-002": {
+          "mean_cosine": 0.9962748377163406,
+          "mean_mse": 0.0001164643980216567,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-join-001": {
+          "mean_cosine": 0.6966724347052939,
+          "mean_mse": 0.00882436369983485,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-agg-001": {
+          "mean_cosine": 0.998287524355829,
+          "mean_mse": 5.382893225200148e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-practical-001": {
+          "mean_cosine": 0.7634802073572896,
+          "mean_mse": 0.007262053565315027,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "sql-practical-002": {
+          "mean_cosine": 0.9970570911417158,
+          "mean_mse": 9.183730696637433e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-set-001": {
+          "mean_cosine": 0.6539863815349507,
+          "mean_mse": 0.009555017719413732,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-func-001": {
+          "mean_cosine": 0.6438916098042339,
+          "mean_mse": 0.009286589234010876,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-func-002": {
+          "mean_cosine": 0.7109599993823016,
+          "mean_mse": 0.008384530504250164,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "sql-subquery-001": {
+          "mean_cosine": 0.6239373251266023,
+          "mean_mse": 0.009826067144341427,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-subquery-002": {
+          "mean_cosine": 0.9964260540105788,
+          "mean_mse": 0.00011150062647057457,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "sql-window-001": {
+          "mean_cosine": 0.6925309527279845,
+          "mean_mse": 0.008529207826367232,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "sql-window-002": {
+          "mean_cosine": 0.7700590488507881,
+          "mean_mse": 0.006968823160066359,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-case-001": {
+          "mean_cosine": 0.9968768717370489,
+          "mean_mse": 9.785428045546631e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-api-001": {
+          "mean_cosine": 0.6655231133587297,
+          "mean_mse": 0.008833721752675015,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "prolog-dialect-001": {
+          "mean_cosine": 0.6858176232621005,
+          "mean_mse": 0.008495950791247882,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "prolog-dialect-002": {
+          "mean_cosine": 0.997382840515696,
+          "mean_mse": 8.223354895833456e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-firewall-001": {
+          "mean_cosine": 0.9956853995521381,
+          "mean_mse": 0.00013465104149446586,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "prolog-fallback-001": {
+          "mean_cosine": 0.750974730655668,
+          "mean_mse": 0.007613425111250538,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "prolog-target-001": {
+          "mean_cosine": 0.6665598874944452,
+          "mean_mse": 0.008881297103254738,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-cmdlet-001": {
+          "mean_cosine": 0.7445197641768434,
+          "mean_mse": 0.007491132417407588,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-cmdlet-002": {
+          "mean_cosine": 0.9962002098136337,
+          "mean_mse": 0.00011914104207668861,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-hosting-001": {
+          "mean_cosine": 0.668595579363322,
+          "mean_mse": 0.009030244711401278,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-dotnet-001": {
+          "mean_cosine": 0.7238510284885429,
+          "mean_mse": 0.008364208573631605,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "ps-dotnet-002": {
+          "mean_cosine": 0.9982314497854746,
+          "mean_mse": 5.5261438705626946e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-facts-001": {
+          "mean_cosine": 0.7565436715417785,
+          "mean_mse": 0.007601033491660789,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ps-facts-002": {
+          "mean_cosine": 0.997705039233667,
+          "mean_mse": 7.21128691249352e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "ps-001": {
+          "mean_cosine": 0.7577822570343241,
+          "mean_mse": 0.007091446981237104,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-001": {
+          "mean_cosine": 0.6076636928136044,
+          "mean_mse": 0.010109160666510537,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ps-windows-002": {
+          "mean_cosine": 0.9970009656648028,
+          "mean_mse": 9.359325364534683e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-adversarial-001": {
+          "mean_cosine": 0.9975639712303439,
+          "mean_mse": 7.609801218167379e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-routing-001": {
+          "mean_cosine": 0.9978305143242391,
+          "mean_mse": 6.841267314376127e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-scalefree-001": {
+          "mean_cosine": 0.9984686952669286,
+          "mean_mse": 4.8554547271976404e-05,
+          "mean_rank": 1.0,
+          "num_queries": 1
+        },
+        "semantic-density-001": {
+          "mean_cosine": 0.6134829374698344,
+          "mean_mse": 0.01010998668789155,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-dist-001": {
+          "mean_cosine": 0.6498550391992324,
+          "mean_mse": 0.009745633880505391,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "semantic-001": {
+          "mean_cosine": 0.6677036570532979,
+          "mean_mse": 0.009466259853621513,
+          "mean_rank": 1.0,
+          "num_queries": 2
+        },
+        "semantic-polyglot-001": {
+          "mean_cosine": 0.74860719488662,
+          "mean_mse": 0.0086920059952743,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-advanced-001": {
+          "mean_cosine": 0.4998472845518869,
+          "mean_mse": 0.013077636338672384,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "ai-deploy-001": {
+          "mean_cosine": 0.7469501689314693,
+          "mean_mse": 0.007546056715719295,
+          "mean_rank": 2.0,
+          "num_queries": 2
+        },
+        "ai-foundations-001": {
+          "mean_cosine": 0.44120773574665545,
+          "mean_mse": 0.013829919416787696,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-kgtopo-001": {
+          "mean_cosine": 0.4093742794358427,
+          "mean_mse": 0.0144896331935724,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "ai-lda-001": {
+          "mean_cosine": 0.5987312557983714,
+          "mean_mse": 0.011943366691930744,
+          "mean_rank": 2.0,
+          "num_queries": 3
+        },
+        "ai-multihead-001": {
+          "mean_cosine": 0.4931058186261696,
+          "mean_mse": 0.013815330879264662,
+          "mean_rank": 2.6666666666666665,
+          "num_queries": 3
+        },
+        "ai-pipeline-001": {
+          "mean_cosine": 0.6640783378557708,
+          "mean_mse": 0.010454960142090401,
+          "mean_rank": 1.5,
+          "num_queries": 2
+        },
+        "ai-distill-001": {
+          "mean_cosine": 0.5405111287148153,
+          "mean_mse": 0.012203381408493705,
+          "mean_rank": 2.3333333333333335,
+          "num_queries": 3
+        },
+        "prereq-prolog-installation": {
+          "mean_cosine": 0.5333966182187916,
+          "mean_mse": 0.012050492825729519,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prereq-init-environment": {
+          "mean_cosine": 0.15544928923443752,
+          "mean_mse": 0.015237050739412344,
+          "mean_rank": 168.8,
+          "num_queries": 5
+        },
+        "prereq-module-paths": {
+          "mean_cosine": 0.45358348797002107,
+          "mean_mse": 0.0133026149298237,
+          "mean_rank": 3.0,
+          "num_queries": 3
+        },
+        "prereq-project-structure": {
+          "mean_cosine": 0.3888749316308779,
+          "mean_mse": 0.01404639754188316,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        }
+      }
+    }
+  ]
+}

--- a/scripts/benchmark_answer_level.py
+++ b/scripts/benchmark_answer_level.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""
+Answer-Level Benchmark for LDA Smoothing.
+
+Unlike cluster-level benchmarks (P@1 = correct cluster), this measures
+distance to the exact target answer:
+
+1. Cosine Similarity: cos(projected_query, target_answer)
+2. MSE: ||projected_query - target_answer||²
+3. Rank of Target: Position of correct answer in similarity-ranked results
+4. Recall@k: Is target answer in top-k results?
+5. Per-cluster breakdown: Which clusters are hardest?
+
+Usage:
+    python scripts/benchmark_answer_level.py
+    python scripts/benchmark_answer_level.py --max-clusters 50
+    python scripts/benchmark_answer_level.py --output reports/answer_level.json
+"""
+
+import argparse
+import json
+import time
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple, Any, Optional
+from dataclasses import dataclass, field
+from collections import defaultdict
+import numpy as np
+
+# Add source path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "unifyweaver" / "targets" / "python_runtime"))
+
+from smoothing_basis import SmoothingBasisProjection, MultiHeadLDABaseline
+from fft_smoothing import FFTSmoothingProjection, AdaptiveFFTSmoothing
+from hierarchical_smoothing import HierarchicalSmoothing
+
+
+@dataclass
+class AnswerLevelMetrics:
+    """Per-query answer-level metrics."""
+    query_id: str
+    cluster_id: str
+    cosine_to_target: float
+    mse_to_target: float
+    target_rank: int  # 1-indexed rank of correct answer
+    recall_at_1: bool
+    recall_at_5: bool
+    recall_at_10: bool
+
+
+@dataclass
+class MethodResult:
+    """Aggregated results for a smoothing method."""
+    method: str
+    params: Dict[str, Any]
+
+    # Answer-level metrics (mean across all queries)
+    mean_cosine_to_target: float
+    std_cosine_to_target: float
+    mean_mse_to_target: float
+    std_mse_to_target: float
+    mean_target_rank: float
+    median_target_rank: float
+
+    # Recall metrics
+    recall_at_1: float
+    recall_at_5: float
+    recall_at_10: float
+    mrr: float  # Mean Reciprocal Rank
+
+    # Timing
+    train_time_ms: float
+    inference_time_us: float
+
+    # Per-cluster breakdown
+    cluster_metrics: Dict[str, Dict[str, float]]
+
+    # Data info
+    num_queries: int
+    num_answers: int
+    num_clusters: int
+
+
+def load_training_data(data_dir: Path, max_clusters: Optional[int] = None) -> Dict[str, List[Dict]]:
+    """Load training data grouped by cluster_id."""
+    clusters = defaultdict(list)
+
+    for jsonl_file in sorted(data_dir.rglob("*.jsonl")):
+        with open(jsonl_file, 'r') as f:
+            for line in f:
+                if line.strip():
+                    try:
+                        pair = json.loads(line)
+                        cluster_id = pair.get("cluster_id", "unknown")
+                        clusters[cluster_id].append(pair)
+                    except json.JSONDecodeError:
+                        pass
+
+    if max_clusters and len(clusters) > max_clusters:
+        cluster_ids = list(clusters.keys())[:max_clusters]
+        clusters = {k: clusters[k] for k in cluster_ids}
+
+    return dict(clusters)
+
+
+def get_text(field: Any) -> str:
+    """Extract text from field."""
+    if isinstance(field, str):
+        return field
+    elif isinstance(field, dict):
+        return field.get("text", str(field))
+    return str(field) if field else ""
+
+
+def simple_embedding(text: str, dim: int = 64) -> np.ndarray:
+    """Deterministic hash-based embedding."""
+    np.random.seed(hash(text) % (2**32))
+    emb = np.random.randn(dim)
+    return emb / (np.linalg.norm(emb) + 1e-8)
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Compute cosine similarity."""
+    a_norm = np.linalg.norm(a)
+    b_norm = np.linalg.norm(b)
+    if a_norm < 1e-8 or b_norm < 1e-8:
+        return 0.0
+    return float(np.dot(a, b) / (a_norm * b_norm))
+
+
+def prepare_data(clusters: Dict[str, List[Dict]], dim: int = 64) -> Tuple[
+    List[Tuple[np.ndarray, np.ndarray]],  # (Q, A) for smoothing
+    List[Dict],  # Individual Q-A pairs with embeddings
+    Dict[str, np.ndarray]  # answer_id -> embedding
+]:
+    """
+    Prepare data for answer-level benchmarking.
+
+    Returns:
+        clusters_for_smoothing: List of (Q, A) tuples per cluster
+        qa_pairs: List of dicts with query/answer embeddings and IDs
+        answer_index: Dict mapping answer_id to embedding
+    """
+    clusters_for_smoothing = []
+    qa_pairs = []
+    answer_index = {}
+
+    for cluster_id, pairs in clusters.items():
+        cluster_questions = []
+        cluster_answers = []
+
+        for i, pair in enumerate(pairs):
+            q_text = get_text(pair.get("question", ""))
+            a_text = get_text(pair.get("answer", ""))
+
+            if q_text and a_text:
+                q_emb = simple_embedding(q_text, dim)
+                a_emb = simple_embedding(a_text, dim)
+
+                answer_id = f"{cluster_id}_{i}"
+                query_id = f"q_{cluster_id}_{i}"
+
+                cluster_questions.append(q_emb)
+                cluster_answers.append(a_emb)
+
+                qa_pairs.append({
+                    'query_id': query_id,
+                    'answer_id': answer_id,
+                    'cluster_id': cluster_id,
+                    'query_emb': q_emb,
+                    'answer_emb': a_emb,
+                    'query_text': q_text,
+                    'answer_text': a_text,
+                })
+
+                answer_index[answer_id] = a_emb
+
+        if cluster_questions:
+            Q = np.array(cluster_questions)
+            # Use mean answer as cluster representation for smoothing
+            A = np.mean(cluster_answers, axis=0).reshape(1, -1)
+            clusters_for_smoothing.append((Q, A))
+
+    return clusters_for_smoothing, qa_pairs, answer_index
+
+
+def compute_answer_level_metrics(
+    projector,
+    qa_pairs: List[Dict],
+    answer_index: Dict[str, np.ndarray]
+) -> List[AnswerLevelMetrics]:
+    """Compute answer-level metrics for each query."""
+    metrics = []
+
+    # Build answer list for ranking
+    answer_ids = list(answer_index.keys())
+    answer_embs = np.array([answer_index[aid] for aid in answer_ids])
+
+    for pair in qa_pairs:
+        query_emb = pair['query_emb']
+        target_answer_id = pair['answer_id']
+        target_answer_emb = pair['answer_emb']
+
+        # Project query
+        projected = projector.project(query_emb)
+
+        # Cosine similarity to target
+        cos_to_target = cosine_similarity(projected, target_answer_emb)
+
+        # MSE to target
+        mse_to_target = float(np.mean((projected - target_answer_emb) ** 2))
+
+        # Compute similarities to all answers for ranking
+        sims = []
+        for aid, a_emb in zip(answer_ids, answer_embs):
+            sim = cosine_similarity(projected, a_emb)
+            sims.append((aid, sim))
+
+        # Sort by similarity descending
+        sims.sort(key=lambda x: x[1], reverse=True)
+        ranked_ids = [aid for aid, _ in sims]
+
+        # Find rank of target answer (1-indexed)
+        try:
+            target_rank = ranked_ids.index(target_answer_id) + 1
+        except ValueError:
+            target_rank = len(ranked_ids) + 1
+
+        metrics.append(AnswerLevelMetrics(
+            query_id=pair['query_id'],
+            cluster_id=pair['cluster_id'],
+            cosine_to_target=cos_to_target,
+            mse_to_target=mse_to_target,
+            target_rank=target_rank,
+            recall_at_1=target_rank <= 1,
+            recall_at_5=target_rank <= 5,
+            recall_at_10=target_rank <= 10,
+        ))
+
+    return metrics
+
+
+def aggregate_metrics(
+    method_name: str,
+    params: Dict[str, Any],
+    metrics: List[AnswerLevelMetrics],
+    train_time_ms: float,
+    inference_time_us: float,
+    num_answers: int,
+    num_clusters: int
+) -> MethodResult:
+    """Aggregate per-query metrics into method-level results."""
+
+    cosines = [m.cosine_to_target for m in metrics]
+    mses = [m.mse_to_target for m in metrics]
+    ranks = [m.target_rank for m in metrics]
+
+    # Per-cluster breakdown
+    cluster_metrics = defaultdict(lambda: {'cosines': [], 'mses': [], 'ranks': []})
+    for m in metrics:
+        cluster_metrics[m.cluster_id]['cosines'].append(m.cosine_to_target)
+        cluster_metrics[m.cluster_id]['mses'].append(m.mse_to_target)
+        cluster_metrics[m.cluster_id]['ranks'].append(m.target_rank)
+
+    # Aggregate per cluster
+    cluster_summary = {}
+    for cid, data in cluster_metrics.items():
+        cluster_summary[cid] = {
+            'mean_cosine': float(np.mean(data['cosines'])),
+            'mean_mse': float(np.mean(data['mses'])),
+            'mean_rank': float(np.mean(data['ranks'])),
+            'num_queries': len(data['cosines']),
+        }
+
+    return MethodResult(
+        method=method_name,
+        params=params,
+        mean_cosine_to_target=float(np.mean(cosines)),
+        std_cosine_to_target=float(np.std(cosines)),
+        mean_mse_to_target=float(np.mean(mses)),
+        std_mse_to_target=float(np.std(mses)),
+        mean_target_rank=float(np.mean(ranks)),
+        median_target_rank=float(np.median(ranks)),
+        recall_at_1=float(np.mean([m.recall_at_1 for m in metrics])),
+        recall_at_5=float(np.mean([m.recall_at_5 for m in metrics])),
+        recall_at_10=float(np.mean([m.recall_at_10 for m in metrics])),
+        mrr=float(np.mean([1.0 / m.target_rank for m in metrics])),
+        train_time_ms=train_time_ms,
+        inference_time_us=inference_time_us,
+        cluster_metrics=cluster_summary,
+        num_queries=len(metrics),
+        num_answers=num_answers,
+        num_clusters=num_clusters,
+    )
+
+
+def benchmark_method(
+    name: str,
+    projector,
+    clusters_for_smoothing: List[Tuple],
+    qa_pairs: List[Dict],
+    answer_index: Dict[str, np.ndarray],
+    train_fn,
+    params: Dict[str, Any]
+) -> MethodResult:
+    """Benchmark a single smoothing method."""
+
+    # Training
+    start = time.perf_counter()
+    train_fn()
+    train_time_ms = (time.perf_counter() - start) * 1000
+
+    # Inference timing
+    start = time.perf_counter()
+    for pair in qa_pairs:
+        _ = projector.project(pair['query_emb'])
+    inference_time_us = (time.perf_counter() - start) * 1e6 / len(qa_pairs)
+
+    # Compute answer-level metrics
+    metrics = compute_answer_level_metrics(projector, qa_pairs, answer_index)
+
+    return aggregate_metrics(
+        name, params, metrics,
+        train_time_ms, inference_time_us,
+        len(answer_index), len(clusters_for_smoothing)
+    )
+
+
+def run_benchmarks(
+    clusters_for_smoothing: List[Tuple],
+    qa_pairs: List[Dict],
+    answer_index: Dict[str, np.ndarray],
+    k_values: List[int] = [4, 8, 16]
+) -> List[MethodResult]:
+    """Run all benchmarks."""
+    results = []
+
+    print(f"\nAnswer-Level Benchmark")
+    print(f"Clusters: {len(clusters_for_smoothing)}, Queries: {len(qa_pairs)}, Answers: {len(answer_index)}")
+    print("=" * 90)
+
+    # 1. Baseline: Multi-head LDA
+    print("\n1. MultiHeadLDA Baseline...")
+    baseline = MultiHeadLDABaseline()
+    result = benchmark_method(
+        "MultiHeadLDA", baseline, clusters_for_smoothing, qa_pairs, answer_index,
+        lambda: baseline.train(clusters_for_smoothing),
+        {"type": "baseline"}
+    )
+    results.append(result)
+    print(f"   Cosine: {result.mean_cosine_to_target:.4f} ± {result.std_cosine_to_target:.4f}")
+    print(f"   MSE: {result.mean_mse_to_target:.4f}, Rank: {result.mean_target_rank:.1f}, MRR: {result.mrr:.4f}")
+
+    # 2. FFT Smoothing
+    for cutoff in [0.3, 0.5, 0.7]:
+        print(f"\n2. FFT (cutoff={cutoff})...")
+        fft = FFTSmoothingProjection(cutoff=cutoff, blend_factor=0.6)
+        result = benchmark_method(
+            f"FFT_c{cutoff}", fft, clusters_for_smoothing, qa_pairs, answer_index,
+            lambda fft=fft: fft.train(clusters_for_smoothing),
+            {"cutoff": cutoff, "blend": 0.6}
+        )
+        results.append(result)
+        print(f"   Cosine: {result.mean_cosine_to_target:.4f} ± {result.std_cosine_to_target:.4f}")
+        print(f"   MSE: {result.mean_mse_to_target:.4f}, Rank: {result.mean_target_rank:.1f}, MRR: {result.mrr:.4f}")
+
+    # 3. Adaptive FFT
+    print("\n3. AdaptiveFFT...")
+    adaptive = AdaptiveFFTSmoothing(min_cutoff=0.2, max_cutoff=0.7)
+    result = benchmark_method(
+        "AdaptiveFFT", adaptive, clusters_for_smoothing, qa_pairs, answer_index,
+        lambda: adaptive.train(clusters_for_smoothing),
+        {"min_cutoff": 0.2, "max_cutoff": 0.7}
+    )
+    results.append(result)
+    print(f"   Cosine: {result.mean_cosine_to_target:.4f} ± {result.std_cosine_to_target:.4f}")
+    print(f"   MSE: {result.mean_mse_to_target:.4f}, Rank: {result.mean_target_rank:.1f}, MRR: {result.mrr:.4f}")
+
+    # 4. Smoothing Basis
+    for K in k_values:
+        if K > len(clusters_for_smoothing):
+            continue
+        print(f"\n4. SmoothingBasis (K={K})...")
+        sb = SmoothingBasisProjection(num_basis=K, cosine_weight=0.5)
+        result = benchmark_method(
+            f"Basis_K{K}", sb, clusters_for_smoothing, qa_pairs, answer_index,
+            lambda sb=sb: sb.train(clusters_for_smoothing, num_iterations=50, log_interval=100),
+            {"K": K, "iterations": 50}
+        )
+        results.append(result)
+        print(f"   Cosine: {result.mean_cosine_to_target:.4f} ± {result.std_cosine_to_target:.4f}")
+        print(f"   MSE: {result.mean_mse_to_target:.4f}, Rank: {result.mean_target_rank:.1f}, MRR: {result.mrr:.4f}")
+
+    return results
+
+
+def print_metric_legend():
+    """Print explanation of metrics."""
+    print("\n" + "=" * 110)
+    print("METRIC LEGEND")
+    print("=" * 110)
+    print("""
+| Metric   | Meaning                                           | Good Value |
+|----------|---------------------------------------------------|------------|
+| Cosine   | Cosine similarity between projected query and     | Higher (1.0 = perfect alignment)
+|          | target answer. Measures direction alignment.      |            |
+| MSE      | Mean Squared Error between projected query and    | Lower (0.0 = identical vectors)
+|          | target answer. Measures magnitude difference.     |            |
+| Rank     | Position of correct answer when all answers are   | Lower (1 = correct answer is top result)
+|          | sorted by similarity to projected query.          |            |
+| MRR      | Mean Reciprocal Rank = average of 1/rank.         | Higher (1.0 = always rank 1)
+|          | Rewards finding correct answer early.             |            |
+| R@k      | Recall at k = % of queries where correct answer   | Higher (100% = always in top k)
+|          | appears in top k results.                         |            |
+""")
+
+
+def print_summary(results: List[MethodResult]):
+    """Print summary table."""
+    print_metric_legend()
+
+    print("\n" + "=" * 110)
+    print("ANSWER-LEVEL SUMMARY")
+    print("=" * 110)
+
+    # Header
+    print(f"{'Method':<20} {'Cosine':>10} {'MSE':>10} {'Rank':>8} {'MRR':>8} "
+          f"{'R@1':>8} {'R@5':>8} {'R@10':>8} {'Train(ms)':>10}")
+    print("-" * 110)
+
+    # Sort by MRR descending
+    for r in sorted(results, key=lambda x: x.mrr, reverse=True):
+        print(f"{r.method:<20} {r.mean_cosine_to_target:<12.4f} {r.mean_mse_to_target:<10.4f} "
+              f"{r.mean_target_rank:<8.1f} {r.mrr:<8.4f} {r.recall_at_1:<8.2%} "
+              f"{r.recall_at_5:<8.2%} {r.recall_at_10:<8.2%} {r.train_time_ms:<10.1f}")
+
+    print("-" * 110)
+
+    # Best by metric
+    print("\nBest by metric:")
+    print(f"  Highest Cosine:  {max(results, key=lambda x: x.mean_cosine_to_target).method} "
+          f"({max(results, key=lambda x: x.mean_cosine_to_target).mean_cosine_to_target:.4f})")
+    print(f"  Lowest MSE:      {min(results, key=lambda x: x.mean_mse_to_target).method} "
+          f"({min(results, key=lambda x: x.mean_mse_to_target).mean_mse_to_target:.4f})")
+    print(f"  Lowest Rank:     {min(results, key=lambda x: x.mean_target_rank).method} "
+          f"({min(results, key=lambda x: x.mean_target_rank).mean_target_rank:.1f})")
+    print(f"  Highest MRR:     {max(results, key=lambda x: x.mrr).method} "
+          f"({max(results, key=lambda x: x.mrr).mrr:.4f})")
+
+
+def print_cluster_analysis(results: List[MethodResult], top_n: int = 5):
+    """Print per-cluster analysis for best method."""
+    best = max(results, key=lambda x: x.mrr)
+
+    print(f"\n{'=' * 80}")
+    print(f"PER-CLUSTER ANALYSIS (Method: {best.method})")
+    print("=" * 80)
+
+    # Sort clusters by difficulty (mean rank)
+    sorted_clusters = sorted(
+        best.cluster_metrics.items(),
+        key=lambda x: x[1]['mean_rank']
+    )
+
+    # Easiest clusters
+    print(f"\nEasiest Clusters (lowest mean rank):")
+    print(f"{'Cluster':<30} {'Cosine':<10} {'MSE':<10} {'Rank':<8} {'N':<5}")
+    print("-" * 65)
+    for cid, m in sorted_clusters[:top_n]:
+        print(f"{cid[:30]:<30} {m['mean_cosine']:<10.4f} {m['mean_mse']:<10.4f} "
+              f"{m['mean_rank']:<8.1f} {m['num_queries']:<5}")
+
+    # Hardest clusters
+    print(f"\nHardest Clusters (highest mean rank):")
+    print(f"{'Cluster':<30} {'Cosine':<10} {'MSE':<10} {'Rank':<8} {'N':<5}")
+    print("-" * 65)
+    for cid, m in sorted_clusters[-top_n:]:
+        print(f"{cid[:30]:<30} {m['mean_cosine']:<10.4f} {m['mean_mse']:<10.4f} "
+              f"{m['mean_rank']:<8.1f} {m['num_queries']:<5}")
+
+    # Variance across clusters
+    all_cosines = [m['mean_cosine'] for m in best.cluster_metrics.values()]
+    all_ranks = [m['mean_rank'] for m in best.cluster_metrics.values()]
+
+    print(f"\nCluster Variance:")
+    print(f"  Cosine: min={min(all_cosines):.4f}, max={max(all_cosines):.4f}, "
+          f"std={np.std(all_cosines):.4f}")
+    print(f"  Rank:   min={min(all_ranks):.1f}, max={max(all_ranks):.1f}, "
+          f"std={np.std(all_ranks):.1f}")
+
+
+def save_results(results: List[MethodResult], output_path: Path):
+    """Save results to JSON with metric explanations."""
+
+    # Metric legend for documentation
+    metric_legend = {
+        "cosine_to_target": {
+            "description": "Cosine similarity between projected query and target answer",
+            "good_value": "Higher is better (1.0 = perfect alignment)",
+            "range": "[-1.0, 1.0]"
+        },
+        "mse_to_target": {
+            "description": "Mean Squared Error between projected query and target answer",
+            "good_value": "Lower is better (0.0 = identical vectors)",
+            "range": "[0.0, inf)"
+        },
+        "target_rank": {
+            "description": "Position of correct answer when sorted by similarity (1-indexed)",
+            "good_value": "Lower is better (1 = correct answer is top result)",
+            "range": "[1, num_answers]"
+        },
+        "mrr": {
+            "description": "Mean Reciprocal Rank = average of 1/rank across all queries",
+            "good_value": "Higher is better (1.0 = always rank 1)",
+            "range": "(0.0, 1.0]"
+        },
+        "recall_at_k": {
+            "description": "Fraction of queries where correct answer is in top k results",
+            "good_value": "Higher is better (1.0 = always in top k)",
+            "range": "[0.0, 1.0]"
+        }
+    }
+
+    # Build results list
+    method_results = []
+    for r in results:
+        method_results.append({
+            "method": r.method,
+            "params": r.params,
+            "mean_cosine_to_target": r.mean_cosine_to_target,
+            "std_cosine_to_target": r.std_cosine_to_target,
+            "mean_mse_to_target": r.mean_mse_to_target,
+            "std_mse_to_target": r.std_mse_to_target,
+            "mean_target_rank": r.mean_target_rank,
+            "median_target_rank": r.median_target_rank,
+            "recall_at_1": r.recall_at_1,
+            "recall_at_5": r.recall_at_5,
+            "recall_at_10": r.recall_at_10,
+            "mrr": r.mrr,
+            "train_time_ms": r.train_time_ms,
+            "inference_time_us": r.inference_time_us,
+            "num_queries": r.num_queries,
+            "num_answers": r.num_answers,
+            "num_clusters": r.num_clusters,
+            "cluster_metrics": r.cluster_metrics,
+        })
+
+    # Find winner for each metric
+    winners = {
+        "highest_cosine": max(results, key=lambda x: x.mean_cosine_to_target).method,
+        "lowest_mse": min(results, key=lambda x: x.mean_mse_to_target).method,
+        "lowest_rank": min(results, key=lambda x: x.mean_target_rank).method,
+        "highest_mrr": max(results, key=lambda x: x.mrr).method,
+        "highest_recall_at_5": max(results, key=lambda x: x.recall_at_5).method,
+    }
+
+    output = {
+        "metric_legend": metric_legend,
+        "winners": winners,
+        "results": method_results,
+    }
+
+    with open(output_path, 'w') as f:
+        json.dump(output, f, indent=2)
+
+    print(f"\nResults saved to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Answer-level benchmark for LDA smoothing")
+    parser.add_argument("--max-clusters", type=int, default=None,
+                        help="Limit number of clusters")
+    parser.add_argument("--dim", type=int, default=64,
+                        help="Embedding dimension")
+    parser.add_argument("--output", type=Path,
+                        default=Path("reports/answer_level_benchmark.json"),
+                        help="Output file")
+    parser.add_argument("--k-values", type=str, default="4,8,16",
+                        help="K values for smoothing basis")
+    parser.add_argument("--cluster-analysis", action="store_true",
+                        help="Print per-cluster breakdown")
+
+    args = parser.parse_args()
+
+    # Find training data
+    project_root = Path(__file__).parent.parent
+    data_dirs = [
+        project_root / "training-data" / "tailored",
+        project_root / "training-data" / "tailored-gemini",
+        project_root / "training-data" / "expanded",
+    ]
+
+    data_dir = None
+    for d in data_dirs:
+        if d.exists():
+            data_dir = d
+            break
+
+    if not data_dir:
+        print("No training data found. Creating synthetic data...")
+        clusters = {}
+        for i in range(30):
+            clusters[f"cluster_{i}"] = [
+                {"question": f"Question {j} about topic {i}",
+                 "answer": f"Answer {j} about topic {i}"}
+                for j in range(np.random.randint(2, 6))
+            ]
+    else:
+        print(f"Loading data from {data_dir}...")
+        clusters = load_training_data(data_dir, args.max_clusters)
+
+    print(f"Loaded {len(clusters)} clusters")
+
+    # Prepare data
+    clusters_for_smoothing, qa_pairs, answer_index = prepare_data(clusters, args.dim)
+    print(f"Prepared {len(qa_pairs)} Q-A pairs, {len(answer_index)} unique answers")
+
+    # Parse K values
+    k_values = [int(k.strip()) for k in args.k_values.split(",")]
+
+    # Run benchmarks
+    results = run_benchmarks(clusters_for_smoothing, qa_pairs, answer_index, k_values)
+
+    # Print summary
+    print_summary(results)
+
+    # Per-cluster analysis
+    if args.cluster_analysis:
+        print_cluster_analysis(results)
+
+    # Save results
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_results(results, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary                                                                                               
- Add `benchmark_answer_level.py` measuring distance to exact target answers (not just cluster accuracy) 
- Include metric legend explaining what each metric means and whether higher/lower is better             
- Update Future Work documentation with prioritized benchmarking tasks                                   
                                                                                                         
## Metrics Measured                                                                                      
                                                                                                         
| Metric | Meaning | Good Value |                                                                        
|--------|---------|------------|                                                                        
| Cosine | Similarity to target answer | Higher (1.0 = perfect) |                                        
| MSE | Mean Squared Error to target | Lower (0.0 = identical) |                                         
| Rank | Position of correct answer | Lower (1 = top result) |                                           
| MRR | Mean Reciprocal Rank | Higher (1.0 = always #1) |                                                
| R@k | Recall at k | Higher (100% = always in top k) |                                                  
                                                                                                         
## Key Results                                                                                           
                                                                                                         
FFT smoothing wins on all metrics:                                                                       
                                                                                                         
| Method | Cosine ↑ | MSE ↓ | Rank ↓ | MRR ↑ | R@5 ↑ | Train (ms) |                                      
|--------|----------|-------|--------|-------|-------|------------|                                      
| FFT_c0.7 | **0.549** | **0.012** | **6.2** | 0.570 | 92% | 118 |                                       
| MultiHeadLDA | 0.519 | 0.012 | 12.3 | 0.550 | 86% | 5 |                                                
| Basis_K16 | 0.479 | 0.013 | 17.7 | 0.525 | 80% | 4390 |                                                
                                                                                                         
FFT achieves best accuracy with ~25x faster training than SmoothingBasis.                                
                                                                                                         
## Test plan                                                                                             
- [x] Benchmark runs successfully on training data                                                       
- [x] Results saved to `reports/answer_level_benchmark.json`                                             
- [x] Per-cluster analysis shows variance across clusters                                                
                                                                                                         
� Generated with [Claude Code](https://claude.com/claude-code)                                           