### PR TITLE
optimizer: restore is_ready/2 for goal ordering

### DIFF
--- a/src/unifyweaver/core/stream_compiler.pl
+++ b/src/unifyweaver/core/stream_compiler.pl
@@ -582,7 +582,7 @@ compile_arithmetic_body(Pred, Arity, Body, BashBody) :-
 %  General arithmetic translation fallback
 %  Handles predicates with arithmetic but no known high-level pattern
 compile_with_arithmetic(Head, Body, _Options, BashCode) :-
-    functor(Head, Pred, Arity),
+    functor(Head, Pred, _Arity),
     atom_string(Pred, PredStr),
 
     % Extract variables from the clause head
@@ -615,7 +615,7 @@ compile_with_arithmetic(Head, Body, _Options, BashCode) :-
 %  Compile predicates with match constraints (regex filtering)
 %  Handles streaming pipeline with integrated match filters
 compile_with_match(Head, Body, Options, BashCode) :-
-    functor(Head, Pred, Arity),
+    functor(Head, Pred, _Arity),
     atom_string(Pred, PredStr),
 
     % Extract predicates and match constraints separately


### PR DESCRIPTION
  - Fixes test_stream_compiler failure by implementing optimizer:is_ready/2 (used by include/3 during goal reordering).
  - Treats predicate calls as ready; requires operands to be bound for filter-style built-ins (comparisons/negation/
    match/etc.).
  - Removes stream_compiler.pl singleton warnings by using _Arity.