### PR TITLE
add user binding directives and custom components for all targets (phase 2)

### DIFF
--- a/docs/proposals/BINDING_PREDICATE_PROPOSAL.md
+++ b/docs/proposals/BINDING_PREDICATE_PROPOSAL.md
@@ -354,6 +354,19 @@ Users can declare their own bindings directly in Prolog code using target-specif
 | Python | `:- py_binding(...)` | ✅ Implemented |
 | Rust | `:- rs_binding(...)` | ✅ Implemented |
 | C# | `:- cs_binding(...)` | ✅ Implemented |
+| Java | `:- java_binding(...)` | ✅ Implemented |
+| Kotlin | `:- kt_binding(...)` | ✅ Implemented |
+| Scala | `:- scala_binding(...)` | ✅ Implemented |
+| Clojure | `:- clj_binding(...)` | ✅ Implemented |
+| Jython | `:- jy_binding(...)` | ✅ Implemented |
+| F# | `:- fs_binding(...)` | ✅ Implemented |
+| VB.NET | `:- vb_binding(...)` | ✅ Implemented |
+| C | `:- c_binding(...)` | ✅ Implemented |
+| C++ | `:- cpp_binding(...)` | ✅ Implemented |
+| LLVM | `:- llvm_binding(...)` | ✅ Implemented |
+| Bash | `:- bash_binding(...)` | ✅ Implemented |
+| PowerShell | `:- ps_binding(...)` | ✅ Implemented |
+| AWK | `:- awk_binding(...)` | ✅ Implemented |
 
 ### Syntax
 

