### PR TITLE
perf(csharp-query): include cache and strategy summaries in trace output

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -90,7 +90,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
 
 ## Diagnostics
 - Plan inspection: `Console.WriteLine(QueryPlanExplainer.Explain(plan));`
-- Execution stats (rows/time per node):
+- Execution stats (rows/time per node, plus cache/index and join-strategy summaries):
   - `var trace = new QueryExecutionTrace();`
   - `foreach (var row in executor.Execute(plan, parameters, trace)) { ... }`
   - `Console.WriteLine(trace.ToString());`

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -526,10 +526,72 @@ namespace UnifyWeaver.QueryRuntime
 
         public override string ToString()
         {
-            var lines = Snapshot()
-                .Select(s =>
-                    $"[{s.Id}] {s.NodeType} invocations={s.Invocations} enumerations={s.Enumerations} rows={s.Rows} elapsed={s.Elapsed}");
-            return string.Join(Environment.NewLine, lines);
+            var builder = new StringBuilder();
+            var nodes = Snapshot();
+            for (var i = 0; i < nodes.Count; i++)
+            {
+                var s = nodes[i];
+                builder.Append('[')
+                    .Append(s.Id)
+                    .Append("] ")
+                    .Append(s.NodeType)
+                    .Append(" invocations=")
+                    .Append(s.Invocations)
+                    .Append(" enumerations=")
+                    .Append(s.Enumerations)
+                    .Append(" rows=")
+                    .Append(s.Rows)
+                    .Append(" elapsed=")
+                    .Append(s.Elapsed);
+                if (i + 1 < nodes.Count)
+                {
+                    builder.AppendLine();
+                }
+            }
+
+            var caches = SnapshotCaches();
+            if (caches.Count > 0)
+            {
+                builder.AppendLine()
+                    .AppendLine()
+                    .AppendLine("Caches:");
+
+                foreach (var cache in caches)
+                {
+                    builder.Append(cache.Cache)
+                        .Append(' ')
+                        .Append(cache.Key)
+                        .Append(" lookups=")
+                        .Append(cache.Lookups)
+                        .Append(" hits=")
+                        .Append(cache.Hits)
+                        .Append(" builds=")
+                        .Append(cache.Builds)
+                        .AppendLine();
+                }
+            }
+
+            var strategies = SnapshotStrategies();
+            if (strategies.Count > 0)
+            {
+                builder.AppendLine()
+                    .AppendLine("Strategies:");
+
+                foreach (var strategy in strategies)
+                {
+                    builder.Append('[')
+                        .Append(strategy.NodeId)
+                        .Append("] ")
+                        .Append(strategy.NodeType)
+                        .Append(' ')
+                        .Append(strategy.Strategy)
+                        .Append(" count=")
+                        .Append(strategy.Count)
+                        .AppendLine();
+                }
+            }
+
+            return builder.ToString().TrimEnd();
         }
     }
 


### PR DESCRIPTION
  - Makes QueryExecutionTrace.ToString() more useful by including cache/index hit stats (SnapshotCaches()) and join
    strategy counts (SnapshotStrategies()) alongside per-node row/time stats.
  - Updates docs/targets/csharp-query-runtime.md to reflect the richer trace output.

  Local test

  - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir (Join-Path $env:TEMP
    'uw_cq_trace_report_smoke') -ProjectFilter "csharp_query_test_fib_param*" (pass)