### PR TITLE
feat: Real embedding model benchmarks (all-MiniLM, e5-small, ModernBERT)

### DIFF
--- a/reports/answer_level_all-minilm.json
+++ b/reports/answer_level_all-minilm.json
@@ -1,0 +1,3936 @@
+{
+  "embedder": {
+    "embedder": "all-minilm",
+    "model_name": "all-MiniLM-L6-v2",
+    "model_id": "all-MiniLM-L6-v2",
+    "dimension": 384,
+    "description": "Small, fast BERT model (384 dim, 512 context)"
+  },
+  "metric_legend": {
+    "cosine_to_target": {
+      "description": "Cosine similarity between projected query and target answer",
+      "good_value": "Higher is better (1.0 = perfect alignment)",
+      "range": "[-1.0, 1.0]"
+    },
+    "mse_to_target": {
+      "description": "Mean Squared Error between projected query and target answer",
+      "good_value": "Lower is better (0.0 = identical vectors)",
+      "range": "[0.0, inf)"
+    },
+    "target_rank": {
+      "description": "Position of correct answer when sorted by similarity (1-indexed)",
+      "good_value": "Lower is better (1 = correct answer is top result)",
+      "range": "[1, num_answers]"
+    },
+    "mrr": {
+      "description": "Mean Reciprocal Rank = average of 1/rank across all queries",
+      "good_value": "Higher is better (1.0 = always rank 1)",
+      "range": "(0.0, 1.0]"
+    },
+    "recall_at_k": {
+      "description": "Fraction of queries where correct answer is in top k results",
+      "good_value": "Higher is better (1.0 = always in top k)",
+      "range": "[0.0, 1.0]"
+    }
+  },
+  "winners": {
+    "highest_cosine": "Residual_K8_r0.01",
+    "lowest_mse": "MultiHeadLDA",
+    "lowest_rank": "Residual_K4_r0.01",
+    "highest_mrr": "Residual_K8_r0.01",
+    "highest_recall_at_5": "FFT_c0.7"
+  },
+  "results": [
+    {
+      "method": "MultiHeadLDA",
+      "params": {
+        "type": "baseline"
+      },
+      "mean_cosine_to_target": 0.8665396782538033,
+      "std_cosine_to_target": 0.06840895589251006,
+      "mean_mse_to_target": 0.0006621252864278407,
+      "std_mse_to_target": 0.0002855152910007206,
+      "mean_target_rank": 8.801980198019802,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.18316831683168316,
+      "recall_at_5": 0.698019801980198,
+      "recall_at_10": 0.8267326732673267,
+      "mrr": 0.3992453021922683,
+      "train_time_ms": 2.856799983419478,
+      "inference_time_us": 456.1113811439217,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8642301055947179,
+          "mean_mse": 0.0006946758981510097,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8948123032374768,
+          "mean_mse": 0.0005656196846932707,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8532858683883997,
+          "mean_mse": 0.0007281464457844062,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8512307418649796,
+          "mean_mse": 0.0007417727494808892,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8203152419332784,
+          "mean_mse": 0.0008608467461662904,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8777682482974201,
+          "mean_mse": 0.0006126269150619957,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8449328262412947,
+          "mean_mse": 0.0007684830789604168,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8448660485506814,
+          "mean_mse": 0.0007687433940681359,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8623565028848607,
+          "mean_mse": 0.0006768335309260329,
+          "mean_rank": 4.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8411938643623608,
+          "mean_mse": 0.0007702984661733906,
+          "mean_rank": 19.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8717980531772379,
+          "mean_mse": 0.0006554269878451214,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9008562936393765,
+          "mean_mse": 0.0005157067779871956,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8923588488537495,
+          "mean_mse": 0.0005066627332920512,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8335564360815774,
+          "mean_mse": 0.0008137123882245096,
+          "mean_rank": 8.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8703554125347677,
+          "mean_mse": 0.0006450150048882898,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8490433300624307,
+          "mean_mse": 0.0007407008611659749,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9348832322284651,
+          "mean_mse": 0.0003542794905635367,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8299171720755858,
+          "mean_mse": 0.0008211463178499355,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9456085106958906,
+          "mean_mse": 0.0002847275413040686,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8818765607110931,
+          "mean_mse": 0.0006028677223758943,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8036405834728413,
+          "mean_mse": 0.000905164608451,
+          "mean_rank": 33.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8918431726539727,
+          "mean_mse": 0.0005491214971132219,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8423176070940598,
+          "mean_mse": 0.0007614838467309383,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.948021267201447,
+          "mean_mse": 0.00028932810811946335,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9083668370148745,
+          "mean_mse": 0.0004951476192535507,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8874622376632785,
+          "mean_mse": 0.000572246057301261,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8478121891777901,
+          "mean_mse": 0.0007658650564123174,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8810695166054704,
+          "mean_mse": 0.0005987237818257093,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8344799177249622,
+          "mean_mse": 0.0008042751568139079,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9089879854801632,
+          "mean_mse": 0.0004812693023484997,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8885459090479992,
+          "mean_mse": 0.0005691311272609368,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8605108332897539,
+          "mean_mse": 0.0006990306886402479,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.7981529202562498,
+          "mean_mse": 0.0009481970911367547,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8695263057691385,
+          "mean_mse": 0.0006418746756132088,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8530635964086606,
+          "mean_mse": 0.0007149916352185161,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9009046508666256,
+          "mean_mse": 0.0005202828357628028,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9109871040028283,
+          "mean_mse": 0.0004763529700738034,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9090944165661905,
+          "mean_mse": 0.0004594228941649247,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8638891200218086,
+          "mean_mse": 0.0006830166026382616,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8095233710422485,
+          "mean_mse": 0.000855604557089134,
+          "mean_rank": 39.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.8996348471871011,
+          "mean_mse": 0.000535352419572744,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9073316648937859,
+          "mean_mse": 0.0004917269154611264,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.8916539018552495,
+          "mean_mse": 0.0005769829896766354,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.8999225515266269,
+          "mean_mse": 0.000530115261694742,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8396362819361779,
+          "mean_mse": 0.0007794331044579126,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8373281471571136,
+          "mean_mse": 0.0007966710550903554,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8159424845377913,
+          "mean_mse": 0.0008872890194937417,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8373744891006515,
+          "mean_mse": 0.0007853392034054064,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8400412176933941,
+          "mean_mse": 0.0007808208850354491,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7839647884115624,
+          "mean_mse": 0.000982136783999331,
+          "mean_rank": 36.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.3",
+      "params": {
+        "cutoff": 0.3,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.868114472701624,
+      "std_cosine_to_target": 0.06490559363527852,
+      "mean_mse_to_target": 0.0008194876047794442,
+      "std_mse_to_target": 0.000277911426739699,
+      "mean_target_rank": 8.386138613861386,
+      "median_target_rank": 3.5,
+      "recall_at_1": 0.18316831683168316,
+      "recall_at_5": 0.693069306930693,
+      "recall_at_10": 0.8514851485148515,
+      "mrr": 0.3914985150280147,
+      "train_time_ms": 3228.7537819938734,
+      "inference_time_us": 4744.75536121996,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8661920451037456,
+          "mean_mse": 0.0008537935949070435,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9000186008521972,
+          "mean_mse": 0.0008622576363762279,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8554252664915419,
+          "mean_mse": 0.0008444286368971148,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8587383056133201,
+          "mean_mse": 0.0009574279903731554,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8328839349835027,
+          "mean_mse": 0.0011205995297593528,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8759718930854599,
+          "mean_mse": 0.0007279625391611002,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8446336685781908,
+          "mean_mse": 0.0008992978964292741,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8420219945504646,
+          "mean_mse": 0.0009627598340437325,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8520432041561252,
+          "mean_mse": 0.000779466745927453,
+          "mean_rank": 6.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8358577418990647,
+          "mean_mse": 0.000991415379558078,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8778628125256678,
+          "mean_mse": 0.0008467116244832967,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8909584567272351,
+          "mean_mse": 0.0006912685357603755,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8948634481601645,
+          "mean_mse": 0.0006766523995965403,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.840409396893836,
+          "mean_mse": 0.0009745360261735805,
+          "mean_rank": 9.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8629532819077737,
+          "mean_mse": 0.0007578158979788856,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8482705951500087,
+          "mean_mse": 0.0008500293833811217,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9225921588009509,
+          "mean_mse": 0.0004966817266311417,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8268005201568502,
+          "mean_mse": 0.00096088856659036,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9300042579646608,
+          "mean_mse": 0.0004016532528609318,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8765255684993667,
+          "mean_mse": 0.0007285357340973863,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8243787950436439,
+          "mean_mse": 0.0008921590180718288,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8904679656011324,
+          "mean_mse": 0.0006764512510491405,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8398584718923292,
+          "mean_mse": 0.0008738572429938931,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9482734633326064,
+          "mean_mse": 0.00044506064011700253,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9170284217520601,
+          "mean_mse": 0.0006240630133064292,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8735718857794225,
+          "mean_mse": 0.0007900145953295364,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8594825887830684,
+          "mean_mse": 0.0009155998140354005,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8920677636127468,
+          "mean_mse": 0.0008443844761472475,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8387765625411705,
+          "mean_mse": 0.0010151102980501974,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9074745268263675,
+          "mean_mse": 0.0006670822018872278,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8978526347134276,
+          "mean_mse": 0.000712282245619198,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8743491410747849,
+          "mean_mse": 0.0009131331520660732,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8109675149182407,
+          "mean_mse": 0.0012017245830935085,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8768807133288602,
+          "mean_mse": 0.0008916435762126237,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8472111945806872,
+          "mean_mse": 0.0008548985455873172,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.8971962323788786,
+          "mean_mse": 0.0006965963597363248,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.91032803079088,
+          "mean_mse": 0.0005441973501832632,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.8981594868060473,
+          "mean_mse": 0.0005438556350478345,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8621585486910058,
+          "mean_mse": 0.0009378641059340432,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.7984242343873718,
+          "mean_mse": 0.0009231050652080167,
+          "mean_rank": 38.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9007452078457427,
+          "mean_mse": 0.0006833489842394401,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9064310640890406,
+          "mean_mse": 0.0007924110384166529,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9115162534406613,
+          "mean_mse": 0.0007257460644157082,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9050071646254153,
+          "mean_mse": 0.0006845859024023305,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.845752357694292,
+          "mean_mse": 0.000824072591996535,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.844979924764441,
+          "mean_mse": 0.0009473563020204584,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8206320366647913,
+          "mean_mse": 0.0011012171942639444,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8622120094885939,
+          "mean_mse": 0.0008436162378708524,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8355079909552661,
+          "mean_mse": 0.0008996994999046232,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7839483826664166,
+          "mean_mse": 0.00109630343214387,
+          "mean_rank": 35.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.5",
+      "params": {
+        "cutoff": 0.5,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.8787053740936505,
+      "std_cosine_to_target": 0.0642795698523128,
+      "mean_mse_to_target": 0.0007113035703233411,
+      "std_mse_to_target": 0.00028252617474678287,
+      "mean_target_rank": 7.198019801980198,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21287128712871287,
+      "recall_at_5": 0.7574257425742574,
+      "recall_at_10": 0.8861386138613861,
+      "mrr": 0.4349030794840498,
+      "train_time_ms": 878.3116639824584,
+      "inference_time_us": 3624.837099237939,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8725390992232268,
+          "mean_mse": 0.0007731148030595898,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9054012751032392,
+          "mean_mse": 0.0007621698865012214,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8625789536415474,
+          "mean_mse": 0.0007820256674262362,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8821817888357449,
+          "mean_mse": 0.0007970809262558315,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8448298862179027,
+          "mean_mse": 0.0009803398217120474,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8876259986031756,
+          "mean_mse": 0.0006594037057958106,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8566606953345339,
+          "mean_mse": 0.0008210374310569479,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8555099921130888,
+          "mean_mse": 0.0008659462440957782,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8693188959079647,
+          "mean_mse": 0.0006996373322762904,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.847462683868487,
+          "mean_mse": 0.0008347867840177007,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8855032865897987,
+          "mean_mse": 0.0007515221778992258,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9106275298000357,
+          "mean_mse": 0.0005472572228775612,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8943646693266618,
+          "mean_mse": 0.0005441500295996352,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8551934457733538,
+          "mean_mse": 0.0008823128162668387,
+          "mean_rank": 6.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8759494346704908,
+          "mean_mse": 0.0006830632008429247,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8546728377306873,
+          "mean_mse": 0.0007827412481501652,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9365915114062978,
+          "mean_mse": 0.00039952267330681327,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.838850689842553,
+          "mean_mse": 0.0008528173426705839,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9450437313011085,
+          "mean_mse": 0.00029475278451789646,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8888407762090111,
+          "mean_mse": 0.0006232735104167007,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8256501135191088,
+          "mean_mse": 0.0008757571057040559,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8959672562689955,
+          "mean_mse": 0.0005713433798742236,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8511253230165511,
+          "mean_mse": 0.0007802394473821737,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9532118338385225,
+          "mean_mse": 0.00031028870702934613,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9242444978412893,
+          "mean_mse": 0.0005305457896874339,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8933263428618818,
+          "mean_mse": 0.0006078283885469827,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8743094877813711,
+          "mean_mse": 0.0007823966779151277,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.899802477290719,
+          "mean_mse": 0.0006335701039670316,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8593714941551639,
+          "mean_mse": 0.0008157519469924933,
+          "mean_rank": 19.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9195237288917407,
+          "mean_mse": 0.0005620570121344776,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9081712111718199,
+          "mean_mse": 0.0006229784895538936,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8811361737201348,
+          "mean_mse": 0.0007606348420629369,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8278669032136003,
+          "mean_mse": 0.0010381713384157562,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8885390513170421,
+          "mean_mse": 0.0006672733536241462,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8599741341219631,
+          "mean_mse": 0.0007516877826722299,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9072907050717329,
+          "mean_mse": 0.0005896201537116113,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9150480140485063,
+          "mean_mse": 0.000512557363091438,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9117295347710916,
+          "mean_mse": 0.0004706597697143296,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8778877105188767,
+          "mean_mse": 0.0007544615579754047,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8164317828275045,
+          "mean_mse": 0.0008212209996891913,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9101022567420456,
+          "mean_mse": 0.0006073585992281651,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9179567158918647,
+          "mean_mse": 0.000618587721501981,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9134172572850165,
+          "mean_mse": 0.0006872988465394095,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9094891251580238,
+          "mean_mse": 0.0005971097419131961,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8447067733271709,
+          "mean_mse": 0.0007938063793877384,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8509062176604263,
+          "mean_mse": 0.00086036966838183,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8377454012855232,
+          "mean_mse": 0.0009291972055381541,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8590814061800601,
+          "mean_mse": 0.0008225830608199139,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8471354574411035,
+          "mean_mse": 0.000819270508081109,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7925977375912592,
+          "mean_mse": 0.0009937612143113754,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.7",
+      "params": {
+        "cutoff": 0.7,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.8791393571382186,
+      "std_cosine_to_target": 0.06446280059695512,
+      "mean_mse_to_target": 0.0007087627760918817,
+      "std_mse_to_target": 0.0002827516482329951,
+      "mean_target_rank": 7.193069306930693,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2079207920792079,
+      "recall_at_5": 0.7623762376237624,
+      "recall_at_10": 0.8861386138613861,
+      "mrr": 0.4325496822708373,
+      "train_time_ms": 670.794497942552,
+      "inference_time_us": 4865.933638434894,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8724257424550121,
+          "mean_mse": 0.0007846140582743978,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9049186167491623,
+          "mean_mse": 0.0007610115923237657,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8622126163401759,
+          "mean_mse": 0.0007856569642873153,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8835139515313848,
+          "mean_mse": 0.0007837175452649818,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8454622824893022,
+          "mean_mse": 0.0009727454901528965,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8876007035082563,
+          "mean_mse": 0.0006562431103307057,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8555832702779289,
+          "mean_mse": 0.000818766130385148,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8563221865380044,
+          "mean_mse": 0.0008647610448777089,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8703254802762086,
+          "mean_mse": 0.0006930083636073489,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8471956707925106,
+          "mean_mse": 0.0008311307448783355,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8860672138567098,
+          "mean_mse": 0.0007440703733025655,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9133232752718177,
+          "mean_mse": 0.000535983189047072,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8949625679531477,
+          "mean_mse": 0.0005403441698773981,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8548715516577422,
+          "mean_mse": 0.0008791261476531435,
+          "mean_rank": 6.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.876852701376301,
+          "mean_mse": 0.0006825310413856116,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.85272644746545,
+          "mean_mse": 0.0007927414512434446,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9373702422188221,
+          "mean_mse": 0.0003979402810405921,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8394153567303132,
+          "mean_mse": 0.0008508301924938318,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9457264510431406,
+          "mean_mse": 0.00029102580087501153,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8907574664996318,
+          "mean_mse": 0.0006173104423029897,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8259998431950273,
+          "mean_mse": 0.0008766847673368596,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.896121205588498,
+          "mean_mse": 0.0005767820773698244,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.852957606868979,
+          "mean_mse": 0.0007774002709035602,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.954396852441503,
+          "mean_mse": 0.0003127996528616183,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9248017594406251,
+          "mean_mse": 0.000525519947604558,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8955218620803114,
+          "mean_mse": 0.0005998186402641477,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8739349037795112,
+          "mean_mse": 0.0007857466619348351,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8999256108484179,
+          "mean_mse": 0.0006228889157441903,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.861112404507173,
+          "mean_mse": 0.0008120170640694975,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9192023663892502,
+          "mean_mse": 0.0005653668607454743,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9086712733633615,
+          "mean_mse": 0.0006200893888481229,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8825982793078309,
+          "mean_mse": 0.000750616981589721,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8286654856577013,
+          "mean_mse": 0.001026445820170892,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8893183215703365,
+          "mean_mse": 0.0006641175940954257,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8591590586240119,
+          "mean_mse": 0.0007550016610923586,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9073735258852984,
+          "mean_mse": 0.000588919821590087,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9154378867412797,
+          "mean_mse": 0.0005108493516733335,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9121183928908368,
+          "mean_mse": 0.00046758598530079854,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8788158606824792,
+          "mean_mse": 0.0007452566561182486,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.817418359960935,
+          "mean_mse": 0.000816943785393751,
+          "mean_rank": 37.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9102416376194045,
+          "mean_mse": 0.0006035463722044762,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9178377264321442,
+          "mean_mse": 0.0006129109372399864,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9137473117251043,
+          "mean_mse": 0.0006874294797349001,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9101007180201595,
+          "mean_mse": 0.0005970149678300842,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8445142166857753,
+          "mean_mse": 0.0007942041471811854,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8519648297938417,
+          "mean_mse": 0.000858164426229037,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8378998787808961,
+          "mean_mse": 0.0009278887125838264,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8583839251666296,
+          "mean_mse": 0.0008241730893607559,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8443005778047423,
+          "mean_mse": 0.0008266989465143717,
+          "mean_rank": 19.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7950628006134579,
+          "mean_mse": 0.0009830454476347065,
+          "mean_rank": 31.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveFFT",
+      "params": {
+        "min_cutoff": 0.2,
+        "max_cutoff": 0.7
+      },
+      "mean_cosine_to_target": 0.8748569634300003,
+      "std_cosine_to_target": 0.06430491467221129,
+      "mean_mse_to_target": 0.0007552026210398065,
+      "std_mse_to_target": 0.0002830353564307572,
+      "mean_target_rank": 7.579207920792079,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.20297029702970298,
+      "recall_at_5": 0.7227722772277227,
+      "recall_at_10": 0.8613861386138614,
+      "mrr": 0.4222764244810287,
+      "train_time_ms": 5244.1758119966835,
+      "inference_time_us": 7947.886713070445,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8687875043453027,
+          "mean_mse": 0.0008242843849276557,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9027828157407174,
+          "mean_mse": 0.0008204415328759377,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8566136895187278,
+          "mean_mse": 0.0008299765013013756,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.874504373087341,
+          "mean_mse": 0.0008615509724914361,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8417537269972274,
+          "mean_mse": 0.0010309057714200244,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8812324634157997,
+          "mean_mse": 0.0007021848451942565,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8493292304796242,
+          "mean_mse": 0.000865815464318089,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8488464773234357,
+          "mean_mse": 0.000926222325229528,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8590909023790717,
+          "mean_mse": 0.0007544909439967336,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8434833314162681,
+          "mean_mse": 0.000903383707618925,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8830361393108047,
+          "mean_mse": 0.0007917948486760414,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8984219110921007,
+          "mean_mse": 0.0006326800824798633,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8966659796072287,
+          "mean_mse": 0.0005483513229035009,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8465806737695066,
+          "mean_mse": 0.000940046833045572,
+          "mean_rank": 8.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.868901675861677,
+          "mean_mse": 0.0007254065374427581,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8510383252339101,
+          "mean_mse": 0.0008258032573880265,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9314586126747867,
+          "mean_mse": 0.0004461805853023257,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8352503037678762,
+          "mean_mse": 0.0008930810824692873,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9435101102288526,
+          "mean_mse": 0.0003105296576759756,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8861223316546833,
+          "mean_mse": 0.000655060840332363,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8244228033674373,
+          "mean_mse": 0.0008945497003551256,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8931461993892265,
+          "mean_mse": 0.0006294566114237616,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8498408026656977,
+          "mean_mse": 0.0007978759379506052,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9525653021418496,
+          "mean_mse": 0.00034505516774419823,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9220422581117143,
+          "mean_mse": 0.0005683299318788811,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8921334404339539,
+          "mean_mse": 0.0006282405097114116,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8692127245479947,
+          "mean_mse": 0.000839632157925712,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8995835173071238,
+          "mean_mse": 0.0006573870896808037,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.854642236491992,
+          "mean_mse": 0.0008835558623548963,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.915488070676848,
+          "mean_mse": 0.000613958565590016,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9056717631483655,
+          "mean_mse": 0.000661172086946569,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8813678469316548,
+          "mean_mse": 0.0007987061064890445,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8231486399878557,
+          "mean_mse": 0.001094728473918175,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8879667786010357,
+          "mean_mse": 0.0006921299712682852,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8559611011776819,
+          "mean_mse": 0.0007974957575673947,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9012975781985157,
+          "mean_mse": 0.0006584384212639344,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9131601427850492,
+          "mean_mse": 0.0005295355147757517,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9091334833960623,
+          "mean_mse": 0.00048790592299710335,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8754371182865133,
+          "mean_mse": 0.000794832277177087,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.812089568721507,
+          "mean_mse": 0.0008528537361167411,
+          "mean_rank": 37.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9036448905464998,
+          "mean_mse": 0.0006583122243768577,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.915024576159315,
+          "mean_mse": 0.0006738568752486067,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9120377198162736,
+          "mean_mse": 0.0007234414215016977,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9065020247946884,
+          "mean_mse": 0.0006524794382798143,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8417152903725903,
+          "mean_mse": 0.0008225041869478138,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8483071101294282,
+          "mean_mse": 0.0009033609757740903,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.829835379673814,
+          "mean_mse": 0.001019572420608223,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8590426260001378,
+          "mean_mse": 0.0008396097686112275,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8405357224003018,
+          "mean_mse": 0.0008689663335782803,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.791491465011802,
+          "mean_mse": 0.001037962973097862,
+          "mean_rank": 32.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K4",
+      "params": {
+        "K": 4,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.8333645511647298,
+      "std_cosine_to_target": 0.06724263493354012,
+      "mean_mse_to_target": 0.0008504181018959391,
+      "std_mse_to_target": 0.00029446848813685563,
+      "mean_target_rank": 12.881188118811881,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.13861386138613863,
+      "recall_at_5": 0.5148514851485149,
+      "recall_at_10": 0.7178217821782178,
+      "mrr": 0.3036062722852258,
+      "train_time_ms": 9834.013152983971,
+      "inference_time_us": 37118.129475424896,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8368625868776027,
+          "mean_mse": 0.0007967634674446883,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8917149587361335,
+          "mean_mse": 0.0007978115924691838,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8352074756633503,
+          "mean_mse": 0.0008060841273911314,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8491763841430189,
+          "mean_mse": 0.0008443287694578598,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8022553978705822,
+          "mean_mse": 0.0010111878346994465,
+          "mean_rank": 27.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.84140624773713,
+          "mean_mse": 0.0007685851814156498,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8102310953257534,
+          "mean_mse": 0.0009653844675904318,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7968711884686055,
+          "mean_mse": 0.0009832792889231676,
+          "mean_rank": 21.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8252155054500202,
+          "mean_mse": 0.0008441498207236679,
+          "mean_rank": 13.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8287084361806163,
+          "mean_mse": 0.0009388755749136818,
+          "mean_rank": 19.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8425253416917757,
+          "mean_mse": 0.0008919066545285492,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8333306297110954,
+          "mean_mse": 0.0008074357604844267,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8924873208938071,
+          "mean_mse": 0.0005501776836447112,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7835877037993572,
+          "mean_mse": 0.0011401611510210127,
+          "mean_rank": 25.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8224461337260891,
+          "mean_mse": 0.0008604579387046216,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8209546473348666,
+          "mean_mse": 0.0008552270414991934,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9031674302265397,
+          "mean_mse": 0.0005120646384489898,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.791057418596223,
+          "mean_mse": 0.0010461076863217788,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9288872410817782,
+          "mean_mse": 0.0003881221745992304,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8274651067708805,
+          "mean_mse": 0.0008503471472344854,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.7857055225872763,
+          "mean_mse": 0.0010101499274799341,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8670999914307694,
+          "mean_mse": 0.0006762060031125025,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8023549544159123,
+          "mean_mse": 0.0009552601557703438,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9085767399861865,
+          "mean_mse": 0.0004657524499728401,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8785543037979814,
+          "mean_mse": 0.0006421040940965831,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8359956824466932,
+          "mean_mse": 0.0008927499159968574,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.7905661981206574,
+          "mean_mse": 0.0010132700901516864,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8704099095154829,
+          "mean_mse": 0.0007720708368620265,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.715278235814959,
+          "mean_mse": 0.0013474274622485459,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.8771325730369045,
+          "mean_mse": 0.0006673241327602032,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8681758343864441,
+          "mean_mse": 0.0007869589816987422,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8328230699775968,
+          "mean_mse": 0.0008871672198923956,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.783711703254832,
+          "mean_mse": 0.0010972635318210896,
+          "mean_rank": 27.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8556459103856416,
+          "mean_mse": 0.000773873656157655,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8319919014800069,
+          "mean_mse": 0.0008668571007183826,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.863618208364917,
+          "mean_mse": 0.0006794893499672927,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.8727215450268776,
+          "mean_mse": 0.000632587002563589,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.8918632548079068,
+          "mean_mse": 0.0005407469214079098,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8377624872701463,
+          "mean_mse": 0.0008889400946840948,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.7540617860620957,
+          "mean_mse": 0.00108269873801988,
+          "mean_rank": 41.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.8704150084716237,
+          "mean_mse": 0.0007432133553783966,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.8687690107345851,
+          "mean_mse": 0.0007425467952115769,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.8739097384508112,
+          "mean_mse": 0.0008244718882574835,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.8718765873183596,
+          "mean_mse": 0.0007273241889966368,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.7932082210861074,
+          "mean_mse": 0.0009805051497756914,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8114377708497853,
+          "mean_mse": 0.0009188762842332157,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.7296445688245846,
+          "mean_mse": 0.001220673880773397,
+          "mean_rank": 43.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8245293539792876,
+          "mean_mse": 0.000874889283604976,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.7982511250441149,
+          "mean_mse": 0.0009470714429162243,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7530595842927454,
+          "mean_mse": 0.0011331084667626859,
+          "mean_rank": 31.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K8",
+      "params": {
+        "K": 8,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.8594339325007563,
+      "std_cosine_to_target": 0.0642245423615146,
+      "mean_mse_to_target": 0.0007489979733232549,
+      "std_mse_to_target": 0.0002790920273655134,
+      "mean_target_rank": 8.653465346534654,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.16831683168316833,
+      "recall_at_5": 0.6584158415841584,
+      "recall_at_10": 0.8168316831683168,
+      "mrr": 0.38044250174876193,
+      "train_time_ms": 12901.174230966717,
+      "inference_time_us": 78688.9866830108,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8583404412482352,
+          "mean_mse": 0.0007587452616272554,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8961038364385788,
+          "mean_mse": 0.0007279130327204817,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8578556768665522,
+          "mean_mse": 0.0007399802935271404,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8761634034920773,
+          "mean_mse": 0.0007501519505633798,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8258726736135145,
+          "mean_mse": 0.0009532765968598455,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8668938628704196,
+          "mean_mse": 0.0006656655689746546,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8436206721298709,
+          "mean_mse": 0.0008123812867263032,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8452706443693497,
+          "mean_mse": 0.0008350155440736977,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8535444371815524,
+          "mean_mse": 0.0007328773437289182,
+          "mean_rank": 6.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8337417616830699,
+          "mean_mse": 0.0009050370874755317,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.860475987512657,
+          "mean_mse": 0.0008258303962544831,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8723112899903985,
+          "mean_mse": 0.0006459302655877837,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8940188235387885,
+          "mean_mse": 0.0005530927001864789,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8328254066959693,
+          "mean_mse": 0.0009006547497153596,
+          "mean_rank": 7.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8463078955897236,
+          "mean_mse": 0.000764499897115125,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8410837345276653,
+          "mean_mse": 0.0007845614257879682,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9105689449896184,
+          "mean_mse": 0.00048462902436366775,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8165582935660761,
+          "mean_mse": 0.000887475626596608,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9372591105708392,
+          "mean_mse": 0.00033536988035866506,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8749552896931867,
+          "mean_mse": 0.0006362229632960907,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.809318286522433,
+          "mean_mse": 0.000890170768585764,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8799638028941434,
+          "mean_mse": 0.0006239129334861014,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.829774375257392,
+          "mean_mse": 0.0008400179694827597,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9403222007614032,
+          "mean_mse": 0.00033176200013982314,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9126136591824787,
+          "mean_mse": 0.0005233557543994295,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8706609979303738,
+          "mean_mse": 0.0007016148107004891,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8316708939805895,
+          "mean_mse": 0.0009173323860556535,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8872213281407191,
+          "mean_mse": 0.0006976624421228449,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.841922482398886,
+          "mean_mse": 0.0008854960894039447,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.8992134065678463,
+          "mean_mse": 0.0005959999085340099,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8882338636679281,
+          "mean_mse": 0.0006913037235399145,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8590175699510603,
+          "mean_mse": 0.0008239003734083991,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.7877747145351386,
+          "mean_mse": 0.001109725109528266,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8749725563579974,
+          "mean_mse": 0.000685911903736545,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8396459279834797,
+          "mean_mse": 0.0008066865395186084,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.8858737945714455,
+          "mean_mse": 0.0006208408108008564,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.8974252707229754,
+          "mean_mse": 0.0005604931988444983,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9080031360484295,
+          "mean_mse": 0.00047559162568469837,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.869570766557455,
+          "mean_mse": 0.0007496071871004528,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8005192217569539,
+          "mean_mse": 0.000864137364532823,
+          "mean_rank": 39.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.8839991675830255,
+          "mean_mse": 0.0006708080460565421,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.8819244382666303,
+          "mean_mse": 0.0006714423799840363,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9026810193152704,
+          "mean_mse": 0.0006678182626245746,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.8934704640507922,
+          "mean_mse": 0.000690552675360928,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8149887644680628,
+          "mean_mse": 0.0008828288581175295,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8259153651281889,
+          "mean_mse": 0.0008972715639194061,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.7772920892000422,
+          "mean_mse": 0.0010902257835253251,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8391596908228001,
+          "mean_mse": 0.000847502223213264,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.826593821653216,
+          "mean_mse": 0.0008514103680900123,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7763058674735148,
+          "mean_mse": 0.001051320673426369,
+          "mean_rank": 27.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K16",
+      "params": {
+        "K": 16,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.8717309123068813,
+      "std_cosine_to_target": 0.06395363559164066,
+      "mean_mse_to_target": 0.0007057978248273827,
+      "std_mse_to_target": 0.0002829463464919063,
+      "mean_target_rank": 7.465346534653466,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.22772277227722773,
+      "recall_at_5": 0.7128712871287128,
+      "recall_at_10": 0.8712871287128713,
+      "mrr": 0.43466070408288165,
+      "train_time_ms": 25299.923648010008,
+      "inference_time_us": 142021.29379684787,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8665226902290621,
+          "mean_mse": 0.0007569424492761039,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9074426545982412,
+          "mean_mse": 0.0007399926337940254,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8595740014780036,
+          "mean_mse": 0.0007430633410855743,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8849716729955077,
+          "mean_mse": 0.0007410685823973698,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8359286385019676,
+          "mean_mse": 0.00093903471081825,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8821402945721887,
+          "mean_mse": 0.0006305871349280817,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8577935503962595,
+          "mean_mse": 0.0007951865604508975,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.85191108333068,
+          "mean_mse": 0.0008432557851381649,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8635285230520461,
+          "mean_mse": 0.0007031960306005762,
+          "mean_rank": 4.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8487113299029458,
+          "mean_mse": 0.0008173213818930672,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8804481809385265,
+          "mean_mse": 0.0007281573368247375,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9058129912712294,
+          "mean_mse": 0.0005507729261786871,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8855588625680366,
+          "mean_mse": 0.0005684313658473791,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8568572438974982,
+          "mean_mse": 0.000851387617198254,
+          "mean_rank": 6.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8754534949545325,
+          "mean_mse": 0.0006754567941639833,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8522353162918963,
+          "mean_mse": 0.0007578229077364086,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9228113102197356,
+          "mean_mse": 0.0004338410447951329,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8326594164149859,
+          "mean_mse": 0.00082466722505098,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9456816087589469,
+          "mean_mse": 0.00028230542798120706,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8784647249920028,
+          "mean_mse": 0.00063861448531571,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8199257536042526,
+          "mean_mse": 0.0008706973274235871,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8862126456200173,
+          "mean_mse": 0.0005890593427882118,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8433979630825459,
+          "mean_mse": 0.0007895018600729071,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9489801231837933,
+          "mean_mse": 0.00030069251689216224,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9177658783679322,
+          "mean_mse": 0.000514218880206286,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8804702185151912,
+          "mean_mse": 0.0006411644977897019,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8585247217053943,
+          "mean_mse": 0.000807932525733551,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8907889427711284,
+          "mean_mse": 0.0006484433486340775,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8553949765098507,
+          "mean_mse": 0.0008105157795003518,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9125125146141804,
+          "mean_mse": 0.0005284567495198521,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8996800681383329,
+          "mean_mse": 0.000627047615650384,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8652294268258304,
+          "mean_mse": 0.0007743569184393724,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8185830326512309,
+          "mean_mse": 0.0009908202308353993,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8847048003054859,
+          "mean_mse": 0.0006429982655133894,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.851583552094688,
+          "mean_mse": 0.0007574444912153873,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.8939436710148915,
+          "mean_mse": 0.0005985396087541563,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9126859869812581,
+          "mean_mse": 0.0005079578287378302,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9106497074400643,
+          "mean_mse": 0.0004638873929197044,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8796166550268876,
+          "mean_mse": 0.0006951760817138575,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8074440715936448,
+          "mean_mse": 0.0008384165849886814,
+          "mean_rank": 38.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.8976663906316673,
+          "mean_mse": 0.0006322790044772671,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9049835493396187,
+          "mean_mse": 0.0005943976794274988,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9114524839068202,
+          "mean_mse": 0.0006524173997788225,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9014614242988321,
+          "mean_mse": 0.0006238282711232299,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8343706726364216,
+          "mean_mse": 0.0008046491552924348,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8326397177516813,
+          "mean_mse": 0.0008662737812752441,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8072283713131331,
+          "mean_mse": 0.0009910072988163299,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.849599437286096,
+          "mean_mse": 0.0008387913164270741,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8383325211064356,
+          "mean_mse": 0.0008267810601061071,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7819777620785131,
+          "mean_mse": 0.0010052856863056727,
+          "mean_rank": 31.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K4_r0.01",
+      "params": {
+        "K": 4,
+        "alpha_reg": 0.01,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8797103546687244,
+      "std_cosine_to_target": 0.06425635325310713,
+      "mean_mse_to_target": 0.000700254296791489,
+      "std_mse_to_target": 0.0002827435940944875,
+      "mean_target_rank": 7.064356435643564,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2079207920792079,
+      "recall_at_5": 0.7574257425742574,
+      "recall_at_10": 0.900990099009901,
+      "mrr": 0.4331323935739435,
+      "train_time_ms": 5779.280661023222,
+      "inference_time_us": 47119.373084497776,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8731533454877344,
+          "mean_mse": 0.0007713169244272846,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.905696867829618,
+          "mean_mse": 0.0007495226628284005,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8624261264613056,
+          "mean_mse": 0.000781174781225162,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8848988445685063,
+          "mean_mse": 0.0007741607560595078,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8466580410175402,
+          "mean_mse": 0.0009590448434828309,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8887180925396082,
+          "mean_mse": 0.0006491919369972933,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8569190289284582,
+          "mean_mse": 0.00080678783324732,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8571862887444959,
+          "mean_mse": 0.000854568527599774,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8717320675251697,
+          "mean_mse": 0.0006866712345010023,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8483915096967645,
+          "mean_mse": 0.000821255326214717,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8864208255449151,
+          "mean_mse": 0.0007357633327685164,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9142906265968564,
+          "mean_mse": 0.0005230460667482997,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8943749939001607,
+          "mean_mse": 0.0005349307091063193,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8563469508812933,
+          "mean_mse": 0.0008679782637085437,
+          "mean_rank": 6.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8779706329741672,
+          "mean_mse": 0.0006739654698452887,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8540420179483482,
+          "mean_mse": 0.0007822540722567305,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9383737104160328,
+          "mean_mse": 0.00038583756212741524,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8410888618931871,
+          "mean_mse": 0.0008386496513337651,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9466738829311231,
+          "mean_mse": 0.0002849199776567146,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8891306971594524,
+          "mean_mse": 0.0006187834404017848,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8257004380956463,
+          "mean_mse": 0.0008752237745004023,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8962764983751899,
+          "mean_mse": 0.0005639657174125361,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8524211658612764,
+          "mean_mse": 0.0007751940527727288,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.953844171371681,
+          "mean_mse": 0.00030060427539512337,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9248473666747328,
+          "mean_mse": 0.0005221567496560524,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8942765374991262,
+          "mean_mse": 0.0005945118179669887,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8745452782255155,
+          "mean_mse": 0.0007779791754364673,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9001442953527204,
+          "mean_mse": 0.0006069709866206784,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8607467154693179,
+          "mean_mse": 0.0008027676744936918,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9204087878725511,
+          "mean_mse": 0.0005538074108962968,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9090055643138943,
+          "mean_mse": 0.0006119526326984126,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8825886408763579,
+          "mean_mse": 0.0007409442293904504,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8301364148165202,
+          "mean_mse": 0.0010083654474762455,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8900422286864608,
+          "mean_mse": 0.0006481084892497752,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8602427557381442,
+          "mean_mse": 0.0007452912036074818,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9072261426591139,
+          "mean_mse": 0.0005853598829209701,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9158574027511226,
+          "mean_mse": 0.0005093124616472503,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9124798156042746,
+          "mean_mse": 0.00046433144533207575,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.878828866906353,
+          "mean_mse": 0.0007413179541639855,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8178809668839819,
+          "mean_mse": 0.0008119435526912203,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9112525095853818,
+          "mean_mse": 0.0005947749971944369,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9189788170768656,
+          "mean_mse": 0.0005972362069719594,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.91353757208976,
+          "mean_mse": 0.0006824666364589129,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9102985871810593,
+          "mean_mse": 0.0005946959839537595,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8443398428121862,
+          "mean_mse": 0.0007922701555234152,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.851531830325967,
+          "mean_mse": 0.0008568991202986707,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8395331270506201,
+          "mean_mse": 0.0009088164920039836,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8585647143243427,
+          "mean_mse": 0.0008216234804719353,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8472070347531301,
+          "mean_mse": 0.0008119125080377191,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7961156538909326,
+          "mean_mse": 0.0009735517256375202,
+          "mean_rank": 30.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K4_r0.1",
+      "params": {
+        "K": 4,
+        "alpha_reg": 0.1,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8795103190166128,
+      "std_cosine_to_target": 0.06424255904115778,
+      "mean_mse_to_target": 0.0007023992371262233,
+      "std_mse_to_target": 0.00028251345830760733,
+      "mean_target_rank": 7.094059405940594,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21287128712871287,
+      "recall_at_5": 0.7574257425742574,
+      "recall_at_10": 0.900990099009901,
+      "mrr": 0.43586825988433187,
+      "train_time_ms": 5622.242548968643,
+      "inference_time_us": 59738.26476723177,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8730781910595611,
+          "mean_mse": 0.0007714010583870585,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056245680802302,
+          "mean_mse": 0.0007517151947841149,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8622816808926022,
+          "mean_mse": 0.0007817911001680818,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.884488717913304,
+          "mean_mse": 0.0007773845539677703,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8461622544044072,
+          "mean_mse": 0.0009637725889801406,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8886136862530867,
+          "mean_mse": 0.000650363992489947,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8571685522707181,
+          "mean_mse": 0.0008080401927593686,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8568255762222735,
+          "mean_mse": 0.0008567383240141443,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8715034173357878,
+          "mean_mse": 0.0006881124424173934,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8481654056074528,
+          "mean_mse": 0.0008244850856966342,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8862349025172473,
+          "mean_mse": 0.0007384076122019509,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9137644025794469,
+          "mean_mse": 0.0005268791736894303,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.894333444826853,
+          "mean_mse": 0.0005367720447258149,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8562306037505302,
+          "mean_mse": 0.0008696820555495804,
+          "mean_rank": 6.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.877585841037559,
+          "mean_mse": 0.0006755946889081189,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.854236730002916,
+          "mean_mse": 0.0007820618114218347,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.938143619666669,
+          "mean_mse": 0.00038767733090444556,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8406173712803222,
+          "mean_mse": 0.0008415188692058914,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9463362942492589,
+          "mean_mse": 0.00028689269271733214,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8889599376257094,
+          "mean_mse": 0.000620412227136883,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8256359154459585,
+          "mean_mse": 0.0008754057456321375,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8962553905042718,
+          "mean_mse": 0.0005654515911566768,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8519653863090225,
+          "mean_mse": 0.0007770244809206787,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9536705234823879,
+          "mean_mse": 0.0003033616658407206,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.924736397883237,
+          "mean_mse": 0.0005238187671664802,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.893890818788363,
+          "mean_mse": 0.0005985984277457238,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8744489141456095,
+          "mean_mse": 0.0007793967658061651,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9000926391636273,
+          "mean_mse": 0.0006119205386521434,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.860462183563003,
+          "mean_mse": 0.0008055675835152744,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9201477284915762,
+          "mean_mse": 0.0005561021213993076,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9087040846686105,
+          "mean_mse": 0.0006155849926379359,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8823650979531081,
+          "mean_mse": 0.0007437907758141523,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8298538205667302,
+          "mean_mse": 0.0010127893308733392,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8896218891599446,
+          "mean_mse": 0.0006526408530610655,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8601195427718265,
+          "mean_mse": 0.0007467998584498571,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.907204702035572,
+          "mean_mse": 0.0005861558335071793,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9155987166696065,
+          "mean_mse": 0.0005103281260339178,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9121091538165187,
+          "mean_mse": 0.00046713938197907406,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.878456322749515,
+          "mean_mse": 0.0007466216797579933,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8172936148970545,
+          "mean_mse": 0.0008153096799887922,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9111678409777497,
+          "mean_mse": 0.000596013755900139,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9187651045845063,
+          "mean_mse": 0.0006012411414156709,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9134868913540315,
+          "mean_mse": 0.0006837011297797253,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9100990084051239,
+          "mean_mse": 0.0005953947543239701,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8445484070039068,
+          "mean_mse": 0.0007919976540400479,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8513312323224537,
+          "mean_mse": 0.0008580280354993756,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8392352388280383,
+          "mean_mse": 0.0009123231378238246,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8588268298571613,
+          "mean_mse": 0.0008208398559375086,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8473491056602399,
+          "mean_mse": 0.0008121550211267072,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7955399054326837,
+          "mean_mse": 0.0009765071244710194,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K8_r0.01",
+      "params": {
+        "K": 8,
+        "alpha_reg": 0.01,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8798744576418851,
+      "std_cosine_to_target": 0.06429477267231916,
+      "mean_mse_to_target": 0.0006975362168294836,
+      "std_mse_to_target": 0.0002830206889282567,
+      "mean_target_rank": 7.089108910891089,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21782178217821782,
+      "recall_at_5": 0.7574257425742574,
+      "recall_at_10": 0.900990099009901,
+      "mrr": 0.43804355418055785,
+      "train_time_ms": 8054.542555939406,
+      "inference_time_us": 73722.24975739246,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8729447814370298,
+          "mean_mse": 0.0007693067561278496,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9057576823584197,
+          "mean_mse": 0.0007477941294448238,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8628956100825714,
+          "mean_mse": 0.0007777806389799981,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8846333127601991,
+          "mean_mse": 0.0007738034915079904,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8465444615762132,
+          "mean_mse": 0.0009553427639799707,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8884545199885907,
+          "mean_mse": 0.0006483052918507766,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8565332213165744,
+          "mean_mse": 0.0008088132315546949,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8574567083320769,
+          "mean_mse": 0.0008518993329241435,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8717856286411593,
+          "mean_mse": 0.0006860644272751595,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8487817821505811,
+          "mean_mse": 0.0008144968555795688,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8864487229649085,
+          "mean_mse": 0.0007353017260827444,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9142366971590007,
+          "mean_mse": 0.000522919988634844,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8944958376552594,
+          "mean_mse": 0.0005342152454992119,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8562305878265966,
+          "mean_mse": 0.0008688267578674108,
+          "mean_rank": 6.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8780793194516572,
+          "mean_mse": 0.0006727665020576625,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8539150489473916,
+          "mean_mse": 0.0007811413791794774,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9383396210378542,
+          "mean_mse": 0.0003849182988128752,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8410525870815478,
+          "mean_mse": 0.0008374957399894603,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9468403597361309,
+          "mean_mse": 0.0002834384250562327,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8907814550817342,
+          "mean_mse": 0.0006107493639925097,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8257825235060434,
+          "mean_mse": 0.0008741592992208656,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8960953289118054,
+          "mean_mse": 0.0005619287094031836,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.852977996354426,
+          "mean_mse": 0.0007700548583611312,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9537999202320013,
+          "mean_mse": 0.0002988055234375514,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9249261858392603,
+          "mean_mse": 0.0005205488393952987,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8952892493950917,
+          "mean_mse": 0.0005894033743647693,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8752369835170647,
+          "mean_mse": 0.0007715253665342007,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9001713574655643,
+          "mean_mse": 0.0006062389862109313,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8615116268838521,
+          "mean_mse": 0.0007889480512487187,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9204450341521362,
+          "mean_mse": 0.0005514851776047265,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9088814278311173,
+          "mean_mse": 0.0006082316564319597,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8822966915893976,
+          "mean_mse": 0.0007410548470047244,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8297618443740521,
+          "mean_mse": 0.0010093557882001403,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.890273488297423,
+          "mean_mse": 0.0006464394733486617,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8602596936432144,
+          "mean_mse": 0.0007437979919251811,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9083233848860354,
+          "mean_mse": 0.0005776037418556275,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9155784595684194,
+          "mean_mse": 0.0005088062419162146,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9130149618681012,
+          "mean_mse": 0.0004621949992460376,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8802038053206614,
+          "mean_mse": 0.0007276556245931292,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8187435039064178,
+          "mean_mse": 0.0008084127855624503,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.911250701932516,
+          "mean_mse": 0.0005937759900795285,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.91910285442666,
+          "mean_mse": 0.0005920397008247276,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9138562624455472,
+          "mean_mse": 0.0006790671405909571,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.910238037912684,
+          "mean_mse": 0.0005890696854981069,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8443991438048807,
+          "mean_mse": 0.0007904409072213798,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8519719454366154,
+          "mean_mse": 0.000849933406209013,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8400382596429876,
+          "mean_mse": 0.0009028432668538476,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8583128526197293,
+          "mean_mse": 0.0008218016806093032,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8467618188456429,
+          "mean_mse": 0.0008131188832765838,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7959427666034162,
+          "mean_mse": 0.0009727338101769219,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K8_r0.1",
+      "params": {
+        "K": 8,
+        "alpha_reg": 0.1,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8796688632833002,
+      "std_cosine_to_target": 0.06428728665704511,
+      "mean_mse_to_target": 0.0006994328475713107,
+      "std_mse_to_target": 0.00028282313274450655,
+      "mean_target_rank": 7.1138613861386135,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21287128712871287,
+      "recall_at_5": 0.7574257425742574,
+      "recall_at_10": 0.900990099009901,
+      "mrr": 0.43513153955716866,
+      "train_time_ms": 8183.344498975202,
+      "inference_time_us": 93580.21597513965,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8728672140465088,
+          "mean_mse": 0.0007694300141956952,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056705071169806,
+          "mean_mse": 0.0007498494977096832,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8626949102781211,
+          "mean_mse": 0.0007784853006979096,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8841521190519548,
+          "mean_mse": 0.0007767175233303879,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8461423925111292,
+          "mean_mse": 0.0009591569134552117,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8883337117398084,
+          "mean_mse": 0.0006494731086912434,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8566763490347106,
+          "mean_mse": 0.0008099492605521009,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.857189415975315,
+          "mean_mse": 0.0008531109975470519,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8716135525918352,
+          "mean_mse": 0.0006868074704020967,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8484825991852587,
+          "mean_mse": 0.0008180167024347061,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8862737104944645,
+          "mean_mse": 0.0007373247967401308,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9136997475941022,
+          "mean_mse": 0.0005263330138966951,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8944064996746771,
+          "mean_mse": 0.0005356348201864607,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8561630196695431,
+          "mean_mse": 0.0008702359176001153,
+          "mean_rank": 6.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8777096337308794,
+          "mean_mse": 0.0006742362818859785,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8540245724249834,
+          "mean_mse": 0.0007810886318017796,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9380927554067751,
+          "mean_mse": 0.0003868158435319216,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.840590826120455,
+          "mean_mse": 0.00084002792791998,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9466497754798516,
+          "mean_mse": 0.0002848177064400032,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8903086058533202,
+          "mean_mse": 0.0006136140991365654,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8256859934144968,
+          "mean_mse": 0.0008744992565795028,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.8960533387680829,
+          "mean_mse": 0.0005628801061970526,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8524882941918552,
+          "mean_mse": 0.000772355187260581,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9537136022234358,
+          "mean_mse": 0.0003012838994288172,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9247574707556734,
+          "mean_mse": 0.0005220106217287589,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8949079837366889,
+          "mean_mse": 0.0005928983907588126,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8750822655308781,
+          "mean_mse": 0.0007736703927212938,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9000527094366864,
+          "mean_mse": 0.0006106056523900877,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8612453649684185,
+          "mean_mse": 0.0007918947527267022,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9201672515690934,
+          "mean_mse": 0.0005536361617192781,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9086819219559454,
+          "mean_mse": 0.0006110142812063395,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8820931124893556,
+          "mean_mse": 0.000743432999584896,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8295379805605938,
+          "mean_mse": 0.0010135099819812343,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.889864114984217,
+          "mean_mse": 0.0006502334939853415,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8600746143437215,
+          "mean_mse": 0.0007452903465982013,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9080458589543693,
+          "mean_mse": 0.000579451905547506,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9153838845195329,
+          "mean_mse": 0.0005094602503132403,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9127450160006674,
+          "mean_mse": 0.00046418667702136074,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8798751877998827,
+          "mean_mse": 0.0007310969483255,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8184593274238031,
+          "mean_mse": 0.0008101982729182226,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9111436918381391,
+          "mean_mse": 0.0005948261290601955,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9189068558661044,
+          "mean_mse": 0.000594918830309122,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9137786544118356,
+          "mean_mse": 0.0006801620392877461,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9100888779970514,
+          "mean_mse": 0.0005902209738891627,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.8444927403917157,
+          "mean_mse": 0.0007904287892426155,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8517887442136969,
+          "mean_mse": 0.0008513140471295847,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8396133530361657,
+          "mean_mse": 0.0009061475974725894,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.8585811225860637,
+          "mean_mse": 0.0008205259725980297,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.846897697700989,
+          "mean_mse": 0.0008132657970744038,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.7953845030914811,
+          "mean_mse": 0.0009755523721387456,
+          "mean_rank": 31.0,
+          "num_queries": 4
+        }
+      }
+    }
+  ]
+}

--- a/reports/answer_level_e5-small.json
+++ b/reports/answer_level_e5-small.json
@@ -1,0 +1,3936 @@
+{
+  "embedder": {
+    "embedder": "e5-small",
+    "model_name": "intfloat/e5-small-v2",
+    "model_id": "intfloat/e5-small-v2",
+    "dimension": 384,
+    "description": "E5 small model with query/passage prefixes (384 dim)"
+  },
+  "metric_legend": {
+    "cosine_to_target": {
+      "description": "Cosine similarity between projected query and target answer",
+      "good_value": "Higher is better (1.0 = perfect alignment)",
+      "range": "[-1.0, 1.0]"
+    },
+    "mse_to_target": {
+      "description": "Mean Squared Error between projected query and target answer",
+      "good_value": "Lower is better (0.0 = identical vectors)",
+      "range": "[0.0, inf)"
+    },
+    "target_rank": {
+      "description": "Position of correct answer when sorted by similarity (1-indexed)",
+      "good_value": "Lower is better (1 = correct answer is top result)",
+      "range": "[1, num_answers]"
+    },
+    "mrr": {
+      "description": "Mean Reciprocal Rank = average of 1/rank across all queries",
+      "good_value": "Higher is better (1.0 = always rank 1)",
+      "range": "(0.0, 1.0]"
+    },
+    "recall_at_k": {
+      "description": "Fraction of queries where correct answer is in top k results",
+      "good_value": "Higher is better (1.0 = always in top k)",
+      "range": "[0.0, 1.0]"
+    }
+  },
+  "winners": {
+    "highest_cosine": "Residual_K8_r0.01",
+    "lowest_mse": "MultiHeadLDA",
+    "lowest_rank": "Residual_K8_r0.01",
+    "highest_mrr": "Residual_K8_r0.01",
+    "highest_recall_at_5": "MultiHeadLDA"
+  },
+  "results": [
+    {
+      "method": "MultiHeadLDA",
+      "params": {
+        "type": "baseline"
+      },
+      "mean_cosine_to_target": 0.9526607958205866,
+      "std_cosine_to_target": 0.011059086502202947,
+      "mean_mse_to_target": 0.0002406984226148632,
+      "std_mse_to_target": 5.472564428618196e-05,
+      "mean_target_rank": 86.32673267326733,
+      "median_target_rank": 79.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.03881878464263873,
+      "train_time_ms": 1.11370000001898,
+      "inference_time_us": 333.77524257424164,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9602081807771231,
+          "mean_mse": 0.0002033548361550122,
+          "mean_rank": 50.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.965704685061956,
+          "mean_mse": 0.00017615716094019127,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9632338459296979,
+          "mean_mse": 0.00018830899119749289,
+          "mean_rank": 40.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9581713555356931,
+          "mean_mse": 0.0002134396644572118,
+          "mean_rank": 54.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9539622116203468,
+          "mean_mse": 0.00023428666758959022,
+          "mean_rank": 80.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9577679617815894,
+          "mean_mse": 0.00021541954431726943,
+          "mean_rank": 58.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9556646814209776,
+          "mean_mse": 0.00022586508045234661,
+          "mean_rank": 71.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9617324776026226,
+          "mean_mse": 0.000195791560513148,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9436111432549046,
+          "mean_mse": 0.0002855103823516415,
+          "mean_rank": 140.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.957149319381299,
+          "mean_mse": 0.00021849375020663824,
+          "mean_rank": 63.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9520720227948699,
+          "mean_mse": 0.00024365575451724015,
+          "mean_rank": 93.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9542838451304654,
+          "mean_mse": 0.00023271528367460224,
+          "mean_rank": 78.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9532338655349089,
+          "mean_mse": 0.0002379166830054769,
+          "mean_rank": 84.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9341129030559341,
+          "mean_mse": 0.0003324598301071003,
+          "mean_rank": 172.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9506230684238032,
+          "mean_mse": 0.000250827483426053,
+          "mean_rank": 102.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9600002854342677,
+          "mean_mse": 0.00020435141828656334,
+          "mean_rank": 48.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9674545159750346,
+          "mean_mse": 0.00016737175675330597,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9595118862070783,
+          "mean_mse": 0.00020674319386300658,
+          "mean_rank": 52.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.950846273637267,
+          "mean_mse": 0.0002497225974210386,
+          "mean_rank": 101.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9516978326979735,
+          "mean_mse": 0.00024548756408074936,
+          "mean_rank": 95.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9459380722482228,
+          "mean_mse": 0.00027399454785752254,
+          "mean_rank": 122.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9592820704734825,
+          "mean_mse": 0.00020794938642216068,
+          "mean_rank": 47.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9431301832309729,
+          "mean_mse": 0.00028785928055545805,
+          "mean_rank": 142.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9379630597286115,
+          "mean_mse": 0.0003133845456862286,
+          "mean_rank": 169.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9409824280038042,
+          "mean_mse": 0.00029847308349909495,
+          "mean_rank": 159.5,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9402548001507441,
+          "mean_mse": 0.000302081033165589,
+          "mean_rank": 156.5,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9265909730913987,
+          "mean_mse": 0.000369606167602017,
+          "mean_rank": 193.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9390368358680292,
+          "mean_mse": 0.0003080891478572833,
+          "mean_rank": 160.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9495564411192743,
+          "mean_mse": 0.00025607223126237593,
+          "mean_rank": 105.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9651028632076704,
+          "mean_mse": 0.00017909945878127355,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9552477877674799,
+          "mean_mse": 0.0002279310540027794,
+          "mean_rank": 73.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.950094599859529,
+          "mean_mse": 0.0002534195528592057,
+          "mean_rank": 107.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9578899611068855,
+          "mean_mse": 0.00021485030612492596,
+          "mean_rank": 57.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9419419272464078,
+          "mean_mse": 0.0002937562906812751,
+          "mean_rank": 150.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9618113408611317,
+          "mean_mse": 0.00019541291391418498,
+          "mean_rank": 33.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9633549673663346,
+          "mean_mse": 0.00018774193935304026,
+          "mean_rank": 29.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9553274708049303,
+          "mean_mse": 0.0002275417707769258,
+          "mean_rank": 68.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.937897028461538,
+          "mean_mse": 0.00031372218693677325,
+          "mean_rank": 166.75,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9524702105530266,
+          "mean_mse": 0.00024168524591602222,
+          "mean_rank": 91.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9288371988505169,
+          "mean_mse": 0.0003584877132251498,
+          "mean_rank": 181.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9600079296093421,
+          "mean_mse": 0.0002043601161968171,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9587687123576945,
+          "mean_mse": 0.00021046208598637792,
+          "mean_rank": 54.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9511010174003433,
+          "mean_mse": 0.00024844378377729333,
+          "mean_rank": 100.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9606921036043179,
+          "mean_mse": 0.00020093776080580572,
+          "mean_rank": 41.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9595237963714466,
+          "mean_mse": 0.00020675178655763475,
+          "mean_rank": 46.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9606142450464221,
+          "mean_mse": 0.00020133366682781298,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9510353279675299,
+          "mean_mse": 0.00024875621692517903,
+          "mean_rank": 100.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9563640146255282,
+          "mean_mse": 0.00022242785345625055,
+          "mean_rank": 64.0,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.958399566902533,
+          "mean_mse": 0.0002122730748511325,
+          "mean_rank": 57.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9596798822189515,
+          "mean_mse": 0.00020599438375663826,
+          "mean_rank": 43.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.3",
+      "params": {
+        "cutoff": 0.3,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.9526876898503914,
+      "std_cosine_to_target": 0.010994230511415709,
+      "mean_mse_to_target": 0.0002559821004688075,
+      "std_mse_to_target": 5.402967838298377e-05,
+      "mean_target_rank": 86.26732673267327,
+      "median_target_rank": 80.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.024752475247524754,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.03865409709377031,
+      "train_time_ms": 1094.829328000003,
+      "inference_time_us": 5639.413534653655,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9601534224506912,
+          "mean_mse": 0.00021582040368572003,
+          "mean_rank": 50.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9654658574674616,
+          "mean_mse": 0.0001996909262177055,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9632239068212853,
+          "mean_mse": 0.00020158499461706665,
+          "mean_rank": 41.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.958107826100786,
+          "mean_mse": 0.00022888684719389986,
+          "mean_rank": 55.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9538414099113743,
+          "mean_mse": 0.00025072610715588535,
+          "mean_rank": 81.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9577453176211406,
+          "mean_mse": 0.00022638512645818104,
+          "mean_rank": 57.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9556962834408974,
+          "mean_mse": 0.00023989536533040612,
+          "mean_rank": 71.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9616398749400554,
+          "mean_mse": 0.0002099989863950424,
+          "mean_rank": 36.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9439639341331594,
+          "mean_mse": 0.00029599026400067613,
+          "mean_rank": 138.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9571270780786094,
+          "mean_mse": 0.0002335726158483963,
+          "mean_rank": 64.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9520885664450751,
+          "mean_mse": 0.00026596528465796994,
+          "mean_rank": 93.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9543011487442197,
+          "mean_mse": 0.0002500829789086885,
+          "mean_rank": 77.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9525577859044485,
+          "mean_mse": 0.00026870380029001955,
+          "mean_rank": 89.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9342064182562154,
+          "mean_mse": 0.0003453539200341952,
+          "mean_rank": 172.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9506889136273794,
+          "mean_mse": 0.00026231695874461653,
+          "mean_rank": 102.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9601044230439989,
+          "mean_mse": 0.00022113689519297723,
+          "mean_rank": 48.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9672523075733165,
+          "mean_mse": 0.00018220435000940407,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9595166300138769,
+          "mean_mse": 0.00022550700085947426,
+          "mean_rank": 51.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9506736254177393,
+          "mean_mse": 0.00026697523669358874,
+          "mean_rank": 103.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9514105158131995,
+          "mean_mse": 0.0002577731485544992,
+          "mean_rank": 97.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9466221384382995,
+          "mean_mse": 0.00028710028651389907,
+          "mean_rank": 119.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9594990824880048,
+          "mean_mse": 0.00022083438863522472,
+          "mean_rank": 46.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9431373600511703,
+          "mean_mse": 0.00030195424293085924,
+          "mean_rank": 141.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9382638374695959,
+          "mean_mse": 0.0003270122645707919,
+          "mean_rank": 168.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9413339192701597,
+          "mean_mse": 0.0003095137165429551,
+          "mean_rank": 158.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9401467846603164,
+          "mean_mse": 0.00031291246010144245,
+          "mean_rank": 157.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9268425254168389,
+          "mean_mse": 0.0003771132922949384,
+          "mean_rank": 193.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9388835350093557,
+          "mean_mse": 0.0003279507118305969,
+          "mean_rank": 161.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9495569046623625,
+          "mean_mse": 0.0002706767539338963,
+          "mean_rank": 106.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9650047084316216,
+          "mean_mse": 0.0001952053882798449,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9551476801227763,
+          "mean_mse": 0.0002423877055175124,
+          "mean_rank": 73.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9497143455266635,
+          "mean_mse": 0.00026994993150147737,
+          "mean_rank": 108.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9578928152467808,
+          "mean_mse": 0.00023301812611356174,
+          "mean_rank": 56.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9417566659032253,
+          "mean_mse": 0.00031142973952250714,
+          "mean_rank": 150.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9616575931398886,
+          "mean_mse": 0.00021279210835775507,
+          "mean_rank": 34.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9632705441553737,
+          "mean_mse": 0.0002017391021380931,
+          "mean_rank": 30.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.955907768543137,
+          "mean_mse": 0.0002431118153536706,
+          "mean_rank": 65.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.938187069386096,
+          "mean_mse": 0.0003262092752768503,
+          "mean_rank": 165.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9523881220850728,
+          "mean_mse": 0.00026250120282043346,
+          "mean_rank": 90.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9291354092580338,
+          "mean_mse": 0.00036584475891269944,
+          "mean_rank": 180.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9599680485313009,
+          "mean_mse": 0.00022457064725041608,
+          "mean_rank": 42.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9584529230171317,
+          "mean_mse": 0.000229149860079584,
+          "mean_rank": 56.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9516590684189794,
+          "mean_mse": 0.0002625197557359585,
+          "mean_rank": 97.0,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9608795576198428,
+          "mean_mse": 0.00021639534082301486,
+          "mean_rank": 40.75,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9596632228466387,
+          "mean_mse": 0.00022048724420818352,
+          "mean_rank": 45.5,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.960609268413018,
+          "mean_mse": 0.00021804262778062956,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9509632542876505,
+          "mean_mse": 0.0002608814793739481,
+          "mean_rank": 101.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568345668202134,
+          "mean_mse": 0.00023919523488378431,
+          "mean_rank": 60.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.958321931669444,
+          "mean_mse": 0.00022586613537227315,
+          "mean_rank": 58.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9597198526534968,
+          "mean_mse": 0.000221823220160845,
+          "mean_rank": 42.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.5",
+      "params": {
+        "cutoff": 0.5,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.9530435977754823,
+      "std_cosine_to_target": 0.01093664309692145,
+      "mean_mse_to_target": 0.00025390108416499773,
+      "std_mse_to_target": 5.380335146873214e-05,
+      "mean_target_rank": 84.51485148514851,
+      "median_target_rank": 78.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.03962176432835056,
+      "train_time_ms": 624.7538740000209,
+      "inference_time_us": 4226.796534653366,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9604586782700257,
+          "mean_mse": 0.00021376891651260613,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.965908763649172,
+          "mean_mse": 0.00019699495392380014,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.963463102305107,
+          "mean_mse": 0.00019995716126808662,
+          "mean_rank": 39.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9584035938088633,
+          "mean_mse": 0.00022697706292191847,
+          "mean_rank": 53.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9541116261046247,
+          "mean_mse": 0.0002488443046508282,
+          "mean_rank": 79.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9580047935493307,
+          "mean_mse": 0.00022460601152946472,
+          "mean_rank": 56.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9559550271355743,
+          "mean_mse": 0.00023808492435253587,
+          "mean_rank": 68.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.961915699303761,
+          "mean_mse": 0.000208176310059298,
+          "mean_rank": 35.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9441542287874997,
+          "mean_mse": 0.00029476792732702716,
+          "mean_rank": 137.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9574057217548582,
+          "mean_mse": 0.0002317644058855586,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9524291074591111,
+          "mean_mse": 0.00026394520202016456,
+          "mean_rank": 90.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9546741879975169,
+          "mean_mse": 0.00024800615567523664,
+          "mean_rank": 75.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9537983437942461,
+          "mean_mse": 0.00026245271266121995,
+          "mean_rank": 81.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9347394302657003,
+          "mean_mse": 0.00034261766459610555,
+          "mean_rank": 171.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9509884005724292,
+          "mean_mse": 0.00026060331596666075,
+          "mean_rank": 100.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9603392472107644,
+          "mean_mse": 0.0002196728699083428,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9676903391255749,
+          "mean_mse": 0.00017957113530375153,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9598294523417169,
+          "mean_mse": 0.0002234127863528973,
+          "mean_rank": 50.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9513183126695833,
+          "mean_mse": 0.00026363365988445913,
+          "mean_rank": 99.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9518885605863685,
+          "mean_mse": 0.0002552382992732808,
+          "mean_rank": 94.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9466783832878936,
+          "mean_mse": 0.00028662200354668025,
+          "mean_rank": 119.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.959657865218911,
+          "mean_mse": 0.00021982911440633404,
+          "mean_rank": 45.75,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9436076964430219,
+          "mean_mse": 0.0002995422871521076,
+          "mean_rank": 139.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9387528923420791,
+          "mean_mse": 0.00032438204946978375,
+          "mean_rank": 166.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414993503481234,
+          "mean_mse": 0.00030843573124734807,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9406805087451416,
+          "mean_mse": 0.0003102348251481068,
+          "mean_rank": 154.75,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9271350533327941,
+          "mean_mse": 0.00037554306933394017,
+          "mean_rank": 192.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9395857326441259,
+          "mean_mse": 0.0003243205682119857,
+          "mean_rank": 159.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9498590618955779,
+          "mean_mse": 0.0002687194492065744,
+          "mean_rank": 104.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9652927505462467,
+          "mean_mse": 0.00019336973143249306,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.955465920914904,
+          "mean_mse": 0.00024059156097107606,
+          "mean_rank": 71.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9503089151154588,
+          "mean_mse": 0.0002666006891125505,
+          "mean_rank": 105.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9581993649338585,
+          "mean_mse": 0.00023102061213187993,
+          "mean_rank": 55.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9424125029374045,
+          "mean_mse": 0.00030798678241170563,
+          "mean_rank": 147.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.962111967130983,
+          "mean_mse": 0.0002099128761565858,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9636162116612184,
+          "mean_mse": 0.00019963021698937778,
+          "mean_rank": 29.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559555066331304,
+          "mean_mse": 0.00024261935687700187,
+          "mean_rank": 64.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9385502750267527,
+          "mean_mse": 0.00032431320666943624,
+          "mean_rank": 163.75,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9528077563498233,
+          "mean_mse": 0.00026009647134310444,
+          "mean_rank": 88.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.929556287151258,
+          "mean_mse": 0.00036370487001894487,
+          "mean_rank": 180.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9604293704025739,
+          "mean_mse": 0.0002219691712378323,
+          "mean_rank": 41.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.959067009106928,
+          "mean_mse": 0.00022556019589101123,
+          "mean_rank": 51.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9517618851327132,
+          "mean_mse": 0.0002617482244077751,
+          "mean_rank": 96.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9611024463248443,
+          "mean_mse": 0.000214926543932518,
+          "mean_rank": 40.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9598207401125747,
+          "mean_mse": 0.00021945662790089605,
+          "mean_rank": 45.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9608136456142343,
+          "mean_mse": 0.00021659574973983682,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.951295264900096,
+          "mean_mse": 0.0002589873586983928,
+          "mean_rank": 100.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568987179574483,
+          "mean_mse": 0.00023863721228506652,
+          "mean_rank": 59.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9586472838796323,
+          "mean_mse": 0.0002238460207831367,
+          "mean_rank": 57.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9599312901169808,
+          "mean_mse": 0.00022035999556487636,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.7",
+      "params": {
+        "cutoff": 0.7,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.9530638247451307,
+      "std_cosine_to_target": 0.01093200023982708,
+      "mean_mse_to_target": 0.00025381777761981987,
+      "std_mse_to_target": 5.3774301998080715e-05,
+      "mean_target_rank": 84.34158415841584,
+      "median_target_rank": 78.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.039659645879147075,
+      "train_time_ms": 712.8562839999972,
+      "inference_time_us": 5129.60560396047,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9604798920935538,
+          "mean_mse": 0.00021373761406207523,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9659122797787196,
+          "mean_mse": 0.00019703520218709107,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9634656592676781,
+          "mean_mse": 0.0001999572319782597,
+          "mean_rank": 39.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9584495760206846,
+          "mean_mse": 0.00022676454672621946,
+          "mean_rank": 53.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9541173848916167,
+          "mean_mse": 0.00024887410334799623,
+          "mean_rank": 79.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9579579523908475,
+          "mean_mse": 0.00022489867417094722,
+          "mean_rank": 56.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9559728857521825,
+          "mean_mse": 0.0002380807921490638,
+          "mean_rank": 68.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9619039311065141,
+          "mean_mse": 0.00020825206799148606,
+          "mean_rank": 35.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9441652547450538,
+          "mean_mse": 0.0002947575361350784,
+          "mean_rank": 137.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9573521906922556,
+          "mean_mse": 0.00023206682659026247,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9524405425611617,
+          "mean_mse": 0.00026392497739616077,
+          "mean_rank": 90.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9547244724114587,
+          "mean_mse": 0.00024783228094852103,
+          "mean_rank": 74.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9538763919480862,
+          "mean_mse": 0.0002620215796834346,
+          "mean_rank": 81.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9347451389921286,
+          "mean_mse": 0.00034263071625640625,
+          "mean_rank": 170.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9510030642557826,
+          "mean_mse": 0.0002605552844553326,
+          "mean_rank": 100.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9603385512447103,
+          "mean_mse": 0.0002196652030127969,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9677943203237089,
+          "mean_mse": 0.00017901768651324072,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.959876635552525,
+          "mean_mse": 0.00022314734393021792,
+          "mean_rank": 49.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9514860244444333,
+          "mean_mse": 0.0002628493560623556,
+          "mean_rank": 97.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9519581920360468,
+          "mean_mse": 0.0002548973253831541,
+          "mean_rank": 94.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.946674786112335,
+          "mean_mse": 0.00028665066678061727,
+          "mean_rank": 119.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9596446139269443,
+          "mean_mse": 0.00021988901834143562,
+          "mean_rank": 46.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9436788969407879,
+          "mean_mse": 0.00029916502537753514,
+          "mean_rank": 139.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.938774801961121,
+          "mean_mse": 0.0003242920509730849,
+          "mean_rank": 166.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414710545824938,
+          "mean_mse": 0.00030859143080446175,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9407267044084795,
+          "mean_mse": 0.0003099851573518392,
+          "mean_rank": 154.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9271548397428103,
+          "mean_mse": 0.00037541974267009826,
+          "mean_rank": 192.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9396492997325981,
+          "mean_mse": 0.00032396817219180666,
+          "mean_rank": 158.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9498376985674367,
+          "mean_mse": 0.0002689081942374804,
+          "mean_rank": 104.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9653656504879087,
+          "mean_mse": 0.00019300831327647181,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9555298442050708,
+          "mean_mse": 0.00024027349896806483,
+          "mean_rank": 70.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9503663816548504,
+          "mean_mse": 0.00026634874585650695,
+          "mean_rank": 104.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9581737954933612,
+          "mean_mse": 0.0002312045377166693,
+          "mean_rank": 55.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9424547339990094,
+          "mean_mse": 0.0003078083656249166,
+          "mean_rank": 146.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9620758187264181,
+          "mean_mse": 0.00021017425101886345,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9636094066565277,
+          "mean_mse": 0.0001996808646262905,
+          "mean_rank": 29.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559617699960768,
+          "mean_mse": 0.00024255884874389448,
+          "mean_rank": 64.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9385480734471332,
+          "mean_mse": 0.0003243386614977504,
+          "mean_rank": 163.75,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9528287532034474,
+          "mean_mse": 0.00025997416447442,
+          "mean_rank": 88.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9295717671412433,
+          "mean_mse": 0.00036363577520900973,
+          "mean_rank": 180.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9604168538257045,
+          "mean_mse": 0.00022205646856989723,
+          "mean_rank": 41.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9591096111160489,
+          "mean_mse": 0.00022536398762974645,
+          "mean_rank": 51.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9517676731230909,
+          "mean_mse": 0.00026171845714551386,
+          "mean_rank": 96.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9610667494857306,
+          "mean_mse": 0.00021510201262743472,
+          "mean_rank": 40.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9598416764723638,
+          "mean_mse": 0.00021937707003026976,
+          "mean_rank": 45.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9608167794361082,
+          "mean_mse": 0.00021660511513985748,
+          "mean_rank": 40.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9513061455029975,
+          "mean_mse": 0.00025891380795427016,
+          "mean_rank": 100.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9569049455423984,
+          "mean_mse": 0.00023859666490732374,
+          "mean_rank": 59.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9587002520765531,
+          "mean_mse": 0.00022359046168228406,
+          "mean_rank": 56.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.959945833118605,
+          "mean_mse": 0.00022028482629511507,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveFFT",
+      "params": {
+        "min_cutoff": 0.2,
+        "max_cutoff": 0.7
+      },
+      "mean_cosine_to_target": 0.952871752032419,
+      "std_cosine_to_target": 0.010920767272150356,
+      "mean_mse_to_target": 0.00025509613922268764,
+      "std_mse_to_target": 5.3662555140100646e-05,
+      "mean_target_rank": 85.34653465346534,
+      "median_target_rank": 79.0,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.024752475247524754,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.03902819529863042,
+      "train_time_ms": 1608.2092220000277,
+      "inference_time_us": 4030.3992326733123,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9600905401749603,
+          "mean_mse": 0.0002160448191344062,
+          "mean_rank": 50.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9654776749569209,
+          "mean_mse": 0.0001996182828805845,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9632795027028298,
+          "mean_mse": 0.0002012735289497118,
+          "mean_rank": 40.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9582325916693774,
+          "mean_mse": 0.00022822507504916467,
+          "mean_rank": 54.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9540051761093961,
+          "mean_mse": 0.0002498407974593407,
+          "mean_rank": 80.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9578988482221712,
+          "mean_mse": 0.00022559945752239084,
+          "mean_rank": 56.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9556438314226929,
+          "mean_mse": 0.00024009914240314295,
+          "mean_rank": 71.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9616489723583842,
+          "mean_mse": 0.00020993497148684147,
+          "mean_rank": 36.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9438748110777697,
+          "mean_mse": 0.00029647545595365334,
+          "mean_rank": 139.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9573084899766635,
+          "mean_mse": 0.00023265568571221925,
+          "mean_rank": 63.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9523552068219875,
+          "mean_mse": 0.00026466467495943335,
+          "mean_rank": 90.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9544788619316573,
+          "mean_mse": 0.00024940994352151024,
+          "mean_rank": 77.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9538727446532473,
+          "mean_mse": 0.00026235149635755426,
+          "mean_rank": 81.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9343165884738921,
+          "mean_mse": 0.0003449076167934141,
+          "mean_rank": 172.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9506987167851784,
+          "mean_mse": 0.00026230806878592644,
+          "mean_rank": 102.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.960162311680623,
+          "mean_mse": 0.0002208886381225825,
+          "mean_rank": 48.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9674437991212395,
+          "mean_mse": 0.00018119564743019747,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9596916957435888,
+          "mean_mse": 0.0002245721484810971,
+          "mean_rank": 51.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9512785160215484,
+          "mean_mse": 0.00026408853561492204,
+          "mean_rank": 100.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9518101618075624,
+          "mean_mse": 0.00025588074688647573,
+          "mean_rank": 95.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9465888502300526,
+          "mean_mse": 0.00028729952294406693,
+          "mean_rank": 120.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9595466068139077,
+          "mean_mse": 0.0002206442505029341,
+          "mean_rank": 46.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9435083147650044,
+          "mean_mse": 0.00030022976137397694,
+          "mean_rank": 140.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.938695349274397,
+          "mean_mse": 0.0003249280195800808,
+          "mean_rank": 166.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414906104933605,
+          "mean_mse": 0.00030875820735678947,
+          "mean_rank": 157.75,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9405883314675021,
+          "mean_mse": 0.0003108799754719984,
+          "mean_rank": 155.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9270443424780737,
+          "mean_mse": 0.00037620660433242755,
+          "mean_rank": 192.75,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9396612892043432,
+          "mean_mse": 0.00032426651000437356,
+          "mean_rank": 158.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9496768967901571,
+          "mean_mse": 0.0002700353600367689,
+          "mean_rank": 105.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.965107228258713,
+          "mean_mse": 0.00019468323112761997,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9552624894155916,
+          "mean_mse": 0.00024186451364418724,
+          "mean_rank": 72.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.95001837802978,
+          "mean_mse": 0.00026841060173368974,
+          "mean_rank": 107.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9580480494833241,
+          "mean_mse": 0.00023222459303008034,
+          "mean_rank": 56.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9422154182075093,
+          "mean_mse": 0.00030923809804596776,
+          "mean_rank": 148.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9617431499497309,
+          "mean_mse": 0.00021226921091299997,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9633155932322428,
+          "mean_mse": 0.00020150256147729358,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559464796957879,
+          "mean_mse": 0.00024296522388106098,
+          "mean_rank": 64.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9384201091670914,
+          "mean_mse": 0.00032515471289613185,
+          "mean_rank": 164.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9527660677659823,
+          "mean_mse": 0.0002606720850190653,
+          "mean_rank": 88.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9294435693296192,
+          "mean_mse": 0.0003644624574062134,
+          "mean_rank": 180.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.960020868592868,
+          "mean_mse": 0.00022435251120790325,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9586945980036257,
+          "mean_mse": 0.00022782333980498503,
+          "mean_rank": 54.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9516540809170526,
+          "mean_mse": 0.00026255129210831743,
+          "mean_rank": 96.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.960981881458363,
+          "mean_mse": 0.00021587411006779517,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9597904151312894,
+          "mean_mse": 0.0002198950093573827,
+          "mean_rank": 45.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9607436947310068,
+          "mean_mse": 0.00021737641891472612,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.950994373902035,
+          "mean_mse": 0.00026075944762086507,
+          "mean_rank": 101.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568395969501882,
+          "mean_mse": 0.00023923897407319617,
+          "mean_rank": 60.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9582673599631929,
+          "mean_mse": 0.00022611423148637203,
+          "mean_rank": 58.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9598325923357562,
+          "mean_mse": 0.00022129369363512122,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K4",
+      "params": {
+        "K": 4,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.9506104889492728,
+      "std_cosine_to_target": 0.011607941294272856,
+      "mean_mse_to_target": 0.00025491668098393146,
+      "std_mse_to_target": 5.7723592036644464e-05,
+      "mean_target_rank": 95.76732673267327,
+      "median_target_rank": 94.0,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.024752475247524754,
+      "recall_at_10": 0.054455445544554455,
+      "mrr": 0.03594720882391118,
+      "train_time_ms": 12301.142831999983,
+      "inference_time_us": 48398.8521534653,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9591838346068079,
+          "mean_mse": 0.00021356659973730032,
+          "mean_rank": 53.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.965013703627216,
+          "mean_mse": 0.00018186871229710808,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9623118239701532,
+          "mean_mse": 0.00019665498789491858,
+          "mean_rank": 43.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9573625802888484,
+          "mean_mse": 0.00022133506871702062,
+          "mean_rank": 59.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9531330902898921,
+          "mean_mse": 0.00024178964935774535,
+          "mean_rank": 87.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9560930371584395,
+          "mean_mse": 0.00023049112470097908,
+          "mean_rank": 67.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9543786571038,
+          "mean_mse": 0.00023722689056441268,
+          "mean_rank": 78.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9605117908770262,
+          "mean_mse": 0.0002065537929021332,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9404948817436294,
+          "mean_mse": 0.00030575568324889323,
+          "mean_rank": 154.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9559770992044935,
+          "mean_mse": 0.00022831413372590922,
+          "mean_rank": 68.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9503579936232472,
+          "mean_mse": 0.0002541433802351022,
+          "mean_rank": 104.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9517866621410155,
+          "mean_mse": 0.000247709791484014,
+          "mean_rank": 94.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9500207157007633,
+          "mean_mse": 0.00025518990162788863,
+          "mean_rank": 107.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.93094862139558,
+          "mean_mse": 0.00035240710614584776,
+          "mean_rank": 181.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9483335940869427,
+          "mean_mse": 0.00026820261533746945,
+          "mean_rank": 117.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9580102205195676,
+          "mean_mse": 0.00021670169519710962,
+          "mean_rank": 58.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.964781261720729,
+          "mean_mse": 0.0001839734289690678,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.957621685891321,
+          "mean_mse": 0.00021776169158977364,
+          "mean_rank": 59.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9474108978246166,
+          "mean_mse": 0.00027021287728868,
+          "mean_rank": 124.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9498435236855317,
+          "mean_mse": 0.00026147085910864157,
+          "mean_rank": 106.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9431022596286947,
+          "mean_mse": 0.0002939888100588933,
+          "mean_rank": 140.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9573511793486442,
+          "mean_mse": 0.00022220185971534568,
+          "mean_rank": 59.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9402684843689864,
+          "mean_mse": 0.00030622475168363186,
+          "mean_rank": 152.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9342921036419924,
+          "mean_mse": 0.00033515289569813563,
+          "mean_rank": 178.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9385713531356975,
+          "mean_mse": 0.00031563814327767133,
+          "mean_rank": 167.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9384208717467185,
+          "mean_mse": 0.0003180588539302806,
+          "mean_rank": 163.5,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9242624061303305,
+          "mean_mse": 0.00038808156623740676,
+          "mean_rank": 195.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9362067989060978,
+          "mean_mse": 0.00032379071222912503,
+          "mean_rank": 169.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9480428425311582,
+          "mean_mse": 0.00026723299191380414,
+          "mean_rank": 112.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9636159784474851,
+          "mean_mse": 0.00018926776289287421,
+          "mean_rank": 24.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9537051102587806,
+          "mean_mse": 0.0002396024047610687,
+          "mean_rank": 83.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9490128859688889,
+          "mean_mse": 0.0002628964937030512,
+          "mean_rank": 112.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9563091746627815,
+          "mean_mse": 0.00022490289255284703,
+          "mean_rank": 65.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9394512772227105,
+          "mean_mse": 0.00031091445630636425,
+          "mean_rank": 162.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9603107037910055,
+          "mean_mse": 0.00020540023518396717,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9617065846485116,
+          "mean_mse": 0.00020016976489272122,
+          "mean_rank": 35.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9521025752077485,
+          "mean_mse": 0.00024633730345892786,
+          "mean_rank": 93.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9344030402672792,
+          "mean_mse": 0.0003354350389620748,
+          "mean_rank": 176.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9508729938719834,
+          "mean_mse": 0.0002524469817106388,
+          "mean_rank": 100.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9247709596357165,
+          "mean_mse": 0.0003833900695345787,
+          "mean_rank": 183.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9581532197401907,
+          "mean_mse": 0.00021617477342059674,
+          "mean_rank": 54.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9566750905274267,
+          "mean_mse": 0.0002242486589260611,
+          "mean_rank": 63.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9487310497123114,
+          "mean_mse": 0.00026527168907352906,
+          "mean_rank": 114.0,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9589678942486053,
+          "mean_mse": 0.00021312994098928904,
+          "mean_rank": 50.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9575822603173079,
+          "mean_mse": 0.00022198153902069258,
+          "mean_rank": 57.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.959340257561279,
+          "mean_mse": 0.00021121743314969909,
+          "mean_rank": 47.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9493780623881485,
+          "mean_mse": 0.00026278242246991585,
+          "mean_rank": 111.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9539288844313809,
+          "mean_mse": 0.00023874097161610984,
+          "mean_rank": 80.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9566703693369024,
+          "mean_mse": 0.00022613852722001764,
+          "mean_rank": 65.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9581864690090945,
+          "mean_mse": 0.00021660175762051875,
+          "mean_rank": 51.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K8",
+      "params": {
+        "K": 8,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.9509099141359897,
+      "std_cosine_to_target": 0.011618519453390637,
+      "mean_mse_to_target": 0.00025222842756836793,
+      "std_mse_to_target": 5.7725836313278795e-05,
+      "mean_target_rank": 94.14851485148515,
+      "median_target_rank": 91.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.054455445544554455,
+      "mrr": 0.03691960277379525,
+      "train_time_ms": 18931.92329499999,
+      "inference_time_us": 81131.22741584147,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9594910563342512,
+          "mean_mse": 0.00021030391469505487,
+          "mean_rank": 53.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9651903366956676,
+          "mean_mse": 0.00018019852088206335,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9626234119649633,
+          "mean_mse": 0.0001937501894429572,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9576182211126357,
+          "mean_mse": 0.00021884577131062535,
+          "mean_rank": 58.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9533612802591469,
+          "mean_mse": 0.00023947248604889326,
+          "mean_rank": 84.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9571154779294329,
+          "mean_mse": 0.00022357299897469074,
+          "mean_rank": 60.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9549493208832106,
+          "mean_mse": 0.0002330454653887799,
+          "mean_rank": 74.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9610393100313265,
+          "mean_mse": 0.00020244581174034884,
+          "mean_rank": 36.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9406467638681122,
+          "mean_mse": 0.0003036904185428937,
+          "mean_rank": 153.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9559908808831437,
+          "mean_mse": 0.00022704853014013525,
+          "mean_rank": 69.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9505668199903541,
+          "mean_mse": 0.0002525392207216007,
+          "mean_rank": 102.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9521416267517473,
+          "mean_mse": 0.0002450484998746829,
+          "mean_rank": 91.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.950346466828626,
+          "mean_mse": 0.0002532945857738092,
+          "mean_rank": 105.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9314016408478277,
+          "mean_mse": 0.00034889427430993917,
+          "mean_rank": 180.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9485659788911851,
+          "mean_mse": 0.00026548918179613,
+          "mean_rank": 115.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9588458613235826,
+          "mean_mse": 0.00021162039585469083,
+          "mean_rank": 54.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9652748486627815,
+          "mean_mse": 0.0001802667713188574,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9577876781373401,
+          "mean_mse": 0.00021617744697386248,
+          "mean_rank": 58.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9483360693803566,
+          "mean_mse": 0.00026456818120833633,
+          "mean_rank": 117.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9501119374985526,
+          "mean_mse": 0.00025853972087801506,
+          "mean_rank": 105.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9436048311176979,
+          "mean_mse": 0.0002903822631359152,
+          "mean_rank": 137.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9580026452393366,
+          "mean_mse": 0.00021763689338490048,
+          "mean_rank": 55.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9406114057745081,
+          "mean_mse": 0.0003033358927045985,
+          "mean_rank": 151.5,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9345463654597954,
+          "mean_mse": 0.0003326143948946599,
+          "mean_rank": 178.0,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9387163344276523,
+          "mean_mse": 0.000313464817677449,
+          "mean_rank": 167.5,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9386483242537063,
+          "mean_mse": 0.0003152593046616115,
+          "mean_rank": 163.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9244766900166246,
+          "mean_mse": 0.00038508290915195324,
+          "mean_rank": 195.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9365796413050211,
+          "mean_mse": 0.0003211206387573023,
+          "mean_rank": 168.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.948163422204005,
+          "mean_mse": 0.00026534666764554114,
+          "mean_rank": 112.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9637137349046607,
+          "mean_mse": 0.00018763217567433632,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9538090074797467,
+          "mean_mse": 0.00023779840578239795,
+          "mean_rank": 82.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.949188205136208,
+          "mean_mse": 0.0002606541378304909,
+          "mean_rank": 110.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.956447726881034,
+          "mean_mse": 0.0002233088937006028,
+          "mean_rank": 63.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.939555455119605,
+          "mean_mse": 0.0003092053737556821,
+          "mean_rank": 162.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9605869457241575,
+          "mean_mse": 0.00020298059386481926,
+          "mean_rank": 38.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9618105862368481,
+          "mean_mse": 0.00019823252841583223,
+          "mean_rank": 35.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9522610048064567,
+          "mean_mse": 0.0002447049267508263,
+          "mean_rank": 92.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9347233554357645,
+          "mean_mse": 0.00033261262666632466,
+          "mean_rank": 175.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.950936346820058,
+          "mean_mse": 0.0002513533762989372,
+          "mean_rank": 99.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9249807716164168,
+          "mean_mse": 0.0003808469121003501,
+          "mean_rank": 183.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9582863600891922,
+          "mean_mse": 0.00021470036950410707,
+          "mean_rank": 52.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9567406272073866,
+          "mean_mse": 0.0002228480760906384,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9491947031504054,
+          "mean_mse": 0.0002619008321765631,
+          "mean_rank": 111.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9593615872492505,
+          "mean_mse": 0.0002101633542804848,
+          "mean_rank": 47.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9579983231583595,
+          "mean_mse": 0.00021855240560940395,
+          "mean_rank": 53.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9594484435090582,
+          "mean_mse": 0.00020957137803062002,
+          "mean_rank": 46.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9496795931046431,
+          "mean_mse": 0.00025967807266096633,
+          "mean_rank": 109.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9541897732397419,
+          "mean_mse": 0.00023655636554707489,
+          "mean_rank": 78.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9569977503037241,
+          "mean_mse": 0.0002230259372870974,
+          "mean_rank": 64.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.958273613443184,
+          "mean_mse": 0.00021500650907152062,
+          "mean_rank": 51.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K16",
+      "params": {
+        "K": 16,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.9517111199777712,
+      "std_cosine_to_target": 0.011360617504734856,
+      "mean_mse_to_target": 0.00024640767541811437,
+      "std_mse_to_target": 5.624342788411759e-05,
+      "mean_target_rank": 90.28217821782178,
+      "median_target_rank": 86.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.0594059405940594,
+      "mrr": 0.03714790694509644,
+      "train_time_ms": 30632.292080000014,
+      "inference_time_us": 191091.01685148518,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9598650954265951,
+          "mean_mse": 0.00020600191730866214,
+          "mean_rank": 50.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9654716207273633,
+          "mean_mse": 0.00017827109873026626,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9628949071505066,
+          "mean_mse": 0.00019053395566402274,
+          "mean_rank": 41.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9579458203921624,
+          "mean_mse": 0.00021543263243709238,
+          "mean_rank": 55.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9537201965159541,
+          "mean_mse": 0.0002360440176271348,
+          "mean_rank": 81.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9573972449269016,
+          "mean_mse": 0.00021929715202465672,
+          "mean_rank": 58.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9553294123417121,
+          "mean_mse": 0.00022885891205143,
+          "mean_rank": 72.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9613822466096229,
+          "mean_mse": 0.00019872546056312062,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9433884264907373,
+          "mean_mse": 0.00028727520533664355,
+          "mean_rank": 141.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9567169950076346,
+          "mean_mse": 0.00022133561446856242,
+          "mean_rank": 65.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9518737126432031,
+          "mean_mse": 0.0002457743018365381,
+          "mean_rank": 93.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9539278956414894,
+          "mean_mse": 0.00023473502620240005,
+          "mean_rank": 79.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9533435419786709,
+          "mean_mse": 0.000238757240626193,
+          "mean_rank": 84.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9341724938076112,
+          "mean_mse": 0.00033278069887659274,
+          "mean_rank": 173.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.950034696518178,
+          "mean_mse": 0.0002551767573894702,
+          "mean_rank": 106.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.959664869185524,
+          "mean_mse": 0.00020630495297551993,
+          "mean_rank": 49.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9660225377705112,
+          "mean_mse": 0.00017469408654590215,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9581897554275166,
+          "mean_mse": 0.00021347444397840895,
+          "mean_rank": 57.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9495328127873128,
+          "mean_mse": 0.00025700671733191533,
+          "mean_rank": 109.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9505663596507722,
+          "mean_mse": 0.0002532081445272727,
+          "mean_rank": 102.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9443477390482085,
+          "mean_mse": 0.0002847201766039839,
+          "mean_rank": 132.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9587012334355196,
+          "mean_mse": 0.0002119228173048855,
+          "mean_rank": 49.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9412747510340204,
+          "mean_mse": 0.00029787034200221154,
+          "mean_rank": 150.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9359274439809909,
+          "mean_mse": 0.0003237706935221652,
+          "mean_rank": 174.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9397710693479765,
+          "mean_mse": 0.0003055378339229702,
+          "mean_rank": 164.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9391420852602995,
+          "mean_mse": 0.00030986771972490404,
+          "mean_rank": 161.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9254756151562918,
+          "mean_mse": 0.0003768701035803245,
+          "mean_rank": 194.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9374211632984926,
+          "mean_mse": 0.00031593396588251737,
+          "mean_rank": 165.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9483565298607725,
+          "mean_mse": 0.0002625399246839605,
+          "mean_rank": 110.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9642154966510827,
+          "mean_mse": 0.00018353012445119452,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9539028440117832,
+          "mean_mse": 0.00023522489244635767,
+          "mean_rank": 80.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9495818762405053,
+          "mean_mse": 0.00025683403981010796,
+          "mean_rank": 109.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9569805320369972,
+          "mean_mse": 0.00021959314657919664,
+          "mean_rank": 60.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9405993589459446,
+          "mean_mse": 0.0003023447671100296,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9611147345854087,
+          "mean_mse": 0.0001988959699924389,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.962218416699813,
+          "mean_mse": 0.00019413768924570686,
+          "mean_rank": 34.5,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9528538407591647,
+          "mean_mse": 0.00024055600638479068,
+          "mean_rank": 88.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9352989778549313,
+          "mean_mse": 0.0003276092542041521,
+          "mean_rank": 175.0,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9514230105709575,
+          "mean_mse": 0.0002480688774841063,
+          "mean_rank": 97.0,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9259508597595356,
+          "mean_mse": 0.0003733290077147602,
+          "mean_rank": 182.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9587846828888709,
+          "mean_mse": 0.0002112548247196314,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9574883017187262,
+          "mean_mse": 0.0002176471986340455,
+          "mean_rank": 60.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9497422728744058,
+          "mean_mse": 0.0002574086630191908,
+          "mean_rank": 108.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9599307150626645,
+          "mean_mse": 0.00020582550951168835,
+          "mean_rank": 43.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9588602070417374,
+          "mean_mse": 0.00021216446877592954,
+          "mean_rank": 48.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9598277719779634,
+          "mean_mse": 0.00020621563382169661,
+          "mean_rank": 45.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9500126017544124,
+          "mean_mse": 0.00025537807463030487,
+          "mean_rank": 107.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.954829670268641,
+          "mean_mse": 0.00023202227247626943,
+          "mean_rank": 73.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9574748035954447,
+          "mean_mse": 0.0002183906582404095,
+          "mean_rank": 61.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9590720820813212,
+          "mean_mse": 0.00020942063957973077,
+          "mean_rank": 46.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K4_r0.01",
+      "params": {
+        "K": 4,
+        "alpha_reg": 0.01,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.9530802273650771,
+      "std_cosine_to_target": 0.010940731684539262,
+      "mean_mse_to_target": 0.00025365373210771604,
+      "std_mse_to_target": 5.383998079117459e-05,
+      "mean_target_rank": 84.34653465346534,
+      "median_target_rank": 78.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.03959973444562796,
+      "train_time_ms": 9956.894809000005,
+      "inference_time_us": 78488.26852475297,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9605449337838975,
+          "mean_mse": 0.00021326571706031997,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9660025121192646,
+          "mean_mse": 0.00019643938478767,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9635038009814472,
+          "mean_mse": 0.00019965739279584246,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9585269350241038,
+          "mean_mse": 0.00022627245465583616,
+          "mean_rank": 53.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9541018619529712,
+          "mean_mse": 0.000248791788631748,
+          "mean_rank": 79.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9580058308148823,
+          "mean_mse": 0.0002245346120548685,
+          "mean_rank": 56.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9560297106239619,
+          "mean_mse": 0.0002376547607727243,
+          "mean_rank": 68.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9619331461922925,
+          "mean_mse": 0.0002079835499957111,
+          "mean_rank": 35.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9442082767635267,
+          "mean_mse": 0.00029448816480671925,
+          "mean_rank": 137.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.957380040683144,
+          "mean_mse": 0.0002318220462393419,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9525166460406905,
+          "mean_mse": 0.00026345118872560247,
+          "mean_rank": 89.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.954682146641602,
+          "mean_mse": 0.0002479581596725351,
+          "mean_rank": 75.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9538862647790958,
+          "mean_mse": 0.00026201111449627746,
+          "mean_rank": 81.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.934713481173015,
+          "mean_mse": 0.00034272877492910937,
+          "mean_rank": 171.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9510736911713136,
+          "mean_mse": 0.0002601520605440745,
+          "mean_rank": 100.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.96035243870194,
+          "mean_mse": 0.0002195205820592741,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9678623336167539,
+          "mean_mse": 0.0001785886991295829,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9598978627006576,
+          "mean_mse": 0.00022296424308693055,
+          "mean_rank": 49.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9514382695749218,
+          "mean_mse": 0.000263013661304535,
+          "mean_rank": 98.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9519045650538269,
+          "mean_mse": 0.00025511473669932624,
+          "mean_rank": 94.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9466531620487939,
+          "mean_mse": 0.00028669395953023074,
+          "mean_rank": 118.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9596469982438651,
+          "mean_mse": 0.00021982711885843814,
+          "mean_rank": 46.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9436583404984411,
+          "mean_mse": 0.0002992244478809676,
+          "mean_rank": 139.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9387827165266903,
+          "mean_mse": 0.00032410698715510007,
+          "mean_rank": 165.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414881578755849,
+          "mean_mse": 0.0003084473101643852,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9407613739443248,
+          "mean_mse": 0.00030979842734362004,
+          "mean_rank": 154.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9271763721384421,
+          "mean_mse": 0.0003752782142535644,
+          "mean_rank": 192.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9396802792230285,
+          "mean_mse": 0.00032381841383766175,
+          "mean_rank": 158.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9498162683524984,
+          "mean_mse": 0.0002688678404900788,
+          "mean_rank": 104.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9653408912891768,
+          "mean_mse": 0.00019304401779377453,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9554961783372153,
+          "mean_mse": 0.00024041313975078148,
+          "mean_rank": 70.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9504751880420792,
+          "mean_mse": 0.00026569629270720683,
+          "mean_rank": 104.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9582016950763734,
+          "mean_mse": 0.0002309313952394548,
+          "mean_rank": 55.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9425002419244629,
+          "mean_mse": 0.00030752787261754933,
+          "mean_rank": 146.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9621472880311768,
+          "mean_mse": 0.00020965952604246128,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.963657369832356,
+          "mean_mse": 0.00019935836912293747,
+          "mean_rank": 29.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559485147171707,
+          "mean_mse": 0.00024257115665238672,
+          "mean_rank": 64.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9385600714886805,
+          "mean_mse": 0.00032422666540931526,
+          "mean_rank": 163.75,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.952786232310189,
+          "mean_mse": 0.00026012983333058287,
+          "mean_rank": 88.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9295566912344265,
+          "mean_mse": 0.00036365766473598395,
+          "mean_rank": 180.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9604285244592278,
+          "mean_mse": 0.00022193046803866217,
+          "mean_rank": 41.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9591568759509902,
+          "mean_mse": 0.0002250035114321349,
+          "mean_rank": 50.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9517388771030766,
+          "mean_mse": 0.0002617944221802092,
+          "mean_rank": 96.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9610695311720188,
+          "mean_mse": 0.0002149911992842462,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9597969657637511,
+          "mean_mse": 0.00021949885717728845,
+          "mean_rank": 45.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9608050537941171,
+          "mean_mse": 0.00021654268928605316,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9513134646439226,
+          "mean_mse": 0.00025883182318413317,
+          "mean_rank": 100.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568882842052947,
+          "mean_mse": 0.0002386235467590253,
+          "mean_rank": 59.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9587580698955567,
+          "mean_mse": 0.00022321472966215167,
+          "mean_rank": 56.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9599666159360184,
+          "mean_mse": 0.00022008624413728852,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K4_r0.1",
+      "params": {
+        "K": 4,
+        "alpha_reg": 0.1,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.9530777070226594,
+      "std_cosine_to_target": 0.010940789933488647,
+      "mean_mse_to_target": 0.0002536692475327041,
+      "std_mse_to_target": 5.383938841707974e-05,
+      "mean_target_rank": 84.34653465346534,
+      "median_target_rank": 78.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.039600033341085444,
+      "train_time_ms": 7905.631770000014,
+      "inference_time_us": 72360.32765841586,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9605401577312978,
+          "mean_mse": 0.0002132932727043949,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9659978414842763,
+          "mean_mse": 0.00019646711309649273,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9635013701926799,
+          "mean_mse": 0.00019967433189877365,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9585204374134497,
+          "mean_mse": 0.00022630907419432842,
+          "mean_rank": 53.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9541015637357981,
+          "mean_mse": 0.0002487984891926599,
+          "mean_rank": 79.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9580044753508162,
+          "mean_mse": 0.00022454425182918698,
+          "mean_rank": 56.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9560263151788655,
+          "mean_mse": 0.0002376742836630693,
+          "mean_rank": 68.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9619321689241487,
+          "mean_mse": 0.00020799361610560277,
+          "mean_rank": 35.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9442064947461744,
+          "mean_mse": 0.0002944975681237907,
+          "mean_rank": 137.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9573806079000077,
+          "mean_mse": 0.00023182228779630053,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9525118519417377,
+          "mean_mse": 0.0002634775913988105,
+          "mean_rank": 89.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9546794952979836,
+          "mean_mse": 0.0002479707261749444,
+          "mean_rank": 75.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.953878380920906,
+          "mean_mse": 0.0002620503554908893,
+          "mean_rank": 81.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9347129992967403,
+          "mean_mse": 0.00034273104512910914,
+          "mean_rank": 171.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9510695079806526,
+          "mean_mse": 0.00026017398391940536,
+          "mean_rank": 100.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9603515960145527,
+          "mean_mse": 0.00021952894518858238,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9678532904265886,
+          "mean_mse": 0.00017864002168556563,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9598937245593958,
+          "mean_mse": 0.00022299026375252167,
+          "mean_rank": 49.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9514294664213209,
+          "mean_mse": 0.0002630574857895007,
+          "mean_rank": 98.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9519027194350842,
+          "mean_mse": 0.00025512516466923624,
+          "mean_rank": 94.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9466541036211411,
+          "mean_mse": 0.00028669145182811257,
+          "mean_rank": 118.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9596475826882489,
+          "mean_mse": 0.00021982670814384798,
+          "mean_rank": 46.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9436544119612718,
+          "mean_mse": 0.0002992463498282578,
+          "mean_rank": 139.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9387805467498913,
+          "mean_mse": 0.00032412494937431697,
+          "mean_rank": 166.0,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414883053558653,
+          "mean_mse": 0.0003084482724806767,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9407548706755892,
+          "mean_mse": 0.0003098323632320669,
+          "mean_rank": 154.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9271741384788893,
+          "mean_mse": 0.0003752924386467115,
+          "mean_rank": 192.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9396725942518699,
+          "mean_mse": 0.0003238571893781721,
+          "mean_rank": 158.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9498170860863124,
+          "mean_mse": 0.0002688661986129107,
+          "mean_rank": 104.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9653371351580892,
+          "mean_mse": 0.00019306708879878863,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9554941426318306,
+          "mean_mse": 0.00024042450563132388,
+          "mean_rank": 70.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9504665450701734,
+          "mean_mse": 0.00026574351975708793,
+          "mean_rank": 104.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9582007777194179,
+          "mean_mse": 0.0002309392155918342,
+          "mean_rank": 55.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9424948713246514,
+          "mean_mse": 0.0003075554175016451,
+          "mean_rank": 146.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.96214584936961,
+          "mean_mse": 0.00020967032585614574,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9636556235868522,
+          "mean_mse": 0.0001993702988266391,
+          "mean_rank": 29.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559485337365419,
+          "mean_mse": 0.00024257527236581255,
+          "mean_rank": 64.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9385594211898114,
+          "mean_mse": 0.00032423099961864,
+          "mean_rank": 163.75,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9527858773228494,
+          "mean_mse": 0.00026013572858088707,
+          "mean_rank": 88.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9295552941628294,
+          "mean_mse": 0.00036366553309155413,
+          "mean_rank": 180.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9604284350543962,
+          "mean_mse": 0.0002219325814684669,
+          "mean_rank": 41.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.959150935968881,
+          "mean_mse": 0.00022503879660657933,
+          "mean_rank": 50.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9517397312825661,
+          "mean_mse": 0.000261793339759155,
+          "mean_rank": 96.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9610711906783515,
+          "mean_mse": 0.00021498772212806804,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9597973338339251,
+          "mean_mse": 0.00021950054803190975,
+          "mean_rank": 45.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9608053951169673,
+          "mean_mse": 0.000216545195928681,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9513121036514696,
+          "mean_mse": 0.0002588420491381042,
+          "mean_rank": 100.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568883112103941,
+          "mean_mse": 0.00023862611280917005,
+          "mean_rank": 59.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9587536306837412,
+          "mean_mse": 0.0002232412519134328,
+          "mean_rank": 56.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.95996508755866,
+          "mean_mse": 0.00022009855035617058,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K8_r0.01",
+      "params": {
+        "K": 8,
+        "alpha_reg": 0.01,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.9530934262978288,
+      "std_cosine_to_target": 0.010952227750079617,
+      "mean_mse_to_target": 0.00025351057807425386,
+      "std_mse_to_target": 5.389228284536539e-05,
+      "mean_target_rank": 84.31683168316832,
+      "median_target_rank": 78.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.03980206877102817,
+      "train_time_ms": 12750.415931000021,
+      "inference_time_us": 113289.09025247517,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.960509200150881,
+          "mean_mse": 0.00021336519422263827,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9660333345134683,
+          "mean_mse": 0.00019621418551486264,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9634959168769133,
+          "mean_mse": 0.00019962626007389997,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9585520147120921,
+          "mean_mse": 0.00022606936756556595,
+          "mean_rank": 53.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9541640153546884,
+          "mean_mse": 0.0002483895349354141,
+          "mean_rank": 79.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9579964737210291,
+          "mean_mse": 0.00022450426888281498,
+          "mean_rank": 57.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9560134790060992,
+          "mean_mse": 0.00023764857681791865,
+          "mean_rank": 68.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9619105515102282,
+          "mean_mse": 0.00020801679520758635,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.9441735585700881,
+          "mean_mse": 0.0002945702148548968,
+          "mean_rank": 137.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9574201782141892,
+          "mean_mse": 0.00023155420390154487,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.952520484994309,
+          "mean_mse": 0.0002633593771434825,
+          "mean_rank": 90.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9547681962891776,
+          "mean_mse": 0.0002474553226620741,
+          "mean_rank": 74.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9539411419607537,
+          "mean_mse": 0.0002616195284384011,
+          "mean_rank": 80.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9347516347478516,
+          "mean_mse": 0.0003424702030004752,
+          "mean_rank": 170.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9510441564928773,
+          "mean_mse": 0.00026021808435832924,
+          "mean_rank": 100.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9603352319345319,
+          "mean_mse": 0.00021952948853555169,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9678772649562276,
+          "mean_mse": 0.00017843231866237566,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.95992469410859,
+          "mean_mse": 0.0002227359235335121,
+          "mean_rank": 49.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.951415376918411,
+          "mean_mse": 0.0002630598625298255,
+          "mean_rank": 98.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9519537312800667,
+          "mean_mse": 0.0002548243183025888,
+          "mean_rank": 94.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9466408807254452,
+          "mean_mse": 0.00028667402780624635,
+          "mean_rank": 119.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9595959619643031,
+          "mean_mse": 0.00022001033811951855,
+          "mean_rank": 46.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9436164951473273,
+          "mean_mse": 0.0002993808998850319,
+          "mean_rank": 139.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9387460583625997,
+          "mean_mse": 0.0003242310716381895,
+          "mean_rank": 166.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414720790853943,
+          "mean_mse": 0.0003084585861618124,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9406914482073322,
+          "mean_mse": 0.0003100819152636668,
+          "mean_rank": 154.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9271433273849305,
+          "mean_mse": 0.00037538454170969504,
+          "mean_rank": 192.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.939732598587247,
+          "mean_mse": 0.0003234696385532517,
+          "mean_rank": 158.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9498870328816563,
+          "mean_mse": 0.0002684516610869633,
+          "mean_rank": 104.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9654421210161044,
+          "mean_mse": 0.00019245724848162679,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.955570326537969,
+          "mean_mse": 0.00023996351507509506,
+          "mean_rank": 70.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9504585283587899,
+          "mean_mse": 0.0002657032751454839,
+          "mean_rank": 104.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9582476861943243,
+          "mean_mse": 0.00023061617611471927,
+          "mean_rank": 55.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9425160755380906,
+          "mean_mse": 0.000307355337116622,
+          "mean_rank": 146.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9622368536539946,
+          "mean_mse": 0.00020913429930130358,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9636559735942749,
+          "mean_mse": 0.00019930817068695877,
+          "mean_rank": 29.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559546865009878,
+          "mean_mse": 0.00024242872220531,
+          "mean_rank": 64.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9385167536564277,
+          "mean_mse": 0.00032436027611705586,
+          "mean_rank": 164.0,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9528748831905,
+          "mean_mse": 0.00025958295778395735,
+          "mean_rank": 87.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9295684171516331,
+          "mean_mse": 0.00036354592571495527,
+          "mean_rank": 180.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9604729127623868,
+          "mean_mse": 0.00022161858643333975,
+          "mean_rank": 40.75,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9591888888981932,
+          "mean_mse": 0.00022473860368104237,
+          "mean_rank": 51.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9517757201020188,
+          "mean_mse": 0.00026153069504489533,
+          "mean_rank": 96.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9610457837590511,
+          "mean_mse": 0.00021502510848616605,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9598412766808078,
+          "mean_mse": 0.00021922005197385415,
+          "mean_rank": 45.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9607941854085229,
+          "mean_mse": 0.0002165226645592592,
+          "mean_rank": 40.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9513481727059108,
+          "mean_mse": 0.0002585825573489399,
+          "mean_rank": 99.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568970151237428,
+          "mean_mse": 0.0002385061081598141,
+          "mean_rank": 59.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9587811299012465,
+          "mean_mse": 0.00022302863756189944,
+          "mean_rank": 56.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.959972820317178,
+          "mean_mse": 0.00021998946192554482,
+          "mean_rank": 42.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K8_r0.1",
+      "params": {
+        "K": 8,
+        "alpha_reg": 0.1,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.9530902665073776,
+      "std_cosine_to_target": 0.010952593342071664,
+      "mean_mse_to_target": 0.00025352963484893704,
+      "std_mse_to_target": 5.3893248432705445e-05,
+      "mean_target_rank": 84.33663366336634,
+      "median_target_rank": 78.5,
+      "recall_at_1": 0.009900990099009901,
+      "recall_at_5": 0.0297029702970297,
+      "recall_at_10": 0.06930693069306931,
+      "mrr": 0.039788432852299965,
+      "train_time_ms": 11205.267125000091,
+      "inference_time_us": 110041.59621287139,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9605052766176191,
+          "mean_mse": 0.00021338847640599623,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9660292871290016,
+          "mean_mse": 0.000196238564675791,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9634938915898754,
+          "mean_mse": 0.0001996414619241952,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.9585469436258712,
+          "mean_mse": 0.00022609953157103993,
+          "mean_rank": 53.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.9541617022310549,
+          "mean_mse": 0.000248406221450468,
+          "mean_rank": 79.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9579948406211687,
+          "mean_mse": 0.00022451560863324612,
+          "mean_rank": 57.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9560105392015281,
+          "mean_mse": 0.0002376665123596232,
+          "mean_rank": 68.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9619092241775888,
+          "mean_mse": 0.00020802847609390572,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.944172582106194,
+          "mean_mse": 0.0002945772714698915,
+          "mean_rank": 137.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9574202122150948,
+          "mean_mse": 0.0002315577451112595,
+          "mean_rank": 63.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9525161933360533,
+          "mean_mse": 0.0002633834810183383,
+          "mean_rank": 90.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9547622211959395,
+          "mean_mse": 0.00024748550819588146,
+          "mean_rank": 74.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9539309037572407,
+          "mean_mse": 0.00026167350499639374,
+          "mean_rank": 80.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.9347486605335883,
+          "mean_mse": 0.0003424851681389761,
+          "mean_rank": 170.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9510402565290001,
+          "mean_mse": 0.00026023969909368724,
+          "mean_rank": 100.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.96033445828505,
+          "mean_mse": 0.00021953758711473718,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.967868617319533,
+          "mean_mse": 0.0001784829297683203,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9599202884853537,
+          "mean_mse": 0.00022276394212955344,
+          "mean_rank": 49.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.951404692731269,
+          "mean_mse": 0.00026311283808783353,
+          "mean_rank": 98.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.951948458975177,
+          "mean_mse": 0.00025485168764524386,
+          "mean_rank": 94.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.9466412296349531,
+          "mean_mse": 0.0002866746542825205,
+          "mean_rank": 119.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9595967102010781,
+          "mean_mse": 0.0002200094701332964,
+          "mean_rank": 46.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.9436115638170982,
+          "mean_mse": 0.00029940733716735037,
+          "mean_rank": 139.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.9387440885705269,
+          "mean_mse": 0.0003242469190726039,
+          "mean_rank": 166.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.9414720162391241,
+          "mean_mse": 0.0003084609155651571,
+          "mean_rank": 157.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.9406853882825816,
+          "mean_mse": 0.00031011349741504914,
+          "mean_rank": 154.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.9271416325347381,
+          "mean_mse": 0.0003753956935928031,
+          "mean_rank": 192.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.9397232824355315,
+          "mean_mse": 0.0003235174735248668,
+          "mean_rank": 158.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.9498858665011064,
+          "mean_mse": 0.00026846018473050394,
+          "mean_rank": 104.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9654369803388535,
+          "mean_mse": 0.0001924877012978769,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.9555663868681771,
+          "mean_mse": 0.00023998525597182144,
+          "mean_rank": 70.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.9504512847947991,
+          "mean_mse": 0.00026574337042213376,
+          "mean_rank": 104.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.9582459418738623,
+          "mean_mse": 0.00023062871283706086,
+          "mean_rank": 55.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.9425106361703262,
+          "mean_mse": 0.0003073842471153413,
+          "mean_rank": 146.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9622346417281701,
+          "mean_mse": 0.0002091497412615739,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9636545042485933,
+          "mean_mse": 0.00019931872148754422,
+          "mean_rank": 29.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9559545533725137,
+          "mean_mse": 0.00024243407678641813,
+          "mean_rank": 64.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.938515023384949,
+          "mean_mse": 0.00032437001900585157,
+          "mean_rank": 164.0,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.9528727383326775,
+          "mean_mse": 0.0002595980485424073,
+          "mean_rank": 87.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.9295644275339492,
+          "mean_mse": 0.0003635659820557757,
+          "mean_rank": 180.25,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9604718142466544,
+          "mean_mse": 0.0002216272573472652,
+          "mean_rank": 41.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9591818652340977,
+          "mean_mse": 0.00022478020947718936,
+          "mean_rank": 51.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.951775077525325,
+          "mean_mse": 0.00026153728118083556,
+          "mean_rank": 96.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9610471480180081,
+          "mean_mse": 0.0002150236171818751,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.959839823027338,
+          "mean_mse": 0.00021923064755289135,
+          "mean_rank": 45.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9607934642760434,
+          "mean_mse": 0.00021653017464120323,
+          "mean_rank": 40.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.9513458672561762,
+          "mean_mse": 0.00025859783583869405,
+          "mean_rank": 99.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9568962029883691,
+          "mean_mse": 0.00023851288033002572,
+          "mean_rank": 59.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9587772599232958,
+          "mean_mse": 0.0002230525217309745,
+          "mean_rank": 56.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9599714779405062,
+          "mean_mse": 0.00022000028653581353,
+          "mean_rank": 42.25,
+          "num_queries": 4
+        }
+      }
+    }
+  ]
+}

--- a/reports/answer_level_modernbert.json
+++ b/reports/answer_level_modernbert.json
@@ -1,0 +1,3936 @@
+{
+  "embedder": {
+    "embedder": "modernbert",
+    "model_name": "nomic-ai/nomic-embed-text-v1.5",
+    "model_id": "nomic-ai/nomic-embed-text-v1.5",
+    "dimension": 768,
+    "description": "ModernBERT with 8192 token context (768 dim)"
+  },
+  "metric_legend": {
+    "cosine_to_target": {
+      "description": "Cosine similarity between projected query and target answer",
+      "good_value": "Higher is better (1.0 = perfect alignment)",
+      "range": "[-1.0, 1.0]"
+    },
+    "mse_to_target": {
+      "description": "Mean Squared Error between projected query and target answer",
+      "good_value": "Lower is better (0.0 = identical vectors)",
+      "range": "[0.0, inf)"
+    },
+    "target_rank": {
+      "description": "Position of correct answer when sorted by similarity (1-indexed)",
+      "good_value": "Lower is better (1 = correct answer is top result)",
+      "range": "[1, num_answers]"
+    },
+    "mrr": {
+      "description": "Mean Reciprocal Rank = average of 1/rank across all queries",
+      "good_value": "Higher is better (1.0 = always rank 1)",
+      "range": "(0.0, 1.0]"
+    },
+    "recall_at_k": {
+      "description": "Fraction of queries where correct answer is in top k results",
+      "good_value": "Higher is better (1.0 = always in top k)",
+      "range": "[0.0, 1.0]"
+    }
+  },
+  "winners": {
+    "highest_cosine": "Residual_K8_r0.01",
+    "lowest_mse": "Basis_K16",
+    "lowest_rank": "Residual_K8_r0.01",
+    "highest_mrr": "Basis_K4",
+    "highest_recall_at_5": "Basis_K4"
+  },
+  "results": [
+    {
+      "method": "MultiHeadLDA",
+      "params": {
+        "type": "baseline"
+      },
+      "mean_cosine_to_target": 0.8858033014543343,
+      "std_cosine_to_target": 0.034451309876868896,
+      "mean_mse_to_target": 0.09724387161699945,
+      "std_mse_to_target": 0.027799405077881367,
+      "mean_target_rank": 20.42079207920792,
+      "median_target_rank": 9.0,
+      "recall_at_1": 0.04455445544554455,
+      "recall_at_5": 0.3564356435643564,
+      "recall_at_10": 0.5247524752475248,
+      "mrr": 0.19369331519482247,
+      "train_time_ms": 1.5189000000646047,
+      "inference_time_us": 404.86138613849306,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9126679445757608,
+          "mean_mse": 0.07130693377337648,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9102076557003489,
+          "mean_mse": 0.07584407458271988,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.894139590255815,
+          "mean_mse": 0.08849966905780379,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.865587700137156,
+          "mean_mse": 0.11342057261826025,
+          "mean_rank": 40.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8562947538167467,
+          "mean_mse": 0.12108998536570673,
+          "mean_rank": 48.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9036445884302347,
+          "mean_mse": 0.08252448405492319,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.896391222896386,
+          "mean_mse": 0.0831346176260003,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9124192111507872,
+          "mean_mse": 0.07591522051710772,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8692695935226391,
+          "mean_mse": 0.11965624576755077,
+          "mean_rank": 19.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8782313583375705,
+          "mean_mse": 0.10380143263222516,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8876459952787307,
+          "mean_mse": 0.09746811113725969,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.899967247932211,
+          "mean_mse": 0.09086507555450689,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9070271857565272,
+          "mean_mse": 0.07816911844341387,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.82153992708534,
+          "mean_mse": 0.1616123270372401,
+          "mean_rank": 71.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8812855746141913,
+          "mean_mse": 0.10428099889291652,
+          "mean_rank": 19.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.896412491290001,
+          "mean_mse": 0.08417940028843662,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.941178622747015,
+          "mean_mse": 0.05738664990438784,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9052657408700808,
+          "mean_mse": 0.07430599263263414,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9197583489236357,
+          "mean_mse": 0.07101245600504862,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8881654844415914,
+          "mean_mse": 0.0937586534321633,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8728193577713805,
+          "mean_mse": 0.1094042746838111,
+          "mean_rank": 36.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9066954061451067,
+          "mean_mse": 0.08000679548754701,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8717480553800115,
+          "mean_mse": 0.1087410149013047,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8637470663636584,
+          "mean_mse": 0.10766322932080676,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.842053578743731,
+          "mean_mse": 0.12494968076366073,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8742610752029596,
+          "mean_mse": 0.09636534341682645,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8384884917497014,
+          "mean_mse": 0.12897814702162558,
+          "mean_rank": 47.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8718748276779898,
+          "mean_mse": 0.10653418059299123,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8433230702992178,
+          "mean_mse": 0.1318609263397141,
+          "mean_rank": 58.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.911502135256987,
+          "mean_mse": 0.07426002214456201,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8712897936763208,
+          "mean_mse": 0.10541316519748294,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8668099096864822,
+          "mean_mse": 0.10960916087487226,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.876573563509491,
+          "mean_mse": 0.10253434660860768,
+          "mean_rank": 31.0,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8592819565991694,
+          "mean_mse": 0.12021353341158392,
+          "mean_rank": 38.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8979467306770017,
+          "mean_mse": 0.08578899808167928,
+          "mean_rank": 19.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9106113610917766,
+          "mean_mse": 0.08366064596926585,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9184934891140565,
+          "mean_mse": 0.07489472866090163,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.8959865985602061,
+          "mean_mse": 0.09191638026842704,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.859816713760509,
+          "mean_mse": 0.11674278801152689,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8540725692980802,
+          "mean_mse": 0.12076346490772558,
+          "mean_rank": 38.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.901087485842635,
+          "mean_mse": 0.08314156582632015,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.8917688843871118,
+          "mean_mse": 0.09360725550732761,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.8930256634378364,
+          "mean_mse": 0.09333844982229672,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9181992292910072,
+          "mean_mse": 0.06959884911196577,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9121966753489799,
+          "mean_mse": 0.08496724881209057,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8878672654137422,
+          "mean_mse": 0.09758360138897607,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.861731155957016,
+          "mean_mse": 0.11611825977271878,
+          "mean_rank": 35.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9094599245186991,
+          "mean_mse": 0.08540671449678591,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9025466467176809,
+          "mean_mse": 0.08677903870500647,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8779854240505796,
+          "mean_mse": 0.10142454402518111,
+          "mean_rank": 27.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.3",
+      "params": {
+        "cutoff": 0.3,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.8886239592388469,
+      "std_cosine_to_target": 0.03323759646351626,
+      "mean_mse_to_target": 0.11480488716771971,
+      "std_mse_to_target": 0.029269493145945125,
+      "mean_target_rank": 18.292079207920793,
+      "median_target_rank": 9.0,
+      "recall_at_1": 0.06930693069306931,
+      "recall_at_5": 0.3811881188118812,
+      "recall_at_10": 0.5495049504950495,
+      "mrr": 0.2191401203120762,
+      "train_time_ms": 3713.5635629999797,
+      "inference_time_us": 17048.523579207973,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9145710921317297,
+          "mean_mse": 0.08667811842962743,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9111328182524456,
+          "mean_mse": 0.09626521093475249,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8941837924530636,
+          "mean_mse": 0.10206099786538585,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8649655979921065,
+          "mean_mse": 0.13402352199738457,
+          "mean_rank": 42.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8564166434616121,
+          "mean_mse": 0.1425847518535338,
+          "mean_rank": 47.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9070095070349288,
+          "mean_mse": 0.09314677379248795,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9012822815226189,
+          "mean_mse": 0.09814264666419369,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9132464301696755,
+          "mean_mse": 0.0981208957403687,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8708628147941901,
+          "mean_mse": 0.13455679439819138,
+          "mean_rank": 14.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8780149514540753,
+          "mean_mse": 0.12172677407904106,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8877851653437746,
+          "mean_mse": 0.12212760028154787,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8981102980625054,
+          "mean_mse": 0.11076826656903145,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9053686046681273,
+          "mean_mse": 0.10951737510201051,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8248215290130144,
+          "mean_mse": 0.17963979661432583,
+          "mean_rank": 64.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.87907638166696,
+          "mean_mse": 0.12090656909575904,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8990386724316751,
+          "mean_mse": 0.09359102446161734,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9376476310890465,
+          "mean_mse": 0.07106379288834273,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9026323631026142,
+          "mean_mse": 0.09098508440979157,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9186609109082309,
+          "mean_mse": 0.08962099573959395,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8865105567573295,
+          "mean_mse": 0.11164626279942577,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.886931735522867,
+          "mean_mse": 0.11712521743269501,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9099006931400831,
+          "mean_mse": 0.08994084838344538,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8747318028860727,
+          "mean_mse": 0.126921971573696,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8703042159932955,
+          "mean_mse": 0.12357851282281201,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8609141507414595,
+          "mean_mse": 0.13567013547642406,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8738042753937462,
+          "mean_mse": 0.11118799202262757,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8502138679909821,
+          "mean_mse": 0.1445144967535433,
+          "mean_rank": 34.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8793269953146137,
+          "mean_mse": 0.13344160701216515,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8455673682927618,
+          "mean_mse": 0.15044510600977007,
+          "mean_rank": 52.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9149675141363376,
+          "mean_mse": 0.09059858880134375,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8784448363786377,
+          "mean_mse": 0.12017019987134299,
+          "mean_rank": 22.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8677683009937939,
+          "mean_mse": 0.13155188470589546,
+          "mean_rank": 34.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8794883627660066,
+          "mean_mse": 0.12434139748940103,
+          "mean_rank": 29.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8634586069648866,
+          "mean_mse": 0.1453349532732262,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9014223184388971,
+          "mean_mse": 0.09979455952838204,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9108586280533973,
+          "mean_mse": 0.10228605152415347,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9269368339583228,
+          "mean_mse": 0.08379048174012542,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9033515879897568,
+          "mean_mse": 0.10637143769117424,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8615586410426116,
+          "mean_mse": 0.14243305184864993,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8571333917454477,
+          "mean_mse": 0.13018048749618585,
+          "mean_rank": 38.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9020387656654031,
+          "mean_mse": 0.10546649214788245,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.889655066784676,
+          "mean_mse": 0.12150395595787328,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9061796490966563,
+          "mean_mse": 0.10739021416763606,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9207075849461318,
+          "mean_mse": 0.08481872627998512,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9155203870497951,
+          "mean_mse": 0.10434102223422938,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.889992702045845,
+          "mean_mse": 0.11510604961873996,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8601830017645065,
+          "mean_mse": 0.13530494869073445,
+          "mean_rank": 37.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9179981863328681,
+          "mean_mse": 0.1027634848917294,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9014923141182364,
+          "mean_mse": 0.10535750440026541,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8793990277521453,
+          "mean_mse": 0.12019302065416863,
+          "mean_rank": 27.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.5",
+      "params": {
+        "cutoff": 0.5,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.8961462544531952,
+      "std_cosine_to_target": 0.032180898664562016,
+      "mean_mse_to_target": 0.10750328873633706,
+      "std_mse_to_target": 0.028429226678366212,
+      "mean_target_rank": 14.341584158415841,
+      "median_target_rank": 6.5,
+      "recall_at_1": 0.09405940594059406,
+      "recall_at_5": 0.4405940594059406,
+      "recall_at_10": 0.6683168316831684,
+      "mrr": 0.2623252105197235,
+      "train_time_ms": 3587.873681000019,
+      "inference_time_us": 27752.85467821741,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9174497307403036,
+          "mean_mse": 0.08221754653829104,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9146838910040616,
+          "mean_mse": 0.09189245911051935,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8979094281211099,
+          "mean_mse": 0.09760178225401646,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8735543862524963,
+          "mean_mse": 0.12622158236721162,
+          "mean_rank": 33.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8637754472299872,
+          "mean_mse": 0.1353540377147467,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9092582959862517,
+          "mean_mse": 0.0899494746973806,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.904694015857036,
+          "mean_mse": 0.09264382171435893,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9163920935281162,
+          "mean_mse": 0.09296916526927554,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8790016458757535,
+          "mean_mse": 0.12614789212856486,
+          "mean_rank": 10.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.885425338080127,
+          "mean_mse": 0.11504775333367595,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8983021082500536,
+          "mean_mse": 0.11269688854398754,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9098621629336526,
+          "mean_mse": 0.1005363518336363,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.922464115959279,
+          "mean_mse": 0.09077324627886958,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8371063164151813,
+          "mean_mse": 0.1694248353415763,
+          "mean_rank": 43.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8878165481709799,
+          "mean_mse": 0.11339004598526616,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9022102431280992,
+          "mean_mse": 0.09005718745805058,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9440894433708795,
+          "mean_mse": 0.06536513274478685,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9126744505906009,
+          "mean_mse": 0.08154422716814543,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9315351680650741,
+          "mean_mse": 0.07792905415130456,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.898497338322364,
+          "mean_mse": 0.10208223535710634,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8884544948234755,
+          "mean_mse": 0.11525552030403358,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9153128404322857,
+          "mean_mse": 0.08480924312715958,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8852693949295155,
+          "mean_mse": 0.11596350041494537,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8888395853736845,
+          "mean_mse": 0.11051459944255541,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8669894031220504,
+          "mean_mse": 0.12925975249991903,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8914772108614873,
+          "mean_mse": 0.09954559956883591,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8585060991026549,
+          "mean_mse": 0.13621954456307467,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8965891744290783,
+          "mean_mse": 0.11872885020187453,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8545834514577608,
+          "mean_mse": 0.14179624228932153,
+          "mean_rank": 43.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9194395388091137,
+          "mean_mse": 0.08577645065317353,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8831867505051657,
+          "mean_mse": 0.1166200424698822,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8785574073454635,
+          "mean_mse": 0.12230623273405972,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8851152723082981,
+          "mean_mse": 0.11864124726115452,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8740237116030294,
+          "mean_mse": 0.13525685696928882,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9046193878445852,
+          "mean_mse": 0.09638111929835588,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9163749667137814,
+          "mean_mse": 0.09529604206699806,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9284660575354579,
+          "mean_mse": 0.08191860215986149,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9097292617862056,
+          "mean_mse": 0.09997822623457231,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8746633501220678,
+          "mean_mse": 0.13035542710286097,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8671470447519896,
+          "mean_mse": 0.12283291788761483,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9084535805425566,
+          "mean_mse": 0.09915146071251049,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9012702700708333,
+          "mean_mse": 0.10913666834380444,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9075880354490924,
+          "mean_mse": 0.10488794867597409,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9245159717878245,
+          "mean_mse": 0.07968569918534864,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9180175441142221,
+          "mean_mse": 0.10040430706380267,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8933233224149058,
+          "mean_mse": 0.1105501998650297,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8687347465052817,
+          "mean_mse": 0.12764681103903155,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9189288122629483,
+          "mean_mse": 0.09967364995146454,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9052193106693358,
+          "mean_mse": 0.09984527196109419,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8862606937580654,
+          "mean_mse": 0.11274014527911322,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "FFT_c0.7",
+      "params": {
+        "cutoff": 0.7,
+        "blend": 0.6
+      },
+      "mean_cosine_to_target": 0.8963710614610303,
+      "std_cosine_to_target": 0.03218565119492634,
+      "mean_mse_to_target": 0.10735242348979275,
+      "std_mse_to_target": 0.028408396476578234,
+      "mean_target_rank": 14.272277227722773,
+      "median_target_rank": 6.5,
+      "recall_at_1": 0.09405940594059406,
+      "recall_at_5": 0.44554455445544555,
+      "recall_at_10": 0.6732673267326733,
+      "mrr": 0.2634928293431735,
+      "train_time_ms": 3847.1543760000486,
+      "inference_time_us": 24383.368608910965,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9168559351929034,
+          "mean_mse": 0.08298180711490259,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9151088572777901,
+          "mean_mse": 0.0916984589788794,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8980512419399195,
+          "mean_mse": 0.09761893401084351,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8741389680556148,
+          "mean_mse": 0.12596528749628805,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8631105891787019,
+          "mean_mse": 0.13638217369702033,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9091091475166032,
+          "mean_mse": 0.09020500069328154,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9047845993692061,
+          "mean_mse": 0.09248727743026479,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9161636609393587,
+          "mean_mse": 0.09323101396396519,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8789552303070278,
+          "mean_mse": 0.12634190722305064,
+          "mean_rank": 11.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8857243770943737,
+          "mean_mse": 0.11470528050117317,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8979533738042844,
+          "mean_mse": 0.1132826537328523,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9108934148113268,
+          "mean_mse": 0.09929332318756781,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9232522539435714,
+          "mean_mse": 0.09042962636552732,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8370878160094284,
+          "mean_mse": 0.16909086775654608,
+          "mean_rank": 43.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8877367420189667,
+          "mean_mse": 0.113322907480262,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.902284359854484,
+          "mean_mse": 0.09001333388089376,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9449242128288664,
+          "mean_mse": 0.06444027945110994,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.913430779885866,
+          "mean_mse": 0.08133997360867827,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9318015130006909,
+          "mean_mse": 0.07782873036778941,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8978081696621263,
+          "mean_mse": 0.1018443431966718,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.88809866041454,
+          "mean_mse": 0.11559227491336566,
+          "mean_rank": 27.0,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.914682405010715,
+          "mean_mse": 0.08540663375907818,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8859075329299959,
+          "mean_mse": 0.11578766351628529,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8889158112518805,
+          "mean_mse": 0.11010163026155656,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8671887968964828,
+          "mean_mse": 0.12933396860191992,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8933616027071349,
+          "mean_mse": 0.09817134646874864,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.859443310016295,
+          "mean_mse": 0.13575006732330153,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.895993643192243,
+          "mean_mse": 0.11869682700472242,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8559051034577774,
+          "mean_mse": 0.14093494882405552,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9191619342725658,
+          "mean_mse": 0.08626831074533768,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8834296715686769,
+          "mean_mse": 0.11630597553008933,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8781258206276219,
+          "mean_mse": 0.12277949352250345,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8854667154881635,
+          "mean_mse": 0.11834991685170708,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8740589006749149,
+          "mean_mse": 0.1352296649577397,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9054894477537825,
+          "mean_mse": 0.09545763710551042,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9161836150589308,
+          "mean_mse": 0.09595799879853842,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9285042288333026,
+          "mean_mse": 0.08163186765459961,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9106979649895877,
+          "mean_mse": 0.09964996981478115,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8751775581957848,
+          "mean_mse": 0.12940285334291213,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8670012123381525,
+          "mean_mse": 0.12300970905938799,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9090953383320584,
+          "mean_mse": 0.09845127296389587,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9016776407750147,
+          "mean_mse": 0.10857542307305104,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9077490237395487,
+          "mean_mse": 0.10486941088972275,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9243526431276472,
+          "mean_mse": 0.07966611950829411,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9184184191224282,
+          "mean_mse": 0.10017639885463306,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.893572666089997,
+          "mean_mse": 0.11034786681684153,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8695358786917557,
+          "mean_mse": 0.12728971102496034,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.918928315755118,
+          "mean_mse": 0.09977991231438901,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9057489081589856,
+          "mean_mse": 0.09954795736600791,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8866798300407078,
+          "mean_mse": 0.11241318148413065,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveFFT",
+      "params": {
+        "min_cutoff": 0.2,
+        "max_cutoff": 0.7
+      },
+      "mean_cosine_to_target": 0.8935353920616549,
+      "std_cosine_to_target": 0.03250033181775946,
+      "mean_mse_to_target": 0.11059730161761867,
+      "std_mse_to_target": 0.028686690062948172,
+      "mean_target_rank": 15.747524752475247,
+      "median_target_rank": 7.5,
+      "recall_at_1": 0.07920792079207921,
+      "recall_at_5": 0.4207920792079208,
+      "recall_at_10": 0.6188118811881188,
+      "mrr": 0.24573795458781666,
+      "train_time_ms": 8560.368649999986,
+      "inference_time_us": 21192.702297030177,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9159783532701411,
+          "mean_mse": 0.08487433564806299,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9129712371223802,
+          "mean_mse": 0.09431023972635236,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8951914417494643,
+          "mean_mse": 0.10088753273669475,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8699395031525918,
+          "mean_mse": 0.12993298376456386,
+          "mean_rank": 37.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8612717829013535,
+          "mean_mse": 0.138807531436309,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9074287246174239,
+          "mean_mse": 0.09229418497524337,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9026675206960876,
+          "mean_mse": 0.09574472799034989,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.91434778775863,
+          "mean_mse": 0.09637951218358631,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8740349958079857,
+          "mean_mse": 0.13113990933817743,
+          "mean_rank": 13.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8829407966387152,
+          "mean_mse": 0.11804993487367464,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8959366284414484,
+          "mean_mse": 0.11546023004927777,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9041171238790079,
+          "mean_mse": 0.1058390871706828,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9221052538464161,
+          "mean_mse": 0.09235529622086061,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8309235276223464,
+          "mean_mse": 0.17486947892268173,
+          "mean_rank": 54.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8828990231568132,
+          "mean_mse": 0.11800263204971081,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9000967684686453,
+          "mean_mse": 0.09256400482815486,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9418109665790083,
+          "mean_mse": 0.06827582356620444,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9086370362949232,
+          "mean_mse": 0.08573230585394902,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9295184087042925,
+          "mean_mse": 0.08049456050495646,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8953972028426598,
+          "mean_mse": 0.10509403317657735,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8867597425666032,
+          "mean_mse": 0.11763163728343119,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9122865049273394,
+          "mean_mse": 0.08797323065119664,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8840489951044738,
+          "mean_mse": 0.11811799436940437,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8867647555937151,
+          "mean_mse": 0.11232711813154299,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8662494723960259,
+          "mean_mse": 0.13073286314136837,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8906720539861837,
+          "mean_mse": 0.100398063223077,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8560311573764111,
+          "mean_mse": 0.1393166162060535,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8952625521428033,
+          "mean_mse": 0.12013748749256913,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8514164308529872,
+          "mean_mse": 0.14539312841639113,
+          "mean_rank": 46.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9165575692687238,
+          "mean_mse": 0.08908056578069254,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8811837925945973,
+          "mean_mse": 0.11868363095926715,
+          "mean_rank": 19.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8743940413839173,
+          "mean_mse": 0.12638271020365177,
+          "mean_rank": 29.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8826903157051526,
+          "mean_mse": 0.12150835005122393,
+          "mean_rank": 27.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8710941546659665,
+          "mean_mse": 0.13867156714973414,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.902938578193165,
+          "mean_mse": 0.0986739281450711,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9128833942880438,
+          "mean_mse": 0.09989083314444623,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9273153842404341,
+          "mean_mse": 0.08351134611221189,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9077051586056848,
+          "mean_mse": 0.10231342986945281,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8715822964361919,
+          "mean_mse": 0.13382539590957762,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8638202407365185,
+          "mean_mse": 0.12579824669241635,
+          "mean_rank": 37.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9047455911900519,
+          "mean_mse": 0.10293332720409096,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.897855789991844,
+          "mean_mse": 0.11351827097179532,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9056261233726798,
+          "mean_mse": 0.10768203790550303,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9219959653624198,
+          "mean_mse": 0.08309292498282297,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9166467206750963,
+          "mean_mse": 0.10316031246998171,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8918012859482909,
+          "mean_mse": 0.11303772621689703,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8645435197452516,
+          "mean_mse": 0.13198050864979632,
+          "mean_rank": 32.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9181679579528232,
+          "mean_mse": 0.10179622678233077,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9029209532130023,
+          "mean_mse": 0.10341518206667319,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8831230861892594,
+          "mean_mse": 0.11656837942578668,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K4",
+      "params": {
+        "K": 4,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.8854651935813108,
+      "std_cosine_to_target": 0.03372256613681515,
+      "mean_mse_to_target": 0.09710809277072983,
+      "std_mse_to_target": 0.027344650282815856,
+      "mean_target_rank": 14.638613861386139,
+      "median_target_rank": 6.0,
+      "recall_at_1": 0.12871287128712872,
+      "recall_at_5": 0.4801980198019802,
+      "recall_at_10": 0.6683168316831684,
+      "mrr": 0.2827225177846988,
+      "train_time_ms": 59761.697335000004,
+      "inference_time_us": 287134.2693217825,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9097205852321721,
+          "mean_mse": 0.07365437107482123,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8984668939989793,
+          "mean_mse": 0.0840855809058284,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.892082216636391,
+          "mean_mse": 0.0894697738161144,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8627736688891743,
+          "mean_mse": 0.11504930252034452,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8368048682042476,
+          "mean_mse": 0.1357629329217252,
+          "mean_rank": 60.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8948791738890258,
+          "mean_mse": 0.08904275471717943,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8921920747447214,
+          "mean_mse": 0.08512649310601729,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9157648111747537,
+          "mean_mse": 0.07161587346931148,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8720875749847998,
+          "mean_mse": 0.11655178382040539,
+          "mean_rank": 10.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8661728475084636,
+          "mean_mse": 0.11302818953304786,
+          "mean_rank": 24.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.874107141191798,
+          "mean_mse": 0.10643621620659464,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9176290279884746,
+          "mean_mse": 0.07492836925757153,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8956966479470438,
+          "mean_mse": 0.08768603992780773,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8232810561134046,
+          "mean_mse": 0.16034304128544066,
+          "mean_rank": 54.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8725244085959074,
+          "mean_mse": 0.11037247945730104,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9030017470362879,
+          "mean_mse": 0.07922165584082994,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9191315646113589,
+          "mean_mse": 0.07253743482929793,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.894920519319848,
+          "mean_mse": 0.08175340018705105,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9153891467584655,
+          "mean_mse": 0.0743585724112141,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9014824962354047,
+          "mean_mse": 0.0822368173436134,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8868855013575523,
+          "mean_mse": 0.10058816506661807,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9117975309013537,
+          "mean_mse": 0.07641756095237848,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8965928203811806,
+          "mean_mse": 0.08877994848442425,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.836305666861376,
+          "mean_mse": 0.12782268817298853,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8191736556272421,
+          "mean_mse": 0.14143114983376612,
+          "mean_rank": 41.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8856808542859484,
+          "mean_mse": 0.08836559227513521,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8155536679814489,
+          "mean_mse": 0.14585049219956733,
+          "mean_rank": 62.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8741597594282668,
+          "mean_mse": 0.10480662117198768,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.851273399569551,
+          "mean_mse": 0.12741670346192532,
+          "mean_rank": 35.25,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.8945745574283273,
+          "mean_mse": 0.08616209104684722,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8452262026342561,
+          "mean_mse": 0.12507125639069566,
+          "mean_rank": 44.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8653822599726764,
+          "mean_mse": 0.11047467751297317,
+          "mean_rank": 24.25,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8784528660127645,
+          "mean_mse": 0.10137944564157482,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.885784251685158,
+          "mean_mse": 0.0995547521793044,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8917484590219893,
+          "mean_mse": 0.0898146618979628,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9048632981422311,
+          "mean_mse": 0.08555744785532099,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9140716671802923,
+          "mean_mse": 0.08105008929422611,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.8945842533652701,
+          "mean_mse": 0.0944581977266296,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.868360322890724,
+          "mean_mse": 0.1105693506777859,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8840989507830106,
+          "mean_mse": 0.10074169757345201,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.8990348190281789,
+          "mean_mse": 0.08430611743253774,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.8945633286635459,
+          "mean_mse": 0.09132275262121309,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9054891739274215,
+          "mean_mse": 0.08246532388872996,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9241965476667278,
+          "mean_mse": 0.06408703566394464,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.912704838376944,
+          "mean_mse": 0.08302156035092365,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.9034768356915988,
+          "mean_mse": 0.08339551181768075,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8709070370644861,
+          "mean_mse": 0.10887147861762696,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9190908746670567,
+          "mean_mse": 0.07715896555477052,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.899055547146385,
+          "mean_mse": 0.08738164211868206,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.9009526992779568,
+          "mean_mse": 0.08315091853220496,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K8",
+      "params": {
+        "K": 8,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.8831361797839463,
+      "std_cosine_to_target": 0.03521349433336573,
+      "mean_mse_to_target": 0.1004554244007498,
+      "std_mse_to_target": 0.029344567610042546,
+      "mean_target_rank": 18.559405940594058,
+      "median_target_rank": 9.0,
+      "recall_at_1": 0.07425742574257425,
+      "recall_at_5": 0.35148514851485146,
+      "recall_at_10": 0.5594059405940595,
+      "mrr": 0.21529035894353693,
+      "train_time_ms": 85913.62128099991,
+      "inference_time_us": 505483.0519950496,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9020294570748025,
+          "mean_mse": 0.07950362406986058,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9106737902405628,
+          "mean_mse": 0.07615106833334877,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8913143927645936,
+          "mean_mse": 0.0904282905391238,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8652485969814387,
+          "mean_mse": 0.115063136432066,
+          "mean_rank": 38.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8489865002333947,
+          "mean_mse": 0.1283258142309333,
+          "mean_rank": 51.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.908618908560969,
+          "mean_mse": 0.07797231941896532,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8892196443723732,
+          "mean_mse": 0.08893732896921189,
+          "mean_rank": 19.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9038521274193932,
+          "mean_mse": 0.08278961192700418,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8548808691903755,
+          "mean_mse": 0.13341204659665767,
+          "mean_rank": 26.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8741745699440331,
+          "mean_mse": 0.10760927466891086,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8892734634669033,
+          "mean_mse": 0.09838549667011261,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8988364652030598,
+          "mean_mse": 0.09475777712277736,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9066338345651193,
+          "mean_mse": 0.08406825798749189,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8209175254068107,
+          "mean_mse": 0.1653800156115366,
+          "mean_rank": 67.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8811157483179454,
+          "mean_mse": 0.1051961463811032,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977409782021585,
+          "mean_mse": 0.08302080621400983,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9384217872991443,
+          "mean_mse": 0.05787571606846627,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9098832869757717,
+          "mean_mse": 0.07034498996626389,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9043391479936161,
+          "mean_mse": 0.08607523085496545,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8862567496041677,
+          "mean_mse": 0.09529726578990629,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8709996275124212,
+          "mean_mse": 0.11168967405387242,
+          "mean_rank": 37.25,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.911803702739594,
+          "mean_mse": 0.07613148898293315,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8818415965520183,
+          "mean_mse": 0.1031567600278962,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8552902057356292,
+          "mean_mse": 0.11522505822252731,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8327299533572663,
+          "mean_mse": 0.13387270031152776,
+          "mean_rank": 41.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8835398724078408,
+          "mean_mse": 0.09030680187598376,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8230259708698995,
+          "mean_mse": 0.14088809301998717,
+          "mean_rank": 55.0,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8637114497696173,
+          "mean_mse": 0.11473714938083708,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8491268193848341,
+          "mean_mse": 0.12917743476035562,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9200928097698847,
+          "mean_mse": 0.06820749322061993,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8787940273815764,
+          "mean_mse": 0.10174510915660813,
+          "mean_rank": 19.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8608803339659468,
+          "mean_mse": 0.11553318295475375,
+          "mean_rank": 36.0,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8866052552376756,
+          "mean_mse": 0.0973281123513719,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8653070690359682,
+          "mean_mse": 0.1180122079671281,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.8977106824223027,
+          "mean_mse": 0.08630802816181822,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9123914947444781,
+          "mean_mse": 0.08055744808236237,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9101861968942414,
+          "mean_mse": 0.08350550447788167,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.8536290348773473,
+          "mean_mse": 0.12949972531993806,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8680150146230247,
+          "mean_mse": 0.1105477405411981,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8331943678174156,
+          "mean_mse": 0.1394454858711421,
+          "mean_rank": 32.5,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.8945447446050114,
+          "mean_mse": 0.09116334079579975,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.8941712623613094,
+          "mean_mse": 0.09499539699047228,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.8894964598305689,
+          "mean_mse": 0.09700792285789643,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9208075578623005,
+          "mean_mse": 0.06794481700038893,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9155272564059251,
+          "mean_mse": 0.08309182761007015,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8885162522317185,
+          "mean_mse": 0.09626201920687417,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8535941438512644,
+          "mean_mse": 0.12233774892249669,
+          "mean_rank": 42.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9169546218341451,
+          "mean_mse": 0.07942084184572011,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8849426776276778,
+          "mean_mse": 0.09955592411646917,
+          "mean_rank": 21.25,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8795791749144527,
+          "mean_mse": 0.10005166074616963,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Basis_K16",
+      "params": {
+        "K": 16,
+        "iterations": 50
+      },
+      "mean_cosine_to_target": 0.8915901827797708,
+      "std_cosine_to_target": 0.032716630064920815,
+      "mean_mse_to_target": 0.09666899054724122,
+      "std_mse_to_target": 0.027539130748039896,
+      "mean_target_rank": 15.351485148514852,
+      "median_target_rank": 7.0,
+      "recall_at_1": 0.08415841584158416,
+      "recall_at_5": 0.4603960396039604,
+      "recall_at_10": 0.6188118811881188,
+      "mrr": 0.25627486311953124,
+      "train_time_ms": 129700.44888799998,
+      "inference_time_us": 824974.9750247527,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9129380091062587,
+          "mean_mse": 0.0745362094674603,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9131698556324948,
+          "mean_mse": 0.07805401917800356,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8951485353829364,
+          "mean_mse": 0.08885051394263548,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8764672404461274,
+          "mean_mse": 0.10869638390555184,
+          "mean_rank": 27.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8657969517750068,
+          "mean_mse": 0.11934572135535637,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9102735863543862,
+          "mean_mse": 0.07778170906304437,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8931182794651231,
+          "mean_mse": 0.087893647741441,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9124413636335917,
+          "mean_mse": 0.08044636198486076,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8738444921857939,
+          "mean_mse": 0.12073701175535112,
+          "mean_rank": 14.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8802755467014792,
+          "mean_mse": 0.10554345319927023,
+          "mean_rank": 21.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8988731375860352,
+          "mean_mse": 0.09503305560505644,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9071879566629792,
+          "mean_mse": 0.09124993272830399,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9173790413835652,
+          "mean_mse": 0.07848232999318044,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8308298959345255,
+          "mean_mse": 0.16050150645345745,
+          "mean_rank": 51.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8821130591475786,
+          "mean_mse": 0.10656923268505061,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8992713958207255,
+          "mean_mse": 0.08339962628002895,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9396921987192672,
+          "mean_mse": 0.05825530077010002,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9100159293918393,
+          "mean_mse": 0.07150120831924327,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9244288452467417,
+          "mean_mse": 0.07180802695376573,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8966543007694077,
+          "mean_mse": 0.08936039655826339,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8838418116633772,
+          "mean_mse": 0.10599111398740632,
+          "mean_rank": 29.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9098468603306668,
+          "mean_mse": 0.08037047045632191,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8807554339690774,
+          "mean_mse": 0.10767658090573437,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8727655242237098,
+          "mean_mse": 0.10348245313105646,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8528183074481264,
+          "mean_mse": 0.12048639219939059,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8815140990258791,
+          "mean_mse": 0.09389546499489967,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8487925614217176,
+          "mean_mse": 0.1258280824455437,
+          "mean_rank": 33.5,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8887196060334409,
+          "mean_mse": 0.10409159279014642,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8425701519554915,
+          "mean_mse": 0.13637882174819857,
+          "mean_rank": 51.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.917515313703842,
+          "mean_mse": 0.07141991488896826,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8773335852581781,
+          "mean_mse": 0.10441425049694979,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8775788717885784,
+          "mean_mse": 0.10664290977149697,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8840529193437247,
+          "mean_mse": 0.10310518851355661,
+          "mean_rank": 24.5,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8721455294701623,
+          "mean_mse": 0.11798594466120421,
+          "mean_rank": 27.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9023494542248598,
+          "mean_mse": 0.08626942322223304,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9114435225034045,
+          "mean_mse": 0.08410405671028763,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9196366306960626,
+          "mean_mse": 0.07377776988674259,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.8993890020842868,
+          "mean_mse": 0.09229918394451482,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8712150279836205,
+          "mean_mse": 0.11372921798968033,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8615058740072454,
+          "mean_mse": 0.11614446484192673,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9064260022896391,
+          "mean_mse": 0.08533712486348588,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9021125646797641,
+          "mean_mse": 0.08936989389745761,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9024309390936024,
+          "mean_mse": 0.091349875742408,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9217106396859912,
+          "mean_mse": 0.0693341462046412,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9130665779782249,
+          "mean_mse": 0.08911871885669669,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.891025120598459,
+          "mean_mse": 0.09772561592822143,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8651630019905305,
+          "mean_mse": 0.11759969211097773,
+          "mean_rank": 29.5,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.918195682215027,
+          "mean_mse": 0.0841831296392635,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.8996582951623644,
+          "mean_mse": 0.09019746585314563,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8836371011734294,
+          "mean_mse": 0.10111978446149718,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K4_r0.01",
+      "params": {
+        "K": 4,
+        "alpha_reg": 0.01,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8969345547092178,
+      "std_cosine_to_target": 0.032081271832789394,
+      "mean_mse_to_target": 0.10674061695177495,
+      "std_mse_to_target": 0.028361126800726576,
+      "mean_target_rank": 14.004950495049505,
+      "median_target_rank": 6.5,
+      "recall_at_1": 0.09405940594059406,
+      "recall_at_5": 0.4504950495049505,
+      "recall_at_10": 0.6782178217821783,
+      "mrr": 0.2651740942198535,
+      "train_time_ms": 36942.79020699992,
+      "inference_time_us": 364590.0402079219,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9173287121153619,
+          "mean_mse": 0.08221026872939073,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9151943867111834,
+          "mean_mse": 0.09132657647699818,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8984163588202205,
+          "mean_mse": 0.09711917973483306,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8752992146220385,
+          "mean_mse": 0.12479964494053736,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8639866688672094,
+          "mean_mse": 0.1352577687072294,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9094382200031088,
+          "mean_mse": 0.08976946152132274,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9048128257135377,
+          "mean_mse": 0.09221448170448869,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9166573952292351,
+          "mean_mse": 0.09254363882227323,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8796517983194103,
+          "mean_mse": 0.12566413568879714,
+          "mean_rank": 10.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8859932647715781,
+          "mean_mse": 0.11447250296329611,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8990963487846443,
+          "mean_mse": 0.1118467488389511,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9118909654731261,
+          "mean_mse": 0.09825518333150243,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.924138269490503,
+          "mean_mse": 0.08858237698828872,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8386162033416475,
+          "mean_mse": 0.16809668328314734,
+          "mean_rank": 41.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8882666515075349,
+          "mean_mse": 0.11305306389369056,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9027324728029503,
+          "mean_mse": 0.08960614931428051,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9448086723844035,
+          "mean_mse": 0.06473217304639069,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9137253471729216,
+          "mean_mse": 0.08076384695633534,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9324591923778608,
+          "mean_mse": 0.07724198411031981,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8991488535158583,
+          "mean_mse": 0.10102542343183628,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8883225865773536,
+          "mean_mse": 0.11531474843589436,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9157590981257098,
+          "mean_mse": 0.0844524139196462,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8862395924961258,
+          "mean_mse": 0.11511920221802949,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8909203705354516,
+          "mean_mse": 0.10854027921208605,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8669855295191226,
+          "mean_mse": 0.12905599685327157,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8947306920317328,
+          "mean_mse": 0.09710678102326849,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8598745112800089,
+          "mean_mse": 0.13517838801224025,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8977994733687487,
+          "mean_mse": 0.11691874848506768,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8560966676901419,
+          "mean_mse": 0.14063974355094297,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.919791465489831,
+          "mean_mse": 0.08543422443497276,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8837491861690967,
+          "mean_mse": 0.11614659455073047,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8795802533165558,
+          "mean_mse": 0.12141490084210214,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8856729495958222,
+          "mean_mse": 0.11808954216553572,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.874902143051818,
+          "mean_mse": 0.13452336597380313,
+          "mean_rank": 26.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9053845630399125,
+          "mean_mse": 0.09559565500513595,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9168684032190827,
+          "mean_mse": 0.09489273447413678,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.928440767314882,
+          "mean_mse": 0.08164093236676048,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9109328660150816,
+          "mean_mse": 0.09926178478271193,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8760149264054904,
+          "mean_mse": 0.12876213143694323,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8681825386588331,
+          "mean_mse": 0.12239901962353465,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9094345945404262,
+          "mean_mse": 0.09818815674022963,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.902199561354155,
+          "mean_mse": 0.10794385122353742,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9075721730312021,
+          "mean_mse": 0.10485234963966567,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9249067353362171,
+          "mean_mse": 0.07925559676815314,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9183580595210068,
+          "mean_mse": 0.10014140216481981,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.893649761928774,
+          "mean_mse": 0.11009535833365061,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8701312286316748,
+          "mean_mse": 0.12669039501982274,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9189110162197988,
+          "mean_mse": 0.09958512594897662,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9057699514515073,
+          "mean_mse": 0.09920590981633212,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8867845244603261,
+          "mean_mse": 0.11193432581573746,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K4_r0.1",
+      "params": {
+        "K": 4,
+        "alpha_reg": 0.1,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.896934243434012,
+      "std_cosine_to_target": 0.03208132752935873,
+      "mean_mse_to_target": 0.10674092734327327,
+      "std_mse_to_target": 0.028361170254850816,
+      "mean_target_rank": 14.004950495049505,
+      "median_target_rank": 6.5,
+      "recall_at_1": 0.09405940594059406,
+      "recall_at_5": 0.4504950495049505,
+      "recall_at_10": 0.6782178217821783,
+      "mrr": 0.2651740942198535,
+      "train_time_ms": 31143.685208999843,
+      "inference_time_us": 266874.5609306924,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9173286734649858,
+          "mean_mse": 0.08221040185851389,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9151942949283771,
+          "mean_mse": 0.0913267069616848,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8984162275064951,
+          "mean_mse": 0.09711932223067164,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8752989793299486,
+          "mean_mse": 0.12479984194832491,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8639864814231006,
+          "mean_mse": 0.1352578658695432,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9094381265508107,
+          "mean_mse": 0.08976950892696886,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9048127394452388,
+          "mean_mse": 0.09221464947431939,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9166573756235523,
+          "mean_mse": 0.09254364676902041,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8796516253351138,
+          "mean_mse": 0.125664189388528,
+          "mean_rank": 10.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8859929252138075,
+          "mean_mse": 0.11447291350467718,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8990961562578713,
+          "mean_mse": 0.11184701485693542,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9118904380083814,
+          "mean_mse": 0.09825605143666019,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9241376911991852,
+          "mean_mse": 0.08858344764655407,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8386156639076068,
+          "mean_mse": 0.16809723392655918,
+          "mean_rank": 41.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8882664565047804,
+          "mean_mse": 0.11305310370603817,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9027323276262782,
+          "mean_mse": 0.08960628729651803,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9448085468488077,
+          "mean_mse": 0.0647321902286306,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9137249502190934,
+          "mean_mse": 0.08076419192541841,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9324586648535206,
+          "mean_mse": 0.07724240316103557,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8991486286424752,
+          "mean_mse": 0.10102582451244281,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8883226220889621,
+          "mean_mse": 0.11531469283758339,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.915758971188729,
+          "mean_mse": 0.084452558672212,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8862388044501343,
+          "mean_mse": 0.11511993015725477,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8909197086916298,
+          "mean_mse": 0.10854111182987401,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.866985228929728,
+          "mean_mse": 0.12905620790848427,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8947298341717276,
+          "mean_mse": 0.09710777845738254,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8598740060701204,
+          "mean_mse": 0.13517887401037765,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.897798924845309,
+          "mean_mse": 0.1169193746574403,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8560960022031285,
+          "mean_mse": 0.14064050695054822,
+          "mean_rank": 41.75,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9197913471204601,
+          "mean_mse": 0.08543431295273937,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8837489351990909,
+          "mean_mse": 0.11614676620869666,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8795799447652726,
+          "mean_mse": 0.12141504744359985,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8856727058210228,
+          "mean_mse": 0.11808967697131074,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8749018055873117,
+          "mean_mse": 0.13452353804648295,
+          "mean_rank": 26.0,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.9053843585477342,
+          "mean_mse": 0.09559580781126296,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9168681619784438,
+          "mean_mse": 0.09489290355730344,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9284407336727925,
+          "mean_mse": 0.0816409351868434,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9109322753409901,
+          "mean_mse": 0.09926224833108019,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.876014369036193,
+          "mean_mse": 0.1287626362172703,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8681819847250605,
+          "mean_mse": 0.1223993175173437,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9094342550718285,
+          "mean_mse": 0.09818857951761682,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.90219866114574,
+          "mean_mse": 0.10794472725121704,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9075720257610371,
+          "mean_mse": 0.10485239872110805,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.924906594815823,
+          "mean_mse": 0.07925578127459038,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9183578916479036,
+          "mean_mse": 0.10014152981293814,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8936495741745054,
+          "mean_mse": 0.11009561648416707,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8701303875154388,
+          "mean_mse": 0.12669108594832937,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9189109942611571,
+          "mean_mse": 0.09958516513032467,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9057698506653286,
+          "mean_mse": 0.0992060607324207,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8867845387248935,
+          "mean_mse": 0.11193450877968107,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K8_r0.01",
+      "params": {
+        "K": 8,
+        "alpha_reg": 0.01,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8971069112009378,
+      "std_cosine_to_target": 0.032077483710968115,
+      "mean_mse_to_target": 0.1066101234843308,
+      "std_mse_to_target": 0.028358083480133998,
+      "mean_target_rank": 13.915841584158416,
+      "median_target_rank": 6.0,
+      "recall_at_1": 0.09405940594059406,
+      "recall_at_5": 0.45544554455445546,
+      "recall_at_10": 0.6782178217821783,
+      "mrr": 0.2665414449285918,
+      "train_time_ms": 35446.53137900014,
+      "inference_time_us": 369128.5335742573,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9173009054635232,
+          "mean_mse": 0.08224230136001093,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.91537386751931,
+          "mean_mse": 0.09122036179131685,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8986076694158387,
+          "mean_mse": 0.09703867934926932,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.875438332809183,
+          "mean_mse": 0.1247862259103493,
+          "mean_rank": 30.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8642298876610683,
+          "mean_mse": 0.13493364799345883,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9094856852978874,
+          "mean_mse": 0.08976399986952437,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9049635799410591,
+          "mean_mse": 0.09212143218308137,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9166811336655354,
+          "mean_mse": 0.09255466217574584,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8796738619910085,
+          "mean_mse": 0.12566357850451382,
+          "mean_rank": 10.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8863480558856454,
+          "mean_mse": 0.11429041136343299,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.899249744289068,
+          "mean_mse": 0.11182070623047181,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.912031314331622,
+          "mean_mse": 0.09813769405926967,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9243667845098414,
+          "mean_mse": 0.08823985011738414,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8386298946318785,
+          "mean_mse": 0.1680308192472102,
+          "mean_rank": 41.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8884489669507233,
+          "mean_mse": 0.11289951890670846,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.9027681953631704,
+          "mean_mse": 0.08955968595483921,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9449183959375587,
+          "mean_mse": 0.06463433564255483,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9139298898128378,
+          "mean_mse": 0.0805884007011891,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9328994223814051,
+          "mean_mse": 0.07665490756674523,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.899316435438914,
+          "mean_mse": 0.10091996689730302,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8882933118601558,
+          "mean_mse": 0.11538147188832219,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9156732134536766,
+          "mean_mse": 0.08447896220019366,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8865777326715765,
+          "mean_mse": 0.11476811754170049,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8914317702091216,
+          "mean_mse": 0.10824505347275534,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8670253653996894,
+          "mean_mse": 0.12903352868058732,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8949629901180183,
+          "mean_mse": 0.09697121953120696,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8600780214822114,
+          "mean_mse": 0.13504884971942932,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.8979869429499532,
+          "mean_mse": 0.11685642575518608,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8562169052764934,
+          "mean_mse": 0.14053373821589796,
+          "mean_rank": 41.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.919809152178466,
+          "mean_mse": 0.08543519893543941,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.8837941378157128,
+          "mean_mse": 0.11613926120228481,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8795795963837957,
+          "mean_mse": 0.12145441636012366,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8858773640335436,
+          "mean_mse": 0.1180140097101723,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8750810193001395,
+          "mean_mse": 0.13439647159682813,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.905547974468244,
+          "mean_mse": 0.09546328339255647,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9169629892394485,
+          "mean_mse": 0.09482363399847486,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9285383146345814,
+          "mean_mse": 0.08156451119931184,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9111925414818782,
+          "mean_mse": 0.09901348364902783,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8765911373999943,
+          "mean_mse": 0.12832767352451796,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.8685005520140698,
+          "mean_mse": 0.12203307400535826,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9094753113644738,
+          "mean_mse": 0.09812336120231505,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9028951770168818,
+          "mean_mse": 0.10749368991930576,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9077937219660188,
+          "mean_mse": 0.10472340428014539,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9251468740255552,
+          "mean_mse": 0.07900791235416235,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.9185673162244747,
+          "mean_mse": 0.09990180326810766,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8937329523640143,
+          "mean_mse": 0.110027943661241,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8704071382729957,
+          "mean_mse": 0.12646902598870138,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.919044414664864,
+          "mean_mse": 0.09953579683344212,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9059413797537013,
+          "mean_mse": 0.09910219072589359,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8869357351708114,
+          "mean_mse": 0.11191893788370652,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Residual_K8_r0.1",
+      "params": {
+        "K": 8,
+        "alpha_reg": 0.1,
+        "fft_cutoff": 0.5
+      },
+      "mean_cosine_to_target": 0.8971066686145762,
+      "std_cosine_to_target": 0.032077533300199024,
+      "mean_mse_to_target": 0.10661036452524726,
+      "std_mse_to_target": 0.028358117183169166,
+      "mean_target_rank": 13.915841584158416,
+      "median_target_rank": 6.0,
+      "recall_at_1": 0.09405940594059406,
+      "recall_at_5": 0.45544554455445546,
+      "recall_at_10": 0.6782178217821783,
+      "mrr": 0.2665414449285918,
+      "train_time_ms": 40973.87553899989,
+      "inference_time_us": 415859.04385148507,
+      "num_queries": 202,
+      "num_answers": 202,
+      "num_clusters": 50,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9173009201475792,
+          "mean_mse": 0.08224237287132173,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9153738689544056,
+          "mean_mse": 0.09122037414465964,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.89860751431789,
+          "mean_mse": 0.0970388062861497,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8754381121813614,
+          "mean_mse": 0.12478638595718539,
+          "mean_rank": 30.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8642295575359038,
+          "mean_mse": 0.13493394537996084,
+          "mean_rank": 39.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9094855966081519,
+          "mean_mse": 0.08976403601248528,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9049636173558738,
+          "mean_mse": 0.09212146575992268,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9166811269402604,
+          "mean_mse": 0.09255463711782091,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8796737362951157,
+          "mean_mse": 0.12566361507135748,
+          "mean_rank": 10.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8863477190257165,
+          "mean_mse": 0.11429075202003999,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8992494841248329,
+          "mean_mse": 0.11182096508166622,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9120310292187773,
+          "mean_mse": 0.09813820848237038,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9243664378493442,
+          "mean_mse": 0.08824064642205069,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8386294872858523,
+          "mean_mse": 0.16803119985092346,
+          "mean_rank": 41.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8884487525914078,
+          "mean_mse": 0.1128995901773623,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.90276814050481,
+          "mean_mse": 0.08955975150621734,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9449182644309133,
+          "mean_mse": 0.06463437316472441,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.913929527223966,
+          "mean_mse": 0.08058873828044139,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9328990413074183,
+          "mean_mse": 0.07665537521264114,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8993162429967754,
+          "mean_mse": 0.10092032439291161,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "scc-tarjan": {
+          "mean_cosine": 0.8882932610920822,
+          "mean_mse": 0.11538144924842492,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "recursion-types": {
+          "mean_cosine": 0.9156731403359638,
+          "mean_mse": 0.08447904948371647,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "memoization-strategy": {
+          "mean_cosine": 0.8865771984867812,
+          "mean_mse": 0.11476857503510121,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-subshells": {
+          "mean_cosine": 0.8914311349903791,
+          "mean_mse": 0.10824573991198082,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "process-substitution": {
+          "mean_cosine": 0.8670251331586735,
+          "mean_mse": 0.12903370098636885,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "bash-arrays": {
+          "mean_cosine": 0.8949622775276463,
+          "mean_mse": 0.09697201621210379,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "bash-redirections": {
+          "mean_cosine": 0.8600775404061507,
+          "mean_mse": 0.13504924215763903,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "bash-trap": {
+          "mean_cosine": 0.897986414306247,
+          "mean_mse": 0.11685703331803086,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "bash-string-ops": {
+          "mean_cosine": 0.8562164266648064,
+          "mean_mse": 0.1405342780945911,
+          "mean_rank": 41.5,
+          "num_queries": 4
+        },
+        "compiler-driver": {
+          "mean_cosine": 0.9198090521889061,
+          "mean_mse": 0.0854352682288728,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "compile-api-reference": {
+          "mean_cosine": 0.883793976801041,
+          "mean_mse": 0.11613935195549191,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "bash-constraints": {
+          "mean_cosine": 0.8795793735636019,
+          "mean_mse": 0.12145453614828754,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "data-sources-overview": {
+          "mean_cosine": 0.8858771265315996,
+          "mean_mse": 0.1180141390098093,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "data-sources-pipeline": {
+          "mean_cosine": 0.8750806446942777,
+          "mean_mse": 0.1343966840154175,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "first-bash-program": {
+          "mean_cosine": 0.90554789860085,
+          "mean_mse": 0.09546332063793891,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "compile-workflow": {
+          "mean_cosine": 0.9169627835507359,
+          "mean_mse": 0.09482378035024137,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "partitioning-overview": {
+          "mean_cosine": 0.9285382994373451,
+          "mean_mse": 0.08156453639024029,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "partitioning-strategies": {
+          "mean_cosine": 0.9111919776776493,
+          "mean_mse": 0.09901393384590952,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "gnu-parallel-backend": {
+          "mean_cosine": 0.8765908295675987,
+          "mean_mse": 0.12832808015691866,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "batch-vs-streaming": {
+          "mean_cosine": 0.868500100093283,
+          "mean_mse": 0.1220333837694231,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-introspection": {
+          "mean_cosine": 0.9094750507701667,
+          "mean_mse": 0.09812369635429098,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "call-graph-construction": {
+          "mean_cosine": 0.9028946857462997,
+          "mean_mse": 0.10749427411531096,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "scc-detection": {
+          "mean_cosine": 0.9077935931392616,
+          "mean_mse": 0.10472344882896929,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "pattern-matching-detection": {
+          "mean_cosine": 0.9251468055768819,
+          "mean_mse": 0.07900803450303204,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "tail-recursion": {
+          "mean_cosine": 0.918567223038469,
+          "mean_mse": 0.09990188724142152,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "linear-recursion": {
+          "mean_cosine": 0.8937328556885956,
+          "mean_mse": 0.11002810511249361,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "tree-recursion": {
+          "mean_cosine": 0.8704066633056273,
+          "mean_mse": 0.12646939596041737,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        },
+        "mutual-recursion": {
+          "mean_cosine": 0.9190442766504906,
+          "mean_mse": 0.0995358658647567,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "stream-compilation": {
+          "mean_cosine": 0.9059413032509441,
+          "mean_mse": 0.09910229386441656,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "bash-pipeline-patterns": {
+          "mean_cosine": 0.8869357354021423,
+          "mean_mse": 0.11191904080058689,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        }
+      }
+    }
+  ]
+}

--- a/src/unifyweaver/targets/python_runtime/modernbert_embedding.py
+++ b/src/unifyweaver/targets/python_runtime/modernbert_embedding.py
@@ -260,6 +260,7 @@ class SentenceTransformerProvider(IEmbeddingProvider):
         self,
         model_name: str = "all-MiniLM-L6-v2",
         device: str = "auto",
+        trust_remote_code: bool = True,
     ):
         """
         Initialize sentence-transformers provider.
@@ -267,6 +268,7 @@ class SentenceTransformerProvider(IEmbeddingProvider):
         Args:
             model_name: Model name from sentence-transformers
             device: Device to use
+            trust_remote_code: Trust remote code for models that require it (e.g., nomic)
         """
         from sentence_transformers import SentenceTransformer
 
@@ -275,7 +277,11 @@ class SentenceTransformerProvider(IEmbeddingProvider):
 
         self.model_name = model_name
         self.device = device
-        self.model = SentenceTransformer(model_name, device=device)
+        self.model = SentenceTransformer(
+            model_name,
+            device=device,
+            trust_remote_code=trust_remote_code
+        )
         self.dimension = self.model.get_sentence_embedding_dimension()
 
         logger.info(f"SentenceTransformer loaded: {model_name}, dim={self.dimension}, device={device}")


### PR DESCRIPTION
## Summary                                                                                                                   
- Add `--embedder` flag to `benchmark_answer_level.py` supporting real embedding models                                      
- Options: `hash`, `all-minilm`, `e5-small`, `modernbert`                                                                    
- Add `trust_remote_code` parameter to `SentenceTransformerProvider` for nomic models                                        
- Include benchmark results for all three real embedding models                                                              
                                                                                                                             
## Benchmark Results                                                                                                         
                                                                                                                             
| Embedder | Best Method | Best MRR | FFT MRR | Improvement |                                                                
|----------|-------------|----------|---------|-------------|                                                                
| all-MiniLM-L6-v2 | ResidualBasis_K8 | **0.4380** | 0.4349 | +0.71% |                                                       
| e5-small-v2 | ResidualBasis_K8 | 0.0398 | 0.0397 | +0.25% |                                                                
| ModernBERT | Basis_K4 | **0.2827** | 0.2635 | N/A* |                                                                       
                                                                                                                             
*ModernBERT: Standalone basis beats both FFT and hybrid, suggesting rich embeddings don't need FFT smoothing.                
                                                                                                                             
## Key Insights                                                                                                              
- FFT smoothing helps smaller embedding models (384 dim)                                                                     
- ModernBERT's 768-dim space has enough structure for basis to learn directly                                                
- 1D FFT may be insufficient for high-dimensional embedding spaces (see discussion on spherical harmonics / kernel smoothing)
                                                                                                                             
## Test plan                                                                                                                 
- [x] Benchmark runs successfully with all-minilm                                                                            
- [x] Benchmark runs successfully with e5-small                                                                              
- [x] Benchmark runs successfully with modernbert                                                                            
- [x] Results saved to reports/                                                                                              
                                                                                                                             
� Generated with [Claude Code](https://claude.com/claude-code)                                                               