--- a/docs/proposals/COMPONENT_REGISTRY.md
+++ b/docs/proposals/COMPONENT_REGISTRY.md
@@ -363,6 +363,19 @@ Custom component types allow injecting raw target language code as reusable comp
 | Python | `custom_python.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
 | Rust | `custom_rust.pl` | `code(...)`, `uses([...])` | ✅ Implemented |
 | C# | `custom_csharp.pl` | `code(...)`, `usings([...])` | ✅ Implemented |
+| Java | `custom_java.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| Kotlin | `custom_kotlin.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| Scala | `custom_scala.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| Clojure | `custom_clojure.pl` | `code(...)`, `requires([...])` | ✅ Implemented |
+| Jython | `custom_jython.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| F# | `custom_fsharp.pl` | `code(...)`, `opens([...])` | ✅ Implemented |
+| VB.NET | `custom_vbnet.pl` | `code(...)`, `imports([...])` | ✅ Implemented |
+| C | `custom_c.pl` | `code(...)`, `includes([...])` | ✅ Implemented |
+| C++ | `custom_cpp.pl` | `code(...)`, `includes([...])` | ✅ Implemented |
+| LLVM | `custom_llvm.pl` | `code(...)`, `declares([...])` | ✅ Implemented |
+| Bash | `custom_bash.pl` | `code(...)`, `sources([...])` | ✅ Implemented |
+| PowerShell | `custom_powershell.pl` | `code(...)`, `usings([...])` | ✅ Implemented |
+| AWK | `custom_awk.pl` | `code(...)`, `includes([...])` | ✅ Implemented |
 
 ### Usage Example
 

--- a/src/unifyweaver/bindings/awk_bindings.pl
+++ b/src/unifyweaver/bindings/awk_bindings.pl
@@ -19,6 +19,7 @@
 :- module(awk_bindings, [
     init_awk_bindings/0,
     awk_binding/5,              % Convenience: awk_binding(Pred, TargetName, Inputs, Outputs, Options)
+    awk_binding_include/2,      % awk_binding_include(Pred, LibFile)
     test_awk_bindings/0
 ]).
 
@@ -47,6 +48,25 @@ init_awk_bindings :-
 %
 awk_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(awk, Pred, TargetName, Inputs, Outputs, Options).
+
+%% awk_binding_include(?Pred, ?LibFile)
+%  Get the include library file required for an AWK binding.
+awk_binding_include(Pred, LibFile) :-
+    awk_binding(Pred, _, _, _, Options),
+    member(include(LibFile), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- awk_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined AWK bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- awk_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(awk, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CORE BUILT-IN BINDINGS

--- a/src/unifyweaver/bindings/bash_bindings.pl
+++ b/src/unifyweaver/bindings/bash_bindings.pl
@@ -20,6 +20,7 @@
 :- module(bash_bindings, [
     init_bash_bindings/0,
     bash_binding/5,             % Convenience: bash_binding(Pred, TargetName, Inputs, Outputs, Options)
+    bash_binding_source/2,      % bash_binding_source(Pred, Script)
     test_bash_bindings/0
 ]).
 
@@ -49,6 +50,25 @@ init_bash_bindings :-
 %
 bash_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(bash, Pred, TargetName, Inputs, Outputs, Options).
+
+%% bash_binding_source(?Pred, ?Script)
+%  Get the source script required for a Bash binding.
+bash_binding_source(Pred, Script) :-
+    bash_binding(Pred, _, _, _, Options),
+    member(source(Script), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- bash_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined Bash bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- bash_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(bash, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CORE BUILT-IN BINDINGS

--- a/src/unifyweaver/bindings/c_bindings.pl
+++ b/src/unifyweaver/bindings/c_bindings.pl
@@ -10,6 +10,7 @@
 :- module(c_bindings, [
     init_c_bindings/0,
     c_binding/5,
+    c_binding_include/2,        % c_binding_include(Pred, Header)
     test_c_bindings/0
 ]).
 
@@ -25,6 +26,25 @@ init_c_bindings :-
 %% c_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 c_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(c, Pred, TargetName, Inputs, Outputs, Options).
+
+%% c_binding_include(?Pred, ?Header)
+%  Get the #include header required for a C binding.
+c_binding_include(Pred, Header) :-
+    c_binding(Pred, _, _, _, Options),
+    member(include(Header), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- c_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined C bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- c_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(c, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % STDLIB BINDINGS

--- a/src/unifyweaver/bindings/clojure_bindings.pl
+++ b/src/unifyweaver/bindings/clojure_bindings.pl
@@ -10,6 +10,7 @@
 :- module(clojure_bindings, [
     init_clojure_bindings/0,
     clj_binding/5,
+    clj_binding_require/2,       % clj_binding_require(Pred, Namespace)
     test_clojure_bindings/0
 ]).
 
@@ -26,6 +27,25 @@ init_clojure_bindings :-
 %% clj_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 clj_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(clojure, Pred, TargetName, Inputs, Outputs, Options).
+
+%% clj_binding_require(?Pred, ?Namespace)
+%  Get the require namespace for a Clojure binding.
+clj_binding_require(Pred, Namespace) :-
+    clj_binding(Pred, _, _, _, Options),
+    member(require(Namespace), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- clj_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined Clojure bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- clj_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(clojure, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CORE BINDINGS

--- a/src/unifyweaver/bindings/cpp_bindings.pl
+++ b/src/unifyweaver/bindings/cpp_bindings.pl
@@ -10,6 +10,7 @@
 :- module(cpp_bindings, [
     init_cpp_bindings/0,
     cpp_binding/5,
+    cpp_binding_include/2,      % cpp_binding_include(Pred, Header)
     test_cpp_bindings/0
 ]).
 
@@ -25,6 +26,25 @@ init_cpp_bindings :-
 %% cpp_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 cpp_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(cpp, Pred, TargetName, Inputs, Outputs, Options).
+
+%% cpp_binding_include(?Pred, ?Header)
+%  Get the #include header required for a C++ binding.
+cpp_binding_include(Pred, Header) :-
+    cpp_binding(Pred, _, _, _, Options),
+    member(include(Header), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- cpp_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined C++ bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- cpp_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(cpp, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % STL CONTAINER BINDINGS

--- a/src/unifyweaver/bindings/fsharp_bindings.pl
+++ b/src/unifyweaver/bindings/fsharp_bindings.pl
@@ -10,6 +10,7 @@
 :- module(fsharp_bindings, [
     init_fsharp_bindings/0,
     fs_binding/5,               % fs_binding(Pred, TargetName, Inputs, Outputs, Options)
+    fs_binding_open/2,          % fs_binding_open(Pred, Module)
     test_fsharp_bindings/0
 ]).
 
@@ -25,6 +26,25 @@ init_fsharp_bindings :-
 %% fs_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 fs_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(fsharp, Pred, TargetName, Inputs, Outputs, Options).
+
+%% fs_binding_open(?Pred, ?Module)
+%  Get the open module required for an F# binding.
+fs_binding_open(Pred, Module) :-
+    fs_binding(Pred, _, _, _, Options),
+    member(open(Module), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- fs_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined F# bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- fs_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(fsharp, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 %% Core Built-in Bindings
 register_fsharp_builtin_bindings :-

--- a/src/unifyweaver/bindings/java_bindings.pl
+++ b/src/unifyweaver/bindings/java_bindings.pl
@@ -10,13 +10,43 @@
 
 :- module(java_bindings, [
     init_java_bindings/0,
-    binding_import/1
+    binding_import/1,
+    java_binding/5,              % java_binding(Pred, TargetName, Inputs, Outputs, Options)
+    java_binding_import/2        % java_binding_import(Pred, Import)
 ]).
 
 :- use_module('../core/binding_registry').
 
 % Track required imports
 :- dynamic binding_import/1.
+
+%% java_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
+%  Query Java bindings with reduced arity (Target=java implied).
+java_binding(Pred, TargetName, Inputs, Outputs, Options) :-
+    binding(java, Pred, TargetName, Inputs, Outputs, Options).
+
+%% java_binding_import(?Pred, ?Import)
+%  Get the import required for a Java binding.
+java_binding_import(Pred, Import) :-
+    java_binding(Pred, _, _, _, Options),
+    member(import(Import), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- java_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined Java bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- java_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(java, Pred, TargetName, Inputs, Outputs, Options)))
+).
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
 
 %% init_java_bindings
 %  Initialize all Java bindings. Call this before using the compiler.

--- a/src/unifyweaver/bindings/jython_bindings.pl
+++ b/src/unifyweaver/bindings/jython_bindings.pl
@@ -14,6 +14,7 @@
 :- module(jython_bindings, [
     init_jython_bindings/0,
     jy_binding/5,               % Convenience: jy_binding(Pred, TargetName, Inputs, Outputs, Options)
+    jy_binding_import/2,        % jy_binding_import(Pred, Import)
     test_jython_bindings/0
 ]).
 
@@ -44,6 +45,25 @@ init_jython_bindings :-
 %  Query Jython bindings (Target=jython implied).
 jy_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(jython, Pred, TargetName, Inputs, Outputs, Options).
+
+%% jy_binding_import(?Pred, ?Import)
+%  Get the import required for a Jython binding.
+jy_binding_import(Pred, Import) :-
+    jy_binding(Pred, _, _, _, Options),
+    member(import(Import), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- jy_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined Jython bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- jy_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(jython, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % PYTHON-COMPATIBLE BINDINGS

--- a/src/unifyweaver/bindings/kotlin_bindings.pl
+++ b/src/unifyweaver/bindings/kotlin_bindings.pl
@@ -10,6 +10,7 @@
 :- module(kotlin_bindings, [
     init_kotlin_bindings/0,
     kt_binding/5,
+    kt_binding_import/2,         % kt_binding_import(Pred, Import)
     test_kotlin_bindings/0
 ]).
 
@@ -26,6 +27,25 @@ init_kotlin_bindings :-
 %% kt_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 kt_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(kotlin, Pred, TargetName, Inputs, Outputs, Options).
+
+%% kt_binding_import(?Pred, ?Import)
+%  Get the import required for a Kotlin binding.
+kt_binding_import(Pred, Import) :-
+    kt_binding(Pred, _, _, _, Options),
+    member(import(Import), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- kt_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined Kotlin bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- kt_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(kotlin, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % STDLIB BINDINGS

--- a/src/unifyweaver/bindings/llvm_bindings.pl
+++ b/src/unifyweaver/bindings/llvm_bindings.pl
@@ -10,6 +10,7 @@
     init_llvm_bindings/0,
     llvm_binding/5,            % llvm_binding(Pred, Instruction, Inputs, Outputs, Options)
     llvm_type/2,               % llvm_type(PrologType, LLVMType)
+    llvm_binding_intrinsic/2,  % llvm_binding_intrinsic(Pred, Intrinsic)
     test_llvm_bindings/0
 ]).
 
@@ -24,6 +25,25 @@ init_llvm_bindings :-
 %% llvm_binding(?Pred, ?Instruction, ?Inputs, ?Outputs, ?Options)
 llvm_binding(Pred, Instruction, Inputs, Outputs, Options) :-
     binding(llvm, Pred, Instruction, Inputs, Outputs, Options).
+
+%% llvm_binding_intrinsic(?Pred, ?Intrinsic)
+%  Get the LLVM intrinsic required for a binding.
+llvm_binding_intrinsic(Pred, Intrinsic) :-
+    llvm_binding(Pred, _, _, _, Options),
+    member(intrinsic(Intrinsic), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- llvm_binding(Pred, Instruction, Inputs, Outputs, Options)
+%  Directive for user-defined LLVM bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- llvm_binding(Pred, Instruction, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(llvm, Pred, Instruction, Inputs, Outputs, Options)))
+).
 
 %% Type mappings
 llvm_type(integer, 'i64').

--- a/src/unifyweaver/bindings/powershell_bindings.pl
+++ b/src/unifyweaver/bindings/powershell_bindings.pl
@@ -17,6 +17,7 @@
 :- module(powershell_bindings, [
     init_powershell_bindings/0,
     ps_binding/5,               % Convenience: ps_binding(Pred, TargetName, Inputs, Outputs, Options)
+    ps_binding_using/2,         % ps_binding_using(Pred, Namespace)
     test_powershell_bindings/0
 ]).
 
@@ -46,6 +47,25 @@ init_powershell_bindings :-
 %
 ps_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(powershell, Pred, TargetName, Inputs, Outputs, Options).
+
+%% ps_binding_using(?Pred, ?Namespace)
+%  Get the using namespace required for a PowerShell binding.
+ps_binding_using(Pred, Namespace) :-
+    ps_binding(Pred, _, _, _, Options),
+    member(using(Namespace), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- ps_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined PowerShell bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- ps_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(powershell, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % CHAPTER 3: CMDLET GENERATION BINDINGS

--- a/src/unifyweaver/bindings/scala_bindings.pl
+++ b/src/unifyweaver/bindings/scala_bindings.pl
@@ -10,6 +10,7 @@
 :- module(scala_bindings, [
     init_scala_bindings/0,
     scala_binding/5,
+    scala_binding_import/2,      % scala_binding_import(Pred, Import)
     test_scala_bindings/0
 ]).
 
@@ -26,6 +27,25 @@ init_scala_bindings :-
 %% scala_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 scala_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(scala, Pred, TargetName, Inputs, Outputs, Options).
+
+%% scala_binding_import(?Pred, ?Import)
+%  Get the import required for a Scala binding.
+scala_binding_import(Pred, Import) :-
+    scala_binding(Pred, _, _, _, Options),
+    member(import(Import), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- scala_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined Scala bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- scala_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(scala, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 % ============================================================================
 % OPTION/EITHER BINDINGS

--- a/src/unifyweaver/bindings/vbnet_bindings.pl
+++ b/src/unifyweaver/bindings/vbnet_bindings.pl
@@ -9,6 +9,7 @@
 :- module(vbnet_bindings, [
     init_vbnet_bindings/0,
     vb_binding/5,               % vb_binding(Pred, TargetName, Inputs, Outputs, Options)
+    vb_binding_imports/2,       % vb_binding_imports(Pred, Namespace)
     test_vbnet_bindings/0
 ]).
 
@@ -24,6 +25,25 @@ init_vbnet_bindings :-
 %% vb_binding(?Pred, ?TargetName, ?Inputs, ?Outputs, ?Options)
 vb_binding(Pred, TargetName, Inputs, Outputs, Options) :-
     binding(vbnet, Pred, TargetName, Inputs, Outputs, Options).
+
+%% vb_binding_imports(?Pred, ?Namespace)
+%  Get the Imports namespace required for a VB.NET binding.
+vb_binding_imports(Pred, Namespace) :-
+    vb_binding(Pred, _, _, _, Options),
+    member(imports(Namespace), Options).
+
+% ============================================================================
+% DIRECTIVE SUPPORT
+% ============================================================================
+
+%% :- vb_binding(Pred, TargetName, Inputs, Outputs, Options)
+%  Directive for user-defined VB.NET bindings.
+:- multifile user:term_expansion/2.
+
+user:term_expansion(
+    (:- vb_binding(Pred, TargetName, Inputs, Outputs, Options)),
+    (:- initialization(binding_registry:declare_binding(vbnet, Pred, TargetName, Inputs, Outputs, Options)))
+).
 
 %% Core Built-in Bindings
 register_vbnet_builtin_bindings :-

--- a/src/unifyweaver/targets/awk_runtime/custom_awk.pl
+++ b/src/unifyweaver/targets/awk_runtime/custom_awk.pl
@@ -1,0 +1,84 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_awk.pl - Custom AWK Component Type
+%
+% Allows injecting raw AWK code as a component.
+% The code is wrapped in a function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_awk, [
+%       code("return toupper(input)"),
+%       includes(["lib/utils.awk"])
+%   ]).
+
+:- module(custom_awk, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom AWK Component'),
+    version('1.0.0'),
+    description('Injects custom AWK code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_awk))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(includes(Includes), Config)
+    ->  maplist(format_awk_include, Includes, IncludeLines),
+        atomic_list_concat(IncludeLines, '\n', IncludesCode)
+    ;   IncludesCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"# Custom Component: ~w
+~w
+
+# Custom component: ~w
+# Process input and return output.
+function comp_~w_invoke(input) {
+    ~w
+}
+", [NameStr, IncludesCode, NameStr, NameStr, Body]).
+
+%% format_awk_include(+File, -IncludeLine)
+format_awk_include(File, IncludeLine) :-
+    format(string(IncludeLine), "@include \"~w\"", [File]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_awk, custom_awk, [
+        description("Custom AWK Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/bash_runtime/custom_bash.pl
+++ b/src/unifyweaver/targets/bash_runtime/custom_bash.pl
@@ -1,0 +1,86 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_bash.pl - Custom Bash Component Type
+%
+% Allows injecting raw Bash code as a component.
+% The code is wrapped in a function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_bash, [
+%       code("echo \"${1^^}\""),
+%       sources(["lib/utils.sh", "lib/helpers.sh"])
+%   ]).
+
+:- module(custom_bash, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom Bash Component'),
+    version('1.0.0'),
+    description('Injects custom Bash code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_bash))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(sources(Sources), Config)
+    ->  maplist(format_bash_source, Sources, SourceLines),
+        atomic_list_concat(SourceLines, '\n', SourcesCode)
+    ;   SourcesCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"#!/bin/bash
+# Custom Component: ~w
+~w
+
+# Custom component: ~w
+# Process input and return output.
+comp_~w_invoke() {
+    local input=\"$1\"
+    ~w
+}
+", [NameStr, SourcesCode, NameStr, NameStr, Body]).
+
+%% format_bash_source(+Script, -SourceLine)
+format_bash_source(Script, SourceLine) :-
+    format(string(SourceLine), "source \"~w\"", [Script]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_bash, custom_bash, [
+        description("Custom Bash Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/c_runtime/custom_c.pl
+++ b/src/unifyweaver/targets/c_runtime/custom_c.pl
@@ -1,0 +1,86 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_c.pl - Custom C Component Type
+%
+% Allows injecting raw C code as a component.
+% The code is wrapped in a function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_c, [
+%       code("return toupper(*input);"),
+%       includes(["<ctype.h>", "<string.h>"])
+%   ]).
+
+:- module(custom_c, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom C Component'),
+    version('1.0.0'),
+    description('Injects custom C code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_c))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(includes(Includes), Config)
+    ->  maplist(format_c_include, Includes, IncludeLines),
+        atomic_list_concat(IncludeLines, '\n', IncludesCode)
+    ;   IncludesCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"/* Custom Component: ~w */
+~w
+
+/**
+ * Custom component: ~w
+ * Process input and return output.
+ */
+void* comp_~w_invoke(void* input) {
+    ~w
+}
+", [NameStr, IncludesCode, NameStr, NameStr, Body]).
+
+%% format_c_include(+Header, -IncludeLine)
+format_c_include(Header, IncludeLine) :-
+    format(string(IncludeLine), "#include ~w", [Header]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_c, custom_c, [
+        description("Custom C Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/clojure_runtime/custom_clojure.pl
+++ b/src/unifyweaver/targets/clojure_runtime/custom_clojure.pl
@@ -1,0 +1,83 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_clojure.pl - Custom Clojure Component Type
+%
+% Allows injecting raw Clojure code as a component.
+% The code is wrapped in a defn with invoke function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_clojure, [
+%       code("(clojure.string/upper-case input)"),
+%       requires(["clojure.string", "clojure.set"])
+%   ]).
+
+:- module(custom_clojure, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom Clojure Component'),
+    version('1.0.0'),
+    description('Injects custom Clojure code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_clojure))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(requires(Requires), Config)
+    ->  maplist(format_clojure_require, Requires, RequireLines),
+        atomic_list_concat(RequireLines, '\n', RequiresCode)
+    ;   RequiresCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+";; Custom Component: ~w
+~w
+
+(defn comp-~w-invoke
+  \"Custom component: ~w\"
+  [input]
+  ~w)
+", [NameStr, RequiresCode, NameStr, NameStr, Body]).
+
+%% format_clojure_require(+Namespace, -RequireLine)
+format_clojure_require(Namespace, RequireLine) :-
+    format(string(RequireLine), "(require '[~w])", [Namespace]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_clojure, custom_clojure, [
+        description("Custom Clojure Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/cpp_runtime/custom_cpp.pl
+++ b/src/unifyweaver/targets/cpp_runtime/custom_cpp.pl
@@ -1,0 +1,92 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_cpp.pl - Custom C++ Component Type
+%
+% Allows injecting raw C++ code as a component.
+% The code is wrapped in a template class with an invoke() method.
+%
+% Example:
+%   declare_component(source, my_transform, custom_cpp, [
+%       code("return std::toupper(input);"),
+%       includes(["<algorithm>", "<string>"])
+%   ]).
+
+:- module(custom_cpp, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom C++ Component'),
+    version('1.0.0'),
+    description('Injects custom C++ code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_cpp))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(includes(Includes), Config)
+    ->  maplist(format_cpp_include, Includes, IncludeLines),
+        atomic_list_concat(IncludeLines, '\n', IncludesCode)
+    ;   IncludesCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/**
+ * Custom component: ~w
+ */
+template<typename T>
+class Comp~w {
+public:
+    /**
+     * Process input and return output.
+     */
+    T invoke(T input) {
+        ~w
+    }
+};
+", [NameStr, IncludesCode, NameStr, NameStr, Body]).
+
+%% format_cpp_include(+Header, -IncludeLine)
+format_cpp_include(Header, IncludeLine) :-
+    format(string(IncludeLine), "#include ~w", [Header]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_cpp, custom_cpp, [
+        description("Custom C++ Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/fsharp_runtime/custom_fsharp.pl
+++ b/src/unifyweaver/targets/fsharp_runtime/custom_fsharp.pl
@@ -1,0 +1,86 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_fsharp.pl - Custom F# Component Type
+%
+% Allows injecting raw F# code as a component.
+% The code is wrapped in a module with an invoke function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_fsharp, [
+%       code("input.ToUpper()"),
+%       opens(["System.Text", "System.IO"])
+%   ]).
+
+:- module(custom_fsharp, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom F# Component'),
+    version('1.0.0'),
+    description('Injects custom F# code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_fsharp))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(opens(Opens), Config)
+    ->  maplist(format_fsharp_open, Opens, OpenLines),
+        atomic_list_concat(OpenLines, '\n', OpensCode)
+    ;   OpensCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/// <summary>
+/// Custom component: ~w
+/// </summary>
+module Comp~w =
+    /// Process input and return output.
+    let invoke (input: 'T) : 'T =
+        ~w
+", [NameStr, OpensCode, NameStr, NameStr, Body]).
+
+%% format_fsharp_open(+Namespace, -OpenLine)
+format_fsharp_open(Namespace, OpenLine) :-
+    format(string(OpenLine), "open ~w", [Namespace]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_fsharp, custom_fsharp, [
+        description("Custom F# Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/java_runtime/custom_java.pl
+++ b/src/unifyweaver/targets/java_runtime/custom_java.pl
@@ -1,0 +1,112 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_java.pl - Custom Java Component Type
+%
+% Allows injecting raw Java code as a component.
+% The code is wrapped in a class with an invoke() method.
+%
+% Example:
+%   declare_component(source, my_transform, custom_java, [
+%       code("return input.toUpperCase();"),
+%       imports(["java.util.List", "java.util.Map"])
+%   ]).
+
+:- module(custom_java, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+%
+%  Metadata about the custom_java component type.
+%
+type_info(info(
+    name('Custom Java Component'),
+    version('1.0.0'),
+    description('Injects custom Java code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+%
+%  Validate that the configuration contains required options.
+%
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  No initialization needed for compile-time component.
+%
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+%
+%  Runtime invocation not supported in Prolog (compilation only).
+%
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_java))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+%
+%  Compile the custom Java component to Java code.
+%  Generates a class with an invoke() method.
+%
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    % Collect import statements if specified
+    (   member(imports(Imports), Config)
+    ->  maplist(format_java_import, Imports, ImportLines),
+        atomic_list_concat(ImportLines, '\n', ImportsCode)
+    ;   ImportsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/**
+ * Custom component: ~w
+ */
+public class Comp~w<T> {
+    /**
+     * Process input and return output.
+     */
+    public T invoke(T input) {
+        ~w
+    }
+}
+", [NameStr, ImportsCode, NameStr, NameStr, Body]).
+
+%% format_java_import(+ClassName, -ImportLine)
+%
+%  Format a Java import statement.
+%
+format_java_import(ClassName, ImportLine) :-
+    format(string(ImportLine), "import ~w;", [ClassName]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+%% Register this component type with the component registry
+%
+:- initialization((
+    register_component_type(source, custom_java, custom_java, [
+        description("Custom Java Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/jython_runtime/custom_jython.pl
+++ b/src/unifyweaver/targets/jython_runtime/custom_jython.pl
@@ -1,0 +1,85 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_jython.pl - Custom Jython Component Type
+%
+% Allows injecting raw Jython/Python code as a component.
+% Can use both Python and Java libraries.
+%
+% Example:
+%   declare_component(source, my_transform, custom_jython, [
+%       code("return input.upper()"),
+%       imports(["java.util.ArrayList", "os"])
+%   ]).
+
+:- module(custom_jython, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom Jython Component'),
+    version('1.0.0'),
+    description('Injects custom Jython code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_jython))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(imports(Imports), Config)
+    ->  maplist(format_jython_import, Imports, ImportLines),
+        atomic_list_concat(ImportLines, '\n', ImportsCode)
+    ;   ImportsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"# Custom Component: ~w
+~w
+
+class Comp_~w:
+    \"\"\"Custom component: ~w\"\"\"
+
+    def invoke(self, input):
+        \"\"\"Process input and return output.\"\"\"
+        ~w
+", [NameStr, ImportsCode, NameStr, NameStr, Body]).
+
+%% format_jython_import(+Module, -ImportLine)
+format_jython_import(Module, ImportLine) :-
+    format(string(ImportLine), "import ~w", [Module]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_jython, custom_jython, [
+        description("Custom Jython Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/kotlin_runtime/custom_kotlin.pl
+++ b/src/unifyweaver/targets/kotlin_runtime/custom_kotlin.pl
@@ -1,0 +1,90 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_kotlin.pl - Custom Kotlin Component Type
+%
+% Allows injecting raw Kotlin code as a component.
+% The code is wrapped in a class with an invoke() function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_kotlin, [
+%       code("input.uppercase()"),
+%       imports(["java.util.List", "kotlinx.coroutines.*"])
+%   ]).
+
+:- module(custom_kotlin, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom Kotlin Component'),
+    version('1.0.0'),
+    description('Injects custom Kotlin code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_kotlin))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(imports(Imports), Config)
+    ->  maplist(format_kotlin_import, Imports, ImportLines),
+        atomic_list_concat(ImportLines, '\n', ImportsCode)
+    ;   ImportsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/**
+ * Custom component: ~w
+ */
+class Comp~w<T> {
+    /**
+     * Process input and return output.
+     */
+    fun invoke(input: T): T {
+        return ~w
+    }
+}
+", [NameStr, ImportsCode, NameStr, NameStr, Body]).
+
+%% format_kotlin_import(+ClassName, -ImportLine)
+format_kotlin_import(ClassName, ImportLine) :-
+    format(string(ImportLine), "import ~w", [ClassName]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_kotlin, custom_kotlin, [
+        description("Custom Kotlin Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/llvm_runtime/custom_llvm.pl
+++ b/src/unifyweaver/targets/llvm_runtime/custom_llvm.pl
@@ -1,0 +1,80 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_llvm.pl - Custom LLVM IR Component Type
+%
+% Allows injecting raw LLVM IR code as a component.
+% The code is wrapped in a function definition.
+%
+% Example:
+%   declare_component(source, my_transform, custom_llvm, [
+%       code("ret i64 %input"),
+%       declares(["declare i64 @llvm.ctpop.i64(i64)"])
+%   ]).
+
+:- module(custom_llvm, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom LLVM IR Component'),
+    version('1.0.0'),
+    description('Injects custom LLVM IR code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_llvm))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(declares(Declares), Config)
+    ->  atomic_list_concat(Declares, '\n', DeclaresCode)
+    ;   DeclaresCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"; Custom Component: ~w
+~w
+
+; Custom component: ~w
+; Process input and return output.
+define i64 @comp_~w_invoke(i64 %input) {
+entry:
+    ~w
+}
+", [NameStr, DeclaresCode, NameStr, NameStr, Body]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_llvm, custom_llvm, [
+        description("Custom LLVM IR Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/powershell_runtime/custom_powershell.pl
+++ b/src/unifyweaver/targets/powershell_runtime/custom_powershell.pl
@@ -1,0 +1,96 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_powershell.pl - Custom PowerShell Component Type
+%
+% Allows injecting raw PowerShell code as a component.
+% The code is wrapped in a function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_powershell, [
+%       code("$input.ToUpper()"),
+%       usings(["System.Text", "System.IO"])
+%   ]).
+
+:- module(custom_powershell, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom PowerShell Component'),
+    version('1.0.0'),
+    description('Injects custom PowerShell code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_powershell))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(usings(Usings), Config)
+    ->  maplist(format_ps_using, Usings, UsingLines),
+        atomic_list_concat(UsingLines, '\n', UsingsCode)
+    ;   UsingsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"# Custom Component: ~w
+~w
+
+<#
+.SYNOPSIS
+Custom component: ~w
+
+.DESCRIPTION
+Process input and return output.
+#>
+function Invoke-Comp~w {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        $Input
+    )
+    process {
+        ~w
+    }
+}
+", [NameStr, UsingsCode, NameStr, NameStr, Body]).
+
+%% format_ps_using(+Namespace, -UsingLine)
+format_ps_using(Namespace, UsingLine) :-
+    format(string(UsingLine), "using namespace ~w", [Namespace]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_powershell, custom_powershell, [
+        description("Custom PowerShell Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/scala_runtime/custom_scala.pl
+++ b/src/unifyweaver/targets/scala_runtime/custom_scala.pl
@@ -1,0 +1,90 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_scala.pl - Custom Scala Component Type
+%
+% Allows injecting raw Scala code as a component.
+% The code is wrapped in a class with an invoke() method.
+%
+% Example:
+%   declare_component(source, my_transform, custom_scala, [
+%       code("input.toUpperCase"),
+%       imports(["scala.collection.mutable._"])
+%   ]).
+
+:- module(custom_scala, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom Scala Component'),
+    version('1.0.0'),
+    description('Injects custom Scala code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_scala))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(imports(Imports), Config)
+    ->  maplist(format_scala_import, Imports, ImportLines),
+        atomic_list_concat(ImportLines, '\n', ImportsCode)
+    ;   ImportsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"// Custom Component: ~w
+~w
+
+/**
+ * Custom component: ~w
+ */
+class Comp~w[T] {
+  /**
+   * Process input and return output.
+   */
+  def invoke(input: T): T = {
+    ~w
+  }
+}
+", [NameStr, ImportsCode, NameStr, NameStr, Body]).
+
+%% format_scala_import(+Package, -ImportLine)
+format_scala_import(Package, ImportLine) :-
+    format(string(ImportLine), "import ~w", [Package]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_scala, custom_scala, [
+        description("Custom Scala Code")
+    ])
+), now).

--- a/src/unifyweaver/targets/vbnet_runtime/custom_vbnet.pl
+++ b/src/unifyweaver/targets/vbnet_runtime/custom_vbnet.pl
@@ -1,0 +1,90 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% This file is part of UnifyWeaver.
+% Licensed under either MIT or Apache-2.0 at your option.
+
+:- encoding(utf8).
+% custom_vbnet.pl - Custom VB.NET Component Type
+%
+% Allows injecting raw VB.NET code as a component.
+% The code is wrapped in a Class with an Invoke function.
+%
+% Example:
+%   declare_component(source, my_transform, custom_vbnet, [
+%       code("Return input.ToUpper()"),
+%       imports(["System.Text", "System.IO"])
+%   ]).
+
+:- module(custom_vbnet, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+%% type_info(-Info)
+type_info(info(
+    name('Custom VB.NET Component'),
+    version('1.0.0'),
+    description('Injects custom VB.NET code and exposes it as a component')
+)).
+
+%% validate_config(+Config)
+validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+%% init_component(+Name, +Config)
+init_component(_Name, _Config).
+
+%% invoke_component(+Name, +Config, +Input, -Output)
+invoke_component(_Name, _Config, _Input, _Output) :-
+    throw(error(runtime_invocation_not_supported(custom_vbnet))).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+
+    (   member(imports(Imports), Config)
+    ->  maplist(format_vbnet_imports, Imports, ImportLines),
+        atomic_list_concat(ImportLines, '\n', ImportsCode)
+    ;   ImportsCode = ''
+    ),
+
+    atom_string(Name, NameStr),
+    format(string(Code),
+"' Custom Component: ~w
+~w
+
+''' <summary>
+''' Custom component: ~w
+''' </summary>
+Public Class Comp~w(Of T)
+    ''' <summary>
+    ''' Process input and return output.
+    ''' </summary>
+    Public Function Invoke(input As T) As T
+        ~w
+    End Function
+End Class
+", [NameStr, ImportsCode, NameStr, NameStr, Body]).
+
+%% format_vbnet_imports(+Namespace, -ImportLine)
+format_vbnet_imports(Namespace, ImportLine) :-
+    format(string(ImportLine), "Imports ~w", [Namespace]).
+
+% ============================================================================
+% REGISTRATION
+% ============================================================================
+
+:- initialization((
+    register_component_type(source, custom_vbnet, custom_vbnet, [
+        description("Custom VB.NET Code")
+    ])
+), now).


### PR DESCRIPTION
  ## Summary

  Extends cross-target feature parity to all remaining language targets, completing the work started in #443.

  ### User-defined binding directives (13 new targets)

  | Category | Targets |
  |----------|---------|
  | JVM | `:- java_binding(...)`, `:- kt_binding(...)`, `:- scala_binding(...)`, `:- clj_binding(...)`, `:- jy_binding(...)` |
  | .NET | `:- fs_binding(...)`, `:- vb_binding(...)` |
  | Native | `:- c_binding(...)`, `:- cpp_binding(...)`, `:- llvm_binding(...)` |
  | Shell | `:- bash_binding(...)`, `:- ps_binding(...)`, `:- awk_binding(...)` |

  ### Custom component types (13 new)

  Each generates idiomatic target code with proper import/include statements:

  | Target | Module | Config Options |
  |--------|--------|----------------|
  | Java | `custom_java.pl` | `imports([...])` |
  | Kotlin | `custom_kotlin.pl` | `imports([...])` |
  | Scala | `custom_scala.pl` | `imports([...])` |
  | Clojure | `custom_clojure.pl` | `requires([...])` |
  | Jython | `custom_jython.pl` | `imports([...])` |
  | F# | `custom_fsharp.pl` | `opens([...])` |
  | VB.NET | `custom_vbnet.pl` | `imports([...])` |
  | C | `custom_c.pl` | `includes([...])` |
  | C++ | `custom_cpp.pl` | `includes([...])` |
  | LLVM | `custom_llvm.pl` | `declares([...])` |
  | Bash | `custom_bash.pl` | `sources([...])` |
  | PowerShell | `custom_powershell.pl` | `usings([...])` |
  | AWK | `custom_awk.pl` | `includes([...])` |

  ### Files Changed (28 files, +1,457 lines)

  - 15 bindings modules updated with directive support
  - 13 new custom component type modules
  - Documentation updated in both proposal files

  ## Test plan

  - [ ] Verify binding directives register correctly for each target
  - [ ] Test custom component code generation produces valid syntax
  - [ ] Confirm documentation tables are accurate

  � Generated with [Claude Code](https://claude.com/claude-code)