### PR TITLE
Feat/cross target custom components

### DIFF
--- a/docs/proposals/COMPONENT_REGISTRY.md
+++ b/docs/proposals/COMPONENT_REGISTRY.md
@@ -343,6 +343,60 @@ Changes required:
 - [ ] Add wrapper predicates for backward compatibility
 - [ ] Preserve effect annotations
 
+## Implementation Status
+
+### Core Registry
+
+- [x] `src/unifyweaver/core/component_registry.pl` - Core registry infrastructure
+- [x] Category definition (`define_category/3`)
+- [x] Type registration (`register_component_type/4`)
+- [x] Instance declaration (`declare_component/4`)
+- [x] Compile component interface (`compile_component/4`)
+
+### Custom Component Types by Target
+
+Custom component types allow injecting raw target language code as reusable components. Each generates a class/struct with an `invoke()` method.
+
+| Target | Module | Config Options | Status |
+|--------|--------|----------------|--------|
+| Go | `custom_go.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| Python | `custom_python.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| Rust | `custom_rust.pl` | `code(...)`, `uses([...])` | ✅ Implemented |
+| C# | `custom_csharp.pl` | `code(...)`, `usings([...])` | ✅ Implemented |
+
+### Usage Example
+
+```prolog
+% Declare a custom Python component
+declare_component(source, my_transform, custom_python, [
+    code("return input.upper()"),
+    imports(["typing", "re"])
+]).
+
+% Declare a custom Rust component
+declare_component(source, my_parser, custom_rust, [
+    code("input.parse().unwrap()"),
+    uses(["std::str::FromStr"])
+]).
+
+% Declare a custom C# component
+declare_component(source, my_formatter, custom_csharp, [
+    code("return input.ToString();"),
+    usings(["System.Text"])
+]).
+```
+
+### Target Integration
+
+Each target has been integrated with the component registry:
+
+| Target | Init Predicate | Helper Predicates | Status |
+|--------|----------------|-------------------|--------|
+| Go | `init_go_target/0` | `collect_declared_component/2`, `compile_collected_components/1` | ✅ |
+| Python | `init_python_target/0` | `collect_declared_component/2`, `compile_collected_components/1` | ✅ |
+| Rust | `init_rust_target/0` | `collect_declared_component/2`, `compile_collected_components/1` | ✅ |
+| C# | `init_csharp_target/0` | `collect_declared_component/2`, `compile_collected_components/1` | ✅ |
+
 ## Runtime Component Example: LDA Projection
 
 ### Prolog Type Module

--- a/src/unifyweaver/bindings/csharp_bindings.pl
+++ b/src/unifyweaver/bindings/csharp_bindings.pl
@@ -21,6 +21,7 @@
 :- module(csharp_bindings, [
     init_csharp_bindings/0,
     cs_binding/5,               % Convenience: cs_binding(Pred, TargetName, Inputs, Outputs, Options)
+    cs_binding_using/2,         % cs_binding_using(Pred, Using) - get required using directive
     test_csharp_bindings/0
 ]).
 
@@ -51,6 +52,33 @@ init_csharp_bindings :-
 %
 cs_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(csharp, Pred, TargetName, Inputs, Outputs, Options).
