### PR TITLE
perf(csharp-query): trace fixpoint iteration counts

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -90,7 +90,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
 
 ## Diagnostics
 - Plan inspection: `Console.WriteLine(QueryPlanExplainer.Explain(plan));`
-- Execution stats (rows/time per node, plus cache/index and join-strategy summaries):
+- Execution stats (rows/time per node, fixpoint iteration counts, plus cache/index and join-strategy summaries):
   - `var trace = new QueryExecutionTrace();`
   - `foreach (var row in executor.Execute(plan, parameters, trace)) { ... }`
   - `Console.WriteLine(trace.ToString());`


### PR DESCRIPTION
  - Adds QueryExecutionTrace.SnapshotFixpointIterations() and records per-iteration delta/total row counts for
    FixpointNode and MutualFixpointNode.
  - Includes a Fixpoints: section in QueryExecutionTrace.ToString() output.
  - Updates docs/targets/csharp-query-runtime.md.

  Local tests

  - scripts/testing/run_csharp_query_runtime_smoke.ps1 with filters csharp_query_test_reachable* and
    csharp_query_test_even* (pass)