### PR TITLE
feat: add MinimalTransformProjection using Procrustes (2x MRR improvement)

### DIFF
--- a/playbooks/lda-training-data/expanded/qa_pairs_v1_expanded.json
+++ b/playbooks/lda-training-data/expanded/qa_pairs_v1_expanded.json
@@ -1,0 +1,373 @@
+{
+  "version": "1.1-expanded",
+  "description": "Expanded from qa_pairs_v1.json - 1-to-1 Q-A pairs",
+  "source_file": "qa_pairs_v1.json",
+  "model_variant": "default",
+  "expanded_at": "2025-12-23T15:18:14.447957",
+  "stats": {
+    "num_clusters": 5,
+    "num_pairs": 40
+  },
+  "pairs": [
+    {
+      "pair_id": "csv_data_source_p0",
+      "cluster_id": "csv_data_source",
+      "question": "csv source",
+      "question_type": "short",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p1",
+      "cluster_id": "csv_data_source",
+      "question": "read csv prolog",
+      "question_type": "short",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p2",
+      "cluster_id": "csv_data_source",
+      "question": "csv data loading",
+      "question_type": "short",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p3",
+      "cluster_id": "csv_data_source",
+      "question": "How do I read CSV files in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p4",
+      "cluster_id": "csv_data_source",
+      "question": "How to define a CSV data source?",
+      "question_type": "medium",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p5",
+      "cluster_id": "csv_data_source",
+      "question": "Load CSV file as Prolog predicate",
+      "question_type": "medium",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p6",
+      "cluster_id": "csv_data_source",
+      "question": "I want to load user data from a CSV file and filter records by name using Prolog predicates",
+      "question_type": "long",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "csv_data_source_p7",
+      "cluster_id": "csv_data_source",
+      "question": "How can I compile a CSV source to a bash script that processes tabular data?",
+      "question_type": "long",
+      "answer": "CSV Data Source Example - Demonstrates how to use UnifyWeaver's CSV source to read and process user data. Define a CSV source using source(csv, predicate_name, [csv_file(Path), has_header(true)]), then compile to bash using compile_dynamic_source/3.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csv_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p0",
+      "cluster_id": "mutual_recursion",
+      "question": "mutual recursion",
+      "question_type": "short",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p1",
+      "cluster_id": "mutual_recursion",
+      "question": "even odd prolog",
+      "question_type": "short",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p2",
+      "cluster_id": "mutual_recursion",
+      "question": "recursive predicates",
+      "question_type": "short",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p3",
+      "cluster_id": "mutual_recursion",
+      "question": "How to compile mutually recursive predicates?",
+      "question_type": "medium",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p4",
+      "cluster_id": "mutual_recursion",
+      "question": "Compile is_even and is_odd to bash",
+      "question_type": "medium",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p5",
+      "cluster_id": "mutual_recursion",
+      "question": "Handle predicates that call each other",
+      "question_type": "medium",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p6",
+      "cluster_id": "mutual_recursion",
+      "question": "I have two Prolog predicates that call each other recursively, how do I compile them to bash?",
+      "question_type": "long",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "mutual_recursion_p7",
+      "cluster_id": "mutual_recursion",
+      "question": "My predicates is_even and is_odd depend on each other, how does UnifyWeaver handle this?",
+      "question_type": "long",
+      "answer": "Mutual Recursion Example - Demonstrates compiling mutually recursive predicates like is_even/is_odd. UnifyWeaver detects mutual recursion and compiles both predicates together, generating separate bash scripts that call each other.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/recursion_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p0",
+      "cluster_id": "xml_python_source",
+      "question": "xml parsing",
+      "question_type": "short",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p1",
+      "cluster_id": "xml_python_source",
+      "question": "python source xml",
+      "question_type": "short",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p2",
+      "cluster_id": "xml_python_source",
+      "question": "parse xml prolog",
+      "question_type": "short",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p3",
+      "cluster_id": "xml_python_source",
+      "question": "How to parse XML in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p4",
+      "cluster_id": "xml_python_source",
+      "question": "Use Python to process XML data",
+      "question_type": "medium",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p5",
+      "cluster_id": "xml_python_source",
+      "question": "XML source with ElementTree",
+      "question_type": "medium",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p6",
+      "cluster_id": "xml_python_source",
+      "question": "I need to sum prices from XML product data using Python and integrate with Prolog predicates",
+      "question_type": "long",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "xml_python_source_p7",
+      "cluster_id": "xml_python_source",
+      "question": "How can I use Python's xml.etree to parse XML and expose results as a Prolog predicate?",
+      "question_type": "long",
+      "answer": "XML Data Source Example - Demonstrates using Python source with XML processing. Define a Python source using source(python, predicate_name, [python_inline(Code)]) where the Python code uses xml.etree.ElementTree to parse and process XML data.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/xml_examples.md"
+    },
+    {
+      "pair_id": "component_registry_p0",
+      "cluster_id": "component_registry",
+      "question": "component registry",
+      "question_type": "short",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p1",
+      "cluster_id": "component_registry",
+      "question": "register component",
+      "question_type": "short",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p2",
+      "cluster_id": "component_registry",
+      "question": "runtime components",
+      "question_type": "short",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p3",
+      "cluster_id": "component_registry",
+      "question": "How to register a runtime component?",
+      "question_type": "medium",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p4",
+      "cluster_id": "component_registry",
+      "question": "What is the component registry?",
+      "question_type": "medium",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p5",
+      "cluster_id": "component_registry",
+      "question": "Declare and invoke components",
+      "question_type": "medium",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p6",
+      "cluster_id": "component_registry",
+      "question": "I want to create a new runtime component that can be loaded lazily and has dependencies on other components",
+      "question_type": "long",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "component_registry_p7",
+      "cluster_id": "component_registry",
+      "question": "How do I register a custom component type and create instances with configuration?",
+      "question_type": "long",
+      "answer": "Component Registry - Unified framework for registering, configuring, and invoking components across categories (runtime, source, binding). Use declare_component(Category, Name, Type, Config) to register, invoke_component(Category, Name, Input, Output) to call.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/COMPONENT_REGISTRY.md"
+    },
+    {
+      "pair_id": "lda_projection_p0",
+      "cluster_id": "lda_projection",
+      "question": "lda projection",
+      "question_type": "short",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p1",
+      "cluster_id": "lda_projection",
+      "question": "semantic projection",
+      "question_type": "short",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p2",
+      "cluster_id": "lda_projection",
+      "question": "query embedding",
+      "question_type": "short",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p3",
+      "cluster_id": "lda_projection",
+      "question": "How does LDA projection work?",
+      "question_type": "medium",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p4",
+      "cluster_id": "lda_projection",
+      "question": "Project queries to answer space",
+      "question_type": "medium",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p5",
+      "cluster_id": "lda_projection",
+      "question": "Learn transformation matrix W",
+      "question_type": "medium",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p6",
+      "cluster_id": "lda_projection",
+      "question": "I want to improve RAG retrieval by learning a projection that maps query embeddings closer to relevant document embeddings",
+      "question_type": "long",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    },
+    {
+      "pair_id": "lda_projection_p7",
+      "cluster_id": "lda_projection",
+      "question": "How can I train a transformation matrix from question-answer pairs to improve semantic search?",
+      "question_type": "long",
+      "answer": "LDA Semantic Projection - Projects query embeddings to answer space using a learned transformation matrix W. Computed via W = A * Q_bar^T * (Q_bar*Q_bar^T + lambda*Delta_w*Delta_w^T + mu*I)^-1. Improves retrieval by mapping questions to their associated answers.",
+      "answer_variant": "default",
+      "answer_source": "docs/proposals/SEMANTIC_PROJECTION_LDA.md"
+    }
+  ]
+}

--- a/playbooks/lda-training-data/expanded/qa_pairs_v2_expanded.json
+++ b/playbooks/lda-training-data/expanded/qa_pairs_v2_expanded.json
@@ -1,0 +1,589 @@
+{
+  "version": "2.0-expanded",
+  "description": "Expanded from qa_pairs_v2.json - 1-to-1 Q-A pairs",
+  "source_file": "qa_pairs_v2.json",
+  "model_variant": "default",
+  "expanded_at": "2025-12-23T15:18:14.448669",
+  "stats": {
+    "num_clusters": 8,
+    "num_pairs": 64
+  },
+  "pairs": [
+    {
+      "pair_id": "sqlite_source_p0",
+      "cluster_id": "sqlite_source",
+      "question": "sqlite source",
+      "question_type": "short",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p1",
+      "cluster_id": "sqlite_source",
+      "question": "query database prolog",
+      "question_type": "short",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p2",
+      "cluster_id": "sqlite_source",
+      "question": "sql data source",
+      "question_type": "short",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p3",
+      "cluster_id": "sqlite_source",
+      "question": "How do I query SQLite from UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p4",
+      "cluster_id": "sqlite_source",
+      "question": "Execute SQL queries as data source",
+      "question_type": "medium",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p5",
+      "cluster_id": "sqlite_source",
+      "question": "Load database records into Prolog",
+      "question_type": "medium",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p6",
+      "cluster_id": "sqlite_source",
+      "question": "I need to fetch user records from a SQLite database and filter them by age using Prolog predicates",
+      "question_type": "long",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "sqlite_source_p7",
+      "cluster_id": "sqlite_source",
+      "question": "How can I compile SQL queries to bash scripts that return data for further processing?",
+      "question_type": "long",
+      "answer": "SQLite Source - Query SQLite databases using UnifyWeaver's sqlite_source plugin. Configure with sqlite_file(Path), query(SQL), and output_format(tsv). Use sqlite_source:compile_source/4 to generate bash scripts that execute SQL queries. Supports parameterized queries, JOINs, and WHERE clause filtering.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sqlite_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p0",
+      "cluster_id": "http_source",
+      "question": "http source",
+      "question_type": "short",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p1",
+      "cluster_id": "http_source",
+      "question": "rest api prolog",
+      "question_type": "short",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p2",
+      "cluster_id": "http_source",
+      "question": "fetch url data",
+      "question_type": "short",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p3",
+      "cluster_id": "http_source",
+      "question": "How to fetch data from REST API?",
+      "question_type": "medium",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p4",
+      "cluster_id": "http_source",
+      "question": "HTTP GET request as data source",
+      "question_type": "medium",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p5",
+      "cluster_id": "http_source",
+      "question": "Cache API responses in UnifyWeaver",
+      "question_type": "medium",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p6",
+      "cluster_id": "http_source",
+      "question": "I need to fetch JSON data from an external API endpoint and process it with Prolog predicates",
+      "question_type": "long",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "http_source_p7",
+      "cluster_id": "http_source",
+      "question": "How can I make HTTP POST requests with custom headers and cache the responses?",
+      "question_type": "long",
+      "answer": "HTTP Source - Fetch data from REST APIs using http_source plugin. Configure with url(URL), method(get/post), headers([...]), cache_duration(Seconds), and timeout(Seconds). Supports both curl and wget backends. Use http_source:compile_source/4 to generate bash scripts that fetch JSON data from APIs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/http_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p0",
+      "cluster_id": "json_source",
+      "question": "json source",
+      "question_type": "short",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p1",
+      "cluster_id": "json_source",
+      "question": "jq filter prolog",
+      "question_type": "short",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p2",
+      "cluster_id": "json_source",
+      "question": "parse json data",
+      "question_type": "short",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p3",
+      "cluster_id": "json_source",
+      "question": "How to process JSON files in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p4",
+      "cluster_id": "json_source",
+      "question": "Filter JSON arrays with jq",
+      "question_type": "medium",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p5",
+      "cluster_id": "json_source",
+      "question": "Extract fields from JSON data",
+      "question_type": "medium",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p6",
+      "cluster_id": "json_source",
+      "question": "I have a JSON file with an array of objects and need to filter entries where score is above 90",
+      "question_type": "long",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "json_source_p7",
+      "cluster_id": "json_source",
+      "question": "How can I use jq to transform JSON data and expose the results as a Prolog predicate?",
+      "question_type": "long",
+      "answer": "JSON Source - Process JSON files using jq filters. Use dynamic_source/3 with json type, json_file(Path), and jq_filter(Filter). The jq filter can select fields (.[].name), filter arrays (.[] | select(.score > 90)), and transform data. Compile to bash scripts that pipe JSON through jq.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_source_examples.md"
+    },
+    {
+      "pair_id": "template_system_p0",
+      "cluster_id": "template_system",
+      "question": "template system",
+      "question_type": "short",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p1",
+      "cluster_id": "template_system",
+      "question": "code generation",
+      "question_type": "short",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p2",
+      "cluster_id": "template_system",
+      "question": "placeholder substitution",
+      "question_type": "short",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p3",
+      "cluster_id": "template_system",
+      "question": "How to use template system for code gen?",
+      "question_type": "medium",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p4",
+      "cluster_id": "template_system",
+      "question": "Generate bash functions from templates",
+      "question_type": "medium",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p5",
+      "cluster_id": "template_system",
+      "question": "Render named templates in UnifyWeaver",
+      "question_type": "medium",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p6",
+      "cluster_id": "template_system",
+      "question": "I want to generate multiple bash functions using a template with placeholders for function name and body",
+      "question_type": "long",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "template_system_p7",
+      "cluster_id": "template_system",
+      "question": "How can I compose multiple templates together to generate complete scripts?",
+      "question_type": "long",
+      "answer": "Template System - Generate code using placeholder substitution. Use render_template(Template, Values, Result) for direct rendering with {{placeholder}} syntax. Use render_named_template(Name, Values, Result) for predefined templates like bash_header, function. Templates can be composed and nested for complex code generation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/template_system_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p0",
+      "cluster_id": "cross_target_glue",
+      "question": "cross target glue",
+      "question_type": "short",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p1",
+      "cluster_id": "cross_target_glue",
+      "question": "multi language pipeline",
+      "question_type": "short",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p2",
+      "cluster_id": "cross_target_glue",
+      "question": "awk python bash",
+      "question_type": "short",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p3",
+      "cluster_id": "cross_target_glue",
+      "question": "How to connect AWK and Python in pipeline?",
+      "question_type": "medium",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p4",
+      "cluster_id": "cross_target_glue",
+      "question": "Build multi-language data pipeline",
+      "question_type": "medium",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p5",
+      "cluster_id": "cross_target_glue",
+      "question": "Generate scripts for different languages",
+      "question_type": "medium",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p6",
+      "cluster_id": "cross_target_glue",
+      "question": "I need to filter data with AWK, aggregate with Python, then format output with Bash in a single pipeline",
+      "question_type": "long",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "cross_target_glue_p7",
+      "cluster_id": "cross_target_glue",
+      "question": "How can I create a cross-language pipeline that passes TSV data between AWK, Python and Bash stages?",
+      "question_type": "long",
+      "answer": "Cross-Target Glue - Build multi-language pipelines connecting AWK, Python, Bash, Go, and Rust. Use shell_glue module with generate_awk_script/4, generate_python_script/4, generate_bash_script/4. Each stage processes data and pipes to the next. Supports TSV format with headers for data exchange between languages.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/cross_target_glue_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p0",
+      "cluster_id": "bash_parallel",
+      "question": "bash parallel",
+      "question_type": "short",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p1",
+      "cluster_id": "bash_parallel",
+      "question": "fork backend",
+      "question_type": "short",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p2",
+      "cluster_id": "bash_parallel",
+      "question": "parallel execution",
+      "question_type": "short",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p3",
+      "cluster_id": "bash_parallel",
+      "question": "How to run bash scripts in parallel?",
+      "question_type": "medium",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p4",
+      "cluster_id": "bash_parallel",
+      "question": "Process data partitions concurrently",
+      "question_type": "medium",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p5",
+      "cluster_id": "bash_parallel",
+      "question": "Parallel execution without GNU Parallel",
+      "question_type": "medium",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p6",
+      "cluster_id": "bash_parallel",
+      "question": "I want to process large data files in parallel using multiple workers without installing GNU Parallel",
+      "question_type": "long",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "bash_parallel_p7",
+      "cluster_id": "bash_parallel",
+      "question": "How can I partition data and execute a processing script on each partition concurrently?",
+      "question_type": "long",
+      "answer": "Bash Parallel Execution - Run processing in parallel using bash fork backend. Use backend_init_impl/2 with Config containing workers(N). Create partitions with partition(Index, Data), then execute with backend_execute_impl/4. No GNU Parallel required - uses pure bash fork. Supports load balancing and result aggregation.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_parallel_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p0",
+      "cluster_id": "awk_source",
+      "question": "awk source",
+      "question_type": "short",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p1",
+      "cluster_id": "awk_source",
+      "question": "awk data processing",
+      "question_type": "short",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p2",
+      "cluster_id": "awk_source",
+      "question": "field parsing awk",
+      "question_type": "short",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p3",
+      "cluster_id": "awk_source",
+      "question": "How to use AWK as data source?",
+      "question_type": "medium",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p4",
+      "cluster_id": "awk_source",
+      "question": "Parse delimited files with AWK",
+      "question_type": "medium",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p5",
+      "cluster_id": "awk_source",
+      "question": "Process TSV with awk in UnifyWeaver",
+      "question_type": "medium",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p6",
+      "cluster_id": "awk_source",
+      "question": "I have a tab-separated file and need to extract specific columns and filter rows using AWK",
+      "question_type": "long",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "awk_source_p7",
+      "cluster_id": "awk_source",
+      "question": "How can I compile an AWK script to process log files and output selected fields?",
+      "question_type": "long",
+      "answer": "AWK Source - Process delimited data using AWK scripts. Define sources with source(awk, predicate, [awk_script(Code), input_file(Path)]). AWK handles field parsing, filtering, and calculations. Output as TSV for further processing. Compile to bash scripts that execute awk commands.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p0",
+      "cluster_id": "yaml_source",
+      "question": "yaml source",
+      "question_type": "short",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p1",
+      "cluster_id": "yaml_source",
+      "question": "yaml config parsing",
+      "question_type": "short",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p2",
+      "cluster_id": "yaml_source",
+      "question": "yq filter prolog",
+      "question_type": "short",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p3",
+      "cluster_id": "yaml_source",
+      "question": "How to parse YAML config files?",
+      "question_type": "medium",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p4",
+      "cluster_id": "yaml_source",
+      "question": "Extract values from YAML in UnifyWeaver",
+      "question_type": "medium",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p5",
+      "cluster_id": "yaml_source",
+      "question": "Process YAML with yq filters",
+      "question_type": "medium",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p6",
+      "cluster_id": "yaml_source",
+      "question": "I have a YAML configuration file and need to extract nested values for use in Prolog predicates",
+      "question_type": "long",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    },
+    {
+      "pair_id": "yaml_source_p7",
+      "cluster_id": "yaml_source",
+      "question": "How can I parse YAML files and filter specific keys using yq in UnifyWeaver?",
+      "question_type": "long",
+      "answer": "YAML Source - Process YAML configuration files using yq or Python yaml module. Define sources with yaml_file(Path) and yq_filter(Filter). Similar to JSON source but for YAML format. Compile to bash scripts that parse YAML and extract values.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/yaml_source_examples.md"
+    }
+  ]
+}

--- a/playbooks/lda-training-data/expanded/qa_pairs_v3_expanded.json
+++ b/playbooks/lda-training-data/expanded/qa_pairs_v3_expanded.json
@@ -1,0 +1,229 @@
+{
+  "version": "3.0-expanded",
+  "description": "Expanded from qa_pairs_v3.json - 1-to-1 Q-A pairs",
+  "source_file": "qa_pairs_v3.json",
+  "model_variant": "default",
+  "expanded_at": "2025-12-23T15:18:14.449509",
+  "stats": {
+    "num_clusters": 3,
+    "num_pairs": 24
+  },
+  "pairs": [
+    {
+      "pair_id": "firewall_security_p0",
+      "cluster_id": "firewall_security",
+      "question": "firewall security",
+      "question_type": "short",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p1",
+      "cluster_id": "firewall_security",
+      "question": "network access control",
+      "question_type": "short",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p2",
+      "cluster_id": "firewall_security",
+      "question": "allowed service policy",
+      "question_type": "short",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p3",
+      "cluster_id": "firewall_security",
+      "question": "How to configure firewall policies?",
+      "question_type": "medium",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p4",
+      "cluster_id": "firewall_security",
+      "question": "Restrict network access in UnifyWeaver",
+      "question_type": "medium",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p5",
+      "cluster_id": "firewall_security",
+      "question": "Whitelist Python modules for security",
+      "question_type": "medium",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p6",
+      "cluster_id": "firewall_security",
+      "question": "I need to restrict my pipeline to only access specific internal domains and block all other network traffic",
+      "question_type": "long",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "firewall_security_p7",
+      "cluster_id": "firewall_security",
+      "question": "How can I configure the firewall to allow specific external tools while denying others in a production environment?",
+      "question_type": "long",
+      "answer": "Firewall and Security - UnifyWeaver's firewall system controls access to external tools, network resources, and file operations. Features strict/permissive modes, whitelist/blacklist policies for domains and tools, and Python module restrictions. Uses fundamental policies like allowed_service/2 and network_access/1 to derive security rules.",
+      "answer_variant": "default",
+      "answer_source": "docs/FIREWALL_GUIDE.md"
+    },
+    {
+      "pair_id": "powershell_target_p0",
+      "cluster_id": "powershell_target",
+      "question": "powershell target",
+      "question_type": "short",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p1",
+      "cluster_id": "powershell_target",
+      "question": "compile to powershell",
+      "question_type": "short",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p2",
+      "cluster_id": "powershell_target",
+      "question": "prolog to powershell",
+      "question_type": "short",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p3",
+      "cluster_id": "powershell_target",
+      "question": "How to compile Prolog to PowerShell?",
+      "question_type": "medium",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p4",
+      "cluster_id": "powershell_target",
+      "question": "Use PowerShell object pipeline with Prolog",
+      "question_type": "medium",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p5",
+      "cluster_id": "powershell_target",
+      "question": "Pure PowerShell vs BaaS mode",
+      "question_type": "medium",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p6",
+      "cluster_id": "powershell_target",
+      "question": "I want to compile a Prolog predicate to a native PowerShell script that outputs objects to the pipeline",
+      "question_type": "long",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "powershell_target_p7",
+      "cluster_id": "powershell_target",
+      "question": "How can I integrate compiled Prolog code with existing PowerShell modules and cmdlets?",
+      "question_type": "long",
+      "answer": "PowerShell Target - Compile Prolog predicates to PowerShell scripts using pure mode or Bash-as-a-Service (BaaS). Supports object pipelines, .NET bindings, and advanced joins. Use compile_to_powershell/3 with options like powershell_mode(pure|baas) and output_format(object).",
+      "answer_variant": "default",
+      "answer_source": "docs/POWERSHELL_TARGET.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p0",
+      "cluster_id": "dotnet_compilation",
+      "question": "c# compilation",
+      "question_type": "short",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p1",
+      "cluster_id": "dotnet_compilation",
+      "question": "dotnet integration",
+      "question_type": "short",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p2",
+      "cluster_id": "dotnet_compilation",
+      "question": "litedb prolog",
+      "question_type": "short",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p3",
+      "cluster_id": "dotnet_compilation",
+      "question": "How to compile C# code in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p4",
+      "cluster_id": "dotnet_compilation",
+      "question": "Integrate LiteDB with Prolog pipeline",
+      "question_type": "medium",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p5",
+      "cluster_id": "dotnet_compilation",
+      "question": "Solve DLL file locking in PowerShell",
+      "question_type": "medium",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p6",
+      "cluster_id": "dotnet_compilation",
+      "question": "I need to use a C# library with NuGet dependencies in my data pipeline",
+      "question_type": "long",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    },
+    {
+      "pair_id": "dotnet_compilation_p7",
+      "cluster_id": "dotnet_compilation",
+      "question": "How does UnifyWeaver handle C# compilation to avoid file locking issues during iterative development?",
+      "question_type": "long",
+      "answer": "C# Compilation and .NET Integration - Compile C# code for Prolog pipelines using external compilation (dotnet build) or pre-compilation (Add-Type). Supports NuGet dependencies and LiteDB integration. Solves DLL file locking issues by using unique build directories.",
+      "answer_variant": "default",
+      "answer_source": "docs/DOTNET_COMPILATION.md"
+    }
+  ]
+}

--- a/playbooks/lda-training-data/expanded/qa_pairs_v4_expanded.json
+++ b/playbooks/lda-training-data/expanded/qa_pairs_v4_expanded.json
@@ -1,0 +1,661 @@
+{
+  "version": "4.0-expanded",
+  "description": "Expanded from qa_pairs_v4.json - 1-to-1 Q-A pairs",
+  "source_file": "qa_pairs_v4.json",
+  "model_variant": "default",
+  "expanded_at": "2025-12-23T15:18:14.449933",
+  "stats": {
+    "num_clusters": 9,
+    "num_pairs": 72
+  },
+  "pairs": [
+    {
+      "pair_id": "csharp_examples_p0",
+      "cluster_id": "csharp_examples",
+      "question": "c# prolog examples",
+      "question_type": "short",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p1",
+      "cluster_id": "csharp_examples",
+      "question": "csharp generator mode",
+      "question_type": "short",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p2",
+      "cluster_id": "csharp_examples",
+      "question": "compile fibonacci c#",
+      "question_type": "short",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p3",
+      "cluster_id": "csharp_examples",
+      "question": "How to use C# generator mode in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p4",
+      "cluster_id": "csharp_examples",
+      "question": "Compile Prolog arithmetic to C#",
+      "question_type": "medium",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p5",
+      "cluster_id": "csharp_examples",
+      "question": "Recursive C# predicates example",
+      "question_type": "medium",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p6",
+      "cluster_id": "csharp_examples",
+      "question": "I want to compile a recursive Prolog predicate like Fibonacci to C# using generator mode",
+      "question_type": "long",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "csharp_examples_p7",
+      "cluster_id": "csharp_examples",
+      "question": "How can I implement arithmetic operations like sum_pair in Prolog and compile them to C#?",
+      "question_type": "long",
+      "answer": "C# Examples - Demonstrate using csharp_target for arithmetic (sum_pair) and generator mode (Fibonacci). Compile Prolog predicates to C# classes that integrate with Bash or PowerShell. Shows handling of recursive arithmetic logic using generator mode.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/csharp_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p0",
+      "cluster_id": "prolog_code_generation",
+      "question": "generate prolog code",
+      "question_type": "short",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p1",
+      "cluster_id": "prolog_code_generation",
+      "question": "dynamic prolog compilation",
+      "question_type": "short",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p2",
+      "cluster_id": "prolog_code_generation",
+      "question": "compile generated predicate",
+      "question_type": "short",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p3",
+      "cluster_id": "prolog_code_generation",
+      "question": "How to generate and compile Prolog code?",
+      "question_type": "medium",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p4",
+      "cluster_id": "prolog_code_generation",
+      "question": "Dynamically create Prolog predicates for compilation",
+      "question_type": "medium",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p5",
+      "cluster_id": "prolog_code_generation",
+      "question": "Script to generate Prolog and compile to bash",
+      "question_type": "medium",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p6",
+      "cluster_id": "prolog_code_generation",
+      "question": "I need to programmatically generate a Prolog predicate and then immediately compile it to a bash script",
+      "question_type": "long",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "prolog_code_generation_p7",
+      "cluster_id": "prolog_code_generation",
+      "question": "How can I automate the creation of Prolog files and their subsequent compilation in a pipeline?",
+      "question_type": "long",
+      "answer": "Prolog Code Generation - Dynamically generate Prolog code and compile it to Bash. Example demonstrates generating a factorial/2 predicate string, writing it to a file, and then using the UnifyWeaver compiler to turn it into an executable bash script.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/prolog_generation_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p0",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "awk aggregations",
+      "question_type": "short",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p1",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "tail recursion awk",
+      "question_type": "short",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p2",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "awk constraints",
+      "question_type": "short",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p3",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "How to compile aggregations to AWK?",
+      "question_type": "medium",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p4",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "Convert tail recursion to AWK loops",
+      "question_type": "medium",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p5",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "Use constraints in AWK target",
+      "question_type": "medium",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p6",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "I want to calculate sum, count, and average of a dataset using compiled AWK scripts from Prolog",
+      "question_type": "long",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "awk_advanced_patterns_p7",
+      "cluster_id": "awk_advanced_patterns",
+      "question": "How does UnifyWeaver compile tail-recursive predicates into efficient AWK while loops?",
+      "question_type": "long",
+      "answer": "AWK Advanced Patterns - Compile aggregations (sum, count, max, min, avg), tail-recursive predicates to while loops, and constraints to AWK. Shows how high-level Prolog patterns map to efficient AWK scripts for data processing.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/awk_advanced_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p0",
+      "cluster_id": "sql_window_functions",
+      "question": "sql window functions",
+      "question_type": "short",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p1",
+      "cluster_id": "sql_window_functions",
+      "question": "recursive cte sql",
+      "question_type": "short",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p2",
+      "cluster_id": "sql_window_functions",
+      "question": "prolog to sql analytics",
+      "question_type": "short",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p3",
+      "cluster_id": "sql_window_functions",
+      "question": "How to use SQL window functions in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p4",
+      "cluster_id": "sql_window_functions",
+      "question": "Compile recursive CTEs from Prolog",
+      "question_type": "medium",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p5",
+      "cluster_id": "sql_window_functions",
+      "question": "Generate RANK and ROW_NUMBER queries",
+      "question_type": "medium",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p6",
+      "cluster_id": "sql_window_functions",
+      "question": "I need to generate SQL queries that use window functions like ROW_NUMBER and running totals from Prolog predicates",
+      "question_type": "long",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "sql_window_functions_p7",
+      "cluster_id": "sql_window_functions",
+      "question": "How can I compile recursive Prolog predicates into SQL WITH RECURSIVE Common Table Expressions?",
+      "question_type": "long",
+      "answer": "SQL Window Functions - Compile Prolog predicates using window functions (ROW_NUMBER, RANK, DENSE_RANK, SUM OVER) and recursive CTEs to SQL. Supports partitioning, ordering, and GROUP BY with HAVING clauses for complex analytical queries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/sql_window_examples.md"
+    },
+    {
+      "pair_id": "python_source_p0",
+      "cluster_id": "python_source",
+      "question": "python source",
+      "question_type": "short",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p1",
+      "cluster_id": "python_source",
+      "question": "inline python prolog",
+      "question_type": "short",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p2",
+      "cluster_id": "python_source",
+      "question": "python sqlite integration",
+      "question_type": "short",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p3",
+      "cluster_id": "python_source",
+      "question": "How to use Python source in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p4",
+      "cluster_id": "python_source",
+      "question": "Execute inline Python from Prolog",
+      "question_type": "medium",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p5",
+      "cluster_id": "python_source",
+      "question": "Query SQLite using Python source",
+      "question_type": "medium",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p6",
+      "cluster_id": "python_source",
+      "question": "I want to embed inline Python code in my Prolog file to process data or query a database",
+      "question_type": "long",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "python_source_p7",
+      "cluster_id": "python_source",
+      "question": "How can I use an external Python script as a data source for my UnifyWeaver pipeline?",
+      "question_type": "long",
+      "answer": "Python Source - Integrate Python code via python_source/3. Supports inline code, external files, and SQLite integration. Compiles to bash scripts that execute the Python code, bridging Prolog logic with Python's ecosystem.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/python_source_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p0",
+      "cluster_id": "powershell_binding_system",
+      "question": "powershell bindings",
+      "question_type": "short",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p1",
+      "cluster_id": "powershell_binding_system",
+      "question": "generate cmdlet code",
+      "question_type": "short",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p2",
+      "cluster_id": "powershell_binding_system",
+      "question": "dotnet method binding",
+      "question_type": "short",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p3",
+      "cluster_id": "powershell_binding_system",
+      "question": "How to use PowerShell bindings?",
+      "question_type": "medium",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p4",
+      "cluster_id": "powershell_binding_system",
+      "question": "Generate .NET math calls in PowerShell",
+      "question_type": "medium",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p5",
+      "cluster_id": "powershell_binding_system",
+      "question": "Create PowerShell cmdlets from bindings",
+      "question_type": "medium",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p6",
+      "cluster_id": "powershell_binding_system",
+      "question": "I need to generate PowerShell code that calls .NET System.IO methods using the binding system",
+      "question_type": "long",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "powershell_binding_system_p7",
+      "cluster_id": "powershell_binding_system",
+      "question": "How can I use bindings to generate PowerShell pipeline operations like ForEach-Object and Where-Object?",
+      "question_type": "long",
+      "answer": "PowerShell Binding System - Generate PowerShell code for .NET methods (Math, IO) and Cmdlets using bindings. Features `generate_binding_call/4` and `generate_cmdlet_from_binding/4`. Supports pipeline operations (ForEach, Where, Sort) and file system interactions.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/powershell_binding_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p0",
+      "cluster_id": "semantic_source",
+      "question": "semantic search source",
+      "question_type": "short",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p1",
+      "cluster_id": "semantic_source",
+      "question": "vector search prolog",
+      "question_type": "short",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p2",
+      "cluster_id": "semantic_source",
+      "question": "semantic query threshold",
+      "question_type": "short",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p3",
+      "cluster_id": "semantic_source",
+      "question": "How to use semantic search in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p4",
+      "cluster_id": "semantic_source",
+      "question": "Configure vector store for semantic source",
+      "question_type": "medium",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p5",
+      "cluster_id": "semantic_source",
+      "question": "Filter semantic results by threshold",
+      "question_type": "medium",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p6",
+      "cluster_id": "semantic_source",
+      "question": "I want to perform a semantic search against a vector store and retrieve the top 5 results",
+      "question_type": "long",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "semantic_source_p7",
+      "cluster_id": "semantic_source",
+      "question": "How can I configure a semantic source to use the python_onnx backend and a specific similarity threshold?",
+      "question_type": "long",
+      "answer": "Semantic Source - Perform vector-based semantic search. Configure `semantic` source with vector store, embedding backend (e.g., python_onnx), similarity threshold, and top_k results. Compiles to scripts that perform semantic retrieval.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/semantic_source_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p0",
+      "cluster_id": "partitioning_strategies",
+      "question": "data partitioning",
+      "question_type": "short",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p1",
+      "cluster_id": "partitioning_strategies",
+      "question": "hash based partitioner",
+      "question_type": "short",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p2",
+      "cluster_id": "partitioning_strategies",
+      "question": "fixed size chunks",
+      "question_type": "short",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p3",
+      "cluster_id": "partitioning_strategies",
+      "question": "How to partition data in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p4",
+      "cluster_id": "partitioning_strategies",
+      "question": "Use hash-based partitioning for parallelism",
+      "question_type": "medium",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p5",
+      "cluster_id": "partitioning_strategies",
+      "question": "Split data into fixed-size chunks",
+      "question_type": "medium",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p6",
+      "cluster_id": "partitioning_strategies",
+      "question": "I need to split a dataset into partitions based on a key field for parallel processing",
+      "question_type": "long",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "partitioning_strategies_p7",
+      "cluster_id": "partitioning_strategies",
+      "question": "How can I use the partitioner module to distribute data items among multiple workers using hashing?",
+      "question_type": "long",
+      "answer": "Partitioning Strategies - Split data for parallel processing using fixed-size, hash-based, or key-based partitioners. Use `partitioner_init/3`, `partitioner_partition/3`, and `partitioner_cleanup/1` to manage data distribution.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/partitioner_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p0",
+      "cluster_id": "bash_pipelines",
+      "question": "bash pipeline source",
+      "question_type": "short",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p1",
+      "cluster_id": "bash_pipelines",
+      "question": "multi stage pipeline",
+      "question_type": "short",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p2",
+      "cluster_id": "bash_pipelines",
+      "question": "pipe grep awk",
+      "question_type": "short",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p3",
+      "cluster_id": "bash_pipelines",
+      "question": "How to create bash pipelines in UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p4",
+      "cluster_id": "bash_pipelines",
+      "question": "Chain grep and awk stages",
+      "question_type": "medium",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p5",
+      "cluster_id": "bash_pipelines",
+      "question": "Define multi-stage data processing",
+      "question_type": "medium",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p6",
+      "cluster_id": "bash_pipelines",
+      "question": "I want to create a pipeline that greps for errors, extracts fields with awk, and sorts the output",
+      "question_type": "long",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    },
+    {
+      "pair_id": "bash_pipelines_p7",
+      "cluster_id": "bash_pipelines",
+      "question": "How can I define a bash_pipeline source with multiple processing stages to filter and aggregate log data?",
+      "question_type": "long",
+      "answer": "Bash Pipelines - Construct multi-stage Unix pipelines (e.g., grep | awk | sort | uniq). Define `bash_pipeline` sources with ordered `stages`. Compiles to efficient bash scripts that pipe data through each tool.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/bash_pipeline_examples.md"
+    }
+  ]
+}

--- a/playbooks/lda-training-data/expanded/qa_pairs_v5_expanded.json
+++ b/playbooks/lda-training-data/expanded/qa_pairs_v5_expanded.json
@@ -1,0 +1,373 @@
+{
+  "version": "5.0-expanded",
+  "description": "Expanded from qa_pairs_v5.json - 1-to-1 Q-A pairs",
+  "source_file": "qa_pairs_v5.json",
+  "model_variant": "default",
+  "expanded_at": "2025-12-23T15:18:14.450709",
+  "stats": {
+    "num_clusters": 5,
+    "num_pairs": 40
+  },
+  "pairs": [
+    {
+      "pair_id": "json_litedb_streaming_p0",
+      "cluster_id": "json_litedb_streaming",
+      "question": "json litedb stream",
+      "question_type": "short",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p1",
+      "cluster_id": "json_litedb_streaming",
+      "question": "litedb prolog",
+      "question_type": "short",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p2",
+      "cluster_id": "json_litedb_streaming",
+      "question": "load json database",
+      "question_type": "short",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p3",
+      "cluster_id": "json_litedb_streaming",
+      "question": "How to stream JSON into LiteDB?",
+      "question_type": "medium",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p4",
+      "cluster_id": "json_litedb_streaming",
+      "question": "Use C# to load LiteDB from Prolog",
+      "question_type": "medium",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p5",
+      "cluster_id": "json_litedb_streaming",
+      "question": "Process large JSON files with LiteDB",
+      "question_type": "medium",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p6",
+      "cluster_id": "json_litedb_streaming",
+      "question": "I want to load a large JSON dataset into a LiteDB database using an efficient streaming approach with C# inline code",
+      "question_type": "long",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "json_litedb_streaming_p7",
+      "cluster_id": "json_litedb_streaming",
+      "question": "How can I use UnifyWeaver to parse JSON files and insert records into a local NoSQL LiteDB database?",
+      "question_type": "long",
+      "answer": "JSON to LiteDB Streaming - Stream large JSON datasets into LiteDB using inline C# sources. Demonstrates reading JSON files, parsing with System.Text.Json, and inserting BsonDocuments into LiteDB collections efficiently. Supports querying the populated database via .NET.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/examples_library/json_litedb_examples.md"
+    },
+    {
+      "pair_id": "tree_recursion_p0",
+      "cluster_id": "tree_recursion",
+      "question": "tree recursion",
+      "question_type": "short",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p1",
+      "cluster_id": "tree_recursion",
+      "question": "tree sum prolog",
+      "question_type": "short",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p2",
+      "cluster_id": "tree_recursion",
+      "question": "recursive tree processing",
+      "question_type": "short",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p3",
+      "cluster_id": "tree_recursion",
+      "question": "How to compile tree recursion?",
+      "question_type": "medium",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p4",
+      "cluster_id": "tree_recursion",
+      "question": "Process tree structures in UnifyWeaver",
+      "question_type": "medium",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p5",
+      "cluster_id": "tree_recursion",
+      "question": "Implement tree_sum in Prolog",
+      "question_type": "medium",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p6",
+      "cluster_id": "tree_recursion",
+      "question": "I need to compile a Prolog predicate that recursively traverses a binary tree structure represented as lists",
+      "question_type": "long",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "tree_recursion_p7",
+      "cluster_id": "tree_recursion",
+      "question": "How does UnifyWeaver handle tree recursion where a function calls itself multiple times on branches?",
+      "question_type": "long",
+      "answer": "Tree Recursion - Compile tree-recursive predicates (like tree_sum) that operate on hierarchical data structures. UnifyWeaver transforms recursive logic handling list-represented trees (e.g., [Val, Left, Right]) into executable bash scripts.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/tree_recursion_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p0",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "xml fragments c#",
+      "question_type": "short",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p1",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "stream xml parsing",
+      "question_type": "short",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p2",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "c# xml reader",
+      "question_type": "short",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p3",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "How to process XML fragments in C#?",
+      "question_type": "medium",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p4",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "Stream XML data with XmlStreamReader",
+      "question_type": "medium",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p5",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "Handle CDATA in XML streams",
+      "question_type": "medium",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p6",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "I want to stream and parse XML fragments separated by newlines using C# integration in UnifyWeaver",
+      "question_type": "long",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "csharp_xml_fragments_p7",
+      "cluster_id": "csharp_xml_fragments",
+      "question": "How can I process XML data preserving CDATA sections and handling specific namespace prefixes?",
+      "question_type": "long",
+      "answer": "C# XML Fragments - Stream and process XML fragments using C# XmlStreamReader. Supports NUL or LF delimited fragments, preserving CDATA, and handling namespaces (including Pearltrees prefixes). Projects elements and attributes into dictionaries.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/csharp_xml_fragments_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p0",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "powershell inline c#",
+      "question_type": "short",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p1",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "add-type caching",
+      "question_type": "short",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p2",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "fast powershell dotnet",
+      "question_type": "short",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p3",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "How to embed C# in PowerShell?",
+      "question_type": "medium",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p4",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "Speed up PowerShell with inline .NET",
+      "question_type": "medium",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p5",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "Cache compiled C# DLLs in PowerShell",
+      "question_type": "medium",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p6",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "I need to optimize a PowerShell script by embedding performance-critical C# code using Add-Type",
+      "question_type": "long",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "powershell_inline_dotnet_p7",
+      "cluster_id": "powershell_inline_dotnet",
+      "question": "How can I compile and cache inline .NET code in PowerShell to achieve faster execution times?",
+      "question_type": "long",
+      "answer": "PowerShell Inline .NET - Embed C# code within PowerShell scripts using Add-Type for high performance (138x speedup with caching). Ideal for automation requiring .NET libraries or tight loops. Supports pre-compilation to cache DLLs and avoid compilation overhead on subsequent runs.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/powershell_inline_dotnet_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p0",
+      "cluster_id": "deployment_glue",
+      "question": "deployment glue",
+      "question_type": "short",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p1",
+      "cluster_id": "deployment_glue",
+      "question": "deploy service ssh",
+      "question_type": "short",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p2",
+      "cluster_id": "deployment_glue",
+      "question": "docker kubernetes prolog",
+      "question_type": "short",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p3",
+      "cluster_id": "deployment_glue",
+      "question": "How to deploy services with UnifyWeaver?",
+      "question_type": "medium",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p4",
+      "cluster_id": "deployment_glue",
+      "question": "Generate Kubernetes manifests from Prolog",
+      "question_type": "medium",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p5",
+      "cluster_id": "deployment_glue",
+      "question": "Deploy via SSH using deployment glue",
+      "question_type": "medium",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p6",
+      "cluster_id": "deployment_glue",
+      "question": "I want to automate service deployment to remote servers via SSH or generate Docker Compose files",
+      "question_type": "long",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    },
+    {
+      "pair_id": "deployment_glue_p7",
+      "cluster_id": "deployment_glue",
+      "question": "How can I declare service configurations and generate deployment scripts for Kubernetes or Cloud Functions?",
+      "question_type": "long",
+      "answer": "Deployment Glue - Manage service deployment via SSH, Docker, Kubernetes, and Cloud Functions. Declare services and deployment methods (ssh, docker, k8s) in Prolog. Generates deployment scripts and manifests for lifecycle management.",
+      "answer_variant": "default",
+      "answer_source": "playbooks/deployment_glue_playbook.md"
+    }
+  ]
+}

--- a/reports/answer_level_all-minilm.json
+++ b/reports/answer_level_all-minilm.json
@@ -56,8 +56,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8902439024390244,
       "mrr": 0.43417879943072507,
-      "train_time_ms": 0.6606999959331006,
-      "inference_time_us": 135.31585367362402,
+      "train_time_ms": 0.6506999998237006,
+      "inference_time_us": 136.97560972082655,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -200,8 +200,8 @@
       "recall_at_5": 0.6829268292682927,
       "recall_at_10": 0.8536585365853658,
       "mrr": 0.40962283526730237,
-      "train_time_ms": 214.78780199686298,
-      "inference_time_us": 1006.6268292664573,
+      "train_time_ms": 295.817395002814,
+      "inference_time_us": 1013.5853537088601,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -344,8 +344,8 @@
       "recall_at_5": 0.7682926829268293,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.441780954925422,
-      "train_time_ms": 152.7866010001162,
-      "inference_time_us": 1109.1402438313064,
+      "train_time_ms": 152.75879700493533,
+      "inference_time_us": 1135.5024268218917,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -488,8 +488,8 @@
       "recall_at_5": 0.7682926829268293,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.44155254119386117,
-      "train_time_ms": 152.6817010017112,
-      "inference_time_us": 1071.7743903003839,
+      "train_time_ms": 154.43469699675916,
+      "inference_time_us": 1346.3146219359394,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -632,8 +632,8 @@
       "recall_at_5": 0.7439024390243902,
       "recall_at_10": 0.9024390243902439,
       "mrr": 0.4254185492707731,
-      "train_time_ms": 425.99020300258417,
-      "inference_time_us": 1211.1195121578044,
+      "train_time_ms": 395.4365940007847,
+      "inference_time_us": 1130.6036341432823,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -776,8 +776,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.36429949692446456,
-      "train_time_ms": 2748.8877149953623,
-      "inference_time_us": 11441.463451153208,
+      "train_time_ms": 2780.1920550045907,
+      "inference_time_us": 11895.85123175653,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -920,8 +920,8 @@
       "recall_at_5": 0.7439024390243902,
       "recall_at_10": 0.8536585365853658,
       "mrr": 0.40008093894237706,
-      "train_time_ms": 4414.318311006355,
-      "inference_time_us": 24593.267134084115,
+      "train_time_ms": 4197.263848000148,
+      "inference_time_us": 22707.93196338473,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1064,8 +1064,8 @@
       "recall_at_5": 0.7926829268292683,
       "recall_at_10": 0.9024390243902439,
       "mrr": 0.4375273191677118,
-      "train_time_ms": 8514.742297003977,
-      "inference_time_us": 46345.40489017282,
+      "train_time_ms": 8847.159604003537,
+      "inference_time_us": 53192.63953664099,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1209,8 +1209,8 @@
       "recall_at_5": 0.7804878048780488,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.4397210214363617,
-      "train_time_ms": 3094.044899000437,
-      "inference_time_us": 22540.247560977063,
+      "train_time_ms": 2050.1777949975803,
+      "inference_time_us": 16324.995024372516,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1354,8 +1354,8 @@
       "recall_at_5": 0.7682926829268293,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.439314517371321,
-      "train_time_ms": 1666.917000002286,
-      "inference_time_us": 14110.891463354985,
+      "train_time_ms": 3544.2103399982443,
+      "inference_time_us": 28097.525012193862,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1499,8 +1499,8 @@
       "recall_at_5": 0.7926829268292683,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.4387223144387307,
-      "train_time_ms": 2584.975800004031,
-      "inference_time_us": 23429.28897553243,
+      "train_time_ms": 2791.2820159981493,
+      "inference_time_us": 22817.807207302838,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1644,8 +1644,8 @@
       "recall_at_5": 0.7804878048780488,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.4383066548767297,
-      "train_time_ms": 2491.075895995891,
-      "inference_time_us": 23100.141390253757,
+      "train_time_ms": 2403.1422089974512,
+      "inference_time_us": 22625.639256059403,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1788,8 +1788,8 @@
       "recall_at_5": 0.23170731707317074,
       "recall_at_10": 0.43902439024390244,
       "mrr": 0.14527393395678023,
-      "train_time_ms": 33.74500000063563,
-      "inference_time_us": 1120.2780243787324,
+      "train_time_ms": 21.04940100252861,
+      "inference_time_us": 1132.3121951846122,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1932,8 +1932,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.25609756097560976,
       "mrr": 0.0964601377637509,
-      "train_time_ms": 23.921898995467927,
-      "inference_time_us": 1002.9621829212041,
+      "train_time_ms": 23.557499996968545,
+      "inference_time_us": 1127.2853780388775,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2076,8 +2076,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.2073170731707317,
       "mrr": 0.08980189028436193,
-      "train_time_ms": 29.787599996780045,
-      "inference_time_us": 1075.7158414912183,
+      "train_time_ms": 24.6155999993789,
+      "inference_time_us": 1765.453670775126,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2220,8 +2220,8 @@
       "recall_at_5": 0.23170731707317074,
       "recall_at_10": 0.43902439024390244,
       "mrr": 0.14820570099992456,
-      "train_time_ms": 27.469399996334687,
-      "inference_time_us": 1309.0036463392785,
+      "train_time_ms": 30.943999998271465,
+      "inference_time_us": 1070.7524511750173,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2364,8 +2364,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.2682926829268293,
       "mrr": 0.09885587759783955,
-      "train_time_ms": 21.131599001819268,
-      "inference_time_us": 1058.6426707471596,
+      "train_time_ms": 23.418999997375067,
+      "inference_time_us": 1172.2536708076382,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2508,8 +2508,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.21951219512195122,
       "mrr": 0.0902840171915475,
-      "train_time_ms": 29.55289900273783,
-      "inference_time_us": 1159.723158485665,
+      "train_time_ms": 27.414600997872185,
+      "inference_time_us": 1003.7000122282757,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2652,8 +2652,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.2926829268292683,
       "mrr": 0.0999811954459338,
-      "train_time_ms": 25.131400005193427,
-      "inference_time_us": 1035.2280366599343,
+      "train_time_ms": 24.900500000512693,
+      "inference_time_us": 1133.8207438778381,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2798,8 +2798,8 @@
       "recall_at_5": 0.2804878048780488,
       "recall_at_10": 0.5487804878048781,
       "mrr": 0.1918273019915067,
-      "train_time_ms": 1953.7637769972207,
-      "inference_time_us": 10391.865743901979,
+      "train_time_ms": 1899.8360149998916,
+      "inference_time_us": 11133.46350003423,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2944,8 +2944,8 @@
       "recall_at_5": 0.43902439024390244,
       "recall_at_10": 0.6463414634146342,
       "mrr": 0.25737948311017217,
-      "train_time_ms": 1898.2926970056724,
-      "inference_time_us": 10656.736560965173,
+      "train_time_ms": 2014.1894150001463,
+      "inference_time_us": 10997.196414636408,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3090,8 +3090,8 @@
       "recall_at_5": 0.4878048780487805,
       "recall_at_10": 0.6707317073170732,
       "mrr": 0.27246522780219823,
-      "train_time_ms": 2020.4088960017543,
-      "inference_time_us": 10946.767048774678,
+      "train_time_ms": 2107.6286940005957,
+      "inference_time_us": 10499.772853619084,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3236,8 +3236,8 @@
       "recall_at_5": 0.25609756097560976,
       "recall_at_10": 0.4878048780487805,
       "mrr": 0.16648426067876645,
-      "train_time_ms": 1933.0228969993186,
-      "inference_time_us": 11548.837792627348,
+      "train_time_ms": 1924.4328069980838,
+      "inference_time_us": 10595.2209390724,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3382,8 +3382,8 @@
       "recall_at_5": 0.3780487804878049,
       "recall_at_10": 0.6341463414634146,
       "mrr": 0.2408432296778621,
-      "train_time_ms": 3428.638397002942,
-      "inference_time_us": 21951.064609754943,
+      "train_time_ms": 3691.3315760029946,
+      "inference_time_us": 22908.144951254988,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3527,8 +3527,8 @@
       "recall_at_5": 0.5,
       "recall_at_10": 0.7317073170731707,
       "mrr": 0.31928185421754446,
-      "train_time_ms": 2750.470300001325,
-      "inference_time_us": 1094.7841463614789,
+      "train_time_ms": 2691.9691910006804,
+      "inference_time_us": 1579.684134102114,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3672,8 +3672,8 @@
       "recall_at_5": 0.4268292682926829,
       "recall_at_10": 0.6707317073170732,
       "mrr": 0.2714562582244981,
-      "train_time_ms": 2518.310699997528,
-      "inference_time_us": 1048.390243895261,
+      "train_time_ms": 2616.326493996894,
+      "inference_time_us": 1100.3280366222918,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3817,8 +3817,8 @@
       "recall_at_5": 0.35365853658536583,
       "recall_at_10": 0.5853658536585366,
       "mrr": 0.19973658258348528,
-      "train_time_ms": 2638.032998998824,
-      "inference_time_us": 960.593902407975,
+      "train_time_ms": 2777.84459299437,
+      "inference_time_us": 1169.1231707007364,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3962,8 +3962,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7926829268292683,
       "mrr": 0.3389038301660228,
-      "train_time_ms": 4882.5424979950185,
-      "inference_time_us": 1338.3755976087186,
+      "train_time_ms": 4332.220750999113,
+      "inference_time_us": 1222.4305121380007,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4107,8 +4107,8 @@
       "recall_at_5": 0.3902439024390244,
       "recall_at_10": 0.6585365853658537,
       "mrr": 0.24769592286414568,
-      "train_time_ms": 2613.1148979984573,
-      "inference_time_us": 1030.0939024224447,
+      "train_time_ms": 2723.5924409978907,
+      "inference_time_us": 1010.3853902120779,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4251,8 +4251,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.3617403792658604,
-      "train_time_ms": 3664.0677969990065,
-      "inference_time_us": 16865.586573148015,
+      "train_time_ms": 3048.2696130056866,
+      "inference_time_us": 10772.12068296986,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4395,8 +4395,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.36793032752897925,
-      "train_time_ms": 4487.154797003313,
-      "inference_time_us": 11370.83535366223,
+      "train_time_ms": 4970.871473000443,
+      "inference_time_us": 17222.952170768844,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4539,8 +4539,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.36793032752897925,
-      "train_time_ms": 3088.5848850011826,
-      "inference_time_us": 10858.33043898896,
+      "train_time_ms": 3833.0071390009834,
+      "inference_time_us": 10372.721792675027,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4683,8 +4683,8 @@
       "recall_at_5": 0.7439024390243902,
       "recall_at_10": 0.8536585365853658,
       "mrr": 0.40785532918627965,
-      "train_time_ms": 5194.84856800409,
-      "inference_time_us": 21448.72789030182,
+      "train_time_ms": 5600.680695999472,
+      "inference_time_us": 23620.412158534902,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4815,7 +4815,8 @@
       "method": "MinTrans_none_f10",
       "params": {
         "smooth_method": "none",
-        "fidelity_weight": 1.0
+        "fidelity_weight": 1.0,
+        "per_pair": false
       },
       "mean_cosine_to_target": 0.78483241973399,
       "std_cosine_to_target": 0.08790213377391279,
@@ -4827,8 +4828,8 @@
       "recall_at_5": 0.9878048780487805,
       "recall_at_10": 1.0,
       "mrr": 0.86880081300813,
-      "train_time_ms": 31.699099999968894,
-      "inference_time_us": 882.9487682882378,
+      "train_time_ms": 29.89520000119228,
+      "inference_time_us": 959.4000000173011,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4959,7 +4960,8 @@
       "method": "MinTrans_fft_f0",
       "params": {
         "smooth_method": "fft",
-        "fidelity_weight": 0.0
+        "fidelity_weight": 0.0,
+        "per_pair": false
       },
       "mean_cosine_to_target": 0.7429413714924822,
       "std_cosine_to_target": 0.1031226562203918,
@@ -4971,8 +4973,8 @@
       "recall_at_5": 0.975609756097561,
       "recall_at_10": 1.0,
       "mrr": 0.8488095238095237,
-      "train_time_ms": 161.67659900384024,
-      "inference_time_us": 855.8743780091257,
+      "train_time_ms": 168.30859900073847,
+      "inference_time_us": 969.4731707873516,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -5103,7 +5105,8 @@
       "method": "MinTrans_fft_f3",
       "params": {
         "smooth_method": "fft",
-        "fidelity_weight": 0.3
+        "fidelity_weight": 0.3,
+        "per_pair": false
       },
       "mean_cosine_to_target": 0.757863006576642,
       "std_cosine_to_target": 0.09720322210728012,
@@ -5115,8 +5118,8 @@
       "recall_at_5": 0.9878048780487805,
       "recall_at_10": 1.0,
       "mrr": 0.8620934959349593,
-      "train_time_ms": 105.52789999928791,
-      "inference_time_us": 988.4085366360434,
+      "train_time_ms": 112.15850000007777,
+      "inference_time_us": 1023.785365893074,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -5247,7 +5250,8 @@
       "method": "MinTrans_fft_f5",
       "params": {
         "smooth_method": "fft",
-        "fidelity_weight": 0.5
+        "fidelity_weight": 0.5,
+        "per_pair": false
       },
       "mean_cosine_to_target": 0.7667096923107363,
       "std_cosine_to_target": 0.09408001782288956,
@@ -5259,8 +5263,8 @@
       "recall_at_5": 0.9878048780487805,
       "recall_at_10": 1.0,
       "mrr": 0.8590447154471544,
-      "train_time_ms": 125.951800000621,
-      "inference_time_us": 1689.7134145682041,
+      "train_time_ms": 128.00589999824297,
+      "inference_time_us": 1160.5316951939064,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -5391,7 +5395,8 @@
       "method": "MinTrans_fft_f7",
       "params": {
         "smooth_method": "fft",
-        "fidelity_weight": 0.7
+        "fidelity_weight": 0.7,
+        "per_pair": false
       },
       "mean_cosine_to_target": 0.7746437059486188,
       "std_cosine_to_target": 0.09140276072669026,
@@ -5403,8 +5408,8 @@
       "recall_at_5": 0.9878048780487805,
       "recall_at_10": 1.0,
       "mrr": 0.8620934959349593,
-      "train_time_ms": 153.5996000020532,
-      "inference_time_us": 1326.804878062387,
+      "train_time_ms": 171.46419899654575,
+      "inference_time_us": 873.3463415055445,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -5535,7 +5540,8 @@
       "method": "MinTrans_kernel_f5",
       "params": {
         "smooth_method": "kernel",
-        "fidelity_weight": 0.5
+        "fidelity_weight": 0.5,
+        "per_pair": false
       },
       "mean_cosine_to_target": 0.7320163378621694,
       "std_cosine_to_target": 0.10031995688086646,
@@ -5547,8 +5553,8 @@
       "recall_at_5": 0.9634146341463414,
       "recall_at_10": 1.0,
       "mrr": 0.8479965156794425,
-      "train_time_ms": 98.7676000004285,
-      "inference_time_us": 944.074390245965,
+      "train_time_ms": 85.00719900621334,
+      "inference_time_us": 1066.8719513022352,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -5670,6 +5676,296 @@
         "fold-pattern": {
           "mean_cosine": 0.800900768121317,
           "mean_mse": 0.0011283363211408571,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_none_f10_pp",
+      "params": {
+        "smooth_method": "none",
+        "fidelity_weight": 1.0,
+        "per_pair": true
+      },
+      "mean_cosine_to_target": 0.7241134350411035,
+      "std_cosine_to_target": 0.17314837092787877,
+      "mean_mse_to_target": 0.0012998817663277475,
+      "std_mse_to_target": 0.0007993379736843598,
+      "mean_target_rank": 1.5853658536585367,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7926829268292683,
+      "recall_at_5": 0.975609756097561,
+      "recall_at_10": 0.9878048780487805,
+      "mrr": 0.8643437862950057,
+      "train_time_ms": 45.894099996075965,
+      "inference_time_us": 1193.1914511767056,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.6491776433844739,
+          "mean_mse": 0.0016083390069398722,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.6593890939945316,
+          "mean_mse": 0.0016170314670406897,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7686684885996367,
+          "mean_mse": 0.0010881189259825809,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7364236001613208,
+          "mean_mse": 0.001244521553402184,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.5622896382691613,
+          "mean_mse": 0.002024634514236501,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7853359724849002,
+          "mean_mse": 0.0010074927044090598,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6594398121077256,
+          "mean_mse": 0.0015890796174506058,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.672140857340872,
+          "mean_mse": 0.0015056875211828641,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8304623716147427,
+          "mean_mse": 0.0008127668784460686,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.6918094737733078,
+          "mean_mse": 0.0014423089094018284,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.6686800357528225,
+          "mean_mse": 0.001584191978021523,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7844950372164315,
+          "mean_mse": 0.001024638805340032,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.6897150486145982,
+          "mean_mse": 0.0014998731514438688,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7315335457644182,
+          "mean_mse": 0.0012682582471331592,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8325643511876051,
+          "mean_mse": 0.0008015848016873418,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7147672657043311,
+          "mean_mse": 0.0013091803872683435,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.87856333123251,
+          "mean_mse": 0.000601035852790814,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.5347436145491157,
+          "mean_mse": 0.002162337775198773,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7799778121329117,
+          "mean_mse": 0.001093526724570238,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8236494451124137,
+          "mean_mse": 0.0008427111063776664,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f5_pp",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.5,
+        "per_pair": true
+      },
+      "mean_cosine_to_target": 0.7172322916812509,
+      "std_cosine_to_target": 0.1682012419591182,
+      "mean_mse_to_target": 0.0013259654902843508,
+      "std_mse_to_target": 0.000771478153524929,
+      "mean_target_rank": 1.646341463414634,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7682926829268293,
+      "recall_at_5": 0.975609756097561,
+      "recall_at_10": 0.9878048780487805,
+      "mrr": 0.8469891896721163,
+      "train_time_ms": 146.88749899505638,
+      "inference_time_us": 1054.2158536448303,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.643464589708341,
+          "mean_mse": 0.0016187388612208275,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.6615217884205555,
+          "mean_mse": 0.0016119968840710237,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7665124192463107,
+          "mean_mse": 0.001096643032498761,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7296453656455073,
+          "mean_mse": 0.0012773414438902377,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.5628889182954093,
+          "mean_mse": 0.0020099027848320137,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7812134315177273,
+          "mean_mse": 0.0010246617474916641,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6408100992988806,
+          "mean_mse": 0.0016519700642998098,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.6649436727406178,
+          "mean_mse": 0.0015339188575840977,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8201492920971145,
+          "mean_mse": 0.0008587108928477633,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.6847436664399077,
+          "mean_mse": 0.0014725006229207747,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.6605622864281874,
+          "mean_mse": 0.0016157289408315853,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7840700224362818,
+          "mean_mse": 0.0010216835991275672,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.6723809638931288,
+          "mean_mse": 0.0015575902652999547,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7329302101097349,
+          "mean_mse": 0.001262335025119691,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8233794458687566,
+          "mean_mse": 0.0008416046197202047,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7083166307102612,
+          "mean_mse": 0.001335461147541028,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8606964988826932,
+          "mean_mse": 0.0006834404538838987,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.5289496044672655,
+          "mean_mse": 0.002184922897741177,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7684463019004981,
+          "mean_mse": 0.0011301171873845065,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8193668958067526,
+          "mean_mse": 0.0008627617430307385,
           "mean_rank": 1.25,
           "num_queries": 4
         }

--- a/reports/answer_level_all-minilm.json
+++ b/reports/answer_level_all-minilm.json
@@ -36,9 +36,9 @@
   "winners": {
     "highest_cosine": "Residual_K8_r0.01",
     "lowest_mse": "MultiHeadLDA",
-    "lowest_rank": "Residual_K8_r0.01",
-    "highest_mrr": "FFT_c0.5",
-    "highest_recall_at_5": "Basis_K16"
+    "lowest_rank": "MinTrans_none_f10",
+    "highest_mrr": "MinTrans_none_f10",
+    "highest_recall_at_5": "MinTrans_none_f10"
   },
   "results": [
     {
@@ -56,8 +56,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8902439024390244,
       "mrr": 0.43417879943072507,
-      "train_time_ms": 0.5221999999776017,
-      "inference_time_us": 139.21341464660279,
+      "train_time_ms": 0.6606999959331006,
+      "inference_time_us": 135.31585367362402,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -200,8 +200,8 @@
       "recall_at_5": 0.6829268292682927,
       "recall_at_10": 0.8536585365853658,
       "mrr": 0.40962283526730237,
-      "train_time_ms": 252.4210060000769,
-      "inference_time_us": 1017.5414877821601,
+      "train_time_ms": 214.78780199686298,
+      "inference_time_us": 1006.6268292664573,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -344,8 +344,8 @@
       "recall_at_5": 0.7682926829268293,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.441780954925422,
-      "train_time_ms": 158.8671039971814,
-      "inference_time_us": 1015.0585609464055,
+      "train_time_ms": 152.7866010001162,
+      "inference_time_us": 1109.1402438313064,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -488,8 +488,8 @@
       "recall_at_5": 0.7682926829268293,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.44155254119386117,
-      "train_time_ms": 156.42680400196696,
-      "inference_time_us": 1034.9231951095578,
+      "train_time_ms": 152.6817010017112,
+      "inference_time_us": 1071.7743903003839,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -632,8 +632,8 @@
       "recall_at_5": 0.7439024390243902,
       "recall_at_10": 0.9024390243902439,
       "mrr": 0.4254185492707731,
-      "train_time_ms": 411.5376110021316,
-      "inference_time_us": 926.4768536590187,
+      "train_time_ms": 425.99020300258417,
+      "inference_time_us": 1211.1195121578044,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -776,8 +776,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.36429949692446456,
-      "train_time_ms": 2761.698071997671,
-      "inference_time_us": 11090.327256081255,
+      "train_time_ms": 2748.8877149953623,
+      "inference_time_us": 11441.463451153208,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -920,8 +920,8 @@
       "recall_at_5": 0.7439024390243902,
       "recall_at_10": 0.8536585365853658,
       "mrr": 0.40008093894237706,
-      "train_time_ms": 4213.170471000922,
-      "inference_time_us": 22441.911890271556,
+      "train_time_ms": 4414.318311006355,
+      "inference_time_us": 24593.267134084115,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1064,8 +1064,8 @@
       "recall_at_5": 0.7926829268292683,
       "recall_at_10": 0.9024390243902439,
       "mrr": 0.4375273191677118,
-      "train_time_ms": 7960.301653998613,
-      "inference_time_us": 52353.82458535818,
+      "train_time_ms": 8514.742297003977,
+      "inference_time_us": 46345.40489017282,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1209,8 +1209,8 @@
       "recall_at_5": 0.7804878048780488,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.4397210214363617,
-      "train_time_ms": 1715.7647990024998,
-      "inference_time_us": 14233.328036602981,
+      "train_time_ms": 3094.044899000437,
+      "inference_time_us": 22540.247560977063,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1354,8 +1354,8 @@
       "recall_at_5": 0.7682926829268293,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.439314517371321,
-      "train_time_ms": 1627.4372990010306,
-      "inference_time_us": 13355.10975607066,
+      "train_time_ms": 1666.917000002286,
+      "inference_time_us": 14110.891463354985,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1499,8 +1499,8 @@
       "recall_at_5": 0.7926829268292683,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.4387223144387307,
-      "train_time_ms": 2506.625038000493,
-      "inference_time_us": 23929.891780470625,
+      "train_time_ms": 2584.975800004031,
+      "inference_time_us": 23429.28897553243,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1644,8 +1644,8 @@
       "recall_at_5": 0.7804878048780488,
       "recall_at_10": 0.9146341463414634,
       "mrr": 0.4383066548767297,
-      "train_time_ms": 4846.360943000036,
-      "inference_time_us": 36494.145439020234,
+      "train_time_ms": 2491.075895995891,
+      "inference_time_us": 23100.141390253757,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1788,8 +1788,8 @@
       "recall_at_5": 0.23170731707317074,
       "recall_at_10": 0.43902439024390244,
       "mrr": 0.14527393395678023,
-      "train_time_ms": 35.21540099973208,
-      "inference_time_us": 1171.6463414791733,
+      "train_time_ms": 33.74500000063563,
+      "inference_time_us": 1120.2780243787324,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1932,8 +1932,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.25609756097560976,
       "mrr": 0.0964601377637509,
-      "train_time_ms": 24.363000000448665,
-      "inference_time_us": 1419.207329246735,
+      "train_time_ms": 23.921898995467927,
+      "inference_time_us": 1002.9621829212041,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2076,8 +2076,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.2073170731707317,
       "mrr": 0.08980189028436193,
-      "train_time_ms": 32.158899997739354,
-      "inference_time_us": 1217.126841433261,
+      "train_time_ms": 29.787599996780045,
+      "inference_time_us": 1075.7158414912183,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2220,8 +2220,8 @@
       "recall_at_5": 0.23170731707317074,
       "recall_at_10": 0.43902439024390244,
       "mrr": 0.14820570099992456,
-      "train_time_ms": 26.82960000311141,
-      "inference_time_us": 1229.3048902636922,
+      "train_time_ms": 27.469399996334687,
+      "inference_time_us": 1309.0036463392785,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2364,8 +2364,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.2682926829268293,
       "mrr": 0.09885587759783955,
-      "train_time_ms": 28.08539999750792,
-      "inference_time_us": 1288.640256106879,
+      "train_time_ms": 21.131599001819268,
+      "inference_time_us": 1058.6426707471596,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2508,8 +2508,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.21951219512195122,
       "mrr": 0.0902840171915475,
-      "train_time_ms": 31.183499999315245,
-      "inference_time_us": 1245.9902561048937,
+      "train_time_ms": 29.55289900273783,
+      "inference_time_us": 1159.723158485665,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2652,8 +2652,8 @@
       "recall_at_5": 0.10975609756097561,
       "recall_at_10": 0.2926829268292683,
       "mrr": 0.0999811954459338,
-      "train_time_ms": 24.399399997491855,
-      "inference_time_us": 1152.9512317438052,
+      "train_time_ms": 25.131400005193427,
+      "inference_time_us": 1035.2280366599343,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2798,8 +2798,8 @@
       "recall_at_5": 0.2804878048780488,
       "recall_at_10": 0.5487804878048781,
       "mrr": 0.1918273019915067,
-      "train_time_ms": 1881.2038139985816,
-      "inference_time_us": 10588.5561829271,
+      "train_time_ms": 1953.7637769972207,
+      "inference_time_us": 10391.865743901979,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2944,8 +2944,8 @@
       "recall_at_5": 0.43902439024390244,
       "recall_at_10": 0.6463414634146342,
       "mrr": 0.25737948311017217,
-      "train_time_ms": 2013.1040140004188,
-      "inference_time_us": 10352.665926824911,
+      "train_time_ms": 1898.2926970056724,
+      "inference_time_us": 10656.736560965173,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3090,8 +3090,8 @@
       "recall_at_5": 0.4878048780487805,
       "recall_at_10": 0.6707317073170732,
       "mrr": 0.27246522780219823,
-      "train_time_ms": 1875.3884129982907,
-      "inference_time_us": 11779.062280499891,
+      "train_time_ms": 2020.4088960017543,
+      "inference_time_us": 10946.767048774678,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3236,8 +3236,8 @@
       "recall_at_5": 0.25609756097560976,
       "recall_at_10": 0.4878048780487805,
       "mrr": 0.16648426067876645,
-      "train_time_ms": 1933.9334109972697,
-      "inference_time_us": 10707.274438994695,
+      "train_time_ms": 1933.0228969993186,
+      "inference_time_us": 11548.837792627348,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3382,8 +3382,8 @@
       "recall_at_5": 0.3780487804878049,
       "recall_at_10": 0.6341463414634146,
       "mrr": 0.2408432296778621,
-      "train_time_ms": 3490.9962199999427,
-      "inference_time_us": 22994.72450001148,
+      "train_time_ms": 3428.638397002942,
+      "inference_time_us": 21951.064609754943,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3527,8 +3527,8 @@
       "recall_at_5": 0.5,
       "recall_at_10": 0.7317073170731707,
       "mrr": 0.31928185421754446,
-      "train_time_ms": 2672.3614119982813,
-      "inference_time_us": 971.4524512230305,
+      "train_time_ms": 2750.470300001325,
+      "inference_time_us": 1094.7841463614789,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3672,8 +3672,8 @@
       "recall_at_5": 0.4268292682926829,
       "recall_at_10": 0.6707317073170732,
       "mrr": 0.2714562582244981,
-      "train_time_ms": 2613.836595999601,
-      "inference_time_us": 1107.2207073040063,
+      "train_time_ms": 2518.310699997528,
+      "inference_time_us": 1048.390243895261,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3817,8 +3817,8 @@
       "recall_at_5": 0.35365853658536583,
       "recall_at_10": 0.5853658536585366,
       "mrr": 0.19973658258348528,
-      "train_time_ms": 2601.8938519991934,
-      "inference_time_us": 1141.0841219380595,
+      "train_time_ms": 2638.032998998824,
+      "inference_time_us": 960.593902407975,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3962,8 +3962,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7926829268292683,
       "mrr": 0.3389038301660228,
-      "train_time_ms": 4271.172311000555,
-      "inference_time_us": 1154.8565243862047,
+      "train_time_ms": 4882.5424979950185,
+      "inference_time_us": 1338.3755976087186,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4107,8 +4107,8 @@
       "recall_at_5": 0.3902439024390244,
       "recall_at_10": 0.6585365853658537,
       "mrr": 0.24769592286414568,
-      "train_time_ms": 2875.7776290003676,
-      "inference_time_us": 1252.64547559931,
+      "train_time_ms": 2613.1148979984573,
+      "inference_time_us": 1030.0939024224447,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4251,8 +4251,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.3617403792658604,
-      "train_time_ms": 3018.2391130001633,
-      "inference_time_us": 11149.082902459379,
+      "train_time_ms": 3664.0677969990065,
+      "inference_time_us": 16865.586573148015,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4395,8 +4395,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.36793032752897925,
-      "train_time_ms": 3182.3212259987486,
-      "inference_time_us": 10847.286341453493,
+      "train_time_ms": 4487.154797003313,
+      "inference_time_us": 11370.83535366223,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4539,8 +4539,8 @@
       "recall_at_5": 0.6097560975609756,
       "recall_at_10": 0.7682926829268293,
       "mrr": 0.36793032752897925,
-      "train_time_ms": 3254.2012829981104,
-      "inference_time_us": 11381.57007317648,
+      "train_time_ms": 3088.5848850011826,
+      "inference_time_us": 10858.33043898896,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4683,8 +4683,8 @@
       "recall_at_5": 0.7439024390243902,
       "recall_at_10": 0.8536585365853658,
       "mrr": 0.40785532918627965,
-      "train_time_ms": 7551.8749189977825,
-      "inference_time_us": 37326.11967075727,
+      "train_time_ms": 5194.84856800409,
+      "inference_time_us": 21448.72789030182,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4807,6 +4807,870 @@
           "mean_cosine": 0.8859788519124596,
           "mean_mse": 0.0005802706508350388,
           "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_none_f10",
+      "params": {
+        "smooth_method": "none",
+        "fidelity_weight": 1.0
+      },
+      "mean_cosine_to_target": 0.78483241973399,
+      "std_cosine_to_target": 0.08790213377391279,
+      "mean_mse_to_target": 0.001356783354208067,
+      "std_mse_to_target": 0.0006186769496384675,
+      "mean_target_rank": 1.451219512195122,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7926829268292683,
+      "recall_at_5": 0.9878048780487805,
+      "recall_at_10": 1.0,
+      "mrr": 0.86880081300813,
+      "train_time_ms": 31.699099999968894,
+      "inference_time_us": 882.9487682882378,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7315972149858979,
+          "mean_mse": 0.0016174127197792873,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.7102348676276448,
+          "mean_mse": 0.0019782614735100305,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7839741335038741,
+          "mean_mse": 0.001350402913640418,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7861461240723764,
+          "mean_mse": 0.0013463804697799885,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7210496620914243,
+          "mean_mse": 0.001975646524090856,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.79561463721527,
+          "mean_mse": 0.0012807246612731994,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6981937276446848,
+          "mean_mse": 0.0018639028171975065,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7234182907407327,
+          "mean_mse": 0.001735115638047187,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8700181188402956,
+          "mean_mse": 0.0007317764074245563,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7590149538748434,
+          "mean_mse": 0.0014951421792562427,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.7788536333260832,
+          "mean_mse": 0.0015244524979410427,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8589036461082735,
+          "mean_mse": 0.0008375528505343957,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.7850383947010704,
+          "mean_mse": 0.001600198024649896,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7821703808665359,
+          "mean_mse": 0.0013270336346826166,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8423623505969637,
+          "mean_mse": 0.0009459889517611131,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7794915838302967,
+          "mean_mse": 0.0013554008737274486,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.863211415416197,
+          "mean_mse": 0.0007775655302609023,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.6927815919851029,
+          "mean_mse": 0.0019440589083543367,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8516969086433815,
+          "mean_mse": 0.0008567014773056605,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8622458435491374,
+          "mean_mse": 0.000755637697521901,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f0",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.0
+      },
+      "mean_cosine_to_target": 0.7429413714924822,
+      "std_cosine_to_target": 0.1031226562203918,
+      "mean_mse_to_target": 0.0015761690901265274,
+      "std_mse_to_target": 0.0006980371791741228,
+      "mean_target_rank": 1.5609756097560976,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7682926829268293,
+      "recall_at_5": 0.975609756097561,
+      "recall_at_10": 1.0,
+      "mrr": 0.8488095238095237,
+      "train_time_ms": 161.67659900384024,
+      "inference_time_us": 855.8743780091257,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.6788719897310436,
+          "mean_mse": 0.0018793518431938312,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.6872642614668474,
+          "mean_mse": 0.0020524451726003415,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7710530876738392,
+          "mean_mse": 0.0013850270051945631,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7561792541832894,
+          "mean_mse": 0.0015218723626005846,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.6725645400270612,
+          "mean_mse": 0.002220328753506651,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7711866056764956,
+          "mean_mse": 0.0014919177485968175,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6604561933908136,
+          "mean_mse": 0.0020513803382048016,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.6926903407443532,
+          "mean_mse": 0.0019072642652590687,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8426775747089202,
+          "mean_mse": 0.0008776074059702353,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7241393909964879,
+          "mean_mse": 0.0016667792682337618,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.7389403123381227,
+          "mean_mse": 0.001780025809573071,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8268311346510286,
+          "mean_mse": 0.0010425744106305904,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.6728385216669985,
+          "mean_mse": 0.0019691602391520664,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7654869764086574,
+          "mean_mse": 0.001415261974473825,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8163186769966491,
+          "mean_mse": 0.0010942093565476491,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.751428700521333,
+          "mean_mse": 0.0014918611606097633,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8040092811985754,
+          "mean_mse": 0.001092189150901104,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.6179220830875641,
+          "mean_mse": 0.002423801190439737,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7714318882584732,
+          "mean_mse": 0.0013122620997091659,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.805966164089937,
+          "mean_mse": 0.0010629294470851668,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f3",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.3
+      },
+      "mean_cosine_to_target": 0.757863006576642,
+      "std_cosine_to_target": 0.09720322210728012,
+      "mean_mse_to_target": 0.0014908790071120614,
+      "std_mse_to_target": 0.0006656863301581724,
+      "mean_target_rank": 1.5121951219512195,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7926829268292683,
+      "recall_at_5": 0.9878048780487805,
+      "recall_at_10": 1.0,
+      "mrr": 0.8620934959349593,
+      "train_time_ms": 105.52789999928791,
+      "inference_time_us": 988.4085366360434,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.6965938867879891,
+          "mean_mse": 0.0017849361448591273,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.6945732966510869,
+          "mean_mse": 0.0020262436363575453,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7753506875917087,
+          "mean_mse": 0.001371278086282294,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7661950131030922,
+          "mean_mse": 0.0014604683889305864,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.6888558734041067,
+          "mean_mse": 0.002128558590465704,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7795156773829951,
+          "mean_mse": 0.0014171263038464243,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6727520202548387,
+          "mean_mse": 0.00198551715576374,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.702819463158679,
+          "mean_mse": 0.0018470828301353946,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8519426344635995,
+          "mean_mse": 0.0008268929382328138,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7358431696421098,
+          "mean_mse": 0.0016046969286752318,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.7522202434742175,
+          "mean_mse": 0.0016886581303215105,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.838032151755022,
+          "mean_mse": 0.0009681457416815305,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.7175112771226975,
+          "mean_mse": 0.0017720009332280963,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7709528636794962,
+          "mean_mse": 0.0013851526710580682,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8253661712675278,
+          "mean_mse": 0.001040487893157206,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7611819183889045,
+          "mean_mse": 0.0014399935381956247,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8247555548026843,
+          "mean_mse": 0.0009779229994469024,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.6428233219121643,
+          "mean_mse": 0.0022461165941335165,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8054686943140839,
+          "mean_mse": 0.0011013189540895493,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8277138411283815,
+          "mean_mse": 0.0009374097846136728,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f5",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.5
+      },
+      "mean_cosine_to_target": 0.7667096923107363,
+      "std_cosine_to_target": 0.09408001782288956,
+      "mean_mse_to_target": 0.0014432924575971454,
+      "std_mse_to_target": 0.000649322862329353,
+      "mean_target_rank": 1.5,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7804878048780488,
+      "recall_at_5": 0.9878048780487805,
+      "recall_at_10": 1.0,
+      "mrr": 0.8590447154471544,
+      "train_time_ms": 125.951800000621,
+      "inference_time_us": 1689.7134145682041,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7075192596693811,
+          "mean_mse": 0.0017295323275456774,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.6992464136953921,
+          "mean_mse": 0.0020106551962507783,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7780123766129123,
+          "mean_mse": 0.0013637129457912697,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7723905494412923,
+          "mean_mse": 0.0014237021235428827,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.6988976601283935,
+          "mean_mse": 0.00207612395520803,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7846240540582119,
+          "mean_mse": 0.0013727098733239279,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6804992930805637,
+          "mean_mse": 0.001946189284678686,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7091503420026215,
+          "mean_mse": 0.0018110270386053787,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8576182840564852,
+          "mean_mse": 0.0007964000398239222,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7430636122238405,
+          "mean_mse": 0.0015683521370006286,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.7604766087248204,
+          "mean_mse": 0.0016347442897547335,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8447760710278935,
+          "mean_mse": 0.0009246800580584437,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.7417497341283501,
+          "mean_mse": 0.0016817378919327442,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7743785583227261,
+          "mean_mse": 0.0013668135171039418,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8308198745576306,
+          "mean_mse": 0.0010090808899228545,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7670531241274905,
+          "mean_mse": 0.0014106196643716487,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8372108040450814,
+          "mean_mse": 0.0009112117866975017,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.6583919193931248,
+          "mean_mse": 0.0021437372973963226,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.823672651619352,
+          "mean_mse": 0.0009960592183900741,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8399982908597269,
+          "mean_mse": 0.0008696024561100645,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f7",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.7
+      },
+      "mean_cosine_to_target": 0.7746437059486188,
+      "std_cosine_to_target": 0.09140276072669026,
+      "mean_mse_to_target": 0.0014031247127446775,
+      "std_mse_to_target": 0.0006357042970664292,
+      "mean_target_rank": 1.475609756097561,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7804878048780488,
+      "recall_at_5": 0.9878048780487805,
+      "recall_at_10": 1.0,
+      "mrr": 0.8620934959349593,
+      "train_time_ms": 153.5996000020532,
+      "inference_time_us": 1326.804878062387,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7177091396116994,
+          "mean_mse": 0.0016801604954933096,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.7037603465126155,
+          "mean_mse": 0.001996570156721421,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7805143623252463,
+          "mean_mse": 0.001357428449660636,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7781923284840339,
+          "mean_mse": 0.0013902716318023483,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7082675243890217,
+          "mean_mse": 0.002030685698699386,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7893400905809714,
+          "mean_mse": 0.0013326490689169774,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6878689812266998,
+          "mean_mse": 0.001910526147360822,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7151293960552545,
+          "mean_mse": 0.001778223379250642,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8628864916279267,
+          "mean_mse": 0.0007685605388145423,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7498068003189989,
+          "mean_mse": 0.0015360420930842248,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.7682248264157422,
+          "mean_mse": 0.0015864288056686993,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8509073687673081,
+          "mean_mse": 0.0008861371176430526,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.7618321710583915,
+          "mean_mse": 0.0016244160474272282,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.777628033726966,
+          "mean_mse": 0.001349861335141585,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8357983215253164,
+          "mean_mse": 0.0009811997312425915,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7724130746286269,
+          "mean_mse": 0.0013854094234426989,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8485055781472619,
+          "mean_mse": 0.0008520735511908217,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.6729782732981653,
+          "mean_mse": 0.0020542196812993567,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.837928097758021,
+          "mean_mse": 0.0009190947051281474,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8503761341496946,
+          "mean_mse": 0.0008144930847883663,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_kernel_f5",
+      "params": {
+        "smooth_method": "kernel",
+        "fidelity_weight": 0.5
+      },
+      "mean_cosine_to_target": 0.7320163378621694,
+      "std_cosine_to_target": 0.10031995688086646,
+      "mean_mse_to_target": 0.0016425338960736032,
+      "std_mse_to_target": 0.0006629663397477273,
+      "mean_target_rank": 1.5731707317073171,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.7682926829268293,
+      "recall_at_5": 0.9634146341463414,
+      "recall_at_10": 1.0,
+      "mrr": 0.8479965156794425,
+      "train_time_ms": 98.7676000004285,
+      "inference_time_us": 944.074390245965,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.658672257469125,
+          "mean_mse": 0.002041144489464707,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.6670223777374763,
+          "mean_mse": 0.0021522276732713376,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.74566194546305,
+          "mean_mse": 0.0015701937960962658,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.739132464543893,
+          "mean_mse": 0.0016249817646175513,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.6640050050868241,
+          "mean_mse": 0.0022243592463398625,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.7545037274214887,
+          "mean_mse": 0.001498167382698834,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.6446854242719399,
+          "mean_mse": 0.002159760663879076,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.6786977506285685,
+          "mean_mse": 0.001989146492330199,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8199138179783301,
+          "mean_mse": 0.0010442785548173497,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7223020883165172,
+          "mean_mse": 0.0017037785881434475,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.7338622321277011,
+          "mean_mse": 0.00173877929159351,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8290265645765053,
+          "mean_mse": 0.001027722403830808,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.6789299040021677,
+          "mean_mse": 0.002018976040384153,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7541847249194155,
+          "mean_mse": 0.001511658696970692,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.7972492890676524,
+          "mean_mse": 0.001206801496772061,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7515774311358011,
+          "mean_mse": 0.0015305494401284246,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.7639458040569395,
+          "mean_mse": 0.0013344644472974446,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.6145627133814572,
+          "mean_mse": 0.0023628935942923077,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7939740001438637,
+          "mean_mse": 0.0011647401724929629,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.800900768121317,
+          "mean_mse": 0.0011283363211408571,
+          "mean_rank": 1.25,
           "num_queries": 4
         }
       }

--- a/reports/answer_level_all-minilm.json
+++ b/reports/answer_level_all-minilm.json
@@ -36,9 +36,9 @@
   "winners": {
     "highest_cosine": "Residual_K8_r0.01",
     "lowest_mse": "MultiHeadLDA",
-    "lowest_rank": "Residual_K4_r0.01",
-    "highest_mrr": "Residual_K8_r0.01",
-    "highest_recall_at_5": "FFT_c0.7"
+    "lowest_rank": "Residual_K8_r0.01",
+    "highest_mrr": "FFT_c0.5",
+    "highest_recall_at_5": "Basis_K16"
   },
   "results": [
     {
@@ -46,320 +46,140 @@
       "params": {
         "type": "baseline"
       },
-      "mean_cosine_to_target": 0.8665396782538033,
-      "std_cosine_to_target": 0.06840895589251006,
-      "mean_mse_to_target": 0.0006621252864278407,
-      "std_mse_to_target": 0.0002855152910007206,
-      "mean_target_rank": 8.801980198019802,
+      "mean_cosine_to_target": 0.8788916713856454,
+      "std_cosine_to_target": 0.05776034048800219,
+      "mean_mse_to_target": 0.0005998059370434141,
+      "std_mse_to_target": 0.0002543848737089664,
+      "mean_target_rank": 5.475609756097561,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.18316831683168316,
-      "recall_at_5": 0.698019801980198,
-      "recall_at_10": 0.8267326732673267,
-      "mrr": 0.3992453021922683,
-      "train_time_ms": 2.856799983419478,
-      "inference_time_us": 456.1113811439217,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8902439024390244,
+      "mrr": 0.43417879943072507,
+      "train_time_ms": 0.5221999999776017,
+      "inference_time_us": 139.21341464660279,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8642301055947179,
-          "mean_mse": 0.0006946758981510097,
-          "mean_rank": 6.5,
+          "mean_cosine": 0.8798239903319774,
+          "mean_mse": 0.0005990990990029013,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.8948123032374768,
-          "mean_mse": 0.0005656196846932707,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.9002046674029134,
+          "mean_mse": 0.0005188732088809074,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8532858683883997,
-          "mean_mse": 0.0007281464457844062,
-          "mean_rank": 10.5,
+          "mean_cosine": 0.8660751751467652,
+          "mean_mse": 0.0006627117625762619,
+          "mean_rank": 7.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8512307418649796,
-          "mean_mse": 0.0007417727494808892,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.8711085975608626,
+          "mean_mse": 0.0006443825856187085,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8203152419332784,
-          "mean_mse": 0.0008608467461662904,
-          "mean_rank": 20.25,
+          "mean_cosine": 0.8500823211929769,
+          "mean_mse": 0.000725404708397378,
+          "mean_rank": 8.75,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8777682482974201,
-          "mean_mse": 0.0006126269150619957,
-          "mean_rank": 8.25,
+          "mean_cosine": 0.892113923662746,
+          "mean_mse": 0.000542204913062987,
+          "mean_rank": 5.75,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8449328262412947,
-          "mean_mse": 0.0007684830789604168,
-          "mean_rank": 6.25,
+          "mean_cosine": 0.8377795091304902,
+          "mean_mse": 0.0007776683774258277,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.8448660485506814,
-          "mean_mse": 0.0007687433940681359,
-          "mean_rank": 10.75,
+          "mean_cosine": 0.8570386685826858,
+          "mean_mse": 0.0007010814049581897,
+          "mean_rank": 8.75,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8623565028848607,
-          "mean_mse": 0.0006768335309260329,
-          "mean_rank": 4.4,
+          "mean_cosine": 0.8698232075357772,
+          "mean_mse": 0.0006430977491510925,
+          "mean_rank": 3.2,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8411938643623608,
-          "mean_mse": 0.0007702984661733906,
-          "mean_rank": 19.0,
+          "mean_cosine": 0.850346252989373,
+          "mean_mse": 0.000728010257533576,
+          "mean_rank": 10.75,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8717980531772379,
-          "mean_mse": 0.0006554269878451214,
-          "mean_rank": 1.75,
+          "mean_cosine": 0.8950486160705151,
+          "mean_mse": 0.0005358257438401964,
+          "mean_rank": 1.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9008562936393765,
-          "mean_mse": 0.0005157067779871956,
+          "mean_cosine": 0.9192702570708937,
+          "mean_mse": 0.00042431530235291157,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8923588488537495,
-          "mean_mse": 0.0005066627332920512,
-          "mean_rank": 18.0,
+          "mean_cosine": 0.898317629044627,
+          "mean_mse": 0.0004801918110173596,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8335564360815774,
-          "mean_mse": 0.0008137123882245096,
-          "mean_rank": 8.4,
+          "mean_cosine": 0.8530865151802308,
+          "mean_mse": 0.0007239129841469102,
+          "mean_rank": 5.0,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8703554125347677,
-          "mean_mse": 0.0006450150048882898,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.8825785637640634,
+          "mean_mse": 0.0005896157046586765,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.8490433300624307,
-          "mean_mse": 0.0007407008611659749,
+          "mean_cosine": 0.826711945059646,
+          "mean_mse": 0.0008293526283936405,
           "mean_rank": 6.0,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9348832322284651,
-          "mean_mse": 0.0003542794905635367,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.9400977890923405,
+          "mean_mse": 0.00031777756450656095,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.8299171720755858,
-          "mean_mse": 0.0008211463178499355,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.8537127921132032,
+          "mean_mse": 0.0007159875696248287,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9456085106958906,
-          "mean_mse": 0.0002847275413040686,
-          "mean_rank": 2.25,
+          "mean_cosine": 0.953026418161062,
+          "mean_mse": 0.00023997941579845174,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8818765607110931,
-          "mean_mse": 0.0006028677223758943,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8036405834728413,
-          "mean_mse": 0.000905164608451,
-          "mean_rank": 33.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8918431726539727,
-          "mean_mse": 0.0005491214971132219,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8423176070940598,
-          "mean_mse": 0.0007614838467309383,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.948021267201447,
-          "mean_mse": 0.00028932810811946335,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9083668370148745,
-          "mean_mse": 0.0004951476192535507,
+          "mean_cosine": 0.890304993633579,
+          "mean_mse": 0.0005547762351181236,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8874622376632785,
-          "mean_mse": 0.000572246057301261,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8478121891777901,
-          "mean_mse": 0.0007658650564123174,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8810695166054704,
-          "mean_mse": 0.0005987237818257093,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8344799177249622,
-          "mean_mse": 0.0008042751568139079,
-          "mean_rank": 22.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9089879854801632,
-          "mean_mse": 0.0004812693023484997,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8885459090479992,
-          "mean_mse": 0.0005691311272609368,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8605108332897539,
-          "mean_mse": 0.0006990306886402479,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.7981529202562498,
-          "mean_mse": 0.0009481970911367547,
-          "mean_rank": 26.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8695263057691385,
-          "mean_mse": 0.0006418746756132088,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8530635964086606,
-          "mean_mse": 0.0007149916352185161,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9009046508666256,
-          "mean_mse": 0.0005202828357628028,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9109871040028283,
-          "mean_mse": 0.0004763529700738034,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9090944165661905,
-          "mean_mse": 0.0004594228941649247,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8638891200218086,
-          "mean_mse": 0.0006830166026382616,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8095233710422485,
-          "mean_mse": 0.000855604557089134,
-          "mean_rank": 39.25,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.8996348471871011,
-          "mean_mse": 0.000535352419572744,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9073316648937859,
-          "mean_mse": 0.0004917269154611264,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.8916539018552495,
-          "mean_mse": 0.0005769829896766354,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.8999225515266269,
-          "mean_mse": 0.000530115261694742,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8396362819361779,
-          "mean_mse": 0.0007794331044579126,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8373281471571136,
-          "mean_mse": 0.0007966710550903554,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8159424845377913,
-          "mean_mse": 0.0008872890194937417,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8373744891006515,
-          "mean_mse": 0.0007853392034054064,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8400412176933941,
-          "mean_mse": 0.0007808208850354491,
-          "mean_rank": 20.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7839647884115624,
-          "mean_mse": 0.000982136783999331,
-          "mean_rank": 36.0,
           "num_queries": 4
         }
       }
@@ -370,320 +190,140 @@
         "cutoff": 0.3,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.868114472701624,
-      "std_cosine_to_target": 0.06490559363527852,
-      "mean_mse_to_target": 0.0008194876047794442,
-      "std_mse_to_target": 0.000277911426739699,
-      "mean_target_rank": 8.386138613861386,
-      "median_target_rank": 3.5,
-      "recall_at_1": 0.18316831683168316,
-      "recall_at_5": 0.693069306930693,
-      "recall_at_10": 0.8514851485148515,
-      "mrr": 0.3914985150280147,
-      "train_time_ms": 3228.7537819938734,
-      "inference_time_us": 4744.75536121996,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.8730489245425724,
+      "std_cosine_to_target": 0.05584803162024712,
+      "mean_mse_to_target": 0.0007660373170547929,
+      "std_mse_to_target": 0.00022305856184329218,
+      "mean_target_rank": 5.695121951219512,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.6829268292682927,
+      "recall_at_10": 0.8536585365853658,
+      "mrr": 0.40962283526730237,
+      "train_time_ms": 252.4210060000769,
+      "inference_time_us": 1017.5414877821601,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8661920451037456,
-          "mean_mse": 0.0008537935949070435,
-          "mean_rank": 6.5,
+          "mean_cosine": 0.876126529386793,
+          "mean_mse": 0.000726267496713108,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9000186008521972,
-          "mean_mse": 0.0008622576363762279,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.8990151711962592,
+          "mean_mse": 0.0007739541121423535,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8554252664915419,
-          "mean_mse": 0.0008444286368971148,
-          "mean_rank": 10.75,
+          "mean_cosine": 0.8645291663483615,
+          "mean_mse": 0.00083182176189087,
+          "mean_rank": 7.0,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8587383056133201,
-          "mean_mse": 0.0009574279903731554,
+          "mean_cosine": 0.858085260207966,
+          "mean_mse": 0.0008673239617708827,
           "mean_rank": 4.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8328839349835027,
-          "mean_mse": 0.0011205995297593528,
-          "mean_rank": 14.5,
+          "mean_cosine": 0.850462624717851,
+          "mean_mse": 0.0009174213690608505,
+          "mean_rank": 8.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8759718930854599,
-          "mean_mse": 0.0007279625391611002,
-          "mean_rank": 8.75,
+          "mean_cosine": 0.8895274465086914,
+          "mean_mse": 0.0006611923465100275,
+          "mean_rank": 6.0,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8446336685781908,
-          "mean_mse": 0.0008992978964292741,
-          "mean_rank": 6.75,
+          "mean_cosine": 0.8257334895657635,
+          "mean_mse": 0.0009487764835821838,
+          "mean_rank": 12.5,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.8420219945504646,
-          "mean_mse": 0.0009627598340437325,
-          "mean_rank": 12.0,
+          "mean_cosine": 0.858408807311773,
+          "mean_mse": 0.0008239323535796524,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8520432041561252,
-          "mean_mse": 0.000779466745927453,
-          "mean_rank": 6.2,
+          "mean_cosine": 0.8544811929193358,
+          "mean_mse": 0.0007770603266942057,
+          "mean_rank": 3.8,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8358577418990647,
-          "mean_mse": 0.000991415379558078,
-          "mean_rank": 20.75,
+          "mean_cosine": 0.849023570017511,
+          "mean_mse": 0.0008682687915585151,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8778628125256678,
-          "mean_mse": 0.0008467116244832967,
-          "mean_rank": 2.5,
+          "mean_cosine": 0.896268251540466,
+          "mean_mse": 0.0007078541974221688,
+          "mean_rank": 2.0,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.8909584567272351,
-          "mean_mse": 0.0006912685357603755,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.8961050358089299,
+          "mean_mse": 0.000630511284770686,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8948634481601645,
-          "mean_mse": 0.0006766523995965403,
-          "mean_rank": 15.5,
+          "mean_cosine": 0.903068227650302,
+          "mean_mse": 0.0006841885185241716,
+          "mean_rank": 9.75,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.840409396893836,
-          "mean_mse": 0.0009745360261735805,
-          "mean_rank": 9.2,
+          "mean_cosine": 0.8495090562193097,
+          "mean_mse": 0.0008786500202095721,
+          "mean_rank": 7.6,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8629532819077737,
-          "mean_mse": 0.0007578158979788856,
-          "mean_rank": 5.25,
+          "mean_cosine": 0.876231479738764,
+          "mean_mse": 0.000702570817359287,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.8482705951500087,
-          "mean_mse": 0.0008500293833811217,
-          "mean_rank": 6.25,
+          "mean_cosine": 0.8201983452694138,
+          "mean_mse": 0.0009603317597938164,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9225921588009509,
-          "mean_mse": 0.0004966817266311417,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.9265087378058572,
+          "mean_mse": 0.00046791600129253864,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.8268005201568502,
-          "mean_mse": 0.00096088856659036,
-          "mean_rank": 11.5,
+          "mean_cosine": 0.8499390662854656,
+          "mean_mse": 0.0008639616088604352,
+          "mean_rank": 6.75,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9300042579646608,
-          "mean_mse": 0.0004016532528609318,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.9474045102456897,
+          "mean_mse": 0.00045679280495180034,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8765255684993667,
-          "mean_mse": 0.0007285357340973863,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8243787950436439,
-          "mean_mse": 0.0008921590180718288,
-          "mean_rank": 16.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8904679656011324,
-          "mean_mse": 0.0006764512510491405,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8398584718923292,
-          "mean_mse": 0.0008738572429938931,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9482734633326064,
-          "mean_mse": 0.00044506064011700253,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9170284217520601,
-          "mean_mse": 0.0006240630133064292,
+          "mean_cosine": 0.8808794220935728,
+          "mean_mse": 0.0007410413962101822,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8735718857794225,
-          "mean_mse": 0.0007900145953295364,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8594825887830684,
-          "mean_mse": 0.0009155998140354005,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8920677636127468,
-          "mean_mse": 0.0008443844761472475,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8387765625411705,
-          "mean_mse": 0.0010151102980501974,
-          "mean_rank": 22.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9074745268263675,
-          "mean_mse": 0.0006670822018872278,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8978526347134276,
-          "mean_mse": 0.000712282245619198,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8743491410747849,
-          "mean_mse": 0.0009131331520660732,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8109675149182407,
-          "mean_mse": 0.0012017245830935085,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8768807133288602,
-          "mean_mse": 0.0008916435762126237,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8472111945806872,
-          "mean_mse": 0.0008548985455873172,
-          "mean_rank": 15.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.8971962323788786,
-          "mean_mse": 0.0006965963597363248,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.91032803079088,
-          "mean_mse": 0.0005441973501832632,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.8981594868060473,
-          "mean_mse": 0.0005438556350478345,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8621585486910058,
-          "mean_mse": 0.0009378641059340432,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.7984242343873718,
-          "mean_mse": 0.0009231050652080167,
-          "mean_rank": 38.25,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9007452078457427,
-          "mean_mse": 0.0006833489842394401,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9064310640890406,
-          "mean_mse": 0.0007924110384166529,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9115162534406613,
-          "mean_mse": 0.0007257460644157082,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9050071646254153,
-          "mean_mse": 0.0006845859024023305,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.845752357694292,
-          "mean_mse": 0.000824072591996535,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.844979924764441,
-          "mean_mse": 0.0009473563020204584,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8206320366647913,
-          "mean_mse": 0.0011012171942639444,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8622120094885939,
-          "mean_mse": 0.0008436162378708524,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8355079909552661,
-          "mean_mse": 0.0008996994999046232,
-          "mean_rank": 22.5,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7839483826664166,
-          "mean_mse": 0.00109630343214387,
-          "mean_rank": 35.25,
           "num_queries": 4
         }
       }
@@ -694,320 +334,140 @@
         "cutoff": 0.5,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.8787053740936505,
-      "std_cosine_to_target": 0.0642795698523128,
-      "mean_mse_to_target": 0.0007113035703233411,
-      "std_mse_to_target": 0.00028252617474678287,
-      "mean_target_rank": 7.198019801980198,
+      "mean_cosine_to_target": 0.8839326881421576,
+      "std_cosine_to_target": 0.056377282811715126,
+      "mean_mse_to_target": 0.0006513121847273761,
+      "std_mse_to_target": 0.0002486103407100182,
+      "mean_target_rank": 4.902439024390244,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.21287128712871287,
-      "recall_at_5": 0.7574257425742574,
-      "recall_at_10": 0.8861386138613861,
-      "mrr": 0.4349030794840498,
-      "train_time_ms": 878.3116639824584,
-      "inference_time_us": 3624.837099237939,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7682926829268293,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.441780954925422,
+      "train_time_ms": 158.8671039971814,
+      "inference_time_us": 1015.0585609464055,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8725390992232268,
-          "mean_mse": 0.0007731148030595898,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.8863919761691256,
+          "mean_mse": 0.0006384947893865705,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9054012751032392,
-          "mean_mse": 0.0007621698865012214,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.9052183655727519,
+          "mean_mse": 0.0006493886178304945,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8625789536415474,
-          "mean_mse": 0.0007820256674262362,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8821817888357449,
-          "mean_mse": 0.0007970809262558315,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8448298862179027,
-          "mean_mse": 0.0009803398217120474,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.8876259986031756,
-          "mean_mse": 0.0006594037057958106,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.8566606953345339,
-          "mean_mse": 0.0008210374310569479,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.8555099921130888,
-          "mean_mse": 0.0008659462440957782,
-          "mean_rank": 10.25,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8693188959079647,
-          "mean_mse": 0.0006996373322762904,
-          "mean_rank": 3.6,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.847462683868487,
-          "mean_mse": 0.0008347867840177007,
-          "mean_rank": 17.5,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.8855032865897987,
-          "mean_mse": 0.0007515221778992258,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.9106275298000357,
-          "mean_mse": 0.0005472572228775612,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.8943646693266618,
-          "mean_mse": 0.0005441500295996352,
-          "mean_rank": 17.0,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8551934457733538,
-          "mean_mse": 0.0008823128162668387,
-          "mean_rank": 6.6,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8759494346704908,
-          "mean_mse": 0.0006830632008429247,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8546728377306873,
-          "mean_mse": 0.0007827412481501652,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9365915114062978,
-          "mean_mse": 0.00039952267330681327,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.838850689842553,
-          "mean_mse": 0.0008528173426705839,
-          "mean_rank": 8.75,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9450437313011085,
-          "mean_mse": 0.00029475278451789646,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8888407762090111,
-          "mean_mse": 0.0006232735104167007,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8256501135191088,
-          "mean_mse": 0.0008757571057040559,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8959672562689955,
-          "mean_mse": 0.0005713433798742236,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8511253230165511,
-          "mean_mse": 0.0007802394473821737,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9532118338385225,
-          "mean_mse": 0.00031028870702934613,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9242444978412893,
-          "mean_mse": 0.0005305457896874339,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8933263428618818,
-          "mean_mse": 0.0006078283885469827,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8743094877813711,
-          "mean_mse": 0.0007823966779151277,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.899802477290719,
-          "mean_mse": 0.0006335701039670316,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8593714941551639,
-          "mean_mse": 0.0008157519469924933,
-          "mean_rank": 19.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9195237288917407,
-          "mean_mse": 0.0005620570121344776,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9081712111718199,
-          "mean_mse": 0.0006229784895538936,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8811361737201348,
-          "mean_mse": 0.0007606348420629369,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8278669032136003,
-          "mean_mse": 0.0010381713384157562,
-          "mean_rank": 22.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8885390513170421,
-          "mean_mse": 0.0006672733536241462,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8599741341219631,
-          "mean_mse": 0.0007516877826722299,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9072907050717329,
-          "mean_mse": 0.0005896201537116113,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9150480140485063,
-          "mean_mse": 0.000512557363091438,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9117295347710916,
-          "mean_mse": 0.0004706597697143296,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8778877105188767,
-          "mean_mse": 0.0007544615579754047,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8164317828275045,
-          "mean_mse": 0.0008212209996891913,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9101022567420456,
-          "mean_mse": 0.0006073585992281651,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9179567158918647,
-          "mean_mse": 0.000618587721501981,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9134172572850165,
-          "mean_mse": 0.0006872988465394095,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9094891251580238,
-          "mean_mse": 0.0005971097419131961,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8447067733271709,
-          "mean_mse": 0.0007938063793877384,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8509062176604263,
-          "mean_mse": 0.00086036966838183,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8377454012855232,
-          "mean_mse": 0.0009291972055381541,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8590814061800601,
-          "mean_mse": 0.0008225830608199139,
+          "mean_cosine": 0.876326393715529,
+          "mean_mse": 0.000721200395597368,
           "mean_rank": 5.5,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.8471354574411035,
-          "mean_mse": 0.000819270508081109,
-          "mean_rank": 18.25,
+        "constraint-usage": {
+          "mean_cosine": 0.8862998150804666,
+          "mean_mse": 0.000688262063165394,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7925977375912592,
-          "mean_mse": 0.0009937612143113754,
-          "mean_rank": 31.5,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8594250727913889,
+          "mean_mse": 0.0008037747857533874,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8995581668566781,
+          "mean_mse": 0.0005844780503647365,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8451521022840831,
+          "mean_mse": 0.0008195839761359232,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8667774088484007,
+          "mean_mse": 0.0007518540003272991,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8711123489665846,
+          "mean_mse": 0.0006823167996551921,
+          "mean_rank": 3.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8535830459051953,
+          "mean_mse": 0.0007821110720062057,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.899497133792616,
+          "mean_mse": 0.0006109260273819822,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9228167680907176,
+          "mean_mse": 0.0004806698302161726,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9009484869182508,
+          "mean_mse": 0.000523462142246878,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.860866533398901,
+          "mean_mse": 0.0007806522773276998,
+          "mean_rank": 4.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8860402296323611,
+          "mean_mse": 0.0006324802654632841,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.827915578421913,
+          "mean_mse": 0.0008742880752322324,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.938027252954989,
+          "mean_mse": 0.0003611578916062835,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8563197229265198,
+          "mean_mse": 0.0007495618993809237,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9529682627007725,
+          "mean_mse": 0.00026892399902066395,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8923807212956174,
+          "mean_mse": 0.0005825705595667956,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -1018,320 +478,140 @@
         "cutoff": 0.7,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.8791393571382186,
-      "std_cosine_to_target": 0.06446280059695512,
-      "mean_mse_to_target": 0.0007087627760918817,
-      "std_mse_to_target": 0.0002827516482329951,
-      "mean_target_rank": 7.193069306930693,
+      "mean_cosine_to_target": 0.884982780905235,
+      "std_cosine_to_target": 0.05611393005344722,
+      "mean_mse_to_target": 0.0006406514372121259,
+      "std_mse_to_target": 0.00024947929955694727,
+      "mean_target_rank": 4.853658536585366,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.2079207920792079,
-      "recall_at_5": 0.7623762376237624,
-      "recall_at_10": 0.8861386138613861,
-      "mrr": 0.4325496822708373,
-      "train_time_ms": 670.794497942552,
-      "inference_time_us": 4865.933638434894,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7682926829268293,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.44155254119386117,
+      "train_time_ms": 156.42680400196696,
+      "inference_time_us": 1034.9231951095578,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8724257424550121,
-          "mean_mse": 0.0007846140582743978,
-          "mean_rank": 5.0,
+          "mean_cosine": 0.8858539481240731,
+          "mean_mse": 0.0006360731414365774,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9049186167491623,
-          "mean_mse": 0.0007610115923237657,
+          "mean_cosine": 0.905949735539779,
+          "mean_mse": 0.0006382715271689428,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8622126163401759,
-          "mean_mse": 0.0007856569642873153,
-          "mean_rank": 8.25,
+          "mean_cosine": 0.8777889978779152,
+          "mean_mse": 0.0007073760246739317,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8835139515313848,
-          "mean_mse": 0.0007837175452649818,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.8898141325466332,
+          "mean_mse": 0.0006649719340663451,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8454622824893022,
-          "mean_mse": 0.0009727454901528965,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.8609616368983289,
+          "mean_mse": 0.0007921014245440098,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8876007035082563,
-          "mean_mse": 0.0006562431103307057,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.8996685413605283,
+          "mean_mse": 0.0005751665390755861,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8555832702779289,
-          "mean_mse": 0.000818766130385148,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.8563221865380044,
-          "mean_mse": 0.0008647610448777089,
+          "mean_cosine": 0.8455215325158405,
+          "mean_mse": 0.0008104159190956864,
           "mean_rank": 10.25,
           "num_queries": 4
         },
+        "generated-code-transitive": {
+          "mean_cosine": 0.867246447680768,
+          "mean_mse": 0.000748083141934997,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8703254802762086,
-          "mean_mse": 0.0006930083636073489,
-          "mean_rank": 3.6,
+          "mean_cosine": 0.8738141838340475,
+          "mean_mse": 0.0006673625906705804,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8471956707925106,
-          "mean_mse": 0.0008311307448783355,
-          "mean_rank": 18.0,
+          "mean_cosine": 0.8551199129298948,
+          "mean_mse": 0.0007651998411313236,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8860672138567098,
-          "mean_mse": 0.0007440703733025655,
+          "mean_cosine": 0.899546889177443,
+          "mean_mse": 0.0006027784791219629,
           "mean_rank": 1.75,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9133232752718177,
-          "mean_mse": 0.000535983189047072,
+          "mean_cosine": 0.9252584660131147,
+          "mean_mse": 0.0004633558160440858,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8949625679531477,
-          "mean_mse": 0.0005403441698773981,
-          "mean_rank": 16.75,
+          "mean_cosine": 0.9009248348314058,
+          "mean_mse": 0.0005139407867092145,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8548715516577422,
-          "mean_mse": 0.0008791261476531435,
-          "mean_rank": 6.4,
+          "mean_cosine": 0.862618708810533,
+          "mean_mse": 0.0007739527736912495,
+          "mean_rank": 4.0,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.876852701376301,
-          "mean_mse": 0.0006825310413856116,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.85272644746545,
-          "mean_mse": 0.0007927414512434446,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9373702422188221,
-          "mean_mse": 0.0003979402810405921,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.8394153567303132,
-          "mean_mse": 0.0008508301924938318,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9457264510431406,
-          "mean_mse": 0.00029102580087501153,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8907574664996318,
-          "mean_mse": 0.0006173104423029897,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8259998431950273,
-          "mean_mse": 0.0008766847673368596,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.896121205588498,
-          "mean_mse": 0.0005767820773698244,
+          "mean_cosine": 0.8867575272652097,
+          "mean_mse": 0.0006265319833624522,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.852957606868979,
-          "mean_mse": 0.0007774002709035602,
-          "mean_rank": 3.25,
+        "recursion-patterns": {
+          "mean_cosine": 0.8297181802970726,
+          "mean_mse": 0.0008605177608999914,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
-        "bash-subshells": {
-          "mean_cosine": 0.954396852441503,
-          "mean_mse": 0.0003127996528616183,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9387220518419477,
+          "mean_mse": 0.00035563980913438193,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "process-substitution": {
-          "mean_cosine": 0.9248017594406251,
-          "mean_mse": 0.000525519947604558,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8567904826486559,
+          "mean_mse": 0.0007431696365820698,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9533186017658688,
+          "mean_mse": 0.0002548842941521012,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8926439734371117,
+          "mean_mse": 0.000573232198262632,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8955218620803114,
-          "mean_mse": 0.0005998186402641477,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8739349037795112,
-          "mean_mse": 0.0007857466619348351,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8999256108484179,
-          "mean_mse": 0.0006228889157441903,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.861112404507173,
-          "mean_mse": 0.0008120170640694975,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9192023663892502,
-          "mean_mse": 0.0005653668607454743,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9086712733633615,
-          "mean_mse": 0.0006200893888481229,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8825982793078309,
-          "mean_mse": 0.000750616981589721,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8286654856577013,
-          "mean_mse": 0.001026445820170892,
-          "mean_rank": 22.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8893183215703365,
-          "mean_mse": 0.0006641175940954257,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8591590586240119,
-          "mean_mse": 0.0007550016610923586,
-          "mean_rank": 12.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9073735258852984,
-          "mean_mse": 0.000588919821590087,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9154378867412797,
-          "mean_mse": 0.0005108493516733335,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9121183928908368,
-          "mean_mse": 0.00046758598530079854,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8788158606824792,
-          "mean_mse": 0.0007452566561182486,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.817418359960935,
-          "mean_mse": 0.000816943785393751,
-          "mean_rank": 37.25,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9102416376194045,
-          "mean_mse": 0.0006035463722044762,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9178377264321442,
-          "mean_mse": 0.0006129109372399864,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9137473117251043,
-          "mean_mse": 0.0006874294797349001,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9101007180201595,
-          "mean_mse": 0.0005970149678300842,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8445142166857753,
-          "mean_mse": 0.0007942041471811854,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8519648297938417,
-          "mean_mse": 0.000858164426229037,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8378998787808961,
-          "mean_mse": 0.0009278887125838264,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8583839251666296,
-          "mean_mse": 0.0008241730893607559,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8443005778047423,
-          "mean_mse": 0.0008266989465143717,
-          "mean_rank": 19.5,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7950628006134579,
-          "mean_mse": 0.0009830454476347065,
-          "mean_rank": 31.0,
           "num_queries": 4
         }
       }
@@ -1342,320 +622,140 @@
         "min_cutoff": 0.2,
         "max_cutoff": 0.7
       },
-      "mean_cosine_to_target": 0.8748569634300003,
-      "std_cosine_to_target": 0.06430491467221129,
-      "mean_mse_to_target": 0.0007552026210398065,
-      "std_mse_to_target": 0.0002830353564307572,
-      "mean_target_rank": 7.579207920792079,
+      "mean_cosine_to_target": 0.8795961176914667,
+      "std_cosine_to_target": 0.05595357141471437,
+      "mean_mse_to_target": 0.0006974858534343098,
+      "std_mse_to_target": 0.00024659864621222376,
+      "mean_target_rank": 5.109756097560975,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.20297029702970298,
-      "recall_at_5": 0.7227722772277227,
-      "recall_at_10": 0.8613861386138614,
-      "mrr": 0.4222764244810287,
-      "train_time_ms": 5244.1758119966835,
-      "inference_time_us": 7947.886713070445,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.7439024390243902,
+      "recall_at_10": 0.9024390243902439,
+      "mrr": 0.4254185492707731,
+      "train_time_ms": 411.5376110021316,
+      "inference_time_us": 926.4768536590187,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8687875043453027,
-          "mean_mse": 0.0008242843849276557,
-          "mean_rank": 6.0,
+          "mean_cosine": 0.8807738728121349,
+          "mean_mse": 0.000692213796803093,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9027828157407174,
-          "mean_mse": 0.0008204415328759377,
+          "mean_cosine": 0.9019038952502818,
+          "mean_mse": 0.000723010107489565,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8566136895187278,
-          "mean_mse": 0.0008299765013013756,
-          "mean_rank": 9.75,
+          "mean_cosine": 0.8695286286729982,
+          "mean_mse": 0.000793199676805773,
+          "mean_rank": 6.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.874504373087341,
-          "mean_mse": 0.0008615509724914361,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.877759472222243,
+          "mean_mse": 0.0007609349039489166,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8417537269972274,
-          "mean_mse": 0.0010309057714200244,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.8812324634157997,
-          "mean_mse": 0.0007021848451942565,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.8493292304796242,
-          "mean_mse": 0.000865815464318089,
+          "mean_cosine": 0.8597111660367383,
+          "mean_mse": 0.0008325130877699959,
           "mean_rank": 5.75,
           "num_queries": 4
         },
+        "practical-compilation": {
+          "mean_cosine": 0.8936758510981944,
+          "mean_mse": 0.0006339085031887878,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8360964280402072,
+          "mean_mse": 0.0008830307351113952,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
         "generated-code-transitive": {
-          "mean_cosine": 0.8488464773234357,
-          "mean_mse": 0.000926222325229528,
-          "mean_rank": 10.75,
+          "mean_cosine": 0.8627622185590536,
+          "mean_mse": 0.0007992401348592439,
+          "mean_rank": 6.75,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8590909023790717,
-          "mean_mse": 0.0007544909439967336,
-          "mean_rank": 5.0,
+          "mean_cosine": 0.8621789743110833,
+          "mean_mse": 0.0007379461819240235,
+          "mean_rank": 3.6,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8434833314162681,
-          "mean_mse": 0.000903383707618925,
-          "mean_rank": 18.5,
+          "mean_cosine": 0.8509908733346943,
+          "mean_mse": 0.0008233959478945292,
+          "mean_rank": 10.75,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8830361393108047,
-          "mean_mse": 0.0007917948486760414,
-          "mean_rank": 1.75,
+          "mean_cosine": 0.899446661442032,
+          "mean_mse": 0.0006433383576457325,
+          "mean_rank": 1.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.8984219110921007,
-          "mean_mse": 0.0006326800824798633,
+          "mean_cosine": 0.9090734505159055,
+          "mean_mse": 0.0005596106193213675,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8966659796072287,
-          "mean_mse": 0.0005483513229035009,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8465806737695066,
-          "mean_mse": 0.000940046833045572,
-          "mean_rank": 8.0,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.868901675861677,
-          "mean_mse": 0.0007254065374427581,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8510383252339101,
-          "mean_mse": 0.0008258032573880265,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9314586126747867,
-          "mean_mse": 0.0004461805853023257,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.8352503037678762,
-          "mean_mse": 0.0008930810824692873,
+          "mean_cosine": 0.9044500506541668,
+          "mean_mse": 0.0005179113402901458,
           "mean_rank": 10.0,
           "num_queries": 4
         },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9435101102288526,
-          "mean_mse": 0.0003105296576759756,
-          "mean_rank": 2.25,
+        "prolog-terms": {
+          "mean_cosine": 0.8538503644762511,
+          "mean_mse": 0.0008430919027799374,
+          "mean_rank": 5.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.880465231756657,
+          "mean_mse": 0.0006725948896684421,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
-        "fold-pattern": {
-          "mean_cosine": 0.8861223316546833,
-          "mean_mse": 0.000655060840332363,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8244228033674373,
-          "mean_mse": 0.0008945497003551256,
-          "mean_rank": 16.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8931461993892265,
-          "mean_mse": 0.0006294566114237616,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8498408026656977,
-          "mean_mse": 0.0007978759379506052,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9525653021418496,
-          "mean_mse": 0.00034505516774419823,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9220422581117143,
-          "mean_mse": 0.0005683299318788811,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8921334404339539,
-          "mean_mse": 0.0006282405097114116,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8692127245479947,
-          "mean_mse": 0.000839632157925712,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8995835173071238,
-          "mean_mse": 0.0006573870896808037,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.854642236491992,
-          "mean_mse": 0.0008835558623548963,
-          "mean_rank": 19.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.915488070676848,
-          "mean_mse": 0.000613958565590016,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9056717631483655,
-          "mean_mse": 0.000661172086946569,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8813678469316548,
-          "mean_mse": 0.0007987061064890445,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8231486399878557,
-          "mean_mse": 0.001094728473918175,
-          "mean_rank": 23.25,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8879667786010357,
-          "mean_mse": 0.0006921299712682852,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8559611011776819,
-          "mean_mse": 0.0007974957575673947,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9012975781985157,
-          "mean_mse": 0.0006584384212639344,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9131601427850492,
-          "mean_mse": 0.0005295355147757517,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9091334833960623,
-          "mean_mse": 0.00048790592299710335,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8754371182865133,
-          "mean_mse": 0.000794832277177087,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.812089568721507,
-          "mean_mse": 0.0008528537361167411,
-          "mean_rank": 37.25,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9036448905464998,
-          "mean_mse": 0.0006583122243768577,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.915024576159315,
-          "mean_mse": 0.0006738568752486067,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9120377198162736,
-          "mean_mse": 0.0007234414215016977,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9065020247946884,
-          "mean_mse": 0.0006524794382798143,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8417152903725903,
-          "mean_mse": 0.0008225041869478138,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8483071101294282,
-          "mean_mse": 0.0009033609757740903,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.829835379673814,
-          "mean_mse": 0.001019572420608223,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8590426260001378,
-          "mean_mse": 0.0008396097686112275,
+        "recursion-patterns": {
+          "mean_cosine": 0.8268150548367492,
+          "mean_mse": 0.0009082944111770612,
           "mean_rank": 5.75,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.8405357224003018,
-          "mean_mse": 0.0008689663335782803,
-          "mean_rank": 21.0,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9341688648941936,
+          "mean_mse": 0.00041442510814047883,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.791491465011802,
-          "mean_mse": 0.001037962973097862,
-          "mean_rank": 32.25,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8552629081193688,
+          "mean_mse": 0.000784728561762173,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9529306525729545,
+          "mean_mse": 0.0002674590918902217,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.890868458372328,
+          "mean_mse": 0.0006123531157564783,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -1666,320 +766,140 @@
         "K": 4,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.8333645511647298,
-      "std_cosine_to_target": 0.06724263493354012,
-      "mean_mse_to_target": 0.0008504181018959391,
-      "std_mse_to_target": 0.00029446848813685563,
-      "mean_target_rank": 12.881188118811881,
-      "median_target_rank": 5.0,
-      "recall_at_1": 0.13861386138613863,
-      "recall_at_5": 0.5148514851485149,
-      "recall_at_10": 0.7178217821782178,
-      "mrr": 0.3036062722852258,
-      "train_time_ms": 9834.013152983971,
-      "inference_time_us": 37118.129475424896,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.8572297175809143,
+      "std_cosine_to_target": 0.058822570673467016,
+      "mean_mse_to_target": 0.0007383254058367316,
+      "std_mse_to_target": 0.0002797064593352633,
+      "mean_target_rank": 7.524390243902439,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.6097560975609756,
+      "recall_at_10": 0.7682926829268293,
+      "mrr": 0.36429949692446456,
+      "train_time_ms": 2761.698071997671,
+      "inference_time_us": 11090.327256081255,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8368625868776027,
-          "mean_mse": 0.0007967634674446883,
-          "mean_rank": 12.5,
+          "mean_cosine": 0.8603546621207276,
+          "mean_mse": 0.0006761292566255471,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.8917149587361335,
-          "mean_mse": 0.0007978115924691838,
-          "mean_rank": 2.5,
+          "mean_cosine": 0.8922003814012156,
+          "mean_mse": 0.0006570445039851982,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8352074756633503,
-          "mean_mse": 0.0008060841273911314,
-          "mean_rank": 13.25,
+          "mean_cosine": 0.860956023513348,
+          "mean_mse": 0.0006896772732693401,
+          "mean_rank": 8.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8491763841430189,
-          "mean_mse": 0.0008443287694578598,
-          "mean_rank": 4.0,
+          "mean_cosine": 0.8857120690347009,
+          "mean_mse": 0.0006226512198579698,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8022553978705822,
-          "mean_mse": 0.0010111878346994465,
-          "mean_rank": 27.5,
+          "mean_cosine": 0.8434641630130387,
+          "mean_mse": 0.0007985707325110065,
+          "mean_rank": 11.75,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.84140624773713,
-          "mean_mse": 0.0007685851814156498,
-          "mean_rank": 15.5,
+          "mean_cosine": 0.860674045665416,
+          "mean_mse": 0.0006853397943530902,
+          "mean_rank": 9.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8102310953257534,
-          "mean_mse": 0.0009653844675904318,
-          "mean_rank": 14.75,
+          "mean_cosine": 0.7988885344262725,
+          "mean_mse": 0.0009779096420125864,
+          "mean_rank": 16.75,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.7968711884686055,
-          "mean_mse": 0.0009832792889231676,
-          "mean_rank": 21.25,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8252155054500202,
-          "mean_mse": 0.0008441498207236679,
-          "mean_rank": 13.0,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.8287084361806163,
-          "mean_mse": 0.0009388755749136818,
-          "mean_rank": 19.25,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.8425253416917757,
-          "mean_mse": 0.0008919066545285492,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.8333306297110954,
-          "mean_mse": 0.0008074357604844267,
+          "mean_cosine": 0.8156500732863632,
+          "mean_mse": 0.0009059059474899089,
           "mean_rank": 10.75,
           "num_queries": 4
         },
-        "init-pl-explained": {
-          "mean_cosine": 0.8924873208938071,
-          "mean_mse": 0.0005501776836447112,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.7835877037993572,
-          "mean_mse": 0.0011401611510210127,
-          "mean_rank": 25.6,
+        "prolog-facts-rules": {
+          "mean_cosine": 0.860934747230969,
+          "mean_mse": 0.0006819570737594133,
+          "mean_rank": 3.8,
           "num_queries": 5
         },
-        "prolog-unification": {
-          "mean_cosine": 0.8224461337260891,
-          "mean_mse": 0.0008604579387046216,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8209546473348666,
-          "mean_mse": 0.0008552270414991934,
+        "prolog-modules": {
+          "mean_cosine": 0.8347102370438155,
+          "mean_mse": 0.000895118800116595,
           "mean_rank": 11.0,
           "num_queries": 4
         },
+        "prolog-directives": {
+          "mean_cosine": 0.8739791063726042,
+          "mean_mse": 0.0007630191253384473,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8797481260381078,
+          "mean_mse": 0.0006010728272730961,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8960062383181069,
+          "mean_mse": 0.0005133049208676099,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8079682357048836,
+          "mean_mse": 0.0010464281683882075,
+          "mean_rank": 14.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8277909732668257,
+          "mean_mse": 0.0008306475416651689,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8004690326941023,
+          "mean_mse": 0.0009653889497880887,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9031674302265397,
-          "mean_mse": 0.0005120646384489898,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.9182612185125036,
+          "mean_mse": 0.0004351036128275365,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.791057418596223,
-          "mean_mse": 0.0010461076863217788,
-          "mean_rank": 25.75,
+          "mean_cosine": 0.8352958799209137,
+          "mean_mse": 0.0009645019600607016,
+          "mean_rank": 8.0,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9288872410817782,
-          "mean_mse": 0.0003881221745992304,
+          "mean_cosine": 0.944243733071809,
+          "mean_mse": 0.0002925263262412954,
           "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8274651067708805,
-          "mean_mse": 0.0008503471472344854,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.7857055225872763,
-          "mean_mse": 0.0010101499274799341,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8670999914307694,
-          "mean_mse": 0.0006762060031125025,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8023549544159123,
-          "mean_mse": 0.0009552601557703438,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9085767399861865,
-          "mean_mse": 0.0004657524499728401,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8785543037979814,
-          "mean_mse": 0.0006421040940965831,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8359956824466932,
-          "mean_mse": 0.0008927499159968574,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.7905661981206574,
-          "mean_mse": 0.0010132700901516864,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8704099095154829,
-          "mean_mse": 0.0007720708368620265,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.715278235814959,
-          "mean_mse": 0.0013474274622485459,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.8771325730369045,
-          "mean_mse": 0.0006673241327602032,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8681758343864441,
-          "mean_mse": 0.0007869589816987422,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8328230699775968,
-          "mean_mse": 0.0008871672198923956,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.783711703254832,
-          "mean_mse": 0.0010972635318210896,
-          "mean_rank": 27.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8556459103856416,
-          "mean_mse": 0.000773873656157655,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8319919014800069,
-          "mean_mse": 0.0008668571007183826,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.863618208364917,
-          "mean_mse": 0.0006794893499672927,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.8727215450268776,
-          "mean_mse": 0.000632587002563589,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.8918632548079068,
-          "mean_mse": 0.0005407469214079098,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8377624872701463,
-          "mean_mse": 0.0008889400946840948,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.7540617860620957,
-          "mean_mse": 0.00108269873801988,
-          "mean_rank": 41.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.8704150084716237,
-          "mean_mse": 0.0007432133553783966,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.8687690107345851,
-          "mean_mse": 0.0007425467952115769,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.8739097384508112,
-          "mean_mse": 0.0008244718882574835,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.8718765873183596,
-          "mean_mse": 0.0007273241889966368,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.7932082210861074,
-          "mean_mse": 0.0009805051497756914,
-          "mean_rank": 15.25,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8114377708497853,
-          "mean_mse": 0.0009188762842332157,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.7296445688245846,
-          "mean_mse": 0.001220673880773397,
-          "mean_rank": 43.0,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8245293539792876,
-          "mean_mse": 0.000874889283604976,
-          "mean_rank": 14.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.7982511250441149,
-          "mean_mse": 0.0009470714429162243,
-          "mean_rank": 26.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7530595842927454,
-          "mean_mse": 0.0011331084667626859,
-          "mean_rank": 31.0,
+          "mean_cosine": 0.8586759840390558,
+          "mean_mse": 0.0007012768326852865,
+          "mean_rank": 2.0,
           "num_queries": 4
         }
       }
@@ -1990,320 +910,140 @@
         "K": 8,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.8594339325007563,
-      "std_cosine_to_target": 0.0642245423615146,
-      "mean_mse_to_target": 0.0007489979733232549,
-      "std_mse_to_target": 0.0002790920273655134,
-      "mean_target_rank": 8.653465346534654,
+      "mean_cosine_to_target": 0.8761172549586116,
+      "std_cosine_to_target": 0.057150232356481215,
+      "mean_mse_to_target": 0.000646849615232862,
+      "std_mse_to_target": 0.00025670805554773945,
+      "mean_target_rank": 5.402439024390244,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.16831683168316833,
-      "recall_at_5": 0.6584158415841584,
-      "recall_at_10": 0.8168316831683168,
-      "mrr": 0.38044250174876193,
-      "train_time_ms": 12901.174230966717,
-      "inference_time_us": 78688.9866830108,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7439024390243902,
+      "recall_at_10": 0.8536585365853658,
+      "mrr": 0.40008093894237706,
+      "train_time_ms": 4213.170471000922,
+      "inference_time_us": 22441.911890271556,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8583404412482352,
-          "mean_mse": 0.0007587452616272554,
-          "mean_rank": 6.75,
+          "mean_cosine": 0.8828406212027,
+          "mean_mse": 0.000604243396033741,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.8961038364385788,
-          "mean_mse": 0.0007279130327204817,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8578556768665522,
-          "mean_mse": 0.0007399802935271404,
-          "mean_rank": 9.5,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8761634034920773,
-          "mean_mse": 0.0007501519505633798,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8258726736135145,
-          "mean_mse": 0.0009532765968598455,
-          "mean_rank": 16.75,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.8668938628704196,
-          "mean_mse": 0.0006656655689746546,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.8436206721298709,
-          "mean_mse": 0.0008123812867263032,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.8452706443693497,
-          "mean_mse": 0.0008350155440736977,
-          "mean_rank": 11.25,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8535444371815524,
-          "mean_mse": 0.0007328773437289182,
-          "mean_rank": 6.0,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.8337417616830699,
-          "mean_mse": 0.0009050370874755317,
-          "mean_rank": 16.75,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.860475987512657,
-          "mean_mse": 0.0008258303962544831,
-          "mean_rank": 1.5,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.8723112899903985,
-          "mean_mse": 0.0006459302655877837,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.8940188235387885,
-          "mean_mse": 0.0005530927001864789,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8328254066959693,
-          "mean_mse": 0.0009006547497153596,
-          "mean_rank": 7.6,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8463078955897236,
-          "mean_mse": 0.000764499897115125,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8410837345276653,
-          "mean_mse": 0.0007845614257879682,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9105689449896184,
-          "mean_mse": 0.00048462902436366775,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.8165582935660761,
-          "mean_mse": 0.000887475626596608,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9372591105708392,
-          "mean_mse": 0.00033536988035866506,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8749552896931867,
-          "mean_mse": 0.0006362229632960907,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.809318286522433,
-          "mean_mse": 0.000890170768585764,
-          "mean_rank": 25.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8799638028941434,
-          "mean_mse": 0.0006239129334861014,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.829774375257392,
-          "mean_mse": 0.0008400179694827597,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9403222007614032,
-          "mean_mse": 0.00033176200013982314,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9126136591824787,
-          "mean_mse": 0.0005233557543994295,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8706609979303738,
-          "mean_mse": 0.0007016148107004891,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8316708939805895,
-          "mean_mse": 0.0009173323860556535,
+          "mean_cosine": 0.8978017190035816,
+          "mean_mse": 0.0005999410576561822,
           "mean_rank": 3.75,
           "num_queries": 4
         },
-        "bash-trap": {
-          "mean_cosine": 0.8872213281407191,
-          "mean_mse": 0.0006976624421228449,
-          "mean_rank": 2.5,
+        "compilation-pipeline": {
+          "mean_cosine": 0.8744946075915045,
+          "mean_mse": 0.000675374915927375,
+          "mean_rank": 6.0,
           "num_queries": 4
         },
-        "bash-string-ops": {
-          "mean_cosine": 0.841922482398886,
-          "mean_mse": 0.0008854960894039447,
-          "mean_rank": 17.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.8992134065678463,
-          "mean_mse": 0.0005959999085340099,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8882338636679281,
-          "mean_mse": 0.0006913037235399145,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8590175699510603,
-          "mean_mse": 0.0008239003734083991,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.7877747145351386,
-          "mean_mse": 0.001109725109528266,
-          "mean_rank": 28.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8749725563579974,
-          "mean_mse": 0.000685911903736545,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8396459279834797,
-          "mean_mse": 0.0008066865395186084,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.8858737945714455,
-          "mean_mse": 0.0006208408108008564,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.8974252707229754,
-          "mean_mse": 0.0005604931988444983,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9080031360484295,
-          "mean_mse": 0.00047559162568469837,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.869570766557455,
-          "mean_mse": 0.0007496071871004528,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8005192217569539,
-          "mean_mse": 0.000864137364532823,
-          "mean_rank": 39.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.8839991675830255,
-          "mean_mse": 0.0006708080460565421,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.8819244382666303,
-          "mean_mse": 0.0006714423799840363,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9026810193152704,
-          "mean_mse": 0.0006678182626245746,
+        "constraint-usage": {
+          "mean_cosine": 0.893163188050575,
+          "mean_mse": 0.0006103128557872707,
           "mean_rank": 2.75,
           "num_queries": 4
         },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.8934704640507922,
-          "mean_mse": 0.000690552675360928,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8523085817601729,
+          "mean_mse": 0.0007807438542852848,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8917864672459999,
+          "mean_mse": 0.0005604503680749527,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8206465173220522,
+          "mean_mse": 0.0008629522308596934,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8668142838916686,
+          "mean_mse": 0.0007161506610799046,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8607787840097222,
+          "mean_mse": 0.0006877577566370505,
+          "mean_rank": 3.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8372070265460554,
+          "mean_mse": 0.0008491100471587617,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8900127506748892,
+          "mean_mse": 0.00063958937096296,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9115043581130275,
+          "mean_mse": 0.00045823217151258553,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9025539224947723,
+          "mean_mse": 0.0004970671958525834,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8493452291108525,
+          "mean_mse": 0.0008180619317617501,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8617208734517763,
+          "mean_mse": 0.0006889366163050877,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8164886192527778,
+          "mean_mse": 0.000912745024426371,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9315444308276788,
+          "mean_mse": 0.00036637855420641296,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.8149887644680628,
-          "mean_mse": 0.0008828288581175295,
-          "mean_rank": 12.0,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8571605150844435,
+          "mean_mse": 0.0007148788783948553,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8259153651281889,
-          "mean_mse": 0.0008972715639194061,
-          "mean_rank": 7.25,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9489146624307131,
+          "mean_mse": 0.0002655442327186155,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.7772920892000422,
-          "mean_mse": 0.0010902257835253251,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8391596908228001,
-          "mean_mse": 0.000847502223213264,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.826593821653216,
-          "mean_mse": 0.0008514103680900123,
-          "mean_rank": 21.0,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7763058674735148,
-          "mean_mse": 0.001051320673426369,
-          "mean_rank": 27.75,
+        "fold-pattern": {
+          "mean_cosine": 0.8857855653064344,
+          "mean_mse": 0.0005754910705325306,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -2314,320 +1054,140 @@
         "K": 16,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.8717309123068813,
-      "std_cosine_to_target": 0.06395363559164066,
-      "mean_mse_to_target": 0.0007057978248273827,
-      "std_mse_to_target": 0.0002829463464919063,
-      "mean_target_rank": 7.465346534653466,
+      "mean_cosine_to_target": 0.8858683458119069,
+      "std_cosine_to_target": 0.0558909268219869,
+      "mean_mse_to_target": 0.0006158564793647918,
+      "std_mse_to_target": 0.0002544878514267185,
+      "mean_target_rank": 4.914634146341464,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.22772277227722773,
-      "recall_at_5": 0.7128712871287128,
-      "recall_at_10": 0.8712871287128713,
-      "mrr": 0.43466070408288165,
-      "train_time_ms": 25299.923648010008,
-      "inference_time_us": 142021.29379684787,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7926829268292683,
+      "recall_at_10": 0.9024390243902439,
+      "mrr": 0.4375273191677118,
+      "train_time_ms": 7960.301653998613,
+      "inference_time_us": 52353.82458535818,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8665226902290621,
-          "mean_mse": 0.0007569424492761039,
-          "mean_rank": 6.25,
+          "mean_cosine": 0.8851607223542743,
+          "mean_mse": 0.0006252746980773603,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9074426545982412,
-          "mean_mse": 0.0007399926337940254,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8595740014780036,
-          "mean_mse": 0.0007430633410855743,
-          "mean_rank": 8.75,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8849716729955077,
-          "mean_mse": 0.0007410685823973698,
+          "mean_cosine": 0.9084397629193123,
+          "mean_mse": 0.0005970568230412388,
           "mean_rank": 3.0,
           "num_queries": 4
         },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8773512641085874,
+          "mean_mse": 0.0006781768799525383,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8929679323479371,
+          "mean_mse": 0.0006251227456291948,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8359286385019676,
-          "mean_mse": 0.00093903471081825,
-          "mean_rank": 13.5,
+          "mean_cosine": 0.8574281664917252,
+          "mean_mse": 0.0007855852772059217,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8821402945721887,
-          "mean_mse": 0.0006305871349280817,
-          "mean_rank": 7.75,
+          "mean_cosine": 0.8958499953979044,
+          "mean_mse": 0.0005723022623218954,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8577935503962595,
-          "mean_mse": 0.0007951865604508975,
-          "mean_rank": 4.0,
+          "mean_cosine": 0.851013855291737,
+          "mean_mse": 0.000767226479479248,
+          "mean_rank": 9.75,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.85191108333068,
-          "mean_mse": 0.0008432557851381649,
-          "mean_rank": 9.0,
+          "mean_cosine": 0.8673453458932968,
+          "mean_mse": 0.0007259226279312315,
+          "mean_rank": 7.0,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8635285230520461,
-          "mean_mse": 0.0007031960306005762,
-          "mean_rank": 4.2,
+          "mean_cosine": 0.8768123742857192,
+          "mean_mse": 0.0006449083265825221,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8487113299029458,
-          "mean_mse": 0.0008173213818930672,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.8574634556503152,
+          "mean_mse": 0.000734800194780058,
+          "mean_rank": 10.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8804481809385265,
-          "mean_mse": 0.0007281573368247375,
-          "mean_rank": 1.75,
+          "mean_cosine": 0.8999333666578663,
+          "mean_mse": 0.0005758582659447994,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9058129912712294,
-          "mean_mse": 0.0005507729261786871,
+          "mean_cosine": 0.9279974691163179,
+          "mean_mse": 0.00042266524706137886,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8855588625680366,
-          "mean_mse": 0.0005684313658473791,
-          "mean_rank": 18.5,
+          "mean_cosine": 0.8948163777043154,
+          "mean_mse": 0.0005203120826842901,
+          "mean_rank": 11.75,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8568572438974982,
-          "mean_mse": 0.000851387617198254,
-          "mean_rank": 6.0,
+          "mean_cosine": 0.865730205383306,
+          "mean_mse": 0.000750025682827204,
+          "mean_rank": 4.0,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8754534949545325,
-          "mean_mse": 0.0006754567941639833,
-          "mean_rank": 4.0,
+          "mean_cosine": 0.8884117930693611,
+          "mean_mse": 0.0006007862560341646,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.8522353162918963,
-          "mean_mse": 0.0007578229077364086,
-          "mean_rank": 5.5,
+          "mean_cosine": 0.8323129495249593,
+          "mean_mse": 0.0008304289817496234,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9228113102197356,
-          "mean_mse": 0.0004338410447951329,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.9381483154895901,
+          "mean_mse": 0.00033511310038470684,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.8326594164149859,
-          "mean_mse": 0.00082466722505098,
-          "mean_rank": 10.75,
+          "mean_cosine": 0.8638409246297546,
+          "mean_mse": 0.0006814016261230446,
+          "mean_rank": 4.75,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9456816087589469,
-          "mean_mse": 0.00028230542798120706,
-          "mean_rank": 1.25,
+          "mean_cosine": 0.9542093321408762,
+          "mean_mse": 0.00023660364548927775,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8784647249920028,
-          "mean_mse": 0.00063861448531571,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8199257536042526,
-          "mean_mse": 0.0008706973274235871,
-          "mean_rank": 17.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8862126456200173,
-          "mean_mse": 0.0005890593427882118,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8433979630825459,
-          "mean_mse": 0.0007895018600729071,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9489801231837933,
-          "mean_mse": 0.00030069251689216224,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9177658783679322,
-          "mean_mse": 0.000514218880206286,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8804702185151912,
-          "mean_mse": 0.0006411644977897019,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8585247217053943,
-          "mean_mse": 0.000807932525733551,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8907889427711284,
-          "mean_mse": 0.0006484433486340775,
+          "mean_cosine": 0.8894318357696811,
+          "mean_mse": 0.0005667531213261036,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8553949765098507,
-          "mean_mse": 0.0008105157795003518,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9125125146141804,
-          "mean_mse": 0.0005284567495198521,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8996800681383329,
-          "mean_mse": 0.000627047615650384,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8652294268258304,
-          "mean_mse": 0.0007743569184393724,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8185830326512309,
-          "mean_mse": 0.0009908202308353993,
-          "mean_rank": 23.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8847048003054859,
-          "mean_mse": 0.0006429982655133894,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.851583552094688,
-          "mean_mse": 0.0007574444912153873,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.8939436710148915,
-          "mean_mse": 0.0005985396087541563,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9126859869812581,
-          "mean_mse": 0.0005079578287378302,
-          "mean_rank": 1.75,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9106497074400643,
-          "mean_mse": 0.0004638873929197044,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8796166550268876,
-          "mean_mse": 0.0006951760817138575,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8074440715936448,
-          "mean_mse": 0.0008384165849886814,
-          "mean_rank": 38.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.8976663906316673,
-          "mean_mse": 0.0006322790044772671,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9049835493396187,
-          "mean_mse": 0.0005943976794274988,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9114524839068202,
-          "mean_mse": 0.0006524173997788225,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9014614242988321,
-          "mean_mse": 0.0006238282711232299,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8343706726364216,
-          "mean_mse": 0.0008046491552924348,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8326397177516813,
-          "mean_mse": 0.0008662737812752441,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8072283713131331,
-          "mean_mse": 0.0009910072988163299,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.849599437286096,
-          "mean_mse": 0.0008387913164270741,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8383325211064356,
-          "mean_mse": 0.0008267810601061071,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7819777620785131,
-          "mean_mse": 0.0010052856863056727,
-          "mean_rank": 31.25,
           "num_queries": 4
         }
       }
@@ -2639,320 +1199,140 @@
         "alpha_reg": 0.01,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8797103546687244,
-      "std_cosine_to_target": 0.06425635325310713,
-      "mean_mse_to_target": 0.000700254296791489,
-      "std_mse_to_target": 0.0002827435940944875,
-      "mean_target_rank": 7.064356435643564,
+      "mean_cosine_to_target": 0.8862674790260805,
+      "std_cosine_to_target": 0.056250165063911235,
+      "mean_mse_to_target": 0.000626057308734026,
+      "std_mse_to_target": 0.00025270964010250144,
+      "mean_target_rank": 4.878048780487805,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.2079207920792079,
-      "recall_at_5": 0.7574257425742574,
-      "recall_at_10": 0.900990099009901,
-      "mrr": 0.4331323935739435,
-      "train_time_ms": 5779.280661023222,
-      "inference_time_us": 47119.373084497776,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7804878048780488,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.4397210214363617,
+      "train_time_ms": 1715.7647990024998,
+      "inference_time_us": 14233.328036602981,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8731533454877344,
-          "mean_mse": 0.0007713169244272846,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.8858245018548524,
+          "mean_mse": 0.0006309202229018639,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.905696867829618,
-          "mean_mse": 0.0007495226628284005,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8624261264613056,
-          "mean_mse": 0.000781174781225162,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8848988445685063,
-          "mean_mse": 0.0007741607560595078,
+          "mean_cosine": 0.9074728728498407,
+          "mean_mse": 0.0006131697833772065,
           "mean_rank": 3.25,
           "num_queries": 4
         },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8807659513255588,
+          "mean_mse": 0.0006859978295961062,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8945796554627833,
+          "mean_mse": 0.0006296856494574496,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8466580410175402,
-          "mean_mse": 0.0009590448434828309,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.8605693969625278,
+          "mean_mse": 0.0007764385067763086,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8887180925396082,
-          "mean_mse": 0.0006491919369972933,
-          "mean_rank": 7.0,
+          "mean_cosine": 0.9009157993251745,
+          "mean_mse": 0.0005687665021925669,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8569190289284582,
-          "mean_mse": 0.00080678783324732,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.8475299874861603,
+          "mean_mse": 0.0007958567845251441,
+          "mean_rank": 10.25,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.8571862887444959,
-          "mean_mse": 0.000854568527599774,
-          "mean_rank": 10.0,
+          "mean_cosine": 0.8685759575604557,
+          "mean_mse": 0.0007385398991211086,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8717320675251697,
-          "mean_mse": 0.0006866712345010023,
-          "mean_rank": 3.6,
+          "mean_cosine": 0.8765290489653921,
+          "mean_mse": 0.0006531424024237484,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8483915096967645,
-          "mean_mse": 0.000821255326214717,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.8538444235282756,
+          "mean_mse": 0.0007633063175758518,
+          "mean_rank": 10.75,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8864208255449151,
-          "mean_mse": 0.0007357633327685164,
+          "mean_cosine": 0.899335178442465,
+          "mean_mse": 0.0005942020783437239,
           "mean_rank": 2.0,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9142906265968564,
-          "mean_mse": 0.0005230460667482997,
+          "mean_cosine": 0.9268272509800989,
+          "mean_mse": 0.00044597254125440815,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8943749939001607,
-          "mean_mse": 0.0005349307091063193,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.8993202383167196,
+          "mean_mse": 0.0005069880317245472,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8563469508812933,
-          "mean_mse": 0.0008679782637085437,
-          "mean_rank": 6.0,
+          "mean_cosine": 0.8639721567343372,
+          "mean_mse": 0.0007607566720388362,
+          "mean_rank": 4.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8779706329741672,
-          "mean_mse": 0.0006739654698452887,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8540420179483482,
-          "mean_mse": 0.0007822540722567305,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9383737104160328,
-          "mean_mse": 0.00038583756212741524,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.8410888618931871,
-          "mean_mse": 0.0008386496513337651,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9466738829311231,
-          "mean_mse": 0.0002849199776567146,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8891306971594524,
-          "mean_mse": 0.0006187834404017848,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8257004380956463,
-          "mean_mse": 0.0008752237745004023,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8962764983751899,
-          "mean_mse": 0.0005639657174125361,
+          "mean_cosine": 0.8881511381064002,
+          "mean_mse": 0.000613002528826178,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.8524211658612764,
-          "mean_mse": 0.0007751940527727288,
-          "mean_rank": 3.75,
+        "recursion-patterns": {
+          "mean_cosine": 0.8311881497580006,
+          "mean_mse": 0.0008490239645680415,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
-        "bash-subshells": {
-          "mean_cosine": 0.953844171371681,
-          "mean_mse": 0.00030060427539512337,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9420685521578874,
+          "mean_mse": 0.0003330448930143145,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "process-substitution": {
-          "mean_cosine": 0.9248473666747328,
-          "mean_mse": 0.0005221567496560524,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8588161224311777,
+          "mean_mse": 0.0007247951469997659,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9533724751143795,
+          "mean_mse": 0.00023973594599548985,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8936991612472291,
+          "mean_mse": 0.0005573543597192271,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8942765374991262,
-          "mean_mse": 0.0005945118179669887,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8745452782255155,
-          "mean_mse": 0.0007779791754364673,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.9001442953527204,
-          "mean_mse": 0.0006069709866206784,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8607467154693179,
-          "mean_mse": 0.0008027676744936918,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9204087878725511,
-          "mean_mse": 0.0005538074108962968,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9090055643138943,
-          "mean_mse": 0.0006119526326984126,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8825886408763579,
-          "mean_mse": 0.0007409442293904504,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8301364148165202,
-          "mean_mse": 0.0010083654474762455,
-          "mean_rank": 21.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8900422286864608,
-          "mean_mse": 0.0006481084892497752,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8602427557381442,
-          "mean_mse": 0.0007452912036074818,
-          "mean_rank": 12.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9072261426591139,
-          "mean_mse": 0.0005853598829209701,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9158574027511226,
-          "mean_mse": 0.0005093124616472503,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9124798156042746,
-          "mean_mse": 0.00046433144533207575,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.878828866906353,
-          "mean_mse": 0.0007413179541639855,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8178809668839819,
-          "mean_mse": 0.0008119435526912203,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9112525095853818,
-          "mean_mse": 0.0005947749971944369,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9189788170768656,
-          "mean_mse": 0.0005972362069719594,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.91353757208976,
-          "mean_mse": 0.0006824666364589129,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9102985871810593,
-          "mean_mse": 0.0005946959839537595,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8443398428121862,
-          "mean_mse": 0.0007922701555234152,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.851531830325967,
-          "mean_mse": 0.0008568991202986707,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8395331270506201,
-          "mean_mse": 0.0009088164920039836,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8585647143243427,
-          "mean_mse": 0.0008216234804719353,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8472070347531301,
-          "mean_mse": 0.0008119125080377191,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7961156538909326,
-          "mean_mse": 0.0009735517256375202,
-          "mean_rank": 30.0,
           "num_queries": 4
         }
       }
@@ -2964,320 +1344,140 @@
         "alpha_reg": 0.1,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8795103190166128,
-      "std_cosine_to_target": 0.06424255904115778,
-      "mean_mse_to_target": 0.0007023992371262233,
-      "std_mse_to_target": 0.00028251345830760733,
-      "mean_target_rank": 7.094059405940594,
+      "mean_cosine_to_target": 0.8859049724521829,
+      "std_cosine_to_target": 0.05629718017444128,
+      "mean_mse_to_target": 0.0006295798858951195,
+      "std_mse_to_target": 0.0002524641241146707,
+      "mean_target_rank": 4.890243902439025,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.21287128712871287,
-      "recall_at_5": 0.7574257425742574,
-      "recall_at_10": 0.900990099009901,
-      "mrr": 0.43586825988433187,
-      "train_time_ms": 5622.242548968643,
-      "inference_time_us": 59738.26476723177,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7682926829268293,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.439314517371321,
+      "train_time_ms": 1627.4372990010306,
+      "inference_time_us": 13355.10975607066,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8730781910595611,
-          "mean_mse": 0.0007714010583870585,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.886070053539644,
+          "mean_mse": 0.0006316331477877851,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9056245680802302,
-          "mean_mse": 0.0007517151947841149,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8622816808926022,
-          "mean_mse": 0.0007817911001680818,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.884488717913304,
-          "mean_mse": 0.0007773845539677703,
+          "mean_cosine": 0.9072761232728394,
+          "mean_mse": 0.0006175790676853058,
           "mean_rank": 3.25,
           "num_queries": 4
         },
+        "compilation-pipeline": {
+          "mean_cosine": 0.880454547757769,
+          "mean_mse": 0.0006888086035196808,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8936444339044692,
+          "mean_mse": 0.000635259315152301,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8461622544044072,
-          "mean_mse": 0.0009637725889801406,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.860026133265798,
+          "mean_mse": 0.0007848546423131487,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8886136862530867,
-          "mean_mse": 0.000650363992489947,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.9004680211586028,
+          "mean_mse": 0.0005723810569528646,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8571685522707181,
-          "mean_mse": 0.0008080401927593686,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.8568255762222735,
-          "mean_mse": 0.0008567383240141443,
+          "mean_cosine": 0.8474702321884152,
+          "mean_mse": 0.0007975495224862699,
           "mean_rank": 10.25,
           "num_queries": 4
         },
+        "generated-code-transitive": {
+          "mean_cosine": 0.868245257512645,
+          "mean_mse": 0.0007401690867783617,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8715034173357878,
-          "mean_mse": 0.0006881124424173934,
-          "mean_rank": 3.6,
+          "mean_cosine": 0.8754743284197797,
+          "mean_mse": 0.0006575224716634483,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8481654056074528,
-          "mean_mse": 0.0008244850856966342,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.85364261674104,
+          "mean_mse": 0.0007673654183599909,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8862349025172473,
-          "mean_mse": 0.0007384076122019509,
+          "mean_cosine": 0.8993210212844499,
+          "mean_mse": 0.000597460664648336,
           "mean_rank": 2.0,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9137644025794469,
-          "mean_mse": 0.0005268791736894303,
+          "mean_cosine": 0.9259504558754172,
+          "mean_mse": 0.0004535310026092973,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.894333444826853,
-          "mean_mse": 0.0005367720447258149,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.899471992165986,
+          "mean_mse": 0.0005085684820955044,
+          "mean_rank": 10.75,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8562306037505302,
-          "mean_mse": 0.0008696820555495804,
-          "mean_rank": 6.2,
+          "mean_cosine": 0.8635153166302502,
+          "mean_mse": 0.000764352749265729,
+          "mean_rank": 4.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.877585841037559,
-          "mean_mse": 0.0006755946889081189,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.854236730002916,
-          "mean_mse": 0.0007820618114218347,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.938143619666669,
-          "mean_mse": 0.00038767733090444556,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.8406173712803222,
-          "mean_mse": 0.0008415188692058914,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9463362942492589,
-          "mean_mse": 0.00028689269271733214,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8889599376257094,
-          "mean_mse": 0.000620412227136883,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8256359154459585,
-          "mean_mse": 0.0008754057456321375,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8962553905042718,
-          "mean_mse": 0.0005654515911566768,
+          "mean_cosine": 0.8877800650630334,
+          "mean_mse": 0.0006152418812929797,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.8519653863090225,
-          "mean_mse": 0.0007770244809206787,
-          "mean_rank": 3.5,
+        "recursion-patterns": {
+          "mean_cosine": 0.830467833675895,
+          "mean_mse": 0.0008542069137061979,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
-        "bash-subshells": {
-          "mean_cosine": 0.9536705234823879,
-          "mean_mse": 0.0003033616658407206,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9417249622526197,
+          "mean_mse": 0.00033538269088068345,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "process-substitution": {
-          "mean_cosine": 0.924736397883237,
-          "mean_mse": 0.0005238187671664802,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8585180858217435,
+          "mean_mse": 0.0007266731112861709,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9533432555856299,
+          "mean_mse": 0.00024134515002782714,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.893439787891215,
+          "mean_mse": 0.0005610338771057746,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.893890818788363,
-          "mean_mse": 0.0005985984277457238,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8744489141456095,
-          "mean_mse": 0.0007793967658061651,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.9000926391636273,
-          "mean_mse": 0.0006119205386521434,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.860462183563003,
-          "mean_mse": 0.0008055675835152744,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9201477284915762,
-          "mean_mse": 0.0005561021213993076,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9087040846686105,
-          "mean_mse": 0.0006155849926379359,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8823650979531081,
-          "mean_mse": 0.0007437907758141523,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8298538205667302,
-          "mean_mse": 0.0010127893308733392,
-          "mean_rank": 21.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8896218891599446,
-          "mean_mse": 0.0006526408530610655,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8601195427718265,
-          "mean_mse": 0.0007467998584498571,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.907204702035572,
-          "mean_mse": 0.0005861558335071793,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9155987166696065,
-          "mean_mse": 0.0005103281260339178,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9121091538165187,
-          "mean_mse": 0.00046713938197907406,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.878456322749515,
-          "mean_mse": 0.0007466216797579933,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8172936148970545,
-          "mean_mse": 0.0008153096799887922,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9111678409777497,
-          "mean_mse": 0.000596013755900139,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9187651045845063,
-          "mean_mse": 0.0006012411414156709,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9134868913540315,
-          "mean_mse": 0.0006837011297797253,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9100990084051239,
-          "mean_mse": 0.0005953947543239701,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8445484070039068,
-          "mean_mse": 0.0007919976540400479,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8513312323224537,
-          "mean_mse": 0.0008580280354993756,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8392352388280383,
-          "mean_mse": 0.0009123231378238246,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8588268298571613,
-          "mean_mse": 0.0008208398559375086,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8473491056602399,
-          "mean_mse": 0.0008121550211267072,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7955399054326837,
-          "mean_mse": 0.0009765071244710194,
-          "mean_rank": 30.75,
           "num_queries": 4
         }
       }
@@ -3289,320 +1489,140 @@
         "alpha_reg": 0.01,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8798744576418851,
-      "std_cosine_to_target": 0.06429477267231916,
-      "mean_mse_to_target": 0.0006975362168294836,
-      "std_mse_to_target": 0.0002830206889282567,
-      "mean_target_rank": 7.089108910891089,
+      "mean_cosine_to_target": 0.886759758294524,
+      "std_cosine_to_target": 0.056327942597032075,
+      "mean_mse_to_target": 0.0006211776481472542,
+      "std_mse_to_target": 0.00025352988836059787,
+      "mean_target_rank": 4.841463414634147,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.21782178217821782,
-      "recall_at_5": 0.7574257425742574,
-      "recall_at_10": 0.900990099009901,
-      "mrr": 0.43804355418055785,
-      "train_time_ms": 8054.542555939406,
-      "inference_time_us": 73722.24975739246,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7926829268292683,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.4387223144387307,
+      "train_time_ms": 2506.625038000493,
+      "inference_time_us": 23929.891780470625,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8729447814370298,
-          "mean_mse": 0.0007693067561278496,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.8865585199985866,
+          "mean_mse": 0.0006271179541265927,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9057576823584197,
-          "mean_mse": 0.0007477941294448238,
+          "mean_cosine": 0.9070095471822497,
+          "mean_mse": 0.0006135245999525968,
           "mean_rank": 3.0,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8628956100825714,
-          "mean_mse": 0.0007777806389799981,
-          "mean_rank": 8.0,
+          "mean_cosine": 0.880841096274468,
+          "mean_mse": 0.0006849139724823747,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8846333127601991,
-          "mean_mse": 0.0007738034915079904,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.8945822487888183,
+          "mean_mse": 0.0006290630350778904,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8465444615762132,
-          "mean_mse": 0.0009553427639799707,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.8621873353046648,
+          "mean_mse": 0.0007648272095575594,
+          "mean_rank": 4.75,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8884545199885907,
-          "mean_mse": 0.0006483052918507766,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.9012958111537319,
+          "mean_mse": 0.000563563726264284,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8565332213165744,
-          "mean_mse": 0.0008088132315546949,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.8487814673384134,
+          "mean_mse": 0.0007876177248579875,
+          "mean_rank": 10.25,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.8574567083320769,
-          "mean_mse": 0.0008518993329241435,
-          "mean_rank": 10.0,
+          "mean_cosine": 0.868676433028654,
+          "mean_mse": 0.0007355970471401915,
+          "mean_rank": 6.75,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8717856286411593,
-          "mean_mse": 0.0006860644272751595,
-          "mean_rank": 3.6,
+          "mean_cosine": 0.8777162798268172,
+          "mean_mse": 0.0006488030239241875,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8487817821505811,
-          "mean_mse": 0.0008144968555795688,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.8548118096100751,
+          "mean_mse": 0.0007498248902807676,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8864487229649085,
-          "mean_mse": 0.0007353017260827444,
-          "mean_rank": 2.0,
+          "mean_cosine": 0.8998506209992123,
+          "mean_mse": 0.0005872589302854636,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9142366971590007,
-          "mean_mse": 0.000522919988634844,
+          "mean_cosine": 0.9291416401978051,
+          "mean_mse": 0.0004260038980051969,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8944958376552594,
-          "mean_mse": 0.0005342152454992119,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.899306355057886,
+          "mean_mse": 0.0005055210653371935,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8562305878265966,
-          "mean_mse": 0.0008688267578674108,
-          "mean_rank": 6.2,
+          "mean_cosine": 0.8644514526427655,
+          "mean_mse": 0.0007535701658098338,
+          "mean_rank": 4.0,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8780793194516572,
-          "mean_mse": 0.0006727665020576625,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.8884993775253136,
+          "mean_mse": 0.0006087800520598947,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.8539150489473916,
-          "mean_mse": 0.0007811413791794774,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.8316776677341596,
+          "mean_mse": 0.0008438417396891873,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9383396210378542,
-          "mean_mse": 0.0003849182988128752,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.9416304322086791,
+          "mean_mse": 0.0003331695901922402,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.8410525870815478,
-          "mean_mse": 0.0008374957399894603,
-          "mean_rank": 8.0,
+          "mean_cosine": 0.8588196783015397,
+          "mean_mse": 0.0007256327054432031,
+          "mean_rank": 6.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9468403597361309,
-          "mean_mse": 0.0002834384250562327,
-          "mean_rank": 2.0,
+          "mean_cosine": 0.9533816109304353,
+          "mean_mse": 0.0002395359063925594,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8907814550817342,
-          "mean_mse": 0.0006107493639925097,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8257825235060434,
-          "mean_mse": 0.0008741592992208656,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8960953289118054,
-          "mean_mse": 0.0005619287094031836,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.852977996354426,
-          "mean_mse": 0.0007700548583611312,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9537999202320013,
-          "mean_mse": 0.0002988055234375514,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9249261858392603,
-          "mean_mse": 0.0005205488393952987,
+          "mean_cosine": 0.8938137278160714,
+          "mean_mse": 0.0005553812527060002,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8952892493950917,
-          "mean_mse": 0.0005894033743647693,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8752369835170647,
-          "mean_mse": 0.0007715253665342007,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.9001713574655643,
-          "mean_mse": 0.0006062389862109313,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8615116268838521,
-          "mean_mse": 0.0007889480512487187,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9204450341521362,
-          "mean_mse": 0.0005514851776047265,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9088814278311173,
-          "mean_mse": 0.0006082316564319597,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8822966915893976,
-          "mean_mse": 0.0007410548470047244,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8297618443740521,
-          "mean_mse": 0.0010093557882001403,
-          "mean_rank": 22.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.890273488297423,
-          "mean_mse": 0.0006464394733486617,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8602596936432144,
-          "mean_mse": 0.0007437979919251811,
-          "mean_rank": 12.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9083233848860354,
-          "mean_mse": 0.0005776037418556275,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9155784595684194,
-          "mean_mse": 0.0005088062419162146,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9130149618681012,
-          "mean_mse": 0.0004621949992460376,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8802038053206614,
-          "mean_mse": 0.0007276556245931292,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8187435039064178,
-          "mean_mse": 0.0008084127855624503,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.911250701932516,
-          "mean_mse": 0.0005937759900795285,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.91910285442666,
-          "mean_mse": 0.0005920397008247276,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9138562624455472,
-          "mean_mse": 0.0006790671405909571,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.910238037912684,
-          "mean_mse": 0.0005890696854981069,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.8443991438048807,
-          "mean_mse": 0.0007904409072213798,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.8519719454366154,
-          "mean_mse": 0.000849933406209013,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8400382596429876,
-          "mean_mse": 0.0009028432668538476,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.8583128526197293,
-          "mean_mse": 0.0008218016806093032,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8467618188456429,
-          "mean_mse": 0.0008131188832765838,
-          "mean_rank": 18.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7959427666034162,
-          "mean_mse": 0.0009727338101769219,
-          "mean_rank": 30.75,
           "num_queries": 4
         }
       }
@@ -3614,320 +1634,3179 @@
         "alpha_reg": 0.1,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8796688632833002,
-      "std_cosine_to_target": 0.06428728665704511,
-      "mean_mse_to_target": 0.0006994328475713107,
-      "std_mse_to_target": 0.00028282313274450655,
-      "mean_target_rank": 7.1138613861386135,
+      "mean_cosine_to_target": 0.8864623440569195,
+      "std_cosine_to_target": 0.056389791312739246,
+      "mean_mse_to_target": 0.0006239945727758154,
+      "std_mse_to_target": 0.00025342612454684735,
+      "mean_target_rank": 4.865853658536586,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.21287128712871287,
-      "recall_at_5": 0.7574257425742574,
-      "recall_at_10": 0.900990099009901,
-      "mrr": 0.43513153955716866,
-      "train_time_ms": 8183.344498975202,
-      "inference_time_us": 93580.21597513965,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.7804878048780488,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.4383066548767297,
+      "train_time_ms": 4846.360943000036,
+      "inference_time_us": 36494.145439020234,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.8728672140465088,
-          "mean_mse": 0.0007694300141956952,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.8867054745979195,
+          "mean_mse": 0.0006279635517858428,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9056705071169806,
-          "mean_mse": 0.0007498494977096832,
+          "mean_cosine": 0.9068365872535353,
+          "mean_mse": 0.0006173055625279779,
           "mean_rank": 3.0,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8626949102781211,
-          "mean_mse": 0.0007784853006979096,
-          "mean_rank": 8.0,
+          "mean_cosine": 0.8805041901750601,
+          "mean_mse": 0.0006876770070447241,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8841521190519548,
-          "mean_mse": 0.0007767175233303879,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.8935367147107703,
+          "mean_mse": 0.0006346303342483007,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8461423925111292,
-          "mean_mse": 0.0009591569134552117,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.8616699783356385,
+          "mean_mse": 0.0007704649677308433,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.8883337117398084,
-          "mean_mse": 0.0006494731086912434,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.900896328677199,
+          "mean_mse": 0.0005669509417301455,
+          "mean_rank": 5.0,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8566763490347106,
-          "mean_mse": 0.0008099492605521009,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.857189415975315,
-          "mean_mse": 0.0008531109975470519,
+          "mean_cosine": 0.8485370230195622,
+          "mean_mse": 0.0007900956616800683,
           "mean_rank": 10.25,
           "num_queries": 4
         },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8684258793842232,
+          "mean_mse": 0.0007372348710596673,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8716135525918352,
-          "mean_mse": 0.0006868074704020967,
-          "mean_rank": 3.6,
+          "mean_cosine": 0.8773031509072231,
+          "mean_mse": 0.0006509667666561652,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8484825991852587,
-          "mean_mse": 0.0008180167024347061,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.854459447265301,
+          "mean_mse": 0.0007542826306880158,
+          "mean_rank": 10.75,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8862737104944645,
-          "mean_mse": 0.0007373247967401308,
-          "mean_rank": 2.0,
+          "mean_cosine": 0.8996328535019186,
+          "mean_mse": 0.0005912198334027347,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9136997475941022,
-          "mean_mse": 0.0005263330138966951,
+          "mean_cosine": 0.9288521183625605,
+          "mean_mse": 0.0004292342876009791,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.8944064996746771,
-          "mean_mse": 0.0005356348201864607,
-          "mean_rank": 17.0,
+          "mean_cosine": 0.8993395478712862,
+          "mean_mse": 0.0005068538826890728,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8561630196695431,
-          "mean_mse": 0.0008702359176001153,
-          "mean_rank": 6.2,
+          "mean_cosine": 0.8640797858701201,
+          "mean_mse": 0.00075589285622679,
+          "mean_rank": 4.0,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8777096337308794,
-          "mean_mse": 0.0006742362818859785,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.8882382635748098,
+          "mean_mse": 0.0006109749122255418,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.8540245724249834,
-          "mean_mse": 0.0007810886318017796,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.8311853283866202,
+          "mean_mse": 0.000847748089101772,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9380927554067751,
-          "mean_mse": 0.0003868158435319216,
+          "mean_cosine": 0.9413799051677657,
+          "mean_mse": 0.00033524055358998835,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8585821571636989,
+          "mean_mse": 0.0007271793572397501,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9533470269908961,
+          "mean_mse": 0.0002406686301942518,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8936205577564018,
+          "mean_mse": 0.0005575891387608434,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls0.5",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 0.5
+      },
+      "mean_cosine_to_target": 0.8080253014788048,
+      "std_cosine_to_target": 0.06978054770681875,
+      "mean_mse_to_target": 0.0012745829986121318,
+      "std_mse_to_target": 0.0002581141879784043,
+      "mean_target_rank": 18.29268292682927,
+      "median_target_rank": 13.5,
+      "recall_at_1": 0.036585365853658534,
+      "recall_at_5": 0.23170731707317074,
+      "recall_at_10": 0.43902439024390244,
+      "mrr": 0.14527393395678023,
+      "train_time_ms": 35.21540099973208,
+      "inference_time_us": 1171.6463414791733,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8054263804219477,
+          "mean_mse": 0.0012190170477867567,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8900335296549565,
+          "mean_mse": 0.0011381763888666,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7949527978305909,
+          "mean_mse": 0.0011967003884212424,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7182071034297522,
+          "mean_mse": 0.0014923634975752029,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8077583291923129,
+          "mean_mse": 0.001486826913028723,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8304117585060292,
+          "mean_mse": 0.0010868970717191999,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7483917528919436,
+          "mean_mse": 0.0013653136131489255,
+          "mean_rank": 33.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7931185412880503,
+          "mean_mse": 0.0012559222587731184,
+          "mean_rank": 21.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7917503040917999,
+          "mean_mse": 0.0012445869900023336,
+          "mean_rank": 19.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8064089651370326,
+          "mean_mse": 0.0012562748050144942,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8464102099744176,
+          "mean_mse": 0.0012420148636536382,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.795172936504063,
+          "mean_mse": 0.0012036385141400653,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8718304499793395,
+          "mean_mse": 0.001457301260431344,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7774217091153403,
+          "mean_mse": 0.0013546500994436378,
+          "mean_rank": 24.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8167618204855769,
+          "mean_mse": 0.0011153088397356393,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7495140378070307,
+          "mean_mse": 0.0014326719978479357,
+          "mean_rank": 30.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9061591709416471,
+          "mean_mse": 0.0008164007756707507,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8059306406772561,
+          "mean_mse": 0.0014084578546966577,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8964826788503932,
+          "mean_mse": 0.001201998885325769,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.720082560234232,
+          "mean_mse": 0.0015046201339051794,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls1.0",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.7725877860329153,
+      "std_cosine_to_target": 0.083160231277789,
+      "mean_mse_to_target": 0.0014838540460238262,
+      "std_mse_to_target": 0.0003030324050286423,
+      "mean_target_rank": 27.365853658536587,
+      "median_target_rank": 27.0,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.10975609756097561,
+      "recall_at_10": 0.25609756097560976,
+      "mrr": 0.0964601377637509,
+      "train_time_ms": 24.363000000448665,
+      "inference_time_us": 1419.207329246735,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7816006176002283,
+          "mean_mse": 0.0013737807445982461,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8845253698183353,
+          "mean_mse": 0.0012725827067837947,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7782387311004724,
+          "mean_mse": 0.0013228317870669533,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.6702405467751704,
+          "mean_mse": 0.0016778506235416266,
+          "mean_rank": 47.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7894897296203123,
+          "mean_mse": 0.0016565026043784405,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8213104424115016,
+          "mean_mse": 0.0012136354216530732,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7246284315541554,
+          "mean_mse": 0.0014934238816232685,
+          "mean_rank": 43.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.777603339930808,
+          "mean_mse": 0.001378419138297335,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7605584654749905,
+          "mean_mse": 0.0014910127071206362,
+          "mean_rank": 32.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.797746534131248,
+          "mean_mse": 0.0013631317137246537,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8289020915335323,
+          "mean_mse": 0.001389347640236393,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7522075240635507,
+          "mean_mse": 0.001440392505891616,
+          "mean_rank": 34.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8200423355553299,
+          "mean_mse": 0.0018089152903048929,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7438468961608766,
+          "mean_mse": 0.0015461753841248943,
+          "mean_rank": 33.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.7936102417580579,
+          "mean_mse": 0.0012991580035384691,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7248317096919876,
+          "mean_mse": 0.001563408237245435,
+          "mean_rank": 38.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8961484900411633,
+          "mean_mse": 0.0010052288567773062,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.7745992354386266,
+          "mean_mse": 0.0016360663135324518,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7415368478765987,
+          "mean_mse": 0.0019025459170678573,
+          "mean_rank": 32.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.6002806927288509,
+          "mean_mse": 0.0018253014431697146,
+          "mean_rank": 67.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls2.0",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 2.0
+      },
+      "mean_cosine_to_target": 0.7638616007820812,
+      "std_cosine_to_target": 0.08774550109971477,
+      "mean_mse_to_target": 0.001530677151393044,
+      "std_mse_to_target": 0.0003087437128264231,
+      "mean_target_rank": 29.475609756097562,
+      "median_target_rank": 28.5,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.10975609756097561,
+      "recall_at_10": 0.2073170731707317,
+      "mrr": 0.08980189028436193,
+      "train_time_ms": 32.158899997739354,
+      "inference_time_us": 1217.126841433261,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7758450719659977,
+          "mean_mse": 0.0014129373941740675,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8827045211481167,
+          "mean_mse": 0.001311580783296912,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7743667826033251,
+          "mean_mse": 0.0013580782406802654,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.6602676614456955,
+          "mean_mse": 0.001720593714055162,
+          "mean_rank": 50.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7857744341259664,
+          "mean_mse": 0.0016953602571861933,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8193813015396589,
+          "mean_mse": 0.0012501546969588661,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7186537383665847,
+          "mean_mse": 0.0015273394123114371,
+          "mean_rank": 44.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7739633692611483,
+          "mean_mse": 0.0014103644038577635,
+          "mean_rank": 26.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7520598751015798,
+          "mean_mse": 0.0015560636691782771,
+          "mean_rank": 34.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7959104393479175,
+          "mean_mse": 0.0013913563712326972,
+          "mean_rank": 21.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.824975267784168,
+          "mean_mse": 0.0014254976145807526,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7417984854777872,
+          "mean_mse": 0.0014985237644000596,
+          "mean_rank": 36.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8043407128217643,
+          "mean_mse": 0.001866337440924637,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7348326218098743,
+          "mean_mse": 0.0015952464321164418,
+          "mean_rank": 34.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.7873162263666191,
+          "mean_mse": 0.0013496204273832034,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7196530370367891,
+          "mean_mse": 0.0015927915522735638,
+          "mean_rank": 40.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8937906008447655,
+          "mean_mse": 0.0010588593186438378,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.7659933067002596,
+          "mean_mse": 0.001689448128789883,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.6973325233264386,
+          "mean_mse": 0.0020040298270870708,
+          "mean_rank": 46.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.5784797147303449,
+          "mean_mse": 0.0018768706291026338,
+          "mean_rank": 69.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls0.5",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 0.5
+      },
+      "mean_cosine_to_target": 0.8114888520637332,
+      "std_cosine_to_target": 0.06848412351383444,
+      "mean_mse_to_target": 0.0012690880655279466,
+      "std_mse_to_target": 0.00024992516855368817,
+      "mean_target_rank": 17.21951219512195,
+      "median_target_rank": 13.0,
+      "recall_at_1": 0.036585365853658534,
+      "recall_at_5": 0.23170731707317074,
+      "recall_at_10": 0.43902439024390244,
+      "mrr": 0.14820570099992456,
+      "train_time_ms": 26.82960000311141,
+      "inference_time_us": 1229.3048902636922,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8086646343191353,
+          "mean_mse": 0.0012116396713388268,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8910855072268876,
+          "mean_mse": 0.00113606157685254,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7974954519810764,
+          "mean_mse": 0.0011937297519651223,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.726422378187637,
+          "mean_mse": 0.0014772494668988435,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8114483113501656,
+          "mean_mse": 0.0014745903369387803,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8333520594880155,
+          "mean_mse": 0.0010821247472303976,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7524019495483603,
+          "mean_mse": 0.0013574894256199567,
+          "mean_rank": 32.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.795902713374441,
+          "mean_mse": 0.0012498747762087622,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7954277980352786,
+          "mean_mse": 0.0012458583279244613,
+          "mean_rank": 18.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8091869612723612,
+          "mean_mse": 0.0012474874848732906,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8501506261835304,
+          "mean_mse": 0.0012301741193742346,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8009400806730265,
+          "mean_mse": 0.0011967099557890232,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8747718552130759,
+          "mean_mse": 0.0014376392085815115,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7806655406020016,
+          "mean_mse": 0.0013507043525933398,
+          "mean_rank": 23.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8186472111150283,
+          "mean_mse": 0.0011158123136792884,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7532884513699956,
+          "mean_mse": 0.0014215199059439449,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9080875063219349,
+          "mean_mse": 0.0008172650329999754,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8099320634229847,
+          "mean_mse": 0.001397654069017568,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8948331960339422,
+          "mean_mse": 0.001236725267872407,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.728793836928332,
+          "mean_mse": 0.001486854881491185,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls1.0",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.7765670635140615,
+      "std_cosine_to_target": 0.08123332961062706,
+      "mean_mse_to_target": 0.0014659475061894606,
+      "std_mse_to_target": 0.0002985580242652013,
+      "mean_target_rank": 26.24390243902439,
+      "median_target_rank": 26.0,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.10975609756097561,
+      "recall_at_10": 0.2682926829268293,
+      "mrr": 0.09885587759783955,
+      "train_time_ms": 28.08539999750792,
+      "inference_time_us": 1288.640256106879,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7843721318369259,
+          "mean_mse": 0.0013586034832020514,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8853522278673324,
+          "mean_mse": 0.001259379223231698,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7801213946422259,
+          "mean_mse": 0.0013106211613339062,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.6753241426711625,
+          "mean_mse": 0.001661048609833884,
+          "mean_rank": 46.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7915796437210323,
+          "mean_mse": 0.0016411116133779053,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8224350047827343,
+          "mean_mse": 0.0012013167196216071,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7274715985117503,
+          "mean_mse": 0.0014805112817515148,
+          "mean_rank": 41.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7794480360801471,
+          "mean_mse": 0.0013661794838822816,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7641944149934004,
+          "mean_mse": 0.001468749606710119,
+          "mean_rank": 30.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7988719632356349,
+          "mean_mse": 0.0013524731813681044,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8310025331680375,
+          "mean_mse": 0.0013752768014178203,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7569158213183229,
+          "mean_mse": 0.0014191438406627253,
+          "mean_rank": 32.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.827098713837834,
+          "mean_mse": 0.0017819870536714797,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7477520134811619,
+          "mean_mse": 0.0015278948202694024,
+          "mean_rank": 32.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.7962550211781336,
+          "mean_mse": 0.0012817570454691355,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7275507890398138,
+          "mean_mse": 0.0015508618583075734,
+          "mean_rank": 37.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.897268892130525,
+          "mean_mse": 0.0009887396691820151,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.7787639342598031,
+          "mean_mse": 0.0016161777220387325,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7586395052799593,
+          "mean_mse": 0.0018598879179830574,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.6112204128836811,
+          "mean_mse": 0.0018010416768240447,
+          "mean_rank": 66.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls2.0",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 2.0
+      },
+      "mean_cosine_to_target": 0.7653472516208617,
+      "std_cosine_to_target": 0.08696272823520554,
+      "mean_mse_to_target": 0.0015231928166276132,
+      "std_mse_to_target": 0.0003079067056808952,
+      "mean_target_rank": 29.158536585365855,
+      "median_target_rank": 28.5,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.10975609756097561,
+      "recall_at_10": 0.21951219512195122,
+      "mrr": 0.0902840171915475,
+      "train_time_ms": 31.183499999315245,
+      "inference_time_us": 1245.9902561048937,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7768593930873212,
+          "mean_mse": 0.0014064379594289486,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8830430415361388,
+          "mean_mse": 0.0013051791677827248,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7750440519470122,
+          "mean_mse": 0.0013522837727453576,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.6619818078092045,
+          "mean_mse": 0.001713663218234435,
+          "mean_rank": 50.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7864321680292992,
+          "mean_mse": 0.001689031794763407,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8197339033921769,
+          "mean_mse": 0.0012441617664745704,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7197126411060609,
+          "mean_mse": 0.0015216906394221537,
+          "mean_rank": 44.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7746140974715086,
+          "mean_mse": 0.0014050299927016918,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7535273313134649,
+          "mean_mse": 0.0015457343224971219,
+          "mean_rank": 34.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7962522006805081,
+          "mean_mse": 0.001386665423638945,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8256763766775695,
+          "mean_mse": 0.0014195503481732106,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7435757834975882,
+          "mean_mse": 0.0014892348577920237,
+          "mean_rank": 36.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8071030841811598,
+          "mean_mse": 0.0018573436772234503,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7363939194439583,
+          "mean_mse": 0.001587256146087886,
+          "mean_rank": 34.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.7884042869767788,
+          "mean_mse": 0.0013414273192603598,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.720557107813917,
+          "mean_mse": 0.0015879018347321474,
+          "mean_rank": 40.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8941994581176531,
+          "mean_mse": 0.0010503624995233055,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.7675654367625766,
+          "mean_mse": 0.0016809062612614422,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7044535466391425,
+          "mean_mse": 0.0019895115508890603,
+          "mean_rank": 44.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.5820087090552695,
+          "mean_mse": 0.0018688325710875776,
+          "mean_rank": 68.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern32_ls1.0",
+      "params": {
+        "kernel": "Matern32",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.7790401260224389,
+      "std_cosine_to_target": 0.08009800277305108,
+      "mean_mse_to_target": 0.0014562767654392756,
+      "std_mse_to_target": 0.00029514344178683833,
+      "mean_target_rank": 25.682926829268293,
+      "median_target_rank": 25.0,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.10975609756097561,
+      "recall_at_10": 0.2926829268292683,
+      "mrr": 0.0999811954459338,
+      "train_time_ms": 24.399399997491855,
+      "inference_time_us": 1152.9512317438052,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7860969777969216,
+          "mean_mse": 0.0013506049708701135,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8858837967532999,
+          "mean_mse": 0.0012529210306589573,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.7813313733757598,
+          "mean_mse": 0.0013045621684378336,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.6787648387824954,
+          "mean_mse": 0.0016513915453078873,
+          "mean_rank": 46.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.7930790707553553,
+          "mean_mse": 0.0016323952927853932,
+          "mean_rank": 22.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8233057174116715,
+          "mean_mse": 0.0011950824393840748,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7293044589596496,
+          "mean_mse": 0.0014735888085400115,
+          "mean_rank": 40.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7806589964885469,
+          "mean_mse": 0.0013597595123380562,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7663882912203255,
+          "mean_mse": 0.001458080385674028,
+          "mean_rank": 29.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.7997537998286691,
+          "mean_mse": 0.001346538737944609,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8324955790323155,
+          "mean_mse": 0.0013673345392167028,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7598832397093032,
+          "mean_mse": 0.0014080835709010249,
+          "mean_rank": 31.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8313713143609985,
+          "mean_mse": 0.0017653993290019407,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7500422536103521,
+          "mean_mse": 0.0015186552067982671,
+          "mean_rank": 31.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.7977490199416729,
+          "mean_mse": 0.0012734771711177602,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7293859985049892,
+          "mean_mse": 0.001543577121296006,
+          "mean_rank": 37.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8980362520093708,
+          "mean_mse": 0.000980985610826111,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.7814660122679844,
+          "mean_mse": 0.00160530921998008,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.7680277453102576,
+          "mean_mse": 0.001835683485242047,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.6181902111323896,
+          "mean_mse": 0.001786059647066176,
+          "mean_rank": 66.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.1",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8193453316552088,
+      "std_cosine_to_target": 0.0676871731924546,
+      "mean_mse_to_target": 0.000916393327114983,
+      "std_mse_to_target": 0.000287594279080677,
+      "mean_target_rank": 15.121951219512194,
+      "median_target_rank": 9.5,
+      "recall_at_1": 0.06097560975609756,
+      "recall_at_5": 0.2804878048780488,
+      "recall_at_10": 0.5487804878048781,
+      "mrr": 0.1918273019915067,
+      "train_time_ms": 1881.2038139985816,
+      "inference_time_us": 10588.5561829271,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8399334577613761,
+          "mean_mse": 0.0007801908757730942,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8935246179615945,
+          "mean_mse": 0.000627237853217922,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8367649576387335,
+          "mean_mse": 0.0007950671358953634,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8381409698668416,
+          "mean_mse": 0.0007931502696621516,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8137914422046905,
+          "mean_mse": 0.0009536591040021343,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8400235438317915,
+          "mean_mse": 0.0007800858645870274,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7593037951188478,
+          "mean_mse": 0.0011529312713504938,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.7995500477511202,
+          "mean_mse": 0.0009683530483504006,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7969073516966342,
+          "mean_mse": 0.0009607626789904462,
+          "mean_rank": 19.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8200942519265746,
+          "mean_mse": 0.000992808119202806,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8577334213888199,
+          "mean_mse": 0.0007972749633859515,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.78764380845517,
+          "mean_mse": 0.0010049487810824306,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8766263203889352,
+          "mean_mse": 0.0008231345241940312,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7679697658000749,
+          "mean_mse": 0.001148735773034134,
+          "mean_rank": 26.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8154312286703964,
+          "mean_mse": 0.0008962134937720399,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7724142895709024,
+          "mean_mse": 0.0011005516320412505,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.909249003127115,
+          "mean_mse": 0.0004822476608929412,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8016728439354169,
+          "mean_mse": 0.0011287083534983321,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8765463702356671,
+          "mean_mse": 0.0007371867144083663,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.7020385322269032,
+          "mean_mse": 0.0013354404755096913,
+          "mean_rank": 37.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.1_k5",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": 5
+      },
+      "mean_cosine_to_target": 0.8367541366626421,
+      "std_cosine_to_target": 0.06295339735172135,
+      "mean_mse_to_target": 0.0008284888028256143,
+      "std_mse_to_target": 0.00029297240765823043,
+      "mean_target_rank": 11.402439024390244,
+      "median_target_rank": 7.5,
+      "recall_at_1": 0.12195121951219512,
+      "recall_at_5": 0.43902439024390244,
+      "recall_at_10": 0.6463414634146342,
+      "mrr": 0.25737948311017217,
+      "train_time_ms": 2013.1040140004188,
+      "inference_time_us": 10352.665926824911,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8521606223581588,
+          "mean_mse": 0.0007192514472468464,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8943590436300329,
+          "mean_mse": 0.0006207980965243824,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8538477451430043,
+          "mean_mse": 0.0007131579934217796,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8684081563630486,
+          "mean_mse": 0.000679883031607702,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8292767580697231,
+          "mean_mse": 0.0008622851082119899,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8439163490309903,
+          "mean_mse": 0.000758496536267644,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7781712426031532,
+          "mean_mse": 0.0010758798217666177,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8044953745730363,
+          "mean_mse": 0.0009465437935686494,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8026619945343285,
+          "mean_mse": 0.0009322521824217621,
+          "mean_rank": 18.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8301530094788302,
+          "mean_mse": 0.0009285478037148495,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8697501738213473,
+          "mean_mse": 0.000762451439346202,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8022511098771374,
+          "mean_mse": 0.0009375092257069282,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9007899239909547,
+          "mean_mse": 0.0005222981966018271,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7780606746441808,
+          "mean_mse": 0.0011367399943013605,
+          "mean_rank": 24.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8198350849534475,
+          "mean_mse": 0.0008717503679976742,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7857215720820839,
+          "mean_mse": 0.001037550122713661,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9106798828707743,
+          "mean_mse": 0.0004716159655338652,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8065474279782296,
+          "mean_mse": 0.001122601000749945,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9233486494987471,
+          "mean_mse": 0.0004223690810283414,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8038443387883218,
+          "mean_mse": 0.0009447912050122838,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.01",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.01,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8403913957952075,
+      "std_cosine_to_target": 0.06309364257863523,
+      "mean_mse_to_target": 0.0008101592747817055,
+      "std_mse_to_target": 0.00029254710802581777,
+      "mean_target_rank": 10.463414634146341,
+      "median_target_rank": 6.0,
+      "recall_at_1": 0.12195121951219512,
+      "recall_at_5": 0.4878048780487805,
+      "recall_at_10": 0.6707317073170732,
+      "mrr": 0.27246522780219823,
+      "train_time_ms": 1875.3884129982907,
+      "inference_time_us": 11779.062280499891,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8545046721404232,
+          "mean_mse": 0.0007065781237787643,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8957292514936606,
+          "mean_mse": 0.0005991299464904275,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8587049881760749,
+          "mean_mse": 0.0006920678776919015,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8781263891694326,
+          "mean_mse": 0.0006405357325898816,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8304596610382052,
+          "mean_mse": 0.000854067715821486,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8487557943788346,
+          "mean_mse": 0.0007384722177029853,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7807666178755694,
+          "mean_mse": 0.0010571132692612048,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.806630172015452,
+          "mean_mse": 0.0009405697942958238,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8310682429520785,
+          "mean_mse": 0.0008132109442871764,
+          "mean_rank": 7.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.83075056882638,
+          "mean_mse": 0.000923707591108983,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8700423926552099,
+          "mean_mse": 0.0007608866290793006,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8049492483922502,
+          "mean_mse": 0.0009262638167013221,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9014912762535799,
+          "mean_mse": 0.0005156482688138181,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7765276161805599,
+          "mean_mse": 0.0011382550466236389,
+          "mean_rank": 24.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8204577548880798,
+          "mean_mse": 0.0008697733583689948,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.787356390139108,
+          "mean_mse": 0.00102330078275015,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9151635656265769,
+          "mean_mse": 0.0004530786210270898,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8155017897309984,
+          "mean_mse": 0.0010783942741301792,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9257585495954607,
+          "mean_mse": 0.000401871044407262,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.7933797074906596,
+          "mean_mse": 0.000987473580366867,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls1.0_\u03bb0.1",
+      "params": {
+        "K": 4,
+        "length_scale": 1.0,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8117054074284993,
+      "std_cosine_to_target": 0.0675445650009893,
+      "mean_mse_to_target": 0.0009619127653201899,
+      "std_mse_to_target": 0.00028481229534593066,
+      "mean_target_rank": 16.28048780487805,
+      "median_target_rank": 11.0,
+      "recall_at_1": 0.036585365853658534,
+      "recall_at_5": 0.25609756097560976,
+      "recall_at_10": 0.4878048780487805,
+      "mrr": 0.16648426067876645,
+      "train_time_ms": 1933.9334109972697,
+      "inference_time_us": 10707.274438994695,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8292609634322929,
+          "mean_mse": 0.0008327957340068408,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8922141053893102,
+          "mean_mse": 0.0006475038426341383,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8235479352467497,
+          "mean_mse": 0.0008644912006714437,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8077803418127398,
+          "mean_mse": 0.0009177347676231458,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.806927867450737,
+          "mean_mse": 0.0010020850189320224,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8365652381228569,
+          "mean_mse": 0.0007993342162709561,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7509990597224749,
+          "mean_mse": 0.0011913735685490426,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.797025022231518,
+          "mean_mse": 0.00098302867039741,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7937658615378611,
+          "mean_mse": 0.000975159961667624,
+          "mean_rank": 20.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8142537347420131,
+          "mean_mse": 0.0010282026490160152,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8517993599902123,
+          "mean_mse": 0.0008202214316708901,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7860142463924451,
+          "mean_mse": 0.0010141215828085325,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8610859430351427,
+          "mean_mse": 0.000999324761798846,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.766338007190813,
+          "mean_mse": 0.0011521346707384413,
+          "mean_rank": 26.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8128681041504007,
+          "mean_mse": 0.0009104089008003463,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7671377585834247,
+          "mean_mse": 0.0011326527572228968,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9057539760808284,
+          "mean_mse": 0.0005009394851164435,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.7977674668276897,
+          "mean_mse": 0.0011449182037656042,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8571363215060744,
+          "mean_mse": 0.0008978773667797734,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.6916935716564829,
+          "mean_mse": 0.0013730792404919652,
+          "mean_rank": 41.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K8_ls0.5_\u03bb0.1",
+      "params": {
+        "K": 8,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8313125410187631,
+      "std_cosine_to_target": 0.06598431639261147,
+      "mean_mse_to_target": 0.0008546551130428083,
+      "std_mse_to_target": 0.000282888395980216,
+      "mean_target_rank": 12.024390243902438,
+      "median_target_rank": 8.0,
+      "recall_at_1": 0.08536585365853659,
+      "recall_at_5": 0.3780487804878049,
+      "recall_at_10": 0.6341463414634146,
+      "mrr": 0.2408432296778621,
+      "train_time_ms": 3490.9962199999427,
+      "inference_time_us": 22994.72450001148,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8487056543369028,
+          "mean_mse": 0.0007398233766171524,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8902732261342392,
+          "mean_mse": 0.0006476334200120325,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.842901367757509,
+          "mean_mse": 0.0007601551386920741,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8407831670115309,
+          "mean_mse": 0.0007849733509856236,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8580214462364542,
+          "mean_mse": 0.0007212153573588891,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8607113531975437,
+          "mean_mse": 0.000679127112149624,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7910666250511683,
+          "mean_mse": 0.0010009148944362,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8319364439119739,
+          "mean_mse": 0.0008273341163795501,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8031994553217571,
+          "mean_mse": 0.0009381691035377499,
+          "mean_rank": 16.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8236344910564493,
+          "mean_mse": 0.0009571803685082394,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.867311367441934,
+          "mean_mse": 0.000744444754219349,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7980244245508654,
+          "mean_mse": 0.0009581582129920363,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8808386714567864,
+          "mean_mse": 0.0007551197909324732,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7823822702571691,
+          "mean_mse": 0.001108551578746337,
+          "mean_rank": 21.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8278817123308213,
+          "mean_mse": 0.000833102294761503,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7851637965777692,
+          "mean_mse": 0.0010314000180192244,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9104919682181294,
+          "mean_mse": 0.000472681470710336,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.800993976616004,
+          "mean_mse": 0.0010899023117304657,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8887493150695231,
+          "mean_mse": 0.0006663513111800396,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.7124409269553794,
+          "mean_mse": 0.0012925116648376468,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.3",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.3
+      },
+      "mean_cosine_to_target": 0.8497309864621188,
+      "std_cosine_to_target": 0.05973234492081899,
+      "mean_mse_to_target": 0.0007972241092764125,
+      "std_mse_to_target": 0.000275802861954297,
+      "mean_target_rank": 8.853658536585366,
+      "median_target_rank": 5.5,
+      "recall_at_1": 0.15853658536585366,
+      "recall_at_5": 0.5,
+      "recall_at_10": 0.7317073170731707,
+      "mrr": 0.31928185421754446,
+      "train_time_ms": 2672.3614119982813,
+      "inference_time_us": 971.4524512230305,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8476950931642883,
+          "mean_mse": 0.0007484084324855333,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8930311000796002,
+          "mean_mse": 0.0006838320118283999,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8452680918395286,
+          "mean_mse": 0.0007711277038389825,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8531697606785278,
+          "mean_mse": 0.0007989315030246442,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8406152428304303,
+          "mean_mse": 0.0008687515369729189,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8569484319918534,
+          "mean_mse": 0.0007090373084111363,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7841879457993788,
+          "mean_mse": 0.0010525145100892207,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8117808247067053,
+          "mean_mse": 0.000933200328490402,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.850413173367798,
+          "mean_mse": 0.0007469374516010476,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8310912262168589,
+          "mean_mse": 0.0009260439632237476,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8720775742254836,
+          "mean_mse": 0.0008019652636960388,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8640820188847523,
+          "mean_mse": 0.0006834308158847378,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8957161645511651,
+          "mean_mse": 0.000578475561758377,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8024937635309556,
+          "mean_mse": 0.0010660876547277994,
+          "mean_rank": 15.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.827077586580927,
+          "mean_mse": 0.0008406913259629693,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7921715841268818,
+          "mean_mse": 0.0010313345468233258,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9179795388315046,
+          "mean_mse": 0.00045603131597891575,
           "mean_rank": 2.75,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.840590826120455,
-          "mean_mse": 0.00084002792791998,
-          "mean_rank": 8.25,
+          "mean_cosine": 0.8334881543094228,
+          "mean_mse": 0.0010132519603999657,
+          "mean_rank": 8.5,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9466497754798516,
-          "mean_mse": 0.0002848177064400032,
-          "mean_rank": 2.0,
+          "mean_cosine": 0.9414209528226922,
+          "mean_mse": 0.00037389759476005586,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8903086058533202,
-          "mean_mse": 0.0006136140991365654,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8256859934144968,
-          "mean_mse": 0.0008744992565795028,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.8960533387680829,
-          "mean_mse": 0.0005628801061970526,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8524882941918552,
-          "mean_mse": 0.000772355187260581,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.9537136022234358,
-          "mean_mse": 0.0003012838994288172,
+          "mean_cosine": 0.8455502597099881,
+          "mean_mse": 0.0008058871736260255,
           "mean_rank": 2.5,
           "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.9247574707556734,
-          "mean_mse": 0.0005220106217287589,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8949079837366889,
-          "mean_mse": 0.0005928983907588126,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8750822655308781,
-          "mean_mse": 0.0007736703927212938,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.9000527094366864,
-          "mean_mse": 0.0006106056523900877,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8612453649684185,
-          "mean_mse": 0.0007918947527267022,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9201672515690934,
-          "mean_mse": 0.0005536361617192781,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.9086819219559454,
-          "mean_mse": 0.0006110142812063395,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8820931124893556,
-          "mean_mse": 0.000743432999584896,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8295379805605938,
-          "mean_mse": 0.0010135099819812343,
-          "mean_rank": 22.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.889864114984217,
-          "mean_mse": 0.0006502334939853415,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8600746143437215,
-          "mean_mse": 0.0007452903465982013,
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.5",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.8418026724595417,
+      "std_cosine_to_target": 0.06119752867373201,
+      "mean_mse_to_target": 0.000855443837051485,
+      "std_mse_to_target": 0.0002691584223058005,
+      "mean_target_rank": 10.317073170731707,
+      "median_target_rank": 7.0,
+      "recall_at_1": 0.10975609756097561,
+      "recall_at_5": 0.4268292682926829,
+      "recall_at_10": 0.6707317073170732,
+      "mrr": 0.2714562582244981,
+      "train_time_ms": 2613.836595999601,
+      "inference_time_us": 1107.2207073040063,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8357498008899544,
+          "mean_mse": 0.0008143679806021093,
           "mean_rank": 12.5,
           "num_queries": 4
         },
-        "compile-workflow": {
-          "mean_cosine": 0.9080458589543693,
-          "mean_mse": 0.000579451905547506,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9153838845195329,
-          "mean_mse": 0.0005094602503132403,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9127450160006674,
-          "mean_mse": 0.00046418667702136074,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8798751877998827,
-          "mean_mse": 0.0007310969483255,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8930609274391508,
+          "mean_mse": 0.000706821482670649,
           "mean_rank": 3.75,
           "num_queries": 4
         },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8184593274238031,
-          "mean_mse": 0.0008101982729182226,
-          "mean_rank": 37.0,
+        "compilation-pipeline": {
+          "mean_cosine": 0.8321385220973918,
+          "mean_mse": 0.0008353304223798425,
+          "mean_rank": 12.75,
           "num_queries": 4
         },
-        "prolog-introspection": {
-          "mean_cosine": 0.9111436918381391,
-          "mean_mse": 0.0005948261290601955,
+        "constraint-usage": {
+          "mean_cosine": 0.8201914988488067,
+          "mean_mse": 0.0009492826511870562,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8378505145657769,
+          "mean_mse": 0.0009300477229375406,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8535889947836014,
+          "mean_mse": 0.0007301535798501542,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7709994481261931,
+          "mean_mse": 0.0011121776133657855,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8075886610905947,
+          "mean_mse": 0.0009599151128937476,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8403308481258124,
+          "mean_mse": 0.0008053836497268249,
+          "mean_rank": 6.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8274414571703234,
+          "mean_mse": 0.0009523339838356129,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8688071288268148,
+          "mean_mse": 0.0008380952981514689,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.849088403698757,
+          "mean_mse": 0.0007570369376597931,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.894018386020427,
+          "mean_mse": 0.000682748582478958,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7971656608065584,
+          "mean_mse": 0.0010874482000872328,
+          "mean_rank": 17.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8259411631990587,
+          "mean_mse": 0.0008523026469588903,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7838175480176399,
+          "mean_mse": 0.001088539594593067,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9172512022583368,
+          "mean_mse": 0.0004754139008843959,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8314718798313794,
+          "mean_mse": 0.001050847650429634,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9357977532182258,
+          "mean_mse": 0.0005081178702779579,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8252808591727067,
+          "mean_mse": 0.0009270258161312088,
           "mean_rank": 2.5,
           "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9189068558661044,
-          "mean_mse": 0.000594918830309122,
-          "mean_rank": 2.25,
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.7",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.7
+      },
+      "mean_cosine_to_target": 0.8305870032844967,
+      "std_cosine_to_target": 0.06433476575959667,
+      "mean_mse_to_target": 0.0009288267060768595,
+      "std_mse_to_target": 0.00026713920431368224,
+      "mean_target_rank": 12.597560975609756,
+      "median_target_rank": 8.0,
+      "recall_at_1": 0.036585365853658534,
+      "recall_at_5": 0.35365853658536583,
+      "recall_at_10": 0.5853658536585366,
+      "mrr": 0.19973658258348528,
+      "train_time_ms": 2601.8938519991934,
+      "inference_time_us": 1141.0841219380595,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8199693425743926,
+          "mean_mse": 0.0008945462739245146,
+          "mean_rank": 15.25,
           "num_queries": 4
         },
-        "scc-detection": {
-          "mean_cosine": 0.9137786544118356,
-          "mean_mse": 0.0006801620392877461,
-          "mean_rank": 2.5,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8925614707639524,
+          "mean_mse": 0.0007339158603780676,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9100888779970514,
-          "mean_mse": 0.0005902209738891627,
-          "mean_rank": 2.25,
+        "compilation-pipeline": {
+          "mean_cosine": 0.8164576741376044,
+          "mean_mse": 0.0009074550866758687,
+          "mean_rank": 18.0,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.8444927403917157,
-          "mean_mse": 0.0007904287892426155,
-          "mean_rank": 6.0,
+        "constraint-usage": {
+          "mean_cosine": 0.775490323179948,
+          "mean_mse": 0.0011258985684279002,
+          "mean_rank": 18.75,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8517887442136969,
-          "mean_mse": 0.0008513140471295847,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8340544176130336,
+          "mean_mse": 0.0010029510967484534,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8494316320268589,
+          "mean_mse": 0.0007555241945792009,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7544989411059314,
+          "mean_mse": 0.001179781937060567,
+          "mean_rank": 29.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.801798881825546,
+          "mean_mse": 0.0009934447220065422,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8271305485804354,
+          "mean_mse": 0.00087593060558528,
+          "mean_rank": 8.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.82259861378607,
+          "mean_mse": 0.0009831626014229701,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.863517932914161,
+          "mean_mse": 0.0008823580883090345,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8297259097221771,
+          "mean_mse": 0.0008456036970324658,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8898328244966864,
+          "mean_mse": 0.0008356823449320381,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7902489716561124,
+          "mean_mse": 0.0011154121226138226,
+          "mean_rank": 20.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8241799260651763,
+          "mean_mse": 0.0008678463401272303,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7722083067823313,
+          "mean_mse": 0.0011563376965568514,
+          "mean_rank": 19.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9159945853573497,
+          "mean_mse": 0.0004991411134358522,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8285950239668126,
+          "mean_mse": 0.0010925198943822875,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9239321439832643,
+          "mean_mse": 0.0007063163563825138,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.7904612167352005,
+          "mean_mse": 0.0010892831919443865,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K8_ls0.5_b0.5",
+      "params": {
+        "K": 8,
+        "length_scale": 0.5,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.8572987124000943,
+      "std_cosine_to_target": 0.058760865139552934,
+      "mean_mse_to_target": 0.0008298126964451587,
+      "std_mse_to_target": 0.00024152886323681723,
+      "mean_target_rank": 7.841463414634147,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.14634146341463414,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7926829268292683,
+      "mrr": 0.3389038301660228,
+      "train_time_ms": 4271.172311000555,
+      "inference_time_us": 1154.8565243862047,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8526454180981584,
+          "mean_mse": 0.0008148615006747369,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8943538262707847,
+          "mean_mse": 0.0007521875821670772,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8496290939673323,
+          "mean_mse": 0.0008408917957565446,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8379431824025617,
+          "mean_mse": 0.0009442221754061605,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8458461458637085,
+          "mean_mse": 0.0009530386935070738,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8618193630123819,
+          "mean_mse": 0.0007457355368467976,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.7840137438787885,
+          "mean_mse": 0.0010779392663617404,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.841408864221725,
+          "mean_mse": 0.0008970528072130252,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8475968102851477,
+          "mean_mse": 0.0008075899543578431,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8357981519046012,
+          "mean_mse": 0.0009226222612106366,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8865730985865545,
+          "mean_mse": 0.0007810447957426902,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8713301153534985,
+          "mean_mse": 0.0007007520351688306,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9012208091913413,
+          "mean_mse": 0.0006748986004457289,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8301511840263446,
+          "mean_mse": 0.0009664003264218882,
+          "mean_rank": 11.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8509456826619128,
+          "mean_mse": 0.0007852522592309018,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7949587040824135,
+          "mean_mse": 0.001097959525995843,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9263091672943775,
+          "mean_mse": 0.0004717264534126096,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.848162079409257,
+          "mean_mse": 0.0009014344287136956,
           "mean_rank": 6.75,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8396133530361657,
-          "mean_mse": 0.0009061475974725894,
-          "mean_rank": 4.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9405078198098402,
+          "mean_mse": 0.0005504705805220191,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "mutual-recursion": {
-          "mean_cosine": 0.8585811225860637,
-          "mean_mse": 0.0008205259725980297,
+        "fold-pattern": {
+          "mean_cosine": 0.8539733453033289,
+          "mean_mse": 0.0008815821277749786,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls1.0_b0.5",
+      "params": {
+        "K": 4,
+        "length_scale": 1.0,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.8383092669052288,
+      "std_cosine_to_target": 0.0619404172879026,
+      "mean_mse_to_target": 0.0008895005638640677,
+      "std_mse_to_target": 0.00026212476186654454,
+      "mean_target_rank": 10.926829268292684,
+      "median_target_rank": 7.0,
+      "recall_at_1": 0.08536585365853659,
+      "recall_at_5": 0.3902439024390244,
+      "recall_at_10": 0.6585365853658537,
+      "mrr": 0.24769592286414568,
+      "train_time_ms": 2875.7776290003676,
+      "inference_time_us": 1252.64547559931,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8326352088390798,
+          "mean_mse": 0.0008387934812247896,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8937675724266444,
+          "mean_mse": 0.0007172548246638067,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8309235710728117,
+          "mean_mse": 0.000847874023314932,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8022112052924921,
+          "mean_mse": 0.0010385956423783617,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8365599643265645,
+          "mean_mse": 0.0009642943130947648,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.85184484603594,
+          "mean_mse": 0.0007451745184479733,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.767643378718679,
+          "mean_mse": 0.0011275436101414388,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8053403581393064,
+          "mean_mse": 0.00097771337368515,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8382137368446394,
+          "mean_mse": 0.000830670322994824,
+          "mean_rank": 6.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8264100413552324,
+          "mean_mse": 0.0009632324466203699,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8670504558246663,
+          "mean_mse": 0.0008576606794825022,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.841582923679927,
+          "mean_mse": 0.0007982381041436688,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8925065220938534,
+          "mean_mse": 0.0007547494978885601,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7937432406278362,
+          "mean_mse": 0.0011036971773072319,
+          "mean_rank": 18.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8251814437678497,
+          "mean_mse": 0.0008634546691174792,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.7810943655080799,
+          "mean_mse": 0.0011084603490952925,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9182785587861576,
+          "mean_mse": 0.0004901078837537378,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8324004863504958,
+          "mean_mse": 0.0010712107081484363,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9284156514582901,
+          "mean_mse": 0.000649516733420241,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8115471960405274,
+          "mean_mse": 0.0010029273252143132,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c10",
+      "params": {
+        "K": 4,
+        "target_cond": 10.0
+      },
+      "mean_cosine_to_target": 0.8581446499292027,
+      "std_cosine_to_target": 0.05843916903250347,
+      "mean_mse_to_target": 0.0007410475895784748,
+      "std_mse_to_target": 0.0002777880956285512,
+      "mean_target_rank": 7.365853658536586,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.6097560975609756,
+      "recall_at_10": 0.7682926829268293,
+      "mrr": 0.3617403792658604,
+      "train_time_ms": 3018.2391130001633,
+      "inference_time_us": 11149.082902459379,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8611875961041409,
+          "mean_mse": 0.0006763102458056436,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8919408312709831,
+          "mean_mse": 0.0006737273793880231,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8613399767335903,
+          "mean_mse": 0.0006944168825363231,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8867950443752772,
+          "mean_mse": 0.0006268922723764837,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8445745471913023,
+          "mean_mse": 0.0008071599386480213,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8619501211354019,
+          "mean_mse": 0.0006849738067331233,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8011022120246272,
+          "mean_mse": 0.0009735621770489652,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8169628683709951,
+          "mean_mse": 0.0009062096803356655,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8606914941828503,
+          "mean_mse": 0.0006910826381475245,
+          "mean_rank": 3.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8356830491471852,
+          "mean_mse": 0.0008946302422849995,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8748049237643887,
+          "mean_mse": 0.0007706824858056471,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8817537191321123,
+          "mean_mse": 0.0005978853673450353,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8960754995899123,
+          "mean_mse": 0.0005158087460471946,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8088653074657154,
+          "mean_mse": 0.0010457299674271603,
+          "mean_rank": 13.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8286440672128328,
+          "mean_mse": 0.0008302166489662006,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8015741835815724,
+          "mean_mse": 0.0009660031181001521,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.918554164277299,
+          "mean_mse": 0.0004424046431018443,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8375965618066709,
+          "mean_mse": 0.0009615143857513703,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9441980513027921,
+          "mean_mse": 0.000299370348833501,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8602819044668627,
+          "mean_mse": 0.0006986914602821847,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c50",
+      "params": {
+        "K": 4,
+        "target_cond": 50.0
+      },
+      "mean_cosine_to_target": 0.8582180521967661,
+      "std_cosine_to_target": 0.05848090718043322,
+      "mean_mse_to_target": 0.0007404190749098929,
+      "std_mse_to_target": 0.00027845889205966467,
+      "mean_target_rank": 7.341463414634147,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.6097560975609756,
+      "recall_at_10": 0.7682926829268293,
+      "mrr": 0.36793032752897925,
+      "train_time_ms": 3182.3212259987486,
+      "inference_time_us": 10847.286341453493,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8611961440794149,
+          "mean_mse": 0.0006763376131749144,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.891861520927757,
+          "mean_mse": 0.00067419826417285,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8614535834287216,
+          "mean_mse": 0.0006941669196226308,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8867875574828887,
+          "mean_mse": 0.0006271030861722635,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8445746595744846,
+          "mean_mse": 0.0008072290735545321,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8618534976802646,
+          "mean_mse": 0.0006853738668297904,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8010726269224786,
+          "mean_mse": 0.0009738339884340211,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8169571007537411,
+          "mean_mse": 0.0009062966348170087,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8618391878075652,
+          "mean_mse": 0.0006850008301758747,
+          "mean_rank": 3.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8355776730306118,
+          "mean_mse": 0.000894957371281674,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8747863928260077,
+          "mean_mse": 0.0007709559366100307,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8815654609918331,
+          "mean_mse": 0.0005986820359389744,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8959538048580964,
+          "mean_mse": 0.0005162542054330549,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8088117075946363,
+          "mean_mse": 0.0010460082475484728,
+          "mean_rank": 13.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8286590534904731,
+          "mean_mse": 0.0008301092230003788,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8018180225463847,
+          "mean_mse": 0.0009655243364351814,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9185453239621854,
+          "mean_mse": 0.00044245598336589535,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8375995832000643,
+          "mean_mse": 0.0009615289815559004,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9446100608161775,
+          "mean_mse": 0.00029112301395669784,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8602843842093693,
+          "mean_mse": 0.0006986991541415722,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c100",
+      "params": {
+        "K": 4,
+        "target_cond": 100.0
+      },
+      "mean_cosine_to_target": 0.8582180521967661,
+      "std_cosine_to_target": 0.05848090718043322,
+      "mean_mse_to_target": 0.0007404190749098929,
+      "std_mse_to_target": 0.00027845889205966467,
+      "mean_target_rank": 7.341463414634147,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.6097560975609756,
+      "recall_at_10": 0.7682926829268293,
+      "mrr": 0.36793032752897925,
+      "train_time_ms": 3254.2012829981104,
+      "inference_time_us": 11381.57007317648,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8611961440794149,
+          "mean_mse": 0.0006763376131749144,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.891861520927757,
+          "mean_mse": 0.00067419826417285,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8614535834287216,
+          "mean_mse": 0.0006941669196226308,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8867875574828887,
+          "mean_mse": 0.0006271030861722635,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8445746595744846,
+          "mean_mse": 0.0008072290735545321,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8618534976802646,
+          "mean_mse": 0.0006853738668297904,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8010726269224786,
+          "mean_mse": 0.0009738339884340211,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8169571007537411,
+          "mean_mse": 0.0009062966348170087,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8618391878075652,
+          "mean_mse": 0.0006850008301758747,
+          "mean_rank": 3.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8355776730306118,
+          "mean_mse": 0.000894957371281674,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8747863928260077,
+          "mean_mse": 0.0007709559366100307,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8815654609918331,
+          "mean_mse": 0.0005986820359389744,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8959538048580964,
+          "mean_mse": 0.0005162542054330549,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8088117075946363,
+          "mean_mse": 0.0010460082475484728,
+          "mean_rank": 13.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8286590534904731,
+          "mean_mse": 0.0008301092230003788,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8018180225463847,
+          "mean_mse": 0.0009655243364351814,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9185453239621854,
+          "mean_mse": 0.00044245598336589535,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8375995832000643,
+          "mean_mse": 0.0009615289815559004,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9446100608161775,
+          "mean_mse": 0.00029112301395669784,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8602843842093693,
+          "mean_mse": 0.0006986991541415722,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K8_c50",
+      "params": {
+        "K": 8,
+        "target_cond": 50.0
+      },
+      "mean_cosine_to_target": 0.8767284698825729,
+      "std_cosine_to_target": 0.05707682990570201,
+      "mean_mse_to_target": 0.0006527304877010073,
+      "std_mse_to_target": 0.0002568004273933345,
+      "mean_target_rank": 5.353658536585366,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.7439024390243902,
+      "recall_at_10": 0.8536585365853658,
+      "mrr": 0.40785532918627965,
+      "train_time_ms": 7551.8749189977825,
+      "inference_time_us": 37326.11967075727,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8839689950496137,
+          "mean_mse": 0.0006082413269928322,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8977347338244186,
+          "mean_mse": 0.000615060447140292,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.875216987769102,
+          "mean_mse": 0.0006842849772481543,
           "mean_rank": 5.75,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.846897697700989,
-          "mean_mse": 0.0008132657970744038,
-          "mean_rank": 18.25,
+        "constraint-usage": {
+          "mean_cosine": 0.8943493261285123,
+          "mean_mse": 0.0006132156564918042,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.7953845030914811,
-          "mean_mse": 0.0009755523721387456,
-          "mean_rank": 31.0,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8522036750499307,
+          "mean_mse": 0.000793753090263109,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8921950817678689,
+          "mean_mse": 0.000569388259025457,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8215852052791227,
+          "mean_mse": 0.0008663027705971085,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8674976045485258,
+          "mean_mse": 0.0007242443048157472,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8620938928376756,
+          "mean_mse": 0.0006899858714803718,
+          "mean_rank": 3.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8380016272772319,
+          "mean_mse": 0.0008521056230032421,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.890358334869701,
+          "mean_mse": 0.0006505066285103193,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9124306628405823,
+          "mean_mse": 0.00046299503741425584,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.902334843987086,
+          "mean_mse": 0.0005022090599567871,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8506769695497146,
+          "mean_mse": 0.0008192768243070395,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8624158660979389,
+          "mean_mse": 0.0006931729240960122,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8175169943023589,
+          "mean_mse": 0.0009152823579155464,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9318885995137016,
+          "mean_mse": 0.0003741746264349059,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8574667331670018,
+          "mean_mse": 0.0007221561890517495,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9488259312233531,
+          "mean_mse": 0.00026703269834402286,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8859788519124596,
+          "mean_mse": 0.0005802706508350388,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }

--- a/reports/answer_level_benchmark.json
+++ b/reports/answer_level_benchmark.json
@@ -1,4 +1,11 @@
 {
+  "embedder": {
+    "embedder": "hash",
+    "model_name": "Hash-based (synthetic)",
+    "model_id": null,
+    "dimension": 64,
+    "description": "Deterministic pseudo-random vectors (no semantic meaning)"
+  },
   "metric_legend": {
     "cosine_to_target": {
       "description": "Cosine similarity between projected query and target answer",
@@ -29,9 +36,9 @@
   "winners": {
     "highest_cosine": "Residual_K8_r0.01",
     "lowest_mse": "Residual_K8_r0.01",
-    "lowest_rank": "AdaptiveFFT",
-    "highest_mrr": "Residual_K8_r0.01",
-    "highest_recall_at_5": "FFT_c0.7"
+    "lowest_rank": "FFT_c0.7",
+    "highest_mrr": "FFT_c0.7",
+    "highest_recall_at_5": "FFT_c0.3"
   },
   "results": [
     {
@@ -39,1328 +46,140 @@
       "params": {
         "type": "baseline"
       },
-      "mean_cosine_to_target": 0.5138911540695331,
-      "std_cosine_to_target": 0.17764496029405769,
-      "mean_mse_to_target": 0.012238195173381513,
-      "std_mse_to_target": 0.002999109845100856,
-      "mean_target_rank": 12.51086956521739,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.3167701863354037,
-      "recall_at_5": 0.8416149068322981,
-      "recall_at_10": 0.9037267080745341,
-      "mrr": 0.5387816332347057,
-      "train_time_ms": 4.640499944798648,
-      "inference_time_us": 1228.1948835400992,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4562344413171066,
+      "std_cosine_to_target": 0.10754527403293843,
+      "mean_mse_to_target": 0.012482248178700042,
+      "std_mse_to_target": 0.0012882702075268863,
+      "mean_target_rank": 3.7195121951219514,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.926829268292683,
+      "recall_at_10": 0.9634146341463414,
+      "mrr": 0.48420441347270615,
+      "train_time_ms": 0.3575000009732321,
+      "inference_time_us": 123.73414627778935,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.33688206100607254,
-          "mean_mse": 0.014561400604599187,
-          "mean_rank": 14.25,
+          "mean_cosine": 0.48867672522839756,
+          "mean_mse": 0.012228357969231374,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5211485268907492,
-          "mean_mse": 0.012710917406431455,
+          "mean_cosine": 0.4835098524224813,
+          "mean_mse": 0.012214868593368592,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.44354381430611156,
-          "mean_mse": 0.013836565772381031,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.38427776236847894,
-          "mean_mse": 0.01423238567389366,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.43114490412615114,
-          "mean_mse": 0.013548210730836226,
-          "mean_rank": 27.75,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.38267546055459556,
-          "mean_mse": 0.01398327807787371,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.3481582556906759,
-          "mean_mse": 0.014333871048762947,
-          "mean_rank": 45.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.43217410533608236,
-          "mean_mse": 0.013956852408253608,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.39204790385877103,
-          "mean_mse": 0.014162429317772025,
-          "mean_rank": 16.0,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.42465755695975993,
-          "mean_mse": 0.014292987944335964,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.35105624115190326,
-          "mean_mse": 0.01449589770032459,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.32695111091842,
-          "mean_mse": 0.014402246793656478,
-          "mean_rank": 62.5,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.43852687747089497,
-          "mean_mse": 0.013724201511305037,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.3373181115745628,
-          "mean_mse": 0.014372744129196865,
-          "mean_rank": 38.2,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.41279018234385334,
-          "mean_mse": 0.013964851400689737,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.37982815354574967,
-          "mean_mse": 0.013776152649861522,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.46471351265608585,
-          "mean_mse": 0.013488726492168245,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.4723583158752277,
-          "mean_mse": 0.013311658857350243,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.40433892278030553,
-          "mean_mse": 0.013944656317893643,
-          "mean_rank": 55.75,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.45481182744191717,
-          "mean_mse": 0.013821066207965983,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.31857108323818756,
-          "mean_mse": 0.014780425198374726,
-          "mean_rank": 36.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.32248411980791475,
-          "mean_mse": 0.014724957284929861,
-          "mean_rank": 38.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.4604357093597994,
-          "mean_mse": 0.013963903663432382,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.43914495643722756,
-          "mean_mse": 0.014009698992932706,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5066881842889549,
-          "mean_mse": 0.012926943459005035,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.40420307570517056,
-          "mean_mse": 0.014040661544168834,
-          "mean_rank": 27.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.4680258161447015,
-          "mean_mse": 0.013007864754600851,
+          "mean_cosine": 0.4889149934634416,
+          "mean_mse": 0.012188274074791729,
           "mean_rank": 2.25,
           "num_queries": 4
         },
-        "bash-trap": {
-          "mean_cosine": 0.48295497546716565,
-          "mean_mse": 0.01347789545165654,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.4454465014027348,
-          "mean_mse": 0.013823645455824858,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.4581558942490265,
-          "mean_mse": 0.013480580264644288,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.43453353597980515,
-          "mean_mse": 0.013891885401555133,
-          "mean_rank": 24.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.4440536760048638,
-          "mean_mse": 0.014061389085322505,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.3824880803902071,
-          "mean_mse": 0.013696247548165065,
-          "mean_rank": 142.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.4326952951645922,
-          "mean_mse": 0.014106143005515106,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.3864936573835892,
-          "mean_mse": 0.01399866444576136,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.38590340344559143,
-          "mean_mse": 0.014126191417717197,
-          "mean_rank": 21.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.23389475760368372,
-          "mean_mse": 0.014907800616627815,
-          "mean_rank": 133.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.35540941614994215,
-          "mean_mse": 0.014049607939610853,
-          "mean_rank": 43.75,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.43769759067415864,
-          "mean_mse": 0.013478961353997322,
-          "mean_rank": 22.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.43107423422902374,
-          "mean_mse": 0.0135443584204347,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.4619416357658184,
-          "mean_mse": 0.013594210966879808,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.4885528111088308,
-          "mean_mse": 0.013715071389801804,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.2925853179700007,
-          "mean_mse": 0.014496519521340488,
-          "mean_rank": 44.0,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5233270429064387,
-          "mean_mse": 0.012688253483433866,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.42796576967332867,
-          "mean_mse": 0.01377695673538856,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.39623525855931907,
-          "mean_mse": 0.014367396856868952,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.4884076784791386,
-          "mean_mse": 0.013224454364666115,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.3555942676043687,
-          "mean_mse": 0.014584303735208953,
-          "mean_rank": 10.25,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.4325431060272379,
-          "mean_mse": 0.013901942758746823,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4065225628055718,
-          "mean_mse": 0.014073151536700381,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.30013481000491915,
-          "mean_mse": 0.014702594583956893,
-          "mean_rank": 98.0,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.37513424995910166,
-          "mean_mse": 0.0143954089961855,
-          "mean_rank": 10.75,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.4853175962060107,
-          "mean_mse": 0.013095335883683244,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.3889696894176877,
-          "mean_mse": 0.013471985330412793,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.3889654751750999,
-          "mean_mse": 0.013671062043800773,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.36801709586053194,
-          "mean_mse": 0.014199015753526419,
-          "mean_rank": 37.25,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.41699128606908364,
-          "mean_mse": 0.014145108755514347,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.42734354165709637,
-          "mean_mse": 0.014220681987741797,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.35786272469428243,
-          "mean_mse": 0.014343023497828976,
-          "mean_rank": 96.25,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.15882739307482918,
-          "mean_mse": 0.015081269484133096,
-          "mean_rank": 190.5,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.371177107036174,
-          "mean_mse": 0.014285644806440644,
-          "mean_rank": 27.25,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4233837939632329,
-          "mean_mse": 0.013595392531370869,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.44968056893282893,
-          "mean_mse": 0.013779962136443336,
+        "constraint-usage": {
+          "mean_cosine": 0.4408639897205005,
+          "mean_mse": 0.012577621546839616,
           "mean_rank": 2.75,
           "num_queries": 4
         },
-        "semantic-crawling": {
-          "mean_cosine": 0.4604757569749163,
-          "mean_mse": 0.013709013837059747,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.25570039529873206,
-          "mean_mse": 0.014872225092551391,
-          "mean_rank": 47.5,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.44578317432047876,
-          "mean_mse": 0.01338175343785276,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.36529003703673085,
-          "mean_mse": 0.014104089162781032,
-          "mean_rank": 16.75,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.2856371980896285,
-          "mean_mse": 0.014478391192054737,
-          "mean_rank": 67.25,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.578422594493675,
-          "mean_mse": 0.01202935073260469,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5668559626691531,
-          "mean_mse": 0.011309412893753463,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.4781330604176992,
-          "mean_mse": 0.013016910369954199,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5917088765204336,
-          "mean_mse": 0.011268052386486921,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.47425854996251876,
-          "mean_mse": 0.012859481148529606,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5080624567932636,
-          "mean_mse": 0.013484182618462917,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6500868596433795,
-          "mean_mse": 0.010352275082956665,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.43362547430354725,
-          "mean_mse": 0.013514453091052791,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.487128765233286,
-          "mean_mse": 0.013332818070581487,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5490081459896017,
-          "mean_mse": 0.013020886624081102,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6358179855311761,
-          "mean_mse": 0.011137555843214858,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5354824002623911,
-          "mean_mse": 0.012263519340148967,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5631494602021866,
-          "mean_mse": 0.01254102127663033,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.5957494129481048,
-          "mean_mse": 0.011883354825931563,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5768946759216619,
-          "mean_mse": 0.012247136591005145,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5402491044603095,
-          "mean_mse": 0.011984105987284749,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5438419973693182,
-          "mean_mse": 0.013073215989332239,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5591309511254532,
-          "mean_mse": 0.011773602816069066,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5300899267401111,
-          "mean_mse": 0.012063673286703809,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5552301818957543,
-          "mean_mse": 0.012235648229861007,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5115857508465204,
-          "mean_mse": 0.01341987629994324,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.4669331944305662,
-          "mean_mse": 0.012960838862146995,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5735904347503485,
-          "mean_mse": 0.011529904570717312,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.5966465677788474,
-          "mean_mse": 0.012157462384335785,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.4938841517043786,
-          "mean_mse": 0.012684146857853844,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.4474412874318385,
-          "mean_mse": 0.013359848415414204,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5359320302382916,
-          "mean_mse": 0.012958642497437728,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5704883988958525,
-          "mean_mse": 0.011701542306582454,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.49796443034462046,
-          "mean_mse": 0.01335787723980523,
-          "mean_rank": 3.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5268139861963324,
-          "mean_mse": 0.013262871075777371,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5059974056754616,
-          "mean_mse": 0.01365121529668493,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.4554459220320158,
-          "mean_mse": 0.012779288705412927,
-          "mean_rank": 4.0,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5648688846737709,
-          "mean_mse": 0.011946207661400185,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5205543197565053,
-          "mean_mse": 0.012797930441483946,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6023704952663071,
-          "mean_mse": 0.012445153482503269,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.5695839031995006,
-          "mean_mse": 0.012381738278948706,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.44138414706187623,
-          "mean_mse": 0.013697563684094428,
-          "mean_rank": 19.333333333333332,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6027413642200348,
-          "mean_mse": 0.012347111075151218,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6211698556847842,
-          "mean_mse": 0.012135494444085354,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.554249864921397,
-          "mean_mse": 0.012134199869350208,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5381905522733643,
-          "mean_mse": 0.0124199817871754,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5473082208094855,
-          "mean_mse": 0.011525728236004012,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5542735637810119,
-          "mean_mse": 0.012957357266167641,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5407438848063691,
-          "mean_mse": 0.012951865840746415,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5698195681592618,
-          "mean_mse": 0.011706406214479855,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.46618820275691925,
-          "mean_mse": 0.013809026335848983,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5274230684709055,
-          "mean_mse": 0.012847188139437965,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5773355575427526,
-          "mean_mse": 0.012308518606697641,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6347196853165918,
-          "mean_mse": 0.01017348022877241,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5915552053786612,
-          "mean_mse": 0.011198058953483081,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5066862132723314,
-          "mean_mse": 0.012866189547145135,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5069949394395882,
-          "mean_mse": 0.012938497436190272,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5417901153099258,
-          "mean_mse": 0.012576027701357531,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5663852501701325,
-          "mean_mse": 0.011768169769982878,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5866643251546545,
-          "mean_mse": 0.011667875844042145,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5106256241573842,
-          "mean_mse": 0.012960133707330719,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.611862681048338,
-          "mean_mse": 0.011517153245057109,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.41760797036905073,
-          "mean_mse": 0.014082564295546737,
-          "mean_rank": 15.666666666666666,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.5055135429925465,
-          "mean_mse": 0.013373915895585009,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5720896111385317,
-          "mean_mse": 0.011815556918892517,
-          "mean_rank": 4.333333333333333,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.4489095502013833,
-          "mean_mse": 0.014035087243275216,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.571014761210526,
-          "mean_mse": 0.011907470342666178,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.5147296463618708,
-          "mean_mse": 0.012210675547399555,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.4578554675282767,
-          "mean_mse": 0.014016789094690849,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5521480720432738,
-          "mean_mse": 0.012637176257921176,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5326309776978878,
-          "mean_mse": 0.012861655555521137,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5889265030617948,
-          "mean_mse": 0.01177157541853025,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5306218584803738,
-          "mean_mse": 0.012972524510917965,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.44657341006245677,
-          "mean_mse": 0.013446001347513628,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6196936334302737,
-          "mean_mse": 0.011547807581773895,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.48339449599238343,
-          "mean_mse": 0.013124936292262981,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4631680514387649,
-          "mean_mse": 0.013503208060668412,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6093238008029646,
-          "mean_mse": 0.011713859472341053,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4383261942111392,
-          "mean_mse": 0.013416354621664045,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.703516988847338,
-          "mean_mse": 0.008191939713644174,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7182446073913935,
-          "mean_mse": 0.008608621603241665,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.999996524249259,
-          "mean_mse": 6.680764904859558e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6716066186740499,
-          "mean_mse": 0.009413908989411196,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.634676709064999,
-          "mean_mse": 0.010348922722173776,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.615883647483773,
-          "mean_mse": 0.010329329307583035,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6222158992652891,
-          "mean_mse": 0.009920264473093987,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6512163988604276,
-          "mean_mse": 0.010000976558985103,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7213354243649006,
-          "mean_mse": 0.00841480850090984,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6497132497380658,
-          "mean_mse": 0.009695501446787866,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7297837249862833,
-          "mean_mse": 0.008630205875968742,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7344944643516755,
-          "mean_mse": 0.007713591845254341,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7530511621701181,
-          "mean_mse": 0.00697718898301879,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999988302405792,
-          "mean_mse": 7.382995999577093e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9999983950617982,
-          "mean_mse": 6.658792791446318e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.660951248860639,
-          "mean_mse": 0.010373758708406945,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6829176304103765,
-          "mean_mse": 0.00851353798781668,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7908149276158289,
-          "mean_mse": 0.0068865285605909324,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9999984202693514,
-          "mean_mse": 7.031872884782832e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.627784748490062,
-          "mean_mse": 0.009701887896035155,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7032678267894754,
-          "mean_mse": 0.008206423006672818,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7289191757935527,
-          "mean_mse": 0.00775897710498402,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999977746564936,
-          "mean_mse": 8.569084491969538e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6766871840346185,
-          "mean_mse": 0.009453810164437672,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9999985017605966,
-          "mean_mse": 8.665635028066604e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6755011690523904,
-          "mean_mse": 0.01105559527266914,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7337297669234748,
-          "mean_mse": 0.00806993783559516,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7163572288070973,
-          "mean_mse": 0.007908872220942786,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9999978594954878,
-          "mean_mse": 5.768657711190044e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6989913051073148,
-          "mean_mse": 0.008483862906769002,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999980595546458,
-          "mean_mse": 9.506272251835834e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7202787784351277,
-          "mean_mse": 0.00781970485021269,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9999954981304997,
-          "mean_mse": 9.973358833674404e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7192538945440401,
-          "mean_mse": 0.009310406891941538,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7612827812545779,
-          "mean_mse": 0.006706295956995855,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7139300041373533,
-          "mean_mse": 0.008575589017453245,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7805514991690063,
-          "mean_mse": 0.006947086955079604,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999989225468217,
-          "mean_mse": 6.3209693344435395e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6350440910936448,
-          "mean_mse": 0.010244961889896147,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6894446907975833,
-          "mean_mse": 0.008587659908255316,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999980626748918,
-          "mean_mse": 9.68976259940215e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.7000085171760044,
-          "mean_mse": 0.010251655306620361,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6979568662412452,
-          "mean_mse": 0.009038282760033026,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999984140447418,
-          "mean_mse": 8.337022365792254e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9999981024200232,
-          "mean_mse": 6.889402864906471e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.7009599044926305,
-          "mean_mse": 0.008985146991556829,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.6837232973720092,
-          "mean_mse": 0.01059576301551636,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7662334641185525,
-          "mean_mse": 0.007134480844426839,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999988061160895,
-          "mean_mse": 5.508060593452839e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6056374515092044,
-          "mean_mse": 0.010324740773275052,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.739458416998581,
-          "mean_mse": 0.008220685175640268,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999973777721072,
-          "mean_mse": 7.175967040372342e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7285097931411416,
-          "mean_mse": 0.00845522375935975,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.999998879957542,
-          "mean_mse": 5.941048219541958e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7959165779680856,
-          "mean_mse": 0.006853545414639817,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7134015376783363,
-          "mean_mse": 0.008065590815366086,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.999997751419129,
-          "mean_mse": 7.077619512216407e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999990365414421,
-          "mean_mse": 5.247841150979098e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9999983171814297,
-          "mean_mse": 6.4172399051295905e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999989327156675,
-          "mean_mse": 8.049136039479425e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7314171971258983,
-          "mean_mse": 0.008021904616040364,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.704541619259502,
-          "mean_mse": 0.007983717387952642,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6795792983834537,
-          "mean_mse": 0.009540469802725219,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7074667192124835,
-          "mean_mse": 0.008099664406361947,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5691432670439477,
-          "mean_mse": 0.011864576094689988,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7379063710355886,
-          "mean_mse": 0.007992822413570307,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.47323195278161184,
-          "mean_mse": 0.01367311500072794,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.3192839903163476,
-          "mean_mse": 0.01451090982437609,
-          "mean_rank": 64.5,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.5837491788093331,
-          "mean_mse": 0.011810231568672294,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5281819744057767,
-          "mean_mse": 0.012088026417385477,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5861763122831936,
-          "mean_mse": 0.010503104487146774,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6139525532589382,
-          "mean_mse": 0.011946678347384927,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5192949937524199,
-          "mean_mse": 0.012022467049268841,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.44718700586346183,
+          "mean_mse": 0.01251363228531727,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "prereq-init-environment": {
-          "mean_cosine": 0.3076559363193999,
-          "mean_mse": 0.015030255463272874,
-          "mean_rank": 79.6,
+        "practical-compilation": {
+          "mean_cosine": 0.5775572445978292,
+          "mean_mse": 0.011075147288194339,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3881665495094845,
+          "mean_mse": 0.013303599575198995,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.41274061221622993,
+          "mean_mse": 0.013029684045119425,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.4621434341530405,
+          "mean_mse": 0.012489257907696743,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5771918617777029,
-          "mean_mse": 0.012885687549707833,
-          "mean_rank": 2.0,
-          "num_queries": 3
+        "prolog-modules": {
+          "mean_cosine": 0.46807821978986885,
+          "mean_mse": 0.012482463212607112,
+          "mean_rank": 2.75,
+          "num_queries": 4
         },
-        "prereq-project-structure": {
-          "mean_cosine": 0.40125544872802155,
-          "mean_mse": 0.014421221803855756,
-          "mean_rank": 4.5,
+        "prolog-directives": {
+          "mean_cosine": 0.5193489079231738,
+          "mean_mse": 0.011606559001086767,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5018772495390115,
+          "mean_mse": 0.011839417194516257,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.3927031168564115,
+          "mean_mse": 0.013180433847798916,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.33366068187603143,
+          "mean_mse": 0.013743285633837208,
+          "mean_rank": 14.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4627548469035348,
+          "mean_mse": 0.01244446874341014,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.37274110858372533,
+          "mean_mse": 0.013615324082319961,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.4367755300946792,
+          "mean_mse": 0.012654295734757098,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.5034877603414459,
+          "mean_mse": 0.011907717457284204,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.46677878041453685,
+          "mean_mse": 0.012416492340098872,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.5058884084961343,
+          "mean_mse": 0.011817051244492734,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -1371,1328 +190,140 @@
         "cutoff": 0.3,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.5417154172182513,
-      "std_cosine_to_target": 0.15272542337732037,
-      "mean_mse_to_target": 0.012779534696778014,
-      "std_mse_to_target": 0.0026899149002681,
-      "mean_target_rank": 6.381987577639752,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.3338509316770186,
-      "recall_at_5": 0.9192546583850931,
-      "recall_at_10": 0.9503105590062112,
-      "mrr": 0.573495143608971,
-      "train_time_ms": 415.7802030676976,
-      "inference_time_us": 2151.517408266548,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4640531615573184,
+      "std_cosine_to_target": 0.09246404658025463,
+      "mean_mse_to_target": 0.013011381482097644,
+      "std_mse_to_target": 0.0009181446348302881,
+      "mean_target_rank": 3.048780487804878,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.9878048780487805,
+      "mrr": 0.47680894308943084,
+      "train_time_ms": 16.204699997615535,
+      "inference_time_us": 195.27804876660656,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.40060914261641256,
-          "mean_mse": 0.014725123057731462,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.4999956145503863,
+          "mean_mse": 0.01287619247473491,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5378092679152049,
-          "mean_mse": 0.013269942373506123,
-          "mean_rank": 2.5,
+          "mean_cosine": 0.4894958473753768,
+          "mean_mse": 0.012838473588499821,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.4998712874947023,
-          "mean_mse": 0.01416462946403428,
-          "mean_rank": 2.5,
+          "mean_cosine": 0.4850598716936072,
+          "mean_mse": 0.01288248020798938,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.4353070533365869,
-          "mean_mse": 0.014484161256910419,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.4336825283464488,
+          "mean_mse": 0.013106227038688209,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.4503169745651252,
-          "mean_mse": 0.014043461354401317,
-          "mean_rank": 7.75,
+          "mean_cosine": 0.44357237372357006,
+          "mean_mse": 0.013051695511885557,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.4084090812632185,
-          "mean_mse": 0.014355378850681107,
-          "mean_rank": 7.75,
+          "mean_cosine": 0.5831694788860962,
+          "mean_mse": 0.01178904578762809,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.3971814316866502,
-          "mean_mse": 0.014437645772124226,
-          "mean_rank": 26.25,
+          "mean_cosine": 0.4142686169921459,
+          "mean_mse": 0.013113450426011471,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.511161516985384,
-          "mean_mse": 0.014203566208982762,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.43594445692417083,
+          "mean_mse": 0.013405801438237946,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.45768578272399124,
-          "mean_mse": 0.014459534210314786,
-          "mean_rank": 3.2,
+          "mean_cosine": 0.47937896476758857,
+          "mean_mse": 0.013114454728454055,
+          "mean_rank": 3.6,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.5012102766584011,
-          "mean_mse": 0.014602333313139738,
+          "mean_cosine": 0.46406357764095874,
+          "mean_mse": 0.013130238064048436,
           "mean_rank": 2.75,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.4289407446190949,
-          "mean_mse": 0.014668170854134518,
-          "mean_rank": 4.0,
+          "mean_cosine": 0.5180528560712501,
+          "mean_mse": 0.012348285475316727,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.36418283175093785,
-          "mean_mse": 0.014584768610231261,
-          "mean_rank": 42.0,
+          "mean_cosine": 0.5007313587123756,
+          "mean_mse": 0.012508254521661896,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.48286405427871837,
-          "mean_mse": 0.014059554968335695,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.40990857708213024,
+          "mean_mse": 0.013576124925528147,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.3875963343122919,
-          "mean_mse": 0.01457593689726271,
-          "mean_rank": 11.6,
+          "mean_cosine": 0.380478018660972,
+          "mean_mse": 0.013961865865099565,
+          "mean_rank": 7.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.4584126019026692,
-          "mean_mse": 0.014217307049931998,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.4648484720537083,
+          "mean_mse": 0.012979882188548866,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.4419075857884983,
-          "mean_mse": 0.01407679205739229,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.37922897825077645,
+          "mean_mse": 0.013907063482988495,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5299148512393453,
-          "mean_mse": 0.013869034622215465,
+          "mean_cosine": 0.4376336676113889,
+          "mean_mse": 0.013189784145535476,
           "mean_rank": 2.75,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.49316630282972673,
-          "mean_mse": 0.013752288725864727,
+          "mean_cosine": 0.49670049243103354,
+          "mean_mse": 0.012666261237846966,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.4747038623708232,
-          "mean_mse": 0.01422606968634857,
-          "mean_rank": 28.25,
+          "mean_cosine": 0.46516588102558104,
+          "mean_mse": 0.013047147995065893,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.4717214995436226,
-          "mean_mse": 0.014214949873273307,
+          "mean_cosine": 0.516745933268323,
+          "mean_mse": 0.012471511130843403,
           "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.38859655138987875,
-          "mean_mse": 0.014951517659417515,
-          "mean_rank": 43.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.37775490844485843,
-          "mean_mse": 0.014708148237032719,
-          "mean_rank": 20.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.4919056738661705,
-          "mean_mse": 0.014380648284775725,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5054204625102455,
-          "mean_mse": 0.014313477984033304,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5290232738930171,
-          "mean_mse": 0.01343770325748264,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.45221046138626464,
-          "mean_mse": 0.01431046672627179,
-          "mean_rank": 27.25,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.48030736972268673,
-          "mean_mse": 0.01343344759284699,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5051038425083315,
-          "mean_mse": 0.013905141492527473,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.4989278461765674,
-          "mean_mse": 0.014165373240598661,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.4832781673989289,
-          "mean_mse": 0.013871172764895145,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5021763850288252,
-          "mean_mse": 0.014305065349760997,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.4787227466607901,
-          "mean_mse": 0.014482995603503432,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.4161211075110748,
-          "mean_mse": 0.014048291787975651,
-          "mean_rank": 106.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.48118394720582564,
-          "mean_mse": 0.01436428804772399,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.43737799836456975,
-          "mean_mse": 0.014281301606891311,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.4106719708568803,
-          "mean_mse": 0.014404833214353995,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.36264288768806185,
-          "mean_mse": 0.0149883742932688,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.4340333034424808,
-          "mean_mse": 0.014278614092310741,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.4797385777341885,
-          "mean_mse": 0.013918004284519992,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.45764010605344735,
-          "mean_mse": 0.013822923681141082,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.49375010585260776,
-          "mean_mse": 0.013989467934071634,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.5072621869269504,
-          "mean_mse": 0.014217971430344993,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.3386042221962669,
-          "mean_mse": 0.014638553605785344,
-          "mean_rank": 21.0,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5210754869816934,
-          "mean_mse": 0.01316895780204847,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.4985147700481389,
-          "mean_mse": 0.014060525667639705,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.4940829017529773,
-          "mean_mse": 0.014548694504730692,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.5301913450077484,
-          "mean_mse": 0.013654777806604339,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.4092270530221458,
-          "mean_mse": 0.014801946085555465,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5088001775125204,
-          "mean_mse": 0.014172920540634557,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4458716423995184,
-          "mean_mse": 0.014445925544055561,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.32799634453192483,
-          "mean_mse": 0.014892338368146034,
-          "mean_rank": 65.0,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.4603287706625216,
-          "mean_mse": 0.01460293957336244,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.4885827100490504,
-          "mean_mse": 0.013577340155568959,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.4046815977931582,
-          "mean_mse": 0.013876722370357288,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.4380578361036095,
-          "mean_mse": 0.013972047814088123,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.4040297761253068,
-          "mean_mse": 0.014520572995433412,
-          "mean_rank": 29.5,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.4654595597294916,
-          "mean_mse": 0.014397699847062542,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.44203661337441363,
-          "mean_mse": 0.01455608382498774,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4317966390112364,
-          "mean_mse": 0.014537450098774581,
-          "mean_rank": 17.25,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.24741798136434925,
-          "mean_mse": 0.015032027452343992,
-          "mean_rank": 87.25,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.4494706230621827,
-          "mean_mse": 0.014535244273871546,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4517814089844331,
-          "mean_mse": 0.013953006751083755,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.4853893260075993,
-          "mean_mse": 0.01411980513773843,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5079685976129635,
-          "mean_mse": 0.013996407674192766,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.3533169115094705,
-          "mean_mse": 0.014925907348444623,
-          "mean_rank": 9.5,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.45335438469409584,
-          "mean_mse": 0.013828783722707953,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.4091563992194376,
-          "mean_mse": 0.014323953471354046,
-          "mean_rank": 10.75,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.4071187470965364,
-          "mean_mse": 0.014533264378446072,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5890143303003113,
-          "mean_mse": 0.012718759281379945,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5631886715734614,
-          "mean_mse": 0.012015062074320201,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.49208605457591287,
-          "mean_mse": 0.013473600603298885,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.598091015112036,
-          "mean_mse": 0.011986728091254562,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.4854077505680543,
-          "mean_mse": 0.01330254196624524,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5240860838030755,
-          "mean_mse": 0.013936108643449513,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6504905844594749,
-          "mean_mse": 0.011290196457659043,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.48703421052383605,
-          "mean_mse": 0.013886134939061845,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5352345480928647,
-          "mean_mse": 0.013811257829712672,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5520847197292228,
-          "mean_mse": 0.013564885360629613,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6412317133751315,
-          "mean_mse": 0.011967188304301308,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5414747992874255,
-          "mean_mse": 0.012897558556927452,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5732588682717946,
-          "mean_mse": 0.013195771024347195,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.5951421028767631,
-          "mean_mse": 0.012703231859376057,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5832701701606324,
-          "mean_mse": 0.012900853937054764,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5529122292651302,
-          "mean_mse": 0.012608257972240806,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5528554616882685,
-          "mean_mse": 0.01353772009314625,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.555348957016888,
-          "mean_mse": 0.012539352134381435,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.54197579895885,
-          "mean_mse": 0.012659758732886781,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5524276305183522,
-          "mean_mse": 0.012857234496558533,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5402214041539973,
-          "mean_mse": 0.013797761901767314,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.5003601777547089,
-          "mean_mse": 0.013353515348977904,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5699230881121141,
-          "mean_mse": 0.012250125076273854,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6065587810130075,
-          "mean_mse": 0.012927741828920614,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5095728276174998,
-          "mean_mse": 0.013049702182598976,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.48633666307190215,
-          "mean_mse": 0.01367001626613087,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5474759278867255,
-          "mean_mse": 0.01349693861842388,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5678408413721316,
-          "mean_mse": 0.01243686481004408,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5667623314038855,
-          "mean_mse": 0.013787798207481656,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5506482172801386,
-          "mean_mse": 0.01371933350616685,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5293418411815448,
-          "mean_mse": 0.014055272650713144,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.49130491613596144,
-          "mean_mse": 0.013292444106125248,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5643169517978085,
-          "mean_mse": 0.012629735926334748,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5366480820567503,
-          "mean_mse": 0.013354922974070751,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6121359869975462,
-          "mean_mse": 0.013146499821544047,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.5997284589997637,
-          "mean_mse": 0.012930673866300106,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5115606290356921,
-          "mean_mse": 0.013850271869227876,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6125101846110469,
-          "mean_mse": 0.0129824011745948,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6536771505004216,
-          "mean_mse": 0.012842713759817367,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5567827637144525,
-          "mean_mse": 0.012746163152488494,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5691350570854953,
-          "mean_mse": 0.012994802546341255,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5414959961516,
-          "mean_mse": 0.0121497647814516,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5805434556176042,
-          "mean_mse": 0.013458838432602122,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5655140272751896,
-          "mean_mse": 0.013522564235887505,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5695127615209585,
-          "mean_mse": 0.01245464080898131,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5026862692158001,
-          "mean_mse": 0.014204534601337025,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5459307808658501,
-          "mean_mse": 0.01332353607361367,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.592605506790714,
-          "mean_mse": 0.012986623463701686,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6339854406328101,
-          "mean_mse": 0.010984215466250896,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.588064298460552,
-          "mean_mse": 0.011991153592767631,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5112282351557007,
-          "mean_mse": 0.013502829901010857,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5445862581156237,
-          "mean_mse": 0.013351403789745147,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5543285045982121,
-          "mean_mse": 0.013126066525388363,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.565095768387513,
-          "mean_mse": 0.012452454804502468,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5793751204927838,
-          "mean_mse": 0.012443958674884507,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5206198929014274,
-          "mean_mse": 0.01349537507399605,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6133215536646415,
-          "mean_mse": 0.012320400935407575,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5166697539877183,
-          "mean_mse": 0.014312594247846559,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.510029979792376,
-          "mean_mse": 0.013900926900403296,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5872336735734126,
-          "mean_mse": 0.012580654335220666,
-          "mean_rank": 3.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.4916625175882037,
-          "mean_mse": 0.014379329315036124,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5806922112173792,
-          "mean_mse": 0.012540583364000144,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.5274474594550314,
-          "mean_mse": 0.012744558605785822,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5464033443288286,
-          "mean_mse": 0.014300047074347004,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.582545130481264,
-          "mean_mse": 0.013240064237267752,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5460262198975301,
-          "mean_mse": 0.013402980918241965,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.58212041387682,
-          "mean_mse": 0.01243106014079839,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5442011671098167,
-          "mean_mse": 0.013519520975231325,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4673973921295848,
-          "mean_mse": 0.013693988215702191,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6212771725664107,
-          "mean_mse": 0.012267842271646574,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5210803542817829,
-          "mean_mse": 0.013513572502440487,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4899978899337271,
-          "mean_mse": 0.013920104265904032,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6360938198218574,
-          "mean_mse": 0.012306835732751771,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4588749505159297,
-          "mean_mse": 0.01372468858316494,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.6981456376346444,
-          "mean_mse": 0.009168843301135661,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7197294445863391,
-          "mean_mse": 0.00970706065610073,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9949061044159161,
-          "mean_mse": 0.0012085933046774551,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6695719761683536,
-          "mean_mse": 0.010474409199129417,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6347241827039487,
-          "mean_mse": 0.011224958057235005,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6098539514955789,
-          "mean_mse": 0.01122129756848676,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6024424338039955,
-          "mean_mse": 0.010893795810639846,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6496297481654247,
-          "mean_mse": 0.010837328445023952,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7123492962755582,
-          "mean_mse": 0.009665277237627019,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6436052404907504,
-          "mean_mse": 0.010688552856091698,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.717313097541562,
-          "mean_mse": 0.009928687712269044,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7332016177800583,
-          "mean_mse": 0.008763136741469061,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7465807276144095,
-          "mean_mse": 0.007909103652315388,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9963501861087778,
-          "mean_mse": 0.0011785585680470544,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9944993000491131,
-          "mean_mse": 0.0011218053774737227,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6497173501041358,
-          "mean_mse": 0.011463868018422339,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.679069778252161,
-          "mean_mse": 0.009334117641604845,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7881716185384033,
-          "mean_mse": 0.00829394754315168,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9970717991377689,
-          "mean_mse": 0.0012715449004301257,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6208281349411461,
-          "mean_mse": 0.010477092027491093,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.6901383503951803,
-          "mean_mse": 0.009269109800272686,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7270730779500763,
-          "mean_mse": 0.008812485441829459,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9963436547495014,
-          "mean_mse": 0.001194488104705229,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6711498558901923,
-          "mean_mse": 0.010381834576657123,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9954826847896288,
-          "mean_mse": 0.001273752882480311,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.683005548757474,
-          "mean_mse": 0.011866754150252613,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7228912335131704,
-          "mean_mse": 0.009490653452561996,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7123434177018885,
-          "mean_mse": 0.008991757357853436,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9940633527860082,
-          "mean_mse": 0.0012614346331912382,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6934550181320547,
-          "mean_mse": 0.009685513163326175,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9926597691162502,
-          "mean_mse": 0.0013800578152091292,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7110010710075794,
-          "mean_mse": 0.008906389507395897,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.990866092545575,
-          "mean_mse": 0.0012929601366299427,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7159929372380833,
-          "mean_mse": 0.010472840363718943,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.758823315046297,
-          "mean_mse": 0.007695863913828175,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7176589357917627,
-          "mean_mse": 0.009691684091986397,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7726309324480609,
-          "mean_mse": 0.008315772097259845,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9948919466104093,
-          "mean_mse": 0.0012700081381374253,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6311074617714176,
-          "mean_mse": 0.011202697051743605,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6861966881272105,
-          "mean_mse": 0.009558895004178183,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9943810634214645,
-          "mean_mse": 0.0013488540175481513,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.7003968316673868,
-          "mean_mse": 0.01129565461937112,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6849502395470111,
-          "mean_mse": 0.01025261992896306,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9962316389972262,
-          "mean_mse": 0.0013123420816965547,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9962262481311046,
-          "mean_mse": 0.001218693887168662,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.6956259463475082,
-          "mean_mse": 0.010197334631084685,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.695812146989575,
-          "mean_mse": 0.011559169272336776,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7623859740015024,
-          "mean_mse": 0.008413342588065406,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.994489696296211,
-          "mean_mse": 0.0012365765867136057,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.5909356182293701,
-          "mean_mse": 0.011220604508558316,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7342369940173075,
-          "mean_mse": 0.009570314084263343,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9913045377479868,
-          "mean_mse": 0.0014251744552336437,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7176730313128008,
-          "mean_mse": 0.009716839656216874,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.999148309046963,
-          "mean_mse": 0.001202718975246612,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7915738371688372,
-          "mean_mse": 0.00828686273180659,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7054028195103159,
-          "mean_mse": 0.009079074213778167,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.990039483189784,
-          "mean_mse": 0.0013518596371565163,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9978771365137791,
-          "mean_mse": 0.0012310028594385305,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9965622858297635,
-          "mean_mse": 0.0011138844188832066,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9921627841022932,
-          "mean_mse": 0.0013150386139771965,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7288421428460489,
-          "mean_mse": 0.009216596150054737,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.6937323875669728,
-          "mean_mse": 0.008959032811447321,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6827249538692122,
-          "mean_mse": 0.010586437430040558,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7018071764805796,
-          "mean_mse": 0.009109587891966874,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5761822908983384,
-          "mean_mse": 0.012547763105379325,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.732510392632585,
-          "mean_mse": 0.009255329724693657,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.528424396631563,
-          "mean_mse": 0.014028093084787946,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.4140019383935556,
-          "mean_mse": 0.014688049899919408,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.594962474193477,
-          "mean_mse": 0.012485758879537843,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.529414223525253,
-          "mean_mse": 0.012727673110103017,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5810143173854712,
-          "mean_mse": 0.011259371415618578,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6158882524681382,
-          "mean_mse": 0.012636315194680827,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5159819086862474,
-          "mean_mse": 0.012685008979174028,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.37341267200869793,
-          "mean_mse": 0.015220256553425368,
-          "mean_rank": 77.0,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5869175751102305,
-          "mean_mse": 0.013499482648443703,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.4469003333619181,
-          "mean_mse": 0.014705562410269418,
-          "mean_rank": 3.0,
           "num_queries": 4
         }
       }
@@ -2703,1328 +334,140 @@
         "cutoff": 0.5,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.5479309208349048,
-      "std_cosine_to_target": 0.15212130991853054,
-      "mean_mse_to_target": 0.01223483955927941,
-      "std_mse_to_target": 0.0029694341764470097,
-      "mean_target_rank": 6.161490683229814,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.34006211180124224,
-      "recall_at_5": 0.9332298136645962,
-      "recall_at_10": 0.9518633540372671,
-      "mrr": 0.5815017460730135,
-      "train_time_ms": 106.66640195995569,
-      "inference_time_us": 1843.6037671393628,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4675436309287104,
+      "std_cosine_to_target": 0.09331522944528264,
+      "mean_mse_to_target": 0.012556401965644635,
+      "std_mse_to_target": 0.0011371528808483296,
+      "mean_target_rank": 3.048780487804878,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.48788344606135137,
+      "train_time_ms": 5.961500006378628,
+      "inference_time_us": 229.62926835511675,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.39377135012165965,
-          "mean_mse": 0.014559666046055738,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.5059536545939887,
+          "mean_mse": 0.012391336055029994,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5390450525957943,
-          "mean_mse": 0.012757718145359058,
+          "mean_cosine": 0.48703753149880935,
+          "mean_mse": 0.012349695650187061,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.5020963698622204,
-          "mean_mse": 0.01379138748118269,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.49076863108698265,
+          "mean_mse": 0.012320367746566295,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.44266705879375423,
-          "mean_mse": 0.014211637030368662,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.43738358199478766,
+          "mean_mse": 0.012714724361196791,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.473952558864675,
-          "mean_mse": 0.013561373208499285,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.4213812104719322,
-          "mean_mse": 0.014013458953802724,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.3788117811036523,
-          "mean_mse": 0.014263083938436654,
-          "mean_rank": 42.5,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.523114783867966,
-          "mean_mse": 0.013800947648172525,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.47397932629305073,
-          "mean_mse": 0.014118871781006731,
-          "mean_rank": 2.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.5100758791599821,
-          "mean_mse": 0.014323725457735074,
+          "mean_cosine": 0.4489841332585498,
+          "mean_mse": 0.012609329177242277,
           "mean_rank": 2.5,
           "num_queries": 4
         },
+        "practical-compilation": {
+          "mean_cosine": 0.5871757373506523,
+          "mean_mse": 0.011166673134089648,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3986149100554752,
+          "mean_mse": 0.013111662823963434,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.4392736150960829,
+          "mean_mse": 0.013013122363952145,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.47600664812934584,
+          "mean_mse": 0.012651263218170155,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.46790071460888555,
+          "mean_mse": 0.012654209991369745,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
         "prolog-directives": {
-          "mean_cosine": 0.4451114468149089,
-          "mean_mse": 0.014409292947407285,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.5231934417020374,
+          "mean_mse": 0.01173060590692471,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.3814056695336585,
-          "mean_mse": 0.01436271658548928,
-          "mean_rank": 36.25,
+          "mean_cosine": 0.5054474076585443,
+          "mean_mse": 0.011976981662236538,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.4916540778388126,
-          "mean_mse": 0.013686694559855914,
+          "mean_cosine": 0.4317520573758181,
+          "mean_mse": 0.013074164018259579,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.39041833924505087,
-          "mean_mse": 0.014351266919146819,
-          "mean_rank": 8.8,
+          "mean_cosine": 0.38495207558302624,
+          "mean_mse": 0.013580118107416472,
+          "mean_rank": 6.4,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.45538551498451535,
-          "mean_mse": 0.013893201393999959,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.4701471889901565,
+          "mean_mse": 0.012503595339914363,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.44814874515401026,
-          "mean_mse": 0.013696799826095417,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.38009900296346144,
+          "mean_mse": 0.013672134764437524,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5374000698179372,
-          "mean_mse": 0.01352071045506543,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.44198149808471154,
+          "mean_mse": 0.012727190652457029,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.4958713266672487,
-          "mean_mse": 0.013330960046766474,
+          "mean_cosine": 0.5014974673395097,
+          "mean_mse": 0.012121502718823226,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.475628984179405,
-          "mean_mse": 0.013867461286205732,
-          "mean_rank": 31.25,
+          "mean_cosine": 0.47577267471509566,
+          "mean_mse": 0.012522477207518659,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.4862232118698855,
-          "mean_mse": 0.01384556728492953,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.4131961539592142,
-          "mean_mse": 0.014741778160745529,
-          "mean_rank": 29.0,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.37023081137612046,
-          "mean_mse": 0.014691632643416826,
-          "mean_rank": 35.5,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.4986054275028846,
-          "mean_mse": 0.014021545904829758,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5088686007111437,
-          "mean_mse": 0.013995169220840483,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5301036857515192,
-          "mean_mse": 0.012943322347375037,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.45349963360441103,
-          "mean_mse": 0.014076715659068694,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.48435620455215367,
-          "mean_mse": 0.012994015565411045,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5189444325366515,
-          "mean_mse": 0.013491749489793495,
+          "mean_cosine": 0.5154627810245478,
+          "mean_mse": 0.01195724006456269,
           "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.5175997026626403,
-          "mean_mse": 0.013756016825184639,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.491232236138358,
-          "mean_mse": 0.01346476888749969,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5066502624134297,
-          "mean_mse": 0.013959624575839342,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.485525385807695,
-          "mean_mse": 0.014169949683570474,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.42643801386336155,
-          "mean_mse": 0.013625488722549676,
-          "mean_rank": 95.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.49807884566938854,
-          "mean_mse": 0.014009086028543142,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.44819188463190385,
-          "mean_mse": 0.013941544768312015,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.42016467617115727,
-          "mean_mse": 0.014114597315449385,
-          "mean_rank": 8.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.367753539485869,
-          "mean_mse": 0.014825870509670791,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.4503164507118461,
-          "mean_mse": 0.01394667914834412,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.478492850773999,
-          "mean_mse": 0.013477811853972094,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.46690022697491834,
-          "mean_mse": 0.013497941094815984,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.5001184496193638,
-          "mean_mse": 0.013552469785945653,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.5039160783614353,
-          "mean_mse": 0.013867062547728903,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.35656812842514735,
-          "mean_mse": 0.014385166921568063,
-          "mean_rank": 21.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5316859704699575,
-          "mean_mse": 0.012679228943026057,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5072412112463702,
-          "mean_mse": 0.013625640704904816,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.5008929601801864,
-          "mean_mse": 0.014294948733071387,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.537283393005735,
-          "mean_mse": 0.013223522467988478,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.41166568756236743,
-          "mean_mse": 0.014607199880329175,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5081129088539507,
-          "mean_mse": 0.013810376605111193,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4577325009557006,
-          "mean_mse": 0.01413024971489057,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.34703558259905165,
-          "mean_mse": 0.014673257820108213,
-          "mean_rank": 50.25,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.45107378213187066,
-          "mean_mse": 0.014358115362168368,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.5083975292833838,
-          "mean_mse": 0.013132862137273719,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.41783269655634137,
-          "mean_mse": 0.013490366981237649,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.4537627307094704,
-          "mean_mse": 0.013620105624460331,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.40839390295486167,
-          "mean_mse": 0.01423512272134751,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.46238695882203534,
-          "mean_mse": 0.014098191316347904,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.45352369063162845,
-          "mean_mse": 0.014273577315101284,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4441874981459185,
-          "mean_mse": 0.01425359314766823,
-          "mean_rank": 15.25,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.23985005764302048,
-          "mean_mse": 0.014898372853125789,
-          "mean_rank": 92.25,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.45652508800441055,
-          "mean_mse": 0.01427053712314711,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4567332554591002,
-          "mean_mse": 0.013538161638857227,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.4890617486826975,
-          "mean_mse": 0.013756517260796738,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5104336495435288,
-          "mean_mse": 0.013638607150098667,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.3448189981028489,
-          "mean_mse": 0.014825595811105107,
-          "mean_rank": 10.75,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.4586054909982123,
-          "mean_mse": 0.013348832136719052,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.4082355699883844,
-          "mean_mse": 0.014054010164743096,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.4141484928470901,
-          "mean_mse": 0.014285453279394055,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5935184721364211,
-          "mean_mse": 0.012023201969360978,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5691557405941262,
-          "mean_mse": 0.01134501946068553,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.5015494554191077,
-          "mean_mse": 0.012987346518343199,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5976430268004929,
-          "mean_mse": 0.011297751882850954,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.4921942470261314,
-          "mean_mse": 0.012802578387109792,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5328815642580212,
-          "mean_mse": 0.013505078405383114,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6486872947031616,
-          "mean_mse": 0.010408060517609086,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.5002472920435198,
-          "mean_mse": 0.013424547285201852,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5412823968855193,
-          "mean_mse": 0.01338048025296226,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5719970347910396,
-          "mean_mse": 0.012925554768389807,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6465429266127402,
-          "mean_mse": 0.011125935362494217,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5405153505808257,
-          "mean_mse": 0.012313819016042171,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5852343853100569,
-          "mean_mse": 0.012586703312229412,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6014844823520872,
-          "mean_mse": 0.011967183881508067,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5882706047621223,
-          "mean_mse": 0.012246059369534093,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5612369664235485,
-          "mean_mse": 0.011934728626157654,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5577634367335672,
-          "mean_mse": 0.013059247492388897,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5567102444883608,
-          "mean_mse": 0.011877214998993113,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5409102318477577,
-          "mean_mse": 0.012082408416708691,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5693597296849227,
-          "mean_mse": 0.012290867740164623,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5541530167124571,
-          "mean_mse": 0.01332913288530795,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.5000135387466124,
-          "mean_mse": 0.012843660716746232,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5789591727672355,
-          "mean_mse": 0.01153531473649084,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6088247917757732,
-          "mean_mse": 0.012210943014042346,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5185111410564054,
-          "mean_mse": 0.012569463384219723,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.49328309484060223,
-          "mean_mse": 0.013160694737722736,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5546726278714057,
-          "mean_mse": 0.013043040903075115,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.574377699741569,
-          "mean_mse": 0.011749359236795357,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5750844755349702,
-          "mean_mse": 0.013344389817267684,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5477172243757126,
-          "mean_mse": 0.013230275782596362,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5374780430308924,
-          "mean_mse": 0.013642684237620233,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.5176415962829112,
-          "mean_mse": 0.012723147584422013,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5682202455970168,
-          "mean_mse": 0.012009606483899052,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5388046821859557,
-          "mean_mse": 0.012873741562905446,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6193057961029401,
-          "mean_mse": 0.012481995638830706,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.5992295997005073,
-          "mean_mse": 0.01238431184032581,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5235762952436319,
-          "mean_mse": 0.013408403324388982,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6202519023120922,
-          "mean_mse": 0.012311338210082156,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6561618949956005,
-          "mean_mse": 0.012139522084699856,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5619998477245429,
-          "mean_mse": 0.012147971884375114,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5807160191910744,
-          "mean_mse": 0.01238007817589491,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5446695336256551,
-          "mean_mse": 0.011560113027920364,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5731184463689516,
-          "mean_mse": 0.012938393636557651,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5711127026175329,
-          "mean_mse": 0.012992625481009658,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5802709837567325,
-          "mean_mse": 0.011719359902966403,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5148086600947125,
-          "mean_mse": 0.013800274838777568,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5509042691539485,
-          "mean_mse": 0.012766309912989167,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5979698875078543,
-          "mean_mse": 0.012355117273976937,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6375469023881243,
-          "mean_mse": 0.010184276110334378,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5963933250926767,
-          "mean_mse": 0.011218810853398292,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5184513796505458,
-          "mean_mse": 0.012921815161036826,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5458296601746867,
-          "mean_mse": 0.01297133213379094,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5539673356743388,
-          "mean_mse": 0.01261135886835924,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5744309811109691,
-          "mean_mse": 0.011765001142856108,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.587701230311318,
-          "mean_mse": 0.01169160878658996,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5280170735964745,
-          "mean_mse": 0.012966575521240338,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6264198780370007,
-          "mean_mse": 0.011486884378567423,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5179889005348951,
-          "mean_mse": 0.013973487387162295,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.5228422745810769,
-          "mean_mse": 0.01345770145627212,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.6002582573222265,
-          "mean_mse": 0.011834155919779469,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5116952583836101,
-          "mean_mse": 0.014021364106350265,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5781633891756405,
-          "mean_mse": 0.011871419761114464,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.5135999500454326,
-          "mean_mse": 0.01227741940971142,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5521631571972692,
-          "mean_mse": 0.013985282245973457,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5863203958517244,
-          "mean_mse": 0.012631828579234452,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5519621910298174,
-          "mean_mse": 0.012833981426555516,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5889945702228824,
-          "mean_mse": 0.011822068495189325,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.544672758552266,
-          "mean_mse": 0.012993218110464817,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4669800080997364,
-          "mean_mse": 0.013378144683676428,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6252536876913042,
-          "mean_mse": 0.011570275526153737,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5228031200215414,
-          "mean_mse": 0.013111960187079635,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4800575503899642,
-          "mean_mse": 0.013552718500478102,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6366396417518111,
-          "mean_mse": 0.011747389417245041,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4573327327725653,
-          "mean_mse": 0.01344152748827136,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.702888085574937,
-          "mean_mse": 0.008245876104325988,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7193028757569074,
-          "mean_mse": 0.008653675390382235,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9999605663376295,
-          "mean_mse": 2.456949488045518e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6705343593327466,
-          "mean_mse": 0.009500469476928647,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6413671679034914,
-          "mean_mse": 0.010357097054342112,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6174982011086665,
-          "mean_mse": 0.010364700393000071,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6213132709563673,
-          "mean_mse": 0.009968908843118653,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6512945362648339,
-          "mean_mse": 0.010042197591726596,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7200416632235735,
-          "mean_mse": 0.008495556024914716,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.650669392323674,
-          "mean_mse": 0.00974501381026533,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7311911424269777,
-          "mean_mse": 0.008677965961626831,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7339867431583418,
-          "mean_mse": 0.007788711018505992,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.753793902446916,
-          "mean_mse": 0.007009472299082371,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999669908537859,
-          "mean_mse": 2.4405885963504123e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9999655533389766,
-          "mean_mse": 2.2048876887457892e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6591401884457311,
-          "mean_mse": 0.010450182046001056,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6830595003271156,
-          "mean_mse": 0.00854205728441565,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7939309877504684,
-          "mean_mse": 0.006903053479024852,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9999764576735327,
-          "mean_mse": 2.59133412665611e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6278485425598118,
-          "mean_mse": 0.009740697744867188,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7020577270929671,
-          "mean_mse": 0.008272277906345729,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7305983260096338,
-          "mean_mse": 0.0077925897303890365,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999732553303171,
-          "mean_mse": 2.5899610240529736e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6774528305015717,
-          "mean_mse": 0.009510790744590296,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.999972088363782,
-          "mean_mse": 2.6370818529703706e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.681544275372062,
-          "mean_mse": 0.011011970495673373,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7332413679696032,
-          "mean_mse": 0.00817429259716173,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7159069293890347,
-          "mean_mse": 0.007964305381285567,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9999706681847574,
-          "mean_mse": 2.2407225119587604e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6991102549476942,
-          "mean_mse": 0.008538460857578239,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999675352558876,
-          "mean_mse": 3.0269989068217516e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7203959079860114,
-          "mean_mse": 0.007859341079733765,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9999511689903319,
-          "mean_mse": 3.114399921633474e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.722329411860875,
-          "mean_mse": 0.009397895003007473,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7615119239066038,
-          "mean_mse": 0.006734953174348544,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7167446658434435,
-          "mean_mse": 0.008629422405923138,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7794914099918124,
-          "mean_mse": 0.0070453999940272675,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999679202384381,
-          "mean_mse": 2.309511910787737e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6359428843275929,
-          "mean_mse": 0.010286613198564741,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6917822538812068,
-          "mean_mse": 0.00859270261915603,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999637186055041,
-          "mean_mse": 3.0199169258616444e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.7001151267495958,
-          "mean_mse": 0.010336946159380262,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6996606804602205,
-          "mean_mse": 0.009105121812719691,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999609512235327,
-          "mean_mse": 2.8109043638314507e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.999970138502797,
-          "mean_mse": 2.2814219740160172e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.703484984271617,
-          "mean_mse": 0.00903782290863163,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.7037178881368019,
-          "mean_mse": 0.010548735381196701,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7696108290573813,
-          "mean_mse": 0.0071371497907481585,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999656701722369,
-          "mean_mse": 2.177813537788546e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6108352939830777,
-          "mean_mse": 0.010294541326162775,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7410687378212304,
-          "mean_mse": 0.008281293403856745,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999602340483542,
-          "mean_mse": 2.6007214557920198e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7270468877374552,
-          "mean_mse": 0.008539443600485877,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999754024835329,
-          "mean_mse": 2.3170356701919077e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7959832317535451,
-          "mean_mse": 0.006911731687199116,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7126789262301001,
-          "mean_mse": 0.008137187778131414,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9999669258140206,
-          "mean_mse": 2.5338456077566806e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999822591575132,
-          "mean_mse": 2.127031119624656e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9999748978964513,
-          "mean_mse": 2.5114317104670254e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999731944190833,
-          "mean_mse": 2.5895277908321378e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7293585063934929,
-          "mean_mse": 0.008135367727247027,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7044755900642055,
-          "mean_mse": 0.008015142657162723,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6823966335006025,
-          "mean_mse": 0.009585723279261832,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7089650586898747,
-          "mean_mse": 0.00811468771052517,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.578500745773721,
-          "mean_mse": 0.01190097123941472,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7381366699334213,
-          "mean_mse": 0.008061810229561771,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5341187199600975,
-          "mean_mse": 0.013569022321245634,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.4316142965488057,
-          "mean_mse": 0.014445192275737824,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.6062182505351267,
-          "mean_mse": 0.011836614634546128,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5310406685786814,
-          "mean_mse": 0.012118787567907028,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5871797512224413,
-          "mean_mse": 0.010526388308006313,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6243471579417176,
-          "mean_mse": 0.012069893873186271,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5239026997401351,
-          "mean_mse": 0.012026262054921976,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.3706241164857972,
-          "mean_mse": 0.015174983195265168,
-          "mean_rank": 75.6,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5813075831257245,
-          "mean_mse": 0.013016959849058124,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.4561215162786743,
-          "mean_mse": 0.014495643210331388,
-          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -4035,1328 +478,140 @@
         "cutoff": 0.7,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.5479638325290441,
-      "std_cosine_to_target": 0.15213623379108682,
-      "mean_mse_to_target": 0.012230316784695659,
-      "std_mse_to_target": 0.0029707727239444703,
-      "mean_target_rank": 6.1770186335403725,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.34316770186335405,
-      "recall_at_5": 0.9347826086956522,
-      "recall_at_10": 0.9518633540372671,
-      "mrr": 0.5822127898037782,
-      "train_time_ms": 114.27960207220167,
-      "inference_time_us": 1893.5804750614145,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4675629444808052,
+      "std_cosine_to_target": 0.09365959654600181,
+      "mean_mse_to_target": 0.012517130978282224,
+      "std_mse_to_target": 0.0011657821940338135,
+      "mean_target_rank": 3.0365853658536586,
+      "median_target_rank": 2.5,
+      "recall_at_1": 0.24390243902439024,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.5050695180864851,
+      "train_time_ms": 8.18499999877531,
+      "inference_time_us": 228.7268292914122,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.3950825268348768,
-          "mean_mse": 0.014552998236086969,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.5065849153893769,
+          "mean_mse": 0.012331619341714077,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5392233431000769,
-          "mean_mse": 0.012752989087455105,
+          "mean_cosine": 0.486442719326713,
+          "mean_mse": 0.01231660376842791,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.5014054411849185,
-          "mean_mse": 0.013791647999079467,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.44453698674098185,
-          "mean_mse": 0.014204915324494253,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.47414651475391556,
-          "mean_mse": 0.013555055432759283,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.41924873213197333,
-          "mean_mse": 0.014020199425686282,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.3788676780295551,
-          "mean_mse": 0.01425878783213838,
-          "mean_rank": 43.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.522849699178679,
-          "mean_mse": 0.013797921137978246,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.4754154785836702,
-          "mean_mse": 0.014114450478406149,
-          "mean_rank": 2.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.508500690370346,
-          "mean_mse": 0.014323821209320872,
+          "mean_cosine": 0.49011361768065265,
+          "mean_mse": 0.012280926941849957,
           "mean_rank": 2.5,
           "num_queries": 4
         },
+        "constraint-usage": {
+          "mean_cosine": 0.43686810564700196,
+          "mean_mse": 0.0126826972217046,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4482499545244646,
+          "mean_mse": 0.012578567575378275,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5853563548013527,
+          "mean_mse": 0.011121188483711828,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.39226856687943934,
+          "mean_mse": 0.013208678274561556,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.4391096610280167,
+          "mean_mse": 0.01299496886256385,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.4766696723497841,
+          "mean_mse": 0.012619559456037604,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.47006639701166325,
+          "mean_mse": 0.01258687732907661,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
         "prolog-directives": {
-          "mean_cosine": 0.44524126850614254,
-          "mean_mse": 0.014406804345628466,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.52191439482659,
+          "mean_mse": 0.011691506882162507,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.3817742056136314,
-          "mean_mse": 0.014360609690839153,
-          "mean_rank": 36.0,
+          "mean_cosine": 0.5065974641117256,
+          "mean_mse": 0.011912817500539769,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.4917462309410531,
-          "mean_mse": 0.013684353804863412,
+          "mean_cosine": 0.4343609664236408,
+          "mean_mse": 0.013013154721922628,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.39148592284850336,
-          "mean_mse": 0.014349461566938148,
-          "mean_rank": 8.6,
+          "mean_cosine": 0.3808316317649102,
+          "mean_mse": 0.013562674017907703,
+          "mean_rank": 6.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.45517540177334714,
-          "mean_mse": 0.013890911494047052,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.46960705571357153,
+          "mean_mse": 0.012476562271138705,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.44695884400771324,
-          "mean_mse": 0.013687888806141735,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.3833965874597622,
+          "mean_mse": 0.013620115514285651,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5382267594931667,
-          "mean_mse": 0.01351425088527064,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.44416458322940355,
+          "mean_mse": 0.012661382644796732,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.49676404705817356,
-          "mean_mse": 0.013324327518894825,
+          "mean_cosine": 0.5019258689055202,
+          "mean_mse": 0.012064669509660725,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.4745302687742585,
-          "mean_mse": 0.01387193694348592,
-          "mean_rank": 31.75,
+          "mean_cosine": 0.47734544866602013,
+          "mean_mse": 0.012463590251578935,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.4850658432935599,
-          "mean_mse": 0.013845650792085771,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.4096287127948341,
-          "mean_mse": 0.01475781844305164,
-          "mean_rank": 31.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.37039139198940274,
-          "mean_mse": 0.014693489072165337,
-          "mean_rank": 36.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.4982339932480331,
-          "mean_mse": 0.014019930126663705,
+          "mean_cosine": 0.5187910700882223,
+          "mean_mse": 0.01186746611727961,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5077999260835222,
-          "mean_mse": 0.01399750110421845,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5306684259512928,
-          "mean_mse": 0.01293715556968257,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.4539891657572548,
-          "mean_mse": 0.014074079723955461,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.4847008654225981,
-          "mean_mse": 0.012985375943141078,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5183427524387144,
-          "mean_mse": 0.013490488940157225,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.5186063490886588,
-          "mean_mse": 0.01374429440490757,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.4910089954622277,
-          "mean_mse": 0.013466126094909053,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5066623020610885,
-          "mean_mse": 0.01395655878546356,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.48597773172016606,
-          "mean_mse": 0.014167241195702989,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.4267282465329517,
-          "mean_mse": 0.013621439271440992,
-          "mean_rank": 94.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.49801778844924804,
-          "mean_mse": 0.014005654200107938,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.4478048808960642,
-          "mean_mse": 0.01393864681971493,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.42172287113582907,
-          "mean_mse": 0.014108169812167068,
-          "mean_rank": 8.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.36891159581249144,
-          "mean_mse": 0.014821059395534202,
-          "mean_rank": 9.75,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.45073715189798175,
-          "mean_mse": 0.013948435211959445,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.47952858331583237,
-          "mean_mse": 0.013467722797495835,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.46748127031482883,
-          "mean_mse": 0.013480401226633479,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.5003608940142175,
-          "mean_mse": 0.013545934456789319,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.503347747473733,
-          "mean_mse": 0.01386682543480643,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.3575564168122326,
-          "mean_mse": 0.014385002599884069,
-          "mean_rank": 21.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5304812464276412,
-          "mean_mse": 0.012687521511640381,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5081059488846728,
-          "mean_mse": 0.013620436496095348,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.5015601394883763,
-          "mean_mse": 0.014286441179253583,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.5374066022854709,
-          "mean_mse": 0.013218632151486798,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.41155010217793747,
-          "mean_mse": 0.014602616287175558,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5077564895757404,
-          "mean_mse": 0.013809338081959213,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4569586415160001,
-          "mean_mse": 0.014132205287040631,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.34729167628483176,
-          "mean_mse": 0.01467193434286844,
-          "mean_rank": 47.5,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.4509328368555124,
-          "mean_mse": 0.014352275610411068,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.5081719132205901,
-          "mean_mse": 0.013131608399128893,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.41904916010790055,
-          "mean_mse": 0.013484089472167927,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.45399859050907787,
-          "mean_mse": 0.013610978771836712,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.4091438024511875,
-          "mean_mse": 0.014231051262033181,
-          "mean_rank": 30.0,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.4630208487096469,
-          "mean_mse": 0.014094562731016525,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.45587881044732176,
-          "mean_mse": 0.014255543257610599,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4432955935390054,
-          "mean_mse": 0.014249776335584533,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.2397065715349402,
-          "mean_mse": 0.014894743039338295,
-          "mean_rank": 94.25,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.45469758456907283,
-          "mean_mse": 0.01427546974746239,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4584523874962949,
-          "mean_mse": 0.013525796940768045,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.48853699725102484,
-          "mean_mse": 0.013755959267797196,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5101399645572573,
-          "mean_mse": 0.013634729370096972,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.344815193078267,
-          "mean_mse": 0.014825165535847683,
-          "mean_rank": 10.75,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.4574277776870272,
-          "mean_mse": 0.013344971298730452,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.4077158336204879,
-          "mean_mse": 0.014055092741750626,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.4134727899344909,
-          "mean_mse": 0.014289609749743686,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5942523917615067,
-          "mean_mse": 0.012010740223061553,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5696192935628078,
-          "mean_mse": 0.011332562363906706,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.5000347120793736,
-          "mean_mse": 0.012992310851852406,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5985617993889341,
-          "mean_mse": 0.011284331503567044,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.4925231921082947,
-          "mean_mse": 0.012799030144392853,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5315861482187553,
-          "mean_mse": 0.013507763972903113,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6495360633852679,
-          "mean_mse": 0.010388883846968275,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.49937567526659227,
-          "mean_mse": 0.01342594371302358,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5413463843646373,
-          "mean_mse": 0.01337977811028383,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5707723742550741,
-          "mean_mse": 0.01292580763098194,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6470141992336346,
-          "mean_mse": 0.011113237084052019,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5395133991027125,
-          "mean_mse": 0.01231768834664522,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5855213338819433,
-          "mean_mse": 0.012581335967134942,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6014707348679785,
-          "mean_mse": 0.011970721700641965,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5878281680829293,
-          "mean_mse": 0.012248292535687114,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5605708367840805,
-          "mean_mse": 0.011934233361651976,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5580614011608254,
-          "mean_mse": 0.013056755575326437,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5555552500272113,
-          "mean_mse": 0.011880172940856882,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.541425706560762,
-          "mean_mse": 0.012075457659178604,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5690396390613962,
-          "mean_mse": 0.012294957880633952,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5551618097485282,
-          "mean_mse": 0.013320112098749714,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.4996864596498938,
-          "mean_mse": 0.012842388981122438,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5780796120761363,
-          "mean_mse": 0.011535763155219555,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.608695126433005,
-          "mean_mse": 0.012200378070908508,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5196275725222806,
-          "mean_mse": 0.012558599502083686,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.49361093860403055,
-          "mean_mse": 0.013153619506781941,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5543095071336432,
-          "mean_mse": 0.013048003568172456,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5733339004894683,
-          "mean_mse": 0.011755399824304916,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5750475947577884,
-          "mean_mse": 0.01333899150652214,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5471243876115319,
-          "mean_mse": 0.0132256399046259,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5388533705982144,
-          "mean_mse": 0.01363217695083648,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.518618107423023,
-          "mean_mse": 0.012714295663464164,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5694888468037557,
-          "mean_mse": 0.01199066556199002,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5392019966082432,
-          "mean_mse": 0.012863141254878377,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6203159005046974,
-          "mean_mse": 0.012464446938662404,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.5986975492393954,
-          "mean_mse": 0.012382163527213571,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.523577519843771,
-          "mean_mse": 0.013405071800626764,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.620098281065188,
-          "mean_mse": 0.01230506468145219,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6567902746455051,
-          "mean_mse": 0.012131753919720739,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5623136099205714,
-          "mean_mse": 0.012146426976394828,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5803313131278484,
-          "mean_mse": 0.012377868880375295,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.545524394136284,
-          "mean_mse": 0.01154893608646884,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5731288580036858,
-          "mean_mse": 0.012931597354991145,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5720756404869071,
-          "mean_mse": 0.012985470523056866,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5799056057729469,
-          "mean_mse": 0.011718005706564075,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5170095350920146,
-          "mean_mse": 0.013790250152998737,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5520818135694436,
-          "mean_mse": 0.012755119749951208,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5979193136216331,
-          "mean_mse": 0.012352405173991637,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6360800216808297,
-          "mean_mse": 0.010199475867826255,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5973468948644166,
-          "mean_mse": 0.011197438292654849,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5193217487408356,
-          "mean_mse": 0.012910347944103827,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5470016483645362,
-          "mean_mse": 0.0129631601035751,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5547012716452885,
-          "mean_mse": 0.012605025406674188,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5742609020496877,
-          "mean_mse": 0.011762862338264268,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.587001309726716,
-          "mean_mse": 0.011688806513994433,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5285393036245816,
-          "mean_mse": 0.012954922853063105,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6259484841058045,
-          "mean_mse": 0.011483484877172998,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5183847763407883,
-          "mean_mse": 0.013972496293295958,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.5244460136742596,
-          "mean_mse": 0.013442361124821509,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5985465102546424,
-          "mean_mse": 0.011841648934398227,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5105388981154342,
-          "mean_mse": 0.014021728340973568,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5786138611248333,
-          "mean_mse": 0.011856305751624503,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.5116456044774614,
-          "mean_mse": 0.012287153316644978,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5524671315440094,
-          "mean_mse": 0.013979612055586177,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5852034081360205,
-          "mean_mse": 0.012632524414755167,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5535921503537997,
-          "mean_mse": 0.012814558337420878,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5894604250832817,
-          "mean_mse": 0.011810341364935022,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5463324438303624,
-          "mean_mse": 0.012987070651104366,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4672573500474502,
-          "mean_mse": 0.013371691848311615,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6251007316432342,
-          "mean_mse": 0.011561183167733982,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5224642518980996,
-          "mean_mse": 0.013113819426462683,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.48129401419995266,
-          "mean_mse": 0.01354182479303505,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.636542687038613,
-          "mean_mse": 0.011746327318842259,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.45768914190751137,
-          "mean_mse": 0.01343805211876196,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.7037137051868771,
-          "mean_mse": 0.008228922843858516,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7194230905363828,
-          "mean_mse": 0.008639178331270623,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9999876258571335,
-          "mean_mse": 2.0780485520623442e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6699731897221564,
-          "mean_mse": 0.009501890697713702,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6421482890350263,
-          "mean_mse": 0.01033793565336771,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6174043629199795,
-          "mean_mse": 0.010361606820127895,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6221042613052498,
-          "mean_mse": 0.009954733881158202,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6507617692098009,
-          "mean_mse": 0.010041867040161759,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7193953446372168,
-          "mean_mse": 0.008485370985757088,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6515523639538416,
-          "mean_mse": 0.009726598520253382,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7305427775288638,
-          "mean_mse": 0.008684881472074659,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7345017063141892,
-          "mean_mse": 0.007775829164736651,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7537932725258979,
-          "mean_mse": 0.007004514561926621,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999902362341481,
-          "mean_mse": 2.168112157108169e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9999873214373554,
-          "mean_mse": 1.9707674366436302e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6587498635214262,
-          "mean_mse": 0.010442319046124048,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6836990036697471,
-          "mean_mse": 0.008530361710173039,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7944220451546862,
-          "mean_mse": 0.006887044757689677,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9999884247104046,
-          "mean_mse": 2.0402919051904535e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6281705573128777,
-          "mean_mse": 0.009730131162895181,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7021546438942781,
-          "mean_mse": 0.008263854325982707,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7302511366863269,
-          "mean_mse": 0.007785321730278159,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999848376507408,
-          "mean_mse": 2.3798143685046688e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6776030929930827,
-          "mean_mse": 0.009504264024514996,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9999840938487252,
-          "mean_mse": 2.2817481318479934e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.679543068110316,
-          "mean_mse": 0.011014171232859459,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.733021679404857,
-          "mean_mse": 0.008162880512099676,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7169271108478139,
-          "mean_mse": 0.007936931494766757,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.999989898273259,
-          "mean_mse": 1.8170189586712412e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6994544284296549,
-          "mean_mse": 0.008524332740426353,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999912469937647,
-          "mean_mse": 2.6255767740897178e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7207080715485361,
-          "mean_mse": 0.007850634427700426,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9999891739559168,
-          "mean_mse": 2.5732017775660003e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7228706284296473,
-          "mean_mse": 0.009383222800981672,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7615000792980391,
-          "mean_mse": 0.006730203446278838,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7160891711493553,
-          "mean_mse": 0.008630883409192266,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7799971202177391,
-          "mean_mse": 0.007023644894464002,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999902658125607,
-          "mean_mse": 1.9508031384305403e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6350370921104997,
-          "mean_mse": 0.010290978899021586,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6903101322381289,
-          "mean_mse": 0.008607524273850087,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999902541906512,
-          "mean_mse": 2.537071232933448e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.6988634681053394,
-          "mean_mse": 0.010338319369834311,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6979926078425986,
-          "mean_mse": 0.009115770158927419,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999893365786501,
-          "mean_mse": 2.37803063708525e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9999862348328167,
-          "mean_mse": 1.96259930467208e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.702727721491,
-          "mean_mse": 0.009035723313224903,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.7041506413531631,
-          "mean_mse": 0.010541666155051022,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7686954165222083,
-          "mean_mse": 0.007145211093086103,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999928708966688,
-          "mean_mse": 1.7474789279206177e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6098299301566865,
-          "mean_mse": 0.010294899005278213,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7400762067368587,
-          "mean_mse": 0.00827954552567954,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999910350029237,
-          "mean_mse": 2.0896955152669012e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7276841710848039,
-          "mean_mse": 0.0085188553780608,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999903204553775,
-          "mean_mse": 1.9351555063569677e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7960995321306115,
-          "mean_mse": 0.006901646801034567,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7134534905084451,
-          "mean_mse": 0.00811324150933136,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9999892734188829,
-          "mean_mse": 2.110649813217872e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999909274367816,
-          "mean_mse": 1.7310362085366622e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9999887923403645,
-          "mean_mse": 1.9404896889668798e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999834277656058,
-          "mean_mse": 2.2952761455917098e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7300092286677988,
-          "mean_mse": 0.008112324016479985,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7044838635985575,
-          "mean_mse": 0.008009618051139124,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6822952275265846,
-          "mean_mse": 0.009580338712968657,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7089231362257029,
-          "mean_mse": 0.008109912467714675,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5791300339735236,
-          "mean_mse": 0.011886998768550983,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7389124808071266,
-          "mean_mse": 0.008041460928001494,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5327096297869033,
-          "mean_mse": 0.013568216446959552,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.43180234355227626,
-          "mean_mse": 0.01444313798087114,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.6055519881868539,
-          "mean_mse": 0.01183992617388869,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5316591549220124,
-          "mean_mse": 0.012101791846941795,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.587676172444443,
-          "mean_mse": 0.010511974443922661,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6242260763589865,
-          "mean_mse": 0.012066762380731852,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5219023139453183,
-          "mean_mse": 0.01203648305044924,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.3708101243455725,
-          "mean_mse": 0.015173466615382608,
-          "mean_rank": 75.2,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5826266311378839,
-          "mean_mse": 0.013007067035894304,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.45443122476412096,
-          "mean_mse": 0.014497638988269425,
-          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -5367,1328 +622,140 @@
         "min_cutoff": 0.2,
         "max_cutoff": 0.7
       },
-      "mean_cosine_to_target": 0.5468531415176324,
-      "std_cosine_to_target": 0.15187892098206618,
-      "mean_mse_to_target": 0.012419303705443665,
-      "std_mse_to_target": 0.0028993483467761203,
-      "mean_target_rank": 5.996894409937888,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.34006211180124224,
-      "recall_at_5": 0.9316770186335404,
-      "recall_at_10": 0.9518633540372671,
-      "mrr": 0.5808653028401561,
-      "train_time_ms": 346.4111000066623,
-      "inference_time_us": 1876.5796599577047,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.46710182109608867,
+      "std_cosine_to_target": 0.0930695836402264,
+      "mean_mse_to_target": 0.012659027238994718,
+      "std_mse_to_target": 0.0010933936773641142,
+      "mean_target_rank": 3.1097560975609757,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.47909311126359344,
+      "train_time_ms": 15.907099994365126,
+      "inference_time_us": 179.65975614682,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.39599786208133414,
-          "mean_mse": 0.014629823486427083,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.5071640179162098,
+          "mean_mse": 0.012419256916430425,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5384661124838399,
-          "mean_mse": 0.013064596005473144,
+          "mean_cosine": 0.4877235006658167,
+          "mean_mse": 0.01242986044985181,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.502836295402306,
-          "mean_mse": 0.013919136981416742,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.4878008896029543,
+          "mean_mse": 0.012549107572610326,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.44238806712433226,
-          "mean_mse": 0.014301391461312898,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.46646654026178946,
-          "mean_mse": 0.01379790370387211,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.4182313656330996,
-          "mean_mse": 0.014141984352293756,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.3895872593167332,
-          "mean_mse": 0.01427946592524216,
-          "mean_rank": 30.0,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.5229608521129174,
-          "mean_mse": 0.013888858287277872,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.47267272511138286,
-          "mean_mse": 0.01421732063060252,
-          "mean_rank": 2.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.5047379137620518,
-          "mean_mse": 0.014467401312917221,
+          "mean_cosine": 0.43846046849482356,
+          "mean_mse": 0.012700117660445136,
           "mean_rank": 2.75,
           "num_queries": 4
         },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.44667640365520456,
+          "mean_mse": 0.012678498438888212,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.58631372151835,
+          "mean_mse": 0.011262420834817202,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.397634470484162,
+          "mean_mse": 0.013138907571263512,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.43756288858242465,
+          "mean_mse": 0.01315685140201021,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.4770715063903195,
+          "mean_mse": 0.01285828859442666,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.46777718676194247,
+          "mean_mse": 0.012739666580056406,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
         "prolog-directives": {
-          "mean_cosine": 0.4417735818506493,
-          "mean_mse": 0.014519607980937996,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.5212501812556831,
+          "mean_mse": 0.011853692839885747,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.3760769803696412,
-          "mean_mse": 0.014464356272694014,
-          "mean_rank": 36.0,
+          "mean_cosine": 0.5029590931469227,
+          "mean_mse": 0.012307474612373265,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.48322565666079087,
-          "mean_mse": 0.01391225169027731,
+          "mean_cosine": 0.42840832946095275,
+          "mean_mse": 0.013181940988649825,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.39037049615252073,
-          "mean_mse": 0.014416561513792864,
-          "mean_rank": 9.0,
+          "mean_cosine": 0.38363341053982236,
+          "mean_mse": 0.013669469334839628,
+          "mean_rank": 6.8,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.45868165753132034,
-          "mean_mse": 0.014016818151318389,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.4693600921807862,
+          "mean_mse": 0.012584681376781226,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.4463236774573226,
-          "mean_mse": 0.013854048779008754,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.38158096322817303,
+          "mean_mse": 0.013760989773570955,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5365278376832743,
-          "mean_mse": 0.01364994049310768,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.4443698431550905,
+          "mean_mse": 0.01270380484828134,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.4958618604052739,
-          "mean_mse": 0.01343401197408851,
+          "mean_cosine": 0.5022049950838848,
+          "mean_mse": 0.012243626357140071,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.47861924999606476,
-          "mean_mse": 0.013950483610650367,
-          "mean_rank": 30.25,
+          "mean_cosine": 0.4756697996286401,
+          "mean_mse": 0.012562679484756173,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.4849297328077887,
-          "mean_mse": 0.013957764287782316,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.402947768144217,
-          "mean_mse": 0.014838814747059876,
-          "mean_rank": 32.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.372381521311778,
-          "mean_mse": 0.014712352739131745,
-          "mean_rank": 30.5,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.49904069935598944,
-          "mean_mse": 0.014097633200238378,
+          "mean_cosine": 0.5167893414851187,
+          "mean_mse": 0.012076783279997064,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5080920272801432,
-          "mean_mse": 0.014085211816979897,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5298610393125772,
-          "mean_mse": 0.013058600027872232,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.45005521458205777,
-          "mean_mse": 0.01420162629270098,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.48442837238489445,
-          "mean_mse": 0.013145477150150041,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5135321674558244,
-          "mean_mse": 0.01372247332852974,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.507110496706521,
-          "mean_mse": 0.014036004553856517,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.487071604303828,
-          "mean_mse": 0.013732406366073594,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5057334738252125,
-          "mean_mse": 0.01407382583380177,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.48295680056553464,
-          "mean_mse": 0.014353883619707216,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.4266978025521451,
-          "mean_mse": 0.013767926083449813,
-          "mean_rank": 93.25,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.4953100547605533,
-          "mean_mse": 0.014095328574304625,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.4469772730837027,
-          "mean_mse": 0.014053720527226582,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.42172077052840595,
-          "mean_mse": 0.014207143067421785,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.36593479355353514,
-          "mean_mse": 0.01489416481621788,
-          "mean_rank": 9.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.4448029770297376,
-          "mean_mse": 0.014092207308634037,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.4798537809395764,
-          "mean_mse": 0.013672589103020962,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.4670716141178446,
-          "mean_mse": 0.0135440424781422,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.4997219353626108,
-          "mean_mse": 0.013694848771759653,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.5047243978455498,
-          "mean_mse": 0.01397076443728736,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.34893632023469856,
-          "mean_mse": 0.014513879778382791,
-          "mean_rank": 22.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.528370388578621,
-          "mean_mse": 0.012944407979808222,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5064026917065908,
-          "mean_mse": 0.013751851444962052,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.4984777357001931,
-          "mean_mse": 0.014380420437962954,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.5365315768788854,
-          "mean_mse": 0.013381921052457177,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.4122030995116467,
-          "mean_mse": 0.014672223763110653,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5084046024313974,
-          "mean_mse": 0.01390128446453843,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4567954179423358,
-          "mean_mse": 0.014213326368051086,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.3466677725532035,
-          "mean_mse": 0.01472029596204821,
-          "mean_rank": 48.75,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.45367969768934335,
-          "mean_mse": 0.014448782062112808,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.5026544135122767,
-          "mean_mse": 0.0133249609043828,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.41681122116460256,
-          "mean_mse": 0.013583115953050257,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.4508264458404113,
-          "mean_mse": 0.013727880819785088,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.407716568117683,
-          "mean_mse": 0.01432620071500708,
-          "mean_rank": 30.25,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.4641702824294047,
-          "mean_mse": 0.014224781898737417,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.44974191614477144,
-          "mean_mse": 0.014382501671759996,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4392451415549611,
-          "mean_mse": 0.014362797613702107,
-          "mean_rank": 16.75,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.24272226145585812,
-          "mean_mse": 0.014956388876390513,
-          "mean_rank": 91.0,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.4535374423525086,
-          "mean_mse": 0.014366929015326702,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4557685363024347,
-          "mean_mse": 0.013662935864864527,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.4878920235424157,
-          "mean_mse": 0.013894981777536449,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5105163360417738,
-          "mean_mse": 0.013808961879195093,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.35019082335619206,
-          "mean_mse": 0.014844690836717276,
-          "mean_rank": 10.75,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.45567183868299355,
-          "mean_mse": 0.013677607686732679,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.40845862131600463,
-          "mean_mse": 0.014154324711913253,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.41475491630115346,
-          "mean_mse": 0.01435478555326947,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5942137186913465,
-          "mean_mse": 0.012154299995220741,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5676868662714153,
-          "mean_mse": 0.011597322393343499,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.4995506073280012,
-          "mean_mse": 0.013144749192712473,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5986348447486789,
-          "mean_mse": 0.011491176044297608,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.4920408798404338,
-          "mean_mse": 0.012997370048984722,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5295705452814427,
-          "mean_mse": 0.01369994927928459,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6499690313654005,
-          "mean_mse": 0.010717843084066129,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.4946341021917046,
-          "mean_mse": 0.013647004095713155,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5403412633035789,
-          "mean_mse": 0.013552105828623068,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5662129234707675,
-          "mean_mse": 0.013172180376240314,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6453473748828967,
-          "mean_mse": 0.011494673658379554,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5408473530017105,
-          "mean_mse": 0.012464238069574545,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5845164020728443,
-          "mean_mse": 0.012767814448771467,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6000003458442364,
-          "mean_mse": 0.012200271748631397,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5869386248760152,
-          "mean_mse": 0.012614836254093029,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.559617411284025,
-          "mean_mse": 0.012106667411274844,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5581637739399071,
-          "mean_mse": 0.013213766472874382,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5560634236493991,
-          "mean_mse": 0.012172493046287933,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5419465998388318,
-          "mean_mse": 0.012155169276828729,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5654537511844749,
-          "mean_mse": 0.012498951476099451,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5523097131914648,
-          "mean_mse": 0.013541141535986756,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.49828088574110607,
-          "mean_mse": 0.013034611379632424,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5751455852047431,
-          "mean_mse": 0.011925355054592137,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6081309611752648,
-          "mean_mse": 0.012372746290299509,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5181427126062285,
-          "mean_mse": 0.0127576064756202,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.4937299463888358,
-          "mean_mse": 0.013274804007936737,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5498650418384826,
-          "mean_mse": 0.013345274576523534,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.571895673613102,
-          "mean_mse": 0.012124402357294136,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.571772329484439,
-          "mean_mse": 0.013541846036051635,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.548465781945311,
-          "mean_mse": 0.013356926331632964,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5380639920124062,
-          "mean_mse": 0.013792374951337777,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.5096880571888898,
-          "mean_mse": 0.012943640452240064,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5682446338542205,
-          "mean_mse": 0.012135580857281184,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5384072072728625,
-          "mean_mse": 0.013017035163546431,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.61854064821784,
-          "mean_mse": 0.0127688543599253,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.6001046554611601,
-          "mean_mse": 0.012630230141800225,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5232581183257433,
-          "mean_mse": 0.013534978291342453,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6198814493160599,
-          "mean_mse": 0.012498577624936849,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.655485801770289,
-          "mean_mse": 0.01244970136586586,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5621390280009307,
-          "mean_mse": 0.012277313892579559,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5773347363337442,
-          "mean_mse": 0.012634188017444542,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5453748774700222,
-          "mean_mse": 0.011746168509684218,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5731144741824992,
-          "mean_mse": 0.013122916131862387,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5708369708087867,
-          "mean_mse": 0.013098433567807717,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5769721438321695,
-          "mean_mse": 0.01206719159613339,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.51182616585373,
-          "mean_mse": 0.013954107800519857,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.551100677553725,
-          "mean_mse": 0.012923087585316349,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5979099369879816,
-          "mean_mse": 0.012503662198911651,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6366831195310559,
-          "mean_mse": 0.010497658848307459,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5948757707219646,
-          "mean_mse": 0.011448944938204421,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5188804412926681,
-          "mean_mse": 0.013044329011872142,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5452686132798717,
-          "mean_mse": 0.01310904999638505,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5547525597226648,
-          "mean_mse": 0.01277482571206715,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5696107259437174,
-          "mean_mse": 0.01222997286697144,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5856256970856629,
-          "mean_mse": 0.011988487839288083,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5241196842244695,
-          "mean_mse": 0.013259580479292545,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6220853622076835,
-          "mean_mse": 0.011900918652414124,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5165917694110689,
-          "mean_mse": 0.01414170182440193,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.519902046354523,
-          "mean_mse": 0.013596110193806856,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5999472709264414,
-          "mean_mse": 0.012079296996828637,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5057171517388062,
-          "mean_mse": 0.014162989764589289,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.579518393810701,
-          "mean_mse": 0.011948352096259949,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.51734308634539,
-          "mean_mse": 0.012418713138750821,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5501891521381754,
-          "mean_mse": 0.014107335001898083,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5856382300085122,
-          "mean_mse": 0.012730252518315591,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5504104937836384,
-          "mean_mse": 0.013151324281747813,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5874904129315179,
-          "mean_mse": 0.01200694618635722,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5451128965686246,
-          "mean_mse": 0.01321414689928005,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.46717286194709334,
-          "mean_mse": 0.013475200036767956,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6247178313260503,
-          "mean_mse": 0.011771191582040147,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5270284317061523,
-          "mean_mse": 0.01319628272037833,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.48315040509997226,
-          "mean_mse": 0.013646056993086833,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6373875408580204,
-          "mean_mse": 0.011936599596543153,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.45716128080728463,
-          "mean_mse": 0.013531205857765844,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.703109682176325,
-          "mean_mse": 0.008568672825623931,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7197044391261611,
-          "mean_mse": 0.008867315271013435,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9995968454667066,
-          "mean_mse": 0.00021615536469854593,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6717287515657598,
-          "mean_mse": 0.009814467908657079,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6404610652795624,
-          "mean_mse": 0.010612539469449674,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6161739978235727,
-          "mean_mse": 0.010636177635787938,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6198036279903583,
-          "mean_mse": 0.010097578954322938,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6521603416235775,
-          "mean_mse": 0.010422254959710562,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7184198133852115,
-          "mean_mse": 0.009117396241997394,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.649655184376005,
-          "mean_mse": 0.010028480108866561,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7282812736268676,
-          "mean_mse": 0.009081833958491613,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7342780011891461,
-          "mean_mse": 0.008096850048408079,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7535914800428221,
-          "mean_mse": 0.007202057892783921,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9997529286650249,
-          "mean_mse": 0.00019314631728498498,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9994596015505526,
-          "mean_mse": 0.00023733892270576024,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6579237718049977,
-          "mean_mse": 0.010831813900474043,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6834092010947682,
-          "mean_mse": 0.008895479142645647,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7933510681411103,
-          "mean_mse": 0.007212240902383104,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9996837373911195,
-          "mean_mse": 0.0003055913264660901,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6268355758048965,
-          "mean_mse": 0.009953721626412466,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7000206613570197,
-          "mean_mse": 0.008620620521623285,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7302319572699738,
-          "mean_mse": 0.008093538999252489,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9995667438912871,
-          "mean_mse": 0.0003845430365548331,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6768891479972687,
-          "mean_mse": 0.009848699776617748,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9994142163306037,
-          "mean_mse": 0.0003457958203949397,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6819422402950178,
-          "mean_mse": 0.011207961643297508,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7301143827138459,
-          "mean_mse": 0.008642599613559194,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7156212655152736,
-          "mean_mse": 0.008370836978523748,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9994043410602949,
-          "mean_mse": 0.00027815689859682943,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6999502251056162,
-          "mean_mse": 0.008954829754828919,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9988949608638908,
-          "mean_mse": 0.0004108497899656296,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7188052017050359,
-          "mean_mse": 0.008332324767348624,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9982578967594138,
-          "mean_mse": 0.0004643644834089594,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7205764521144552,
-          "mean_mse": 0.009713861214309465,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.761401123796901,
-          "mean_mse": 0.006891822175035904,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7176039929756992,
-          "mean_mse": 0.008990923642477272,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7787322455604051,
-          "mean_mse": 0.00742836521612511,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9997182988442527,
-          "mean_mse": 0.00016628271895473637,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.634805707618879,
-          "mean_mse": 0.01048859230928413,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6906533882202275,
-          "mean_mse": 0.008744850131566378,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.999302447882502,
-          "mean_mse": 0.00033173552783597,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.7004594472650245,
-          "mean_mse": 0.010641725626636529,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6971141185360288,
-          "mean_mse": 0.009447889178489537,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9993956163093102,
-          "mean_mse": 0.0003864932261145698,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9994425417924349,
-          "mean_mse": 0.000377003146880279,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.7019785012385249,
-          "mean_mse": 0.009310755192310935,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.7018354972711527,
-          "mean_mse": 0.01102343635979588,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.768565562483327,
-          "mean_mse": 0.007462368882440551,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9995269268150105,
-          "mean_mse": 0.00022829307310065603,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6085424195349974,
-          "mean_mse": 0.010473343676220343,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.739208817333205,
-          "mean_mse": 0.008914560646490521,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9986022026988288,
-          "mean_mse": 0.0004691617655826837,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7269930025820035,
-          "mean_mse": 0.00866486633734233,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999438830124147,
-          "mean_mse": 0.00017142855799804656,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7946903095501312,
-          "mean_mse": 0.007475200975137297,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7117608800812375,
-          "mean_mse": 0.008468616832601908,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9987105825905218,
-          "mean_mse": 0.00037089753823186226,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999220752895946,
-          "mean_mse": 0.0001216574980328388,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9997493109087784,
-          "mean_mse": 0.00018944489658407384,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9994835248172411,
-          "mean_mse": 0.0002225850212969785,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7309092210812503,
-          "mean_mse": 0.008408832673978957,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7029400949959406,
-          "mean_mse": 0.00829918252230688,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6816164455209203,
-          "mean_mse": 0.009923206376192891,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7073561349571215,
-          "mean_mse": 0.008535218495645234,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5781703058495303,
-          "mean_mse": 0.012075574707500071,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7383356265917396,
-          "mean_mse": 0.008367748428063813,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5335382936938259,
-          "mean_mse": 0.013671714513602017,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.42786039358557765,
-          "mean_mse": 0.014527512014556723,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.6038431668550638,
-          "mean_mse": 0.012011993969122682,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5323187268815318,
-          "mean_mse": 0.012327843133195238,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5868463483533966,
-          "mean_mse": 0.010695852506393485,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.619729226129193,
-          "mean_mse": 0.01241435504548541,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5223142737228028,
-          "mean_mse": 0.012187648095238202,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.37840441661962554,
-          "mean_mse": 0.015150396103717267,
-          "mean_rank": 66.2,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5833731701745123,
-          "mean_mse": 0.013121224203296374,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.4549553166058352,
-          "mean_mse": 0.014562833812160973,
-          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -6699,1328 +766,140 @@
         "K": 4,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.2855423036868361,
-      "std_cosine_to_target": 0.25763617943530803,
-      "mean_mse_to_target": 0.013802741860768202,
-      "std_mse_to_target": 0.003113947040720443,
-      "mean_target_rank": 106.2360248447205,
-      "median_target_rank": 20.0,
-      "recall_at_1": 0.18012422360248448,
-      "recall_at_5": 0.3944099378881988,
-      "recall_at_10": 0.4472049689440994,
-      "mrr": 0.28608634348951834,
-      "train_time_ms": 2108.72112296056,
-      "inference_time_us": 5836.459468928692,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4073377348217932,
+      "std_cosine_to_target": 0.15080016856992481,
+      "mean_mse_to_target": 0.013085960346948804,
+      "std_mse_to_target": 0.0014058328677226247,
+      "mean_target_rank": 4.682926829268292,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.9390243902439024,
+      "mrr": 0.46316289676465694,
+      "train_time_ms": 208.5030000016559,
+      "inference_time_us": 522.4134146396309,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.2783527538072758,
-          "mean_mse": 0.015063744818582244,
-          "mean_rank": 70.0,
+          "mean_cosine": 0.24247715453629953,
+          "mean_mse": 0.013342856124232815,
+          "mean_rank": 22.75,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.4591815992926026,
-          "mean_mse": 0.013523628949613828,
-          "mean_rank": 3.75,
+          "mean_cosine": 0.4818581484174512,
+          "mean_mse": 0.01222747196393268,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.1330757046804517,
-          "mean_mse": 0.015423289972236744,
-          "mean_rank": 150.75,
+          "mean_cosine": 0.49180637352038387,
+          "mean_mse": 0.012127595495539337,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.239406020421423,
-          "mean_mse": 0.015043850569349246,
-          "mean_rank": 28.0,
+          "mean_cosine": 0.42432826935090007,
+          "mean_mse": 0.012772152747326342,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.12220195950793067,
-          "mean_mse": 0.015411841107865868,
-          "mean_rank": 174.5,
+          "mean_cosine": 0.43678696848874243,
+          "mean_mse": 0.012674776257682643,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.13259190163305173,
-          "mean_mse": 0.015421206877422988,
-          "mean_rank": 142.75,
+          "mean_cosine": 0.561125645269952,
+          "mean_mse": 0.0117200200140525,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.13224534820242825,
-          "mean_mse": 0.015522425847928699,
-          "mean_rank": 144.5,
+          "mean_cosine": 0.38759928637644636,
+          "mean_mse": 0.013344109803410715,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.050422500275546275,
-          "mean_mse": 0.015513152128553536,
-          "mean_rank": 276.75,
+          "mean_cosine": 0.25579759096473015,
+          "mean_mse": 0.014663980079996135,
+          "mean_rank": 9.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.1005472437442287,
-          "mean_mse": 0.015534710455143227,
-          "mean_rank": 169.6,
+          "mean_cosine": 0.3629374085091649,
+          "mean_mse": 0.013747148109308636,
+          "mean_rank": 5.0,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.15302361146575486,
-          "mean_mse": 0.015374358821352557,
-          "mean_rank": 156.5,
+          "mean_cosine": 0.3119955478051182,
+          "mean_mse": 0.01426114746194319,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.03311086626573906,
-          "mean_mse": 0.015599786850684246,
-          "mean_rank": 314.75,
+          "mean_cosine": 0.45264494229087227,
+          "mean_mse": 0.01277430469548409,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": -0.032018968965837544,
-          "mean_mse": 0.01569608064489262,
-          "mean_rank": 378.75,
+          "mean_cosine": 0.5098950594658943,
+          "mean_mse": 0.01178967408781797,
+          "mean_rank": 2.0,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.1673887943562547,
-          "mean_mse": 0.015353019731160027,
-          "mean_rank": 128.0,
+          "mean_cosine": 0.41385482668409246,
+          "mean_mse": 0.013320461602304504,
+          "mean_rank": 1.75,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.05478284576783247,
-          "mean_mse": 0.015492030579246668,
-          "mean_rank": 248.2,
+          "mean_cosine": 0.3904759106436132,
+          "mean_mse": 0.013391218478374869,
+          "mean_rank": 7.0,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.29275162511883746,
-          "mean_mse": 0.014957294136098566,
-          "mean_rank": 18.5,
+          "mean_cosine": 0.40033317788785244,
+          "mean_mse": 0.013405897468849839,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.0908700291096784,
-          "mean_mse": 0.01546147751056622,
-          "mean_rank": 201.25,
+          "mean_cosine": 0.33653336990169147,
+          "mean_mse": 0.014254732130866143,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.23845456595801529,
-          "mean_mse": 0.015027442918756469,
-          "mean_rank": 61.25,
+          "mean_cosine": 0.42311380694870837,
+          "mean_mse": 0.012832832048348265,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.17288403793922996,
-          "mean_mse": 0.015138311563264215,
-          "mean_rank": 104.25,
+          "mean_cosine": 0.40377343257383225,
+          "mean_mse": 0.013096511832373679,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.08932132311628427,
-          "mean_mse": 0.015510452334623268,
-          "mean_rank": 167.25,
+          "mean_cosine": 0.4680410125479239,
+          "mean_mse": 0.012505562441829203,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.1916989128343696,
-          "mean_mse": 0.015331741941161239,
-          "mean_rank": 70.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.166153608827717,
-          "mean_mse": 0.015410491654034283,
-          "mean_rank": 126.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.021182591296266755,
-          "mean_mse": 0.015794176640855785,
-          "mean_rank": 292.75,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.08542269850156169,
-          "mean_mse": 0.015494837247430834,
-          "mean_rank": 200.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.12226742405177518,
-          "mean_mse": 0.015458925273239455,
-          "mean_rank": 148.0,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.11424958368976054,
-          "mean_mse": 0.01538118358840386,
-          "mean_rank": 197.75,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.012222450405277155,
-          "mean_mse": 0.015620121713675742,
-          "mean_rank": 314.5,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.1236089885495455,
-          "mean_mse": 0.015320249135697158,
-          "mean_rank": 215.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.14135406451022975,
-          "mean_mse": 0.01547938169291518,
-          "mean_rank": 133.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.06659770508538052,
-          "mean_mse": 0.015546694630609363,
-          "mean_rank": 222.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.08568917086758739,
-          "mean_mse": 0.01546133514159424,
-          "mean_rank": 221.75,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.10719667802298866,
-          "mean_mse": 0.0154901738293828,
-          "mean_rank": 188.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.17144170385641483,
-          "mean_mse": 0.01540369753359874,
-          "mean_rank": 103.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.1076365165518586,
-          "mean_mse": 0.015485430781459798,
-          "mean_rank": 153.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.1715979009941555,
-          "mean_mse": 0.015397991596884443,
-          "mean_rank": 158.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": -0.027823083884802327,
-          "mean_mse": 0.0157279636569819,
-          "mean_rank": 371.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.07115844826520869,
-          "mean_mse": 0.015583891391546287,
-          "mean_rank": 221.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": -0.03940778900605314,
-          "mean_mse": 0.0157165999135102,
-          "mean_rank": 383.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.07645740360555275,
-          "mean_mse": 0.015435096300176209,
-          "mean_rank": 246.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.14362163971833736,
-          "mean_mse": 0.015385942138508111,
-          "mean_rank": 141.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.12859214837723457,
-          "mean_mse": 0.015348900261679933,
-          "mean_rank": 177.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.1873152219905137,
-          "mean_mse": 0.01545113830777452,
-          "mean_rank": 104.0,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.22507134524584624,
-          "mean_mse": 0.015334764607575204,
-          "mean_rank": 52.0,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.12268186166425984,
-          "mean_mse": 0.015456151947043107,
-          "mean_rank": 152.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.3183280625897782,
-          "mean_mse": 0.014682478123250518,
-          "mean_rank": 38.5,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.20084770205995878,
-          "mean_mse": 0.015295604448662901,
-          "mean_rank": 72.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.05543900517471664,
-          "mean_mse": 0.015590896369271239,
-          "mean_rank": 234.5,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.17654159822774368,
-          "mean_mse": 0.015293012129821182,
-          "mean_rank": 98.75,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.11263738290489829,
-          "mean_mse": 0.015513969553675656,
-          "mean_rank": 143.25,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.12778811451530056,
-          "mean_mse": 0.015395654086114888,
-          "mean_rank": 179.75,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.09186014996649972,
-          "mean_mse": 0.0155221418738337,
-          "mean_rank": 188.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.08020692057353167,
-          "mean_mse": 0.015556661138351788,
-          "mean_rank": 170.75,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.13413687847371683,
-          "mean_mse": 0.015474108405796435,
-          "mean_rank": 116.75,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.031657150206527054,
-          "mean_mse": 0.015587398710623495,
-          "mean_rank": 265.5,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.05045473125994917,
-          "mean_mse": 0.015591541226652256,
-          "mean_rank": 244.25,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.13565039491080644,
-          "mean_mse": 0.015259545641866299,
-          "mean_rank": 139.5,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": -0.028483029626174883,
-          "mean_mse": 0.01568956965960153,
-          "mean_rank": 362.75,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.11008291284191575,
-          "mean_mse": 0.015542687279571555,
-          "mean_rank": 207.25,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.24945381204637707,
-          "mean_mse": 0.01532333563448451,
-          "mean_rank": 83.0,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.09835422721075618,
-          "mean_mse": 0.01548129438984086,
-          "mean_rank": 187.5,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.03427608797403356,
-          "mean_mse": 0.015637617464800885,
-          "mean_rank": 289.5,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.05547478653242474,
-          "mean_mse": 0.015507600480878134,
-          "mean_rank": 251.75,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.06773010268930922,
-          "mean_mse": 0.015552746691171189,
-          "mean_rank": 223.25,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.26019106160393757,
-          "mean_mse": 0.015194102321454253,
-          "mean_rank": 32.5,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.24544998547991137,
-          "mean_mse": 0.015007677630449849,
-          "mean_rank": 53.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": -0.04979664843759158,
-          "mean_mse": 0.01571891256722891,
-          "mean_rank": 415.75,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.04223658208479059,
-          "mean_mse": 0.015597886705515963,
-          "mean_rank": 260.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": -0.026744095184984426,
-          "mean_mse": 0.01571334639225379,
-          "mean_rank": 384.75,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.02038517630069188,
-          "mean_mse": 0.015656401899389723,
-          "mean_rank": 317.75,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.3178354338763342,
-          "mean_mse": 0.014433863439391993,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.37924303926144803,
-          "mean_mse": 0.013609815365727094,
-          "mean_rank": 5.333333333333333,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.15365545693022417,
-          "mean_mse": 0.015305634184614421,
-          "mean_rank": 147.0,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.3344079358337329,
-          "mean_mse": 0.014288295801789494,
-          "mean_rank": 11.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.2098827122141381,
-          "mean_mse": 0.01517789919848326,
-          "mean_rank": 54.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.1466298349621472,
-          "mean_mse": 0.015399385245224476,
-          "mean_rank": 115.66666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.5224366822022409,
-          "mean_mse": 0.012300546061955112,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.12261955732911571,
-          "mean_mse": 0.015457306608725803,
-          "mean_rank": 115.33333333333333,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.11380849757634455,
-          "mean_mse": 0.01538093667370153,
-          "mean_rank": 158.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.3043530636776883,
-          "mean_mse": 0.014687754273409813,
-          "mean_rank": 34.333333333333336,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.4818492923302462,
-          "mean_mse": 0.013034894321780621,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.32734294882445636,
-          "mean_mse": 0.014545657851278334,
-          "mean_rank": 14.666666666666666,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.27410917235222176,
-          "mean_mse": 0.015057594818620306,
-          "mean_rank": 52.333333333333336,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.475750833894528,
-          "mean_mse": 0.013503086535517258,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.41810853793232533,
-          "mean_mse": 0.013797797034985652,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.4291137663687811,
-          "mean_mse": 0.013487801411981025,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.20004250844059634,
-          "mean_mse": 0.015124346148327987,
-          "mean_rank": 111.33333333333333,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.4727479497555773,
-          "mean_mse": 0.012997483741505472,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.3911968609723237,
-          "mean_mse": 0.01368267236766338,
-          "mean_rank": 3.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.24171627663896947,
-          "mean_mse": 0.01493930576703636,
-          "mean_rank": 27.333333333333332,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.46924148577043884,
-          "mean_mse": 0.01415809022280895,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.05176303137513999,
-          "mean_mse": 0.015643742187094554,
-          "mean_rank": 234.33333333333334,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.29041118253902115,
-          "mean_mse": 0.014536955495026977,
-          "mean_rank": 21.666666666666668,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.428641711742698,
-          "mean_mse": 0.014007811019379703,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.3450273112109337,
-          "mean_mse": 0.014453394371448791,
-          "mean_rank": 3.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.31851752837236963,
-          "mean_mse": 0.014656653664517566,
-          "mean_rank": 4.0,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.2805495487726562,
-          "mean_mse": 0.014952808835883217,
-          "mean_rank": 32.333333333333336,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.2816532330617967,
-          "mean_mse": 0.014701586183394033,
-          "mean_rank": 39.333333333333336,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.320309117473831,
-          "mean_mse": 0.014886811364187227,
-          "mean_rank": 13.0,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.24515527897403414,
-          "mean_mse": 0.01506125328629957,
-          "mean_rank": 36.666666666666664,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.10424189118787347,
-          "mean_mse": 0.015450185848684609,
-          "mean_rank": 181.66666666666666,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.29912574110912843,
-          "mean_mse": 0.01430275638847243,
-          "mean_rank": 37.0,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.4033341057310939,
-          "mean_mse": 0.01344938376078387,
-          "mean_rank": 9.0,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": -0.017316916339302085,
-          "mean_mse": 0.015592469697819836,
-          "mean_rank": 358.3333333333333,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.37912115221592324,
-          "mean_mse": 0.01411483872579961,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.17677762131277605,
-          "mean_mse": 0.015172593451605529,
-          "mean_rank": 129.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.03374924584244395,
-          "mean_mse": 0.01562014443168309,
-          "mean_rank": 262.6666666666667,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.5105345433870744,
-          "mean_mse": 0.013329145187085797,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.30565971932083386,
-          "mean_mse": 0.014821937802155563,
-          "mean_rank": 33.333333333333336,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.17103112212199612,
-          "mean_mse": 0.015026618575172615,
-          "mean_rank": 142.33333333333334,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.3224861897196653,
-          "mean_mse": 0.014461275257293453,
-          "mean_rank": 8.333333333333334,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.35270028321395835,
-          "mean_mse": 0.013669011647920918,
-          "mean_rank": 7.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.06015270474532697,
-          "mean_mse": 0.015544512274121812,
-          "mean_rank": 232.33333333333334,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.23070678924683255,
-          "mean_mse": 0.01504404640065615,
-          "mean_rank": 45.333333333333336,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.33355565189546327,
-          "mean_mse": 0.01422237335179404,
-          "mean_rank": 4.666666666666667,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.1619555112077331,
-          "mean_mse": 0.01539738163571306,
-          "mean_rank": 81.0,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.32158649658941935,
-          "mean_mse": 0.01454699696064681,
-          "mean_rank": 8.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.27980155524086686,
-          "mean_mse": 0.014756753393476256,
-          "mean_rank": 63.666666666666664,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.4482771651429331,
-          "mean_mse": 0.012730749248534269,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.42741045268728195,
-          "mean_mse": 0.013343668726069152,
-          "mean_rank": 4.333333333333333,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.40816171056101797,
-          "mean_mse": 0.014123332849406816,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.42138313894583623,
-          "mean_mse": 0.014251935704669483,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.291910653576386,
-          "mean_mse": 0.0147472076766465,
-          "mean_rank": 19.333333333333332,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.3407554961095785,
-          "mean_mse": 0.014150599490232098,
-          "mean_rank": 6.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.4496603918764768,
-          "mean_mse": 0.01318654837985154,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.2802783815606447,
-          "mean_mse": 0.014824486768159712,
-          "mean_rank": 84.66666666666667,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.43914090476488754,
-          "mean_mse": 0.01363939438358302,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.07850694923374175,
-          "mean_mse": 0.015520478277352765,
-          "mean_rank": 235.33333333333334,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.054547881482093385,
-          "mean_mse": 0.015518496539508334,
-          "mean_rank": 246.33333333333334,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5819564086576438,
-          "mean_mse": 0.012479377739254007,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.10088223695326153,
-          "mean_mse": 0.015505137241141937,
-          "mean_rank": 167.66666666666666,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.26687724662523243,
-          "mean_mse": 0.01466838386501756,
-          "mean_rank": 44.0,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.33251925665706,
-          "mean_mse": 0.014262365992500964,
-          "mean_rank": 11.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.0707900828018488,
-          "mean_mse": 0.015548535810286417,
-          "mean_rank": 201.33333333333334,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.25460386605239144,
-          "mean_mse": 0.014919603773961315,
-          "mean_rank": 27.666666666666668,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.43969384931541056,
-          "mean_mse": 0.013961487010896926,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.2151231957276357,
-          "mean_mse": 0.01482491902155547,
-          "mean_rank": 98.33333333333333,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.24196713633310066,
-          "mean_mse": 0.014892191549628878,
-          "mean_rank": 58.666666666666664,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.2807929972263848,
-          "mean_mse": 0.014700506333092741,
-          "mean_rank": 16.333333333333332,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.47823189456485987,
-          "mean_mse": 0.013504254692230813,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.22555111370126138,
-          "mean_mse": 0.014961850965885209,
-          "mean_rank": 57.666666666666664,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.029204975952759064,
-          "mean_mse": 0.015574111970834248,
-          "mean_rank": 286.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.32170374057130074,
-          "mean_mse": 0.014299484107841218,
-          "mean_rank": 27.666666666666668,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.22808024452448147,
-          "mean_mse": 0.01518699996338511,
-          "mean_rank": 59.333333333333336,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.6357231767841239,
-          "mean_mse": 0.009495450102059235,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.6892023516583092,
-          "mean_mse": 0.00915289732855045,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9833198135336711,
-          "mean_mse": 0.0005195228662984988,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.5631453474966408,
-          "mean_mse": 0.011275811361274642,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.5665325873595004,
-          "mean_mse": 0.011332397991707604,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.598523822390103,
-          "mean_mse": 0.010795390820290483,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.532074574389099,
-          "mean_mse": 0.011326054429922999,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.598423041425079,
-          "mean_mse": 0.010909422106459106,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.616410479825843,
-          "mean_mse": 0.010132446308345495,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.5001221779554516,
-          "mean_mse": 0.012078656890069366,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.6374477425003647,
-          "mean_mse": 0.010158930235310035,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.6596859743183058,
-          "mean_mse": 0.009142498079041148,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.6709082954493975,
-          "mean_mse": 0.00866662957382969,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9796191084916008,
-          "mean_mse": 0.0006327664199245221,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.986752500896946,
-          "mean_mse": 0.00041382049536326426,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.5663538552356842,
-          "mean_mse": 0.011489806136873424,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.614506799702478,
-          "mean_mse": 0.009802084809696368,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7241399065083685,
-          "mean_mse": 0.00812534984380987,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9821408155899128,
-          "mean_mse": 0.0005559083826857841,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.5148875150618406,
-          "mean_mse": 0.011549400504283219,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.6299726150932137,
-          "mean_mse": 0.009606525675346159,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.67620054078312,
-          "mean_mse": 0.008884132684921317,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9878197105645263,
-          "mean_mse": 0.00038021030911352673,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.5838208176758635,
-          "mean_mse": 0.010974757244164114,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9916377898980743,
-          "mean_mse": 0.00026150999630521123,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6270242152787009,
-          "mean_mse": 0.011619605536734197,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7057385523588477,
-          "mean_mse": 0.008622520988420614,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.6890728489683109,
-          "mean_mse": 0.00851367737687891,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9886397792171251,
-          "mean_mse": 0.0003556765694567475,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6641401176607831,
-          "mean_mse": 0.00921132537249608,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9822888522965426,
-          "mean_mse": 0.0005502239335315295,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.609814313553908,
-          "mean_mse": 0.009912192237138791,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9852277982542581,
-          "mean_mse": 0.0004597435231738429,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.643994281547495,
-          "mean_mse": 0.010360426796693871,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.6952590997552465,
-          "mean_mse": 0.008105911518520355,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.6205161009675961,
-          "mean_mse": 0.010153012189108525,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7154049170270007,
-          "mean_mse": 0.008274636479607734,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9902575503809112,
-          "mean_mse": 0.00030611767678391424,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.5363382702971872,
-          "mean_mse": 0.011726547022093671,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.5762755766677203,
-          "mean_mse": 0.0106311643714177,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9880107356383478,
-          "mean_mse": 0.0003741780501129992,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.6367145447705849,
-          "mean_mse": 0.01125145280447307,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6542602422900667,
-          "mean_mse": 0.009861987921715925,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9877808830239947,
-          "mean_mse": 0.00037989069367622613,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9822172039603617,
-          "mean_mse": 0.0005527586657017274,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.6431496737126375,
-          "mean_mse": 0.009907627033067724,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.6678261473049694,
-          "mean_mse": 0.010956806746764445,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7250974991602472,
-          "mean_mse": 0.008056002501133003,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9852335757430069,
-          "mean_mse": 0.0004620494881209233,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.5031070664394799,
-          "mean_mse": 0.01184271019966762,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.6575435159067926,
-          "mean_mse": 0.00958626978750128,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9900439954510013,
-          "mean_mse": 0.0003120834307901001,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.667029047389019,
-          "mean_mse": 0.00942791585293003,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9823667219098123,
-          "mean_mse": 0.000549370079349794,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.782142917735531,
-          "mean_mse": 0.007229708936384355,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.6610844454277638,
-          "mean_mse": 0.009128524400884026,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9919756253912314,
-          "mean_mse": 0.0002520788879875046,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9881320685244803,
-          "mean_mse": 0.00037158837200172083,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9850681166496061,
-          "mean_mse": 0.0004661080892033147,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9864900333017249,
-          "mean_mse": 0.00042091142507907496,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7051511444644489,
-          "mean_mse": 0.008694274402269393,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.6815132774103361,
-          "mean_mse": 0.008526050577528534,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6419910947453885,
-          "mean_mse": 0.010265627264055603,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.5819752290007516,
-          "mean_mse": 0.01039188638886732,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.4687058045390779,
-          "mean_mse": 0.013173810790900242,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.6798865320384972,
-          "mean_mse": 0.009055751807150736,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.05445366983060226,
-          "mean_mse": 0.015589137605570708,
-          "mean_rank": 219.33333333333334,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.13074172849538052,
-          "mean_mse": 0.01546917830304097,
-          "mean_rank": 170.25,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.5069040382809887,
-          "mean_mse": 0.013221345120377342,
-          "mean_rank": 1.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.41103129324796345,
-          "mean_mse": 0.013373391786475274,
-          "mean_rank": 6.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.47962532381395595,
-          "mean_mse": 0.012123316988079882,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.4393339843565965,
-          "mean_mse": 0.013644827003941326,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.4527489352502693,
-          "mean_mse": 0.01296757930195421,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.042295881131888875,
-          "mean_mse": 0.015619369111092227,
-          "mean_rank": 255.6,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.19283821862765801,
-          "mean_mse": 0.015245528641044255,
-          "mean_rank": 133.33333333333334,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.023833326966264765,
-          "mean_mse": 0.015606406774438489,
-          "mean_rank": 288.5,
+          "mean_cosine": 0.406692301874895,
+          "mean_mse": 0.013225142621856036,
+          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -8031,1328 +910,140 @@
         "K": 8,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.40056492621121753,
-      "std_cosine_to_target": 0.22723960917294708,
-      "mean_mse_to_target": 0.013112400185520425,
-      "std_mse_to_target": 0.0031162451560864082,
-      "mean_target_rank": 42.60248447204969,
+      "mean_cosine_to_target": 0.44375411884256516,
+      "std_cosine_to_target": 0.10939668137409948,
+      "mean_mse_to_target": 0.012653041798098926,
+      "std_mse_to_target": 0.0013709131786865335,
+      "mean_target_rank": 3.5,
       "median_target_rank": 3.0,
-      "recall_at_1": 0.25,
-      "recall_at_5": 0.6180124223602484,
-      "recall_at_10": 0.687888198757764,
-      "mrr": 0.4196260259606736,
-      "train_time_ms": 2878.9999110158533,
-      "inference_time_us": 9220.65309316834,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.9146341463414634,
+      "recall_at_10": 0.9512195121951219,
+      "mrr": 0.46730952820891847,
+      "train_time_ms": 263.2891999965068,
+      "inference_time_us": 802.1182926845873,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.23051486630487122,
-          "mean_mse": 0.01496281250431461,
-          "mean_rank": 105.75,
+          "mean_cosine": 0.416073484205125,
+          "mean_mse": 0.012805428483407186,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.4811889240228518,
-          "mean_mse": 0.013217507466957254,
-          "mean_rank": 8.25,
+          "mean_cosine": 0.4791367713679422,
+          "mean_mse": 0.012199684157519614,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.2934112112321994,
-          "mean_mse": 0.014795581189658652,
-          "mean_rank": 17.75,
+          "mean_cosine": 0.49889054864441174,
+          "mean_mse": 0.012137953303694219,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.3270869436280023,
-          "mean_mse": 0.014666074131861433,
-          "mean_rank": 20.0,
+          "mean_cosine": 0.43606876126641203,
+          "mean_mse": 0.012636790843552244,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.39702450694577596,
-          "mean_mse": 0.013956798338669958,
-          "mean_rank": 90.0,
+          "mean_cosine": 0.44582222839599706,
+          "mean_mse": 0.012506246387091503,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.2594701188904559,
-          "mean_mse": 0.01455730505975962,
-          "mean_rank": 121.0,
+          "mean_cosine": 0.573610289794824,
+          "mean_mse": 0.011076770935216947,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.29768011238391545,
-          "mean_mse": 0.014728328159903839,
-          "mean_rank": 68.5,
+          "mean_cosine": 0.385175310439582,
+          "mean_mse": 0.013386550681357435,
+          "mean_rank": 7.0,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.39285660740003864,
-          "mean_mse": 0.014375156242865408,
-          "mean_rank": 29.0,
+          "mean_cosine": 0.42388148607874787,
+          "mean_mse": 0.01288105987961957,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.18387563553874325,
-          "mean_mse": 0.015304952448441378,
-          "mean_rank": 63.0,
+          "mean_cosine": 0.4250201919530651,
+          "mean_mse": 0.012968502291771175,
+          "mean_rank": 4.2,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.2614505853249456,
-          "mean_mse": 0.015169749266315598,
-          "mean_rank": 46.0,
+          "mean_cosine": 0.35352742419397565,
+          "mean_mse": 0.013787029508141299,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.09411367326011028,
-          "mean_mse": 0.015409286663397529,
-          "mean_rank": 217.25,
+          "mean_cosine": 0.5289804084556279,
+          "mean_mse": 0.011605034217636881,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.09953919907490165,
-          "mean_mse": 0.015598681428925251,
-          "mean_rank": 215.75,
+          "mean_cosine": 0.4971469391495048,
+          "mean_mse": 0.011965865113294708,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.2766379469681027,
-          "mean_mse": 0.014818722127776513,
-          "mean_rank": 100.0,
+          "mean_cosine": 0.3918782001738171,
+          "mean_mse": 0.01323336821319494,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.14851566850752432,
-          "mean_mse": 0.01531428637018501,
-          "mean_rank": 122.6,
+          "mean_cosine": 0.3614297389245472,
+          "mean_mse": 0.013567406808537737,
+          "mean_rank": 8.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.34974172520004043,
-          "mean_mse": 0.014691357140556444,
-          "mean_rank": 20.0,
+          "mean_cosine": 0.44627568349724545,
+          "mean_mse": 0.01268914863872323,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.19715627043631873,
-          "mean_mse": 0.014970840759043468,
-          "mean_rank": 109.0,
+          "mean_cosine": 0.3221657754991136,
+          "mean_mse": 0.014237901908270335,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.3412248215892999,
-          "mean_mse": 0.014357136931033763,
-          "mean_rank": 18.5,
+          "mean_cosine": 0.4326016557549237,
+          "mean_mse": 0.012730878199737011,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.3373360454259789,
-          "mean_mse": 0.01450204461426522,
-          "mean_rank": 14.0,
+          "mean_cosine": 0.4922196134730003,
+          "mean_mse": 0.012063746412848632,
+          "mean_rank": 1.75,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.11445896317780037,
-          "mean_mse": 0.015412312387796535,
-          "mean_rank": 205.75,
+          "mean_cosine": 0.472887703395497,
+          "mean_mse": 0.012462175604761119,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.1899823304889806,
-          "mean_mse": 0.015326091348172574,
-          "mean_rank": 63.5,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.30617485836731995,
-          "mean_mse": 0.014964146917877104,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.15393093229357346,
-          "mean_mse": 0.015591693820097322,
-          "mean_rank": 125.75,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.29179043140439254,
-          "mean_mse": 0.015103094266503175,
-          "mean_rank": 29.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.24751422423678834,
-          "mean_mse": 0.015154058912714876,
-          "mean_rank": 40.0,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.3807806436816698,
-          "mean_mse": 0.014091568536923244,
-          "mean_rank": 22.75,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.11154623289392614,
-          "mean_mse": 0.015397709810748117,
-          "mean_rank": 183.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.2996195751904101,
-          "mean_mse": 0.014548791211312289,
-          "mean_rank": 16.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.1703742649723209,
-          "mean_mse": 0.015370454654446395,
-          "mean_rank": 112.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.20742851503359655,
-          "mean_mse": 0.015192058791272505,
-          "mean_rank": 44.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.2003216601394648,
-          "mean_mse": 0.015107681880113365,
-          "mean_rank": 77.75,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.24386749624283233,
-          "mean_mse": 0.014967519884607877,
-          "mean_rank": 72.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.18431212382675438,
-          "mean_mse": 0.015330233095465882,
-          "mean_rank": 147.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.2986274265321873,
-          "mean_mse": 0.01455763487703754,
-          "mean_rank": 87.25,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.2566426129747424,
-          "mean_mse": 0.015202119339815762,
-          "mean_rank": 31.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.23002308764029045,
-          "mean_mse": 0.015128687629969249,
-          "mean_rank": 51.75,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.25154671874552,
-          "mean_mse": 0.015035938138063564,
-          "mean_rank": 78.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.046071968743554126,
-          "mean_mse": 0.015581624493550925,
-          "mean_rank": 266.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.08261925463566644,
-          "mean_mse": 0.015515227127537978,
-          "mean_rank": 190.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.37001857288588735,
-          "mean_mse": 0.014391240441634569,
-          "mean_rank": 9.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.30749837717346656,
-          "mean_mse": 0.01483071663659346,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.2501885325981564,
-          "mean_mse": 0.014887174026025518,
-          "mean_rank": 50.75,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.3724082186826684,
-          "mean_mse": 0.014633155288422276,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.2095551410364594,
-          "mean_mse": 0.015027542012270663,
-          "mean_rank": 124.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.38788453150051416,
-          "mean_mse": 0.013870229027540693,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.23880061770748612,
-          "mean_mse": 0.014929037081920175,
-          "mean_rank": 158.25,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.2794223177119437,
-          "mean_mse": 0.015053080616818367,
-          "mean_rank": 21.25,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.36441817926517484,
-          "mean_mse": 0.014432830383055748,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.2027552122112333,
-          "mean_mse": 0.015327319151762494,
-          "mean_rank": 79.0,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.38111453718223653,
-          "mean_mse": 0.014379750582875134,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.21263225321094387,
-          "mean_mse": 0.014985413067410767,
-          "mean_rank": 106.0,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.14810875298894113,
-          "mean_mse": 0.015398161001140652,
-          "mean_rank": 108.0,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.21182471362095368,
-          "mean_mse": 0.015339222343314737,
-          "mean_rank": 71.5,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.31661048148970466,
-          "mean_mse": 0.014502912515242501,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.3843468987380305,
-          "mean_mse": 0.014103272605378662,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.3255053685986678,
-          "mean_mse": 0.014614450973970829,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.08635279050492352,
-          "mean_mse": 0.0155039590080705,
-          "mean_rank": 200.5,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.13930363613900948,
-          "mean_mse": 0.01533003319334172,
-          "mean_rank": 121.25,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.15060982134063372,
-          "mean_mse": 0.015488594700419835,
-          "mean_rank": 123.0,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.09027554700934629,
-          "mean_mse": 0.015441088931272898,
-          "mean_rank": 240.0,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": -0.0069872337322157765,
-          "mean_mse": 0.015693350018972718,
-          "mean_rank": 320.0,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.2583356813591909,
-          "mean_mse": 0.015117746503269636,
-          "mean_rank": 31.0,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.24447068017345294,
-          "mean_mse": 0.014917495047260025,
-          "mean_rank": 40.5,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.35993955815242684,
-          "mean_mse": 0.014518019152382523,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.38063503530436726,
-          "mean_mse": 0.01434297783568357,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.09127036455795355,
-          "mean_mse": 0.015493593431729784,
-          "mean_rank": 169.25,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.226644117905876,
-          "mean_mse": 0.014919297116151378,
-          "mean_rank": 73.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.1673238999122722,
-          "mean_mse": 0.015273705698812692,
-          "mean_rank": 121.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.0950601626525116,
-          "mean_mse": 0.015449061177588272,
-          "mean_rank": 209.0,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.41464262862750084,
-          "mean_mse": 0.013607401279692672,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.45205412581344123,
-          "mean_mse": 0.012883129696529919,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.3866358490931592,
-          "mean_mse": 0.013902609132403279,
-          "mean_rank": 23.333333333333332,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.473560134350703,
-          "mean_mse": 0.012756366546040282,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.44730819142045214,
-          "mean_mse": 0.013512263245558912,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.3391586485200431,
-          "mean_mse": 0.014585368121379389,
-          "mean_rank": 5.666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.5531050604388452,
-          "mean_mse": 0.01175931171330894,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.3517234146353314,
-          "mean_mse": 0.014323019640793978,
-          "mean_rank": 18.666666666666668,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.33869156374091985,
-          "mean_mse": 0.01442888279562281,
-          "mean_rank": 9.666666666666666,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.4646267436904417,
-          "mean_mse": 0.013699464912913161,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.5887319682848172,
-          "mean_mse": 0.011985749843842456,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.42618490864781516,
-          "mean_mse": 0.013603492422529105,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5358341959043837,
-          "mean_mse": 0.013009866691681587,
-          "mean_rank": 1.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.5426163510970669,
-          "mean_mse": 0.012541927321125053,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5430943330423291,
-          "mean_mse": 0.012711900721146767,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.4846380479656314,
-          "mean_mse": 0.012877936573910564,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.435817654138601,
-          "mean_mse": 0.01374999544313763,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.4675265266863729,
-          "mean_mse": 0.012892336749449266,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.4236450061864554,
-          "mean_mse": 0.013293004437890521,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.4361942113596025,
-          "mean_mse": 0.013398102076059204,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.4924879239056888,
-          "mean_mse": 0.013662436070391243,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.29866380069462406,
-          "mean_mse": 0.014714664918796867,
-          "mean_rank": 8.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.49082350442276756,
-          "mean_mse": 0.012637029061219556,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.49142241865611097,
-          "mean_mse": 0.013199181802089573,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.46315882414844317,
-          "mean_mse": 0.013120553647560568,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.35534856878860605,
-          "mean_mse": 0.01415515709055634,
-          "mean_rank": 5.333333333333333,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.3832147586147367,
-          "mean_mse": 0.01423305060650598,
-          "mean_rank": 19.0,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.45634677611411406,
-          "mean_mse": 0.01298532743981399,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.4500869440210167,
-          "mean_mse": 0.013668111241450107,
-          "mean_rank": 11.666666666666666,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.3998038337076489,
-          "mean_mse": 0.014050453266479255,
-          "mean_rank": 13.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.31966708843824115,
-          "mean_mse": 0.014785439492634021,
-          "mean_rank": 6.333333333333333,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.4461226559674339,
-          "mean_mse": 0.0134785555966042,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.42461089965040677,
-          "mean_mse": 0.01325381076179175,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.33271465084319035,
-          "mean_mse": 0.014349014255994963,
-          "mean_rank": 8.333333333333334,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.5098580851334741,
-          "mean_mse": 0.013225283146992313,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.574042595596788,
-          "mean_mse": 0.012781881487983315,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.30697345324547504,
-          "mean_mse": 0.014754173081126122,
-          "mean_rank": 12.0,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.5122069817512197,
-          "mean_mse": 0.013024228229301086,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.5369664592547622,
-          "mean_mse": 0.013044667127689221,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.456485274035517,
-          "mean_mse": 0.0129878244011023,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.46831122879229575,
-          "mean_mse": 0.013159781526406364,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.42031759811785374,
-          "mean_mse": 0.012971453057262666,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.4400683681579058,
-          "mean_mse": 0.014011243742221428,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.41874076840560065,
-          "mean_mse": 0.013695119437269069,
-          "mean_rank": 4.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.4862261324454835,
-          "mean_mse": 0.012732398709060434,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.40788810025347083,
-          "mean_mse": 0.01437637915190487,
-          "mean_rank": 5.0,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.4728107401246903,
-          "mean_mse": 0.013569146779514386,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5088672910714943,
-          "mean_mse": 0.013260830708703458,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.5384353156124696,
-          "mean_mse": 0.011466814452805806,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5602951742587376,
-          "mean_mse": 0.01171829898575697,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.4093167327768672,
-          "mean_mse": 0.013847954493264557,
-          "mean_rank": 5.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.486433120660859,
-          "mean_mse": 0.01347282728309134,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.4115159813742019,
-          "mean_mse": 0.013871308008632408,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.489985617127254,
-          "mean_mse": 0.01268594017098758,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5179163973342079,
-          "mean_mse": 0.0126797686418954,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.3885508873543049,
-          "mean_mse": 0.014103620658187785,
-          "mean_rank": 7.0,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.45231890083494397,
-          "mean_mse": 0.013119389866888162,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.2704945866537298,
-          "mean_mse": 0.014883717120044623,
-          "mean_rank": 24.333333333333332,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.4072474842125369,
-          "mean_mse": 0.014109837770318356,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5728920122454515,
-          "mean_mse": 0.012137443031530795,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.25074178202944525,
-          "mean_mse": 0.015071181366708883,
-          "mean_rank": 27.0,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.4956060768695994,
-          "mean_mse": 0.012795782881999639,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.4571199647859913,
-          "mean_mse": 0.01305333563962092,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.2825593745609162,
-          "mean_mse": 0.01485982748381306,
-          "mean_rank": 47.333333333333336,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.47648818678077215,
-          "mean_mse": 0.013424974696297083,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.45034852004638265,
-          "mean_mse": 0.013628470738337872,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5828754269152255,
-          "mean_mse": 0.011874262283056172,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.4744045711893959,
-          "mean_mse": 0.013548362028731145,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4091412629409303,
-          "mean_mse": 0.013985396251093116,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.5744177967765115,
-          "mean_mse": 0.012132030041996311,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.3262441897841373,
-          "mean_mse": 0.014427002796045188,
-          "mean_rank": 32.333333333333336,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.2958171379663887,
-          "mean_mse": 0.01455616227911919,
-          "mean_rank": 30.333333333333332,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.4730552429308335,
-          "mean_mse": 0.013198392051063495,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.3308827555239355,
-          "mean_mse": 0.014490428708115113,
-          "mean_rank": 9.666666666666666,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.6994258096441863,
-          "mean_mse": 0.008300325361243682,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.6855919767153751,
-          "mean_mse": 0.009132412126708365,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9912698308217545,
-          "mean_mse": 0.0002725041289455131,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6320008143546816,
-          "mean_mse": 0.009963869696294862,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6069343570848538,
-          "mean_mse": 0.010877527396685911,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6097329197483721,
-          "mean_mse": 0.010560136483609556,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.5504311373503077,
-          "mean_mse": 0.01110731385577986,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6150707611088706,
-          "mean_mse": 0.010487061632835777,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.6854956831522286,
-          "mean_mse": 0.008987181676452377,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6121791778749118,
-          "mean_mse": 0.01027076909667866,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7088652473870809,
-          "mean_mse": 0.009121682101701292,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.6936978638695162,
-          "mean_mse": 0.008544367019199294,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7154020918323267,
-          "mean_mse": 0.007747815767993396,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9888020406451349,
-          "mean_mse": 0.00034890524157284066,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9924075935300947,
-          "mean_mse": 0.00023795882625983578,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6335795979017947,
-          "mean_mse": 0.01063698376130028,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6346168713753579,
-          "mean_mse": 0.009437458798859544,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7873528472754859,
-          "mean_mse": 0.006931962301812608,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9911042738402267,
-          "mean_mse": 0.0002782049265246834,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6032740161917467,
-          "mean_mse": 0.010139289115110195,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.6521301254098939,
-          "mean_mse": 0.009181574460861059,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7037466255891747,
-          "mean_mse": 0.008243790973392725,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9936328638360521,
-          "mean_mse": 0.00019947778762888764,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6438601188509447,
-          "mean_mse": 0.010070589123009864,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9940193584996461,
-          "mean_mse": 0.00018668805037726528,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6272754251465084,
-          "mean_mse": 0.01147207921111447,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7166078102941437,
-          "mean_mse": 0.008368110669204365,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.6469984001994882,
-          "mean_mse": 0.009174915194484237,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9924145654588886,
-          "mean_mse": 0.0002374217426788691,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6512023763500929,
-          "mean_mse": 0.009272278015813212,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9917299265971762,
-          "mean_mse": 0.00025784323722528136,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.6989210689984634,
-          "mean_mse": 0.008337760439346455,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9918990914007726,
-          "mean_mse": 0.00025279885525574116,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.6767754809955864,
-          "mean_mse": 0.009896436696355048,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7373768395739563,
-          "mean_mse": 0.007238230654595992,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.6911971257602811,
-          "mean_mse": 0.008971459871240922,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7412294645744646,
-          "mean_mse": 0.007623002128275991,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9929111400630685,
-          "mean_mse": 0.00022189519348475478,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6298258603556743,
-          "mean_mse": 0.010428812425258165,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6084612295426138,
-          "mean_mse": 0.00995677098088563,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9924837320442039,
-          "mean_mse": 0.00023426155095633344,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.6491838224611373,
-          "mean_mse": 0.010841584504922036,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6545068972540393,
-          "mean_mse": 0.009743372666573475,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9879544527817691,
-          "mean_mse": 0.00037415711061971517,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9898988995675774,
-          "mean_mse": 0.00031509851454841894,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.689633983083783,
-          "mean_mse": 0.009273797737436376,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.6799592150706375,
-          "mean_mse": 0.01059574852869374,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7406886328383364,
-          "mean_mse": 0.007610022385806044,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.991516878199232,
-          "mean_mse": 0.0002656604517406957,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.5292307858404874,
-          "mean_mse": 0.011413865125059095,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7140958965341475,
-          "mean_mse": 0.008610476007265493,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9929552060302921,
-          "mean_mse": 0.00022086636731377587,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7185071359189772,
-          "mean_mse": 0.008703171206030808,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.993301186380758,
-          "mean_mse": 0.00021035483397757092,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.771912134851305,
-          "mean_mse": 0.007314263252076429,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7307278922553375,
-          "mean_mse": 0.007828621626384456,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9966544521879278,
-          "mean_mse": 0.00010565460032464799,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9929889021628843,
-          "mean_mse": 0.00022053609905978782,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9912773454368565,
-          "mean_mse": 0.00027245586846906956,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9941028632558605,
-          "mean_mse": 0.00018436860942997935,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.6785978738461138,
-          "mean_mse": 0.008904857963848305,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.6423458089962398,
-          "mean_mse": 0.00919860359233355,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6372802246745017,
-          "mean_mse": 0.01013502705846243,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7348651847082561,
-          "mean_mse": 0.007723198703685102,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5076048747141604,
-          "mean_mse": 0.012740739387367743,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.6802788044553725,
-          "mean_mse": 0.009004924705553419,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.28542559726129846,
-          "mean_mse": 0.014887393411932704,
-          "mean_rank": 15.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.1864093987321538,
-          "mean_mse": 0.015163529902739883,
-          "mean_rank": 142.0,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.5081726088558872,
-          "mean_mse": 0.012501983840674571,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.444448700314153,
-          "mean_mse": 0.012952079175959827,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5491702098602171,
-          "mean_mse": 0.011092469776421018,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.5536772857660974,
-          "mean_mse": 0.012729579198489908,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.511601413556413,
-          "mean_mse": 0.012270596539159268,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": -0.0761324654683441,
-          "mean_mse": 0.015868469528799802,
-          "mean_rank": 417.4,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.4354329914759521,
-          "mean_mse": 0.014110929201390393,
-          "mean_rank": 5.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.24519260643027582,
-          "mean_mse": 0.0152821756541006,
-          "mean_rank": 39.25,
+          "mean_cosine": 0.517554738889825,
+          "mean_mse": 0.011811837997574988,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -9363,1328 +1054,140 @@
         "K": 16,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.4819131562093473,
-      "std_cosine_to_target": 0.19244099724792102,
-      "mean_mse_to_target": 0.012539634605004407,
-      "std_mse_to_target": 0.0030477291676536777,
-      "mean_target_rank": 19.444099378881987,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.3167701863354037,
-      "recall_at_5": 0.8105590062111802,
-      "recall_at_10": 0.8742236024844721,
-      "mrr": 0.5305927750040169,
-      "train_time_ms": 4410.0965859834105,
-      "inference_time_us": 15781.466982917433,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.46369327192778825,
+      "std_cosine_to_target": 0.09943650824056033,
+      "mean_mse_to_target": 0.012478851559458983,
+      "std_mse_to_target": 0.0012654633342296265,
+      "mean_target_rank": 3.3292682926829267,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.48967332072000347,
+      "train_time_ms": 427.2369000027538,
+      "inference_time_us": 1402.276829250651,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.3108626128695172,
-          "mean_mse": 0.01471570413622425,
-          "mean_rank": 23.25,
+          "mean_cosine": 0.5064651706840704,
+          "mean_mse": 0.012227779009145448,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5008951368796593,
-          "mean_mse": 0.012963863425564753,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.48555828725931743,
+          "mean_mse": 0.012226131988739307,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.4330544307798988,
-          "mean_mse": 0.014162025829704964,
-          "mean_rank": 4.25,
+          "mean_cosine": 0.49155168379404,
+          "mean_mse": 0.012118172705305581,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.3539432676660194,
-          "mean_mse": 0.014486822016858518,
-          "mean_rank": 7.25,
+          "mean_cosine": 0.43975460993191273,
+          "mean_mse": 0.012578103171198125,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.43370184194882466,
-          "mean_mse": 0.01372542194113817,
-          "mean_rank": 38.5,
+          "mean_cosine": 0.4488916109068787,
+          "mean_mse": 0.01250902874691279,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.3705451521536618,
-          "mean_mse": 0.014248707195407648,
-          "mean_rank": 20.5,
+          "mean_cosine": 0.5856229170865141,
+          "mean_mse": 0.011067434800378393,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.3141371511052553,
-          "mean_mse": 0.014630248973919078,
-          "mean_rank": 75.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.40480071518207944,
-          "mean_mse": 0.014207509001908973,
+          "mean_cosine": 0.38561760107643583,
+          "mean_mse": 0.013360443241062609,
           "mean_rank": 7.25,
           "num_queries": 4
         },
+        "generated-code-transitive": {
+          "mean_cosine": 0.4406883283638176,
+          "mean_mse": 0.012912112215596384,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.2895133056608985,
-          "mean_mse": 0.014606713421565129,
-          "mean_rank": 96.2,
+          "mean_cosine": 0.45891764933653506,
+          "mean_mse": 0.012609371584611579,
+          "mean_rank": 3.6,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.47542601995095496,
-          "mean_mse": 0.014246570239447372,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.4602898627501782,
+          "mean_mse": 0.012642346674617192,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.2570538330591831,
-          "mean_mse": 0.01483364230630816,
-          "mean_rank": 110.5,
+          "mean_cosine": 0.5199896016649027,
+          "mean_mse": 0.01161461433377485,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.33960922084039374,
-          "mean_mse": 0.014539532782116232,
-          "mean_rank": 16.5,
+          "mean_cosine": 0.508307774150107,
+          "mean_mse": 0.011788238844161674,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.43519128604276586,
-          "mean_mse": 0.013771423843975523,
+          "mean_cosine": 0.4334736882287239,
+          "mean_mse": 0.012916136688216846,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.32019146512317187,
-          "mean_mse": 0.014507087500407445,
-          "mean_rank": 73.2,
+          "mean_cosine": 0.36148425654045113,
+          "mean_mse": 0.013601365615265325,
+          "mean_rank": 10.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.40694459674821704,
-          "mean_mse": 0.014194515740595376,
-          "mean_rank": 4.5,
+          "mean_cosine": 0.4713681303015158,
+          "mean_mse": 0.01239426996802312,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.3613024879037544,
-          "mean_mse": 0.014001593680757471,
-          "mean_rank": 36.5,
+          "mean_cosine": 0.376474187834024,
+          "mean_mse": 0.013648060543418786,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.3731097804054946,
-          "mean_mse": 0.014043954430076337,
-          "mean_rank": 40.75,
+          "mean_cosine": 0.4436314234803109,
+          "mean_mse": 0.012572975114970582,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.39156233212233055,
-          "mean_mse": 0.014069321411995954,
-          "mean_rank": 4.0,
+          "mean_cosine": 0.5011725767880425,
+          "mean_mse": 0.011975733773480926,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.36979907949181395,
-          "mean_mse": 0.01417633016942751,
-          "mean_rank": 27.5,
+          "mean_cosine": 0.47627930946059105,
+          "mean_mse": 0.012406364583156797,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.42391463005722774,
-          "mean_mse": 0.01416819749305792,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.33536980243080383,
-          "mean_mse": 0.01485332684447381,
-          "mean_rank": 20.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.24374448325125408,
-          "mean_mse": 0.015116578607178102,
-          "mean_rank": 69.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.4087134027455699,
-          "mean_mse": 0.014364394712865098,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.42492266665913603,
-          "mean_mse": 0.014183947025513975,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.4496579745231602,
-          "mean_mse": 0.0134647271728167,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.3231957872333892,
-          "mean_mse": 0.01482559521376465,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.41993049054281567,
-          "mean_mse": 0.01342629826436002,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.48761876929327375,
-          "mean_mse": 0.013965193802640514,
-          "mean_rank": 1.75,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.40638961882072594,
-          "mean_mse": 0.014184788724030905,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.38351962312725,
-          "mean_mse": 0.014098793651239155,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.3003254849707394,
-          "mean_mse": 0.014517858116886075,
-          "mean_rank": 136.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.33001472137177845,
-          "mean_mse": 0.0147690845528269,
-          "mean_rank": 20.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.3737178674360957,
-          "mean_mse": 0.01396780380939815,
-          "mean_rank": 46.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.42503789290867106,
-          "mean_mse": 0.014295642408410364,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.3276083501198409,
-          "mean_mse": 0.014498190265034634,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.3023093812832543,
-          "mean_mse": 0.014631904420954953,
-          "mean_rank": 48.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.08890418839056823,
-          "mean_mse": 0.015459578804821177,
-          "mean_rank": 227.25,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.3752435840318268,
-          "mean_mse": 0.014213906204761135,
-          "mean_rank": 40.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.45813576512039234,
-          "mean_mse": 0.013591201703550111,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.38941583693876963,
-          "mean_mse": 0.013891287621501585,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.37519507941053,
-          "mean_mse": 0.014173501110761958,
-          "mean_rank": 58.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.4371103257042979,
-          "mean_mse": 0.014058721459439066,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.27132175922016877,
-          "mean_mse": 0.014670482888229103,
-          "mean_rank": 84.0,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.44466678928581266,
-          "mean_mse": 0.013299910446913308,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.36071252814601573,
-          "mean_mse": 0.014235437030002306,
-          "mean_rank": 101.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.3386376437988642,
-          "mean_mse": 0.014725023981029631,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.4299461303529225,
-          "mean_mse": 0.013843636781604182,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.2614842076316421,
-          "mean_mse": 0.014993769202882194,
-          "mean_rank": 27.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.4526619184805916,
-          "mean_mse": 0.013940926048423253,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.33929791826889427,
-          "mean_mse": 0.014442930117490586,
-          "mean_rank": 28.5,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.18219980660366017,
-          "mean_mse": 0.015226956332122645,
-          "mean_rank": 124.75,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.3573318636864862,
-          "mean_mse": 0.014666845035593987,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.4245729863932384,
-          "mean_mse": 0.013648425385166873,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.40073876649223084,
-          "mean_mse": 0.013616181104558533,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.40052794324581925,
-          "mean_mse": 0.014059303251960644,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.25665688700094497,
-          "mean_mse": 0.014764506005937365,
-          "mean_rank": 137.25,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.29901987595744406,
-          "mean_mse": 0.014673107185962262,
-          "mean_rank": 27.25,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.3143023056490698,
-          "mean_mse": 0.014856767592279569,
-          "mean_rank": 20.5,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.24184306047186457,
-          "mean_mse": 0.01471196447636973,
-          "mean_rank": 161.0,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.09775039963557786,
-          "mean_mse": 0.015462011384205564,
-          "mean_rank": 235.0,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.3394146557085326,
-          "mean_mse": 0.014640794844840077,
-          "mean_rank": 23.5,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.37756600727872985,
-          "mean_mse": 0.014050123826690943,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.4840735144811573,
-          "mean_mse": 0.013867074761013402,
-          "mean_rank": 1.75,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.48480611779102867,
-          "mean_mse": 0.013627564236643332,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.16916543884995378,
-          "mean_mse": 0.015223077500225718,
-          "mean_rank": 96.0,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.44855287855708303,
-          "mean_mse": 0.013721597388494485,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.3218456986215569,
-          "mean_mse": 0.014681552750520946,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.3068895034937069,
-          "mean_mse": 0.014284079629847315,
-          "mean_rank": 75.0,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5536766066941985,
-          "mean_mse": 0.012326139051191475,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5096387957081717,
-          "mean_mse": 0.012069443675810981,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.4345423388054767,
-          "mean_mse": 0.01348104680206894,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5403104037816329,
-          "mean_mse": 0.01199552444005724,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.4904511331542413,
-          "mean_mse": 0.013034621686216906,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.40745691660403754,
-          "mean_mse": 0.014105824175602763,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.5942007722030477,
-          "mean_mse": 0.011148967289232632,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.4597030627321385,
-          "mean_mse": 0.013512292025472083,
-          "mean_rank": 8.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.4277715151923058,
-          "mean_mse": 0.013728154882358316,
-          "mean_rank": 4.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.4870294384229137,
-          "mean_mse": 0.013421540069653647,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.5703844609558616,
-          "mean_mse": 0.011908735413059326,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.4786067959984601,
-          "mean_mse": 0.012908593573890495,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5249081900236482,
-          "mean_mse": 0.012896154697960698,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.5616526395085158,
-          "mean_mse": 0.012254175411118165,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5628541369579838,
-          "mean_mse": 0.012398272719689088,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5030287629572006,
-          "mean_mse": 0.012517805721772324,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.4764144545721069,
-          "mean_mse": 0.01349862670852587,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5233462485131447,
-          "mean_mse": 0.012225767291007002,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5230130616082543,
-          "mean_mse": 0.01212464351299528,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.49445248727413965,
-          "mean_mse": 0.012730937785025197,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5516908524795826,
-          "mean_mse": 0.013280060104974692,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.479819167418642,
-          "mean_mse": 0.013084810957680318,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5678952165971753,
-          "mean_mse": 0.011679770913586013,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.5961780907517854,
-          "mean_mse": 0.012237463933789614,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5035015537080408,
-          "mean_mse": 0.012622114823597722,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.5077419881956191,
-          "mean_mse": 0.013219375762746038,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5295224020982079,
-          "mean_mse": 0.01321108332712366,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5459010987665888,
-          "mean_mse": 0.0119298193375596,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5223923757263546,
-          "mean_mse": 0.013363598809282872,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.48732752151903663,
-          "mean_mse": 0.013603846841929968,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5021825454121601,
-          "mean_mse": 0.013711440916279835,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.49139155875792007,
-          "mean_mse": 0.012881311756871424,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5245813316948017,
-          "mean_mse": 0.012479180775856094,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.43474835746099433,
-          "mean_mse": 0.013580392724220005,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.5786463069799823,
-          "mean_mse": 0.012528132908853346,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.6031570829257397,
-          "mean_mse": 0.012266078146658843,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.4430119489639895,
-          "mean_mse": 0.013906420987471047,
-          "mean_rank": 6.0,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.5751838955312221,
-          "mean_mse": 0.012588824150171268,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6189758641417352,
-          "mean_mse": 0.012142623582385973,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5257147220805376,
-          "mean_mse": 0.0123142348970057,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5508565409878843,
-          "mean_mse": 0.01261819698281204,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.4824068733191369,
-          "mean_mse": 0.012361577663779348,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5072010427830776,
-          "mean_mse": 0.013284672933097411,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.4737983045984515,
-          "mean_mse": 0.013453199305086037,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5265520161501506,
-          "mean_mse": 0.012200157252911419,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5106868881418763,
-          "mean_mse": 0.01375756668850594,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.45298895251325577,
-          "mean_mse": 0.013486151799883543,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5582083779945147,
-          "mean_mse": 0.01259343105835449,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.5666143972958466,
-          "mean_mse": 0.011069162774082457,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.602523777936237,
-          "mean_mse": 0.011068457218353494,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.48996407214216897,
-          "mean_mse": 0.013227512553666929,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5207617181802828,
-          "mean_mse": 0.012979635588089103,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.4870006825508304,
-          "mean_mse": 0.01317485036831604,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5439650391597395,
-          "mean_mse": 0.012020693591285785,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.579298463713587,
-          "mean_mse": 0.01164714889840888,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5092826895775645,
-          "mean_mse": 0.013086043848489805,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.5926303762357271,
-          "mean_mse": 0.011780439238912527,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.4051615955444346,
-          "mean_mse": 0.014305007548643785,
-          "mean_rank": 6.666666666666667,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.46306603427383725,
-          "mean_mse": 0.013720901861426766,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.600299491604464,
-          "mean_mse": 0.011850677486609363,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.4247014070086362,
-          "mean_mse": 0.01434045094551136,
+          "mean_cosine": 0.5050729284120455,
+          "mean_mse": 0.01209508906690358,
           "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5141971654939225,
-          "mean_mse": 0.012468967655909777,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.4591537513696,
-          "mean_mse": 0.012791982102787751,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.46215978403929103,
-          "mean_mse": 0.0141495254118146,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5579285551265432,
-          "mean_mse": 0.012817187570402946,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.47698261477153975,
-          "mean_mse": 0.013348573619500528,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5561597131132643,
-          "mean_mse": 0.012040136341164354,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5054550066899769,
-          "mean_mse": 0.01335917176808285,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.40716342166839087,
-          "mean_mse": 0.013822152609886612,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.5887260848436008,
-          "mean_mse": 0.011919248500781486,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.483263530323274,
-          "mean_mse": 0.01330609775183847,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4056239159940764,
-          "mean_mse": 0.013898217238083738,
-          "mean_rank": 3.6666666666666665,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.5643764726775814,
-          "mean_mse": 0.012052928224475366,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.3518086813022807,
-          "mean_mse": 0.014223432980797321,
-          "mean_rank": 5.666666666666667,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.7049079750018593,
-          "mean_mse": 0.008165613677443825,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.6981409264619602,
-          "mean_mse": 0.008898318936687029,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9955098893687822,
-          "mean_mse": 0.00014000946392591463,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6276114394178602,
-          "mean_mse": 0.01006926236909468,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6225416792594408,
-          "mean_mse": 0.010449226383687785,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.5907644602650433,
-          "mean_mse": 0.010702255012243615,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6400324028965905,
-          "mean_mse": 0.009678331976676249,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6403397701814851,
-          "mean_mse": 0.01010936687151593,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7005973524099718,
-          "mean_mse": 0.008684746778571412,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6332637882811154,
-          "mean_mse": 0.009882570219945704,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7246441016850573,
-          "mean_mse": 0.008697379710557396,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7085402786163326,
-          "mean_mse": 0.008150759296817401,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7214062579744265,
-          "mean_mse": 0.00761426881012402,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9974138002669026,
-          "mean_mse": 8.083340160926206e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9972133118953617,
-          "mean_mse": 8.702698073724238e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6967419497655932,
-          "mean_mse": 0.009943412635662782,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6680398155393326,
-          "mean_mse": 0.008788803524979403,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7961034663124888,
-          "mean_mse": 0.0067263903823209115,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9968202056016501,
-          "mean_mse": 9.930969955738936e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6105874401705851,
-          "mean_mse": 0.009981452090474404,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.669563149618417,
-          "mean_mse": 0.008799124748154785,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7336505020488768,
-          "mean_mse": 0.007663278219416676,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9977291274671314,
-          "mean_mse": 7.109331112514711e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6554554453596215,
-          "mean_mse": 0.009757220591308827,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9969676926578386,
-          "mean_mse": 9.461991084254513e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6486011572725976,
-          "mean_mse": 0.011257645231689681,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7239447192330172,
-          "mean_mse": 0.008221238144780589,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.6912092534730855,
-          "mean_mse": 0.008339269647814458,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9979621547372879,
-          "mean_mse": 6.401695267592039e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6964206089312381,
-          "mean_mse": 0.008448102197597757,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9980596512718011,
-          "mean_mse": 6.059095650886294e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.6941808353616761,
-          "mean_mse": 0.00831006477862751,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9945723299273708,
-          "mean_mse": 0.00016916297524551313,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7156092560872531,
-          "mean_mse": 0.009310898427945496,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7571683484544098,
-          "mean_mse": 0.006775441664889986,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7104450615127577,
-          "mean_mse": 0.008593208307446181,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7842139626343941,
-          "mean_mse": 0.006855713624244884,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.998349690441019,
-          "mean_mse": 5.208638551893101e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6272589299749405,
-          "mean_mse": 0.010332625073676825,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6699784119398784,
-          "mean_mse": 0.00890263394368938,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9976701973885399,
-          "mean_mse": 7.272361608543282e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.715701893897539,
-          "mean_mse": 0.010106969129695512,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6971829428762695,
-          "mean_mse": 0.009053906739543493,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9971796208474223,
-          "mean_mse": 8.805385339827413e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9974432835496015,
-          "mean_mse": 7.996159402909378e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.6843487076516088,
-          "mean_mse": 0.009243302257827643,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.6769140174714903,
-          "mean_mse": 0.010632696350358966,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7524128018819776,
-          "mean_mse": 0.007351137118505849,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9982090155474764,
-          "mean_mse": 5.6984614406826335e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6042355994498,
-          "mean_mse": 0.01032747822954383,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7310102527443926,
-          "mean_mse": 0.008302121418774584,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9975084649094704,
-          "mean_mse": 7.815519816384842e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.6984181381987074,
-          "mean_mse": 0.008916754243247024,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9964986144945898,
-          "mean_mse": 0.00010924930204373154,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7890441829963722,
-          "mean_mse": 0.006976080082947485,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7109347513520383,
-          "mean_mse": 0.008100872197394495,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9976267384732793,
-          "mean_mse": 7.441024308063697e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9957107116465247,
-          "mean_mse": 0.00013431685371175238,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9982540155419617,
-          "mean_mse": 5.497945954369074e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9971573984290879,
-          "mean_mse": 8.877887800692946e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7230032513044213,
-          "mean_mse": 0.008107984843978936,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.6723931902594235,
-          "mean_mse": 0.008602432635923501,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6591978108853431,
-          "mean_mse": 0.009779014378365269,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.6997712194401748,
-          "mean_mse": 0.008201480457722727,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5782806049666807,
-          "mean_mse": 0.011977858267777322,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7027410021368538,
-          "mean_mse": 0.008555932582999512,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.4248615807133185,
-          "mean_mse": 0.013992882743757375,
-          "mean_rank": 4.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.31492958826575757,
-          "mean_mse": 0.014553194433676624,
-          "mean_rank": 61.5,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.5477430265671317,
-          "mean_mse": 0.01186496732032822,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5253461526089399,
-          "mean_mse": 0.012212557266283758,
-          "mean_rank": 1.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5663366770796663,
-          "mean_mse": 0.010791311454161075,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.574428260519713,
-          "mean_mse": 0.012291319728154648,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.52260680931755,
-          "mean_mse": 0.01199335750370374,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.09252761294474138,
-          "mean_mse": 0.015652355417798934,
-          "mean_rank": 219.2,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5024228799811555,
-          "mean_mse": 0.013431863001150813,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.3122902371437045,
-          "mean_mse": 0.014920847639036328,
-          "mean_rank": 18.25,
           "num_queries": 4
         }
       }
@@ -10696,1328 +1199,140 @@
         "alpha_reg": 0.01,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.5479865783513058,
-      "std_cosine_to_target": 0.15206057218316263,
-      "mean_mse_to_target": 0.01222096437805795,
-      "std_mse_to_target": 0.002973578026483864,
-      "mean_target_rank": 6.156832298136646,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.33540372670807456,
-      "recall_at_5": 0.9332298136645962,
-      "recall_at_10": 0.9518633540372671,
-      "mrr": 0.5791746503518036,
-      "train_time_ms": 1313.9161530416459,
-      "inference_time_us": 6322.774307416196,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.46750728653239815,
+      "std_cosine_to_target": 0.09498523192480668,
+      "mean_mse_to_target": 0.012457990999209575,
+      "std_mse_to_target": 0.0012290996990668873,
+      "mean_target_rank": 3.073170731707317,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.48982561564746074,
+      "train_time_ms": 115.65549999795621,
+      "inference_time_us": 570.9426829814287,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.39440719204158836,
-          "mean_mse": 0.014549939917202962,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.5095053215863068,
+          "mean_mse": 0.012223732637449154,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5401348172869018,
-          "mean_mse": 0.012732271466761449,
+          "mean_cosine": 0.4870498588302307,
+          "mean_mse": 0.01221642883887706,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.5019244661467703,
-          "mean_mse": 0.013779273017805852,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.48888089666719525,
+          "mean_mse": 0.01220478745707955,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.44418035194116384,
-          "mean_mse": 0.014196745464542434,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.43966440142821345,
+          "mean_mse": 0.012592970579546628,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.4754609467467268,
-          "mean_mse": 0.01354002448908908,
-          "mean_rank": 6.25,
+          "mean_cosine": 0.44655231812161156,
+          "mean_mse": 0.012551115963856411,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.42021278909905363,
-          "mean_mse": 0.01401695767083827,
-          "mean_rank": 6.0,
+          "mean_cosine": 0.5865525467267633,
+          "mean_mse": 0.011019094917919687,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.37871479209801023,
-          "mean_mse": 0.014256866238731486,
-          "mean_rank": 43.25,
+          "mean_cosine": 0.38650853422853804,
+          "mean_mse": 0.013322065028357293,
+          "mean_rank": 7.0,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.5224587622077332,
-          "mean_mse": 0.013793018627205488,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.4377783171024485,
+          "mean_mse": 0.01295344655989746,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.474361790897864,
-          "mean_mse": 0.014112110337767478,
-          "mean_rank": 2.2,
+          "mean_cosine": 0.47348230115413303,
+          "mean_mse": 0.012557707199123195,
+          "mean_rank": 3.6,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.5092952596965777,
-          "mean_mse": 0.01431299134828835,
+          "mean_cosine": 0.46801021943139526,
+          "mean_mse": 0.01253270230451502,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.4456126584040633,
-          "mean_mse": 0.014403142642271292,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.5221926013892738,
+          "mean_mse": 0.011598184710464653,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.3820934837285244,
-          "mean_mse": 0.014360452281264653,
-          "mean_rank": 34.75,
+          "mean_cosine": 0.5058972392955892,
+          "mean_mse": 0.011847572593079028,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.4915066505131508,
-          "mean_mse": 0.013678636021831192,
+          "mean_cosine": 0.43199359006954796,
+          "mean_mse": 0.0129770006095549,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.3913010001381987,
-          "mean_mse": 0.014341461367610591,
-          "mean_rank": 8.6,
+          "mean_cosine": 0.37930766749615474,
+          "mean_mse": 0.013541742718299065,
+          "mean_rank": 6.8,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.4560429477673391,
-          "mean_mse": 0.013886691717687704,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.47091196835839655,
+          "mean_mse": 0.012408204262895494,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.4479197567966369,
-          "mean_mse": 0.013690445109981348,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.38728806455178133,
+          "mean_mse": 0.013564197726507236,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5378954178273893,
-          "mean_mse": 0.013513994627324749,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.44518877140110014,
+          "mean_mse": 0.012615861992322758,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.4961649149519135,
-          "mean_mse": 0.013319720701009605,
+          "mean_cosine": 0.5032884386837082,
+          "mean_mse": 0.012006231504488013,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.4745382056181956,
-          "mean_mse": 0.013860247902228826,
-          "mean_rank": 31.5,
+          "mean_cosine": 0.4808917216100256,
+          "mean_mse": 0.012361351464144172,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.48622438155877257,
-          "mean_mse": 0.013835398255246304,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.41176324710116413,
-          "mean_mse": 0.014740662473975976,
-          "mean_rank": 29.0,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.3693470139080494,
-          "mean_mse": 0.014696722317169269,
-          "mean_rank": 36.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.49915374923725586,
-          "mean_mse": 0.014014055618364555,
+          "mean_cosine": 0.5197571036191756,
+          "mean_mse": 0.011769553936063964,
           "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5071679244100801,
-          "mean_mse": 0.013993970824974514,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.529624624445826,
-          "mean_mse": 0.012933870802745644,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.45262275706437427,
-          "mean_mse": 0.014073907556088405,
-          "mean_rank": 25.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.48431772572368764,
-          "mean_mse": 0.01298118204595889,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5188008939729081,
-          "mean_mse": 0.013484028158505907,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.5189538220333438,
-          "mean_mse": 0.013736317081620888,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.49103234062080225,
-          "mean_mse": 0.01345657846541876,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5071581443368636,
-          "mean_mse": 0.013947580986624639,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.48594958966221896,
-          "mean_mse": 0.014161956749405274,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.4264786481137185,
-          "mean_mse": 0.013617843445284656,
-          "mean_rank": 95.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.4978964406382537,
-          "mean_mse": 0.014002539705201858,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.44797760940107556,
-          "mean_mse": 0.01393150626524036,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.4219008837801875,
-          "mean_mse": 0.014102047140383189,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.3679623541285132,
-          "mean_mse": 0.014819825036344781,
-          "mean_rank": 9.75,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.45044844029120107,
-          "mean_mse": 0.013939624735137914,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.4787220170663826,
-          "mean_mse": 0.013458530244898534,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.4676303045018796,
-          "mean_mse": 0.013473704302484821,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.49987540465827884,
-          "mean_mse": 0.01354139794165624,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.503807186305581,
-          "mean_mse": 0.013861215844290257,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.35745138175101915,
-          "mean_mse": 0.014377584408007578,
-          "mean_rank": 22.0,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5311845803457941,
-          "mean_mse": 0.012671667843685366,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5079052040094303,
-          "mean_mse": 0.013613795050115587,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.5002219604347673,
-          "mean_mse": 0.014288265868593882,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.536896439624811,
-          "mean_mse": 0.01321403700022519,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.4111242957743329,
-          "mean_mse": 0.014598984338379518,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5077506712302118,
-          "mean_mse": 0.013802773094166916,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.45782774647831836,
-          "mean_mse": 0.014121250747108762,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.34807695687837,
-          "mean_mse": 0.014667469041465521,
-          "mean_rank": 46.5,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.4504394764835274,
-          "mean_mse": 0.014345800067529498,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.5083757720935249,
-          "mean_mse": 0.013122245168123617,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.41832089379652015,
-          "mean_mse": 0.01348264117723986,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.45425726194032845,
-          "mean_mse": 0.013603095499860928,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.4083960231338053,
-          "mean_mse": 0.014227415113698384,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.4623672463936225,
-          "mean_mse": 0.014089682987766826,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.45552119030308946,
-          "mean_mse": 0.014251720794776674,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4427418259673853,
-          "mean_mse": 0.014241527020708794,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.23944276771566553,
-          "mean_mse": 0.01489513396446156,
-          "mean_rank": 93.75,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.4561960709708889,
-          "mean_mse": 0.014263968538354937,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.45870638359356897,
-          "mean_mse": 0.01351393551449947,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.48896557954578945,
-          "mean_mse": 0.013752418658619042,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5107157282468038,
-          "mean_mse": 0.013626492570698413,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.34629057223464355,
-          "mean_mse": 0.014820784007437741,
-          "mean_rank": 10.25,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.458233250455399,
-          "mean_mse": 0.013334678912199267,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.4080270243474713,
-          "mean_mse": 0.014049247974536104,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.4142888532970104,
-          "mean_mse": 0.014279372127654396,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5939124180167925,
-          "mean_mse": 0.012009715642974143,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.570083322418555,
-          "mean_mse": 0.011311752475673955,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.5010585985594845,
-          "mean_mse": 0.012980428074249485,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5980565354502416,
-          "mean_mse": 0.011272953984713447,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.49299400030343654,
-          "mean_mse": 0.012787122862583045,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5316470099690752,
-          "mean_mse": 0.013499075747196575,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6490365222753011,
-          "mean_mse": 0.010392960064827894,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.49990525303068617,
-          "mean_mse": 0.013419151286242775,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5407567865457332,
-          "mean_mse": 0.013373789651262227,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5718754988378317,
-          "mean_mse": 0.012901822605651155,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.646606229269224,
-          "mean_mse": 0.01110810475744462,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5402611360010413,
-          "mean_mse": 0.0123052021151002,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5853849336804747,
-          "mean_mse": 0.012558906743314965,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6010596677781463,
-          "mean_mse": 0.01195257301616334,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5878282968602165,
-          "mean_mse": 0.012234596932760598,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5606127011956499,
-          "mean_mse": 0.011922424855304129,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5585136024596709,
-          "mean_mse": 0.013041219737842462,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5550399861786081,
-          "mean_mse": 0.011866650020471195,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5418939981654075,
-          "mean_mse": 0.012058626644274964,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5694929561168084,
-          "mean_mse": 0.012286392642150762,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5563189186216221,
-          "mean_mse": 0.01330097912652122,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.49850471940613317,
-          "mean_mse": 0.012846210162064678,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5779495171228098,
-          "mean_mse": 0.011536354012812134,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6093467465791415,
-          "mean_mse": 0.012191072534133105,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5203624091552954,
-          "mean_mse": 0.012544399347943843,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.49384534340446923,
-          "mean_mse": 0.013139367707489443,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5547613259115112,
-          "mean_mse": 0.013036605284745572,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5735374017927984,
-          "mean_mse": 0.011733708751051236,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.574461391276916,
-          "mean_mse": 0.01332998823585776,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5472815243982027,
-          "mean_mse": 0.013219316718558083,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.539241715515315,
-          "mean_mse": 0.013620943282992036,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.5174954659523546,
-          "mean_mse": 0.012719977985709762,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.568853412975869,
-          "mean_mse": 0.011989961713690775,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5392994687101836,
-          "mean_mse": 0.012850574752323275,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.619570816011578,
-          "mean_mse": 0.012449901931591381,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.5985475612493156,
-          "mean_mse": 0.012367877127100274,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5233323225871244,
-          "mean_mse": 0.013397904291546048,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6189805752169301,
-          "mean_mse": 0.012298326947256978,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6571458031793855,
-          "mean_mse": 0.012113021840881248,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5617218519493933,
-          "mean_mse": 0.012132053669457075,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5808590094693612,
-          "mean_mse": 0.012365599975243849,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5451605908320619,
-          "mean_mse": 0.011539462985389848,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5726413410736666,
-          "mean_mse": 0.01293189170003557,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5720787134447941,
-          "mean_mse": 0.01297257799010286,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5802627552936657,
-          "mean_mse": 0.011709229264703315,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5163486406246992,
-          "mean_mse": 0.013782917158319521,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5519088739193916,
-          "mean_mse": 0.012752195462607857,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5980260798063355,
-          "mean_mse": 0.012336881359592692,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6369782003061767,
-          "mean_mse": 0.010179959392855691,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5969384233440104,
-          "mean_mse": 0.01120621353885963,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5198927250951514,
-          "mean_mse": 0.012898306458536147,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5475087490167442,
-          "mean_mse": 0.012945930324398417,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.552571725663738,
-          "mean_mse": 0.01261059220770879,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.573861744255037,
-          "mean_mse": 0.011753428872143973,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5873060192945082,
-          "mean_mse": 0.011670297919434788,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5279999287576548,
-          "mean_mse": 0.012949862123888092,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6261117616557388,
-          "mean_mse": 0.011470733801933598,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5186986960254701,
-          "mean_mse": 0.013958938039159782,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.522928295445476,
-          "mean_mse": 0.013442206867909782,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.6006513398727273,
-          "mean_mse": 0.011813298387702538,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5109317856489444,
-          "mean_mse": 0.014008386127524476,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5791549436087302,
-          "mean_mse": 0.011834297229075327,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.5117226584618394,
-          "mean_mse": 0.012278744202793191,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5530411492345606,
-          "mean_mse": 0.013972622816978933,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5851807559010794,
-          "mean_mse": 0.012621294047184322,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5535773259290475,
-          "mean_mse": 0.012798052502631468,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.589091703813143,
-          "mean_mse": 0.011803263580307416,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5455946587400294,
-          "mean_mse": 0.01298491637673369,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4673184991545504,
-          "mean_mse": 0.013363181266466434,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6244353373427519,
-          "mean_mse": 0.011546849481409572,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.522972200836351,
-          "mean_mse": 0.013099649649352655,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4798876432775958,
-          "mean_mse": 0.01354171984909045,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6360412578238397,
-          "mean_mse": 0.011731916449379794,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4568147636056575,
-          "mean_mse": 0.013440076368608044,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.7037731796308502,
-          "mean_mse": 0.008208352101159212,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7198545056972729,
-          "mean_mse": 0.008600511602833915,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9999956146790941,
-          "mean_mse": 1.2448051375107254e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6691653537816591,
-          "mean_mse": 0.009495406387675414,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6420288955807725,
-          "mean_mse": 0.010313734591024875,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6180799483600601,
-          "mean_mse": 0.010329993682532363,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6214105547155492,
-          "mean_mse": 0.009954711724016543,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6510355415066278,
-          "mean_mse": 0.01003473449938422,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7193850971916966,
-          "mean_mse": 0.008477985147603605,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6513886215605867,
-          "mean_mse": 0.009712042877471821,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7314319884965833,
-          "mean_mse": 0.008654695746922203,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7338918004655606,
-          "mean_mse": 0.007762691468041747,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7542006196078341,
-          "mean_mse": 0.006988651237765617,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999869017673969,
-          "mean_mse": 1.686594478652899e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9999904983190266,
-          "mean_mse": 1.5119632416205676e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.659166577573244,
-          "mean_mse": 0.01043030126538548,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6823127867393542,
-          "mean_mse": 0.00855283085473903,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7939642243019713,
-          "mean_mse": 0.00687009902167187,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9999800993330982,
-          "mean_mse": 1.6156080742558756e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6283069457334054,
-          "mean_mse": 0.009715636493560904,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.702841645353659,
-          "mean_mse": 0.008239848322413968,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7304234919040893,
-          "mean_mse": 0.007759510723910554,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999861124970966,
-          "mean_mse": 1.8662206183770058e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6779615724734444,
-          "mean_mse": 0.00947747025446714,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9999949411354379,
-          "mean_mse": 1.37747677301674e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.680292171963375,
-          "mean_mse": 0.010985807046859468,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7334434927799351,
-          "mean_mse": 0.008118898851751193,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7167046062190274,
-          "mean_mse": 0.00792079444195617,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.999996705882349,
-          "mean_mse": 1.021538116818985e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.7002314454979243,
-          "mean_mse": 0.008494361009954217,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999861595753735,
-          "mean_mse": 1.7285280636609533e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7202871637843772,
-          "mean_mse": 0.007845157565610017,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.999993121408413,
-          "mean_mse": 1.4849610453703949e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7217970364612756,
-          "mean_mse": 0.009369385668802197,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.761613677804646,
-          "mean_mse": 0.006712021125749463,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7161384185349511,
-          "mean_mse": 0.008598665560669141,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.779956080220919,
-          "mean_mse": 0.006989757117985223,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999967201066331,
-          "mean_mse": 1.1168694073396349e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.634607384660645,
-          "mean_mse": 0.010286233871209863,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6908586551093798,
-          "mean_mse": 0.008579375976673817,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999907777694435,
-          "mean_mse": 1.730595648878959e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.698558710701888,
-          "mean_mse": 0.010323269494038419,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6984939734074131,
-          "mean_mse": 0.009080061500819274,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999921938710211,
-          "mean_mse": 1.486537128159128e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9999953477247923,
-          "mean_mse": 1.2380647700698053e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.7018760656314229,
-          "mean_mse": 0.009036092144838498,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.7046204910180038,
-          "mean_mse": 0.010509830075109795,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7687648036954019,
-          "mean_mse": 0.007113985617196814,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999950332528713,
-          "mean_mse": 9.786535467916981e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.609533743960216,
-          "mean_mse": 0.010298549114854949,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7397650302289298,
-          "mean_mse": 0.008258579628455382,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999736664996082,
-          "mean_mse": 1.706210231043736e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.727538328992714,
-          "mean_mse": 0.008511745418766233,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999723860986246,
-          "mean_mse": 1.768487242766395e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.796796132420462,
-          "mean_mse": 0.006873369540016038,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7125922425502356,
-          "mean_mse": 0.008114596015758188,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9999966913864549,
-          "mean_mse": 1.1953241142919088e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999952340263663,
-          "mean_mse": 1.0183689042854873e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9999960291220086,
-          "mean_mse": 1.0631899711330083e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999839591088809,
-          "mean_mse": 2.0850970857412918e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7306586775504424,
-          "mean_mse": 0.008073984506278446,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7039081408744948,
-          "mean_mse": 0.008010012505589238,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6819408591779555,
-          "mean_mse": 0.009569345149001918,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7083908826570247,
-          "mean_mse": 0.008107057207916287,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5787391499435315,
-          "mean_mse": 0.01187428842807099,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7382862530476766,
-          "mean_mse": 0.008025801994342604,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5337196942987573,
-          "mean_mse": 0.013561207289023075,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.43180537484174597,
-          "mean_mse": 0.014442598551503597,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.6053610611345559,
-          "mean_mse": 0.011821961211547065,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5321193088636238,
-          "mean_mse": 0.01208180419169729,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5880592379241307,
-          "mean_mse": 0.010503580351211968,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6238843945064346,
-          "mean_mse": 0.012060378320337123,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5223345804393408,
-          "mean_mse": 0.012032888768827278,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.370943839806222,
-          "mean_mse": 0.015173236919032922,
-          "mean_rank": 75.4,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5821134186265987,
-          "mean_mse": 0.01299162914027672,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.45598081512072763,
-          "mean_mse": 0.014488305906537609,
-          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -12029,1328 +1344,140 @@
         "alpha_reg": 0.1,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.547975120755429,
-      "std_cosine_to_target": 0.15209147495606545,
-      "mean_mse_to_target": 0.012229648169118831,
-      "std_mse_to_target": 0.002970545370172295,
-      "mean_target_rank": 6.175465838509317,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.3385093167701863,
-      "recall_at_5": 0.9332298136645962,
-      "recall_at_10": 0.9518633540372671,
-      "mrr": 0.5806088381521851,
-      "train_time_ms": 1329.8515969654545,
-      "inference_time_us": 6863.889307570384,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4675439621748831,
+      "std_cosine_to_target": 0.09476098860924291,
+      "mean_mse_to_target": 0.012486241176784091,
+      "std_mse_to_target": 0.0012062710209632033,
+      "mean_target_rank": 3.1097560975609757,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.47867085489036704,
+      "train_time_ms": 125.70419999974547,
+      "inference_time_us": 567.4219511736117,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.3941168603811839,
-          "mean_mse": 0.014555013445642485,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.5081450868422763,
+          "mean_mse": 0.012264713787103155,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5395460813469402,
-          "mean_mse": 0.012746473712448962,
+          "mean_cosine": 0.48719388499775046,
+          "mean_mse": 0.01224271381850137,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.5020853367698301,
-          "mean_mse": 0.013784774805491038,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.4433785252795858,
-          "mean_mse": 0.014204903724461971,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.4748810731947387,
-          "mean_mse": 0.013549617520855933,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.420983149838581,
-          "mean_mse": 0.014015303698988504,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.3787960343904062,
-          "mean_mse": 0.0142604979193069,
-          "mean_rank": 42.75,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.5228192764849909,
-          "mean_mse": 0.013797385137101423,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.4741186285422801,
-          "mean_mse": 0.014115754977521138,
-          "mean_rank": 2.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.5099505202649193,
-          "mean_mse": 0.014318026008722977,
+          "mean_cosine": 0.4893467900785662,
+          "mean_mse": 0.012232789181683506,
           "mean_rank": 2.5,
           "num_queries": 4
         },
+        "constraint-usage": {
+          "mean_cosine": 0.4398203101771655,
+          "mean_mse": 0.012612301588284601,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4470857109408073,
+          "mean_mse": 0.012571955860966197,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5874273279813759,
+          "mean_mse": 0.011037215088384927,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3897008498328002,
+          "mean_mse": 0.013260598426505277,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.43816398272191925,
+          "mean_mse": 0.012971556229412323,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.47414783302886165,
+          "mean_mse": 0.01258406653118157,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.46756171804714897,
+          "mean_mse": 0.012570382143756565,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
         "prolog-directives": {
-          "mean_cosine": 0.44544431825881975,
-          "mean_mse": 0.014406412961479364,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.5225695350356668,
+          "mean_mse": 0.011625310366555754,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.38156324548795206,
-          "mean_mse": 0.014362111404381485,
-          "mean_rank": 36.0,
+          "mean_cosine": 0.5056813021382077,
+          "mean_mse": 0.01188659913499241,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.4915433958448611,
-          "mean_mse": 0.013683202522837428,
+          "mean_cosine": 0.431620058553992,
+          "mean_mse": 0.01301691415500979,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.39096254110784434,
-          "mean_mse": 0.014346295005218723,
-          "mean_rank": 8.6,
+          "mean_cosine": 0.38141781690670706,
+          "mean_mse": 0.013559186814740018,
+          "mean_rank": 6.6,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.4557207561178851,
-          "mean_mse": 0.01389111473431804,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.47088946197214515,
+          "mean_mse": 0.012439834319463414,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.4481561728354388,
-          "mean_mse": 0.013695238524440108,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.3849449433813433,
+          "mean_mse": 0.01360399704430387,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.537573244688964,
-          "mean_mse": 0.01351907093266928,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.44402629973472907,
+          "mean_mse": 0.012667757214610689,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.4959627948621229,
-          "mean_mse": 0.013326441733834418,
+          "mean_cosine": 0.5031840271329334,
+          "mean_mse": 0.012051690768753835,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.4752041485754091,
-          "mean_mse": 0.013864265762253903,
-          "mean_rank": 31.5,
+          "mean_cosine": 0.47931377527505653,
+          "mean_mse": 0.01241185242289904,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.48626576896825535,
-          "mean_mse": 0.013840874869149089,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.4126449502627215,
-          "mean_mse": 0.014741406089555927,
-          "mean_rank": 29.0,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.3698000845917091,
-          "mean_mse": 0.014694670906927188,
-          "mean_rank": 35.5,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.49889291777256733,
-          "mean_mse": 0.01401893709308016,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5082169101280254,
-          "mean_mse": 0.013994918718180049,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5298072581357889,
-          "mean_mse": 0.01294003691097101,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.4530398495821575,
-          "mean_mse": 0.014076284343428178,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.48438539131883995,
-          "mean_mse": 0.012987983739575422,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5188883555591736,
-          "mean_mse": 0.013489393002306213,
+          "mean_cosine": 0.5185190973217585,
+          "mean_mse": 0.011820695890485136,
           "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.5182789618043704,
-          "mean_mse": 0.01374673984767129,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.4911565482384897,
-          "mean_mse": 0.013461902273116132,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5069730699236039,
-          "mean_mse": 0.013953633655200507,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.4856726274864198,
-          "mean_mse": 0.01416671778510388,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.4264768662581909,
-          "mean_mse": 0.013622712560328331,
-          "mean_rank": 95.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.4980216386168259,
-          "mean_mse": 0.014006610937662957,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.44817683802701525,
-          "mean_mse": 0.013936665697108669,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.42109218354582495,
-          "mean_mse": 0.014108727293742823,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.36769438987465936,
-          "mean_mse": 0.014823871498083535,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.4504414841855199,
-          "mean_mse": 0.013943154127877621,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.47868340783088026,
-          "mean_mse": 0.013467615730127268,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.4672405935493743,
-          "mean_mse": 0.013485732793277227,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.49998664992043207,
-          "mean_mse": 0.013548379932742199,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.5040852259358323,
-          "mean_mse": 0.013864313856418956,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.3569512106213502,
-          "mean_mse": 0.014382081118321989,
-          "mean_rank": 22.0,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5315057427193162,
-          "mean_mse": 0.012674755468580493,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5075398065923731,
-          "mean_mse": 0.013621197012769445,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.5007135595907665,
-          "mean_mse": 0.014292255801281826,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.5370854612774693,
-          "mean_mse": 0.013219922980041241,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.4114024331094476,
-          "mean_mse": 0.014603800776673606,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5079659495760701,
-          "mean_mse": 0.013807877555260325,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.45797683086950347,
-          "mean_mse": 0.014126116798333341,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.34743624554036806,
-          "mean_mse": 0.014670938224315665,
-          "mean_rank": 49.5,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.4508287323717689,
-          "mean_mse": 0.014352621935291401,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.5084203783389303,
-          "mean_mse": 0.013127675495621396,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.4178805826199846,
-          "mean_mse": 0.013487725281821246,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.4539915771445705,
-          "mean_mse": 0.013611989033461797,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.4083343213488254,
-          "mean_mse": 0.014231849556351567,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.46243565315643564,
-          "mean_mse": 0.014094767925521907,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.4543372855277166,
-          "mean_mse": 0.014264353920287926,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4436080518432317,
-          "mean_mse": 0.014246545463843284,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.2395482397740057,
-          "mean_mse": 0.014897249159540892,
-          "mean_rank": 93.25,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.4564342046375079,
-          "mean_mse": 0.014267701654831037,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4575592606918578,
-          "mean_mse": 0.013527885785748005,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.4890766005409829,
-          "mean_mse": 0.013755535825756268,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5105255794190373,
-          "mean_mse": 0.013633214058811925,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.345270665054911,
-          "mean_mse": 0.014824236584242718,
-          "mean_rank": 10.75,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.4583849858292801,
-          "mean_mse": 0.013341728449367046,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.40814659589285734,
-          "mean_mse": 0.01405231201088235,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.4142894039115168,
-          "mean_mse": 0.014282636894040723,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.593687990969649,
-          "mean_mse": 0.01201866986144937,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5695892102824837,
-          "mean_mse": 0.011330587717203392,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.5014010091966729,
-          "mean_mse": 0.012985707479760964,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5978314703333156,
-          "mean_mse": 0.01128801186783819,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.4925837857529907,
-          "mean_mse": 0.01279542138488563,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5323102169925442,
-          "mean_mse": 0.013503625779649878,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6487921471275238,
-          "mean_mse": 0.010404852232124602,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.5002293807066914,
-          "mean_mse": 0.013423064975998619,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5411379591603908,
-          "mean_mse": 0.013377252487176944,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5719501148616531,
-          "mean_mse": 0.012914458512686905,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6465779753101814,
-          "mean_mse": 0.011119329049279066,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5404807388224965,
-          "mean_mse": 0.012311539313208969,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5852462369492458,
-          "mean_mse": 0.012575092375282254,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6013321669074047,
-          "mean_mse": 0.0119610738260226,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.588247016616573,
-          "mean_mse": 0.012241443479239361,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5610382553251166,
-          "mean_mse": 0.011930873068231157,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5581113170163491,
-          "mean_mse": 0.013051899289732419,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5561268068004147,
-          "mean_mse": 0.011872767070198464,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5412434793821888,
-          "mean_mse": 0.012075027698047637,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5694184801659178,
-          "mean_mse": 0.012289841043379787,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.554837752805423,
-          "mean_mse": 0.01332047355718874,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.4995048451579523,
-          "mean_mse": 0.012845224646089068,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5786103397433155,
-          "mean_mse": 0.011537121841415967,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6090848431333106,
-          "mean_mse": 0.012204604016629247,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5193275905599166,
-          "mean_mse": 0.01255868334792873,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.493447962709565,
-          "mean_mse": 0.013153429284679696,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5547133657330529,
-          "mean_mse": 0.013041365199796049,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5741692960655892,
-          "mean_mse": 0.011742037360249674,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5748073167575463,
-          "mean_mse": 0.013339592623082366,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5476437916436919,
-          "mean_mse": 0.013226670539864366,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5381507241782056,
-          "mean_mse": 0.013634499423980907,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.517526603857663,
-          "mean_mse": 0.01272292719402307,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5683749113159046,
-          "mean_mse": 0.012004676392558242,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5390481682100844,
-          "mean_mse": 0.012864080560953705,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6192914835174301,
-          "mean_mse": 0.012468828667024352,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.59894798316846,
-          "mean_mse": 0.012378041620872512,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5235240114882528,
-          "mean_mse": 0.013404417976926064,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6197127774076825,
-          "mean_mse": 0.012306904309977112,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6566914477593021,
-          "mean_mse": 0.012125815114440686,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.5618397907272743,
-          "mean_mse": 0.01214207727328523,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5808067376424204,
-          "mean_mse": 0.012375230438042376,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5449332381427661,
-          "mean_mse": 0.011550636623784985,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5730133221426825,
-          "mean_mse": 0.012937039572156611,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5714846724109478,
-          "mean_mse": 0.012986028553935713,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5803186091593991,
-          "mean_mse": 0.011716876728619735,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5155040337907872,
-          "mean_mse": 0.013793146027974879,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5513249804661192,
-          "mean_mse": 0.012761734200284957,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5979735875536082,
-          "mean_mse": 0.012349301625363837,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6374253773620836,
-          "mean_mse": 0.010182653546587523,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5965445757240055,
-          "mean_mse": 0.011216540276728438,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5189282003731527,
-          "mean_mse": 0.012914457904202066,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5464637683410404,
-          "mean_mse": 0.01296176949931161,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5534522135528401,
-          "mean_mse": 0.012612176709165769,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5742523198970579,
-          "mean_mse": 0.011760107355234362,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5875287685763455,
-          "mean_mse": 0.011682421766330463,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5279719799714732,
-          "mean_mse": 0.012959963679933203,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6263363351552095,
-          "mean_mse": 0.011481616540423128,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5181952795841088,
-          "mean_mse": 0.013967547785777802,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.5228972647646778,
-          "mean_mse": 0.013452095921373147,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.6006532138597587,
-          "mean_mse": 0.01182425186520289,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5114089932387863,
-          "mean_mse": 0.014016125607832886,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.578618493075858,
-          "mean_mse": 0.01185450716704913,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.512842943236474,
-          "mean_mse": 0.012278310569921761,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5525051432433973,
-          "mean_mse": 0.01398143929084038,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.585890920092158,
-          "mean_mse": 0.012627392940689389,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5526521130579344,
-          "mean_mse": 0.012818502023249292,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5890371164810118,
-          "mean_mse": 0.011814985242118084,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5449151983565846,
-          "mean_mse": 0.012991826158217782,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4671517317237946,
-          "mean_mse": 0.013372589051923326,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.62484913390157,
-          "mean_mse": 0.011559128739070378,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5228052583645472,
-          "mean_mse": 0.013107771421302846,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4799553093929807,
-          "mean_mse": 0.013549115063418929,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6363361735427691,
-          "mean_mse": 0.011740570736452573,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4571552786966803,
-          "mean_mse": 0.013440595423291594,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.7031574454331153,
-          "mean_mse": 0.008233199878906361,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7195328142032892,
-          "mean_mse": 0.00863430627364881,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9999840532248261,
-          "mean_mse": 2.028439191074744e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6701240704626417,
-          "mean_mse": 0.009499841208666034,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6416007956651137,
-          "mean_mse": 0.010342854384910932,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.617663689265252,
-          "mean_mse": 0.010355627298956432,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6212501792524099,
-          "mean_mse": 0.00996713488510797,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.6512258953231538,
-          "mean_mse": 0.010042779689105849,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7198433579969213,
-          "mean_mse": 0.008492263474786411,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6508670876575373,
-          "mean_mse": 0.009736966621102884,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7313259359023287,
-          "mean_mse": 0.008672113862908903,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7339470273966675,
-          "mean_mse": 0.007779601876398279,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7539186772556848,
-          "mean_mse": 0.007004496222523392,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999757136413931,
-          "mean_mse": 2.312615939505623e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9999751340540697,
-          "mean_mse": 2.080705110493761e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6591120906596869,
-          "mean_mse": 0.01044652272235996,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6827799463345435,
-          "mean_mse": 0.00854778862878973,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7939527812145079,
-          "mean_mse": 0.006893625407152061,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9999829837516082,
-          "mean_mse": 2.3859869858149398e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6279319299596334,
-          "mean_mse": 0.009733556315240682,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7023257928504882,
-          "mean_mse": 0.008261594568043238,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7304903608874473,
-          "mean_mse": 0.007781145573250492,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999783393037607,
-          "mean_mse": 2.488848662504571e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6776587551039424,
-          "mean_mse": 0.009500426530092245,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9999860115598982,
-          "mean_mse": 2.1785771636409536e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6812582802324529,
-          "mean_mse": 0.011004570093847149,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7333385278039138,
-          "mean_mse": 0.008151984014656326,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7162298344609209,
-          "mean_mse": 0.007947241138147754,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9999884396810597,
-          "mean_mse": 1.776052863103533e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6995174192423588,
-          "mean_mse": 0.008524910790301043,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999775566959007,
-          "mean_mse": 2.6704937713494988e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.720296360074673,
-          "mean_mse": 0.007856412847211221,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9999789971643289,
-          "mean_mse": 2.3867369430001673e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7221734184842568,
-          "mean_mse": 0.009388130644220971,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.761579676572767,
-          "mean_mse": 0.006725684023890054,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7165103906210909,
-          "mean_mse": 0.008619516791507721,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7797175896022599,
-          "mean_mse": 0.007021171146807873,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999838499633027,
-          "mean_mse": 1.927698479217378e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6354999053314014,
-          "mean_mse": 0.010288020995928425,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6914305072053404,
-          "mean_mse": 0.008589430896016919,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999806457245218,
-          "mean_mse": 2.6458814957692828e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.6996797768124696,
-          "mean_mse": 0.01033353652910251,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6993047290682588,
-          "mean_mse": 0.009096343469186665,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999787093497747,
-          "mean_mse": 2.4200831158432924e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9999869939804208,
-          "mean_mse": 1.912926155172951e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.703151043607792,
-          "mean_mse": 0.009038516961051506,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.7039534215147127,
-          "mean_mse": 0.010539119083513421,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7693506615016548,
-          "mean_mse": 0.007127659150973631,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999841039441878,
-          "mean_mse": 1.7390258242985726e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6103856616460003,
-          "mean_mse": 0.010298396458011831,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7406414289213016,
-          "mean_mse": 0.008274551345119917,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999653347331524,
-          "mean_mse": 2.456702650592946e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7272079638883038,
-          "mean_mse": 0.00853279845755055,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999735133985208,
-          "mean_mse": 2.31920162734303e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7962772529394496,
-          "mean_mse": 0.006901115855754139,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7125555857428664,
-          "mean_mse": 0.008131967705779057,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9999858937719645,
-          "mean_mse": 2.0385531042764194e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999899845228538,
-          "mean_mse": 1.826172985112647e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9999919652637363,
-          "mean_mse": 1.9208490424048007e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999754735200571,
-          "mean_mse": 2.5936378951964684e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.72987056884107,
-          "mean_mse": 0.00811076652756856,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7042991539613506,
-          "mean_mse": 0.008013380143099918,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6822179163164626,
-          "mean_mse": 0.009583392882904218,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7089288041088473,
-          "mean_mse": 0.008111042193212337,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5786001013377434,
-          "mean_mse": 0.01189043358749767,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7382326447107326,
-          "mean_mse": 0.008048576343116395,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5339947191147981,
-          "mean_mse": 0.013566775191302812,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.4316262857482178,
-          "mean_mse": 0.014444586157233966,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.6058217831885734,
-          "mean_mse": 0.01182994095881385,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5315788010975687,
-          "mean_mse": 0.0121014612922768,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5873941861658439,
-          "mean_mse": 0.010521887252305006,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6241779197941456,
-          "mean_mse": 0.012067401609037097,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5233065375759975,
-          "mean_mse": 0.012029721686550638,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.3709657290438305,
-          "mean_mse": 0.015173208461276552,
-          "mean_rank": 75.6,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5816569793580059,
-          "mean_mse": 0.013006182143755133,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.4561081225978393,
-          "mean_mse": 0.014492441102570697,
-          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -13362,1328 +1489,140 @@
         "alpha_reg": 0.01,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.548043493215603,
-      "std_cosine_to_target": 0.15207250494514346,
-      "mean_mse_to_target": 0.012215138713679505,
-      "std_mse_to_target": 0.0029752077961077055,
-      "mean_target_rank": 6.159937888198757,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.34316770186335405,
-      "recall_at_5": 0.9332298136645962,
-      "recall_at_10": 0.953416149068323,
-      "mrr": 0.5833322632615713,
-      "train_time_ms": 1588.5730360168964,
-      "inference_time_us": 9094.692872597125,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.4679736534562013,
+      "std_cosine_to_target": 0.09492298698715211,
+      "mean_mse_to_target": 0.012438122976052764,
+      "std_mse_to_target": 0.0012304959919901466,
+      "mean_target_rank": 3.097560975609756,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.1951219512195122,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.4756220744025622,
+      "train_time_ms": 145.77719999942929,
+      "inference_time_us": 804.5390243684623,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.3947447945550324,
-          "mean_mse": 0.01454744419347535,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.508382445848395,
+          "mean_mse": 0.012228348220576654,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5399544521284919,
-          "mean_mse": 0.012733298233715402,
+          "mean_cosine": 0.487157598865348,
+          "mean_mse": 0.01221026860856083,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.5016524756637091,
-          "mean_mse": 0.013779715077686352,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.4439805564891106,
-          "mean_mse": 0.014196097541580452,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.47548597501646556,
-          "mean_mse": 0.013536457666134724,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.41908598084215887,
-          "mean_mse": 0.014012335288238418,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.37839369188862515,
-          "mean_mse": 0.014253325755537501,
-          "mean_rank": 44.5,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.5229131043519587,
-          "mean_mse": 0.013787520422061925,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.4750713254572119,
-          "mean_mse": 0.014105292433340466,
-          "mean_rank": 2.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.5094941474134438,
-          "mean_mse": 0.014310827398730847,
+          "mean_cosine": 0.4893073163572752,
+          "mean_mse": 0.01219424407159976,
           "mean_rank": 2.5,
           "num_queries": 4
         },
+        "constraint-usage": {
+          "mean_cosine": 0.43972939101795744,
+          "mean_mse": 0.012591488721274099,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4481489401174574,
+          "mean_mse": 0.012517901105344688,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5865635760267395,
+          "mean_mse": 0.01101336178118384,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3880216554063799,
+          "mean_mse": 0.013300089393497399,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.4380891546016038,
+          "mean_mse": 0.012946647182897978,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.4735200832533552,
+          "mean_mse": 0.01254103270462574,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4689861442690053,
+          "mean_mse": 0.012513045855599005,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
         "prolog-directives": {
-          "mean_cosine": 0.44625103812000966,
-          "mean_mse": 0.014399107126196435,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.5228532165849716,
+          "mean_mse": 0.011587723284126793,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.3829685146070623,
-          "mean_mse": 0.01435269394995706,
-          "mean_rank": 35.5,
+          "mean_cosine": 0.5078962858729318,
+          "mean_mse": 0.011811956796398399,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.49145243931292193,
-          "mean_mse": 0.013678189815322792,
+          "mean_cosine": 0.43669843520331253,
+          "mean_mse": 0.012920924706128076,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.3914028760216615,
-          "mean_mse": 0.014341054812349121,
-          "mean_rank": 8.6,
+          "mean_cosine": 0.38132514577122784,
+          "mean_mse": 0.013484957869160616,
+          "mean_rank": 6.6,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.45503451563105723,
-          "mean_mse": 0.013882642641687235,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.4706514317062377,
+          "mean_mse": 0.012398490417052986,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.44701771684691255,
-          "mean_mse": 0.013675764931706823,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.3809417601687053,
+          "mean_mse": 0.013605629558705874,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5383725661741434,
-          "mean_mse": 0.01349979163231629,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.44520948440880836,
+          "mean_mse": 0.012578579780602572,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.49622190830812185,
-          "mean_mse": 0.013318271529543933,
+          "mean_cosine": 0.5049032393484079,
+          "mean_mse": 0.01193056147558468,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.47525050797144364,
-          "mean_mse": 0.013856813336742926,
-          "mean_rank": 31.5,
+          "mean_cosine": 0.48187101576884683,
+          "mean_mse": 0.012336991299406585,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.48546671004221276,
-          "mean_mse": 0.013834853776504605,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.4115583983792712,
-          "mean_mse": 0.014741608885477825,
-          "mean_rank": 29.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.36940421823775543,
-          "mean_mse": 0.01469695146230806,
-          "mean_rank": 36.5,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.4985053295351732,
-          "mean_mse": 0.014007895813565898,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5070264201050588,
-          "mean_mse": 0.013990354360521729,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5305090174827477,
-          "mean_mse": 0.0129225077118339,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.4542398857407345,
-          "mean_mse": 0.01406483039423929,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.4844314570135285,
-          "mean_mse": 0.012980259376191945,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5186827358111176,
-          "mean_mse": 0.013479606968284721,
+          "mean_cosine": 0.5194922679990153,
+          "mean_mse": 0.011762780533308486,
           "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.5187404707830575,
-          "mean_mse": 0.01373655851649547,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.4915266821765444,
-          "mean_mse": 0.013447967313778973,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.5072520705445941,
-          "mean_mse": 0.013944222356608377,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.4862913106546527,
-          "mean_mse": 0.014156936486409652,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.42748018467427706,
-          "mean_mse": 0.013605984378754262,
-          "mean_rank": 94.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.4980395069370614,
-          "mean_mse": 0.013994568362610791,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.4474909860696813,
-          "mean_mse": 0.01393202795332369,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.42250202080202376,
-          "mean_mse": 0.014096216414840886,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.36952752507609116,
-          "mean_mse": 0.014813758741276686,
-          "mean_rank": 9.75,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.4503976097893567,
-          "mean_mse": 0.013938560403515706,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.479054144801504,
-          "mean_mse": 0.013454634459143489,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.46775054396484356,
-          "mean_mse": 0.013470303053161437,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.49990937142133895,
-          "mean_mse": 0.013535611963110778,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.5024125000832538,
-          "mean_mse": 0.01385819114073826,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.35795451929157,
-          "mean_mse": 0.014374508987722849,
-          "mean_rank": 21.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5308808908962361,
-          "mean_mse": 0.01267142134034797,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5084506827216875,
-          "mean_mse": 0.013607014658512322,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.5019239727507422,
-          "mean_mse": 0.014279052978858914,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.537136772071317,
-          "mean_mse": 0.013206644146024096,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.4111065783068901,
-          "mean_mse": 0.014598613469359159,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5073928755291347,
-          "mean_mse": 0.013800181599135933,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4578361309691362,
-          "mean_mse": 0.014119176373453717,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.34804312267622334,
-          "mean_mse": 0.014666460023713484,
-          "mean_rank": 47.5,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.45059258452433626,
-          "mean_mse": 0.014344353810377448,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "test-runner-inference": {
-          "mean_cosine": 0.5082726865839025,
-          "mean_mse": 0.013122125024047877,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.4181566461094186,
-          "mean_mse": 0.013480622033485289,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.4537559643534566,
-          "mean_mse": 0.013604983287137313,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.40872510973674986,
-          "mean_mse": 0.014221439103520783,
-          "mean_rank": 30.5,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.46217021314717593,
-          "mean_mse": 0.014090078973748114,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.45567653745856623,
-          "mean_mse": 0.014249482608409234,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.4426405300011429,
-          "mean_mse": 0.014240953428747267,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.239126241907539,
-          "mean_mse": 0.014892992756488426,
-          "mean_rank": 93.5,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.45531922623390503,
-          "mean_mse": 0.014261935136519391,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.45866761136755163,
-          "mean_mse": 0.013514008084900794,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.48858102442206375,
-          "mean_mse": 0.013746778760449292,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "semantic-crawling": {
-          "mean_cosine": 0.5112021652546974,
-          "mean_mse": 0.013620926417615737,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "vector-search": {
-          "mean_cosine": 0.3452765305432334,
-          "mean_mse": 0.014820572732665552,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "powershell-semantic": {
-          "mean_cosine": 0.4582582019970831,
-          "mean_mse": 0.013333967523619697,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "csharp-stream-target": {
-          "mean_cosine": 0.407874967106189,
-          "mean_mse": 0.01404367862039299,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.41423209707512054,
-          "mean_mse": 0.01428074671186651,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5939606794857112,
-          "mean_mse": 0.0119913383318557,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5701169330385457,
-          "mean_mse": 0.011309511270220488,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.5009243059299388,
-          "mean_mse": 0.01297382272069876,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5980591850887782,
-          "mean_mse": 0.01127166691081386,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.49281912457489896,
-          "mean_mse": 0.012787752455493363,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5320505865703454,
-          "mean_mse": 0.013492032529788324,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6489847874442026,
-          "mean_mse": 0.010371950282024226,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.49877951688322053,
-          "mean_mse": 0.013418379140577585,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.541052639067963,
-          "mean_mse": 0.013371951602542878,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5715230295431388,
-          "mean_mse": 0.012902057477059038,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6468904154119361,
-          "mean_mse": 0.01108840302668409,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5401869671412595,
-          "mean_mse": 0.012295668473275428,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5853102602845724,
-          "mean_mse": 0.01255923122603733,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6012979935268267,
-          "mean_mse": 0.011949153737769516,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.58749474400829,
-          "mean_mse": 0.012229246603264056,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5607572344413357,
-          "mean_mse": 0.011916331855788878,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.5586334441784565,
-          "mean_mse": 0.013037767633802178,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5550985852841418,
-          "mean_mse": 0.01186510380476583,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5414988684158702,
-          "mean_mse": 0.012055048263867696,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5694200939134487,
-          "mean_mse": 0.012277660280644984,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5564462394548185,
-          "mean_mse": 0.013295780061570311,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.49901067297308904,
-          "mean_mse": 0.012833647785137585,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5783642787376954,
-          "mean_mse": 0.011515012086891652,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6085740441925542,
-          "mean_mse": 0.012179452238498686,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5202481051812259,
-          "mean_mse": 0.01254455183505837,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.4936521816177219,
-          "mean_mse": 0.013139540948483616,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5539908498497199,
-          "mean_mse": 0.013035984716904973,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5736205036643578,
-          "mean_mse": 0.011732626532385689,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5752481518407221,
-          "mean_mse": 0.013321040776614841,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5467666941117563,
-          "mean_mse": 0.013212099652753703,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5389535430657945,
-          "mean_mse": 0.013619876136748957,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.5189203173697802,
-          "mean_mse": 0.012703340571728658,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5687280468838188,
-          "mean_mse": 0.011980801341240117,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5392706882635018,
-          "mean_mse": 0.01284938211240907,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6194877149456742,
-          "mean_mse": 0.01244765695119175,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.5988684553897757,
-          "mean_mse": 0.0123618333808999,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5239583488198958,
-          "mean_mse": 0.013389034764041534,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6202228719855977,
-          "mean_mse": 0.0122833501384023,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6570646408411412,
-          "mean_mse": 0.012111335036237023,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.561769290050574,
-          "mean_mse": 0.01212994553206607,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5803907213961498,
-          "mean_mse": 0.01235995198497035,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5450830688686575,
-          "mean_mse": 0.011538970763511255,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5724398367764201,
-          "mean_mse": 0.012914860266796993,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5721097846589215,
-          "mean_mse": 0.012968059760181241,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5804528006626822,
-          "mean_mse": 0.011689956827745464,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5161443966868061,
-          "mean_mse": 0.013779035810031088,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5514015151499548,
-          "mean_mse": 0.012740709397271151,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5976614878534688,
-          "mean_mse": 0.01233508286380787,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6364797862457426,
-          "mean_mse": 0.010174098782622865,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5973365179790955,
-          "mean_mse": 0.011177343663052059,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.519551148489625,
-          "mean_mse": 0.01289292585398393,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5476384535557363,
-          "mean_mse": 0.012945164755798636,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.553997628394219,
-          "mean_mse": 0.012591694084204873,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.5737261933744539,
-          "mean_mse": 0.011749104858822789,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5874464322529639,
-          "mean_mse": 0.011667495974932338,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5287439965324466,
-          "mean_mse": 0.012941733495068962,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6253399029351451,
-          "mean_mse": 0.011463075935558101,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5192467777163999,
-          "mean_mse": 0.013953113910429424,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.5236418421608904,
-          "mean_mse": 0.013435391699333277,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.5994828396634259,
-          "mean_mse": 0.011814954415124548,
-          "mean_rank": 3.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5112956390900564,
-          "mean_mse": 0.01400514971477601,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5789134984634255,
-          "mean_mse": 0.011832827221090839,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.5120518167088334,
-          "mean_mse": 0.01227222772261377,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5521985622043762,
-          "mean_mse": 0.013967723770205762,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5853320913468999,
-          "mean_mse": 0.01261455116673968,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.55369367999216,
-          "mean_mse": 0.012797311645202617,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.5894732822737362,
-          "mean_mse": 0.011791982585239141,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5458598168505984,
-          "mean_mse": 0.012972592642585407,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4672023461113923,
-          "mean_mse": 0.013363604535055135,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.6246007090752439,
-          "mean_mse": 0.011544299176949394,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5233303406002325,
-          "mean_mse": 0.013096027739502759,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.48038913050847204,
-          "mean_mse": 0.013532903360881922,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6368597702301196,
-          "mean_mse": 0.011724498225750562,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4570361989279319,
-          "mean_mse": 0.01343807442382941,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.7034006817784773,
-          "mean_mse": 0.008212243383822298,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7196840135877713,
-          "mean_mse": 0.008599427831167487,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9999958954861297,
-          "mean_mse": 1.080182429023711e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6699702644491048,
-          "mean_mse": 0.009471233133791303,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.6420477212654809,
-          "mean_mse": 0.010309108582373903,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.618031316035291,
-          "mean_mse": 0.010327550246631572,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6222460922445208,
-          "mean_mse": 0.009936204300694088,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.65125078114402,
-          "mean_mse": 0.010011005491595617,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7192329898611803,
-          "mean_mse": 0.008453333853826564,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6512287923062456,
-          "mean_mse": 0.009705178451824652,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7304653681661658,
-          "mean_mse": 0.00864982623160709,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7340680227194047,
-          "mean_mse": 0.007756798123430159,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7536068343893277,
-          "mean_mse": 0.006992523599310998,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999951556324873,
-          "mean_mse": 1.2763752890267952e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.999995761032559,
-          "mean_mse": 1.1211503311687204e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6596046132364193,
-          "mean_mse": 0.010398788010638961,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6837081939868264,
-          "mean_mse": 0.00851320917016112,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.7936739582734382,
-          "mean_mse": 0.006854486112277146,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.9999945579075513,
-          "mean_mse": 1.1144912231667087e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6282715162785542,
-          "mean_mse": 0.009713817991547274,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7026849217118296,
-          "mean_mse": 0.008237278364797285,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7307413308348778,
-          "mean_mse": 0.007751795665703131,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999941446259577,
-          "mean_mse": 1.3810050791283876e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.6777520074556367,
-          "mean_mse": 0.009478570595439925,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9999945003444016,
-          "mean_mse": 1.3519541847255995e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.68005818790746,
-          "mean_mse": 0.010977884395918826,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7334981802677534,
-          "mean_mse": 0.008117098606776719,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7164116256611359,
-          "mean_mse": 0.0079224075517535,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9999953240148639,
-          "mean_mse": 9.472619473221717e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.7001143240573349,
-          "mean_mse": 0.008483250229104067,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999950394102087,
-          "mean_mse": 1.4056352859504744e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7212626467532443,
-          "mean_mse": 0.007820056244899178,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9999947652217818,
-          "mean_mse": 1.4075364398141083e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7219407147898675,
-          "mean_mse": 0.0093596881722721,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7617081545915523,
-          "mean_mse": 0.0067080562583080785,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.716314176300588,
-          "mean_mse": 0.00859221336561055,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.780211332763327,
-          "mean_mse": 0.006981584729551779,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999965927410348,
-          "mean_mse": 1.0857785154727253e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6354205934412778,
-          "mean_mse": 0.010262483335236175,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.690789231335626,
-          "mean_mse": 0.008579003126407626,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999950014177019,
-          "mean_mse": 1.4700139722249768e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.6989013795666149,
-          "mean_mse": 0.010300502904720288,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.698548812777802,
-          "mean_mse": 0.009075404241463357,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999959612343436,
-          "mean_mse": 1.3223653939523803e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9999938999563199,
-          "mean_mse": 1.1497619369274356e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.7015076229767987,
-          "mean_mse": 0.009016446631438309,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.7050424024160842,
-          "mean_mse": 0.010499094899994304,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.769218670906036,
-          "mean_mse": 0.007099759777605844,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999955327846839,
-          "mean_mse": 8.995321673752784e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6103400607254492,
-          "mean_mse": 0.010271885074553087,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7399392486607214,
-          "mean_mse": 0.00824191873486879,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999943004204995,
-          "mean_mse": 1.1328311917816067e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7273703116099195,
-          "mean_mse": 0.008490190248373466,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999930107296181,
-          "mean_mse": 9.494735806976171e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7963083445926812,
-          "mean_mse": 0.0068576939831850505,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7131930239047135,
-          "mean_mse": 0.008096980103342841,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9999963243037769,
-          "mean_mse": 1.1151442149880564e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999951963619677,
-          "mean_mse": 8.40215078825646e-06,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.999994845940033,
-          "mean_mse": 1.03586112099654e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999964260387058,
-          "mean_mse": 1.321611318323659e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7304375421009464,
-          "mean_mse": 0.008076317926396223,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7042398799437697,
-          "mean_mse": 0.008001264300486692,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6831469763883385,
-          "mean_mse": 0.009535106809003567,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7082194271072886,
-          "mean_mse": 0.008098989096655542,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5791247868565481,
-          "mean_mse": 0.011868316897159975,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7382566338390932,
-          "mean_mse": 0.008016930598273159,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5334580568608582,
-          "mean_mse": 0.013548590197109155,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.4327674591690478,
-          "mean_mse": 0.014433800003646437,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "ai-lda-001": {
-          "mean_cosine": 0.6054511725047087,
-          "mean_mse": 0.011821222344742205,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5321664552696014,
-          "mean_mse": 0.012081014600085871,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5881451552514833,
-          "mean_mse": 0.010492653901316186,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ai-distill-001": {
-          "mean_cosine": 0.6238740797148813,
-          "mean_mse": 0.012048537179261617,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5219264889803674,
-          "mean_mse": 0.01202145267567123,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "prereq-init-environment": {
-          "mean_cosine": 0.3703357163982807,
-          "mean_mse": 0.015173509849956236,
-          "mean_rank": 75.6,
-          "num_queries": 5
-        },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5819620829236193,
-          "mean_mse": 0.01299167818319606,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "prereq-project-structure": {
-          "mean_cosine": 0.4560356637770365,
-          "mean_mse": 0.01448768470418262,
-          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -14695,1328 +1634,4043 @@
         "alpha_reg": 0.1,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.5480083646715858,
-      "std_cosine_to_target": 0.15208986949477685,
-      "mean_mse_to_target": 0.012225981466063945,
-      "std_mse_to_target": 0.0029716201621249154,
-      "mean_target_rank": 6.175465838509317,
-      "median_target_rank": 2.0,
-      "recall_at_1": 0.34006211180124224,
-      "recall_at_5": 0.9332298136645962,
-      "recall_at_10": 0.9518633540372671,
-      "mrr": 0.5814862923882416,
-      "train_time_ms": 1682.400060002692,
-      "inference_time_us": 10241.415871159747,
-      "num_queries": 644,
-      "num_answers": 644,
-      "num_clusters": 218,
+      "mean_cosine_to_target": 0.467967708982693,
+      "std_cosine_to_target": 0.09478722865371951,
+      "mean_mse_to_target": 0.012459667516574848,
+      "std_mse_to_target": 0.0012138931861399903,
+      "mean_target_rank": 3.0853658536585367,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.9512195121951219,
+      "recall_at_10": 0.975609756097561,
+      "mrr": 0.481719635378172,
+      "train_time_ms": 141.41689999814844,
+      "inference_time_us": 818.5475609668463,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.3941528964255864,
-          "mean_mse": 0.014553636455731867,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.5072204364472476,
+          "mean_mse": 0.012268149070330843,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.5394501345218502,
-          "mean_mse": 0.012746625384613557,
+          "mean_cosine": 0.4872136849910266,
+          "mean_mse": 0.012236498558270498,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.5019621534918312,
-          "mean_mse": 0.01378472196376844,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.49064879969291036,
+          "mean_mse": 0.012208125627164466,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.44322373718911384,
-          "mean_mse": 0.014204733956058903,
-          "mean_rank": 3.5,
+          "mean_cosine": 0.4399807394802735,
+          "mean_mse": 0.012606877239017798,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.47489449582191356,
-          "mean_mse": 0.01354702163425573,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.4204874537767662,
-          "mean_mse": 0.01401258624809279,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.37847043052768536,
-          "mean_mse": 0.014258962150146864,
-          "mean_rank": 44.25,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.5230372158612374,
-          "mean_mse": 0.01379409828696477,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.47457645313477564,
-          "mean_mse": 0.014111221294568804,
-          "mean_rank": 2.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.5099992007139662,
-          "mean_mse": 0.014316734360629439,
+          "mean_cosine": 0.44856891651899233,
+          "mean_mse": 0.012529796995950984,
           "mean_rank": 2.5,
           "num_queries": 4
         },
+        "practical-compilation": {
+          "mean_cosine": 0.5871413686869154,
+          "mean_mse": 0.011031437432043927,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.39022832306856187,
+          "mean_mse": 0.013250129684224805,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.4386615457119968,
+          "mean_mse": 0.012954705740789454,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.47354466753888486,
+          "mean_mse": 0.012561762708903215,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.4683980255790914,
+          "mean_mse": 0.012548664045885678,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
         "prolog-directives": {
-          "mean_cosine": 0.4457261784751037,
-          "mean_mse": 0.014403978256949564,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.5233935072640596,
+          "mean_mse": 0.011607724226397186,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.382146871088639,
-          "mean_mse": 0.014357887826688377,
-          "mean_rank": 36.0,
+          "mean_cosine": 0.5078102485462911,
+          "mean_mse": 0.011836460173787164,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.4915020927286592,
-          "mean_mse": 0.013683012765054552,
+          "mean_cosine": 0.4357680485756306,
+          "mean_mse": 0.012951338900518559,
           "mean_rank": 3.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.3909689206888742,
-          "mean_mse": 0.014345939971373168,
-          "mean_rank": 8.6,
+          "mean_cosine": 0.3825533229533349,
+          "mean_mse": 0.013503126855241085,
+          "mean_rank": 6.6,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.45521814472406974,
-          "mean_mse": 0.013888251871255058,
-          "mean_rank": 3.0,
+          "mean_cosine": 0.47077974752780194,
+          "mean_mse": 0.012416958039595591,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.44781014766705546,
-          "mean_mse": 0.013685932032215815,
-          "mean_rank": 3.25,
+          "mean_cosine": 0.379820910448127,
+          "mean_mse": 0.013627267201183563,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.5378326670985871,
-          "mean_mse": 0.013511429942143476,
-          "mean_rank": 2.75,
+          "mean_cosine": 0.44433973226467505,
+          "mean_mse": 0.01261407586749326,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.4960833610616867,
-          "mean_mse": 0.013324757841273061,
+          "mean_cosine": 0.5044945104172025,
+          "mean_mse": 0.011967395285384704,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.4755554528622851,
-          "mean_mse": 0.013862027216791277,
-          "mean_rank": 31.25,
+          "mean_cosine": 0.48064763233094443,
+          "mean_mse": 0.012378900247345576,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.485803565309143,
-          "mean_mse": 0.013840280519411476,
+          "mean_cosine": 0.5180993684781837,
+          "mean_mse": 0.011807567799219964,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls0.5",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 0.5
+      },
+      "mean_cosine_to_target": 0.405937361030147,
+      "std_cosine_to_target": 0.11493473599628763,
+      "mean_mse_to_target": 0.014941582978064858,
+      "std_mse_to_target": 0.0002439363115025019,
+      "mean_target_rank": 4.329268292682927,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.24390243902439024,
+      "recall_at_5": 0.8414634146341463,
+      "recall_at_10": 0.9634146341463414,
+      "mrr": 0.4638811459543168,
+      "train_time_ms": 1.6953000013018027,
+      "inference_time_us": 236.25121950938527,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4936075412637767,
+          "mean_mse": 0.014798978014472932,
           "mean_rank": 2.0,
           "num_queries": 4
         },
-        "scc-tarjan": {
-          "mean_cosine": 0.4123570889869681,
-          "mean_mse": 0.014741877945383938,
-          "mean_rank": 29.0,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.44681179815410865,
+          "mean_mse": 0.014913263124256646,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "recursion-types": {
-          "mean_cosine": 0.3698046659749623,
-          "mean_mse": 0.01469491235186074,
-          "mean_rank": 35.5,
+        "compilation-pipeline": {
+          "mean_cosine": 0.44150542854565633,
+          "mean_mse": 0.014902785756286124,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.4986311599751022,
-          "mean_mse": 0.01401466427635951,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.5079975732488768,
-          "mean_mse": 0.013992702091904122,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.5302100933479298,
-          "mean_mse": 0.012934242294642857,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.4540199494896099,
-          "mean_mse": 0.014070112251124015,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.4844778641149584,
-          "mean_mse": 0.012987172479688475,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.5188668738602696,
-          "mean_mse": 0.013485859632631159,
+        "constraint-usage": {
+          "mean_cosine": 0.42200666584620633,
+          "mean_mse": 0.014849825670176883,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "bash-string-ops": {
-          "mean_cosine": 0.5181909996706784,
-          "mean_mse": 0.013746496955084366,
-          "mean_rank": 2.25,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4078827418245754,
+          "mean_mse": 0.014882384063847821,
+          "mean_rank": 2.75,
           "num_queries": 4
         },
-        "compiler-driver": {
-          "mean_cosine": 0.4914776549047301,
-          "mean_mse": 0.013455931351308868,
+        "practical-compilation": {
+          "mean_cosine": 0.5230677030920059,
+          "mean_mse": 0.014613370737948096,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "compile-api-reference": {
-          "mean_cosine": 0.5070764952577711,
-          "mean_mse": 0.013951260287549217,
-          "mean_rank": 2.5,
+        "generated-code-facts": {
+          "mean_cosine": 0.4199269728834154,
+          "mean_mse": 0.014799015493032888,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
-        "bash-constraints": {
-          "mean_cosine": 0.48586281126103653,
-          "mean_mse": 0.014163909938024036,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.4270413434994915,
-          "mean_mse": 0.013615619863335721,
-          "mean_rank": 95.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.4980801052634759,
-          "mean_mse": 0.014001560543341736,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.4478320220987662,
-          "mean_mse": 0.013936907945424331,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.42142102438957985,
-          "mean_mse": 0.01410538463269342,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.3684020095291751,
-          "mean_mse": 0.014820726738510828,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.4504664236814636,
-          "mean_mse": 0.013942072896571955,
-          "mean_rank": 3.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.4788740799955039,
-          "mean_mse": 0.01346483356517093,
+        "generated-code-transitive": {
+          "mean_cosine": 0.34121463634402893,
+          "mean_mse": 0.015107722176770151,
           "mean_rank": 5.75,
           "num_queries": 4
         },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.46742543077844506,
-          "mean_mse": 0.013483267397937194,
+        "prolog-facts-rules": {
+          "mean_cosine": 0.41063110878793363,
+          "mean_mse": 0.015025600440055362,
+          "mean_rank": 3.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.42447257497966306,
+          "mean_mse": 0.014969762004672451,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4588649720108513,
+          "mean_mse": 0.0147621536089797,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.44238945576679856,
+          "mean_mse": 0.014818139331768827,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "prolog-introspection": {
-          "mean_cosine": 0.4999833269923808,
-          "mean_mse": 0.013544241522975524,
-          "mean_rank": 2.5,
+        "init-pl-explained": {
+          "mean_cosine": 0.25560595760837534,
+          "mean_mse": 0.015210997519551113,
+          "mean_rank": 16.5,
           "num_queries": 4
         },
-        "call-graph-construction": {
-          "mean_cosine": 0.5033913017692954,
-          "mean_mse": 0.013862496732156846,
-          "mean_rank": 2.25,
+        "prolog-terms": {
+          "mean_cosine": 0.2867719052974832,
+          "mean_mse": 0.015244574558156726,
+          "mean_rank": 11.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4062346040245703,
+          "mean_mse": 0.014938782834185928,
+          "mean_rank": 3.5,
           "num_queries": 4
         },
-        "scc-detection": {
-          "mean_cosine": 0.3572372005052493,
-          "mean_mse": 0.014380243787333793,
-          "mean_rank": 21.75,
+        "recursion-patterns": {
+          "mean_cosine": 0.28709200215618746,
+          "mean_mse": 0.015227628423874286,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.5313122070258157,
-          "mean_mse": 0.01267441805435137,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.5079249206144801,
-          "mean_mse": 0.013616635030883645,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.5017064953681003,
-          "mean_mse": 0.014286018055214435,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.5372287114650887,
-          "mean_mse": 0.013215539116500075,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.41142444204146655,
-          "mean_mse": 0.014603155441343496,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.5076600927334629,
-          "mean_mse": 0.013806485403395932,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.4579850874630106,
-          "mean_mse": 0.014124477126658574,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "template-system": {
-          "mean_cosine": 0.34741028417683,
-          "mean_mse": 0.014670463251292882,
-          "mean_rank": 49.75,
-          "num_queries": 4
-        },
-        "template-customization": {
-          "mean_cosine": 0.45091479339832335,
-          "mean_mse": 0.014351649447360613,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.3636745590018896,
+          "mean_mse": 0.015061549827254299,
           "mean_rank": 4.0,
           "num_queries": 4
         },
-        "test-runner-inference": {
-          "mean_cosine": 0.5083592528461122,
-          "mean_mse": 0.013127379293054957,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4515950883758759,
+          "mean_mse": 0.014849196512279063,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.41829383158807865,
+          "mean_mse": 0.014927943761130531,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.4457156000451796,
+          "mean_mse": 0.014831233442076803,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls1.0",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.34018595737251617,
+      "std_cosine_to_target": 0.1251295707380046,
+      "mean_mse_to_target": 0.015216463675987106,
+      "std_mse_to_target": 0.00016333097494742934,
+      "mean_target_rank": 6.439024390243903,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.6707317073170732,
+      "recall_at_10": 0.8170731707317073,
+      "mrr": 0.39598345355160275,
+      "train_time_ms": 4.60219999513356,
+      "inference_time_us": 303.68658536179106,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.46375242491472235,
+          "mean_mse": 0.015067412274080677,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.38641089171888937,
+          "mean_mse": 0.015183458213255448,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.3802538886659678,
+          "mean_mse": 0.015159121242499268,
           "mean_rank": 2.75,
           "num_queries": 4
         },
-        "test-inference-heuristics": {
-          "mean_cosine": 0.4178758326733621,
-          "mean_mse": 0.013485981017884395,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "runtime-architecture": {
-          "mean_cosine": 0.4537405410754411,
-          "mean_mse": 0.013612809120263702,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "dotnet-deployment": {
-          "mean_cosine": 0.4084733883358111,
-          "mean_mse": 0.014228525571948866,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "csharp-testing": {
-          "mean_cosine": 0.46237280096534544,
-          "mean_mse": 0.014094769531442425,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "multi-target-overview": {
-          "mean_cosine": 0.4544192880156737,
-          "mean_mse": 0.01426317456955744,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "csharp-setup": {
-          "mean_cosine": 0.44358049836420416,
-          "mean_mse": 0.014245887424450291,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "query-runtime-overview": {
-          "mean_cosine": 0.23934696523267782,
-          "mean_mse": 0.014895846666184811,
-          "mean_rank": 93.5,
-          "num_queries": 4
-        },
-        "ir-components": {
-          "mean_cosine": 0.45597018404983103,
-          "mean_mse": 0.014265927978655998,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "fixpoint-iteration": {
-          "mean_cosine": 0.4575014027360097,
-          "mean_mse": 0.01352809125404304,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "mutual-recursion-csharp": {
-          "mean_cosine": 0.4889182267306251,
-          "mean_mse": 0.013752474583391305,
+        "constraint-usage": {
+          "mean_cosine": 0.3551542706562568,
+          "mean_mse": 0.015179606993277982,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "semantic-crawling": {
-          "mean_cosine": 0.5108544590616441,
-          "mean_mse": 0.013629273013486438,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.3330405254435198,
+          "mean_mse": 0.015225943760059542,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4423894732046525,
+          "mean_mse": 0.015067160162150999,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.387229820033105,
+          "mean_mse": 0.015128823496642695,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2733578463935698,
+          "mean_mse": 0.015319378855038594,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3460426755806767,
+          "mean_mse": 0.015230158066368616,
+          "mean_rank": 4.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3568203390085788,
+          "mean_mse": 0.015206827842414039,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.385748777726969,
+          "mean_mse": 0.015126773411302061,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.37776300933777396,
+          "mean_mse": 0.015151183812396843,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.17607492093836885,
+          "mean_mse": 0.015408584140214773,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.2335308078123904,
+          "mean_mse": 0.015381524952780357,
+          "mean_rank": 14.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.33922761246550454,
+          "mean_mse": 0.015225188057339963,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.20465394475106186,
+          "mean_mse": 0.015412175830317502,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.2727487463949086,
+          "mean_mse": 0.015345580995198158,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.38400562336259936,
+          "mean_mse": 0.01514000584544036,
           "mean_rank": 2.75,
           "num_queries": 4
         },
-        "vector-search": {
-          "mean_cosine": 0.3449659085564682,
-          "mean_mse": 0.014823319884305736,
-          "mean_rank": 10.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.35379398076982693,
+          "mean_mse": 0.015189912604323282,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
-        "powershell-semantic": {
-          "mean_cosine": 0.4583776388267201,
-          "mean_mse": 0.013340982858768318,
-          "mean_rank": 4.0,
+        "fold-pattern": {
+          "mean_cosine": 0.37691917610897374,
+          "mean_mse": 0.015135764047847245,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls2.0",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 2.0
+      },
+      "mean_cosine_to_target": 0.3196518607580046,
+      "std_cosine_to_target": 0.12710972855467173,
+      "mean_mse_to_target": 0.015265125077611522,
+      "std_mse_to_target": 0.00015330392346390252,
+      "mean_target_rank": 7.463414634146342,
+      "median_target_rank": 3.5,
+      "recall_at_1": 0.15853658536585366,
+      "recall_at_5": 0.6219512195121951,
+      "recall_at_10": 0.7926829268292683,
+      "mrr": 0.37377564591523404,
+      "train_time_ms": 1.5720000010333024,
+      "inference_time_us": 338.4853658733447,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4529404194150339,
+          "mean_mse": 0.015115764774433434,
+          "mean_rank": 2.0,
           "num_queries": 4
         },
-        "csharp-stream-target": {
-          "mean_cosine": 0.4080537879963372,
-          "mean_mse": 0.014048675213940993,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "csharp-stream-rules": {
-          "mean_cosine": 0.4144034033200391,
-          "mean_mse": 0.014282701010431184,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "stream-target-limitations": {
-          "mean_cosine": 0.5937563613861186,
-          "mean_mse": 0.012007688909158142,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "b4-c4-cost-speed-quality": {
-          "mean_cosine": 0.5696384189263147,
-          "mean_mse": 0.011328106656796484,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c4-decision-heuristics": {
-          "mean_cosine": 0.5013294270259921,
-          "mean_mse": 0.01298242446788541,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b4-c4-resource-constraints": {
-          "mean_cosine": 0.5978421453504684,
-          "mean_mse": 0.011286548188792052,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-enhanced-pipeline-stages": {
-          "mean_cosine": 0.49245921745472687,
-          "mean_mse": 0.012795769246429804,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-stream-combination": {
-          "mean_cosine": 0.5324919050699585,
-          "mean_mse": 0.013499592038466497,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c6-flow-control": {
-          "mean_cosine": 0.6488000202019187,
-          "mean_mse": 0.010391120552360463,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c6-error-throughput": {
-          "mean_cosine": 0.4996279414663975,
-          "mean_mse": 0.013422136276118215,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b4-c5-example-libraries": {
-          "mean_cosine": 0.5411908371791688,
-          "mean_mse": 0.01337634927400654,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c5-example-record-format": {
-          "mean_cosine": 0.5717444216905324,
-          "mean_mse": 0.012914263820645228,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c5-cross-references": {
-          "mean_cosine": 0.6467024928583237,
-          "mean_mse": 0.011106163399677557,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-multi-target-pipelines": {
-          "mean_cosine": 0.5404441662320321,
-          "mean_mse": 0.012306331793208072,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-target-selection": {
-          "mean_cosine": 0.5851721661837547,
-          "mean_mse": 0.012574532824760435,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c3-pipeline-composition": {
-          "mean_cosine": 0.6014435029903007,
-          "mean_mse": 0.01195933849975684,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c1-workflows-vs-playbooks": {
-          "mean_cosine": 0.5879908206088017,
-          "mean_mse": 0.012238179780863764,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b4-c2-playbook-format": {
-          "mean_cosine": 0.5611043054055056,
-          "mean_mse": 0.011927342670580517,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b4-c2-callout-types": {
-          "mean_cosine": 0.558278066305212,
-          "mean_mse": 0.01304881259321903,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-generator-mode": {
-          "mean_cosine": 0.5561319744836731,
-          "mean_mse": 0.01187214395262824,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c3-frozendict": {
-          "mean_cosine": 0.5410935606832926,
-          "mean_mse": 0.01207200853098711,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c3-negation": {
-          "mean_cosine": 0.5693801468146743,
-          "mean_mse": 0.012285207284786168,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c1-python-overview": {
-          "mean_cosine": 0.5549977382479744,
-          "mean_mse": 0.013316227239939553,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c1-target-comparison": {
-          "mean_cosine": 0.4996939593893097,
-          "mean_mse": 0.01283863157548612,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-procedural-mode": {
-          "mean_cosine": 0.5787788628042989,
-          "mean_mse": 0.011523891486858775,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-constraints-arithmetic": {
-          "mean_cosine": 0.6086943891421042,
-          "mean_mse": 0.012196775817770135,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c2-io-formats": {
-          "mean_cosine": 0.5192599947563181,
-          "mean_mse": 0.01255890525012459,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-recursion-overview": {
-          "mean_cosine": 0.4933944521593345,
-          "mean_mse": 0.01315284696213092,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b5-c4-tail-recursion": {
-          "mean_cosine": 0.5542859864842238,
-          "mean_mse": 0.01304029419209613,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b5-c4-memoization": {
-          "mean_cosine": 0.5742254259327423,
-          "mean_mse": 0.01174096665095859,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c4-mutual-recursion": {
-          "mean_cosine": 0.5751973192261667,
-          "mean_mse": 0.01333337268077637,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-semantic-overview": {
-          "mean_cosine": 0.5474921820709518,
-          "mean_mse": 0.013221783229255912,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-vector-search": {
-          "mean_cosine": 0.5380443493635579,
-          "mean_mse": 0.01363388658480399,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b5-c5-graph-rag": {
-          "mean_cosine": 0.5182079991295304,
-          "mean_mse": 0.012715658850771994,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b5-c5-crawling-llm": {
-          "mean_cosine": 0.5683208087536529,
-          "mean_mse": 0.011998475519504776,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-c3-regex-constraints": {
-          "mean_cosine": 0.5390693810283248,
-          "mean_mse": 0.012862563631094432,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c4-json-processing": {
-          "mean_cosine": 0.6193330909061944,
-          "mean_mse": 0.012466045299719092,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-core-apis": {
-          "mean_cosine": 0.599126734005465,
-          "mean_mse": 0.01237381815323979,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a1-recursion-apis": {
-          "mean_cosine": 0.5237796853087785,
-          "mean_mse": 0.013400099325132435,
-          "mean_rank": 2.6666666666666665,
-          "num_queries": 3
-        },
-        "b6-a1-api-selection": {
-          "mean_cosine": 0.6203423248937004,
-          "mean_mse": 0.012297398321506095,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a2-mode-complexity": {
-          "mean_cosine": 0.6566900021149408,
-          "mean_mse": 0.012124319870886647,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-recursion-complexity": {
-          "mean_cosine": 0.561916626167622,
-          "mean_mse": 0.012140542428627818,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a2-db-complexity": {
-          "mean_cosine": 0.5806138423400689,
-          "mean_mse": 0.012371366071265369,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-boltdb-schema": {
-          "mean_cosine": 0.5448551104904239,
-          "mean_mse": 0.011550739853316373,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-key-strategies": {
-          "mean_cosine": 0.5728317081434112,
-          "mean_mse": 0.012927668926266622,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b6-a3-query-outside": {
-          "mean_cosine": 0.5715568052463823,
-          "mean_mse": 0.012982154075318114,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-a3-incremental": {
-          "mean_cosine": 0.5804298156745619,
-          "mean_mse": 0.011705357828699062,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-generator-mode": {
-          "mean_cosine": 0.5154195265916662,
-          "mean_mse": 0.013790810301512671,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b6-c6-aggregation-negation": {
-          "mean_cosine": 0.5511213464089005,
-          "mean_mse": 0.012755112400133363,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c6-parallel-persistence": {
-          "mean_cosine": 0.5977839376774526,
-          "mean_mse": 0.012348320639479769,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c1-go-overview": {
-          "mean_cosine": 0.6371379868514171,
-          "mean_mse": 0.010178799481284395,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c2-basic-compilation": {
-          "mean_cosine": 0.5967922285543099,
-          "mean_mse": 0.01119996034415618,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursive-compilation": {
-          "mean_cosine": 0.5189184181126515,
-          "mean_mse": 0.012908582636302568,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c7-recursion-patterns": {
-          "mean_cosine": 0.5465027042064109,
-          "mean_mse": 0.012961473812977554,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b6-c5-semantic-runtime": {
-          "mean_cosine": 0.5541022691690706,
-          "mean_mse": 0.012602405879239303,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12a-service-mesh": {
-          "mean_cosine": 0.57418783431191,
-          "mean_mse": 0.011756346442963639,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12b-polyglot": {
-          "mean_cosine": 0.5876664359296359,
-          "mean_mse": 0.011679649009556495,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12c-discovery-tracing": {
-          "mean_cosine": 0.5283677372141397,
-          "mean_mse": 0.012955826696232964,
-          "mean_rank": 1.3333333333333333,
-          "num_queries": 3
-        },
-        "b7-c12d-kg-topology": {
-          "mean_cosine": 0.6259417724390474,
-          "mean_mse": 0.011477202127904144,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c7-dotnet-bridges": {
-          "mean_cosine": 0.5184872889712441,
-          "mean_mse": 0.013964087760063394,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c8-ironpython-compat": {
-          "mean_cosine": 0.5232546508111584,
-          "mean_mse": 0.013448317847500607,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c1-cross-target-overview": {
-          "mean_cosine": 0.6002574877998156,
-          "mean_mse": 0.011822413310940631,
-          "mean_rank": 3.0,
-          "num_queries": 3
-        },
-        "b7-c1-runtime-families": {
-          "mean_cosine": 0.5116523708050517,
-          "mean_mse": 0.01401385894154542,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c2-design-principles": {
-          "mean_cosine": 0.5783968804417535,
-          "mean_mse": 0.011853588426441604,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c2-data-formats": {
-          "mean_cosine": 0.512975004368761,
-          "mean_mse": 0.012274194879026182,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c9-native-code-gen": {
-          "mean_cosine": 0.5521960272749737,
-          "mean_mse": 0.013977871080591403,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c10-native-orchestration": {
-          "mean_cosine": 0.5859352406407814,
-          "mean_mse": 0.012623729437433081,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c11-http-services": {
-          "mean_cosine": 0.5528055050169512,
-          "mean_mse": 0.01281700950612792,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c12-distributed-pipelines": {
-          "mean_cosine": 0.589348483730594,
-          "mean_mse": 0.011806290328863813,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
-        },
-        "b7-c15-deployment": {
-          "mean_cosine": 0.5450259341422916,
-          "mean_mse": 0.01298575456799217,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c16-cloud-enterprise": {
-          "mean_cosine": 0.4670075804476687,
-          "mean_mse": 0.013373151835051797,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c14-case-studies": {
-          "mean_cosine": 0.624908679047054,
-          "mean_mse": 0.011557708975713059,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c5-shell-glue": {
-          "mean_cosine": 0.5229788035540818,
-          "mean_mse": 0.01310589695045498,
-          "mean_rank": 2.3333333333333335,
-          "num_queries": 3
-        },
-        "b7-c6-pipeline-orchestration": {
-          "mean_cosine": 0.4802600388926403,
-          "mean_mse": 0.013544022749336915,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-target-registry": {
-          "mean_cosine": 0.6367789708210919,
-          "mean_mse": 0.0117356113806218,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "b7-c3-location-resolution": {
-          "mean_cosine": 0.4572670103573832,
-          "mean_mse": 0.013439374869922785,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "firewall-001": {
-          "mean_cosine": 0.702977224404474,
-          "mean_mse": 0.008234161414322119,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-002": {
-          "mean_cosine": 0.7194410138141207,
-          "mean_mse": 0.008632399953691524,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "firewall-003": {
-          "mean_cosine": 0.9999834717605959,
-          "mean_mse": 1.8845158773259053e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "security-001": {
-          "mean_cosine": 0.6704077458529929,
-          "mean_mse": 0.00948787426007019,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "security-002": {
-          "mean_cosine": 0.641666391661398,
-          "mean_mse": 0.010339293938717999,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "hooks-001": {
-          "mean_cosine": 0.6176476423052999,
-          "mean_mse": 0.010354187017327744,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "hooks-002": {
-          "mean_cosine": 0.6215819654178956,
-          "mean_mse": 0.00995868796192028,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "production-001": {
-          "mean_cosine": 0.651297120702515,
-          "mean_mse": 0.010031272681614276,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-002": {
-          "mean_cosine": 0.7196830700333872,
-          "mean_mse": 0.008473552493979642,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "production-003": {
-          "mean_cosine": 0.6508240303825549,
-          "mean_mse": 0.009731895860154006,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "target-sec-001": {
-          "mean_cosine": 0.7308448876710825,
-          "mean_mse": 0.008668629857190111,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "target-sec-002": {
-          "mean_cosine": 0.7340429395263338,
-          "mean_mse": 0.007775588613101502,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "validation-001": {
-          "mean_cosine": 0.7536399296806866,
-          "mean_mse": 0.007004452423999469,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "validation-002": {
-          "mean_cosine": 0.9999863496171348,
-          "mean_mse": 1.992443868964308e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "validation-003": {
-          "mean_cosine": 0.9999805153185134,
-          "mean_mse": 1.8450377531535644e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-compile-001": {
-          "mean_cosine": 0.6594362176160702,
-          "mean_mse": 0.01042569812218367,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-compile-002": {
-          "mean_cosine": 0.6833799474816102,
-          "mean_mse": 0.008529299318971022,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-001": {
-          "mean_cosine": 0.793761790441323,
-          "mean_mse": 0.006884576111614627,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-002": {
-          "mean_cosine": 0.999990649163958,
-          "mean_mse": 1.987365615164115e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "rust-project-001": {
-          "mean_cosine": 0.6279149243558718,
-          "mean_mse": 0.009731767962320382,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "rust-advanced-001": {
-          "mean_cosine": 0.7023134882857966,
-          "mean_mse": 0.008258264418570525,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-basic-001": {
-          "mean_cosine": 0.7307272269594205,
-          "mean_mse": 0.007774396454251811,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-basic-002": {
-          "mean_cosine": 0.9999853950975626,
-          "mean_mse": 2.1759271967618236e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-case-001": {
-          "mean_cosine": 0.677604222866371,
-          "mean_mse": 0.009500767589052966,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-case-002": {
-          "mean_cosine": 0.9999863905189693,
-          "mean_mse": 2.1427658284592103e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-cte-001": {
-          "mean_cosine": 0.6810479819973217,
-          "mean_mse": 0.0109997309003284,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-cte-002": {
-          "mean_cosine": 0.7333211528071802,
-          "mean_mse": 0.00814959181460806,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-001": {
-          "mean_cosine": 0.7159496662028384,
-          "mean_mse": 0.007949654203975962,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-002": {
-          "mean_cosine": 0.9999864540511949,
-          "mean_mse": 1.716238050068155e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-join-001": {
-          "mean_cosine": 0.6995716341691915,
-          "mean_mse": 0.00851446850271664,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-agg-001": {
-          "mean_cosine": 0.9999851265820914,
-          "mean_mse": 2.3252357616625532e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-practical-001": {
-          "mean_cosine": 0.7208195430737174,
-          "mean_mse": 0.00784187058031767,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-practical-002": {
-          "mean_cosine": 0.9999792217017858,
-          "mean_mse": 2.2994617783396532e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-set-001": {
-          "mean_cosine": 0.7222534631929313,
-          "mean_mse": 0.009382750769788164,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-001": {
-          "mean_cosine": 0.7616546181263106,
-          "mean_mse": 0.006722224270807343,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-func-002": {
-          "mean_cosine": 0.7165670628475782,
-          "mean_mse": 0.008616882310397811,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "sql-subquery-001": {
-          "mean_cosine": 0.7799041485281961,
-          "mean_mse": 0.007014742538054113,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "sql-subquery-002": {
-          "mean_cosine": 0.9999853074679719,
-          "mean_mse": 1.8791240824373874e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "sql-window-001": {
-          "mean_cosine": 0.6358262077819834,
-          "mean_mse": 0.010277204206673517,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "sql-window-002": {
-          "mean_cosine": 0.6913467044772873,
-          "mean_mse": 0.008588543269973353,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "prolog-case-001": {
-          "mean_cosine": 0.9999877306938848,
-          "mean_mse": 2.3278241922452323e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-api-001": {
-          "mean_cosine": 0.6997219667331616,
-          "mean_mse": 0.010322268496935067,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-dialect-001": {
-          "mean_cosine": 0.6993623139229971,
-          "mean_mse": 0.009092978715936827,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "prolog-dialect-002": {
-          "mean_cosine": 0.9999846852262518,
-          "mean_mse": 2.196653510035261e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-firewall-001": {
-          "mean_cosine": 0.9999852144864477,
-          "mean_mse": 1.843502691261379e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "prolog-fallback-001": {
-          "mean_cosine": 0.7027261215718262,
-          "mean_mse": 0.009027475835309499,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "prolog-target-001": {
-          "mean_cosine": 0.704162742756685,
-          "mean_mse": 0.010533716746343715,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-001": {
-          "mean_cosine": 0.7695198538510046,
-          "mean_mse": 0.007121299129476778,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-cmdlet-002": {
-          "mean_cosine": 0.9999835637581724,
-          "mean_mse": 1.6506484135742977e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-hosting-001": {
-          "mean_cosine": 0.6105731363523201,
-          "mean_mse": 0.01028673519417982,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-dotnet-001": {
-          "mean_cosine": 0.7406210967420068,
-          "mean_mse": 0.008265316427155894,
-          "mean_rank": 2.0,
-          "num_queries": 2
-        },
-        "ps-dotnet-002": {
-          "mean_cosine": 0.9999865126629498,
-          "mean_mse": 1.897628994708885e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-facts-001": {
-          "mean_cosine": 0.7271812483216982,
-          "mean_mse": 0.008519177770675542,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-facts-002": {
-          "mean_cosine": 0.9999893574992488,
-          "mean_mse": 1.689529751691269e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "ps-001": {
-          "mean_cosine": 0.7960936571183377,
-          "mean_mse": 0.006891374751487354,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-001": {
-          "mean_cosine": 0.7128900645632603,
-          "mean_mse": 0.008119782026646451,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ps-windows-002": {
-          "mean_cosine": 0.9999840036841792,
-          "mean_mse": 1.987585248067475e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-adversarial-001": {
-          "mean_cosine": 0.9999900930086487,
-          "mean_mse": 1.625458824546231e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-routing-001": {
-          "mean_cosine": 0.9999911074030677,
-          "mean_mse": 1.8504636629463655e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-scalefree-001": {
-          "mean_cosine": 0.9999880364037922,
-          "mean_mse": 2.1505562725363924e-05,
-          "mean_rank": 1.0,
-          "num_queries": 1
-        },
-        "semantic-density-001": {
-          "mean_cosine": 0.7297961471612542,
-          "mean_mse": 0.008110334428773671,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-dist-001": {
-          "mean_cosine": 0.7044852522458551,
-          "mean_mse": 0.008007343978450095,
-          "mean_rank": 1.0,
-          "num_queries": 2
-        },
-        "semantic-001": {
-          "mean_cosine": 0.6827330169974624,
-          "mean_mse": 0.009567596293825337,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "semantic-polyglot-001": {
-          "mean_cosine": 0.7088491943334361,
-          "mean_mse": 0.008106080859291109,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-advanced-001": {
-          "mean_cosine": 0.5788366623693343,
-          "mean_mse": 0.01188630914504421,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-deploy-001": {
-          "mean_cosine": 0.7381566380481019,
-          "mean_mse": 0.008042958102385513,
-          "mean_rank": 1.5,
-          "num_queries": 2
-        },
-        "ai-foundations-001": {
-          "mean_cosine": 0.5338611173139056,
-          "mean_mse": 0.01356109295244604,
-          "mean_rank": 2.0,
-          "num_queries": 3
-        },
-        "ai-kgtopo-001": {
-          "mean_cosine": 0.4321295369720706,
-          "mean_mse": 0.014439855630576119,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.3667145134545533,
+          "mean_mse": 0.015231703692795435,
           "mean_rank": 4.25,
           "num_queries": 4
         },
-        "ai-lda-001": {
-          "mean_cosine": 0.60583432258759,
-          "mean_mse": 0.011829662164233116,
-          "mean_rank": 2.0,
-          "num_queries": 3
+        "compilation-pipeline": {
+          "mean_cosine": 0.3618800978451339,
+          "mean_mse": 0.015205376961234312,
+          "mean_rank": 3.75,
+          "num_queries": 4
         },
-        "ai-multihead-001": {
-          "mean_cosine": 0.5316498807278336,
-          "mean_mse": 0.012099823500323076,
-          "mean_rank": 2.0,
-          "num_queries": 3
+        "constraint-usage": {
+          "mean_cosine": 0.3307928562569845,
+          "mean_mse": 0.015234561247108746,
+          "mean_rank": 4.25,
+          "num_queries": 4
         },
-        "ai-pipeline-001": {
-          "mean_cosine": 0.5875908320575594,
-          "mean_mse": 0.010513361841653326,
-          "mean_rank": 2.0,
-          "num_queries": 2
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.30742828120763005,
+          "mean_mse": 0.01528366568778114,
+          "mean_rank": 8.25,
+          "num_queries": 4
         },
-        "ai-distill-001": {
-          "mean_cosine": 0.6241417119551825,
-          "mean_mse": 0.012059938543593175,
-          "mean_rank": 1.6666666666666667,
-          "num_queries": 3
+        "practical-compilation": {
+          "mean_cosine": 0.4150871425959187,
+          "mean_mse": 0.015144204124796019,
+          "mean_rank": 3.5,
+          "num_queries": 4
         },
-        "prereq-prolog-installation": {
-          "mean_cosine": 0.5229528514175756,
-          "mean_mse": 0.012022599748125756,
+        "generated-code-facts": {
+          "mean_cosine": 0.3713241435098161,
+          "mean_mse": 0.015186004786206814,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2539562906099904,
+          "mean_mse": 0.015357678867771226,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.32599659163351313,
+          "mean_mse": 0.01526960802424647,
+          "mean_rank": 5.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.33668436263687007,
+          "mean_mse": 0.015250003160607723,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.3629779406248097,
+          "mean_mse": 0.01518948909018175,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.357093648689157,
+          "mean_mse": 0.015210576930558856,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.1561228328452625,
+          "mean_mse": 0.015445249391765973,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.2184605430821649,
+          "mean_mse": 0.015408173734700442,
+          "mean_rank": 14.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.3182948339975532,
+          "mean_mse": 0.015275692796261687,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.1830290096554953,
+          "mean_mse": 0.015444508403211507,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.24479366074735281,
+          "mean_mse": 0.015393057573645553,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.36347108693641794,
+          "mean_mse": 0.015192081829500962,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.3337872377061584,
+          "mean_mse": 0.015237437833683953,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.35591336841036025,
+          "mean_mse": 0.015190779740807493,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls0.5",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 0.5
+      },
+      "mean_cosine_to_target": 0.4161653932633903,
+      "std_cosine_to_target": 0.11288062049449174,
+      "mean_mse_to_target": 0.014866066964442379,
+      "std_mse_to_target": 0.0002688360367163572,
+      "mean_target_rank": 4.170731707317073,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.25609756097560976,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.9634146341463414,
+      "mrr": 0.471508978826052,
+      "train_time_ms": 1.6318000052706338,
+      "inference_time_us": 220.82804881814278,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.49792564330181355,
+          "mean_mse": 0.014721438544931027,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4554859826438704,
+          "mean_mse": 0.014833793463498274,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.45199728685957485,
+          "mean_mse": 0.014826475599101684,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4269854827016234,
+          "mean_mse": 0.01477288094627928,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4148928206205189,
+          "mean_mse": 0.01480468843970025,
           "mean_rank": 2.5,
           "num_queries": 4
         },
-        "prereq-init-environment": {
-          "mean_cosine": 0.3706144498820293,
-          "mean_mse": 0.015173332387346056,
-          "mean_rank": 75.6,
+        "practical-compilation": {
+          "mean_cosine": 0.5338063779715255,
+          "mean_mse": 0.014493380106453532,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.4199384336361399,
+          "mean_mse": 0.014722622221794036,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.35478997631243786,
+          "mean_mse": 0.015043656272137326,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.42191371862583704,
+          "mean_mse": 0.014963398679671374,
+          "mean_rank": 3.6,
           "num_queries": 5
         },
-        "prereq-module-paths": {
-          "mean_cosine": 0.5815892970695068,
-          "mean_mse": 0.013005725362684108,
-          "mean_rank": 2.0,
-          "num_queries": 3
+        "prolog-modules": {
+          "mean_cosine": 0.43493918526648,
+          "mean_mse": 0.014899979744714367,
+          "mean_rank": 2.25,
+          "num_queries": 4
         },
-        "prereq-project-structure": {
-          "mean_cosine": 0.4561089944634415,
-          "mean_mse": 0.014492068968000999,
+        "prolog-directives": {
+          "mean_cosine": 0.47034216486110536,
+          "mean_mse": 0.014664240030033443,
           "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.4534658861537717,
+          "mean_mse": 0.01472862167570352,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.27293977782766987,
+          "mean_mse": 0.015151097615382867,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.2977521570358971,
+          "mean_mse": 0.015202914550313204,
+          "mean_rank": 10.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4165622008284184,
+          "mean_mse": 0.014860721673320549,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.3020139332669869,
+          "mean_mse": 0.015177829081166737,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.37676435703100086,
+          "mean_mse": 0.014983082424703753,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4636749751470336,
+          "mean_mse": 0.014765437007686448,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.4280595944444555,
+          "mean_mse": 0.014853646926675595,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.45722413844790655,
+          "mean_mse": 0.014742889460305334,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls1.0",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.35111617259727734,
+      "std_cosine_to_target": 0.12393810230807152,
+      "mean_mse_to_target": 0.015186490911292197,
+      "std_mse_to_target": 0.00017021719108202015,
+      "mean_target_rank": 5.951219512195122,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.7439024390243902,
+      "recall_at_10": 0.8658536585365854,
+      "mrr": 0.4230189187506261,
+      "train_time_ms": 1.563599995279219,
+      "inference_time_us": 218.93536585394475,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4693332839986665,
+          "mean_mse": 0.01503737052818866,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.3968002820672408,
+          "mean_mse": 0.015153200470038281,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.3904511531019128,
+          "mean_mse": 0.015130194579505091,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.36664809566971124,
+          "mean_mse": 0.01514654565799822,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.34560180019587694,
+          "mean_mse": 0.015191632778568236,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4563855949335015,
+          "mean_mse": 0.015019479787020628,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.39435856188562224,
+          "mean_mse": 0.015094608408865028,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.28434752957979803,
+          "mean_mse": 0.015295280126962643,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3570359511874086,
+          "mean_mse": 0.015205870009800646,
+          "mean_rank": 4.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.36786485270395036,
+          "mean_mse": 0.015180008420841433,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.39802026411092883,
+          "mean_mse": 0.015088067069401493,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.38881623967752027,
+          "mean_mse": 0.015115024081346934,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.18751932197171473,
+          "mean_mse": 0.015385811469740496,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.2419384830619725,
+          "mean_mse": 0.015365156226032784,
+          "mean_rank": 13.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.35031823976190485,
+          "mean_mse": 0.015194199814342788,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.21696869861223644,
+          "mean_mse": 0.015392276080079505,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.2876913771728531,
+          "mean_mse": 0.015315535006531341,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.39547546464125316,
+          "mean_mse": 0.015107699777102713,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.3643183541814024,
+          "mean_mse": 0.015160687640697366,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.38824438116636595,
+          "mean_mse": 0.015101659189467433,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls2.0",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 2.0
+      },
+      "mean_cosine_to_target": 0.32361393523055937,
+      "std_cosine_to_target": 0.12676389047392594,
+      "mean_mse_to_target": 0.015256445111845955,
+      "std_mse_to_target": 0.0001549669675200642,
+      "mean_target_rank": 7.365853658536586,
+      "median_target_rank": 3.5,
+      "recall_at_1": 0.15853658536585366,
+      "recall_at_5": 0.6341463414634146,
+      "recall_at_10": 0.8048780487804879,
+      "mrr": 0.37647329060332324,
+      "train_time_ms": 1.9136000046273693,
+      "inference_time_us": 319.5743902768122,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.455100341365948,
+          "mean_mse": 0.01510707085050289,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.37054921036118466,
+          "mean_mse": 0.015223019181695682,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.36543490735209716,
+          "mean_mse": 0.015197031674999988,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.33538547414020825,
+          "mean_mse": 0.015225015578426005,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.3122928980848545,
+          "mean_mse": 0.015273657228737312,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4203992382106377,
+          "mean_mse": 0.01513060646147556,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.37449675851027986,
+          "mean_mse": 0.015175976198727504,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2577189468093207,
+          "mean_mse": 0.015350751313658826,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3299083381632994,
+          "mean_mse": 0.015262406312910547,
+          "mean_rank": 5.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.34054271769706235,
+          "mean_mse": 0.01524221325032596,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.36737793856411005,
+          "mean_mse": 0.01517839292916192,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.3611373249296747,
+          "mean_mse": 0.015200019253936778,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.1598893268493329,
+          "mean_mse": 0.015438602883113028,
+          "mean_rank": 24.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.2213646621754176,
+          "mean_mse": 0.015403301148720964,
+          "mean_rank": 14.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.322328851678118,
+          "mean_mse": 0.015266709532645587,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.1870841549734377,
+          "mean_mse": 0.015438761507726738,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.25015623837851664,
+          "mean_mse": 0.015384635306752454,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.3674713984955271,
+          "mean_mse": 0.015182736859971183,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.33764203970018697,
+          "mean_mse": 0.015228904144764284,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.3599866557025721,
+          "mean_mse": 0.015180886309180922,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern32_ls1.0",
+      "params": {
+        "kernel": "Matern32",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.35863189280062713,
+      "std_cosine_to_target": 0.12306615791611791,
+      "mean_mse_to_target": 0.01516391754105198,
+      "std_mse_to_target": 0.00017569600663536137,
+      "mean_target_rank": 5.658536585365853,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.7439024390243902,
+      "recall_at_10": 0.9024390243902439,
+      "mrr": 0.42747823399500234,
+      "train_time_ms": 1.5735999986645766,
+      "inference_time_us": 330.87682929429474,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4731365749393706,
+          "mean_mse": 0.015014533361877476,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.40387196392004165,
+          "mean_mse": 0.01513006092933859,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.3976764446056411,
+          "mean_mse": 0.015108046163052327,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.37381194935036643,
+          "mean_mse": 0.015122374222136003,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.35361833427041645,
+          "mean_mse": 0.015166782717590341,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.4657414015806439,
+          "mean_mse": 0.014983671630846542,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3985104176498963,
+          "mean_mse": 0.015069825867561424,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2922830400224624,
+          "mean_mse": 0.01527671965202483,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3648063638981361,
+          "mean_mse": 0.015187288713742489,
+          "mean_rank": 4.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3755633495911954,
+          "mean_mse": 0.015159564219044377,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.406539908589405,
+          "mean_mse": 0.015058960521501966,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.39653310619265886,
+          "mean_mse": 0.015087986746038538,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.19584083814693826,
+          "mean_mse": 0.0153683416723382,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.24798553091519676,
+          "mean_mse": 0.015352644834756434,
+          "mean_rank": 12.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.3579230762633938,
+          "mean_mse": 0.015170923872532712,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.2257749073527921,
+          "mean_mse": 0.015377360075875472,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.29787754427366375,
+          "mean_mse": 0.015292714289210203,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.40368125688742307,
+          "mean_mse": 0.015083154745571167,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.37147199208022363,
+          "mean_mse": 0.015138639226982813,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.39610782817965745,
+          "mean_mse": 0.015075732742418945,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.1",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.26653943410853237,
+      "std_cosine_to_target": 0.1699937527137012,
+      "mean_mse_to_target": 0.014419152587003456,
+      "std_mse_to_target": 0.0014533077858181987,
+      "mean_target_rank": 12.682926829268293,
+      "median_target_rank": 6.0,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.47560975609756095,
+      "recall_at_10": 0.6463414634146342,
+      "mrr": 0.2636378789565726,
+      "train_time_ms": 182.67249999917112,
+      "inference_time_us": 573.2573170950295,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.5183438407027111,
+          "mean_mse": 0.011648627063899984,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4653366496977606,
+          "mean_mse": 0.012337288078085458,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.48786473902067823,
+          "mean_mse": 0.011926944267223953,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.42592116200734403,
+          "mean_mse": 0.012789344011053307,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.2552712165601992,
+          "mean_mse": 0.014578598860980327,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.2691753635490536,
+          "mean_mse": 0.014614036011088604,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.29965777547300215,
+          "mean_mse": 0.014682547814742087,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.17308982875240597,
+          "mean_mse": 0.015402162068052914,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.2074333498639139,
+          "mean_mse": 0.015123598638112922,
+          "mean_rank": 17.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.20000750275130313,
+          "mean_mse": 0.015045346786485291,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.256391825382183,
+          "mean_mse": 0.01462178526098011,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.28942125615530345,
+          "mean_mse": 0.014625737697488265,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.13629256343423526,
+          "mean_mse": 0.01552358744410827,
+          "mean_rank": 26.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.09920319868297175,
+          "mean_mse": 0.015527396291675686,
+          "mean_rank": 25.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.21827665547150732,
+          "mean_mse": 0.014912521176161462,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.15466275281750128,
+          "mean_mse": 0.015233827879579127,
+          "mean_rank": 22.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.1912383734180621,
+          "mean_mse": 0.014974743014070046,
+          "mean_rank": 19.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.33367173297078945,
+          "mean_mse": 0.014221775386041646,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.17955687237639578,
+          "mean_mse": 0.0152647981857992,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.22658260300087074,
+          "mean_mse": 0.014875213365495023,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.1_k5",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": 5
+      },
+      "mean_cosine_to_target": 0.2272918804534964,
+      "std_cosine_to_target": 0.18157596567720252,
+      "mean_mse_to_target": 0.014641296728733488,
+      "std_mse_to_target": 0.0014413265845321863,
+      "mean_target_rank": 15.829268292682928,
+      "median_target_rank": 9.5,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.4024390243902439,
+      "recall_at_10": 0.5121951219512195,
+      "mrr": 0.23358990390358275,
+      "train_time_ms": 173.36629999772413,
+      "inference_time_us": 580.8804877543902,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.5201898282402507,
+          "mean_mse": 0.01169924599110806,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.478279173290095,
+          "mean_mse": 0.01220519715516616,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49554364443934906,
+          "mean_mse": 0.011871650170421157,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4412791970335171,
+          "mean_mse": 0.012565546081399528,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.25357475251420836,
+          "mean_mse": 0.014651226746915708,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.21911161779819588,
+          "mean_mse": 0.015025094735479435,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.20445510218786767,
+          "mean_mse": 0.015542422003323446,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.14764447284250048,
+          "mean_mse": 0.015447650098461389,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.15873805699011162,
+          "mean_mse": 0.015378769249976826,
+          "mean_rank": 19.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.126207595862482,
+          "mean_mse": 0.015375851602531299,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.19106182208619496,
+          "mean_mse": 0.015130915751508232,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.23646944023470376,
+          "mean_mse": 0.01508745235511285,
+          "mean_rank": 11.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.1260808996579103,
+          "mean_mse": 0.015508358505272853,
+          "mean_rank": 27.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.05319426758610586,
+          "mean_mse": 0.01560590543756136,
+          "mean_rank": 31.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.11886547486744321,
+          "mean_mse": 0.015392042923286081,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.08980627109693617,
+          "mean_mse": 0.015454191049730004,
+          "mean_rank": 27.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.14666348741859395,
+          "mean_mse": 0.015178342540111573,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.24799293811944406,
+          "mean_mse": 0.014910302793683812,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.13337619600270145,
+          "mean_mse": 0.015432750905746546,
+          "mean_rank": 24.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.2179662298840102,
+          "mean_mse": 0.01493749817035563,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.01",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.01,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.23926337903899447,
+      "std_cosine_to_target": 0.18284889639508317,
+      "mean_mse_to_target": 0.014549507114178302,
+      "std_mse_to_target": 0.0014333359329982587,
+      "mean_target_rank": 15.060975609756097,
+      "median_target_rank": 9.5,
+      "recall_at_1": 0.10975609756097561,
+      "recall_at_5": 0.3902439024390244,
+      "recall_at_10": 0.5609756097560976,
+      "mrr": 0.2499880021585575,
+      "train_time_ms": 171.31749899999704,
+      "inference_time_us": 575.5878048991534,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.5136847718630257,
+          "mean_mse": 0.011886867779387838,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4801633912621569,
+          "mean_mse": 0.01219314132004862,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49653416492386226,
+          "mean_mse": 0.01186031347101209,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4432788803896567,
+          "mean_mse": 0.012535611028474855,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.27357576445473497,
+          "mean_mse": 0.014524382799956877,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.35991844808482537,
+          "mean_mse": 0.013900205026227911,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.18791815781085422,
+          "mean_mse": 0.015652343274811884,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.11971901997771692,
+          "mean_mse": 0.015501505094307888,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.1413142202308469,
+          "mean_mse": 0.015368406426212122,
+          "mean_rank": 22.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.09235575648721914,
+          "mean_mse": 0.015485030481089745,
+          "mean_rank": 24.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.20781462763317066,
+          "mean_mse": 0.015097608199092737,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.34371235349089735,
+          "mean_mse": 0.014487674883075556,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.13379608333116083,
+          "mean_mse": 0.015424067531404486,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.08875951079848696,
+          "mean_mse": 0.015475776189672993,
+          "mean_rank": 26.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.09442332671169679,
+          "mean_mse": 0.015482791683949036,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.11237807722733094,
+          "mean_mse": 0.015406499573422952,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.13796802896219207,
+          "mean_mse": 0.015138773974285188,
+          "mean_rank": 25.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.2382002773667346,
+          "mean_mse": 0.014932414612544331,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.1700036026657937,
+          "mean_mse": 0.015230624812205787,
+          "mean_rank": 19.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.21186237386969112,
+          "mean_mse": 0.014969812025501029,
+          "mean_rank": 13.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls1.0_\u03bb0.1",
+      "params": {
+        "K": 4,
+        "length_scale": 1.0,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.2770857034846716,
+      "std_cosine_to_target": 0.16616156663839718,
+      "mean_mse_to_target": 0.014347045064725792,
+      "std_mse_to_target": 0.0014548479775221106,
+      "mean_target_rank": 11.829268292682928,
+      "median_target_rank": 5.5,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.5,
+      "recall_at_10": 0.6585365853658537,
+      "mrr": 0.28411288417086855,
+      "train_time_ms": 180.3513999984716,
+      "inference_time_us": 579.6073170885637,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.5147733593843603,
+          "mean_mse": 0.011701479805117557,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4611650662542993,
+          "mean_mse": 0.012392257781409191,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.48347245412632434,
+          "mean_mse": 0.011987791514469024,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.41646878633218404,
+          "mean_mse": 0.012922714189077589,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.26596918994402113,
+          "mean_mse": 0.014478063851394917,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.28797909989412296,
+          "mean_mse": 0.0144561954455814,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3197557104035905,
+          "mean_mse": 0.014418127090161445,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.18115009087197587,
+          "mean_mse": 0.015378153133883143,
+          "mean_rank": 21.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.22039892315845008,
+          "mean_mse": 0.015024622306624585,
+          "mean_rank": 16.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.2200282577763849,
+          "mean_mse": 0.014917610306121412,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.2743115496702564,
+          "mean_mse": 0.014461273020466826,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.3013468856751562,
+          "mean_mse": 0.014481787562246586,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.14237194039572323,
+          "mean_mse": 0.015524281637145365,
+          "mean_rank": 26.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.11122691180708619,
+          "mean_mse": 0.015503833485488384,
+          "mean_rank": 23.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.23576946036233626,
+          "mean_mse": 0.014779077868219422,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.16752401852182044,
+          "mean_mse": 0.015191153757758823,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.20573649383220452,
+          "mean_mse": 0.014872320428586314,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.35224897959395457,
+          "mean_mse": 0.014023586930645853,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.1935073437811043,
+          "mean_mse": 0.015195251303863658,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.2421459409090282,
+          "mean_mse": 0.014772728460589014,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K8_ls0.5_\u03bb0.1",
+      "params": {
+        "K": 8,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.2970414104452913,
+      "std_cosine_to_target": 0.17916138855957425,
+      "mean_mse_to_target": 0.014061431120024372,
+      "std_mse_to_target": 0.0015834323220858208,
+      "mean_target_rank": 11.414634146341463,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.13414634146341464,
+      "recall_at_5": 0.5121951219512195,
+      "recall_at_10": 0.7195121951219512,
+      "mrr": 0.2968606653242724,
+      "train_time_ms": 329.6711000002688,
+      "inference_time_us": 888.7780488471547,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.4924178463788031,
+          "mean_mse": 0.012134533499058088,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4598363559354049,
+          "mean_mse": 0.012472663348772513,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.47469581788856274,
+          "mean_mse": 0.012181485917575969,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.40656506579145935,
+          "mean_mse": 0.013036117695025188,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.39843512190311914,
+          "mean_mse": 0.013104235074270104,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5399518687047756,
+          "mean_mse": 0.01139875956638823,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.4310096202018535,
+          "mean_mse": 0.01272278352644303,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.3845261706378048,
+          "mean_mse": 0.013394824065882568,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.19714841331892644,
+          "mean_mse": 0.015095634231223893,
+          "mean_rank": 18.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.20985489994222933,
+          "mean_mse": 0.01497656428580812,
+          "mean_rank": 11.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.28054509383497467,
+          "mean_mse": 0.014454561625185464,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.31513070436406143,
+          "mean_mse": 0.014370282155721047,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.07943999429429544,
+          "mean_mse": 0.015836731171062848,
+          "mean_rank": 33.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.07102928351185589,
+          "mean_mse": 0.01574000711644219,
+          "mean_rank": 30.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.21973098474398495,
+          "mean_mse": 0.014885991442503401,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.14749800661331391,
+          "mean_mse": 0.015349721893096933,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.19120451005061298,
+          "mean_mse": 0.015001244740650385,
+          "mean_rank": 19.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.30150303766305203,
+          "mean_mse": 0.014420556054758405,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.18935833100835311,
+          "mean_mse": 0.015107075472073395,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.2324233631333335,
+          "mean_mse": 0.01486665474164136,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.3",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.3
+      },
+      "mean_cosine_to_target": 0.40499236598753413,
+      "std_cosine_to_target": 0.15147105831758229,
+      "mean_mse_to_target": 0.01337441781272568,
+      "std_mse_to_target": 0.0012067016909671215,
+      "mean_target_rank": 4.817073170731708,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.926829268292683,
+      "mrr": 0.46686620067420187,
+      "train_time_ms": 201.85900000069523,
+      "inference_time_us": 296.0524390091007,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.2530342568411758,
+          "mean_mse": 0.01371307351148885,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4779267460558263,
+          "mean_mse": 0.012590808538447719,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49393766825425667,
+          "mean_mse": 0.01237574943354804,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.42679748442479826,
+          "mean_mse": 0.013030670752262618,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.43252909104316706,
+          "mean_mse": 0.013027377841705693,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5619526716517921,
+          "mean_mse": 0.01202589469021438,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3876141892220478,
+          "mean_mse": 0.013364092511833611,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.23377295372238083,
+          "mean_mse": 0.014895977313471143,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3568510631730754,
+          "mean_mse": 0.014023802743503417,
+          "mean_rank": 5.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3130734360962444,
+          "mean_mse": 0.014415543956512766,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.44818141217879337,
+          "mean_mse": 0.013183432650797407,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5058262628547798,
+          "mean_mse": 0.012286689380847168,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.4196159505231666,
+          "mean_mse": 0.013565255546489432,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.38072429829519683,
+          "mean_mse": 0.013756172095668479,
+          "mean_rank": 7.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.3958598157319039,
+          "mean_mse": 0.013778391755330445,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.3311218014157703,
+          "mean_mse": 0.014444954101418054,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.42054955333203126,
+          "mean_mse": 0.013156725736673971,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4034568278957451,
+          "mean_mse": 0.01331432437175661,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.47093607525861275,
+          "mean_mse": 0.01279616085661852,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.4041881044066147,
+          "mean_mse": 0.013485473662495076,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.5",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.3999856784629676,
+      "std_cosine_to_target": 0.15326268002210314,
+      "mean_mse_to_target": 0.013708417354380236,
+      "std_mse_to_target": 0.0010425168314337023,
+      "mean_target_rank": 5.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.4648549236006091,
+      "train_time_ms": 222.42060000280617,
+      "inference_time_us": 312.48170729135956,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.26222223934281336,
+          "mean_mse": 0.014209345549148794,
+          "mean_rank": 22.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.47322008344737365,
+          "mean_mse": 0.012941289315221224,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.4954572695857633,
+          "mean_mse": 0.012603471569709184,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4270321219846511,
+          "mean_mse": 0.013359517793680175,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4256000348533919,
+          "mean_mse": 0.013421377386377133,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5597750156085841,
+          "mean_mse": 0.012534395435832759,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.38649163006780285,
+          "mean_mse": 0.013735141772633727,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.20727760417646535,
+          "mean_mse": 0.015096340607272446,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3459055554133135,
+          "mean_mse": 0.014315612644592616,
+          "mean_rank": 6.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.31035970848020417,
+          "mean_mse": 0.014576863418956167,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4388225809208242,
+          "mean_mse": 0.013655462144722809,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5003039561193108,
+          "mean_mse": 0.012783975678815134,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.42281020063220986,
+          "mean_mse": 0.013802884823720923,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.3690420841135077,
+          "mean_mse": 0.014067121866819899,
+          "mean_rank": 8.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.3869055375676383,
+          "mean_mse": 0.014236150921718546,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.31853338721642277,
+          "mean_mse": 0.014655698710112193,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.41518766601654156,
+          "mean_mse": 0.013522029845152774,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.40249988153717,
+          "mean_mse": 0.01357382862132685,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.4722135612719845,
+          "mean_mse": 0.013110257085060757,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.4013093802531582,
+          "mean_mse": 0.013726106946067552,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.7",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.7
+      },
+      "mean_cosine_to_target": 0.38510375663114627,
+      "std_cosine_to_target": 0.15774379092883256,
+      "mean_mse_to_target": 0.014155772549997626,
+      "std_mse_to_target": 0.0008660669095830873,
+      "mean_target_rank": 5.780487804878049,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.21951219512195122,
+      "recall_at_5": 0.8414634146341463,
+      "recall_at_10": 0.9024390243902439,
+      "mrr": 0.44342945187930477,
+      "train_time_ms": 207.0917000019108,
+      "inference_time_us": 266.7695121866617,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.2658793204310402,
+          "mean_mse": 0.014905185945847811,
+          "mean_rank": 21.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.46474697455885167,
+          "mean_mse": 0.013378375211168874,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49688695060393695,
+          "mean_mse": 0.012881022653191323,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.42127766196896366,
+          "mean_mse": 0.013813566201827832,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.40831472701781074,
+          "mean_mse": 0.013942522392059911,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5465297242616577,
+          "mean_mse": 0.013286563615154089,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.37789076758454543,
+          "mean_mse": 0.014392372993591637,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.16087519517172646,
+          "mean_mse": 0.015333262679930997,
+          "mean_rank": 18.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3183578995716734,
+          "mean_mse": 0.014693321330681066,
+          "mean_rank": 7.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.2990431432415617,
+          "mean_mse": 0.01478489365591118,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4071076064004789,
+          "mean_mse": 0.014286913659773862,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.48848578117118613,
+          "mean_mse": 0.01341401619764776,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.4228594346071839,
+          "mean_mse": 0.014100060755559193,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.34620822411428076,
+          "mean_mse": 0.014432189529597145,
+          "mean_rank": 9.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.34846001968516466,
+          "mean_mse": 0.014861453803069212,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.2875753021138032,
+          "mean_mse": 0.014933587289549306,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.40038019693421634,
+          "mean_mse": 0.014006833943052157,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.3996379726101645,
+          "mean_mse": 0.013924769584913173,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.47169676991678894,
+          "mean_mse": 0.01352064447885628,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.3962718080519754,
+          "mean_mse": 0.014020403638499025,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K8_ls0.5_b0.5",
+      "params": {
+        "K": 8,
+        "length_scale": 0.5,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.4281453693251436,
+      "std_cosine_to_target": 0.12947831635297694,
+      "mean_mse_to_target": 0.01333658276494438,
+      "std_mse_to_target": 0.0010912631904573412,
+      "mean_target_rank": 4.585365853658536,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.8536585365853658,
+      "recall_at_10": 0.9390243902439024,
+      "mrr": 0.4519716829821359,
+      "train_time_ms": 263.0919000002905,
+      "inference_time_us": 252.21463413511563,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.3594188696973064,
+          "mean_mse": 0.013696492494094522,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.47015563033647745,
+          "mean_mse": 0.012754476929494251,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.5066124190967093,
+          "mean_mse": 0.012777679794997304,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4286108236366889,
+          "mean_mse": 0.01352290431132342,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4335248438849035,
+          "mean_mse": 0.013123441259268724,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5720637367771267,
+          "mean_mse": 0.011495805214026069,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.37354781159965134,
+          "mean_mse": 0.01377462195087694,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.40461072476824606,
+          "mean_mse": 0.013437264561936738,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.40504784152863105,
+          "mean_mse": 0.013698244467231646,
+          "mean_rank": 4.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3465875023386967,
+          "mean_mse": 0.014204732925394342,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.5233952293870746,
+          "mean_mse": 0.012448489442837702,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.4875959271485639,
+          "mean_mse": 0.012827196510972586,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.34090796179586075,
+          "mean_mse": 0.013969211872200583,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.34153484142465795,
+          "mean_mse": 0.014147642246400773,
+          "mean_rank": 9.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4372332718963482,
+          "mean_mse": 0.013317238346368717,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.2887777789852808,
+          "mean_mse": 0.014747942626086892,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.39375044342590126,
+          "mean_mse": 0.013821931509080782,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4837804759529426,
+          "mean_mse": 0.012977723598851907,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.45984571858574813,
+          "mean_mse": 0.01316790446768001,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.5333325481603058,
+          "mean_mse": 0.012527530473827785,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls1.0_b0.5",
+      "params": {
+        "K": 4,
+        "length_scale": 1.0,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.3990675564821616,
+      "std_cosine_to_target": 0.1541107956465562,
+      "mean_mse_to_target": 0.013787515351393992,
+      "std_mse_to_target": 0.0010047091474700183,
+      "mean_target_rank": 5.097560975609756,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.8536585365853658,
+      "recall_at_10": 0.9146341463414634,
+      "mrr": 0.4631025456910202,
+      "train_time_ms": 196.88260000111768,
+      "inference_time_us": 333.71829269482276,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.26390021663819635,
+          "mean_mse": 0.014315737975499883,
+          "mean_rank": 22.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.4721249290474821,
+          "mean_mse": 0.01302351137796767,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.4956203252315041,
+          "mean_mse": 0.012683827468252827,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4269915696802947,
+          "mean_mse": 0.013396799223989942,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.423232178986543,
+          "mean_mse": 0.013539117549004092,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5594200263585085,
+          "mean_mse": 0.012678817314127098,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.38609692656623645,
+          "mean_mse": 0.013842622018497331,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2020290579456937,
+          "mean_mse": 0.015135501005034569,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.3434665607134152,
+          "mean_mse": 0.014384122662812937,
+          "mean_rank": 6.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3091570624844857,
+          "mean_mse": 0.014613988491276906,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.4380330275033888,
+          "mean_mse": 0.013741393502446048,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.499533449515985,
+          "mean_mse": 0.01290845548135335,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.4249138159742293,
+          "mean_mse": 0.013863101786099074,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.3691828821985927,
+          "mean_mse": 0.014110976274848941,
+          "mean_rank": 8.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.38455693082517683,
+          "mean_mse": 0.014335173656427017,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.31759673948056477,
+          "mean_mse": 0.0146909862687143,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.41445841512646325,
+          "mean_mse": 0.013594604217346108,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4015622038877935,
+          "mean_mse": 0.01366094611320181,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.47158303201634844,
+          "mean_mse": 0.013203655658035062,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.3992631969754083,
+          "mean_mse": 0.013796951924226418,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c10",
+      "params": {
+        "K": 4,
+        "target_cond": 10.0
+      },
+      "mean_cosine_to_target": 0.40976210030839216,
+      "std_cosine_to_target": 0.14969923705078542,
+      "mean_mse_to_target": 0.013075492214662067,
+      "std_mse_to_target": 0.0013773140308701926,
+      "mean_target_rank": 4.634146341463414,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.9390243902439024,
+      "mrr": 0.4700583522576734,
+      "train_time_ms": 216.74570000323,
+      "inference_time_us": 577.9756097692326,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.2422799362218374,
+          "mean_mse": 0.013357095808038158,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.48199904036094765,
+          "mean_mse": 0.012286465944836717,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49168010990623845,
+          "mean_mse": 0.012228125204483301,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.424527229572884,
+          "mean_mse": 0.01279331580605925,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4374969438438633,
+          "mean_mse": 0.012675991713943685,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5611349476732799,
+          "mean_mse": 0.011719660766952779,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.38925162174966044,
+          "mean_mse": 0.013297808099609218,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2647084210160275,
+          "mean_mse": 0.014583305476096294,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.36819486748292085,
+          "mean_mse": 0.013690235861411687,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.32386189018295997,
+          "mean_mse": 0.014149652688517034,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.45733445897480085,
+          "mean_mse": 0.012722696361138403,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5098404812121252,
+          "mean_mse": 0.011810999731921724,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.4159538240986857,
+          "mean_mse": 0.013299244903329451,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.38947815196227487,
+          "mean_mse": 0.013418367084720223,
+          "mean_rank": 6.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4021494294502458,
+          "mean_mse": 0.013395996241182038,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.3401058567871328,
+          "mean_mse": 0.01424087984485331,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.42309152736206074,
+          "mean_mse": 0.012843624341887029,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.4064330786745912,
+          "mean_mse": 0.0130713562202815,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.4691135242407589,
+          "mean_mse": 0.012513384365661476,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.41206946068744554,
+          "mean_mse": 0.013172233199116132,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c50",
+      "params": {
+        "K": 4,
+        "target_cond": 50.0
+      },
+      "mean_cosine_to_target": 0.4097196120960591,
+      "std_cosine_to_target": 0.14941889927511137,
+      "mean_mse_to_target": 0.013067899772008097,
+      "std_mse_to_target": 0.0013872924826206035,
+      "mean_target_rank": 4.621951219512195,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.9390243902439024,
+      "mrr": 0.47010318726484696,
+      "train_time_ms": 288.1245000025956,
+      "inference_time_us": 661.7829268379421,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.2435207359875977,
+          "mean_mse": 0.013324085956149371,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.48159726420774146,
+          "mean_mse": 0.012239743074069942,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49159784134989915,
+          "mean_mse": 0.012135729483594627,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4238432158911034,
+          "mean_mse": 0.012779697735081107,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4374638643066747,
+          "mean_mse": 0.012676099172293957,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5611418406030819,
+          "mean_mse": 0.011721008714267981,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3890435840792057,
+          "mean_mse": 0.013327991571002763,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2647219084514707,
+          "mean_mse": 0.014583021698197508,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.36793095927693586,
+          "mean_mse": 0.0136908152540308,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3239319832929711,
+          "mean_mse": 0.014149149392369286,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.45728728800006246,
+          "mean_mse": 0.01272305110348055,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5097906533568447,
+          "mean_mse": 0.011811277463865243,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.41586517862672817,
+          "mean_mse": 0.013299208644693833,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.3894065150429122,
+          "mean_mse": 0.013418628989234632,
+          "mean_rank": 6.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4021334337369643,
+          "mean_mse": 0.013397735948761908,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.34021453957114867,
+          "mean_mse": 0.014237899653889278,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.4230262617534253,
+          "mean_mse": 0.012844023362858456,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.40644342493477714,
+          "mean_mse": 0.01307102957007129,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.4689137396382139,
+          "mean_mse": 0.012513392751282795,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.41204344728148834,
+          "mean_mse": 0.013170994726154359,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c100",
+      "params": {
+        "K": 4,
+        "target_cond": 100.0
+      },
+      "mean_cosine_to_target": 0.4097196120960591,
+      "std_cosine_to_target": 0.14941889927511137,
+      "mean_mse_to_target": 0.013067899772008097,
+      "std_mse_to_target": 0.0013872924826206035,
+      "mean_target_rank": 4.621951219512195,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.23170731707317074,
+      "recall_at_5": 0.8658536585365854,
+      "recall_at_10": 0.9390243902439024,
+      "mrr": 0.47010318726484696,
+      "train_time_ms": 343.2131000008667,
+      "inference_time_us": 594.7365853211434,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.2435207359875977,
+          "mean_mse": 0.013324085956149371,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.48159726420774146,
+          "mean_mse": 0.012239743074069942,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49159784134989915,
+          "mean_mse": 0.012135729483594627,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.4238432158911034,
+          "mean_mse": 0.012779697735081107,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4374638643066747,
+          "mean_mse": 0.012676099172293957,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5611418406030819,
+          "mean_mse": 0.011721008714267981,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3890435840792057,
+          "mean_mse": 0.013327991571002763,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.2647219084514707,
+          "mean_mse": 0.014583021698197508,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.36793095927693586,
+          "mean_mse": 0.0136908152540308,
+          "mean_rank": 5.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.3239319832929711,
+          "mean_mse": 0.014149149392369286,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.45728728800006246,
+          "mean_mse": 0.01272305110348055,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.5097906533568447,
+          "mean_mse": 0.011811277463865243,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.41586517862672817,
+          "mean_mse": 0.013299208644693833,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.3894065150429122,
+          "mean_mse": 0.013418628989234632,
+          "mean_rank": 6.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.4021334337369643,
+          "mean_mse": 0.013397735948761908,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.34021453957114867,
+          "mean_mse": 0.014237899653889278,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.4230262617534253,
+          "mean_mse": 0.012844023362858456,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.40644342493477714,
+          "mean_mse": 0.01307102957007129,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.4689137396382139,
+          "mean_mse": 0.012513392751282795,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.41204344728148834,
+          "mean_mse": 0.013170994726154359,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K8_c50",
+      "params": {
+        "K": 8,
+        "target_cond": 50.0
+      },
+      "mean_cosine_to_target": 0.44457536226377636,
+      "std_cosine_to_target": 0.10860370078100887,
+      "mean_mse_to_target": 0.012656175738631372,
+      "std_mse_to_target": 0.0013617061065661674,
+      "mean_target_rank": 3.4390243902439024,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.2073170731707317,
+      "recall_at_5": 0.926829268292683,
+      "recall_at_10": 0.9634146341463414,
+      "mrr": 0.46996409810139156,
+      "train_time_ms": 385.82370000222,
+      "inference_time_us": 883.4939024648231,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.41874479846305557,
+          "mean_mse": 0.012802939701044774,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.47904008391070235,
+          "mean_mse": 0.012207725516486596,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.49908133767259943,
+          "mean_mse": 0.012145347445625308,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.435838214495489,
+          "mean_mse": 0.01264828683251611,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.4460493388086203,
+          "mean_mse": 0.012505764511689672,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.5730796762930946,
+          "mean_mse": 0.011092175338196637,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.3851938050877612,
+          "mean_mse": 0.013382930188253978,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.42392484766014027,
+          "mean_mse": 0.012889403570846772,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.4277191472948999,
+          "mean_mse": 0.012956487746297055,
+          "mean_rank": 4.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.36015692622728385,
+          "mean_mse": 0.013725844661434478,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.5290337062701924,
+          "mean_mse": 0.011620230239270588,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.49687170289510685,
+          "mean_mse": 0.011986315372778347,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.3925861157765191,
+          "mean_mse": 0.013236376379055646,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.3610320718372815,
+          "mean_mse": 0.01358538833119068,
+          "mean_rank": 8.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.44694066493710166,
+          "mean_mse": 0.012691106626461907,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.3239097967341541,
+          "mean_mse": 0.014229004742315627,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.4330692386931936,
+          "mean_mse": 0.012739540348576937,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.49340975447281943,
+          "mean_mse": 0.012069218102880822,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.47300110832351006,
+          "mean_mse": 0.012475448032002548,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.5179247857708442,
+          "mean_mse": 0.011826599935646685,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_none_f10",
+      "params": {
+        "smooth_method": "none",
+        "fidelity_weight": 1.0
+      },
+      "mean_cosine_to_target": 0.18610116064255497,
+      "std_cosine_to_target": 0.13166215304338222,
+      "mean_mse_to_target": 0.024268805865385632,
+      "std_mse_to_target": 0.00425597411071367,
+      "mean_target_rank": 14.939024390243903,
+      "median_target_rank": 7.0,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.3780487804878049,
+      "recall_at_10": 0.6097560975609756,
+      "mrr": 0.24929424459720936,
+      "train_time_ms": 2.3255999985849485,
+      "inference_time_us": 222.44756092266294,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.166035936142469,
+          "mean_mse": 0.026768422738085412,
+          "mean_rank": 17.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.14854965275204202,
+          "mean_mse": 0.026567794224736884,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.23149752296847115,
+          "mean_mse": 0.02297064612133596,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.23734608017431666,
+          "mean_mse": 0.019933667565526222,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.17877668159644403,
+          "mean_mse": 0.02113440881526353,
+          "mean_rank": 24.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.28418077872576974,
+          "mean_mse": 0.023958924931953018,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.15355826152387086,
+          "mean_mse": 0.025126592439383155,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.0869230086242008,
+          "mean_mse": 0.02732850350553053,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.13690651693962647,
+          "mean_mse": 0.028823151609546422,
+          "mean_rank": 17.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.2261586238516294,
+          "mean_mse": 0.02359980727548419,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.17627105233995846,
+          "mean_mse": 0.025263294225251837,
+          "mean_rank": 27.75,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.2658790209849235,
+          "mean_mse": 0.021436300553009328,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.1656613454592659,
+          "mean_mse": 0.025230843126344597,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.1373247538213688,
+          "mean_mse": 0.026331325182074573,
+          "mean_rank": 14.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.1342393713729133,
+          "mean_mse": 0.024772068842959412,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.13311533597358494,
+          "mean_mse": 0.02144150666552705,
+          "mean_rank": 23.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.2570893054956851,
+          "mean_mse": 0.020199607537569556,
+          "mean_rank": 7.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.15220613797877933,
+          "mean_mse": 0.02562765359940737,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.23172840895254046,
+          "mean_mse": 0.023849611206544948,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.24306817980426865,
+          "mean_mse": 0.023357770876966222,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f0",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.0
+      },
+      "mean_cosine_to_target": 0.11153008674651947,
+      "std_cosine_to_target": 0.12333174347130801,
+      "mean_mse_to_target": 0.025712231783113916,
+      "std_mse_to_target": 0.00395436703396394,
+      "mean_target_rank": 23.317073170731707,
+      "median_target_rank": 13.5,
+      "recall_at_1": 0.07317073170731707,
+      "recall_at_5": 0.25609756097560976,
+      "recall_at_10": 0.3902439024390244,
+      "mrr": 0.1640142797579474,
+      "train_time_ms": 6.831300001067575,
+      "inference_time_us": 333.06951223582985,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.13503173035230637,
+          "mean_mse": 0.0249313158331231,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.07008902760927375,
+          "mean_mse": 0.027491696158425716,
+          "mean_rank": 26.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.15448590090099149,
+          "mean_mse": 0.025613867827690134,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.12260015672037533,
+          "mean_mse": 0.02443490847922941,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.07791745437290087,
+          "mean_mse": 0.02491696768785935,
+          "mean_rank": 34.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.2145958169161528,
+          "mean_mse": 0.024371027910765466,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.07611923581886756,
+          "mean_mse": 0.024980536836350445,
+          "mean_rank": 33.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.030799489257926103,
+          "mean_mse": 0.02891533293112717,
+          "mean_rank": 36.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.07136226892548593,
+          "mean_mse": 0.02911346909507042,
+          "mean_rank": 26.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.15307135582563647,
+          "mean_mse": 0.02386410244618633,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.09412150106888909,
+          "mean_mse": 0.02846754145582581,
+          "mean_rank": 35.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.18546445774257547,
+          "mean_mse": 0.021748410076606516,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.10585202671987762,
+          "mean_mse": 0.02755061768327787,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.08986078755272989,
+          "mean_mse": 0.026307951798249067,
+          "mean_rank": 23.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.05169172670049353,
+          "mean_mse": 0.027824976929412708,
+          "mean_rank": 35.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.05933129983730196,
+          "mean_mse": 0.024396850459228347,
+          "mean_rank": 35.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.154389806596538,
+          "mean_mse": 0.023056603799306498,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.06296940639120331,
+          "mean_mse": 0.0278447619751718,
+          "mean_rank": 23.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.16132839264027374,
+          "mean_mse": 0.02390026081203956,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.1749791722342962,
+          "mean_mse": 0.023514196135559592,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f3",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.3
+      },
+      "mean_cosine_to_target": 0.13573833651312084,
+      "std_cosine_to_target": 0.1253925941038319,
+      "mean_mse_to_target": 0.025049210863366617,
+      "std_mse_to_target": 0.003990285694923444,
+      "mean_target_rank": 20.524390243902438,
+      "median_target_rank": 11.0,
+      "recall_at_1": 0.06097560975609756,
+      "recall_at_5": 0.3048780487804878,
+      "recall_at_10": 0.47560975609756095,
+      "mrr": 0.183209435343779,
+      "train_time_ms": 6.9048000004841015,
+      "inference_time_us": 228.11463421065838,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.14586018763004516,
+          "mean_mse": 0.025317789202457877,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.09532260245123789,
+          "mean_mse": 0.027033995173170497,
+          "mean_rank": 24.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.1786527086441021,
+          "mean_mse": 0.024629105103606094,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.15798995001687133,
+          "mean_mse": 0.02272164109639497,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.11008363136518783,
+          "mean_mse": 0.02343906422437582,
+          "mean_rank": 32.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.23880365722454963,
+          "mean_mse": 0.023985053471120878,
+          "mean_rank": 6.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.10247453218417767,
+          "mean_mse": 0.024587917511457738,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.04832473942245477,
+          "mean_mse": 0.028230595156584052,
+          "mean_rank": 32.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.09284123340605728,
+          "mean_mse": 0.028838085673233156,
+          "mean_rank": 23.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.17769088128305027,
+          "mean_mse": 0.02360823976139898,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.12076662223107605,
+          "mean_mse": 0.027197453224464867,
+          "mean_rank": 33.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.21403721066740913,
+          "mean_mse": 0.021439092076083674,
+          "mean_rank": 15.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.12456711423142018,
+          "mean_mse": 0.026677443116196776,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.10516658138562265,
+          "mean_mse": 0.02619542500589041,
+          "mean_rank": 20.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.07686921183215514,
+          "mean_mse": 0.026662389243906234,
+          "mean_rank": 28.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.0804347101552747,
+          "mean_mse": 0.02334093441645137,
+          "mean_rank": 32.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.1886321837078533,
+          "mean_mse": 0.02192768764989335,
+          "mean_rank": 14.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.09077659199977754,
+          "mean_mse": 0.02696230431138197,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.18526747515183847,
+          "mean_mse": 0.02369027236879031,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.198572119830896,
+          "mean_mse": 0.0232659572423757,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f5",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.5
+      },
+      "mean_cosine_to_target": 0.15116737004505865,
+      "std_cosine_to_target": 0.1271666911505085,
+      "mean_mse_to_target": 0.02471671746183452,
+      "std_mse_to_target": 0.0040481115065426785,
+      "mean_target_rank": 18.390243902439025,
+      "median_target_rank": 9.5,
+      "recall_at_1": 0.06097560975609756,
+      "recall_at_5": 0.3170731707317073,
+      "recall_at_10": 0.5365853658536586,
+      "mrr": 0.20100352162742266,
+      "train_time_ms": 4.696600000897888,
+      "inference_time_us": 224.5000000473782,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.1522906703325797,
+          "mean_mse": 0.02565384702113531,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.11142031447062906,
+          "mean_mse": 0.026814828042594913,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.19441668675567397,
+          "mean_mse": 0.024063928150491874,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.18173360098111085,
+          "mean_mse": 0.021752270035802233,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.13113534626866674,
+          "mean_mse": 0.02261719324953193,
+          "mean_rank": 29.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.2533484708147947,
+          "mean_mse": 0.02385266267612013,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.11893626191774488,
+          "mean_mse": 0.024533997964292373,
+          "mean_rank": 29.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.05980743612211448,
+          "mean_mse": 0.02787347899587156,
+          "mean_rank": 30.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.10637042353717432,
+          "mean_mse": 0.028744157761617872,
+          "mean_rank": 20.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.19285594054120764,
+          "mean_mse": 0.023521747558958233,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.1378409825519111,
+          "mean_mse": 0.026497782052218883,
+          "mean_rank": 31.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.23092264199738838,
+          "mean_mse": 0.021335587286898775,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.13680804449353978,
+          "mean_mse": 0.026179727785762292,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.1148872569166928,
+          "mean_mse": 0.026177330385987647,
+          "mean_rank": 17.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.09366443289794436,
+          "mean_mse": 0.026004814243840248,
+          "mean_rank": 25.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.09518492038199604,
+          "mean_mse": 0.02271761558063176,
+          "mean_rank": 29.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.21030646889940355,
+          "mean_mse": 0.02130451367928081,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.10899821894239467,
+          "mean_mse": 0.026477487369360415,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.1998766984075556,
+          "mean_mse": 0.023643038912148365,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.21281184857971228,
+          "mean_mse": 0.023196327178160663,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f7",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.7
+      },
+      "mean_cosine_to_target": 0.16582821394349997,
+      "std_cosine_to_target": 0.1290449654623825,
+      "mean_mse_to_target": 0.024471840496275307,
+      "std_mse_to_target": 0.004123041337485652,
+      "mean_target_rank": 16.804878048780488,
+      "median_target_rank": 9.0,
+      "recall_at_1": 0.08536585365853659,
+      "recall_at_5": 0.35365853658536583,
+      "recall_at_10": 0.5609756097560976,
+      "mrr": 0.22668600150557316,
+      "train_time_ms": 6.807099998695776,
+      "inference_time_us": 364.29876836780574,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.15815914060134897,
+          "mean_mse": 0.0260526319644428,
+          "mean_rank": 18.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.12683526556483948,
+          "mean_mse": 0.02666443439969497,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.20972063284207937,
+          "mean_mse": 0.02357181642106443,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.20491169616047325,
+          "mean_mse": 0.02092114473091369,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.1512724014121896,
+          "mean_mse": 0.021926040675337488,
+          "mean_rank": 27.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.2666088459622582,
+          "mean_mse": 0.0238202122795959,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.13402391047702716,
+          "mean_mse": 0.024646339752670818,
+          "mean_rank": 27.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.07098042069995186,
+          "mean_mse": 0.027595863386345395,
+          "mean_rank": 27.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.11917110337132444,
+          "mean_mse": 0.02872195867902356,
+          "mean_rank": 19.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.20696727561077877,
+          "mean_mse": 0.02350252169311813,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.15404655054144833,
+          "mean_mse": 0.025915754332235284,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.24610574314147377,
+          "mean_mse": 0.021314248266644804,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.14870565849256434,
+          "mean_mse": 0.02574953329342347,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.12418910663598307,
+          "mean_mse": 0.02620477435942061,
+          "mean_rank": 15.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.11023131600389253,
+          "mean_mse": 0.025441226009324917,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.11028236143422626,
+          "mean_mse": 0.022158796898970858,
+          "mean_rank": 27.25,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.23044507634703937,
+          "mean_mse": 0.020784889145198576,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.12676037352514935,
+          "mean_mse": 0.0260754609610762,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.21340142222862724,
+          "mean_mse": 0.023670012526592465,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.22582003228724695,
+          "mean_mse": 0.02320338713893835,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_kernel_f5",
+      "params": {
+        "smooth_method": "kernel",
+        "fidelity_weight": 0.5
+      },
+      "mean_cosine_to_target": 0.1772445968071631,
+      "std_cosine_to_target": 0.1568930136732839,
+      "mean_mse_to_target": 0.028656381373953342,
+      "std_mse_to_target": 0.01490076933828963,
+      "mean_target_rank": 17.341463414634145,
+      "median_target_rank": 7.0,
+      "recall_at_1": 0.12195121951219512,
+      "recall_at_5": 0.4268292682926829,
+      "recall_at_10": 0.5853658536585366,
+      "mrr": 0.26661029231228717,
+      "train_time_ms": 6.327399998554029,
+      "inference_time_us": 295.3585366102322,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.18175612013391235,
+          "mean_mse": 0.02792270973177955,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.16663977717972134,
+          "mean_mse": 0.02815091186212563,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.21175585242840367,
+          "mean_mse": 0.022773845855780604,
+          "mean_rank": 13.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": -0.17371011557176488,
+          "mean_mse": 0.08811282058503848,
+          "mean_rank": 68.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.3171221966373262,
+          "mean_mse": 0.030460762150144198,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.31254572137495096,
+          "mean_mse": 0.026600078190779166,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.18627836804017955,
+          "mean_mse": 0.026050093390326403,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.06714038022902764,
+          "mean_mse": 0.028159129588124596,
+          "mean_rank": 29.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.12805243630828583,
+          "mean_mse": 0.029489400633803852,
+          "mean_rank": 18.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.2719483977847176,
+          "mean_mse": 0.022492219059306803,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.209943656776089,
+          "mean_mse": 0.02667473324329568,
+          "mean_rank": 24.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.23436570869054713,
+          "mean_mse": 0.021850331646323176,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.13410309421365277,
+          "mean_mse": 0.026586328934514673,
+          "mean_rank": 16.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.14088874007365776,
+          "mean_mse": 0.02561375161206672,
+          "mean_rank": 14.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.1305164778197224,
+          "mean_mse": 0.024725432331414818,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.12485131315950179,
+          "mean_mse": 0.021537155154486624,
+          "mean_rank": 26.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.2920923817178811,
+          "mean_mse": 0.019990480666133088,
+          "mean_rank": 5.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.12197129267661916,
+          "mean_mse": 0.026925021994335264,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.3011719816117197,
+          "mean_mse": 0.02571094255707014,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.20684515916720664,
+          "mean_mse": 0.0238538809177263,
+          "mean_rank": 9.25,
           "num_queries": 4
         }
       }

--- a/reports/answer_level_modernbert.json
+++ b/reports/answer_level_modernbert.json
@@ -36,9 +36,9 @@
   "winners": {
     "highest_cosine": "Residual_K8_r0.01",
     "lowest_mse": "Basis_K8",
-    "lowest_rank": "Residual_K8_r0.01",
-    "highest_mrr": "Residual_K8_r0.01",
-    "highest_recall_at_5": "Residual_K4_r0.01"
+    "lowest_rank": "MinTrans_none_f10",
+    "highest_mrr": "MinTrans_none_f10",
+    "highest_recall_at_5": "MinTrans_none_f10"
   },
   "results": [
     {
@@ -56,8 +56,8 @@
       "recall_at_5": 0.6341463414634146,
       "recall_at_10": 0.7926829268292683,
       "mrr": 0.31982445470964127,
-      "train_time_ms": 0.5611000015051104,
-      "inference_time_us": 148.86220733609574,
+      "train_time_ms": 0.6157999960123561,
+      "inference_time_us": 147.93903658467505,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -200,8 +200,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7317073170731707,
       "mrr": 0.29432069031270675,
-      "train_time_ms": 914.7202139974979,
-      "inference_time_us": 6022.064731729277,
+      "train_time_ms": 936.1101149988826,
+      "inference_time_us": 5465.223256157137,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -344,8 +344,8 @@
       "recall_at_5": 0.6707317073170732,
       "recall_at_10": 0.8170731707317073,
       "mrr": 0.3757760074295225,
-      "train_time_ms": 778.7905120021605,
-      "inference_time_us": 6803.981804895136,
+      "train_time_ms": 855.8752719982294,
+      "inference_time_us": 7085.549804842009,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -488,8 +488,8 @@
       "recall_at_5": 0.6707317073170732,
       "recall_at_10": 0.8292682926829268,
       "mrr": 0.37938021914216474,
-      "train_time_ms": 888.6579130012251,
-      "inference_time_us": 6524.818390261782,
+      "train_time_ms": 1042.8092299989657,
+      "inference_time_us": 6618.208012141844,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -632,8 +632,8 @@
       "recall_at_5": 0.6463414634146342,
       "recall_at_10": 0.7926829268292683,
       "mrr": 0.3223582361307937,
-      "train_time_ms": 2006.5225280013692,
-      "inference_time_us": 6211.458621958339,
+      "train_time_ms": 2028.158319000795,
+      "inference_time_us": 5285.21346344993,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -776,8 +776,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7804878048780488,
       "mrr": 0.3507524537497204,
-      "train_time_ms": 14448.818898999889,
-      "inference_time_us": 68003.75868291799,
+      "train_time_ms": 16447.937607001222,
+      "inference_time_us": 66603.97387806769,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -920,8 +920,8 @@
       "recall_at_5": 0.6463414634146342,
       "recall_at_10": 0.8170731707317073,
       "mrr": 0.3576830975309059,
-      "train_time_ms": 25889.87131599788,
-      "inference_time_us": 187259.2351219504,
+      "train_time_ms": 21737.502649004455,
+      "inference_time_us": 128922.76858536473,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1064,8 +1064,8 @@
       "recall_at_5": 0.6951219512195121,
       "recall_at_10": 0.8170731707317073,
       "mrr": 0.37505000433020147,
-      "train_time_ms": 50651.91422499993,
-      "inference_time_us": 246247.13681707985,
+      "train_time_ms": 39647.06657300121,
+      "inference_time_us": 204140.83924395792,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1209,8 +1209,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.389046717305573,
-      "train_time_ms": 12483.476751000126,
-      "inference_time_us": 92900.4715975369,
+      "train_time_ms": 9261.497004001285,
+      "inference_time_us": 81168.08587803417,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1354,8 +1354,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.389046717305573,
-      "train_time_ms": 9286.710357999254,
-      "inference_time_us": 96367.70680485714,
+      "train_time_ms": 8683.652314000938,
+      "inference_time_us": 82753.46323175544,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1499,8 +1499,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 14725.366419999773,
-      "inference_time_us": 161185.59221951463,
+      "train_time_ms": 12784.592541000166,
+      "inference_time_us": 142621.3265365776,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1644,8 +1644,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 14351.842833999399,
-      "inference_time_us": 138945.3815122024,
+      "train_time_ms": 12589.689287997317,
+      "inference_time_us": 121647.59337806239,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1788,8 +1788,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 98.77220699854661,
-      "inference_time_us": 5437.655256084726,
+      "train_time_ms": 87.32190100272419,
+      "inference_time_us": 5690.43660972256,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -1932,8 +1932,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 94.01710699967225,
-      "inference_time_us": 5697.244304850224,
+      "train_time_ms": 96.3398000021698,
+      "inference_time_us": 8078.008585360339,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2076,8 +2076,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 99.83230700163404,
-      "inference_time_us": 5646.1930731840275,
+      "train_time_ms": 135.92100099776872,
+      "inference_time_us": 5481.429292647191,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2220,8 +2220,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 99.82670699901064,
-      "inference_time_us": 5577.512585393667,
+      "train_time_ms": 89.2868009977974,
+      "inference_time_us": 5388.909780488509,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2364,8 +2364,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 117.1342090019607,
-      "inference_time_us": 5533.610536608981,
+      "train_time_ms": 84.84230100293644,
+      "inference_time_us": 5140.581731677407,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2508,8 +2508,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900318024475127,
-      "train_time_ms": 120.89317199934158,
-      "inference_time_us": 5195.858536597637,
+      "train_time_ms": 85.06550000311108,
+      "inference_time_us": 5192.241500037376,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2652,8 +2652,8 @@
       "recall_at_5": 0.7073170731707317,
       "recall_at_10": 0.8414634146341463,
       "mrr": 0.3900766374546863,
-      "train_time_ms": 105.8753750003234,
-      "inference_time_us": 5260.714621970958,
+      "train_time_ms": 95.80330099561252,
+      "inference_time_us": 5856.898817089642,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2798,8 +2798,8 @@
       "recall_at_5": 0.18292682926829268,
       "recall_at_10": 0.4146341463414634,
       "mrr": 0.14757965012951585,
-      "train_time_ms": 12629.906853999273,
-      "inference_time_us": 76603.1729268079,
+      "train_time_ms": 10042.335664998973,
+      "inference_time_us": 89584.04065853712,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -2944,8 +2944,8 @@
       "recall_at_5": 0.18292682926829268,
       "recall_at_10": 0.4146341463414634,
       "mrr": 0.14757965012951585,
-      "train_time_ms": 10345.855766998284,
-      "inference_time_us": 66849.78882926438,
+      "train_time_ms": 10377.721472999838,
+      "inference_time_us": 65833.65867073752,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3090,8 +3090,8 @@
       "recall_at_5": 0.18292682926829268,
       "recall_at_10": 0.4146341463414634,
       "mrr": 0.14757965012951585,
-      "train_time_ms": 10798.45067199858,
-      "inference_time_us": 76368.75114635253,
+      "train_time_ms": 10557.718279997061,
+      "inference_time_us": 64582.86517076109,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3236,8 +3236,8 @@
       "recall_at_5": 0.18292682926829268,
       "recall_at_10": 0.4146341463414634,
       "mrr": 0.1478623045200008,
-      "train_time_ms": 12898.857500000304,
-      "inference_time_us": 72297.5096341099,
+      "train_time_ms": 10668.323354999302,
+      "inference_time_us": 79707.15582925506,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3382,8 +3382,8 @@
       "recall_at_5": 0.5365853658536586,
       "recall_at_10": 0.7195121951219512,
       "mrr": 0.30792802934219377,
-      "train_time_ms": 17460.618301000068,
-      "inference_time_us": 122117.22804878684,
+      "train_time_ms": 17594.503116997657,
+      "inference_time_us": 111511.43531703672,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3527,8 +3527,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7804878048780488,
       "mrr": 0.3507524537497204,
-      "train_time_ms": 14643.63578999837,
-      "inference_time_us": 7085.6390609661485,
+      "train_time_ms": 13560.963800999161,
+      "inference_time_us": 8478.446231736863,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3672,8 +3672,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7804878048780488,
       "mrr": 0.3507524537497204,
-      "train_time_ms": 15219.621561998792,
-      "inference_time_us": 5607.840231699279,
+      "train_time_ms": 15717.242933002126,
+      "inference_time_us": 6179.585134083116,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3817,8 +3817,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7804878048780488,
       "mrr": 0.3507524537497204,
-      "train_time_ms": 14407.802245001221,
-      "inference_time_us": 5350.2560975441775,
+      "train_time_ms": 13275.033133999386,
+      "inference_time_us": 5388.945134100362,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -3962,8 +3962,8 @@
       "recall_at_5": 0.6463414634146342,
       "recall_at_10": 0.8170731707317073,
       "mrr": 0.3576830975309059,
-      "train_time_ms": 22740.230677998625,
-      "inference_time_us": 5621.729451199715,
+      "train_time_ms": 21447.956292002345,
+      "inference_time_us": 5570.404841397781,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4107,8 +4107,8 @@
       "recall_at_5": 0.573170731707317,
       "recall_at_10": 0.7804878048780488,
       "mrr": 0.3507524537497204,
-      "train_time_ms": 15438.877461001539,
-      "inference_time_us": 6307.945365844672,
+      "train_time_ms": 13672.653668996645,
+      "inference_time_us": 5826.282829242168,
       "num_queries": 82,
       "num_answers": 82,
       "num_clusters": 20,
@@ -4231,6 +4231,1446 @@
           "mean_cosine": 0.9052374516270097,
           "mean_mse": 0.08398726464917101,
           "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c10",
+      "params": {
+        "K": 4,
+        "target_cond": 10.0
+      },
+      "mean_cosine_to_target": 0.8179672886714011,
+      "std_cosine_to_target": 0.036182927728666194,
+      "mean_mse_to_target": 0.15887038085998867,
+      "std_mse_to_target": 0.03088871993362424,
+      "mean_target_rank": 29.451219512195124,
+      "median_target_rank": 25.0,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.17073170731707318,
+      "recall_at_10": 0.2804878048780488,
+      "mrr": 0.1162451728315173,
+      "train_time_ms": 20881.802534997405,
+      "inference_time_us": 62383.409804879644,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8316156801007037,
+          "mean_mse": 0.14006367320785865,
+          "mean_rank": 20.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8364219981862616,
+          "mean_mse": 0.1406238155956546,
+          "mean_rank": 19.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8090004472448635,
+          "mean_mse": 0.15830985063633046,
+          "mean_rank": 37.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7885154179202776,
+          "mean_mse": 0.18031494382959543,
+          "mean_rank": 50.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8056977441879166,
+          "mean_mse": 0.17392627741731786,
+          "mean_rank": 39.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.815575334697558,
+          "mean_mse": 0.15640976004815063,
+          "mean_rank": 37.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8174642071562129,
+          "mean_mse": 0.14797357726948038,
+          "mean_rank": 28.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8337107762317736,
+          "mean_mse": 0.14729650742518205,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7921501976573688,
+          "mean_mse": 0.1891544631694522,
+          "mean_rank": 39.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8086213774929052,
+          "mean_mse": 0.16466538079347082,
+          "mean_rank": 36.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8403064962868321,
+          "mean_mse": 0.14753888305521967,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7599729549456018,
+          "mean_mse": 0.2030863681337569,
+          "mean_rank": 69.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8131670027379363,
+          "mean_mse": 0.1607523624973182,
+          "mean_rank": 25.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7606843650836821,
+          "mean_mse": 0.21906694610529995,
+          "mean_rank": 59.8,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8240621907884552,
+          "mean_mse": 0.15817057599836162,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8223325621643222,
+          "mean_mse": 0.14780280394858478,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8594420306306289,
+          "mean_mse": 0.13647128159764843,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.829536131683523,
+          "mean_mse": 0.13907193011396354,
+          "mean_rank": 27.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8856553990303657,
+          "mean_mse": 0.10851509195681734,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8461884628512669,
+          "mean_mse": 0.1355729625116159,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c50",
+      "params": {
+        "K": 4,
+        "target_cond": 50.0
+      },
+      "mean_cosine_to_target": 0.8668609699682551,
+      "std_cosine_to_target": 0.037897025150445206,
+      "mean_mse_to_target": 0.11475104856669008,
+      "std_mse_to_target": 0.033333232423783526,
+      "mean_target_rank": 21.658536585365855,
+      "median_target_rank": 19.0,
+      "recall_at_1": 0.024390243902439025,
+      "recall_at_5": 0.23170731707317074,
+      "recall_at_10": 0.34146341463414637,
+      "mrr": 0.13272873973732915,
+      "train_time_ms": 15826.289666998491,
+      "inference_time_us": 53010.57423169302,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.881887824371607,
+          "mean_mse": 0.09684108136070048,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8994808387679474,
+          "mean_mse": 0.08634704368894233,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8645307574610333,
+          "mean_mse": 0.11198821098782795,
+          "mean_rank": 25.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.836954015918716,
+          "mean_mse": 0.1369991254277195,
+          "mean_rank": 37.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8517511075642047,
+          "mean_mse": 0.12965667919587306,
+          "mean_rank": 30.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8861559333250112,
+          "mean_mse": 0.09692118509088331,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8632091273369961,
+          "mean_mse": 0.10836834551137917,
+          "mean_rank": 23.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.884726376570224,
+          "mean_mse": 0.09996961463414314,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8288122190765114,
+          "mean_mse": 0.1532736305771652,
+          "mean_rank": 39.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8657215768116693,
+          "mean_mse": 0.11568790801672806,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8830190180908487,
+          "mean_mse": 0.10432547062910975,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8380712451888657,
+          "mean_mse": 0.1412123350869913,
+          "mean_rank": 34.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8826551258111307,
+          "mean_mse": 0.10376260312983315,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.797742005221102,
+          "mean_mse": 0.18400972805801497,
+          "mean_rank": 57.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8668211165722938,
+          "mean_mse": 0.1168538703116364,
+          "mean_rank": 20.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8513085833023933,
+          "mean_mse": 0.11989389257191507,
+          "mean_rank": 22.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9308630096510977,
+          "mean_mse": 0.06688080639919589,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.898869733664067,
+          "mean_mse": 0.08104122319915841,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8951135012946254,
+          "mean_mse": 0.09411553444513354,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8563182122744835,
+          "mean_mse": 0.1199273676360014,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K4_c100",
+      "params": {
+        "K": 4,
+        "target_cond": 100.0
+      },
+      "mean_cosine_to_target": 0.8776615619573769,
+      "std_cosine_to_target": 0.03677783003495514,
+      "mean_mse_to_target": 0.10504216442959687,
+      "std_mse_to_target": 0.03238880153735674,
+      "mean_target_rank": 18.841463414634145,
+      "median_target_rank": 15.5,
+      "recall_at_1": 0.036585365853658534,
+      "recall_at_5": 0.23170731707317074,
+      "recall_at_10": 0.36585365853658536,
+      "mrr": 0.14225015618979886,
+      "train_time_ms": 14668.508788003237,
+      "inference_time_us": 54407.42478041523,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8926403148722837,
+          "mean_mse": 0.08785340700018103,
+          "mean_rank": 14.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9078678392045015,
+          "mean_mse": 0.07841970236544246,
+          "mean_rank": 8.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8755356129393299,
+          "mean_mse": 0.10297899607547735,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8468863482447216,
+          "mean_mse": 0.12814972069680508,
+          "mean_rank": 33.75,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8587181016382688,
+          "mean_mse": 0.12221822884788305,
+          "mean_rank": 27.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8938133600232834,
+          "mean_mse": 0.08976792379091308,
+          "mean_rank": 15.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8719790634471425,
+          "mean_mse": 0.100902708311302,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8942475438753729,
+          "mean_mse": 0.09074727579993346,
+          "mean_rank": 14.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8395807448272764,
+          "mean_mse": 0.14334353953675746,
+          "mean_rank": 35.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8788750968382595,
+          "mean_mse": 0.10455591371536409,
+          "mean_rank": 16.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8888511163877457,
+          "mean_mse": 0.09751869225049525,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8665824565977499,
+          "mean_mse": 0.11805280805102733,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9048812965174331,
+          "mean_mse": 0.08489116160115148,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8160518248973126,
+          "mean_mse": 0.1686391998961469,
+          "mean_rank": 46.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8713610864287236,
+          "mean_mse": 0.1119170052864798,
+          "mean_rank": 20.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8591831231642213,
+          "mean_mse": 0.11303289761388206,
+          "mean_rank": 20.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9387550766230153,
+          "mean_mse": 0.057548643884014886,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9062404486971308,
+          "mean_mse": 0.07375882205836619,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9022710821023735,
+          "mean_mse": 0.08775002972257209,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8638323403689288,
+          "mean_mse": 0.11332200944431449,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "AdaptiveCond_K8_c50",
+      "params": {
+        "K": 8,
+        "target_cond": 50.0
+      },
+      "mean_cosine_to_target": 0.8503824067401649,
+      "std_cosine_to_target": 0.051836527907367036,
+      "mean_mse_to_target": 0.12650262449084426,
+      "std_mse_to_target": 0.04241096566948756,
+      "mean_target_rank": 20.26829268292683,
+      "median_target_rank": 14.5,
+      "recall_at_1": 0.06097560975609756,
+      "recall_at_5": 0.2804878048780488,
+      "recall_at_10": 0.36585365853658536,
+      "mrr": 0.1726791318805934,
+      "train_time_ms": 25590.96360499825,
+      "inference_time_us": 97875.33936584469,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8438821592783194,
+          "mean_mse": 0.12320270571633957,
+          "mean_rank": 22.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8977443116079237,
+          "mean_mse": 0.08844904057016852,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8039123159506117,
+          "mean_mse": 0.1551669725758371,
+          "mean_rank": 39.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.7993376532660699,
+          "mean_mse": 0.16350108589402884,
+          "mean_rank": 35.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8566701888581888,
+          "mean_mse": 0.1265882655934429,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8989245802915474,
+          "mean_mse": 0.08753853859822044,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8369590233978829,
+          "mean_mse": 0.12622559295653724,
+          "mean_rank": 23.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8529092294535419,
+          "mean_mse": 0.12281654983790266,
+          "mean_rank": 18.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.7702471626335232,
+          "mean_mse": 0.19589116852933472,
+          "mean_rank": 52.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8478570060280612,
+          "mean_mse": 0.12826351541243342,
+          "mean_rank": 17.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8645136365524613,
+          "mean_mse": 0.11791836537101869,
+          "mean_rank": 12.5,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8782180045807904,
+          "mean_mse": 0.11150287368032077,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8861020936965107,
+          "mean_mse": 0.09957571778970092,
+          "mean_rank": 7.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7654674579974745,
+          "mean_mse": 0.20755929958826846,
+          "mean_rank": 51.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8214871267416861,
+          "mean_mse": 0.15040497122971946,
+          "mean_rank": 26.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8121451227424904,
+          "mean_mse": 0.1464552110436712,
+          "mean_rank": 30.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.936634150272363,
+          "mean_mse": 0.06130837307937802,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.899674325991535,
+          "mean_mse": 0.08057419409279115,
+          "mean_rank": 8.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8937156501817434,
+          "mean_mse": 0.09814542736959127,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8825094834929035,
+          "mean_mse": 0.10135331610420126,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_none_f10",
+      "params": {
+        "smooth_method": "none",
+        "fidelity_weight": 1.0
+      },
+      "mean_cosine_to_target": 0.8608217152740425,
+      "std_cosine_to_target": 0.0457573095259807,
+      "mean_mse_to_target": 0.1392330735456539,
+      "std_mse_to_target": 0.0472205457956076,
+      "mean_target_rank": 1.170731707317073,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.8658536585365854,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.926829268292683,
+      "train_time_ms": 134.4143009991967,
+      "inference_time_us": 3980.3585487988594,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8162340910522865,
+          "mean_mse": 0.18031046275610235,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.804533471383481,
+          "mean_mse": 0.1965394006697349,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8410289748698485,
+          "mean_mse": 0.15358787539943033,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8572661463339684,
+          "mean_mse": 0.14430127635913975,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8640314559909418,
+          "mean_mse": 0.1334840263421334,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8725893310775368,
+          "mean_mse": 0.12549914286771957,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.824815743914318,
+          "mean_mse": 0.16673345054493313,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8455679594800731,
+          "mean_mse": 0.1490033369703033,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8855341354429596,
+          "mean_mse": 0.1193304797014018,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8606851322716587,
+          "mean_mse": 0.14332770157479324,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8458056303184396,
+          "mean_mse": 0.16593322696945093,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8884341129491033,
+          "mean_mse": 0.11518735538711908,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8683386192968969,
+          "mean_mse": 0.13186430579630656,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8696163306975683,
+          "mean_mse": 0.14062268345968063,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8653321977298813,
+          "mean_mse": 0.1395846394700049,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8658059457587105,
+          "mean_mse": 0.13190483371776074,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8974134060592225,
+          "mean_mse": 0.10058894290572078,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8386240390762829,
+          "mean_mse": 0.15484564205938525,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9061137214190536,
+          "mean_mse": 0.08967131202537562,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8902871014605094,
+          "mean_mse": 0.10696962191913738,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f0",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.0
+      },
+      "mean_cosine_to_target": 0.8453325503820898,
+      "std_cosine_to_target": 0.048931343762709995,
+      "mean_mse_to_target": 0.15398980291657538,
+      "std_mse_to_target": 0.05040593410986916,
+      "mean_target_rank": 1.2073170731707317,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.8658536585365854,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.9227642276422763,
+      "train_time_ms": 1195.3830889979145,
+      "inference_time_us": 3669.0511829297843,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7961487771463418,
+          "mean_mse": 0.20098189624390403,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.7941950340553859,
+          "mean_mse": 0.206226012612736,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8328392963693457,
+          "mean_mse": 0.16044640977829228,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8496632384028084,
+          "mean_mse": 0.14955634462070563,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8441690030181019,
+          "mean_mse": 0.15142611463054925,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8653599219878676,
+          "mean_mse": 0.1332988346197606,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8119007742454669,
+          "mean_mse": 0.17868521802314144,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8373101730244259,
+          "mean_mse": 0.15636824943182284,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8747145770881126,
+          "mean_mse": 0.130635141469915,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8503201753210223,
+          "mean_mse": 0.15286502761412568,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8323889036410654,
+          "mean_mse": 0.1780284960149862,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8746612919777548,
+          "mean_mse": 0.12827060932679793,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8347058893549394,
+          "mean_mse": 0.16291540314052633,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.863864037120439,
+          "mean_mse": 0.1459862757944948,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8585061224511787,
+          "mean_mse": 0.1475989844330251,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.852587565745427,
+          "mean_mse": 0.1455411889373618,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8819988842971183,
+          "mean_mse": 0.11841692239512876,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8142264978111091,
+          "mean_mse": 0.1811418391315599,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8665538785565017,
+          "mean_mse": 0.12218392140294101,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8585585876662903,
+          "mean_mse": 0.1370627158519186,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f3",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.3
+      },
+      "mean_cosine_to_target": 0.8505380122413745,
+      "std_cosine_to_target": 0.04771303083784736,
+      "mean_mse_to_target": 0.14889105423104124,
+      "std_mse_to_target": 0.04921242016354152,
+      "mean_target_rank": 1.2073170731707317,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.8658536585365854,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.9227642276422763,
+      "train_time_ms": 787.9261929992936,
+      "inference_time_us": 3766.4853293014257,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8025087284893826,
+          "mean_mse": 0.1942619260597754,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.7974047715829451,
+          "mean_mse": 0.20317153410067662,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.835395168065519,
+          "mean_mse": 0.15827426103840078,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.852139835820421,
+          "mean_mse": 0.1477455384955645,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8507256708016377,
+          "mean_mse": 0.1453411791115792,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8676518907204684,
+          "mean_mse": 0.13080615148344837,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8159915887372359,
+          "mean_mse": 0.17481777286042863,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8399261051881142,
+          "mean_mse": 0.1539947740302685,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8781777620401817,
+          "mean_mse": 0.12697333984489637,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8536758389869563,
+          "mean_mse": 0.14968127901924544,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8368234850147462,
+          "mean_mse": 0.17382509177744182,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8791690321504086,
+          "mean_mse": 0.12389628015301474,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8463495811766131,
+          "mean_mse": 0.1516876457925227,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8657272723262883,
+          "mean_mse": 0.1441993797840078,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8607235191953265,
+          "mean_mse": 0.1449652478597504,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8569206817255715,
+          "mean_mse": 0.14095356734924802,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8869595488881261,
+          "mean_mse": 0.11256771269969663,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8220631503751531,
+          "mean_mse": 0.17242092444999357,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.882084253817113,
+          "mean_mse": 0.10870998043655336,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.869635107254356,
+          "mean_mse": 0.12617984548260625,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f5",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.5
+      },
+      "mean_cosine_to_target": 0.8537448012949088,
+      "std_cosine_to_target": 0.04706786508274671,
+      "mean_mse_to_target": 0.1458117598093793,
+      "std_mse_to_target": 0.0485742208481298,
+      "mean_target_rank": 1.1951219512195121,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.8658536585365854,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.9237804878048781,
+      "train_time_ms": 635.5140980012948,
+      "inference_time_us": 4804.29145123131,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8065938709851672,
+          "mean_mse": 0.19002886981216027,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.7994934624000981,
+          "mean_mse": 0.20120592696366515,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8370520194486963,
+          "mean_mse": 0.1568807277957269,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8536969142294412,
+          "mean_mse": 0.14664989900579012,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8548139691490431,
+          "mean_mse": 0.14161898830485886,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8691218799154852,
+          "mean_mse": 0.1292171130167164,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8186170453093224,
+          "mean_mse": 0.17237372128492978,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8416043454930767,
+          "mean_mse": 0.1524905531259459,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8803840481829323,
+          "mean_mse": 0.12466090213986711,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8557963539871793,
+          "mean_mse": 0.14771237556698266,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8395867644300684,
+          "mean_mse": 0.1712965477733093,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.881996140113491,
+          "mean_mse": 0.12119403831900669,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8533883310477726,
+          "mean_mse": 0.14511315429610971,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8669039628415314,
+          "mean_mse": 0.14309279116275112,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8621218269120954,
+          "mean_mse": 0.14331867732726666,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8596376155007311,
+          "mean_mse": 0.1381316839201405,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8901119073892992,
+          "mean_mse": 0.10890672330684177,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.827052151939176,
+          "mean_mse": 0.16700319826224175,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.890680164387899,
+          "mean_mse": 0.10149885700806544,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8762936501270112,
+          "mean_mse": 0.11980790437424468,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_fft_f7",
+      "params": {
+        "smooth_method": "fft",
+        "fidelity_weight": 0.7
+      },
+      "mean_cosine_to_target": 0.8567372687951372,
+      "std_cosine_to_target": 0.04650907595346686,
+      "mean_mse_to_target": 0.14298836248267263,
+      "std_mse_to_target": 0.04800996052503943,
+      "mean_target_rank": 1.1951219512195121,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.8658536585365854,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.9237804878048781,
+      "train_time_ms": 610.5406979986583,
+      "inference_time_us": 4753.729256108494,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8105500931667552,
+          "mean_mse": 0.1859933526646548,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.8015407951217783,
+          "mean_mse": 0.19929688932347622,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8386711406745626,
+          "mean_mse": 0.155530847286856,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8551796539026347,
+          "mean_mse": 0.14564351119093816,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8586736159149321,
+          "mean_mse": 0.1381643437962129,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8705447361383909,
+          "mean_mse": 0.12768627478263198,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8211596278980019,
+          "mean_mse": 0.1700370658691453,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8432296763641374,
+          "mean_mse": 0.1510488090456607,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8825071904537788,
+          "mean_mse": 0.1224514751374911,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8578228227269193,
+          "mean_mse": 0.14586634860351247,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8421931650121711,
+          "mean_mse": 0.16898698415922775,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8846796487404549,
+          "mean_mse": 0.11866297857714321,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8598277274703371,
+          "mean_mse": 0.13926720685483485,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8680282280494194,
+          "mean_mse": 0.14205394285008216,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8634552622026421,
+          "mean_mse": 0.14175950987454233,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8622133383581533,
+          "mean_mse": 0.1354990252614076,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.89313435696054,
+          "mean_mse": 0.10543652090393343,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8318402929257186,
+          "mean_mse": 0.16190244562112374,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8978774014912025,
+          "mean_mse": 0.09570493668552722,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.882351382101982,
+          "mean_mse": 0.11414260790949377,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "MinTrans_kernel_f5",
+      "params": {
+        "smooth_method": "kernel",
+        "fidelity_weight": 0.5
+      },
+      "mean_cosine_to_target": 0.8376851511155693,
+      "std_cosine_to_target": 0.04888768824652438,
+      "mean_mse_to_target": 0.16104426483579226,
+      "std_mse_to_target": 0.049680970740840845,
+      "mean_target_rank": 1.2560975609756098,
+      "median_target_rank": 1.0,
+      "recall_at_1": 0.8414634146341463,
+      "recall_at_5": 1.0,
+      "recall_at_10": 1.0,
+      "mrr": 0.9079268292682925,
+      "train_time_ms": 555.5763980009942,
+      "inference_time_us": 5178.1694999634765,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.7839705973295397,
+          "mean_mse": 0.2114337229112068,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.7861143380057891,
+          "mean_mse": 0.21281488039803031,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.822649831421641,
+          "mean_mse": 0.17061860348687075,
+          "mean_rank": 2.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8407010398003093,
+          "mean_mse": 0.15916733228678775,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8416009488437667,
+          "mean_mse": 0.15437703158001986,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.856960918309972,
+          "mean_mse": 0.13955142235589876,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8011462589843068,
+          "mean_mse": 0.18784128036011596,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8292187236288355,
+          "mean_mse": 0.16297685368709355,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.862320699169433,
+          "mean_mse": 0.14342539197236995,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8474497662068988,
+          "mean_mse": 0.1548706648482407,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8251312508740357,
+          "mean_mse": 0.18369243079282313,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8699046280408647,
+          "mean_mse": 0.13344431498436587,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8253647739870198,
+          "mean_mse": 0.16894414525827656,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8582407026587828,
+          "mean_mse": 0.15170270723714915,
+          "mean_rank": 1.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8458436499787906,
+          "mean_mse": 0.15855646798362197,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.851502911065795,
+          "mean_mse": 0.14555386371747073,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.8555384804653602,
+          "mean_mse": 0.14222638390043993,
+          "mean_rank": 1.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8041502473343936,
+          "mean_mse": 0.1882276860621329,
+          "mean_rank": 1.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8746064276845249,
+          "mean_mse": 0.12024288187216042,
+          "mean_rank": 1.25,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.859989053622056,
+          "mean_mse": 0.13795733863628648,
+          "mean_rank": 1.0,
           "num_queries": 4
         }
       }

--- a/reports/answer_level_modernbert.json
+++ b/reports/answer_level_modernbert.json
@@ -35,10 +35,10 @@
   },
   "winners": {
     "highest_cosine": "Residual_K8_r0.01",
-    "lowest_mse": "Basis_K16",
+    "lowest_mse": "Basis_K8",
     "lowest_rank": "Residual_K8_r0.01",
-    "highest_mrr": "Basis_K4",
-    "highest_recall_at_5": "Basis_K4"
+    "highest_mrr": "Residual_K8_r0.01",
+    "highest_recall_at_5": "Residual_K4_r0.01"
   },
   "results": [
     {
@@ -46,320 +46,140 @@
       "params": {
         "type": "baseline"
       },
-      "mean_cosine_to_target": 0.8858033014543343,
-      "std_cosine_to_target": 0.034451309876868896,
-      "mean_mse_to_target": 0.09724387161699945,
-      "std_mse_to_target": 0.027799405077881367,
-      "mean_target_rank": 20.42079207920792,
-      "median_target_rank": 9.0,
-      "recall_at_1": 0.04455445544554455,
-      "recall_at_5": 0.3564356435643564,
-      "recall_at_10": 0.5247524752475248,
-      "mrr": 0.19369331519482247,
-      "train_time_ms": 1.5189000000646047,
-      "inference_time_us": 404.86138613849306,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.909242611216307,
+      "std_cosine_to_target": 0.03344798058764164,
+      "mean_mse_to_target": 0.07874832550601615,
+      "std_mse_to_target": 0.02990271508080448,
+      "mean_target_rank": 7.7560975609756095,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.6341463414634146,
+      "recall_at_10": 0.7926829268292683,
+      "mrr": 0.31982445470964127,
+      "train_time_ms": 0.5611000015051104,
+      "inference_time_us": 148.86220733609574,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9126679445757608,
-          "mean_mse": 0.07130693377337648,
-          "mean_rank": 5.75,
+          "mean_cosine": 0.9241699514437839,
+          "mean_mse": 0.06181693250316411,
+          "mean_rank": 5.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9102076557003489,
-          "mean_mse": 0.07584407458271988,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.9254453300775906,
+          "mean_mse": 0.06333986726060366,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.894139590255815,
-          "mean_mse": 0.08849966905780379,
-          "mean_rank": 16.5,
+          "mean_cosine": 0.8971997898224713,
+          "mean_mse": 0.0857289400877182,
+          "mean_rank": 12.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.865587700137156,
-          "mean_mse": 0.11342057261826025,
-          "mean_rank": 40.5,
+          "mean_cosine": 0.8856499034062507,
+          "mean_mse": 0.09736885017044886,
+          "mean_rank": 15.75,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8562947538167467,
-          "mean_mse": 0.12108998536570673,
-          "mean_rank": 48.25,
+          "mean_cosine": 0.8800373337889292,
+          "mean_mse": 0.10256071943313919,
+          "mean_rank": 16.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.9036445884302347,
-          "mean_mse": 0.08252448405492319,
-          "mean_rank": 17.25,
+          "mean_cosine": 0.9159025466586668,
+          "mean_mse": 0.07238978648865718,
+          "mean_rank": 8.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.896391222896386,
-          "mean_mse": 0.0831346176260003,
-          "mean_rank": 17.75,
+          "mean_cosine": 0.9083872456446378,
+          "mean_mse": 0.07389076550710576,
+          "mean_rank": 10.0,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.9124192111507872,
-          "mean_mse": 0.07591522051710772,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8692695935226391,
-          "mean_mse": 0.11965624576755077,
-          "mean_rank": 19.8,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.8782313583375705,
-          "mean_mse": 0.10380143263222516,
-          "mean_rank": 23.25,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.8876459952787307,
-          "mean_mse": 0.09746811113725969,
-          "mean_rank": 14.0,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.899967247932211,
-          "mean_mse": 0.09086507555450689,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.9070271857565272,
-          "mean_mse": 0.07816911844341387,
-          "mean_rank": 16.0,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.82153992708534,
-          "mean_mse": 0.1616123270372401,
-          "mean_rank": 71.6,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8812855746141913,
-          "mean_mse": 0.10428099889291652,
-          "mean_rank": 19.25,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.896412491290001,
-          "mean_mse": 0.08417940028843662,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.941178622747015,
-          "mean_mse": 0.05738664990438784,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9052657408700808,
-          "mean_mse": 0.07430599263263414,
-          "mean_rank": 12.0,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9197583489236357,
-          "mean_mse": 0.07101245600504862,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8881654844415914,
-          "mean_mse": 0.0937586534321633,
-          "mean_rank": 13.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8728193577713805,
-          "mean_mse": 0.1094042746838111,
-          "mean_rank": 36.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9066954061451067,
-          "mean_mse": 0.08000679548754701,
-          "mean_rank": 9.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8717480553800115,
-          "mean_mse": 0.1087410149013047,
-          "mean_rank": 23.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8637470663636584,
-          "mean_mse": 0.10766322932080676,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.842053578743731,
-          "mean_mse": 0.12494968076366073,
-          "mean_rank": 30.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8742610752029596,
-          "mean_mse": 0.09636534341682645,
-          "mean_rank": 14.5,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8384884917497014,
-          "mean_mse": 0.12897814702162558,
-          "mean_rank": 47.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8718748276779898,
-          "mean_mse": 0.10653418059299123,
-          "mean_rank": 23.0,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8433230702992178,
-          "mean_mse": 0.1318609263397141,
-          "mean_rank": 58.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.911502135256987,
-          "mean_mse": 0.07426002214456201,
+          "mean_cosine": 0.9162556090832963,
+          "mean_mse": 0.07195140385972228,
           "mean_rank": 6.5,
           "num_queries": 4
         },
-        "compile-api-reference": {
-          "mean_cosine": 0.8712897936763208,
-          "mean_mse": 0.10541316519748294,
-          "mean_rank": 28.25,
+        "prolog-facts-rules": {
+          "mean_cosine": 0.886351903026922,
+          "mean_mse": 0.10513568234200235,
+          "mean_rank": 6.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8980667556517964,
+          "mean_mse": 0.08791573226840353,
+          "mean_rank": 9.75,
           "num_queries": 4
         },
-        "bash-constraints": {
-          "mean_cosine": 0.8668099096864822,
-          "mean_mse": 0.10960916087487226,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.876573563509491,
-          "mean_mse": 0.10253434660860768,
-          "mean_rank": 31.0,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8592819565991694,
-          "mean_mse": 0.12021353341158392,
-          "mean_rank": 38.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8979467306770017,
-          "mean_mse": 0.08578899808167928,
-          "mean_rank": 19.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9106113610917766,
-          "mean_mse": 0.08366064596926585,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9184934891140565,
-          "mean_mse": 0.07489472866090163,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.8959865985602061,
-          "mean_mse": 0.09191638026842704,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.859816713760509,
-          "mean_mse": 0.11674278801152689,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8540725692980802,
-          "mean_mse": 0.12076346490772558,
-          "mean_rank": 38.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.901087485842635,
-          "mean_mse": 0.08314156582632015,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.8917688843871118,
-          "mean_mse": 0.09360725550732761,
-          "mean_rank": 14.0,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.8930256634378364,
-          "mean_mse": 0.09333844982229672,
-          "mean_rank": 10.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9181992292910072,
-          "mean_mse": 0.06959884911196577,
+        "prolog-directives": {
+          "mean_cosine": 0.9188752675745476,
+          "mean_mse": 0.07231310660828459,
           "mean_rank": 3.5,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.9121966753489799,
-          "mean_mse": 0.08496724881209057,
-          "mean_rank": 4.5,
+        "prolog-file-io": {
+          "mean_cosine": 0.9192335105987437,
+          "mean_mse": 0.07425492101314894,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8878672654137422,
-          "mean_mse": 0.09758360138897607,
-          "mean_rank": 18.25,
+        "init-pl-explained": {
+          "mean_cosine": 0.9328225226920488,
+          "mean_mse": 0.056982079428940985,
+          "mean_rank": 8.25,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.861731155957016,
-          "mean_mse": 0.11611825977271878,
-          "mean_rank": 35.25,
+        "prolog-terms": {
+          "mean_cosine": 0.8539670403426884,
+          "mean_mse": 0.13550348885351676,
+          "mean_rank": 16.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9003635693608643,
+          "mean_mse": 0.08829677253942293,
+          "mean_rank": 5.5,
           "num_queries": 4
         },
-        "mutual-recursion": {
-          "mean_cosine": 0.9094599245186991,
-          "mean_mse": 0.08540671449678591,
-          "mean_rank": 10.75,
+        "recursion-patterns": {
+          "mean_cosine": 0.8905429500771305,
+          "mean_mse": 0.08850903397203244,
+          "mean_rank": 9.75,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.9025466467176809,
-          "mean_mse": 0.08677903870500647,
-          "mean_rank": 11.75,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9571141356176616,
+          "mean_mse": 0.042150136893166615,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8779854240505796,
-          "mean_mse": 0.10142454402518111,
-          "mean_rank": 27.25,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9272157616504817,
+          "mean_mse": 0.05795402672250083,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9531060226193879,
+          "mean_mse": 0.04239505057515821,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9136866449539893,
+          "mean_mse": 0.07372358354731375,
+          "mean_rank": 3.0,
           "num_queries": 4
         }
       }
@@ -370,320 +190,140 @@
         "cutoff": 0.3,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.8886239592388469,
-      "std_cosine_to_target": 0.03323759646351626,
-      "mean_mse_to_target": 0.11480488716771971,
-      "std_mse_to_target": 0.029269493145945125,
-      "mean_target_rank": 18.292079207920793,
-      "median_target_rank": 9.0,
-      "recall_at_1": 0.06930693069306931,
-      "recall_at_5": 0.3811881188118812,
-      "recall_at_10": 0.5495049504950495,
-      "mrr": 0.2191401203120762,
-      "train_time_ms": 3713.5635629999797,
-      "inference_time_us": 17048.523579207973,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9038260142177057,
+      "std_cosine_to_target": 0.03132124243476559,
+      "mean_mse_to_target": 0.09685223918382345,
+      "std_mse_to_target": 0.02975437601697026,
+      "mean_target_rank": 8.268292682926829,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7317073170731707,
+      "mrr": 0.29432069031270675,
+      "train_time_ms": 914.7202139974979,
+      "inference_time_us": 6022.064731729277,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9145710921317297,
-          "mean_mse": 0.08667811842962743,
+          "mean_cosine": 0.9218110611340582,
+          "mean_mse": 0.07541268244215427,
           "mean_rank": 4.75,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9111328182524456,
-          "mean_mse": 0.09626521093475249,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.9243147217116655,
+          "mean_mse": 0.08135026650032685,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8941837924530636,
-          "mean_mse": 0.10206099786538585,
-          "mean_rank": 17.5,
+          "mean_cosine": 0.8955167786744149,
+          "mean_mse": 0.09972115907145715,
+          "mean_rank": 12.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8649655979921065,
-          "mean_mse": 0.13402352199738457,
-          "mean_rank": 42.5,
+          "mean_cosine": 0.8822736930273807,
+          "mean_mse": 0.11529858670260629,
+          "mean_rank": 17.25,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8564166434616121,
-          "mean_mse": 0.1425847518535338,
-          "mean_rank": 47.5,
+          "mean_cosine": 0.8765562424036522,
+          "mean_mse": 0.12199623698704115,
+          "mean_rank": 19.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.9070095070349288,
-          "mean_mse": 0.09314677379248795,
-          "mean_rank": 16.25,
+          "mean_cosine": 0.9129241418749696,
+          "mean_mse": 0.08513652445588182,
+          "mean_rank": 9.5,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.9012822815226189,
-          "mean_mse": 0.09814264666419369,
-          "mean_rank": 14.25,
+          "mean_cosine": 0.9070173418431856,
+          "mean_mse": 0.08605138648869136,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.9132464301696755,
-          "mean_mse": 0.0981208957403687,
-          "mean_rank": 6.0,
+          "mean_cosine": 0.9150890287415421,
+          "mean_mse": 0.0906976574497331,
+          "mean_rank": 6.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8708628147941901,
-          "mean_mse": 0.13455679439819138,
-          "mean_rank": 14.8,
+          "mean_cosine": 0.8800107465279069,
+          "mean_mse": 0.1209866379283712,
+          "mean_rank": 6.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8780149514540753,
-          "mean_mse": 0.12172677407904106,
-          "mean_rank": 24.0,
+          "mean_cosine": 0.8954716861977245,
+          "mean_mse": 0.10343610678430916,
+          "mean_rank": 10.0,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8877851653437746,
-          "mean_mse": 0.12212760028154787,
-          "mean_rank": 14.0,
+          "mean_cosine": 0.9137893630459395,
+          "mean_mse": 0.09665577199239113,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.8981102980625054,
-          "mean_mse": 0.11076826656903145,
+          "mean_cosine": 0.9097696340645105,
+          "mean_mse": 0.09443623852303287,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.9053686046681273,
-          "mean_mse": 0.10951737510201051,
-          "mean_rank": 11.75,
+          "mean_cosine": 0.9273144721804875,
+          "mean_mse": 0.08050605210441485,
+          "mean_rank": 7.25,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8248215290130144,
-          "mean_mse": 0.17963979661432583,
-          "mean_rank": 64.6,
+          "mean_cosine": 0.8523090337436372,
+          "mean_mse": 0.15332523886194524,
+          "mean_rank": 15.4,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.87907638166696,
-          "mean_mse": 0.12090656909575904,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8990386724316751,
-          "mean_mse": 0.09359102446161734,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9376476310890465,
-          "mean_mse": 0.07106379288834273,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9026323631026142,
-          "mean_mse": 0.09098508440979157,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9186609109082309,
-          "mean_mse": 0.08962099573959395,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8865105567573295,
-          "mean_mse": 0.11164626279942577,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.886931735522867,
-          "mean_mse": 0.11712521743269501,
-          "mean_rank": 28.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9099006931400831,
-          "mean_mse": 0.08994084838344538,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8747318028860727,
-          "mean_mse": 0.126921971573696,
-          "mean_rank": 21.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8703042159932955,
-          "mean_mse": 0.12357851282281201,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8609141507414595,
-          "mean_mse": 0.13567013547642406,
-          "mean_rank": 11.75,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8738042753937462,
-          "mean_mse": 0.11118799202262757,
-          "mean_rank": 14.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8502138679909821,
-          "mean_mse": 0.1445144967535433,
-          "mean_rank": 34.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8793269953146137,
-          "mean_mse": 0.13344160701216515,
-          "mean_rank": 13.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8455673682927618,
-          "mean_mse": 0.15044510600977007,
-          "mean_rank": 52.5,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9149675141363376,
-          "mean_mse": 0.09059858880134375,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8784448363786377,
-          "mean_mse": 0.12017019987134299,
-          "mean_rank": 22.25,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8677683009937939,
-          "mean_mse": 0.13155188470589546,
-          "mean_rank": 34.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8794883627660066,
-          "mean_mse": 0.12434139748940103,
-          "mean_rank": 29.25,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8634586069648866,
-          "mean_mse": 0.1453349532732262,
-          "mean_rank": 34.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.9014223184388971,
-          "mean_mse": 0.09979455952838204,
-          "mean_rank": 17.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9108586280533973,
-          "mean_mse": 0.10228605152415347,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9269368339583228,
-          "mean_mse": 0.08379048174012542,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9033515879897568,
-          "mean_mse": 0.10637143769117424,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8615586410426116,
-          "mean_mse": 0.14243305184864993,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8571333917454477,
-          "mean_mse": 0.13018048749618585,
-          "mean_rank": 38.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9020387656654031,
-          "mean_mse": 0.10546649214788245,
+          "mean_cosine": 0.8938610228443549,
+          "mean_mse": 0.10418377768424475,
           "mean_rank": 6.75,
           "num_queries": 4
         },
-        "call-graph-construction": {
-          "mean_cosine": 0.889655066784676,
-          "mean_mse": 0.12150395595787328,
-          "mean_rank": 13.5,
+        "recursion-patterns": {
+          "mean_cosine": 0.8891147517747713,
+          "mean_mse": 0.10113420085257507,
+          "mean_rank": 9.75,
           "num_queries": 4
         },
-        "scc-detection": {
-          "mean_cosine": 0.9061796490966563,
-          "mean_mse": 0.10739021416763606,
-          "mean_rank": 5.75,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9502663442676585,
+          "mean_mse": 0.05489301392475046,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9207075849461318,
-          "mean_mse": 0.08481872627998512,
-          "mean_rank": 3.25,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9152875109889977,
+          "mean_mse": 0.07877370865969674,
+          "mean_rank": 7.25,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.9155203870497951,
-          "mean_mse": 0.10434102223422938,
-          "mean_rank": 4.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9389653516478688,
+          "mean_mse": 0.06928031695087736,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.889992702045845,
-          "mean_mse": 0.11510604961873996,
-          "mean_rank": 17.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8601830017645065,
-          "mean_mse": 0.13530494869073445,
-          "mean_rank": 37.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.9179981863328681,
-          "mean_mse": 0.1027634848917294,
-          "mean_rank": 9.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.9014923141182364,
-          "mean_mse": 0.10535750440026541,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8793990277521453,
-          "mean_mse": 0.12019302065416863,
-          "mean_rank": 27.25,
+        "fold-pattern": {
+          "mean_cosine": 0.8936904197003532,
+          "mean_mse": 0.10361736970630103,
+          "mean_rank": 5.25,
           "num_queries": 4
         }
       }
@@ -694,320 +334,140 @@
         "cutoff": 0.5,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.8961462544531952,
-      "std_cosine_to_target": 0.032180898664562016,
-      "mean_mse_to_target": 0.10750328873633706,
-      "std_mse_to_target": 0.028429226678366212,
-      "mean_target_rank": 14.341584158415841,
-      "median_target_rank": 6.5,
-      "recall_at_1": 0.09405940594059406,
-      "recall_at_5": 0.4405940594059406,
-      "recall_at_10": 0.6683168316831684,
-      "mrr": 0.2623252105197235,
-      "train_time_ms": 3587.873681000019,
-      "inference_time_us": 27752.85467821741,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9133654365943901,
+      "std_cosine_to_target": 0.031744607308495654,
+      "mean_mse_to_target": 0.08656000624004391,
+      "std_mse_to_target": 0.030293770286368035,
+      "mean_target_rank": 6.414634146341464,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.15853658536585366,
+      "recall_at_5": 0.6707317073170732,
+      "recall_at_10": 0.8170731707317073,
+      "mrr": 0.3757760074295225,
+      "train_time_ms": 778.7905120021605,
+      "inference_time_us": 6803.981804895136,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9174497307403036,
-          "mean_mse": 0.08221754653829104,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9146838910040616,
-          "mean_mse": 0.09189245911051935,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8979094281211099,
-          "mean_mse": 0.09760178225401646,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8735543862524963,
-          "mean_mse": 0.12622158236721162,
-          "mean_rank": 33.0,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8637754472299872,
-          "mean_mse": 0.1353540377147467,
-          "mean_rank": 39.75,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.9092582959862517,
-          "mean_mse": 0.0899494746973806,
-          "mean_rank": 15.75,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.904694015857036,
-          "mean_mse": 0.09264382171435893,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9163920935281162,
-          "mean_mse": 0.09296916526927554,
+          "mean_cosine": 0.9267813864331553,
+          "mean_mse": 0.06971437935969108,
           "mean_rank": 4.5,
           "num_queries": 4
         },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8790016458757535,
-          "mean_mse": 0.12614789212856486,
-          "mean_rank": 10.8,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.885425338080127,
-          "mean_mse": 0.11504775333367595,
-          "mean_rank": 18.75,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9290340096491361,
+          "mean_mse": 0.07539113492234861,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
-        "prolog-directives": {
-          "mean_cosine": 0.8983021082500536,
-          "mean_mse": 0.11269688854398754,
-          "mean_rank": 7.75,
+        "compilation-pipeline": {
+          "mean_cosine": 0.9003991839537386,
+          "mean_mse": 0.09358574790102682,
+          "mean_rank": 11.25,
           "num_queries": 4
         },
-        "prolog-file-io": {
-          "mean_cosine": 0.9098621629336526,
-          "mean_mse": 0.1005363518336363,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.922464115959279,
-          "mean_mse": 0.09077324627886958,
-          "mean_rank": 13.0,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8371063164151813,
-          "mean_mse": 0.1694248353415763,
-          "mean_rank": 43.0,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8878165481709799,
-          "mean_mse": 0.11339004598526616,
+        "constraint-usage": {
+          "mean_cosine": 0.8941133612125723,
+          "mean_mse": 0.10381893244365181,
           "mean_rank": 12.25,
           "num_queries": 4
         },
-        "recursion-patterns": {
-          "mean_cosine": 0.9022102431280992,
-          "mean_mse": 0.09005718745805058,
-          "mean_rank": 11.5,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.885440073429709,
+          "mean_mse": 0.11274734139230523,
+          "mean_rank": 14.0,
           "num_queries": 4
         },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9440894433708795,
-          "mean_mse": 0.06536513274478685,
-          "mean_rank": 3.75,
+        "practical-compilation": {
+          "mean_cosine": 0.9191541596504557,
+          "mean_mse": 0.07919593892176277,
+          "mean_rank": 8.25,
           "num_queries": 4
         },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9126744505906009,
-          "mean_mse": 0.08154422716814543,
-          "mean_rank": 9.25,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9315351680650741,
-          "mean_mse": 0.07792905415130456,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.898497338322364,
-          "mean_mse": 0.10208223535710634,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8884544948234755,
-          "mean_mse": 0.11525552030403358,
-          "mean_rank": 26.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9153128404322857,
-          "mean_mse": 0.08480924312715958,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8852693949295155,
-          "mean_mse": 0.11596350041494537,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8888395853736845,
-          "mean_mse": 0.11051459944255541,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8669894031220504,
-          "mean_mse": 0.12925975249991903,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8914772108614873,
-          "mean_mse": 0.09954559956883591,
+        "generated-code-facts": {
+          "mean_cosine": 0.9135723547279901,
+          "mean_mse": 0.07923213192371789,
           "mean_rank": 8.5,
           "num_queries": 4
         },
-        "bash-redirections": {
-          "mean_cosine": 0.8585060991026549,
-          "mean_mse": 0.13621954456307467,
-          "mean_rank": 26.5,
+        "generated-code-transitive": {
+          "mean_cosine": 0.9202694780674973,
+          "mean_mse": 0.08474731647054794,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "bash-trap": {
-          "mean_cosine": 0.8965891744290783,
-          "mean_mse": 0.11872885020187453,
-          "mean_rank": 6.5,
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8907013973002945,
+          "mean_mse": 0.1102779957597367,
+          "mean_rank": 3.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.902200360667724,
+          "mean_mse": 0.0950106092193449,
+          "mean_rank": 9.25,
           "num_queries": 4
         },
-        "bash-string-ops": {
-          "mean_cosine": 0.8545834514577608,
-          "mean_mse": 0.14179624228932153,
-          "mean_rank": 43.25,
+        "prolog-directives": {
+          "mean_cosine": 0.9238402361196099,
+          "mean_mse": 0.08467097856522204,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
-        "compiler-driver": {
-          "mean_cosine": 0.9194395388091137,
-          "mean_mse": 0.08577645065317353,
-          "mean_rank": 5.5,
+        "prolog-file-io": {
+          "mean_cosine": 0.9234812571376718,
+          "mean_mse": 0.0817724509287395,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
-        "compile-api-reference": {
-          "mean_cosine": 0.8831867505051657,
-          "mean_mse": 0.1166200424698822,
-          "mean_rank": 18.25,
+        "init-pl-explained": {
+          "mean_cosine": 0.9386450627484652,
+          "mean_mse": 0.06522788146763514,
+          "mean_rank": 7.5,
           "num_queries": 4
         },
-        "bash-constraints": {
-          "mean_cosine": 0.8785574073454635,
-          "mean_mse": 0.12230623273405972,
-          "mean_rank": 25.5,
+        "prolog-terms": {
+          "mean_cosine": 0.8635132419734045,
+          "mean_mse": 0.14155018710219083,
+          "mean_rank": 11.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9032203175853929,
+          "mean_mse": 0.09531469954769914,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "data-sources-overview": {
-          "mean_cosine": 0.8851152723082981,
-          "mean_mse": 0.11864124726115452,
-          "mean_rank": 26.25,
+        "recursion-patterns": {
+          "mean_cosine": 0.8958002024551104,
+          "mean_mse": 0.0938300195891021,
+          "mean_rank": 8.0,
           "num_queries": 4
         },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8740237116030294,
-          "mean_mse": 0.13525685696928882,
-          "mean_rank": 26.5,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.9046193878445852,
-          "mean_mse": 0.09638111929835588,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9163749667137814,
-          "mean_mse": 0.09529604206699806,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9284660575354579,
-          "mean_mse": 0.08191860215986149,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9097292617862056,
-          "mean_mse": 0.09997822623457231,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8746633501220678,
-          "mean_mse": 0.13035542710286097,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8671470447519896,
-          "mean_mse": 0.12283291788761483,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9084535805425566,
-          "mean_mse": 0.09915146071251049,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9012702700708333,
-          "mean_mse": 0.10913666834380444,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9075880354490924,
-          "mean_mse": 0.10488794867597409,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9245159717878245,
-          "mean_mse": 0.07968569918534864,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9560946651290508,
+          "mean_mse": 0.04857559108799837,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.9180175441142221,
-          "mean_mse": 0.10040430706380267,
-          "mean_rank": 4.0,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9290838892630405,
+          "mean_mse": 0.06581055283975934,
+          "mean_rank": 4.75,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8933233224149058,
-          "mean_mse": 0.1105501998650297,
-          "mean_rank": 13.5,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9542939746410486,
+          "mean_mse": 0.0481407540836367,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8687347465052817,
-          "mean_mse": 0.12764681103903155,
-          "mean_rank": 26.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.9189288122629483,
-          "mean_mse": 0.09967364995146454,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.9052193106693358,
-          "mean_mse": 0.09984527196109419,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8862606937580654,
-          "mean_mse": 0.11274014527911322,
-          "mean_rank": 24.0,
+        "fold-pattern": {
+          "mean_cosine": 0.9157991782215055,
+          "mean_mse": 0.08290843867930123,
+          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -1018,320 +478,140 @@
         "cutoff": 0.7,
         "blend": 0.6
       },
-      "mean_cosine_to_target": 0.8963710614610303,
-      "std_cosine_to_target": 0.03218565119492634,
-      "mean_mse_to_target": 0.10735242348979275,
-      "std_mse_to_target": 0.028408396476578234,
-      "mean_target_rank": 14.272277227722773,
-      "median_target_rank": 6.5,
-      "recall_at_1": 0.09405940594059406,
-      "recall_at_5": 0.44554455445544555,
-      "recall_at_10": 0.6732673267326733,
-      "mrr": 0.2634928293431735,
-      "train_time_ms": 3847.1543760000486,
-      "inference_time_us": 24383.368608910965,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9142203448591903,
+      "std_cosine_to_target": 0.031828574728354146,
+      "mean_mse_to_target": 0.08561076690122744,
+      "std_mse_to_target": 0.030368874169381315,
+      "mean_target_rank": 6.2560975609756095,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.15853658536585366,
+      "recall_at_5": 0.6707317073170732,
+      "recall_at_10": 0.8292682926829268,
+      "mrr": 0.37938021914216474,
+      "train_time_ms": 888.6579130012251,
+      "inference_time_us": 6524.818390261782,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9168559351929034,
-          "mean_mse": 0.08298180711490259,
-          "mean_rank": 4.25,
+          "mean_cosine": 0.9275054292783037,
+          "mean_mse": 0.0688522322345247,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9151088572777901,
-          "mean_mse": 0.0916984589788794,
-          "mean_rank": 6.25,
+          "mean_cosine": 0.9291363921319649,
+          "mean_mse": 0.07488616173229237,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8980512419399195,
-          "mean_mse": 0.09761893401084351,
-          "mean_rank": 14.5,
+          "mean_cosine": 0.9002892135820824,
+          "mean_mse": 0.09360534981846223,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8741389680556148,
-          "mean_mse": 0.12596528749628805,
-          "mean_rank": 31.5,
+          "mean_cosine": 0.8944445126843565,
+          "mean_mse": 0.10389001777057491,
+          "mean_rank": 12.0,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8631105891787019,
-          "mean_mse": 0.13638217369702033,
-          "mean_rank": 39.75,
+          "mean_cosine": 0.8861631433730333,
+          "mean_mse": 0.11145824171607878,
+          "mean_rank": 13.5,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.9091091475166032,
-          "mean_mse": 0.09020500069328154,
-          "mean_rank": 15.75,
+          "mean_cosine": 0.9199880940254105,
+          "mean_mse": 0.07827694535799881,
+          "mean_rank": 7.75,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.9047845993692061,
-          "mean_mse": 0.09248727743026479,
-          "mean_rank": 11.5,
+          "mean_cosine": 0.9147073643673105,
+          "mean_mse": 0.07842465035701722,
+          "mean_rank": 8.75,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.9161636609393587,
-          "mean_mse": 0.09323101396396519,
+          "mean_cosine": 0.9203184296052809,
+          "mean_mse": 0.08411804172256011,
           "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8789552303070278,
-          "mean_mse": 0.12634190722305064,
-          "mean_rank": 11.0,
+          "mean_cosine": 0.8914579504338249,
+          "mean_mse": 0.10980084052623218,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8857243770943737,
-          "mean_mse": 0.11470528050117317,
-          "mean_rank": 18.5,
+          "mean_cosine": 0.90271472106305,
+          "mean_mse": 0.09448008554871866,
+          "mean_rank": 9.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8979533738042844,
-          "mean_mse": 0.1132826537328523,
-          "mean_rank": 8.0,
+          "mean_cosine": 0.9250451364015466,
+          "mean_mse": 0.08372617510424346,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9108934148113268,
-          "mean_mse": 0.09929332318756781,
-          "mean_rank": 2.5,
+          "mean_cosine": 0.9247470567836547,
+          "mean_mse": 0.08055713439782952,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.9232522539435714,
-          "mean_mse": 0.09042962636552732,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8370878160094284,
-          "mean_mse": 0.16909086775654608,
-          "mean_rank": 43.4,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8877367420189667,
-          "mean_mse": 0.113322907480262,
-          "mean_rank": 13.0,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.902284359854484,
-          "mean_mse": 0.09001333388089376,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9449242128288664,
-          "mean_mse": 0.06444027945110994,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.913430779885866,
-          "mean_mse": 0.08133997360867827,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9318015130006909,
-          "mean_mse": 0.07782873036778941,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8978081696621263,
-          "mean_mse": 0.1018443431966718,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.88809866041454,
-          "mean_mse": 0.11559227491336566,
-          "mean_rank": 27.0,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.914682405010715,
-          "mean_mse": 0.08540663375907818,
+          "mean_cosine": 0.9388521722357597,
+          "mean_mse": 0.06468894826197544,
           "mean_rank": 7.25,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.8859075329299959,
-          "mean_mse": 0.11578766351628529,
-          "mean_rank": 17.75,
-          "num_queries": 4
+        "prolog-terms": {
+          "mean_cosine": 0.8645159655174849,
+          "mean_mse": 0.14032672806887844,
+          "mean_rank": 11.2,
+          "num_queries": 5
         },
-        "bash-subshells": {
-          "mean_cosine": 0.8889158112518805,
-          "mean_mse": 0.11010163026155656,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8671887968964828,
-          "mean_mse": 0.12933396860191992,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8933616027071349,
-          "mean_mse": 0.09817134646874864,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.859443310016295,
-          "mean_mse": 0.13575006732330153,
-          "mean_rank": 26.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.895993643192243,
-          "mean_mse": 0.11869682700472242,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8559051034577774,
-          "mean_mse": 0.14093494882405552,
-          "mean_rank": 42.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9191619342725658,
-          "mean_mse": 0.08626831074533768,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8834296715686769,
-          "mean_mse": 0.11630597553008933,
-          "mean_rank": 18.75,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8781258206276219,
-          "mean_mse": 0.12277949352250345,
-          "mean_rank": 25.5,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8854667154881635,
-          "mean_mse": 0.11834991685170708,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8740589006749149,
-          "mean_mse": 0.1352296649577397,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.9054894477537825,
-          "mean_mse": 0.09545763710551042,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9161836150589308,
-          "mean_mse": 0.09595799879853842,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9285042288333026,
-          "mean_mse": 0.08163186765459961,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9106979649895877,
-          "mean_mse": 0.09964996981478115,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8751775581957848,
-          "mean_mse": 0.12940285334291213,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8670012123381525,
-          "mean_mse": 0.12300970905938799,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9090953383320584,
-          "mean_mse": 0.09845127296389587,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9016776407750147,
-          "mean_mse": 0.10857542307305104,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9077490237395487,
-          "mean_mse": 0.10486941088972275,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9243526431276472,
-          "mean_mse": 0.07966611950829411,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.9184184191224282,
-          "mean_mse": 0.10017639885463306,
+        "prolog-unification": {
+          "mean_cosine": 0.9036417763540028,
+          "mean_mse": 0.09493382419632512,
           "mean_rank": 4.25,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.893572666089997,
-          "mean_mse": 0.11034786681684153,
-          "mean_rank": 12.75,
+        "recursion-patterns": {
+          "mean_cosine": 0.8971542031791291,
+          "mean_mse": 0.09266599996188664,
+          "mean_rank": 7.25,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8695358786917557,
-          "mean_mse": 0.12728971102496034,
-          "mean_rank": 25.75,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9572351758107904,
+          "mean_mse": 0.047021952325409885,
+          "mean_rank": 3.0,
           "num_queries": 4
         },
-        "mutual-recursion": {
-          "mean_cosine": 0.918928315755118,
-          "mean_mse": 0.09977991231438901,
-          "mean_rank": 8.25,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9308460157276719,
+          "mean_mse": 0.06353930737390429,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.9057489081589856,
-          "mean_mse": 0.09954795736600791,
-          "mean_rank": 9.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9550240961336048,
+          "mean_mse": 0.04740868953147709,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8866798300407078,
-          "mean_mse": 0.11241318148413065,
-          "mean_rank": 24.75,
+        "fold-pattern": {
+          "mean_cosine": 0.9187367419373131,
+          "mean_mse": 0.07982750331999533,
+          "mean_rank": 2.5,
           "num_queries": 4
         }
       }
@@ -1342,320 +622,140 @@
         "min_cutoff": 0.2,
         "max_cutoff": 0.7
       },
-      "mean_cosine_to_target": 0.8935353920616549,
-      "std_cosine_to_target": 0.03250033181775946,
-      "mean_mse_to_target": 0.11059730161761867,
-      "std_mse_to_target": 0.028686690062948172,
-      "mean_target_rank": 15.747524752475247,
-      "median_target_rank": 7.5,
-      "recall_at_1": 0.07920792079207921,
-      "recall_at_5": 0.4207920792079208,
-      "recall_at_10": 0.6188118811881188,
-      "mrr": 0.24573795458781666,
-      "train_time_ms": 8560.368649999986,
-      "inference_time_us": 21192.702297030177,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9092699665684811,
+      "std_cosine_to_target": 0.032109462132265905,
+      "mean_mse_to_target": 0.0914760049708499,
+      "std_mse_to_target": 0.030843305747775336,
+      "mean_target_rank": 7.2317073170731705,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.0975609756097561,
+      "recall_at_5": 0.6463414634146342,
+      "recall_at_10": 0.7926829268292683,
+      "mrr": 0.3223582361307937,
+      "train_time_ms": 2006.5225280013692,
+      "inference_time_us": 6211.458621958339,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9159783532701411,
-          "mean_mse": 0.08487433564806299,
-          "mean_rank": 4.75,
+          "mean_cosine": 0.9237679288111139,
+          "mean_mse": 0.07321474073357724,
+          "mean_rank": 4.5,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9129712371223802,
-          "mean_mse": 0.09431023972635236,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8951914417494643,
-          "mean_mse": 0.10088753273669475,
-          "mean_rank": 16.5,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8699395031525918,
-          "mean_mse": 0.12993298376456386,
-          "mean_rank": 37.0,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8612717829013535,
-          "mean_mse": 0.138807531436309,
-          "mean_rank": 41.75,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.9074287246174239,
-          "mean_mse": 0.09229418497524337,
-          "mean_rank": 16.25,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.9026675206960876,
-          "mean_mse": 0.09574472799034989,
-          "mean_rank": 13.0,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.91434778775863,
-          "mean_mse": 0.09637951218358631,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8740349958079857,
-          "mean_mse": 0.13113990933817743,
-          "mean_rank": 13.0,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.8829407966387152,
-          "mean_mse": 0.11804993487367464,
-          "mean_rank": 19.75,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.8959366284414484,
-          "mean_mse": 0.11546023004927777,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.9041171238790079,
-          "mean_mse": 0.1058390871706828,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.9221052538464161,
-          "mean_mse": 0.09235529622086061,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8309235276223464,
-          "mean_mse": 0.17486947892268173,
-          "mean_rank": 54.4,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8828990231568132,
-          "mean_mse": 0.11800263204971081,
-          "mean_rank": 16.25,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.9000967684686453,
-          "mean_mse": 0.09256400482815486,
-          "mean_rank": 12.0,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9418109665790083,
-          "mean_mse": 0.06827582356620444,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9086370362949232,
-          "mean_mse": 0.08573230585394902,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9295184087042925,
-          "mean_mse": 0.08049456050495646,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8953972028426598,
-          "mean_mse": 0.10509403317657735,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8867597425666032,
-          "mean_mse": 0.11763163728343119,
-          "mean_rank": 28.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9122865049273394,
-          "mean_mse": 0.08797323065119664,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8840489951044738,
-          "mean_mse": 0.11811799436940437,
-          "mean_rank": 18.25,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8867647555937151,
-          "mean_mse": 0.11232711813154299,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8662494723960259,
-          "mean_mse": 0.13073286314136837,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8906720539861837,
-          "mean_mse": 0.100398063223077,
-          "mean_rank": 8.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8560311573764111,
-          "mean_mse": 0.1393166162060535,
-          "mean_rank": 28.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8952625521428033,
-          "mean_mse": 0.12013748749256913,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8514164308529872,
-          "mean_mse": 0.14539312841639113,
-          "mean_rank": 46.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9165575692687238,
-          "mean_mse": 0.08908056578069254,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8811837925945973,
-          "mean_mse": 0.11868363095926715,
-          "mean_rank": 19.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8743940413839173,
-          "mean_mse": 0.12638271020365177,
-          "mean_rank": 29.25,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8826903157051526,
-          "mean_mse": 0.12150835005122393,
-          "mean_rank": 27.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8710941546659665,
-          "mean_mse": 0.13867156714973414,
-          "mean_rank": 28.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.902938578193165,
-          "mean_mse": 0.0986739281450711,
-          "mean_rank": 16.5,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9128833942880438,
-          "mean_mse": 0.09989083314444623,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9273153842404341,
-          "mean_mse": 0.08351134611221189,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9077051586056848,
-          "mean_mse": 0.10231342986945281,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8715822964361919,
-          "mean_mse": 0.13382539590957762,
-          "mean_rank": 17.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8638202407365185,
-          "mean_mse": 0.12579824669241635,
-          "mean_rank": 37.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9047455911900519,
-          "mean_mse": 0.10293332720409096,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.897855789991844,
-          "mean_mse": 0.11351827097179532,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9056261233726798,
-          "mean_mse": 0.10768203790550303,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9219959653624198,
-          "mean_mse": 0.08309292498282297,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.9166467206750963,
-          "mean_mse": 0.10316031246998171,
+          "mean_cosine": 0.9249086706608544,
+          "mean_mse": 0.08032664017812301,
           "mean_rank": 4.0,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8918012859482909,
-          "mean_mse": 0.11303772621689703,
+        "compilation-pipeline": {
+          "mean_cosine": 0.8969087898909055,
+          "mean_mse": 0.09829903410495511,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8872209074756422,
+          "mean_mse": 0.1112929043076266,
           "mean_rank": 15.0,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8645435197452516,
-          "mean_mse": 0.13198050864979632,
-          "mean_rank": 32.0,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8825580958437939,
+          "mean_mse": 0.11624415515558743,
+          "mean_rank": 14.75,
           "num_queries": 4
         },
-        "mutual-recursion": {
-          "mean_cosine": 0.9181679579528232,
-          "mean_mse": 0.10179622678233077,
+        "practical-compilation": {
+          "mean_cosine": 0.9151431213818644,
+          "mean_mse": 0.08360939269554352,
           "mean_rank": 8.5,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.9029209532130023,
-          "mean_mse": 0.10341518206667319,
-          "mean_rank": 11.25,
+        "generated-code-facts": {
+          "mean_cosine": 0.9091384108593326,
+          "mean_mse": 0.08458838288764853,
+          "mean_rank": 10.0,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8831230861892594,
-          "mean_mse": 0.11656837942578668,
-          "mean_rank": 25.5,
+        "generated-code-transitive": {
+          "mean_cosine": 0.9172273606572846,
+          "mean_mse": 0.0887069824471126,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8834863778510084,
+          "mean_mse": 0.11792193754392524,
+          "mean_rank": 5.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8985301106880845,
+          "mean_mse": 0.10052967339357863,
+          "mean_rank": 9.75,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9200787024195566,
+          "mean_mse": 0.09017174925445937,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9158865406820209,
+          "mean_mse": 0.08914736362643544,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9374035219918265,
+          "mean_mse": 0.06788395256061822,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8575289044198598,
+          "mean_mse": 0.14843758544971403,
+          "mean_rank": 13.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8970706473924912,
+          "mean_mse": 0.10188041548913851,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8935478873380154,
+          "mean_mse": 0.09717271352571782,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9530715507930575,
+          "mean_mse": 0.05311295819676025,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.923736147201015,
+          "mean_mse": 0.07107914353852886,
+          "mean_rank": 5.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9541974621122188,
+          "mean_mse": 0.04883336505582422,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.913369355616201,
+          "mean_mse": 0.0862151310091389,
+          "mean_rank": 3.0,
           "num_queries": 4
         }
       }
@@ -1666,320 +766,140 @@
         "K": 4,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.8854651935813108,
-      "std_cosine_to_target": 0.03372256613681515,
-      "mean_mse_to_target": 0.09710809277072983,
-      "std_mse_to_target": 0.027344650282815856,
-      "mean_target_rank": 14.638613861386139,
-      "median_target_rank": 6.0,
-      "recall_at_1": 0.12871287128712872,
-      "recall_at_5": 0.4801980198019802,
-      "recall_at_10": 0.6683168316831684,
-      "mrr": 0.2827225177846988,
-      "train_time_ms": 59761.697335000004,
-      "inference_time_us": 287134.2693217825,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.8715898367887795,
+      "std_cosine_to_target": 0.04988526253957751,
+      "mean_mse_to_target": 0.1158344469754284,
+      "std_mse_to_target": 0.054325694002661615,
+      "mean_target_rank": 8.24390243902439,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7804878048780488,
+      "mrr": 0.3507524537497204,
+      "train_time_ms": 14448.818898999889,
+      "inference_time_us": 68003.75868291799,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9097205852321721,
-          "mean_mse": 0.07365437107482123,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.8984668939989793,
-          "mean_mse": 0.0840855809058284,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.892082216636391,
-          "mean_mse": 0.0894697738161144,
-          "mean_rank": 13.25,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8627736688891743,
-          "mean_mse": 0.11504930252034452,
-          "mean_rank": 30.25,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8368048682042476,
-          "mean_mse": 0.1357629329217252,
-          "mean_rank": 60.75,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.8948791738890258,
-          "mean_mse": 0.08904275471717943,
-          "mean_rank": 18.25,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.8921920747447214,
-          "mean_mse": 0.08512649310601729,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9157648111747537,
-          "mean_mse": 0.07161587346931148,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8720875749847998,
-          "mean_mse": 0.11655178382040539,
-          "mean_rank": 10.2,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.8661728475084636,
-          "mean_mse": 0.11302818953304786,
-          "mean_rank": 24.25,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.874107141191798,
-          "mean_mse": 0.10643621620659464,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.9176290279884746,
-          "mean_mse": 0.07492836925757153,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.8956966479470438,
-          "mean_mse": 0.08768603992780773,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8232810561134046,
-          "mean_mse": 0.16034304128544066,
-          "mean_rank": 54.6,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8725244085959074,
-          "mean_mse": 0.11037247945730104,
-          "mean_rank": 16.5,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.9030017470362879,
-          "mean_mse": 0.07922165584082994,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9191315646113589,
-          "mean_mse": 0.07253743482929793,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.894920519319848,
-          "mean_mse": 0.08175340018705105,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9153891467584655,
-          "mean_mse": 0.0743585724112141,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.9014824962354047,
-          "mean_mse": 0.0822368173436134,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8868855013575523,
-          "mean_mse": 0.10058816506661807,
-          "mean_rank": 23.5,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9117975309013537,
-          "mean_mse": 0.07641756095237848,
-          "mean_rank": 7.5,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8965928203811806,
-          "mean_mse": 0.08877994848442425,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.836305666861376,
-          "mean_mse": 0.12782268817298853,
-          "mean_rank": 13.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8191736556272421,
-          "mean_mse": 0.14143114983376612,
-          "mean_rank": 41.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8856808542859484,
-          "mean_mse": 0.08836559227513521,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8155536679814489,
-          "mean_mse": 0.14585049219956733,
-          "mean_rank": 62.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8741597594282668,
-          "mean_mse": 0.10480662117198768,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.851273399569551,
-          "mean_mse": 0.12741670346192532,
-          "mean_rank": 35.25,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.8945745574283273,
-          "mean_mse": 0.08616209104684722,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8452262026342561,
-          "mean_mse": 0.12507125639069566,
-          "mean_rank": 44.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8653822599726764,
-          "mean_mse": 0.11047467751297317,
-          "mean_rank": 24.25,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8784528660127645,
-          "mean_mse": 0.10137944564157482,
-          "mean_rank": 19.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.885784251685158,
-          "mean_mse": 0.0995547521793044,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8917484590219893,
-          "mean_mse": 0.0898146618979628,
-          "mean_rank": 17.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9048632981422311,
-          "mean_mse": 0.08555744785532099,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9140716671802923,
-          "mean_mse": 0.08105008929422611,
-          "mean_rank": 1.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.8945842533652701,
-          "mean_mse": 0.0944581977266296,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.868360322890724,
-          "mean_mse": 0.1105693506777859,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8840989507830106,
-          "mean_mse": 0.10074169757345201,
-          "mean_rank": 15.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.8990348190281789,
-          "mean_mse": 0.08430611743253774,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.8945633286635459,
-          "mean_mse": 0.09132275262121309,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9054891739274215,
-          "mean_mse": 0.08246532388872996,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9241965476667278,
-          "mean_mse": 0.06408703566394464,
-          "mean_rank": 2.25,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.912704838376944,
-          "mean_mse": 0.08302156035092365,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.9034768356915988,
-          "mean_mse": 0.08339551181768075,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8709070370644861,
-          "mean_mse": 0.10887147861762696,
-          "mean_rank": 20.0,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.9190908746670567,
-          "mean_mse": 0.07715896555477052,
+          "mean_cosine": 0.9122721911881922,
+          "mean_mse": 0.07404074583460572,
           "mean_rank": 3.5,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.899055547146385,
-          "mean_mse": 0.08738164211868206,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056033026210508,
+          "mean_mse": 0.08103197815504067,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8810910491163949,
+          "mean_mse": 0.1000032710681127,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8560586100666514,
+          "mean_mse": 0.12077597012819904,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.872244012066832,
+          "mean_mse": 0.10913823407431257,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9037362062019944,
+          "mean_mse": 0.08295037411189536,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8850569018296252,
+          "mean_mse": 0.09237428029613942,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9070787122597045,
+          "mean_mse": 0.07921594341049588,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8469575456601925,
+          "mean_mse": 0.171924998707,
+          "mean_rank": 3.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8629122186317713,
+          "mean_mse": 0.1171689750794326,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8723148976717516,
+          "mean_mse": 0.11084942813214953,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7816012094661056,
+          "mean_mse": 0.20951637304554036,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.873764318556556,
+          "mean_mse": 0.10410730438537874,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7809049192096389,
+          "mean_mse": 0.2232212331354447,
+          "mean_rank": 13.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8058733639055212,
+          "mean_mse": 0.1828765946669465,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.876098518108389,
+          "mean_mse": 0.10112878485637698,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9224906377921912,
+          "mean_mse": 0.07041287011589718,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9101063920010098,
+          "mean_mse": 0.07059964016281736,
           "mean_rank": 6.0,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.9009526992779568,
-          "mean_mse": 0.08315091853220496,
-          "mean_rank": 6.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.8992235795197899,
+          "mean_mse": 0.09049534176591605,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9052374520791613,
+          "mean_mse": 0.08398726390396966,
+          "mean_rank": 2.5,
           "num_queries": 4
         }
       }
@@ -1990,320 +910,140 @@
         "K": 8,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.8831361797839463,
-      "std_cosine_to_target": 0.03521349433336573,
-      "mean_mse_to_target": 0.1004554244007498,
-      "std_mse_to_target": 0.029344567610042546,
-      "mean_target_rank": 18.559405940594058,
-      "median_target_rank": 9.0,
-      "recall_at_1": 0.07425742574257425,
-      "recall_at_5": 0.35148514851485146,
-      "recall_at_10": 0.5594059405940595,
-      "mrr": 0.21529035894353693,
-      "train_time_ms": 85913.62128099991,
-      "inference_time_us": 505483.0519950496,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9121788189207933,
+      "std_cosine_to_target": 0.03270356785814729,
+      "mean_mse_to_target": 0.07835349176905483,
+      "std_mse_to_target": 0.03027668660828248,
+      "mean_target_rank": 6.695121951219512,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.13414634146341464,
+      "recall_at_5": 0.6463414634146342,
+      "recall_at_10": 0.8170731707317073,
+      "mrr": 0.3576830975309059,
+      "train_time_ms": 25889.87131599788,
+      "inference_time_us": 187259.2351219504,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9020294570748025,
-          "mean_mse": 0.07950362406986058,
-          "mean_rank": 9.25,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9106737902405628,
-          "mean_mse": 0.07615106833334877,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8913143927645936,
-          "mean_mse": 0.0904282905391238,
-          "mean_rank": 19.75,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8652485969814387,
-          "mean_mse": 0.115063136432066,
-          "mean_rank": 38.25,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8489865002333947,
-          "mean_mse": 0.1283258142309333,
-          "mean_rank": 51.25,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.908618908560969,
-          "mean_mse": 0.07797231941896532,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.8892196443723732,
-          "mean_mse": 0.08893732896921189,
-          "mean_rank": 19.25,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9038521274193932,
-          "mean_mse": 0.08278961192700418,
-          "mean_rank": 12.0,
-          "num_queries": 4
-        },
-        "prolog-facts-rules": {
-          "mean_cosine": 0.8548808691903755,
-          "mean_mse": 0.13341204659665767,
-          "mean_rank": 26.4,
-          "num_queries": 5
-        },
-        "prolog-modules": {
-          "mean_cosine": 0.8741745699440331,
-          "mean_mse": 0.10760927466891086,
-          "mean_rank": 26.25,
-          "num_queries": 4
-        },
-        "prolog-directives": {
-          "mean_cosine": 0.8892734634669033,
-          "mean_mse": 0.09838549667011261,
-          "mean_rank": 12.0,
-          "num_queries": 4
-        },
-        "prolog-file-io": {
-          "mean_cosine": 0.8988364652030598,
-          "mean_mse": 0.09475777712277736,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "init-pl-explained": {
-          "mean_cosine": 0.9066338345651193,
-          "mean_mse": 0.08406825798749189,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8209175254068107,
-          "mean_mse": 0.1653800156115366,
-          "mean_rank": 67.2,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8811157483179454,
-          "mean_mse": 0.1051961463811032,
-          "mean_rank": 18.25,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.8977409782021585,
-          "mean_mse": 0.08302080621400983,
-          "mean_rank": 12.0,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9384217872991443,
-          "mean_mse": 0.05787571606846627,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9098832869757717,
-          "mean_mse": 0.07034498996626389,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9043391479936161,
-          "mean_mse": 0.08607523085496545,
-          "mean_rank": 6.75,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8862567496041677,
-          "mean_mse": 0.09529726578990629,
-          "mean_rank": 14.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8709996275124212,
-          "mean_mse": 0.11168967405387242,
-          "mean_rank": 37.25,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.911803702739594,
-          "mean_mse": 0.07613148898293315,
-          "mean_rank": 7.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8818415965520183,
-          "mean_mse": 0.1031567600278962,
-          "mean_rank": 16.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8552902057356292,
-          "mean_mse": 0.11522505822252731,
-          "mean_rank": 9.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8327299533572663,
-          "mean_mse": 0.13387270031152776,
-          "mean_rank": 41.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8835398724078408,
-          "mean_mse": 0.09030680187598376,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8230259708698995,
-          "mean_mse": 0.14088809301998717,
-          "mean_rank": 55.0,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8637114497696173,
-          "mean_mse": 0.11473714938083708,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8491268193848341,
-          "mean_mse": 0.12917743476035562,
-          "mean_rank": 42.0,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9200928097698847,
-          "mean_mse": 0.06820749322061993,
-          "mean_rank": 4.0,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8787940273815764,
-          "mean_mse": 0.10174510915660813,
-          "mean_rank": 19.0,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8608803339659468,
-          "mean_mse": 0.11553318295475375,
-          "mean_rank": 36.0,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8866052552376756,
-          "mean_mse": 0.0973281123513719,
-          "mean_rank": 18.25,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8653070690359682,
-          "mean_mse": 0.1180122079671281,
-          "mean_rank": 25.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.8977106824223027,
-          "mean_mse": 0.08630802816181822,
-          "mean_rank": 15.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9123914947444781,
-          "mean_mse": 0.08055744808236237,
-          "mean_rank": 6.0,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9101861968942414,
-          "mean_mse": 0.08350550447788167,
-          "mean_rank": 2.0,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.8536290348773473,
-          "mean_mse": 0.12949972531993806,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8680150146230247,
-          "mean_mse": 0.1105477405411981,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8331943678174156,
-          "mean_mse": 0.1394454858711421,
-          "mean_rank": 32.5,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.8945447446050114,
-          "mean_mse": 0.09116334079579975,
-          "mean_rank": 10.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.8941712623613094,
-          "mean_mse": 0.09499539699047228,
-          "mean_rank": 11.0,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.8894964598305689,
-          "mean_mse": 0.09700792285789643,
-          "mean_rank": 10.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9208075578623005,
-          "mean_mse": 0.06794481700038893,
-          "mean_rank": 3.0,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.9155272564059251,
-          "mean_mse": 0.08309182761007015,
+          "mean_cosine": 0.9255342098144795,
+          "mean_mse": 0.06313349736102944,
           "mean_rank": 5.0,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8885162522317185,
-          "mean_mse": 0.09626201920687417,
-          "mean_rank": 16.5,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9244754988688912,
+          "mean_mse": 0.06724561880439354,
+          "mean_rank": 4.0,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8535941438512644,
-          "mean_mse": 0.12233774892249669,
-          "mean_rank": 42.0,
+        "compilation-pipeline": {
+          "mean_cosine": 0.8992140346712711,
+          "mean_mse": 0.08540980409014468,
+          "mean_rank": 11.0,
           "num_queries": 4
         },
-        "mutual-recursion": {
-          "mean_cosine": 0.9169546218341451,
-          "mean_mse": 0.07942084184572011,
-          "mean_rank": 6.5,
+        "constraint-usage": {
+          "mean_cosine": 0.8916102589346534,
+          "mean_mse": 0.09439231874857856,
+          "mean_rank": 12.25,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.8849426776276778,
-          "mean_mse": 0.09955592411646917,
-          "mean_rank": 21.25,
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8906375013279825,
+          "mean_mse": 0.09760000335539237,
+          "mean_rank": 10.75,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8795791749144527,
-          "mean_mse": 0.10005166074616963,
-          "mean_rank": 16.25,
+        "practical-compilation": {
+          "mean_cosine": 0.9175674599084555,
+          "mean_mse": 0.0707738083295741,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9105272862043174,
+          "mean_mse": 0.07300171903415134,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9177462046177189,
+          "mean_mse": 0.07295244212006652,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8940058688065463,
+          "mean_mse": 0.10078051095882179,
+          "mean_rank": 3.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8985007259567455,
+          "mean_mse": 0.09034811206748695,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9254457025132876,
+          "mean_mse": 0.07022773365157024,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9221330622097259,
+          "mean_mse": 0.0751629134943576,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408473481053222,
+          "mean_mse": 0.05378790792021333,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8534036400057767,
+          "mean_mse": 0.14083101060333425,
+          "mean_rank": 16.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8972996065201466,
+          "mean_mse": 0.09171315831783446,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8938720390069014,
+          "mean_mse": 0.08725116741997459,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9582946536103665,
+          "mean_mse": 0.039557925134534655,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.933234849787529,
+          "mean_mse": 0.05351910928193267,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9515008023213061,
+          "mean_mse": 0.045629902174472756,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9169626574817593,
+          "mean_mse": 0.0725250380072214,
+          "mean_rank": 2.75,
           "num_queries": 4
         }
       }
@@ -2314,320 +1054,140 @@
         "K": 16,
         "iterations": 50
       },
-      "mean_cosine_to_target": 0.8915901827797708,
-      "std_cosine_to_target": 0.032716630064920815,
-      "mean_mse_to_target": 0.09666899054724122,
-      "std_mse_to_target": 0.027539130748039896,
-      "mean_target_rank": 15.351485148514852,
-      "median_target_rank": 7.0,
-      "recall_at_1": 0.08415841584158416,
-      "recall_at_5": 0.4603960396039604,
-      "recall_at_10": 0.6188118811881188,
-      "mrr": 0.25627486311953124,
-      "train_time_ms": 129700.44888799998,
-      "inference_time_us": 824974.9750247527,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9147456464077812,
+      "std_cosine_to_target": 0.032272248005802424,
+      "mean_mse_to_target": 0.07893618681638162,
+      "std_mse_to_target": 0.030598259534507764,
+      "mean_target_rank": 6.365853658536586,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.14634146341463414,
+      "recall_at_5": 0.6951219512195121,
+      "recall_at_10": 0.8170731707317073,
+      "mrr": 0.37505000433020147,
+      "train_time_ms": 50651.91422499993,
+      "inference_time_us": 246247.13681707985,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9129380091062587,
-          "mean_mse": 0.0745362094674603,
-          "mean_rank": 5.0,
+          "mean_cosine": 0.9287150587637627,
+          "mean_mse": 0.061260126264685986,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9131698556324948,
-          "mean_mse": 0.07805401917800356,
-          "mean_rank": 7.0,
+          "mean_cosine": 0.9312868282487438,
+          "mean_mse": 0.06591802528854758,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "compilation-pipeline": {
-          "mean_cosine": 0.8951485353829364,
-          "mean_mse": 0.08885051394263548,
-          "mean_rank": 16.0,
+          "mean_cosine": 0.9001292654191761,
+          "mean_mse": 0.08683428955369908,
+          "mean_rank": 11.25,
           "num_queries": 4
         },
         "constraint-usage": {
-          "mean_cosine": 0.8764672404461274,
-          "mean_mse": 0.10869638390555184,
-          "mean_rank": 27.5,
+          "mean_cosine": 0.895472902911841,
+          "mean_mse": 0.09524687776536626,
+          "mean_rank": 11.5,
           "num_queries": 4
         },
         "troubleshooting-compilation": {
-          "mean_cosine": 0.8657969517750068,
-          "mean_mse": 0.11934572135535637,
-          "mean_rank": 36.75,
+          "mean_cosine": 0.8875426733740077,
+          "mean_mse": 0.10178514421801052,
+          "mean_rank": 13.0,
           "num_queries": 4
         },
         "practical-compilation": {
-          "mean_cosine": 0.9102735863543862,
-          "mean_mse": 0.07778170906304437,
-          "mean_rank": 14.5,
+          "mean_cosine": 0.9216384888382628,
+          "mean_mse": 0.07011202416453997,
+          "mean_rank": 7.75,
           "num_queries": 4
         },
         "generated-code-facts": {
-          "mean_cosine": 0.8931182794651231,
-          "mean_mse": 0.087893647741441,
-          "mean_rank": 17.25,
+          "mean_cosine": 0.9148013059714191,
+          "mean_mse": 0.07178230142898287,
+          "mean_rank": 9.0,
           "num_queries": 4
         },
         "generated-code-transitive": {
-          "mean_cosine": 0.9124413636335917,
-          "mean_mse": 0.08044636198486076,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.9217078174325888,
+          "mean_mse": 0.07339006606044521,
+          "mean_rank": 3.75,
           "num_queries": 4
         },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8738444921857939,
-          "mean_mse": 0.12073701175535112,
-          "mean_rank": 14.6,
+          "mean_cosine": 0.89306822872438,
+          "mean_mse": 0.10514822171443187,
+          "mean_rank": 3.4,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8802755467014792,
-          "mean_mse": 0.10554345319927023,
-          "mean_rank": 21.25,
+          "mean_cosine": 0.9007713513477082,
+          "mean_mse": 0.0903511494123219,
+          "mean_rank": 9.5,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8988731375860352,
-          "mean_mse": 0.09503305560505644,
-          "mean_rank": 7.5,
+          "mean_cosine": 0.9251134167118684,
+          "mean_mse": 0.07639379150519743,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9071879566629792,
-          "mean_mse": 0.09124993272830399,
+          "mean_cosine": 0.9255975388324511,
+          "mean_mse": 0.07561968622493322,
           "mean_rank": 2.25,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.9173790413835652,
-          "mean_mse": 0.07848232999318044,
-          "mean_rank": 9.25,
+          "mean_cosine": 0.9400801894407566,
+          "mean_mse": 0.057342422021207,
+          "mean_rank": 6.0,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8308298959345255,
-          "mean_mse": 0.16050150645345745,
-          "mean_rank": 51.6,
+          "mean_cosine": 0.86327306013277,
+          "mean_mse": 0.1362803154413532,
+          "mean_rank": 12.2,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8821130591475786,
-          "mean_mse": 0.10656923268505061,
-          "mean_rank": 18.5,
+          "mean_cosine": 0.9043228435399303,
+          "mean_mse": 0.08874091654196739,
+          "mean_rank": 4.75,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.8992713958207255,
-          "mean_mse": 0.08339962628002895,
-          "mean_rank": 12.25,
+          "mean_cosine": 0.891741682415196,
+          "mean_mse": 0.09131746828878522,
+          "mean_rank": 9.75,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9396921987192672,
-          "mean_mse": 0.05825530077010002,
-          "mean_rank": 4.0,
+          "mean_cosine": 0.9562902175869737,
+          "mean_mse": 0.04328330917615737,
+          "mean_rank": 3.25,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.9100159293918393,
-          "mean_mse": 0.07150120831924327,
-          "mean_rank": 8.25,
+          "mean_cosine": 0.9334413661011377,
+          "mean_mse": 0.054866121686129206,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9244288452467417,
-          "mean_mse": 0.07180802695376573,
+          "mean_cosine": 0.9569023201417665,
+          "mean_mse": 0.04082180510359948,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "fold-pattern": {
-          "mean_cosine": 0.8966543007694077,
-          "mean_mse": 0.08936039655826339,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8838418116633772,
-          "mean_mse": 0.10599111398740632,
-          "mean_rank": 29.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9098468603306668,
-          "mean_mse": 0.08037047045632191,
-          "mean_rank": 9.25,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8807554339690774,
-          "mean_mse": 0.10767658090573437,
-          "mean_rank": 20.0,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8727655242237098,
-          "mean_mse": 0.10348245313105646,
+          "mean_cosine": 0.9213038732104872,
+          "mean_mse": 0.07134063358651596,
           "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8528183074481264,
-          "mean_mse": 0.12048639219939059,
-          "mean_rank": 11.25,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8815140990258791,
-          "mean_mse": 0.09389546499489967,
-          "mean_rank": 9.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8487925614217176,
-          "mean_mse": 0.1258280824455437,
-          "mean_rank": 33.5,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8887196060334409,
-          "mean_mse": 0.10409159279014642,
-          "mean_rank": 9.75,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8425701519554915,
-          "mean_mse": 0.13637882174819857,
-          "mean_rank": 51.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.917515313703842,
-          "mean_mse": 0.07141991488896826,
-          "mean_rank": 4.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8773335852581781,
-          "mean_mse": 0.10441425049694979,
-          "mean_rank": 16.5,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8775788717885784,
-          "mean_mse": 0.10664290977149697,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8840529193437247,
-          "mean_mse": 0.10310518851355661,
-          "mean_rank": 24.5,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8721455294701623,
-          "mean_mse": 0.11798594466120421,
-          "mean_rank": 27.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.9023494542248598,
-          "mean_mse": 0.08626942322223304,
-          "mean_rank": 15.25,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9114435225034045,
-          "mean_mse": 0.08410405671028763,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9196366306960626,
-          "mean_mse": 0.07377776988674259,
-          "mean_rank": 2.75,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.8993890020842868,
-          "mean_mse": 0.09229918394451482,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8712150279836205,
-          "mean_mse": 0.11372921798968033,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8615058740072454,
-          "mean_mse": 0.11614446484192673,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9064260022896391,
-          "mean_mse": 0.08533712486348588,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9021125646797641,
-          "mean_mse": 0.08936989389745761,
-          "mean_rank": 5.0,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9024309390936024,
-          "mean_mse": 0.091349875742408,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9217106396859912,
-          "mean_mse": 0.0693341462046412,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "tail-recursion": {
-          "mean_cosine": 0.9130665779782249,
-          "mean_mse": 0.08911871885669669,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "linear-recursion": {
-          "mean_cosine": 0.891025120598459,
-          "mean_mse": 0.09772561592822143,
-          "mean_rank": 15.25,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8651630019905305,
-          "mean_mse": 0.11759969211097773,
-          "mean_rank": 29.5,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.918195682215027,
-          "mean_mse": 0.0841831296392635,
-          "mean_rank": 10.5,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.8996582951623644,
-          "mean_mse": 0.09019746585314563,
-          "mean_rank": 12.0,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8836371011734294,
-          "mean_mse": 0.10111978446149718,
-          "mean_rank": 23.75,
           "num_queries": 4
         }
       }
@@ -2639,320 +1199,140 @@
         "alpha_reg": 0.01,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8969345547092178,
-      "std_cosine_to_target": 0.032081271832789394,
-      "mean_mse_to_target": 0.10674061695177495,
-      "std_mse_to_target": 0.028361126800726576,
-      "mean_target_rank": 14.004950495049505,
-      "median_target_rank": 6.5,
-      "recall_at_1": 0.09405940594059406,
-      "recall_at_5": 0.4504950495049505,
-      "recall_at_10": 0.6782178217821783,
-      "mrr": 0.2651740942198535,
-      "train_time_ms": 36942.79020699992,
-      "inference_time_us": 364590.0402079219,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9157922216582833,
+      "std_cosine_to_target": 0.032044988377667706,
+      "mean_mse_to_target": 0.0838334903926388,
+      "std_mse_to_target": 0.030649874758903378,
+      "mean_target_rank": 6.097560975609756,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.389046717305573,
+      "train_time_ms": 12483.476751000126,
+      "inference_time_us": 92900.4715975369,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9173287121153619,
-          "mean_mse": 0.08221026872939073,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9151943867111834,
-          "mean_mse": 0.09132657647699818,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8984163588202205,
-          "mean_mse": 0.09711917973483306,
-          "mean_rank": 14.5,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8752992146220385,
-          "mean_mse": 0.12479964494053736,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8639866688672094,
-          "mean_mse": 0.1352577687072294,
-          "mean_rank": 39.0,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.9094382200031088,
-          "mean_mse": 0.08976946152132274,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.9048128257135377,
-          "mean_mse": 0.09221448170448869,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9166573952292351,
-          "mean_mse": 0.09254363882227323,
+          "mean_cosine": 0.9283244387921915,
+          "mean_mse": 0.06755044352908686,
           "mean_rank": 4.5,
           "num_queries": 4
         },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299331738187894,
+          "mean_mse": 0.0736312280246322,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9014128998707689,
+          "mean_mse": 0.09223641859178713,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8968670652456009,
+          "mean_mse": 0.1014862321010465,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8866476700595278,
+          "mean_mse": 0.1106529727310597,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9207472874954794,
+          "mean_mse": 0.07704967456140606,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9145765587164139,
+          "mean_mse": 0.07835614323164757,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9218263039531278,
+          "mean_mse": 0.08250656322617458,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8796517983194103,
-          "mean_mse": 0.12566413568879714,
-          "mean_rank": 10.8,
+          "mean_cosine": 0.8932238175773961,
+          "mean_mse": 0.10815420659397205,
+          "mean_rank": 3.2,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8859932647715781,
-          "mean_mse": 0.11447250296329611,
-          "mean_rank": 18.75,
+          "mean_cosine": 0.9028369817500956,
+          "mean_mse": 0.0942168772595635,
+          "mean_rank": 9.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8990963487846443,
-          "mean_mse": 0.1118467488389511,
-          "mean_rank": 7.25,
+          "mean_cosine": 0.9269056531153763,
+          "mean_mse": 0.0818006727768861,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9118909654731261,
-          "mean_mse": 0.09825518333150243,
+          "mean_cosine": 0.9280290129768416,
+          "mean_mse": 0.07726399893400843,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.924138269490503,
-          "mean_mse": 0.08858237698828872,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8386162033416475,
-          "mean_mse": 0.16809668328314734,
-          "mean_rank": 41.2,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8882666515075349,
-          "mean_mse": 0.11305306389369056,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.9027324728029503,
-          "mean_mse": 0.08960614931428051,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9448086723844035,
-          "mean_mse": 0.06473217304639069,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9137253471729216,
-          "mean_mse": 0.08076384695633534,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9324591923778608,
-          "mean_mse": 0.07724198411031981,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8991488535158583,
-          "mean_mse": 0.10102542343183628,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8883225865773536,
-          "mean_mse": 0.11531474843589436,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9157590981257098,
-          "mean_mse": 0.0844524139196462,
+          "mean_cosine": 0.9398813752156144,
+          "mean_mse": 0.06228239466153956,
           "mean_rank": 7.0,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.8862395924961258,
-          "mean_mse": 0.11511920221802949,
-          "mean_rank": 17.75,
+        "prolog-terms": {
+          "mean_cosine": 0.8666226409514912,
+          "mean_mse": 0.13857952340119625,
+          "mean_rank": 10.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9052861881183049,
+          "mean_mse": 0.09319334670041751,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "bash-subshells": {
-          "mean_cosine": 0.8909203705354516,
-          "mean_mse": 0.10854027921208605,
-          "mean_rank": 2.5,
+        "recursion-patterns": {
+          "mean_cosine": 0.8975756207812452,
+          "mean_mse": 0.09206398413713594,
+          "mean_rank": 7.25,
           "num_queries": 4
         },
-        "process-substitution": {
-          "mean_cosine": 0.8669855295191226,
-          "mean_mse": 0.12905599685327157,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8947306920317328,
-          "mean_mse": 0.09710678102326849,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8598745112800089,
-          "mean_mse": 0.13517838801224025,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8977994733687487,
-          "mean_mse": 0.11691874848506768,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8560966676901419,
-          "mean_mse": 0.14063974355094297,
-          "mean_rank": 41.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.919791465489831,
-          "mean_mse": 0.08543422443497276,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8837491861690967,
-          "mean_mse": 0.11614659455073047,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8795802533165558,
-          "mean_mse": 0.12141490084210214,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8856729495958222,
-          "mean_mse": 0.11808954216553572,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.874902143051818,
-          "mean_mse": 0.13452336597380313,
-          "mean_rank": 26.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.9053845630399125,
-          "mean_mse": 0.09559565500513595,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9168684032190827,
-          "mean_mse": 0.09489273447413678,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.928440767314882,
-          "mean_mse": 0.08164093236676048,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9109328660150816,
-          "mean_mse": 0.09926178478271193,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8760149264054904,
-          "mean_mse": 0.12876213143694323,
-          "mean_rank": 14.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8681825386588331,
-          "mean_mse": 0.12239901962353465,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9094345945404262,
-          "mean_mse": 0.09818815674022963,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.902199561354155,
-          "mean_mse": 0.10794385122353742,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9075721730312021,
-          "mean_mse": 0.10485234963966567,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9249067353362171,
-          "mean_mse": 0.07925559676815314,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9586196133832493,
+          "mean_mse": 0.04589420828900275,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.9183580595210068,
-          "mean_mse": 0.10014140216481981,
-          "mean_rank": 4.0,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341130454707673,
+          "mean_mse": 0.060350818050939704,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.893649761928774,
-          "mean_mse": 0.11009535833365061,
-          "mean_rank": 12.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575139024393351,
+          "mean_mse": 0.044044533426424885,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8701312286316748,
-          "mean_mse": 0.12669039501982274,
-          "mean_rank": 25.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.9189110162197988,
-          "mean_mse": 0.09958512594897662,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.9057699514515073,
-          "mean_mse": 0.09920590981633212,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8867845244603261,
-          "mean_mse": 0.11193432581573746,
-          "mean_rank": 23.75,
+        "fold-pattern": {
+          "mean_cosine": 0.9228356796309726,
+          "mean_mse": 0.07558888032237596,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -2964,320 +1344,140 @@
         "alpha_reg": 0.1,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.896934243434012,
-      "std_cosine_to_target": 0.03208132752935873,
-      "mean_mse_to_target": 0.10674092734327327,
-      "std_mse_to_target": 0.028361170254850816,
-      "mean_target_rank": 14.004950495049505,
-      "median_target_rank": 6.5,
-      "recall_at_1": 0.09405940594059406,
-      "recall_at_5": 0.4504950495049505,
-      "recall_at_10": 0.6782178217821783,
-      "mrr": 0.2651740942198535,
-      "train_time_ms": 31143.685208999843,
-      "inference_time_us": 266874.5609306924,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9157914103923412,
+      "std_cosine_to_target": 0.032044982721272874,
+      "mean_mse_to_target": 0.08383440659007484,
+      "std_mse_to_target": 0.030649803754757354,
+      "mean_target_rank": 6.097560975609756,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.389046717305573,
+      "train_time_ms": 9286.710357999254,
+      "inference_time_us": 96367.70680485714,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9173286734649858,
-          "mean_mse": 0.08221040185851389,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9151942949283771,
-          "mean_mse": 0.0913267069616848,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8984162275064951,
-          "mean_mse": 0.09711932223067164,
-          "mean_rank": 14.5,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8752989793299486,
-          "mean_mse": 0.12479984194832491,
-          "mean_rank": 30.75,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8639864814231006,
-          "mean_mse": 0.1352578658695432,
-          "mean_rank": 39.0,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.9094381265508107,
-          "mean_mse": 0.08976950892696886,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.9048127394452388,
-          "mean_mse": 0.09221464947431939,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9166573756235523,
-          "mean_mse": 0.09254364676902041,
+          "mean_cosine": 0.9283237690701035,
+          "mean_mse": 0.06755091035134708,
           "mean_rank": 4.5,
           "num_queries": 4
         },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299331132618808,
+          "mean_mse": 0.07363157937345176,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.901413469492821,
+          "mean_mse": 0.09223586401855378,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8968664776690982,
+          "mean_mse": 0.10148645528518346,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8866458181416732,
+          "mean_mse": 0.11065543177187988,
+          "mean_rank": 13.25,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9207463537143212,
+          "mean_mse": 0.07705047870646889,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9145757774670848,
+          "mean_mse": 0.07835686543564571,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9218260186520791,
+          "mean_mse": 0.08250676178667384,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8796516253351138,
-          "mean_mse": 0.125664189388528,
-          "mean_rank": 10.8,
+          "mean_cosine": 0.8932227949666169,
+          "mean_mse": 0.10815501987911824,
+          "mean_rank": 3.2,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8859929252138075,
-          "mean_mse": 0.11447291350467718,
-          "mean_rank": 18.75,
+          "mean_cosine": 0.9028355904407706,
+          "mean_mse": 0.09421793046970796,
+          "mean_rank": 9.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8990961562578713,
-          "mean_mse": 0.11184701485693542,
-          "mean_rank": 7.25,
+          "mean_cosine": 0.9269040460497581,
+          "mean_mse": 0.08180181885906693,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9118904380083814,
-          "mean_mse": 0.09825605143666019,
+          "mean_cosine": 0.9280279063123023,
+          "mean_mse": 0.07726479699637313,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.9241376911991852,
-          "mean_mse": 0.08858344764655407,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "prolog-terms": {
-          "mean_cosine": 0.8386156639076068,
-          "mean_mse": 0.16809723392655918,
-          "mean_rank": 41.2,
-          "num_queries": 5
-        },
-        "prolog-unification": {
-          "mean_cosine": 0.8882664565047804,
-          "mean_mse": 0.11305310370603817,
-          "mean_rank": 12.25,
-          "num_queries": 4
-        },
-        "recursion-patterns": {
-          "mean_cosine": 0.9027323276262782,
-          "mean_mse": 0.08960628729651803,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9448085468488077,
-          "mean_mse": 0.0647321902286306,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9137249502190934,
-          "mean_mse": 0.08076419192541841,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9324586648535206,
-          "mean_mse": 0.07724240316103557,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8991486286424752,
-          "mean_mse": 0.10102582451244281,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8883226220889621,
-          "mean_mse": 0.11531469283758339,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.915758971188729,
-          "mean_mse": 0.084452558672212,
+          "mean_cosine": 0.9398797053121601,
+          "mean_mse": 0.062284888278268204,
           "mean_rank": 7.0,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.8862388044501343,
-          "mean_mse": 0.11511993015725477,
-          "mean_rank": 17.75,
+        "prolog-terms": {
+          "mean_cosine": 0.8666218556949856,
+          "mean_mse": 0.1385803116594026,
+          "mean_rank": 10.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.905285455856935,
+          "mean_mse": 0.09319391181148737,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "bash-subshells": {
-          "mean_cosine": 0.8909197086916298,
-          "mean_mse": 0.10854111182987401,
-          "mean_rank": 2.5,
+        "recursion-patterns": {
+          "mean_cosine": 0.8975751579997693,
+          "mean_mse": 0.09206442871225748,
+          "mean_rank": 7.25,
           "num_queries": 4
         },
-        "process-substitution": {
-          "mean_cosine": 0.866985228929728,
-          "mean_mse": 0.12905620790848427,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8947298341717276,
-          "mean_mse": 0.09710777845738254,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8598740060701204,
-          "mean_mse": 0.13517887401037765,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.897798924845309,
-          "mean_mse": 0.1169193746574403,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8560960022031285,
-          "mean_mse": 0.14064050695054822,
-          "mean_rank": 41.75,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9197913471204601,
-          "mean_mse": 0.08543431295273937,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8837489351990909,
-          "mean_mse": 0.11614676620869666,
-          "mean_rank": 18.0,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8795799447652726,
-          "mean_mse": 0.12141504744359985,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8856727058210228,
-          "mean_mse": 0.11808967697131074,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8749018055873117,
-          "mean_mse": 0.13452353804648295,
-          "mean_rank": 26.0,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.9053843585477342,
-          "mean_mse": 0.09559580781126296,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9168681619784438,
-          "mean_mse": 0.09489290355730344,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9284407336727925,
-          "mean_mse": 0.0816409351868434,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9109322753409901,
-          "mean_mse": 0.09926224833108019,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.876014369036193,
-          "mean_mse": 0.1287626362172703,
-          "mean_rank": 14.5,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8681819847250605,
-          "mean_mse": 0.1223993175173437,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9094342550718285,
-          "mean_mse": 0.09818857951761682,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.90219866114574,
-          "mean_mse": 0.10794472725121704,
-          "mean_rank": 6.5,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9075720257610371,
-          "mean_mse": 0.10485239872110805,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.924906594815823,
-          "mean_mse": 0.07925578127459038,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9586188837130858,
+          "mean_mse": 0.0458950592363347,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.9183578916479036,
-          "mean_mse": 0.10014152981293814,
-          "mean_rank": 4.0,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341125310602404,
+          "mean_mse": 0.060351441709376674,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8936495741745054,
-          "mean_mse": 0.11009561648416707,
-          "mean_rank": 12.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575133558151869,
+          "mean_mse": 0.04404610536760663,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8701303875154388,
-          "mean_mse": 0.12669108594832937,
-          "mean_rank": 25.25,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.9189109942611571,
-          "mean_mse": 0.09958516513032467,
-          "mean_rank": 8.25,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.9057698506653286,
-          "mean_mse": 0.0992060607324207,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8867845387248935,
-          "mean_mse": 0.11193450877968107,
-          "mean_rank": 23.75,
+        "fold-pattern": {
+          "mean_cosine": 0.9228346696867277,
+          "mean_mse": 0.07559144250369983,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -3289,320 +1489,140 @@
         "alpha_reg": 0.01,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8971069112009378,
-      "std_cosine_to_target": 0.032077483710968115,
-      "mean_mse_to_target": 0.1066101234843308,
-      "std_mse_to_target": 0.028358083480133998,
-      "mean_target_rank": 13.915841584158416,
-      "median_target_rank": 6.0,
-      "recall_at_1": 0.09405940594059406,
-      "recall_at_5": 0.45544554455445546,
-      "recall_at_10": 0.6782178217821783,
-      "mrr": 0.2665414449285918,
-      "train_time_ms": 35446.53137900014,
-      "inference_time_us": 369128.5335742573,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9161544275203135,
+      "std_cosine_to_target": 0.032029902079510134,
+      "mean_mse_to_target": 0.0835124212861715,
+      "std_mse_to_target": 0.030614421897231882,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 14725.366419999773,
+      "inference_time_us": 161185.59221951463,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9173009054635232,
-          "mean_mse": 0.08224230136001093,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.91537386751931,
-          "mean_mse": 0.09122036179131685,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.8986076694158387,
-          "mean_mse": 0.09703867934926932,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.875438332809183,
-          "mean_mse": 0.1247862259103493,
-          "mean_rank": 30.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8642298876610683,
-          "mean_mse": 0.13493364799345883,
-          "mean_rank": 39.0,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.9094856852978874,
-          "mean_mse": 0.08976399986952437,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.9049635799410591,
-          "mean_mse": 0.09212143218308137,
-          "mean_rank": 11.25,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9166811336655354,
-          "mean_mse": 0.09255466217574584,
+          "mean_cosine": 0.9284532965686332,
+          "mean_mse": 0.06748638476461266,
           "mean_rank": 4.5,
           "num_queries": 4
         },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299341115508245,
+          "mean_mse": 0.07374300066217102,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9017551534960109,
+          "mean_mse": 0.09187182020459754,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8971160739350645,
+          "mean_mse": 0.1011623716874156,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8877892231737753,
+          "mean_mse": 0.1095492617383649,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9211310723220129,
+          "mean_mse": 0.07687705142616433,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153948485666479,
+          "mean_mse": 0.07775710055170304,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219469044918224,
+          "mean_mse": 0.08242886681964244,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8796738619910085,
-          "mean_mse": 0.12566357850451382,
-          "mean_rank": 10.8,
+          "mean_cosine": 0.8935268902078277,
+          "mean_mse": 0.10786240422734109,
+          "mean_rank": 3.2,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8863480558856454,
-          "mean_mse": 0.11429041136343299,
-          "mean_rank": 18.25,
+          "mean_cosine": 0.9040520715896947,
+          "mean_mse": 0.09273620847226946,
+          "mean_rank": 9.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.899249744289068,
-          "mean_mse": 0.11182070623047181,
-          "mean_rank": 7.25,
+          "mean_cosine": 0.927286804225827,
+          "mean_mse": 0.0812576619194449,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.912031314331622,
-          "mean_mse": 0.09813769405926967,
+          "mean_cosine": 0.9281126714530392,
+          "mean_mse": 0.07725398360699123,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.9243667845098414,
-          "mean_mse": 0.08823985011738414,
-          "mean_rank": 12.75,
+          "mean_cosine": 0.9408023329612264,
+          "mean_mse": 0.06160207314263884,
+          "mean_rank": 6.75,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8386298946318785,
-          "mean_mse": 0.1680308192472102,
-          "mean_rank": 41.4,
+          "mean_cosine": 0.8667365232512646,
+          "mean_mse": 0.13846324979831018,
+          "mean_rank": 10.4,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8884489669507233,
-          "mean_mse": 0.11289951890670846,
-          "mean_rank": 12.25,
+          "mean_cosine": 0.9056805299417585,
+          "mean_mse": 0.09294213330986872,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.9027681953631704,
-          "mean_mse": 0.08955968595483921,
-          "mean_rank": 11.5,
-          "num_queries": 4
-        },
-        "unifyweaver-overview": {
-          "mean_cosine": 0.9449183959375587,
-          "mean_mse": 0.06463433564255483,
-          "mean_rank": 3.75,
-          "num_queries": 4
-        },
-        "unifyweaver-targets": {
-          "mean_cosine": 0.9139298898128378,
-          "mean_mse": 0.0805884007011891,
-          "mean_rank": 8.5,
-          "num_queries": 4
-        },
-        "accumulator-pattern": {
-          "mean_cosine": 0.9328994223814051,
-          "mean_mse": 0.07665490756674523,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.899316435438914,
-          "mean_mse": 0.10091996689730302,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8882933118601558,
-          "mean_mse": 0.11538147188832219,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9156732134536766,
-          "mean_mse": 0.08447896220019366,
+          "mean_cosine": 0.8978069350123784,
+          "mean_mse": 0.0919752138738446,
           "mean_rank": 7.0,
           "num_queries": 4
         },
-        "memoization-strategy": {
-          "mean_cosine": 0.8865777326715765,
-          "mean_mse": 0.11476811754170049,
-          "mean_rank": 17.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8914317702091216,
-          "mean_mse": 0.10824505347275534,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8670253653996894,
-          "mean_mse": 0.12903352868058732,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8949629901180183,
-          "mean_mse": 0.09697121953120696,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8600780214822114,
-          "mean_mse": 0.13504884971942932,
-          "mean_rank": 25.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.8979869429499532,
-          "mean_mse": 0.11685642575518608,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8562169052764934,
-          "mean_mse": 0.14053373821589796,
-          "mean_rank": 41.5,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.919809152178466,
-          "mean_mse": 0.08543519893543941,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.8837941378157128,
-          "mean_mse": 0.11613926120228481,
-          "mean_rank": 17.75,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8795795963837957,
-          "mean_mse": 0.12145441636012366,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8858773640335436,
-          "mean_mse": 0.1180140097101723,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8750810193001395,
-          "mean_mse": 0.13439647159682813,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.905547974468244,
-          "mean_mse": 0.09546328339255647,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9169629892394485,
-          "mean_mse": 0.09482363399847486,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9285383146345814,
-          "mean_mse": 0.08156451119931184,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9111925414818782,
-          "mean_mse": 0.09901348364902783,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8765911373999943,
-          "mean_mse": 0.12832767352451796,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.8685005520140698,
-          "mean_mse": 0.12203307400535826,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9094753113644738,
-          "mean_mse": 0.09812336120231505,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9028951770168818,
-          "mean_mse": 0.10749368991930576,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9077937219660188,
-          "mean_mse": 0.10472340428014539,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9251468740255552,
-          "mean_mse": 0.07900791235416235,
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587278664897272,
+          "mean_mse": 0.04588968902023352,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.9185673162244747,
-          "mean_mse": 0.09990180326810766,
-          "mean_rank": 3.75,
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341793154324541,
+          "mean_mse": 0.0603141930207523,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8937329523640143,
-          "mean_mse": 0.110027943661241,
-          "mean_rank": 12.75,
+        "accumulator-pattern": {
+          "mean_cosine": 0.957508340636768,
+          "mean_mse": 0.043931797080090526,
+          "mean_rank": 2.5,
           "num_queries": 4
         },
-        "tree-recursion": {
-          "mean_cosine": 0.8704071382729957,
-          "mean_mse": 0.12646902598870138,
-          "mean_rank": 25.0,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.919044414664864,
-          "mean_mse": 0.09953579683344212,
-          "mean_rank": 7.75,
-          "num_queries": 4
-        },
-        "stream-compilation": {
-          "mean_cosine": 0.9059413797537013,
-          "mean_mse": 0.09910219072589359,
-          "mean_rank": 9.75,
-          "num_queries": 4
-        },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8869357351708114,
-          "mean_mse": 0.11191893788370652,
-          "mean_rank": 23.75,
+        "fold-pattern": {
+          "mean_cosine": 0.9231589454948963,
+          "mean_mse": 0.07531875753364635,
+          "mean_rank": 2.25,
           "num_queries": 4
         }
       }
@@ -3614,320 +1634,2603 @@
         "alpha_reg": 0.1,
         "fft_cutoff": 0.5
       },
-      "mean_cosine_to_target": 0.8971066686145762,
-      "std_cosine_to_target": 0.032077533300199024,
-      "mean_mse_to_target": 0.10661036452524726,
-      "std_mse_to_target": 0.028358117183169166,
-      "mean_target_rank": 13.915841584158416,
-      "median_target_rank": 6.0,
-      "recall_at_1": 0.09405940594059406,
-      "recall_at_5": 0.45544554455445546,
-      "recall_at_10": 0.6782178217821783,
-      "mrr": 0.2665414449285918,
-      "train_time_ms": 40973.87553899989,
-      "inference_time_us": 415859.04385148507,
-      "num_queries": 202,
-      "num_answers": 202,
-      "num_clusters": 50,
+      "mean_cosine_to_target": 0.9161539415363797,
+      "std_cosine_to_target": 0.03202986311567515,
+      "mean_mse_to_target": 0.08351290798500342,
+      "std_mse_to_target": 0.030614317902800756,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 14351.842833999399,
+      "inference_time_us": 138945.3815122024,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
       "cluster_metrics": {
         "bash-target-design": {
-          "mean_cosine": 0.9173009201475792,
-          "mean_mse": 0.08224237287132173,
-          "mean_rank": 4.25,
-          "num_queries": 4
-        },
-        "prolog-to-bash-bridge": {
-          "mean_cosine": 0.9153738689544056,
-          "mean_mse": 0.09122037414465964,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "compilation-pipeline": {
-          "mean_cosine": 0.89860751431789,
-          "mean_mse": 0.0970388062861497,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "constraint-usage": {
-          "mean_cosine": 0.8754381121813614,
-          "mean_mse": 0.12478638595718539,
-          "mean_rank": 30.5,
-          "num_queries": 4
-        },
-        "troubleshooting-compilation": {
-          "mean_cosine": 0.8642295575359038,
-          "mean_mse": 0.13493394537996084,
-          "mean_rank": 39.0,
-          "num_queries": 4
-        },
-        "practical-compilation": {
-          "mean_cosine": 0.9094855966081519,
-          "mean_mse": 0.08976403601248528,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "generated-code-facts": {
-          "mean_cosine": 0.9049636173558738,
-          "mean_mse": 0.09212146575992268,
-          "mean_rank": 11.25,
-          "num_queries": 4
-        },
-        "generated-code-transitive": {
-          "mean_cosine": 0.9166811269402604,
-          "mean_mse": 0.09255463711782091,
+          "mean_cosine": 0.9284527684737292,
+          "mean_mse": 0.06748679329050077,
           "mean_rank": 4.5,
           "num_queries": 4
         },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299338704566442,
+          "mean_mse": 0.07374333105897071,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9017555618244872,
+          "mean_mse": 0.09187128090021873,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8971156298120735,
+          "mean_mse": 0.10116238188178027,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8877887530908898,
+          "mean_mse": 0.10954983050658,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9211301843999071,
+          "mean_mse": 0.07687773150605792,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153941279632087,
+          "mean_mse": 0.07775771468751967,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219466086131561,
+          "mean_mse": 0.0824290071632334,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
         "prolog-facts-rules": {
-          "mean_cosine": 0.8796737362951157,
-          "mean_mse": 0.12566361507135748,
-          "mean_rank": 10.8,
+          "mean_cosine": 0.893526371574427,
+          "mean_mse": 0.10786280907623624,
+          "mean_rank": 3.2,
           "num_queries": 5
         },
         "prolog-modules": {
-          "mean_cosine": 0.8863477190257165,
-          "mean_mse": 0.11429075202003999,
-          "mean_rank": 18.25,
+          "mean_cosine": 0.9040514837621262,
+          "mean_mse": 0.09273657704447148,
+          "mean_rank": 9.25,
           "num_queries": 4
         },
         "prolog-directives": {
-          "mean_cosine": 0.8992494841248329,
-          "mean_mse": 0.11182096508166622,
-          "mean_rank": 7.25,
+          "mean_cosine": 0.9272858938361984,
+          "mean_mse": 0.08125816835186969,
+          "mean_rank": 2.25,
           "num_queries": 4
         },
         "prolog-file-io": {
-          "mean_cosine": 0.9120310292187773,
-          "mean_mse": 0.09813820848237038,
+          "mean_cosine": 0.9281120184736416,
+          "mean_mse": 0.07725467214616923,
           "mean_rank": 2.5,
           "num_queries": 4
         },
         "init-pl-explained": {
-          "mean_cosine": 0.9243664378493442,
-          "mean_mse": 0.08824064642205069,
-          "mean_rank": 12.75,
+          "mean_cosine": 0.9408018437014268,
+          "mean_mse": 0.061603323533955416,
+          "mean_rank": 6.75,
           "num_queries": 4
         },
         "prolog-terms": {
-          "mean_cosine": 0.8386294872858523,
-          "mean_mse": 0.16803119985092346,
-          "mean_rank": 41.4,
+          "mean_cosine": 0.866736063644,
+          "mean_mse": 0.13846374993150207,
+          "mean_rank": 10.4,
           "num_queries": 5
         },
         "prolog-unification": {
-          "mean_cosine": 0.8884487525914078,
-          "mean_mse": 0.1128995901773623,
-          "mean_rank": 12.25,
+          "mean_cosine": 0.9056802655199646,
+          "mean_mse": 0.09294222592937301,
+          "mean_rank": 4.25,
           "num_queries": 4
         },
         "recursion-patterns": {
-          "mean_cosine": 0.90276814050481,
-          "mean_mse": 0.08955975150621734,
-          "mean_rank": 11.5,
+          "mean_cosine": 0.8978066440398762,
+          "mean_mse": 0.09197540958983724,
+          "mean_rank": 7.0,
           "num_queries": 4
         },
         "unifyweaver-overview": {
-          "mean_cosine": 0.9449182644309133,
-          "mean_mse": 0.06463437316472441,
+          "mean_cosine": 0.9587272419009962,
+          "mean_mse": 0.045890184083092894,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341786908107561,
+          "mean_mse": 0.06031480440019798,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575079267222495,
+          "mean_mse": 0.04393280616867302,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231582440714239,
+          "mean_mse": 0.07532017269039594,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls0.5",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 0.5
+      },
+      "mean_cosine_to_target": 0.9161490537149591,
+      "std_cosine_to_target": 0.0320323392896768,
+      "mean_mse_to_target": 0.08352317547185074,
+      "std_mse_to_target": 0.030596716043598256,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 98.77220699854661,
+      "inference_time_us": 5437.655256084726,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9284521104790506,
+          "mean_mse": 0.06751520156886406,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299290252070316,
+          "mean_mse": 0.07371596648754351,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.901731721621722,
+          "mean_mse": 0.09187603612670021,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8970614852903395,
+          "mean_mse": 0.10118544665406445,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.887766713749464,
+          "mean_mse": 0.10956450179980413,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.921138063686278,
+          "mean_mse": 0.07687087525227501,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153821931721997,
+          "mean_mse": 0.0777715357819351,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219305282246503,
+          "mean_mse": 0.082424978262801,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8935232191308486,
+          "mean_mse": 0.1078743938081412,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9040461118832933,
+          "mean_mse": 0.09275062842966778,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272973833193525,
+          "mean_mse": 0.08128104203082981,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9280997443587597,
+          "mean_mse": 0.07725414956772038,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408092043381081,
+          "mean_mse": 0.06162361095819157,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8667301063703624,
+          "mean_mse": 0.13843803499204796,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9056831132223386,
+          "mean_mse": 0.09296120868535368,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977976460829196,
+          "mean_mse": 0.09198167561847069,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587368970239951,
+          "mean_mse": 0.04590160464873605,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341956056075552,
+          "mean_mse": 0.06030647967617783,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.957543461322419,
+          "mean_mse": 0.04398164523670835,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231379356906727,
+          "mean_mse": 0.07536797438685992,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls1.0",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.9161490537149591,
+      "std_cosine_to_target": 0.0320323392896768,
+      "mean_mse_to_target": 0.08352317547185074,
+      "std_mse_to_target": 0.030596716043598256,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 94.01710699967225,
+      "inference_time_us": 5697.244304850224,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9284521104790506,
+          "mean_mse": 0.06751520156886406,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299290252070316,
+          "mean_mse": 0.07371596648754351,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.901731721621722,
+          "mean_mse": 0.09187603612670021,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8970614852903395,
+          "mean_mse": 0.10118544665406445,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.887766713749464,
+          "mean_mse": 0.10956450179980413,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.921138063686278,
+          "mean_mse": 0.07687087525227501,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153821931721997,
+          "mean_mse": 0.0777715357819351,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219305282246503,
+          "mean_mse": 0.082424978262801,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8935232191308486,
+          "mean_mse": 0.1078743938081412,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9040461118832933,
+          "mean_mse": 0.09275062842966778,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272973833193525,
+          "mean_mse": 0.08128104203082981,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9280997443587597,
+          "mean_mse": 0.07725414956772038,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408092043381081,
+          "mean_mse": 0.06162361095819157,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8667301063703624,
+          "mean_mse": 0.13843803499204796,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9056831132223386,
+          "mean_mse": 0.09296120868535368,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977976460829196,
+          "mean_mse": 0.09198167561847069,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587368970239951,
+          "mean_mse": 0.04590160464873605,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341956056075552,
+          "mean_mse": 0.06030647967617783,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.957543461322419,
+          "mean_mse": 0.04398164523670835,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231379356906727,
+          "mean_mse": 0.07536797438685992,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Gaussian_ls2.0",
+      "params": {
+        "kernel": "Gaussian",
+        "length_scale": 2.0
+      },
+      "mean_cosine_to_target": 0.9161486127090142,
+      "std_cosine_to_target": 0.03203240512877665,
+      "mean_mse_to_target": 0.08352364093072076,
+      "std_mse_to_target": 0.030596798054657447,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 99.83230700163404,
+      "inference_time_us": 5646.1930731840275,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9284517123564916,
+          "mean_mse": 0.06751578312062646,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299281813378381,
+          "mean_mse": 0.07371710998762579,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9017312149891168,
+          "mean_mse": 0.09187647604795719,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8970611078617836,
+          "mean_mse": 0.10118580135067624,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8877668249906853,
+          "mean_mse": 0.10956453188970143,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9211366318747876,
+          "mean_mse": 0.07687208057245813,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153815167707137,
+          "mean_mse": 0.07777224343079031,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219295184642129,
+          "mean_mse": 0.0824260453428059,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.893522487799905,
+          "mean_mse": 0.10787510423139395,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9040460231818988,
+          "mean_mse": 0.09275076043355415,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272973680153199,
+          "mean_mse": 0.08128109369282366,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9280991289135002,
+          "mean_mse": 0.07725474771958243,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408092577634874,
+          "mean_mse": 0.06162362124108272,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8667296670600912,
+          "mean_mse": 0.13843851775612298,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9056828169740729,
+          "mean_mse": 0.09296151542375085,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977963273533224,
+          "mean_mse": 0.09198280601531336,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587368560113074,
+          "mean_mse": 0.04590168474069493,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341955403227705,
+          "mean_mse": 0.06030657145914967,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575434192885117,
+          "mean_mse": 0.04398171620970603,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231379204899774,
+          "mean_mse": 0.07536802291708022,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls0.5",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 0.5
+      },
+      "mean_cosine_to_target": 0.9161490537149591,
+      "std_cosine_to_target": 0.03203233928967682,
+      "mean_mse_to_target": 0.08352317547185077,
+      "std_mse_to_target": 0.030596716043598253,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 99.82670699901064,
+      "inference_time_us": 5577.512585393667,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9284521104790506,
+          "mean_mse": 0.06751520156886409,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299290252070315,
+          "mean_mse": 0.07371596648754361,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.901731721621722,
+          "mean_mse": 0.09187603612670023,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8970614852903394,
+          "mean_mse": 0.10118544665406445,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.887766713749464,
+          "mean_mse": 0.10956450179980413,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9211380636862779,
+          "mean_mse": 0.07687087525227512,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153821931721997,
+          "mean_mse": 0.07777153578193514,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219305282246502,
+          "mean_mse": 0.08242497826280104,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8935232191308484,
+          "mean_mse": 0.10787439380814123,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9040461118832933,
+          "mean_mse": 0.09275062842966778,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272973833193525,
+          "mean_mse": 0.08128104203082981,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9280997443587597,
+          "mean_mse": 0.07725414956772038,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408092043381081,
+          "mean_mse": 0.06162361095819157,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8667301063703624,
+          "mean_mse": 0.13843803499204796,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9056831132223386,
+          "mean_mse": 0.0929612086853537,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977976460829195,
+          "mean_mse": 0.09198167561847075,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587368970239951,
+          "mean_mse": 0.04590160464873605,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341956056075553,
+          "mean_mse": 0.060306479676177846,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.957543461322419,
+          "mean_mse": 0.04398164523670835,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231379356906727,
+          "mean_mse": 0.07536797438685992,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls1.0",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.9161490500143321,
+      "std_cosine_to_target": 0.032032339896603174,
+      "mean_mse_to_target": 0.08352317936267994,
+      "std_mse_to_target": 0.030596716786309333,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 117.1342090019607,
+      "inference_time_us": 5533.610536608981,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9284521071854499,
+          "mean_mse": 0.06751520622590755,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299290187493331,
+          "mean_mse": 0.07371597516604338,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9017317168530614,
+          "mean_mse": 0.0918760403037683,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8970614816908038,
+          "mean_mse": 0.10118545001207002,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8877667145007511,
+          "mean_mse": 0.10956450215084892,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9211380533191345,
+          "mean_mse": 0.07687088414745383,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9153821877117976,
+          "mean_mse": 0.07777154148077926,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219305199678678,
+          "mean_mse": 0.08242498694822178,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8935232127899907,
+          "mean_mse": 0.10787439991913936,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9040461106911217,
+          "mean_mse": 0.09275063000708055,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272973830778273,
+          "mean_mse": 0.08128104257885303,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9280997389527861,
+          "mean_mse": 0.07725415478744208,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408092047423463,
+          "mean_mse": 0.06162361103923937,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8667301020320876,
+          "mean_mse": 0.138438039633736,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9056831100207813,
+          "mean_mse": 0.09296121184379504,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977976362611996,
+          "mean_mse": 0.09198168413788094,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587368964896783,
+          "mean_mse": 0.04590160556355144,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341956049701272,
+          "mean_mse": 0.060306480537779636,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575434610233164,
+          "mean_mse": 0.04398164576383567,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231379355588315,
+          "mean_mse": 0.07536797479929348,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern52_ls2.0",
+      "params": {
+        "kernel": "Matern52",
+        "length_scale": 2.0
+      },
+      "mean_cosine_to_target": 0.9160786383897908,
+      "std_cosine_to_target": 0.03204552029834002,
+      "mean_mse_to_target": 0.08359812978355359,
+      "std_mse_to_target": 0.030611759664088512,
+      "mean_target_rank": 6.024390243902439,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900318024475127,
+      "train_time_ms": 120.89317199934158,
+      "inference_time_us": 5195.858536597637,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9283948956199505,
+          "mean_mse": 0.06758803537366488,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9298412354914617,
+          "mean_mse": 0.07382887980273974,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9016236736184533,
+          "mean_mse": 0.09197488729165729,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8969614799678456,
+          "mean_mse": 0.10127836233449398,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8877505639716553,
+          "mean_mse": 0.10959678433840832,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9210219378028588,
+          "mean_mse": 0.07698369415838344,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9152907580944709,
+          "mean_mse": 0.07786836775440482,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9218083404325366,
+          "mean_mse": 0.08255536694493368,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8934159632662928,
+          "mean_mse": 0.10797940062516878,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.9039860084844302,
+          "mean_mse": 0.09282063280592942,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272636228478045,
+          "mean_mse": 0.08132331624290465,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9279985364678367,
+          "mean_mse": 0.07735416102312895,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.940809802223856,
+          "mean_mse": 0.06163241210534941,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8666210468312032,
+          "mean_mse": 0.1385506743270442,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9055767118486886,
+          "mean_mse": 0.09306047647394809,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8976907955770015,
+          "mean_mse": 0.09208332932525932,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587164898157226,
+          "mean_mse": 0.04593402695271344,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341617672458229,
+          "mean_mse": 0.060344019093192224,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575401215441295,
+          "mean_mse": 0.04398945552558687,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231290833143124,
+          "mean_mse": 0.07538285932588376,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Kernel_Matern32_ls1.0",
+      "params": {
+        "kernel": "Matern32",
+        "length_scale": 1.0
+      },
+      "mean_cosine_to_target": 0.9161490058243092,
+      "std_cosine_to_target": 0.03203234795029528,
+      "mean_mse_to_target": 0.08352322566478633,
+      "std_mse_to_target": 0.030596726410134733,
+      "mean_target_rank": 6.012195121951219,
+      "median_target_rank": 3.0,
+      "recall_at_1": 0.17073170731707318,
+      "recall_at_5": 0.7073170731707317,
+      "recall_at_10": 0.8414634146341463,
+      "mrr": 0.3900766374546863,
+      "train_time_ms": 105.8753750003234,
+      "inference_time_us": 5260.714621970958,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9284520687003753,
+          "mean_mse": 0.06751525816596798,
+          "mean_rank": 4.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9299289518992988,
+          "mean_mse": 0.07371606367364075,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.9017316521583297,
+          "mean_mse": 0.09187609761750799,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8970614311968969,
+          "mean_mse": 0.10118549679513743,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8877667192994336,
+          "mean_mse": 0.1095645091649638,
+          "mean_rank": 12.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9211379557284172,
+          "mean_mse": 0.07687097120228772,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.915382125786897,
+          "mean_mse": 0.07777160598718345,
+          "mean_rank": 8.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9219304261173475,
+          "mean_mse": 0.08242508526791693,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8935231352563953,
+          "mean_mse": 0.10787447412941058,
+          "mean_rank": 3.2,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.904046088490779,
+          "mean_mse": 0.09275065721667701,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9272973770325381,
+          "mean_mse": 0.0812810524334421,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9280996711739634,
+          "mean_mse": 0.07725421988765292,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408092086981465,
+          "mean_mse": 0.06162361215239375,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8667300405510892,
+          "mean_mse": 0.13843810380901003,
+          "mean_rank": 10.4,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.9056830599037112,
+          "mean_mse": 0.09296125936826627,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8977975393648314,
+          "mean_mse": 0.09198177010516745,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9587368871355625,
+          "mean_mse": 0.04590162040027368,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9341955949255948,
+          "mean_mse": 0.06030649323526526,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9575434582834015,
+          "mean_mse": 0.04398165102609817,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9231379337434618,
+          "mean_mse": 0.07536798000525133,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.1",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8673352541821087,
+      "std_cosine_to_target": 0.042653861288417846,
+      "mean_mse_to_target": 0.11714588227397928,
+      "std_mse_to_target": 0.0417826642176318,
+      "mean_target_rank": 18.609756097560975,
+      "median_target_rank": 13.0,
+      "recall_at_1": 0.04878048780487805,
+      "recall_at_5": 0.18292682926829268,
+      "recall_at_10": 0.4146341463414634,
+      "mrr": 0.14757965012951585,
+      "train_time_ms": 12629.906853999273,
+      "inference_time_us": 76603.1729268079,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8837600178084656,
+          "mean_mse": 0.09801156699919396,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.905640637465983,
+          "mean_mse": 0.07972286203974649,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8949714894465197,
+          "mean_mse": 0.08906336134295417,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8479682832403109,
+          "mean_mse": 0.126710893220982,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8570881017720129,
+          "mean_mse": 0.12069259381199932,
+          "mean_rank": 28.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8819495475890282,
+          "mean_mse": 0.10046169762562344,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8347244313556286,
+          "mean_mse": 0.13758154428604225,
+          "mean_rank": 34.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8926367287234063,
+          "mean_mse": 0.0913092973884928,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8342116150279946,
+          "mean_mse": 0.15202341071827982,
+          "mean_rank": 28.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8895927419038966,
+          "mean_mse": 0.09529382318266603,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8953064530045475,
+          "mean_mse": 0.09048045959518806,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8441501614832917,
+          "mean_mse": 0.14176664768224248,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8820192373218598,
+          "mean_mse": 0.100325399868229,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.785236280305803,
+          "mean_mse": 0.20265685939804187,
+          "mean_rank": 50.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8883473217612396,
+          "mean_mse": 0.102587411382039,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8521621416795133,
+          "mean_mse": 0.12644873222452832,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9355539423999872,
+          "mean_mse": 0.05904160708057904,
           "mean_rank": 3.75,
           "num_queries": 4
         },
         "unifyweaver-targets": {
-          "mean_cosine": 0.913929527223966,
-          "mean_mse": 0.08058873828044139,
-          "mean_rank": 8.5,
+          "mean_cosine": 0.8871404345789713,
+          "mean_mse": 0.08649238824048484,
+          "mean_rank": 18.75,
           "num_queries": 4
         },
         "accumulator-pattern": {
-          "mean_cosine": 0.9328990413074183,
-          "mean_mse": 0.07665537521264114,
-          "mean_rank": 3.5,
-          "num_queries": 4
-        },
-        "fold-pattern": {
-          "mean_cosine": 0.8993162429967754,
-          "mean_mse": 0.10092032439291161,
-          "mean_rank": 5.75,
-          "num_queries": 4
-        },
-        "scc-tarjan": {
-          "mean_cosine": 0.8882932610920822,
-          "mean_mse": 0.11538144924842492,
-          "mean_rank": 26.75,
-          "num_queries": 4
-        },
-        "recursion-types": {
-          "mean_cosine": 0.9156731403359638,
-          "mean_mse": 0.08447904948371647,
-          "mean_rank": 7.0,
-          "num_queries": 4
-        },
-        "memoization-strategy": {
-          "mean_cosine": 0.8865771984867812,
-          "mean_mse": 0.11476857503510121,
-          "mean_rank": 17.75,
-          "num_queries": 4
-        },
-        "bash-subshells": {
-          "mean_cosine": 0.8914311349903791,
-          "mean_mse": 0.10824573991198082,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "process-substitution": {
-          "mean_cosine": 0.8670251331586735,
-          "mean_mse": 0.12903370098636885,
-          "mean_rank": 10.0,
-          "num_queries": 4
-        },
-        "bash-arrays": {
-          "mean_cosine": 0.8949622775276463,
-          "mean_mse": 0.09697201621210379,
-          "mean_rank": 8.0,
-          "num_queries": 4
-        },
-        "bash-redirections": {
-          "mean_cosine": 0.8600775404061507,
-          "mean_mse": 0.13504924215763903,
-          "mean_rank": 25.25,
-          "num_queries": 4
-        },
-        "bash-trap": {
-          "mean_cosine": 0.897986414306247,
-          "mean_mse": 0.11685703331803086,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "bash-string-ops": {
-          "mean_cosine": 0.8562164266648064,
-          "mean_mse": 0.1405342780945911,
-          "mean_rank": 41.5,
-          "num_queries": 4
-        },
-        "compiler-driver": {
-          "mean_cosine": 0.9198090521889061,
-          "mean_mse": 0.0854352682288728,
-          "mean_rank": 5.5,
-          "num_queries": 4
-        },
-        "compile-api-reference": {
-          "mean_cosine": 0.883793976801041,
-          "mean_mse": 0.11613935195549191,
-          "mean_rank": 17.75,
-          "num_queries": 4
-        },
-        "bash-constraints": {
-          "mean_cosine": 0.8795793735636019,
-          "mean_mse": 0.12145453614828754,
-          "mean_rank": 24.75,
-          "num_queries": 4
-        },
-        "data-sources-overview": {
-          "mean_cosine": 0.8858771265315996,
-          "mean_mse": 0.1180141390098093,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "data-sources-pipeline": {
-          "mean_cosine": 0.8750806446942777,
-          "mean_mse": 0.1343966840154175,
-          "mean_rank": 25.75,
-          "num_queries": 4
-        },
-        "first-bash-program": {
-          "mean_cosine": 0.90554789860085,
-          "mean_mse": 0.09546332063793891,
-          "mean_rank": 15.0,
-          "num_queries": 4
-        },
-        "compile-workflow": {
-          "mean_cosine": 0.9169627835507359,
-          "mean_mse": 0.09482378035024137,
-          "mean_rank": 4.75,
-          "num_queries": 4
-        },
-        "partitioning-overview": {
-          "mean_cosine": 0.9285382994373451,
-          "mean_mse": 0.08156453639024029,
-          "mean_rank": 2.5,
-          "num_queries": 4
-        },
-        "partitioning-strategies": {
-          "mean_cosine": 0.9111919776776493,
-          "mean_mse": 0.09901393384590952,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "gnu-parallel-backend": {
-          "mean_cosine": 0.8765908295675987,
-          "mean_mse": 0.12832808015691866,
-          "mean_rank": 14.25,
-          "num_queries": 4
-        },
-        "batch-vs-streaming": {
-          "mean_cosine": 0.868500100093283,
-          "mean_mse": 0.1220333837694231,
-          "mean_rank": 36.75,
-          "num_queries": 4
-        },
-        "prolog-introspection": {
-          "mean_cosine": 0.9094750507701667,
-          "mean_mse": 0.09812369635429098,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "call-graph-construction": {
-          "mean_cosine": 0.9028946857462997,
-          "mean_mse": 0.10749427411531096,
-          "mean_rank": 6.25,
-          "num_queries": 4
-        },
-        "scc-detection": {
-          "mean_cosine": 0.9077935931392616,
-          "mean_mse": 0.10472344882896929,
-          "mean_rank": 5.25,
-          "num_queries": 4
-        },
-        "pattern-matching-detection": {
-          "mean_cosine": 0.9251468055768819,
-          "mean_mse": 0.07900803450303204,
+          "mean_cosine": 0.8516076144330884,
+          "mean_mse": 0.15914542515479066,
           "mean_rank": 3.0,
           "num_queries": 4
         },
-        "tail-recursion": {
-          "mean_cosine": 0.918567223038469,
-          "mean_mse": 0.09990188724142152,
-          "mean_rank": 3.75,
+        "fold-pattern": {
+          "mean_cosine": 0.83144355559823,
+          "mean_mse": 0.1530045378453912,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.1_k5",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": 5
+      },
+      "mean_cosine_to_target": 0.8673352541821087,
+      "std_cosine_to_target": 0.042653861288417846,
+      "mean_mse_to_target": 0.11714588227397928,
+      "std_mse_to_target": 0.0417826642176318,
+      "mean_target_rank": 18.609756097560975,
+      "median_target_rank": 13.0,
+      "recall_at_1": 0.04878048780487805,
+      "recall_at_5": 0.18292682926829268,
+      "recall_at_10": 0.4146341463414634,
+      "mrr": 0.14757965012951585,
+      "train_time_ms": 10345.855766998284,
+      "inference_time_us": 66849.78882926438,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8837600178084656,
+          "mean_mse": 0.09801156699919396,
+          "mean_rank": 14.25,
           "num_queries": 4
         },
-        "linear-recursion": {
-          "mean_cosine": 0.8937328556885956,
-          "mean_mse": 0.11002810511249361,
-          "mean_rank": 12.75,
-          "num_queries": 4
-        },
-        "tree-recursion": {
-          "mean_cosine": 0.8704066633056273,
-          "mean_mse": 0.12646939596041737,
-          "mean_rank": 25.0,
-          "num_queries": 4
-        },
-        "mutual-recursion": {
-          "mean_cosine": 0.9190442766504906,
-          "mean_mse": 0.0995358658647567,
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.905640637465983,
+          "mean_mse": 0.07972286203974649,
           "mean_rank": 7.75,
           "num_queries": 4
         },
-        "stream-compilation": {
-          "mean_cosine": 0.9059413032509441,
-          "mean_mse": 0.09910229386441656,
-          "mean_rank": 9.75,
+        "compilation-pipeline": {
+          "mean_cosine": 0.8949714894465197,
+          "mean_mse": 0.08906336134295417,
+          "mean_rank": 10.5,
           "num_queries": 4
         },
-        "bash-pipeline-patterns": {
-          "mean_cosine": 0.8869357354021423,
-          "mean_mse": 0.11191904080058689,
-          "mean_rank": 23.75,
+        "constraint-usage": {
+          "mean_cosine": 0.8479682832403109,
+          "mean_mse": 0.126710893220982,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8570881017720129,
+          "mean_mse": 0.12069259381199932,
+          "mean_rank": 28.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8819495475890282,
+          "mean_mse": 0.10046169762562344,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8347244313556286,
+          "mean_mse": 0.13758154428604225,
+          "mean_rank": 34.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8926367287234063,
+          "mean_mse": 0.0913092973884928,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8342116150279946,
+          "mean_mse": 0.15202341071827982,
+          "mean_rank": 28.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8895927419038966,
+          "mean_mse": 0.09529382318266603,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8953064530045475,
+          "mean_mse": 0.09048045959518806,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8441501614832917,
+          "mean_mse": 0.14176664768224248,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8820192373218598,
+          "mean_mse": 0.100325399868229,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.785236280305803,
+          "mean_mse": 0.20265685939804187,
+          "mean_rank": 50.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8883473217612396,
+          "mean_mse": 0.102587411382039,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8521621416795133,
+          "mean_mse": 0.12644873222452832,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9355539423999872,
+          "mean_mse": 0.05904160708057904,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8871404345789713,
+          "mean_mse": 0.08649238824048484,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8516076144330884,
+          "mean_mse": 0.15914542515479066,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.83144355559823,
+          "mean_mse": 0.1530045378453912,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls0.5_\u03bb0.01",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.01,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8673352541821087,
+      "std_cosine_to_target": 0.042653861288417846,
+      "mean_mse_to_target": 0.11714588227397928,
+      "std_mse_to_target": 0.0417826642176318,
+      "mean_target_rank": 18.609756097560975,
+      "median_target_rank": 13.0,
+      "recall_at_1": 0.04878048780487805,
+      "recall_at_5": 0.18292682926829268,
+      "recall_at_10": 0.4146341463414634,
+      "mrr": 0.14757965012951585,
+      "train_time_ms": 10798.45067199858,
+      "inference_time_us": 76368.75114635253,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.8837600178084656,
+          "mean_mse": 0.09801156699919396,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.905640637465983,
+          "mean_mse": 0.07972286203974649,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8949714894465197,
+          "mean_mse": 0.08906336134295417,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8479682832403109,
+          "mean_mse": 0.126710893220982,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8570881017720129,
+          "mean_mse": 0.12069259381199932,
+          "mean_rank": 28.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8819495475890282,
+          "mean_mse": 0.10046169762562344,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8347244313556286,
+          "mean_mse": 0.13758154428604225,
+          "mean_rank": 34.75,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8926367287234063,
+          "mean_mse": 0.0913092973884928,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8342116150279946,
+          "mean_mse": 0.15202341071827982,
+          "mean_rank": 28.6,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8895927419038966,
+          "mean_mse": 0.09529382318266603,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8953064530045475,
+          "mean_mse": 0.09048045959518806,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8441501614832917,
+          "mean_mse": 0.14176664768224248,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8820192373218598,
+          "mean_mse": 0.100325399868229,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.785236280305803,
+          "mean_mse": 0.20265685939804187,
+          "mean_rank": 50.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8883473217612396,
+          "mean_mse": 0.102587411382039,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8521621416795133,
+          "mean_mse": 0.12644873222452832,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9355539423999872,
+          "mean_mse": 0.05904160708057904,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8871404345789713,
+          "mean_mse": 0.08649238824048484,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8516076144330884,
+          "mean_mse": 0.15914542515479066,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.83144355559823,
+          "mean_mse": 0.1530045378453912,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K4_ls1.0_\u03bb0.1",
+      "params": {
+        "K": 4,
+        "length_scale": 1.0,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8673197621918767,
+      "std_cosine_to_target": 0.04266771416146506,
+      "mean_mse_to_target": 0.11716396817691149,
+      "std_mse_to_target": 0.041799007990900104,
+      "mean_target_rank": 18.609756097560975,
+      "median_target_rank": 13.0,
+      "recall_at_1": 0.04878048780487805,
+      "recall_at_5": 0.18292682926829268,
+      "recall_at_10": 0.4146341463414634,
+      "mrr": 0.1478623045200008,
+      "train_time_ms": 12898.857500000304,
+      "inference_time_us": 72297.5096341099,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.883726891945601,
+          "mean_mse": 0.09804278471661036,
+          "mean_rank": 14.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056254449614021,
+          "mean_mse": 0.0797371098221793,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8949795795953805,
+          "mean_mse": 0.08905980318907462,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8479738337910573,
+          "mean_mse": 0.1267056533749475,
+          "mean_rank": 34.0,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8570851762853438,
+          "mean_mse": 0.12069341266295544,
+          "mean_rank": 27.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.8819463160759902,
+          "mean_mse": 0.10046556601192956,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8346767290978766,
+          "mean_mse": 0.13762617007348185,
+          "mean_rank": 35.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.8926160968293051,
+          "mean_mse": 0.09132853527715556,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8341722162295504,
+          "mean_mse": 0.15206462461124082,
+          "mean_rank": 28.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8895982481079433,
+          "mean_mse": 0.0952897757572724,
+          "mean_rank": 11.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8953020980338131,
+          "mean_mse": 0.09048280778517306,
+          "mean_rank": 9.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.8441152097866857,
+          "mean_mse": 0.14180622138699803,
+          "mean_rank": 19.75,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8820102328333472,
+          "mean_mse": 0.10033255941893196,
+          "mean_rank": 10.25,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7851852622744668,
+          "mean_mse": 0.20271197731440468,
+          "mean_rank": 50.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8883391774442887,
+          "mean_mse": 0.10259932725701842,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8521438350302772,
+          "mean_mse": 0.12647335234451945,
+          "mean_rank": 17.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9355622408930576,
+          "mean_mse": 0.05903436218190965,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.8871479479126312,
+          "mean_mse": 0.08648679500270309,
+          "mean_rank": 18.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8516043753613926,
+          "mean_mse": 0.15917025213011868,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.8314048428180606,
+          "mean_mse": 0.1530561068266498,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Unified_K8_ls0.5_\u03bb0.1",
+      "params": {
+        "K": 8,
+        "length_scale": 0.5,
+        "smoothing_strength": 0.1,
+        "k_neighbors": null
+      },
+      "mean_cosine_to_target": 0.8995903687106085,
+      "std_cosine_to_target": 0.03331385692567114,
+      "mean_mse_to_target": 0.08636133306684227,
+      "std_mse_to_target": 0.030523419432254183,
+      "mean_target_rank": 9.341463414634147,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.12195121951219512,
+      "recall_at_5": 0.5365853658536586,
+      "recall_at_10": 0.7195121951219512,
+      "mrr": 0.30792802934219377,
+      "train_time_ms": 17460.618301000068,
+      "inference_time_us": 122117.22804878684,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9229001477215978,
+          "mean_mse": 0.06357889303272576,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9187945437065507,
+          "mean_mse": 0.06864803493822844,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8864859462913076,
+          "mean_mse": 0.09402552056479091,
+          "mean_rank": 16.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8801724270836984,
+          "mean_mse": 0.10192301190872877,
+          "mean_rank": 16.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8802255750710575,
+          "mean_mse": 0.10318858065730159,
+          "mean_rank": 12.0,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9032262124593569,
+          "mean_mse": 0.0826951951982958,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9048611285166018,
+          "mean_mse": 0.07599284424339768,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9139999457950222,
+          "mean_mse": 0.07365030147537727,
+          "mean_rank": 7.0,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8693020837222487,
+          "mean_mse": 0.11820695655562026,
+          "mean_rank": 8.8,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8969580008513713,
+          "mean_mse": 0.0888837079368737,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9032370782630692,
+          "mean_mse": 0.0834972333098007,
+          "mean_rank": 3.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9061207727047729,
+          "mean_mse": 0.08381886690312168,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9193363000356976,
+          "mean_mse": 0.06763963478494013,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8337010349371553,
+          "mean_mse": 0.1534548061015481,
+          "mean_rank": 32.2,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8866804822696405,
+          "mean_mse": 0.09906935687595576,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8890497302902015,
+          "mean_mse": 0.08956048707618759,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9509444950815452,
+          "mean_mse": 0.0461354473451039,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9027689526241706,
+          "mean_mse": 0.0761621907789476,
+          "mean_rank": 10.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.935370112639552,
+          "mean_mse": 0.0573044657067043,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9117168088380063,
+          "mean_mse": 0.07505635181232448,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.3",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.3
+      },
+      "mean_cosine_to_target": 0.8715898367887795,
+      "std_cosine_to_target": 0.04988526253957752,
+      "mean_mse_to_target": 0.1158344468104835,
+      "std_mse_to_target": 0.05432569368691151,
+      "mean_target_rank": 8.24390243902439,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7804878048780488,
+      "mrr": 0.3507524537497204,
+      "train_time_ms": 14643.63578999837,
+      "inference_time_us": 7085.6390609661485,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9122721911881921,
+          "mean_mse": 0.07404074581850903,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056033026210509,
+          "mean_mse": 0.08103197808164006,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.881091049116395,
+          "mean_mse": 0.10000327104222612,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8560586100666514,
+          "mean_mse": 0.12077597002338258,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.872244012066832,
+          "mean_mse": 0.10913823409861079,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9037362062019945,
+          "mean_mse": 0.08295037399573789,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8850569018296253,
+          "mean_mse": 0.09237428022046246,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9070787122597044,
+          "mean_mse": 0.07921594347591807,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8469575456601923,
+          "mean_mse": 0.17192499765681074,
+          "mean_rank": 3.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8629122186317714,
+          "mean_mse": 0.11716897504697217,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8723148976717515,
+          "mean_mse": 0.11084942797037542,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7816012094661057,
+          "mean_mse": 0.20951637212377378,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8737643185565562,
+          "mean_mse": 0.10410730423610254,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7809049192096389,
+          "mean_mse": 0.22322123244034703,
+          "mean_rank": 13.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.805873363905521,
+          "mean_mse": 0.18287659420844263,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8760985181083891,
+          "mean_mse": 0.1011287849798349,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9224906377921912,
+          "mean_mse": 0.0704128700357321,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.91010639200101,
+          "mean_mse": 0.07059964008183323,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8992235795197898,
+          "mean_mse": 0.09049534226751654,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9052374520791615,
+          "mean_mse": 0.08398726428639418,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.5",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.8715898367887794,
+      "std_cosine_to_target": 0.049885262539577514,
+      "mean_mse_to_target": 0.11583444681048351,
+      "std_mse_to_target": 0.054325693686911515,
+      "mean_target_rank": 8.24390243902439,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7804878048780488,
+      "mrr": 0.3507524537497204,
+      "train_time_ms": 15219.621561998792,
+      "inference_time_us": 5607.840231699279,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9122721911881921,
+          "mean_mse": 0.07404074581850903,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.905603302621051,
+          "mean_mse": 0.08103197808164006,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8810910491163949,
+          "mean_mse": 0.10000327104222612,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8560586100666514,
+          "mean_mse": 0.12077597002338257,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.872244012066832,
+          "mean_mse": 0.10913823409861077,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9037362062019945,
+          "mean_mse": 0.08295037399573792,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8850569018296253,
+          "mean_mse": 0.09237428022046246,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9070787122597044,
+          "mean_mse": 0.07921594347591807,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8469575456601923,
+          "mean_mse": 0.17192499765681074,
+          "mean_rank": 3.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8629122186317714,
+          "mean_mse": 0.11716897504697218,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8723148976717516,
+          "mean_mse": 0.11084942797037542,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7816012094661057,
+          "mean_mse": 0.2095163721237738,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8737643185565561,
+          "mean_mse": 0.10410730423610255,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7809049192096389,
+          "mean_mse": 0.22322123244034703,
+          "mean_rank": 13.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8058733639055211,
+          "mean_mse": 0.18287659420844263,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8760985181083891,
+          "mean_mse": 0.10112878497983488,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9224906377921911,
+          "mean_mse": 0.0704128700357321,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.91010639200101,
+          "mean_mse": 0.07059964008183323,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8992235795197898,
+          "mean_mse": 0.09049534226751654,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9052374520791615,
+          "mean_mse": 0.08398726428639416,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls0.5_b0.7",
+      "params": {
+        "K": 4,
+        "length_scale": 0.5,
+        "kernel_blend": 0.7
+      },
+      "mean_cosine_to_target": 0.8715898367887794,
+      "std_cosine_to_target": 0.04988526253957752,
+      "mean_mse_to_target": 0.11583444681048351,
+      "std_mse_to_target": 0.054325693686911515,
+      "mean_target_rank": 8.24390243902439,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7804878048780488,
+      "mrr": 0.3507524537497204,
+      "train_time_ms": 14407.802245001221,
+      "inference_time_us": 5350.2560975441775,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9122721911881921,
+          "mean_mse": 0.07404074581850903,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056033026210509,
+          "mean_mse": 0.08103197808164006,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.881091049116395,
+          "mean_mse": 0.10000327104222612,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8560586100666514,
+          "mean_mse": 0.12077597002338257,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.872244012066832,
+          "mean_mse": 0.10913823409861079,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9037362062019945,
+          "mean_mse": 0.08295037399573792,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8850569018296254,
+          "mean_mse": 0.09237428022046246,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9070787122597044,
+          "mean_mse": 0.07921594347591808,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8469575456601925,
+          "mean_mse": 0.17192499765681077,
+          "mean_rank": 3.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8629122186317714,
+          "mean_mse": 0.11716897504697218,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8723148976717515,
+          "mean_mse": 0.11084942797037542,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7816012094661057,
+          "mean_mse": 0.2095163721237738,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8737643185565561,
+          "mean_mse": 0.10410730423610255,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7809049192096389,
+          "mean_mse": 0.22322123244034703,
+          "mean_rank": 13.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8058733639055211,
+          "mean_mse": 0.1828765942084426,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8760985181083891,
+          "mean_mse": 0.10112878497983488,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9224906377921911,
+          "mean_mse": 0.07041287003573211,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.91010639200101,
+          "mean_mse": 0.07059964008183323,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8992235795197898,
+          "mean_mse": 0.09049534226751654,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9052374520791615,
+          "mean_mse": 0.08398726428639418,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K8_ls0.5_b0.5",
+      "params": {
+        "K": 8,
+        "length_scale": 0.5,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.9121788189207931,
+      "std_cosine_to_target": 0.03270356785814729,
+      "mean_mse_to_target": 0.07835349196971676,
+      "std_mse_to_target": 0.03027668659937376,
+      "mean_target_rank": 6.695121951219512,
+      "median_target_rank": 4.0,
+      "recall_at_1": 0.13414634146341464,
+      "recall_at_5": 0.6463414634146342,
+      "recall_at_10": 0.8170731707317073,
+      "mrr": 0.3576830975309059,
+      "train_time_ms": 22740.230677998625,
+      "inference_time_us": 5621.729451199715,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9255342098144794,
+          "mean_mse": 0.06313349745233729,
+          "mean_rank": 5.0,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9244754988688912,
+          "mean_mse": 0.06724561893378468,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8992140346712711,
+          "mean_mse": 0.08540980415506608,
+          "mean_rank": 11.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8916102589346534,
+          "mean_mse": 0.09439231890428877,
+          "mean_rank": 12.25,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8906375013279826,
+          "mean_mse": 0.097600003579648,
+          "mean_rank": 10.75,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9175674599084553,
+          "mean_mse": 0.07077380842234847,
+          "mean_rank": 7.75,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.9105272862043177,
+          "mean_mse": 0.07300171917904069,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9177462046177189,
+          "mean_mse": 0.07295244225152994,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8940058688065463,
+          "mean_mse": 0.10078051118983382,
+          "mean_rank": 3.4,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8985007259567455,
+          "mean_mse": 0.09034811226320151,
+          "mean_rank": 9.5,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.9254457025132874,
+          "mean_mse": 0.0702277339022992,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.9221330622097259,
+          "mean_mse": 0.07516291381605877,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.9408473481053222,
+          "mean_mse": 0.053787908275142814,
+          "mean_rank": 5.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.8534036400057768,
+          "mean_mse": 0.14083101086813238,
+          "mean_rank": 16.0,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8972996065201466,
+          "mean_mse": 0.09171315848397635,
+          "mean_rank": 6.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8938720390069014,
+          "mean_mse": 0.08725116757616834,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9582946536103665,
+          "mean_mse": 0.0395579252844312,
+          "mean_rank": 3.0,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9332348497875291,
+          "mean_mse": 0.05351910939420434,
+          "mean_rank": 4.75,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.9515008023213061,
+          "mean_mse": 0.04562990263231312,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9169626574817593,
+          "mean_mse": 0.07252503830089609,
+          "mean_rank": 2.75,
+          "num_queries": 4
+        }
+      }
+    },
+    {
+      "method": "Hybrid_K4_ls1.0_b0.5",
+      "params": {
+        "K": 4,
+        "length_scale": 1.0,
+        "kernel_blend": 0.5
+      },
+      "mean_cosine_to_target": 0.87158983655106,
+      "std_cosine_to_target": 0.04988526249050499,
+      "mean_mse_to_target": 0.11583444684304084,
+      "std_mse_to_target": 0.05432569339568437,
+      "mean_target_rank": 8.24390243902439,
+      "median_target_rank": 5.0,
+      "recall_at_1": 0.18292682926829268,
+      "recall_at_5": 0.573170731707317,
+      "recall_at_10": 0.7804878048780488,
+      "mrr": 0.3507524537497204,
+      "train_time_ms": 15438.877461001539,
+      "inference_time_us": 6307.945365844672,
+      "num_queries": 82,
+      "num_answers": 82,
+      "num_clusters": 20,
+      "cluster_metrics": {
+        "bash-target-design": {
+          "mean_cosine": 0.9122721905575261,
+          "mean_mse": 0.07404074615697277,
+          "mean_rank": 3.5,
+          "num_queries": 4
+        },
+        "prolog-to-bash-bridge": {
+          "mean_cosine": 0.9056033022750861,
+          "mean_mse": 0.08103197826541562,
+          "mean_rank": 1.75,
+          "num_queries": 4
+        },
+        "compilation-pipeline": {
+          "mean_cosine": 0.8810910478711576,
+          "mean_mse": 0.10000327207191323,
+          "mean_rank": 17.0,
+          "num_queries": 4
+        },
+        "constraint-usage": {
+          "mean_cosine": 0.8560586100115246,
+          "mean_mse": 0.12077596994192916,
+          "mean_rank": 15.5,
+          "num_queries": 4
+        },
+        "troubleshooting-compilation": {
+          "mean_cosine": 0.8722440120677409,
+          "mean_mse": 0.10913823410725638,
+          "mean_rank": 10.5,
+          "num_queries": 4
+        },
+        "practical-compilation": {
+          "mean_cosine": 0.9037362057623405,
+          "mean_mse": 0.0829503743610442,
+          "mean_rank": 4.0,
+          "num_queries": 4
+        },
+        "generated-code-facts": {
+          "mean_cosine": 0.8850569023332849,
+          "mean_mse": 0.09237427971229638,
+          "mean_rank": 9.0,
+          "num_queries": 4
+        },
+        "generated-code-transitive": {
+          "mean_cosine": 0.9070787121144298,
+          "mean_mse": 0.07921594367783813,
+          "mean_rank": 6.5,
+          "num_queries": 4
+        },
+        "prolog-facts-rules": {
+          "mean_cosine": 0.8469575458614592,
+          "mean_mse": 0.1719249967032412,
+          "mean_rank": 3.0,
+          "num_queries": 5
+        },
+        "prolog-modules": {
+          "mean_cosine": 0.8629122181253207,
+          "mean_mse": 0.1171689754723769,
+          "mean_rank": 15.25,
+          "num_queries": 4
+        },
+        "prolog-directives": {
+          "mean_cosine": 0.8723148979089279,
+          "mean_mse": 0.11084942771779574,
+          "mean_rank": 2.25,
+          "num_queries": 4
+        },
+        "prolog-file-io": {
+          "mean_cosine": 0.7816012084012518,
+          "mean_mse": 0.20951637253745076,
+          "mean_rank": 8.5,
+          "num_queries": 4
+        },
+        "init-pl-explained": {
+          "mean_cosine": 0.8737643187662203,
+          "mean_mse": 0.10410730400924635,
+          "mean_rank": 3.75,
+          "num_queries": 4
+        },
+        "prolog-terms": {
+          "mean_cosine": 0.7809049193874477,
+          "mean_mse": 0.2232212316352133,
+          "mean_rank": 13.6,
+          "num_queries": 5
+        },
+        "prolog-unification": {
+          "mean_cosine": 0.8058733636444353,
+          "mean_mse": 0.1828765939980015,
+          "mean_rank": 21.75,
+          "num_queries": 4
+        },
+        "recursion-patterns": {
+          "mean_cosine": 0.8760985173285292,
+          "mean_mse": 0.10112878545782579,
+          "mean_rank": 13.75,
+          "num_queries": 4
+        },
+        "unifyweaver-overview": {
+          "mean_cosine": 0.9224906376351871,
+          "mean_mse": 0.07041287016540951,
+          "mean_rank": 4.25,
+          "num_queries": 4
+        },
+        "unifyweaver-targets": {
+          "mean_cosine": 0.9101063917865819,
+          "mean_mse": 0.07059964025100582,
+          "mean_rank": 6.0,
+          "num_queries": 4
+        },
+        "accumulator-pattern": {
+          "mean_cosine": 0.8992235795190432,
+          "mean_mse": 0.09049534230631975,
+          "mean_rank": 2.5,
+          "num_queries": 4
+        },
+        "fold-pattern": {
+          "mean_cosine": 0.9052374516270097,
+          "mean_mse": 0.08398726464917101,
+          "mean_rank": 2.5,
           "num_queries": 4
         }
       }

--- a/src/unifyweaver/targets/python_runtime/minimal_transform.py
+++ b/src/unifyweaver/targets/python_runtime/minimal_transform.py
@@ -1,0 +1,435 @@
+"""
+Minimal Transformation Projection using Procrustes analysis.
+
+This module implements projection learning via minimal transformations
+(rotations + scaling) rather than regularized least squares.
+
+The key insight: instead of solving min ||QW - A||² + λ||W||², we find
+the minimal transformation (fewest degrees of freedom) that maps Q to A.
+
+Approach:
+1. For each cluster, compute per-sample minimal transforms via Procrustes
+2. Smooth these transforms across clusters (FFT or kernel smoothing)
+3. Balance smoothness with fidelity to the minimal transform
+
+This gives automatic null-space structure without hyperparameter tuning.
+"""
+
+import numpy as np
+from typing import List, Tuple, Optional, Dict
+from scipy.linalg import svd, orthogonal_procrustes
+from scipy.fft import fft, ifft
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def compute_minimal_transform(
+    source: np.ndarray,
+    target: np.ndarray,
+    allow_scaling: bool = True,
+    allow_reflection: bool = False,
+) -> Tuple[np.ndarray, float, dict]:
+    """
+    Compute minimal transformation from source to target via Procrustes.
+
+    Args:
+        source: Source points (n × d) or single point (d,)
+        target: Target points (n × d) or single point (d,)
+        allow_scaling: If True, include uniform scaling
+        allow_reflection: If True, allow improper rotations (det = -1)
+
+    Returns:
+        W: Transformation matrix (d × d)
+        scale: Scaling factor (1.0 if allow_scaling=False)
+        info: Dict with diagnostics
+    """
+    source = np.atleast_2d(source)
+    target = np.atleast_2d(target)
+
+    n, d = source.shape
+
+    if n == 1:
+        # Single point: align directions + scale
+        s_norm = np.linalg.norm(source)
+        t_norm = np.linalg.norm(target)
+
+        if s_norm < 1e-10 or t_norm < 1e-10:
+            return np.eye(d), 1.0, {"degenerate": True}
+
+        s_unit = source.flatten() / s_norm
+        t_unit = target.flatten() / t_norm
+
+        # Rotation to align s_unit with t_unit
+        # _rotation_between_vectors gives R such that R @ s_unit = t_unit
+        # For row vector multiplication (source @ W), we need W = R.T
+        R = _rotation_between_vectors(s_unit, t_unit)
+
+        scale = t_norm / s_norm if allow_scaling else 1.0
+        W = scale * R.T  # Transpose for row vector multiplication
+
+        return W, scale, {
+            "degenerate": False,
+            "source_norm": s_norm,
+            "target_norm": t_norm,
+        }
+
+    # Multiple points: use scipy's orthogonal_procrustes
+    # Center the data
+    source_centered = source - source.mean(axis=0)
+    target_centered = target - target.mean(axis=0)
+
+    # Compute optimal rotation
+    R, _ = orthogonal_procrustes(source_centered, target_centered)
+
+    if not allow_reflection:
+        # Ensure proper rotation (det = +1)
+        U, S, Vt = svd(R)
+        if np.linalg.det(R) < 0:
+            Vt[-1, :] *= -1
+            R = U @ Vt
+
+    # Compute optimal scale
+    if allow_scaling:
+        source_rot = source_centered @ R
+        scale = np.trace(target_centered.T @ source_rot) / np.trace(source_centered.T @ source_centered)
+        scale = max(0.01, scale)  # Prevent negative/zero scaling
+    else:
+        scale = 1.0
+
+    W = scale * R
+
+    # Compute residual
+    residual = np.linalg.norm(source @ W - target + (target.mean(axis=0) - scale * source.mean(axis=0) @ R))
+
+    return W, scale, {
+        "residual": residual,
+        "scale": scale,
+        "rotation_det": np.linalg.det(R),
+    }
+
+
+def _rotation_between_vectors(v1: np.ndarray, v2: np.ndarray) -> np.ndarray:
+    """
+    Compute rotation matrix that rotates v1 to v2.
+
+    Uses the formula: R = I + [v]_× + [v]_×² * (1-c)/s²
+    where v = v1 × v2, c = v1 · v2, s = ||v||
+
+    For high dimensions, we use the Householder-based approach.
+    """
+    d = len(v1)
+    c = np.dot(v1, v2)
+
+    if c > 0.9999:
+        # Nearly aligned, return identity
+        return np.eye(d)
+
+    if c < -0.9999:
+        # Nearly opposite, return reflection through orthogonal vector
+        # Find a vector orthogonal to v1
+        ortho = np.zeros(d)
+        min_idx = np.argmin(np.abs(v1))
+        ortho[min_idx] = 1.0
+        ortho = ortho - np.dot(ortho, v1) * v1
+        ortho = ortho / np.linalg.norm(ortho)
+        # Rotation by π in the plane spanned by v1 and ortho
+        return 2 * np.outer(ortho, ortho) - np.eye(d)
+
+    # General case: rotation in the plane spanned by v1 and v2
+    # Construct orthonormal basis for this plane
+    u1 = v1
+    u2 = v2 - c * v1
+    u2 = u2 / np.linalg.norm(u2)
+
+    # Rotation in this plane by angle theta where cos(theta) = c
+    s = np.sqrt(1 - c * c)  # sin(theta)
+
+    # R = I + (cos-1)(u1⊗u1 + u2⊗u2) + sin(u2⊗u1 - u1⊗u2)
+    R = np.eye(d)
+    R += (c - 1) * (np.outer(u1, u1) + np.outer(u2, u2))
+    R += s * (np.outer(u2, u1) - np.outer(u1, u2))
+
+    return R
+
+
+class MinimalTransformProjection:
+    """
+    Projection using minimal transformations with optional smoothing.
+
+    For each cluster, computes the minimal (Procrustes) transformation,
+    then optionally smooths across clusters.
+    """
+
+    def __init__(
+        self,
+        smooth_method: str = "fft",  # "fft", "kernel", or "none"
+        fft_cutoff_ratio: float = 0.3,
+        fidelity_weight: float = 0.5,  # Balance between smooth and minimal
+        allow_scaling: bool = True,
+        temperature: float = 0.1,
+    ):
+        """
+        Initialize minimal transform projection.
+
+        Args:
+            smooth_method: Smoothing method ("fft", "kernel", "none")
+            fft_cutoff_ratio: For FFT, keep this fraction of frequencies
+            fidelity_weight: Weight for staying close to minimal transform (0-1)
+                            0 = fully smoothed, 1 = pure minimal transforms
+            allow_scaling: Whether to allow scaling in Procrustes
+            temperature: Softmax temperature for routing
+        """
+        self.smooth_method = smooth_method
+        self.fft_cutoff_ratio = fft_cutoff_ratio
+        self.fidelity_weight = fidelity_weight
+        self.allow_scaling = allow_scaling
+        self.temperature = temperature
+
+        # Trained state
+        self.W_minimal: Dict[int, np.ndarray] = {}
+        self.W_smoothed: Dict[int, np.ndarray] = {}
+        self.W_final: Dict[int, np.ndarray] = {}
+        self.centroids: List[np.ndarray] = []
+        self.cluster_order: List[int] = []
+        self.scales: List[float] = []
+
+    def train(self, clusters: List[Tuple[np.ndarray, np.ndarray]]) -> dict:
+        """
+        Train minimal transform projection.
+
+        Args:
+            clusters: List of (Q_i, A_i) tuples where:
+                     Q_i = query embeddings for cluster i (n_i × d)
+                     A_i = answer embedding for cluster i (d,) or (1 × d)
+
+        Returns:
+            Training statistics
+        """
+        N = len(clusters)
+        if N == 0:
+            raise ValueError("No clusters provided")
+
+        d = clusters[0][0].shape[1] if clusters[0][0].ndim > 1 else len(clusters[0][0])
+
+        logger.info(f"Training MinimalTransformProjection: N={N}, d={d}")
+
+        # Step 1: Compute minimal transform for each cluster
+        for i, (Q, A) in enumerate(clusters):
+            if Q.ndim == 1:
+                Q = Q.reshape(1, -1)
+            if A.ndim == 1:
+                A = A.reshape(1, -1)
+
+            # Compute centroid
+            centroid = Q.mean(axis=0)
+            self.centroids.append(centroid)
+
+            # Get answer (use first row if multiple, typically just one)
+            answer = A[0] if A.shape[0] >= 1 else A.flatten()
+
+            # Minimal transform from centroid to answer (single point to single point)
+            W, scale, info = compute_minimal_transform(
+                centroid.reshape(1, -1),
+                answer.reshape(1, -1),
+                allow_scaling=self.allow_scaling,
+            )
+
+            self.W_minimal[i] = W
+            self.scales.append(scale)
+
+        # Step 2: Order clusters by centroid similarity (for FFT)
+        self._compute_cluster_order()
+
+        # Step 3: Apply smoothing
+        if self.smooth_method == "fft":
+            self._apply_fft_smoothing()
+        elif self.smooth_method == "kernel":
+            self._apply_kernel_smoothing()
+        else:
+            # No smoothing
+            self.W_smoothed = self.W_minimal.copy()
+
+        # Step 4: Blend minimal and smoothed
+        for i in range(N):
+            self.W_final[i] = (
+                self.fidelity_weight * self.W_minimal[i] +
+                (1 - self.fidelity_weight) * self.W_smoothed[i]
+            )
+
+        return self._compute_stats()
+
+    def _compute_cluster_order(self):
+        """Order clusters by centroid similarity (greedy nearest neighbor)."""
+        N = len(self.centroids)
+        if N == 0:
+            return
+
+        # Normalize centroids
+        norms = [np.linalg.norm(c) + 1e-8 for c in self.centroids]
+        normalized = [c / n for c, n in zip(self.centroids, norms)]
+
+        # Greedy ordering
+        remaining = set(range(N))
+        order = [0]
+        remaining.remove(0)
+
+        while remaining:
+            last = order[-1]
+            best_sim = -2
+            best_next = None
+
+            for candidate in remaining:
+                sim = np.dot(normalized[last], normalized[candidate])
+                if sim > best_sim:
+                    best_sim = sim
+                    best_next = candidate
+
+            order.append(best_next)
+            remaining.remove(best_next)
+
+        self.cluster_order = order
+
+    def _apply_fft_smoothing(self):
+        """Apply FFT-based smoothing to W matrices."""
+        N = len(self.W_minimal)
+        if N == 0:
+            return
+
+        # Stack W matrices in similarity order
+        W_stacked = np.stack([self.W_minimal[i] for i in self.cluster_order])
+        original_shape = W_stacked.shape
+
+        # Flatten for FFT
+        W_flat = W_stacked.reshape(N, -1)
+
+        # FFT along cluster axis
+        W_freq = fft(W_flat, axis=0)
+
+        # Low-pass filter
+        cutoff = max(1, int(N * self.fft_cutoff_ratio))
+        mask = np.zeros(N)
+        mask[:cutoff] = 1
+        if N > 1:
+            mask[-cutoff + 1:] = 1  # Symmetric for real signal
+
+        W_freq_filtered = W_freq * mask[:, np.newaxis]
+
+        # Inverse FFT
+        W_smoothed_flat = np.real(ifft(W_freq_filtered, axis=0))
+        W_smoothed_stacked = W_smoothed_flat.reshape(original_shape)
+
+        # Map back to original indices
+        for i, orig_idx in enumerate(self.cluster_order):
+            self.W_smoothed[orig_idx] = W_smoothed_stacked[i]
+
+    def _apply_kernel_smoothing(self):
+        """Apply kernel-based smoothing to W matrices."""
+        N = len(self.W_minimal)
+        if N == 0:
+            return
+
+        # Compute kernel matrix (cosine similarity)
+        K = np.zeros((N, N))
+        for i in range(N):
+            for j in range(N):
+                c_i = self.centroids[i]
+                c_j = self.centroids[j]
+                K[i, j] = np.dot(c_i, c_j) / (np.linalg.norm(c_i) * np.linalg.norm(c_j) + 1e-8)
+
+        # Normalize rows
+        K_norm = K / (K.sum(axis=1, keepdims=True) + 1e-8)
+
+        # Smooth each W
+        for i in range(N):
+            W_smooth = np.zeros_like(self.W_minimal[0])
+            for j in range(N):
+                W_smooth += K_norm[i, j] * self.W_minimal[j]
+            self.W_smoothed[i] = W_smooth
+
+    def _compute_stats(self) -> dict:
+        """Compute training statistics."""
+        N = len(self.W_minimal)
+
+        # Measure deviation from minimal
+        deviations = []
+        for i in range(N):
+            diff = np.linalg.norm(self.W_final[i] - self.W_minimal[i])
+            norm = np.linalg.norm(self.W_minimal[i])
+            deviations.append(diff / (norm + 1e-8))
+
+        return {
+            "num_clusters": N,
+            "smooth_method": self.smooth_method,
+            "fidelity_weight": self.fidelity_weight,
+            "mean_scale": float(np.mean(self.scales)),
+            "std_scale": float(np.std(self.scales)),
+            "mean_deviation_from_minimal": float(np.mean(deviations)),
+            "max_deviation_from_minimal": float(np.max(deviations)),
+        }
+
+    def project(self, query_emb: np.ndarray) -> np.ndarray:
+        """
+        Project query embedding using soft routing.
+
+        Args:
+            query_emb: Query embedding (d,)
+
+        Returns:
+            Projected embedding (d,)
+        """
+        if not self.centroids or not self.W_final:
+            raise ValueError("Model not trained. Call train() first.")
+
+        query_emb = query_emb.flatten()
+
+        # Compute routing weights
+        similarities = []
+        for centroid in self.centroids:
+            c_norm = centroid / (np.linalg.norm(centroid) + 1e-8)
+            q_norm = query_emb / (np.linalg.norm(query_emb) + 1e-8)
+            similarities.append(np.dot(q_norm, c_norm))
+
+        similarities = np.array(similarities)
+        exp_sim = np.exp((similarities - np.max(similarities)) / self.temperature)
+        weights = exp_sim / (np.sum(exp_sim) + 1e-8)
+
+        # Weighted projection
+        projected = np.zeros_like(query_emb)
+        for i, weight in enumerate(weights):
+            projected += weight * (query_emb @ self.W_final[i])
+
+        return projected
+
+    def get_diagnostics(self) -> dict:
+        """Get diagnostics about the learned transformations."""
+        if not self.W_minimal:
+            return {"trained": False}
+
+        N = len(self.W_minimal)
+
+        # Analyze transformation structure
+        rotation_quality = []  # How close to orthogonal?
+        effective_ranks = []
+
+        for i in range(N):
+            W = self.W_final[i]
+            U, S, Vt = svd(W)
+
+            # Orthogonality: ||W^T W - I|| (for scaled rotation, compare to s²I)
+            WtW = W.T @ W
+            s_sq = np.mean(np.diag(WtW))
+            ortho_err = np.linalg.norm(WtW - s_sq * np.eye(W.shape[0])) / np.linalg.norm(WtW)
+            rotation_quality.append(1 - ortho_err)
+
+            # Effective rank
+            S_norm = S / (S[0] + 1e-8)
+            effective_ranks.append(np.sum(S_norm > 0.01))
+
+        return {
+            "trained": True,
+            "num_clusters": N,
+            "mean_rotation_quality": float(np.mean(rotation_quality)),
+            "mean_effective_rank": float(np.mean(effective_ranks)),
+            "scales": self.scales,
+        }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                           
                                                                                                                                                                                                                     
Implements projection learning via minimal transformations (Procrustes analysis) instead of regularized least squares. This achieves **2x better MRR** than all previous approaches.                                 
                                                                                                                                                                                                                     
## Key insight                                                                                                                                                                                                       
                                                                                                                                                                                                                     
Instead of solving `min ||QW - A||² + λ||W||²` with arbitrary regularization, find the **minimal transformation** (rotation + scaling) that maps centroid → answer. This:                                            
- Automatically creates null space structure for deviations                                                                                                                                                          
- Requires no hyperparameter tuning                                                                                                                                                                                  
- Is dramatically more effective                                                                                                                                                                                     
                                                                                                                                                                                                                     
## Results                                                                                                                                                                                                           
                                                                                                                                                                                                                     
| Embedder | Method | MRR | R@1 | Train Time |                                                                                                                                                                       
|----------|--------|-----|-----|------------|                                                                                                                                                                       
| all-MiniLM | **MinTrans_none** | **0.8688** | 79% | 30ms |                                                                                                                                                         
| all-MiniLM | FFT (best alternative) | 0.4418 | 22% | 153ms |                                                                                                                                                       
| ModernBERT | **MinTrans_none** | **0.9268** | 87% | 134ms |                                                                                                                                                        
| ModernBERT | FFT (best alternative) | 0.3794 | 16% | 1043ms |                                                                                                                                                      
                                                                                                                                                                                                                     
## Implementation                                                                                                                                                                                                    
                                                                                                                                                                                                                     
- `minimal_transform.py`: New module with:                                                                                                                                                                           
  - `compute_minimal_transform()`: Procrustes for single/multiple points                                                                                                                                             
  - `_rotation_between_vectors()`: Generalized rotation in d dimensions                                                                                                                                              
  - `MinimalTransformProjection` class with centroid-based and per-pair modes                                                                                                                                        
                                                                                                                                                                                                                     
- Two approaches tested:                                                                                                                                                                                             
  - **Centroid-based** (default): `centroid(Q) → A`, one W per cluster ✓ Best                                                                                                                                        
  - **Per-pair**: each `q_j → a_j`, then average within cluster                                                                                                                                                      
                                                                                                                                                                                                                     
## Why smoothing doesn't help                                                                                                                                                                                        
                                                                                                                                                                                                                     
For good embeddings, clusters are well-separated and the exact centroid→answer mapping is correct. Smoothing corrupts this. Smoothing should happen at the **routing layer** (softmax temperature) not on W matrices.
                                                                                                                                                                                                                     
## Test plan                                                                                                                                                                                                         
                                                                                                                                                                                                                     
- [x] Unit tests for rotation and Procrustes                                                                                                                                                                         
- [x] Benchmark on hash embeddings                                                                                                                                                                                   
- [x] Benchmark on all-MiniLM (384 dim)                                                                                                                                                                              
- [x] Benchmark on ModernBERT (768 dim)                                                                                                                                                                              
- [x] Compare centroid-based vs per-pair modes                                                                                                                                                                       
                                                                                                                                                                                                                     
� Generated with [Claude Code](https://claude.com/claude-code)                                                                                                                                                       