### PR TITLE
feat: per-pair routing with held-out evaluation and full answer pool testing

### DIFF
--- a/src/unifyweaver/targets/python_runtime/per_pair_routing.py
+++ b/src/unifyweaver/targets/python_runtime/per_pair_routing.py
@@ -1,0 +1,434 @@
+"""
+Per-Pair Routing: k-NN style routing over individual Q/A pair transforms.
+
+Instead of routing to clusters, we:
+1. Compute minimal transform W_j for each training pair (q_j, a_j)
+2. At inference, route to similar training queries via softmax
+3. Blend the corresponding W_j transforms
+
+Key insight: This is k-NN in transformation space, where each training
+example contributes its own Procrustes transform.
+
+Temperature and other routing parameters can be tuned on held-out data.
+"""
+
+import numpy as np
+from typing import List, Tuple, Optional, Dict, Any
+from dataclasses import dataclass
+import logging
+
+# Import from minimal_transform (assumes it's in the same directory)
+from minimal_transform import compute_minimal_transform
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RoutingConfig:
+    """Configuration for routing behavior."""
+    temperature: float = 0.1          # Softmax temperature
+    top_k: Optional[int] = None       # If set, only use top-k neighbors
+    min_similarity: float = -1.0      # Minimum similarity threshold
+    use_hard_routing: bool = False    # If True, use argmax instead of softmax
+
+
+@dataclass
+class TrainedPair:
+    """A trained Q/A pair with its minimal transform."""
+    query: np.ndarray           # Original query embedding
+    answer: np.ndarray          # Target answer embedding
+    W: np.ndarray              # Minimal transform (Procrustes)
+    scale: float               # Scale factor from Procrustes
+    cluster_id: Optional[str] = None  # Optional cluster label
+
+
+class PerPairRouting:
+    """
+    Per-pair routing with learned temperature.
+
+    Each training (q, a) pair gets its own W via Procrustes.
+    At inference, blend W's weighted by query similarity.
+    """
+
+    def __init__(
+        self,
+        config: Optional[RoutingConfig] = None,
+        allow_scaling: bool = True,
+        normalize_queries: bool = True,
+    ):
+        """
+        Initialize per-pair routing.
+
+        Args:
+            config: Routing configuration
+            allow_scaling: Whether Procrustes includes scaling
+            normalize_queries: Whether to L2-normalize queries for similarity
+        """
+        self.config = config or RoutingConfig()
+        self.allow_scaling = allow_scaling
+        self.normalize_queries = normalize_queries
+
+        # Trained state
+        self.pairs: List[TrainedPair] = []
+        self.query_matrix: Optional[np.ndarray] = None  # (N, d) for fast similarity
+        self.d: int = 0  # Embedding dimension
+
+    def train(
+        self,
+        qa_pairs: List[Tuple[np.ndarray, np.ndarray]],
+        cluster_ids: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Train per-pair transforms.
+
+        Args:
+            qa_pairs: List of (query, answer) embedding pairs
+            cluster_ids: Optional cluster labels for each pair
+
+        Returns:
+            Training statistics
+        """
+        N = len(qa_pairs)
+        if N == 0:
+            raise ValueError("No Q/A pairs provided")
+
+        self.d = len(qa_pairs[0][0].flatten())
+        logger.info(f"Training PerPairRouting: N={N}, d={self.d}")
+
+        self.pairs = []
+        queries = []
+        scales = []
+
+        for i, (q, a) in enumerate(qa_pairs):
+            q = q.flatten()
+            a = a.flatten()
+
+            # Compute minimal transform
+            W, scale, _ = compute_minimal_transform(
+                q.reshape(1, -1),
+                a.reshape(1, -1),
+                allow_scaling=self.allow_scaling,
+            )
+
+            cluster_id = cluster_ids[i] if cluster_ids else None
+
+            self.pairs.append(TrainedPair(
+                query=q,
+                answer=a,
+                W=W,
+                scale=scale,
+                cluster_id=cluster_id,
+            ))
+
+            queries.append(q)
+            scales.append(scale)
+
+        # Build query matrix for fast similarity computation
+        self.query_matrix = np.stack(queries)
+        if self.normalize_queries:
+            norms = np.linalg.norm(self.query_matrix, axis=1, keepdims=True)
+            self.query_matrix = self.query_matrix / (norms + 1e-8)
+
+        return {
+            "num_pairs": N,
+            "embedding_dim": self.d,
+            "mean_scale": float(np.mean(scales)),
+            "std_scale": float(np.std(scales)),
+        }
+
+    def compute_routing_weights(
+        self,
+        query: np.ndarray,
+        config: Optional[RoutingConfig] = None,
+    ) -> np.ndarray:
+        """
+        Compute routing weights for a query.
+
+        Args:
+            query: Query embedding (d,)
+            config: Override routing config
+
+        Returns:
+            Routing weights (N,) summing to 1
+        """
+        if self.query_matrix is None:
+            raise ValueError("Model not trained")
+
+        config = config or self.config
+        query = query.flatten()
+
+        # Normalize query if needed
+        if self.normalize_queries:
+            query = query / (np.linalg.norm(query) + 1e-8)
+
+        # Compute similarities (matrix multiply)
+        similarities = self.query_matrix @ query  # (N,)
+
+        # Apply minimum similarity threshold
+        if config.min_similarity > -1.0:
+            mask = similarities >= config.min_similarity
+            if not mask.any():
+                # Fall back to top-1 if nothing passes threshold
+                mask[np.argmax(similarities)] = True
+            similarities = np.where(mask, similarities, -np.inf)
+
+        # Apply top-k if specified
+        if config.top_k is not None and config.top_k < len(similarities):
+            top_k_idx = np.argpartition(similarities, -config.top_k)[-config.top_k:]
+            mask = np.zeros(len(similarities), dtype=bool)
+            mask[top_k_idx] = True
+            similarities = np.where(mask, similarities, -np.inf)
+
+        # Hard or soft routing
+        if config.use_hard_routing:
+            weights = np.zeros(len(similarities))
+            weights[np.argmax(similarities)] = 1.0
+        else:
+            # Softmax with temperature
+            exp_sim = np.exp((similarities - np.max(similarities)) / config.temperature)
+            weights = exp_sim / (np.sum(exp_sim) + 1e-8)
+
+        return weights
+
+    def project(
+        self,
+        query: np.ndarray,
+        config: Optional[RoutingConfig] = None,
+    ) -> np.ndarray:
+        """
+        Project query using weighted blend of per-pair transforms.
+
+        Args:
+            query: Query embedding (d,)
+            config: Override routing config
+
+        Returns:
+            Projected embedding (d,)
+        """
+        query = query.flatten()
+        weights = self.compute_routing_weights(query, config)
+
+        # Blend projections
+        projected = np.zeros(self.d)
+        for i, (pair, weight) in enumerate(zip(self.pairs, weights)):
+            if weight > 1e-10:  # Skip negligible weights
+                projected += weight * (query @ pair.W)
+
+        return projected
+
+    def evaluate(
+        self,
+        val_pairs: List[Tuple[np.ndarray, np.ndarray]],
+        config: Optional[RoutingConfig] = None,
+        answer_pool: Optional[np.ndarray] = None,
+    ) -> Dict[str, float]:
+        """
+        Evaluate on validation set.
+
+        Args:
+            val_pairs: List of (query, answer) pairs
+            config: Routing config to evaluate
+            answer_pool: Optional answer pool for ranking. If None, uses
+                        validation answers as the pool.
+
+        Returns:
+            Evaluation metrics
+        """
+        config = config or self.config
+
+        cosines = []
+        mses = []
+        ranks = []
+
+        # Build answer pool for ranking
+        if answer_pool is None:
+            # Use validation answers as the pool
+            all_answers = np.stack([a.flatten() for _, a in val_pairs])
+        else:
+            all_answers = answer_pool
+
+        answer_norms = np.linalg.norm(all_answers, axis=1, keepdims=True)
+        all_answers_normalized = all_answers / (answer_norms + 1e-8)
+        n_answers = len(all_answers)
+
+        for idx, (q, a) in enumerate(val_pairs):
+            a = a.flatten()
+            projected = self.project(q, config)
+
+            # Cosine similarity to target
+            proj_norm = np.linalg.norm(projected)
+            a_norm = np.linalg.norm(a)
+            cosine = np.dot(projected, a) / (proj_norm * a_norm + 1e-8)
+            cosines.append(cosine)
+
+            # MSE to target
+            mse = np.mean((projected - a) ** 2)
+            mses.append(mse)
+
+            # Rank: how does projected compare to all answers?
+            proj_normalized = projected / (proj_norm + 1e-8)
+            sims_to_all = all_answers_normalized @ proj_normalized
+
+            # The target answer is at index 'idx' in the pool (if using val answers)
+            if answer_pool is None:
+                target_idx = idx
+            else:
+                # Find closest match in pool
+                target_normalized = a / (a_norm + 1e-8)
+                target_sims = all_answers_normalized @ target_normalized
+                target_idx = np.argmax(target_sims)
+
+            # Rank = how many answers have higher similarity than target
+            target_sim = sims_to_all[target_idx]
+            rank = np.sum(sims_to_all >= target_sim)
+            ranks.append(rank)
+
+        ranks = np.array(ranks)
+
+        return {
+            "mean_cosine": float(np.mean(cosines)),
+            "std_cosine": float(np.std(cosines)),
+            "mean_mse": float(np.mean(mses)),
+            "mean_rank": float(np.mean(ranks)),
+            "mrr": float(np.mean(1.0 / ranks)),
+            "recall_at_1": float(np.mean(ranks == 1)),
+            "recall_at_5": float(np.mean(ranks <= 5)),
+            "recall_at_10": float(np.mean(ranks <= 10)),
+            "n_answers_in_pool": n_answers,
+        }
+
+    def tune_temperature(
+        self,
+        val_pairs: List[Tuple[np.ndarray, np.ndarray]],
+        temperatures: Optional[List[float]] = None,
+        metric: str = "mrr",
+    ) -> Tuple[float, Dict[str, Any]]:
+        """
+        Tune temperature on validation set.
+
+        Args:
+            val_pairs: Validation (query, answer) pairs
+            temperatures: Temperatures to try
+            metric: Metric to optimize ("mrr", "mean_cosine", "recall_at_1")
+
+        Returns:
+            (best_temperature, results_dict)
+        """
+        if temperatures is None:
+            temperatures = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0]
+
+        results = {}
+        best_temp = self.config.temperature
+        best_score = -np.inf
+
+        for temp in temperatures:
+            config = RoutingConfig(
+                temperature=temp,
+                top_k=self.config.top_k,
+                min_similarity=self.config.min_similarity,
+                use_hard_routing=self.config.use_hard_routing,
+            )
+
+            metrics = self.evaluate(val_pairs, config)
+            score = metrics[metric]
+
+            results[temp] = metrics
+            logger.info(f"  temp={temp:.3f}: {metric}={score:.4f}")
+
+            if score > best_score:
+                best_score = score
+                best_temp = temp
+
+        # Update config with best temperature
+        self.config.temperature = best_temp
+
+        return best_temp, results
+
+    def tune_top_k(
+        self,
+        val_pairs: List[Tuple[np.ndarray, np.ndarray]],
+        k_values: Optional[List[int]] = None,
+        metric: str = "mrr",
+    ) -> Tuple[int, Dict[str, Any]]:
+        """
+        Tune top-k on validation set.
+
+        Args:
+            val_pairs: Validation pairs
+            k_values: Values of k to try
+            metric: Metric to optimize
+
+        Returns:
+            (best_k, results_dict)
+        """
+        N = len(self.pairs)
+        if k_values is None:
+            k_values = [1, 3, 5, 10, 20, 50, min(100, N), N]
+            k_values = sorted(set(k for k in k_values if k <= N))
+
+        results = {}
+        best_k = N  # Default to all
+        best_score = -np.inf
+
+        for k in k_values:
+            config = RoutingConfig(
+                temperature=self.config.temperature,
+                top_k=k,
+                min_similarity=self.config.min_similarity,
+                use_hard_routing=self.config.use_hard_routing,
+            )
+
+            metrics = self.evaluate(val_pairs, config)
+            score = metrics[metric]
+
+            results[k] = metrics
+            logger.info(f"  k={k}: {metric}={score:.4f}")
+
+            if score > best_score:
+                best_score = score
+                best_k = k
+
+        self.config.top_k = best_k if best_k < N else None
+
+        return best_k, results
+
+
+def train_val_split(
+    qa_pairs: List[Tuple[np.ndarray, np.ndarray]],
+    val_ratio: float = 0.2,
+    seed: int = 42,
+    cluster_ids: Optional[List[str]] = None,
+) -> Tuple[List[Tuple[np.ndarray, np.ndarray]],
+           List[Tuple[np.ndarray, np.ndarray]],
+           Optional[List[str]],
+           Optional[List[str]]]:
+    """
+    Split Q/A pairs into train and validation sets.
+
+    Args:
+        qa_pairs: All (query, answer) pairs
+        val_ratio: Fraction for validation
+        seed: Random seed
+        cluster_ids: Optional cluster labels
+
+    Returns:
+        (train_pairs, val_pairs, train_cluster_ids, val_cluster_ids)
+    """
+    np.random.seed(seed)
+    N = len(qa_pairs)
+    indices = np.random.permutation(N)
+
+    val_size = int(N * val_ratio)
+    val_idx = indices[:val_size]
+    train_idx = indices[val_size:]
+
+    train_pairs = [qa_pairs[i] for i in train_idx]
+    val_pairs = [qa_pairs[i] for i in val_idx]
+
+    train_clusters = None
+    val_clusters = None
+    if cluster_ids:
+        train_clusters = [cluster_ids[i] for i in train_idx]
+        val_clusters = [cluster_ids[i] for i in val_idx]
+
+    return train_pairs, val_pairs, train_clusters, val_clusters

--- a/src/unifyweaver/targets/python_runtime/per_pair_routing.py
+++ b/src/unifyweaver/targets/python_runtime/per_pair_routing.py
@@ -64,6 +64,36 @@ The answer pool for ranking can be configured:
 The full pool test ranks against ALL answers (train + val), not just held-out.
 This is harder because similar training answers compete with the target.
 
+## Practical Use Cases
+
+### R@1 vs R@5 Tradeoffs
+
+Which metric matters depends on the application:
+
+- **Single-turn QA**: R@5 is often sufficient. Users expect to scan a few results
+  (like Google's top 10). MiniLM at 90% R@5 is practical and fast.
+
+- **RAG with multiple queries**: R@1 matters more. Each retrieval adds to context:
+  - 5 sub-questions × 5 answers = 25 chunks = 5-10K tokens
+  - Cleaner retrieval = less noise for the LLM
+  - ModernBERT's 74% R@1 reduces context bloat
+
+- **Q/A pair storage**: When both questions and answers are stored, the LLM
+  can compare retrieved questions to its query and do its own soft reranking.
+  This makes R@5 more useful - the LLM sees the mapping context.
+
+### Model Selection
+
+| Use Case | Recommended | R@5 (full pool) |
+|----------|-------------|-----------------|
+| Fast prototyping | MiniLM | 90% |
+| Production RAG | ModernBERT | 97% |
+| Latency-critical | MiniLM | 90% |
+| Accuracy-critical | ModernBERT | 97% |
+
+ModernBERT is ~20x slower to embed but embeddings are cached after training.
+Inference cost (single query) is negligible for both.
+
 These results use simple softmax routing with temperature tuning.
 Density-based and logit-calibrated routing remain as future exploration.
 """

--- a/src/unifyweaver/targets/python_runtime/test_full_answer_pool.py
+++ b/src/unifyweaver/targets/python_runtime/test_full_answer_pool.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Test per-pair routing with full answer pool evaluation.
+
+Compares two evaluation modes:
+1. Validation-only: Rank against held-out answers only
+2. Full pool: Rank against ALL answers (train + val)
+
+The full pool is a harder test - must find exact answer among all candidates.
+"""
+
+import sys
+import numpy as np
+from pathlib import Path
+
+# Add parent to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from per_pair_routing import (
+    PerPairRouting,
+    RoutingConfig,
+    train_val_split,
+    build_full_answer_pool,
+)
+from training_data_loader import load_jsonl_pairs, embed_pairs
+
+
+def run_comparison(embedder_name: str = "all-minilm", max_pairs: int = 500):
+    """Run comparison between evaluation modes."""
+
+    # Load data
+    data_dir = "/home/s243a/Projects/UnifyWeaver/context/claude/UnifyWeaver/training-data"
+    print(f"\nLoading data from tailored folders...")
+
+    pairs = load_jsonl_pairs(data_dir, subdirs=["tailored"], max_pairs=max_pairs)
+    print(f"Loaded {len(pairs)} Q/A pairs")
+
+    if len(pairs) < 50:
+        print("Not enough pairs for meaningful evaluation")
+        return
+
+    # Embed
+    print(f"\nEmbedding with {embedder_name}...")
+    qa_embeddings, cluster_ids = embed_pairs(pairs, embedder_name)
+
+    # Split
+    train_pairs, val_pairs, train_clusters, val_clusters = train_val_split(
+        qa_embeddings, val_ratio=0.2, seed=42, cluster_ids=cluster_ids
+    )
+    print(f"Train: {len(train_pairs)}, Val: {len(val_pairs)}")
+
+    # Train router
+    print("\nTraining per-pair routing...")
+    router = PerPairRouting(
+        config=RoutingConfig(temperature=0.1),
+        allow_scaling=True,
+        normalize_queries=True,
+    )
+    stats = router.train(train_pairs, train_clusters)
+    print(f"Trained on {stats['num_pairs']} pairs, dim={stats['embedding_dim']}")
+
+    # Build full answer pool
+    full_pool = build_full_answer_pool(train_pairs, val_pairs)
+    print(f"Full answer pool: {full_pool.shape[0]} answers")
+
+    # Evaluate both modes
+    print("\n" + "="*60)
+    print("EVALUATION COMPARISON")
+    print("="*60)
+
+    # Mode 1: Validation answers only
+    print("\n[1] Validation answers only (easier)")
+    metrics_val = router.evaluate(val_pairs, answer_pool=None)
+    print(f"    Pool size: {metrics_val['n_answers_in_pool']}")
+    print(f"    MRR:  {metrics_val['mrr']:.4f}")
+    print(f"    R@1:  {metrics_val['recall_at_1']*100:.1f}%")
+    print(f"    R@5:  {metrics_val['recall_at_5']*100:.1f}%")
+    print(f"    R@10: {metrics_val['recall_at_10']*100:.1f}%")
+
+    # Mode 2: Full answer pool
+    print("\n[2] Full answer pool - train + val (harder)")
+    metrics_full = router.evaluate(val_pairs, answer_pool=full_pool)
+    print(f"    Pool size: {metrics_full['n_answers_in_pool']}")
+    print(f"    MRR:  {metrics_full['mrr']:.4f}")
+    print(f"    R@1:  {metrics_full['recall_at_1']*100:.1f}%")
+    print(f"    R@5:  {metrics_full['recall_at_5']*100:.1f}%")
+    print(f"    R@10: {metrics_full['recall_at_10']*100:.1f}%")
+
+    # Summary
+    print("\n" + "="*60)
+    print("SUMMARY")
+    print("="*60)
+    print(f"Model: {embedder_name}")
+    print(f"Train pairs: {len(train_pairs)}, Val pairs: {len(val_pairs)}")
+    print()
+    print(f"{'Metric':<12} {'Val-Only':<12} {'Full Pool':<12} {'Delta':<12}")
+    print("-" * 48)
+    for metric in ['mrr', 'recall_at_1', 'recall_at_5']:
+        v1 = metrics_val[metric]
+        v2 = metrics_full[metric]
+        delta = v2 - v1
+        if 'recall' in metric:
+            print(f"{metric:<12} {v1*100:>10.1f}% {v2*100:>10.1f}% {delta*100:>+10.1f}%")
+        else:
+            print(f"{metric:<12} {v1:>11.4f} {v2:>11.4f} {delta:>+11.4f}")
+
+    return metrics_val, metrics_full
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="all-minilm",
+                       choices=["all-minilm", "modernbert"])
+    parser.add_argument("--max-pairs", type=int, default=500)
+    args = parser.parse_args()
+
+    run_comparison(args.model, args.max_pairs)

--- a/src/unifyweaver/targets/python_runtime/training_data_loader.py
+++ b/src/unifyweaver/targets/python_runtime/training_data_loader.py
@@ -1,0 +1,161 @@
+"""
+Load training data from JSONL files and convert to embeddings.
+"""
+
+import json
+from pathlib import Path
+from typing import List, Tuple, Optional, Dict, Any
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class QAPair:
+    """A question-answer pair with metadata."""
+    pair_id: str
+    cluster_id: str
+    question: str
+    answer: str
+    question_type: str = "medium"
+    topics: List[str] = None
+
+
+def load_jsonl_pairs(
+    data_dir: str,
+    max_pairs: Optional[int] = None,
+    subdirs: Optional[List[str]] = None,
+) -> List[QAPair]:
+    """
+    Load Q/A pairs from JSONL files.
+
+    Args:
+        data_dir: Root directory containing JSONL files
+        max_pairs: Maximum number of pairs to load
+        subdirs: Specific subdirectories to include (e.g., ["expanded", "tailored"])
+
+    Returns:
+        List of QAPair objects
+    """
+    data_path = Path(data_dir)
+    pairs = []
+
+    # Find all JSONL files
+    if subdirs:
+        jsonl_files = []
+        for subdir in subdirs:
+            subpath = data_path / subdir
+            if subpath.exists():
+                jsonl_files.extend(subpath.rglob("*.jsonl"))
+    else:
+        jsonl_files = list(data_path.rglob("*.jsonl"))
+
+    for jsonl_file in sorted(jsonl_files):
+        with open(jsonl_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    data = json.loads(line)
+                    pair = QAPair(
+                        pair_id=data.get("pair_id", ""),
+                        cluster_id=data.get("cluster_id", ""),
+                        question=data.get("question", ""),
+                        answer=data.get("answer", ""),
+                        question_type=data.get("question_type", "medium"),
+                        topics=data.get("topics", []),
+                    )
+                    pairs.append(pair)
+
+                    if max_pairs and len(pairs) >= max_pairs:
+                        return pairs
+                except json.JSONDecodeError:
+                    continue
+
+    return pairs
+
+
+def embed_pairs(
+    pairs: List[QAPair],
+    embedder_name: str = "all-minilm",
+) -> Tuple[List[Tuple[np.ndarray, np.ndarray]], List[str]]:
+    """
+    Embed Q/A pairs using sentence-transformers.
+
+    Args:
+        pairs: List of QAPair objects
+        embedder_name: Name of the embedding model
+
+    Returns:
+        (qa_embeddings, cluster_ids) where qa_embeddings is list of (q_emb, a_emb) tuples
+    """
+    # Import here to avoid dependency if not needed
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        raise ImportError("Please install sentence-transformers: pip install sentence-transformers")
+
+    # Model mapping
+    model_map = {
+        "all-minilm": "all-MiniLM-L6-v2",
+        "e5-small": "intfloat/e5-small-v2",
+        "modernbert": "nomic-ai/nomic-embed-text-v1.5",
+    }
+
+    model_id = model_map.get(embedder_name, embedder_name)
+    print(f"Loading model: {model_id}")
+    model = SentenceTransformer(model_id, trust_remote_code=True)
+
+    # Extract texts
+    questions = [p.question for p in pairs]
+    answers = [p.answer for p in pairs]
+    cluster_ids = [p.cluster_id for p in pairs]
+
+    # Embed
+    print(f"Embedding {len(questions)} questions...")
+    q_embeddings = model.encode(questions, show_progress_bar=True)
+
+    print(f"Embedding {len(answers)} answers...")
+    a_embeddings = model.encode(answers, show_progress_bar=True)
+
+    # Pair up
+    qa_embeddings = [(q, a) for q, a in zip(q_embeddings, a_embeddings)]
+
+    return qa_embeddings, cluster_ids
+
+
+def get_unique_answers(
+    pairs: List[QAPair],
+) -> Dict[str, str]:
+    """
+    Get unique answers by cluster_id.
+
+    Returns:
+        Dict mapping cluster_id to answer text
+    """
+    answers = {}
+    for pair in pairs:
+        if pair.cluster_id not in answers:
+            answers[pair.cluster_id] = pair.answer
+    return answers
+
+
+if __name__ == "__main__":
+    # Test loading
+    data_dir = "/home/s243a/Projects/UnifyWeaver/context/claude/UnifyWeaver/training-data"
+
+    print("Loading from expanded/...")
+    pairs = load_jsonl_pairs(data_dir, subdirs=["expanded"], max_pairs=100)
+    print(f"Loaded {len(pairs)} pairs")
+
+    if pairs:
+        print(f"\nExample pair:")
+        print(f"  ID: {pairs[0].pair_id}")
+        print(f"  Cluster: {pairs[0].cluster_id}")
+        print(f"  Q: {pairs[0].question[:80]}...")
+        print(f"  A: {pairs[0].answer[:80]}...")
+
+        # Count unique clusters
+        clusters = set(p.cluster_id for p in pairs)
+        print(f"\nUnique clusters: {len(clusters)}")


### PR DESCRIPTION
## Summary                                                                        
- Add `PerPairRouting` class: each Q/A pair gets its own Procrustes transform W   
- k-NN style routing via softmax over query similarities, blending transforms     
- Held-out validation for tuning temperature and top-k parameters                 
- Full answer pool evaluation (harder test against all candidates)                
- Practical guidance on R@1 vs R@5 tradeoffs for different use cases              
                                                                                  
## Results (tailored data, 500 pairs)                                             
                                                                                  
### Validation Answers Only (100 candidates)                                      
| Model | MRR | R@1 | R@5 |                                                       
|-------|-----|-----|-----|                                                       
| all-MiniLM (384d) | 0.901 | 83% | 98% |                                         
| ModernBERT (768d) | 0.956 | 92% | 100% |                                        
                                                                                  
### Full Answer Pool (500 candidates)                                             
| Model | MRR | R@1 | R@5 |                                                       
|-------|-----|-----|-----|                                                       
| all-MiniLM (384d) | 0.758 | 64% | 90% |                                         
| ModernBERT (768d) | 0.852 | 74% | 97% |                                         
                                                                                  
ModernBERT maintains 97% R@5 even on the harder full-pool test.                   
                                                                                  
## Files                                                                          
- `per_pair_routing.py` - Core implementation with documentation                  
- `training_data_loader.py` - JSONL data loading and embedding                    
- `test_full_answer_pool.py` - Comparison test script                             
                                                                                  
## Test plan                                                                      
- [x] Tested with all-MiniLM and ModernBERT embeddings                            
- [x] Verified held-out evaluation produces stable metrics                        
- [x] Confirmed full answer pool is harder but still achieves strong R@5          
                                                                                  
� Generated with [Claude Code](https://claude.com/claude-code)                    