+
+%% cs_binding_using(?Pred, ?Using)
+%
+%  Get the using directive required for a C# binding.
+%
+cs_binding_using(Pred, Using) :-
+    cs_binding(Pred, _, _, _, Options),
+    member(using(Using), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- cs_binding(Pred, TargetName, Inputs, Outputs, Options)
+%
+%  Directive for user-defined C# bindings.
+%  Allows users to declare bindings in their Prolog code.
+%
+%  Example:
+%    :- cs_binding(my_hash/2, 'MyLib.Hash', [string], [string], [using('MyLib')]).
+%
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- cs_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(csharp, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CORE BUILT-IN BINDINGS

--- a/src/unifyweaver/bindings/python_bindings.pl
+++ b/src/unifyweaver/bindings/python_bindings.pl
@@ -26,6 +26,7 @@
 :- module(python_bindings, [
     init_python_bindings/0,
     py_binding/5,               % Convenience: py_binding(Pred, TargetName, Inputs, Outputs, Options)
+    py_binding_import/2,        % py_binding_import(Pred, Import) - get required import
     test_python_bindings/0
 ]).
 
@@ -60,6 +61,33 @@ init_python_bindings :-
 %
 py_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(python, Pred, TargetName, Inputs, Outputs, Options).
+
+%% py_binding_import(?Pred, ?Import)
+%
+%  Get the import required for a Python binding.
+%
+py_binding_import(Pred, Import) :-
+    py_binding(Pred, _, _, _, Options),
+    member(import(Import), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- py_binding(Pred, TargetName, Inputs, Outputs, Options)
+%
+%  Directive for user-defined Python bindings.
+%  Allows users to declare bindings in their Prolog code.
+%
+%  Example:
+%    :- py_binding(my_func/2, 'my_module.my_func', [string], [int], [import('my_module')]).
+%
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- py_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(python, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CORE BUILT-IN BINDINGS

--- a/src/unifyweaver/bindings/rust_bindings.pl
+++ b/src/unifyweaver/bindings/rust_bindings.pl
@@ -22,6 +22,7 @@
 :- module(rust_bindings, [
     init_rust_bindings/0,
     rs_binding/5,               % Convenience: rs_binding(Pred, TargetName, Inputs, Outputs, Options)
+    rs_binding_import/2,        % rs_binding_import(Pred, Import) - get required import/use
     test_rust_bindings/0
 ]).
 
@@ -53,6 +54,33 @@ init_rust_bindings :-
 %
 rs_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(rust, Pred, TargetName, Inputs, Outputs, Options).
+
+%% rs_binding_import(?Pred, ?Import)
+%
+%  Get the use/crate required for a Rust binding.
+%
+rs_binding_import(Pred, Import) :-
+    rs_binding(Pred, _, _, _, Options),
+    member(import(Import), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- rs_binding(Pred, TargetName, Inputs, Outputs, Options)
+%
+%  Directive for user-defined Rust bindings.
+%  Allows users to declare bindings in their Prolog code.
+%
+%  Example:
+%    :- rs_binding(my_hash/2, 'my_crate::hash', [string], [string], [import('my_crate')]).
+%
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- rs_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(rust, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CORE BUILT-IN BINDINGS

--- a/src/unifyweaver/targets/csharp_runtime/custom_csharp.pl
+++ b/src/unifyweaver/targets/csharp_runtime/custom_csharp.pl
@@ -1,0 +1,114 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_csharp.pl - Custom C# Component Type
+%
+% Allows injecting raw C# code as a component.
+% The code is wrapped in a class with an Invoke() method.
+%
+% Example:
+%   declare_component(source, my_transform, custom_csharp, [
+%       code("return input.ToUpper();"),
+%       usings(["System.Text", "System.Linq"])
+%   ]).
+
+:- module(custom_csharp, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+%
+%  Metadata about the custom_csharp component type.
+%
+type_info(info(
+    name('Custom C# Component'),
+    version('1.0.0'),
+    description('Injects custom C# code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+%
+%  Validate that the configuration contains required options.
+%
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  No initialization needed for compile-time component.
+%
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+%
+%  Runtime invocation not supported in Prolog (compilation only).
+%
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_csharp))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+%
+%  Compile the custom C# component to C# code.
+%  Generates a class with an Invoke() method.
+%
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    % Collect using directives if specified
+    (   member(usings(Usings), Config)
+    ->  maplist(format_csharp_using, Usings, UsingLines),
+        atomic_list_concat(UsingLines, '\n', UsingsCode)
+    ;   UsingsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/// <summary>
+/// Custom component: ~w
+/// </summary>
+public class Comp~w
+{
+    /// <summary>
+    /// Process input and return output.
+    /// </summary>
+    public T Invoke<T>(T input)
+    {
+        ~w
+    }
+}
+", [NameStr, UsingsCode, NameStr, NameStr, Body]).
+
+%% format_csharp_using(+Namespace, -UsingLine)
+%
+%  Format a C# using directive.
+%
+format_csharp_using(Namespace, UsingLine) :-
+    format(string(UsingLine), "using ~w;", [Namespace]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+%% Register this component type with the component registry
+%
+:- initialization((
+    register_component_type(source, custom_csharp, custom_csharp, [
+        description("Custom C# Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/python_runtime/custom_python.pl
+++ b/src/unifyweaver/targets/python_runtime/custom_python.pl
@@ -1,0 +1,107 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_python.pl - Custom Python Component Type
+%
+% Allows injecting raw Python code as a component.
+% The code is wrapped in a class with an invoke() method.
+%
+% Example:
+%   declare_component(source, my_transform, custom_python, [
+%       code("return input.upper()"),
+%       imports(["re", "json"])
+%   ]).
+
+:- module(custom_python, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+%
+%  Metadata about the custom_python component type.
+%
+type_info(info(
+    name('Custom Python Component'),
+    version('1.0.0'),
+    description('Injects custom Python code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+%
+%  Validate that the configuration contains required options.
+%
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  No initialization needed for compile-time component.
+%
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+%
+%  Runtime invocation not supported in Prolog (compilation only).
+%
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_python))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+%
+%  Compile the custom Python component to Python code.
+%  Generates a class with an invoke() method.
+%
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    % Collect imports if specified
+    (   member(imports(Imports), Config)
+    ->  maplist(format_python_import, Imports, ImportLines),
+        atomic_list_concat(ImportLines, '\n', ImportsCode)
+    ;   ImportsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"# Custom Component: ~w
+~w
+
+class Comp_~w:
+    \"\"\"Custom component: ~w\"\"\"
+
+    def invoke(self, input):
+        \"\"\"Process input and return output.\"\"\"
+~w
+", [NameStr, ImportsCode, NameStr, NameStr, Body]).
+
+%% format_python_import(+Module, -ImportLine)
+%
+%  Format a Python import statement.
+%
+format_python_import(Module, ImportLine) :-
+    format(string(ImportLine), "import ~w", [Module]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+%% Register this component type with the component registry
+%
+:- initialization((
+    register_component_type(source, custom_python, custom_python, [
+        description("Custom Python Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/rust_runtime/custom_rust.pl
+++ b/src/unifyweaver/targets/rust_runtime/custom_rust.pl
@@ -1,0 +1,113 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_rust.pl - Custom Rust Component Type
+%
+% Allows injecting raw Rust code as a component.
+% The code is wrapped in a struct with an invoke() method.
+%
+% Example:
+%   declare_component(source, my_transform, custom_rust, [
+%       code("input.to_uppercase()"),
+%       uses(["std::collections::HashMap", "serde_json"])
+%   ]).
+
+:- module(custom_rust, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+%
+%  Metadata about the custom_rust component type.
+%
+type_info(info(
+    name('Custom Rust Component'),
+    version('1.0.0'),
+    description('Injects custom Rust code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+%
+%  Validate that the configuration contains required options.
+%
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  No initialization needed for compile-time component.
+%
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+%
+%  Runtime invocation not supported in Prolog (compilation only).
+%
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_rust))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+%
+%  Compile the custom Rust component to Rust code.
+%  Generates a struct with an invoke() method.
+%
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    % Collect use statements if specified
+    (   member(uses(Uses), Config)
+    ->  maplist(format_rust_use, Uses, UseLines),
+        atomic_list_concat(UseLines, '\n', UsesCode)
+    ;   UsesCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/// Custom component: ~w
+pub struct Comp~w;
+
+impl Comp~w {
+    /// Process input and return output.
+    pub fn invoke<T>(&self, input: T) -> Result<T, Box<dyn std::error::Error>>
+    where
+        T: Clone,
+    {
+        Ok(~w)
+    }
+}
+", [NameStr, UsesCode, NameStr, NameStr, NameStr, Body]).
+
+%% format_rust_use(+Module, -UseLine)
+%
+%  Format a Rust use statement.
+%
+format_rust_use(Module, UseLine) :-
+    format(string(UseLine), "use ~w;", [Module]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+%% Register this component type with the component registry
+%
+:- initialization((
+    register_component_type(source, custom_rust, custom_rust, [
+        description("Custom Rust Code")
+    ])
+), now).


### PR DESCRIPTION
  ## Summary                                                                                                                                       
                                                                                                                                                   
  Ports the custom function/component/binding features from the Go target to Python, Rust, and C# targets, achieving cross-target feature parity.  
                                                                                                                                                   
  ### Features Added                                                                                                                               
                                                                                                                                                   
  **User-defined binding directives:**                                                                                                             
  - `:- py_binding(Pred, TargetName, Inputs, Outputs, Options)` for Python                                                                         
  - `:- rs_binding(Pred, TargetName, Inputs, Outputs, Options)` for Rust                                                                           
  - `:- cs_binding(Pred, TargetName, Inputs, Outputs, Options)` for C#                                                                             
                                                                                                                                                   
  **Custom component types:**                                                                                                                      
  - `custom_python.pl` - generates Python class with `invoke()` method                                                                             
  - `custom_rust.pl` - generates Rust struct with `invoke()` method                                                                                
  - `custom_csharp.pl` - generates C# class with `Invoke<T>()` method                                                                              
                                                                                                                                                   
  **Component registry integration:**                                                                                                              
  - All targets now use `component_registry` for component management                                                                              
  - Added `collect_declared_component/2` and `compile_collected_components/1` helpers                                                              
  - Updated `init_*_target` predicates to clear component state                                                                                    
                                                                                                                                                   
  ### Files Changed (11 files, +642 lines)                                                                                                         
                                                                                                                                                   
  | Category | Files |                                                                                                                             
  |----------|-------|                                                                                                                             
  | Bindings | `python_bindings.pl`, `rust_bindings.pl`, `csharp_bindings.pl` |                                                                    
  | Custom Components | `custom_python.pl`, `custom_rust.pl`, `custom_csharp.pl` (new) |                                                           
  | Target Integration | `python_target.pl`, `rust_target.pl`, `csharp_target.pl` |                                                                
  | Documentation | `BINDING_PREDICATE_PROPOSAL.md`, `COMPONENT_REGISTRY.md` |                                                                     
                                                                                                                                                   
  ## Test plan                                                                                                                                     
                                                                                                                                                   
  - [ ] Verify binding directives register correctly for each target                                                                               
  - [ ] Test custom component code generation for Python, Rust, C#                                                                                 
  - [ ] Verify component compilation produces valid target code                                                                                    
                                                                                                                                                   
  � Generated with [Claude Code](https://claude.com/claude-code)                                                                                   