### PR TITLE
testing: fail C# query runtime smoke on Prolog errors

### DIFF
--- a/scripts/testing/run_csharp_query_runtime_smoke.ps1
+++ b/scripts/testing/run_csharp_query_runtime_smoke.ps1
@@ -182,6 +182,9 @@ if (-not $SkipCodegen) {
 
     & $swipl -q -f $init -s $testFile -g "test_csharp_query_target:test_csharp_query_target" -t halt -- `
         --csharp-query-output $outputPath --csharp-query-keep
+    if ($LASTEXITCODE -ne 0) {
+        throw "SWI-Prolog C# query target test suite failed (exit code $LASTEXITCODE)."
+    }
 }
 
 Assert-DotnetAvailable


### PR DESCRIPTION
  - Fixes scripts/testing/run_csharp_query_runtime_smoke.ps1 to check SWI-Prolog’s exit code after running
    test_csharp_query_target.pl and throw on failure.
  - Prevents “false green” smoke runs where Prolog test failures print but the script continues to build/run generated
    C# projects.
  - No runtime/compiler changes; script-only.

  Local validation (fast):

  - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir (Join-Path $env:TEMP
    'unifyweaver_csharp_query_smoke_link_only') -ProjectFilter 'csharp_query_test_link_*'