### PR TITLE
feat(rpyc): add RPyC transport for network-based Python RPC

### DIFF
--- a/docs/research/RPYC_LANGUAGE_COMPATIBILITY.md
+++ b/docs/research/RPYC_LANGUAGE_COMPATIBILITY.md
@@ -1,0 +1,345 @@
+# RPyC Language Compatibility Matrix
+
+**Status:** Research Document
+**Date:** 2025-12-26
+**Author:** Claude Code (Opus 4.5)
+
+## Key Insight
+
+RPyC is **Python-only**, but any language that can embed a real CPython runtime can use RPyC. The critical requirements are:
+
+1. **Embed CPython** - Not a reimplementation (like Jython), but actual CPython
+2. **RPyC available** - The rpyc module importable (see installation options below)
+3. **Call Python functions** - Invoke RPyC's connect/call APIs
+4. **Handle Python objects** - Pass RPyC proxy objects back to host language
+
+## Installing RPyC Without pip
+
+pip is convenient but **not required**. RPyC is pure Python with one dependency (plumbum), so you have options:
+
+### Option 1: Wheel Files (Recommended for Embedded)
+
+```bash
+# Download wheels (no pip needed to use them)
+wget https://files.pythonhosted.org/packages/.../rpyc-6.0.2-py3-none-any.whl
+wget https://files.pythonhosted.org/packages/.../plumbum-1.9.0-py3-none-any.whl
+
+# Extract to your embedded Python's site-packages
+unzip rpyc-6.0.2-py3-none-any.whl -d /path/to/embedded/python/site-packages/
+unzip plumbum-1.9.0-py3-none-any.whl -d /path/to/embedded/python/site-packages/
+```
+
+### Option 2: Vendoring (Bundle with Your App)
+
+```
+your_app/
+├── vendor/
+│   ├── rpyc/           # Copy from rpyc source
+│   └── plumbum/        # Copy from plumbum source
+└── main.py
+```
+
+```python
+import sys
+sys.path.insert(0, 'vendor')
+import rpyc  # Works!
+```
+
+### Option 3: Source Installation
+
+```bash
+# No pip, just Python
+tar xzf rpyc-6.0.2.tar.gz
+cd rpyc-6.0.2
+python setup.py install --prefix=/path/to/embedded/python
+```
+
+### Option 4: Single-File Bundling
+
+For truly minimal deployments, tools like [PyInstaller](https://pyinstaller.org/) or [Nuitka](https://nuitka.net/) can bundle RPyC into a single executable or library.
+
+### Dependency Note
+
+RPyC depends on **plumbum** (shell command toolkit). For RPyC classic mode (which we use), plumbum is required but only uses its basic features. Both are pure Python - no C extensions.
+
+## Compatibility Matrix
+
+| Language | Bridge Technology | CPython? | pip? | RPyC Feasibility | Notes |
+|----------|------------------|----------|------|------------------|-------|
+| **Prolog (SWI)** | [Janus](https://www.swi-prolog.org/pldoc/man?section=janus) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | This project |
+| **C#/F#** | [Python.NET](https://pythonnet.github.io/) | ✅ Yes | ✅ Yes | ✅ High | Mature, well-documented |
+| **C#** | [CSnakes](https://tonybaloney.github.io/posts/embedding-python-in-dot-net-with-csnakes.html) | ✅ Yes | ✅ Yes | ✅ High | Newer, simpler API |
+| **Java** | [JPype](https://github.com/jpype-project/jpype) | ✅ Yes | ✅ Yes | ✅ High | Shared memory approach |
+| **Java** | [jpy](https://jpy.readthedocs.io/) | ✅ Yes | ✅ Yes | ✅ High | Bi-directional bridge |
+| **Java** | [GraalPy](https://github.com/oracle/graalpython) | ⚠️ GraalVM | ⚠️ Limited | ⚠️ Medium | May have C extension issues |
+| **Rust** | [PyO3](https://pyo3.rs/) | ✅ Yes | ✅ Yes | ✅ High | Very active, mature |
+| **Ruby** | [PyCall.rb](https://github.com/red-data-tools/pycall.rb) | ✅ Yes | ✅ Yes | ✅ High | v1.5.2 (May 2024) |
+| **Go** | [go-python3](https://github.com/DataDog/go-python3) | ✅ Yes | ✅ Yes | ⚠️ Medium | GIL management complex |
+| **Go** | [go-embed-python](https://github.com/kluctl/go-embed-python) | ✅ Yes | ✅ Yes | ⚠️ Medium | No CGO, uses subprocess |
+| **Lua** | [lupa](https://github.com/scoder/lupa) | ❌ No* | ❌ No | ❌ Low | Lua embeds in Python, not reverse |
+| **Lua** | [lunatic-python](https://github.com/bastibe/lunatic-python) | ⚠️ Partial | ⚠️ Partial | ⚠️ Low | Bi-directional but limited |
+| **Node.js** | python-shell | ❌ Subprocess | ✅ Yes | ⚠️ Low | IPC overhead defeats purpose |
+| **JavaScript** | [GraalJS + GraalPy](https://www.graalvm.org/latest/reference-manual/polyglot-programming/) | ⚠️ GraalVM | ⚠️ Limited | ⚠️ Medium | Polyglot context |
+
+*lupa embeds Lua in Python, not Python in Lua
+
+## Tier 1: High Confidence (Should Work)
+
+### Prolog (SWI-Prolog + Janus) ✅ TESTED
+
+```prolog
+% Already implemented and tested in this project
+rpyc_connect(localhost, [security(unsecured), acknowledge_risk(true)], Proxy),
+rpyc_import(Proxy, math, Math),
+py_call(Math:sqrt(16), Result).
+% Result = 4.0
+```
+
+### C# / F# (Python.NET)
+
+```csharp
+using Python.Runtime;
+
+// Initialize Python
+PythonEngine.Initialize();
+
+using (Py.GIL())
+{
+    // Import RPyC
+    dynamic rpyc = Py.Import("rpyc");
+
+    // Connect to server
+    dynamic conn = rpyc.classic.connect("localhost", 18812);
+
+    // Use remote modules
+    dynamic math = conn.modules.math;
+    var result = math.sqrt(16);
+    Console.WriteLine($"sqrt(16) = {result}");  // 4.0
+
+    conn.close();
+}
+```
+
+### Java (JPype)
+
+```java
+import org.jpype.*;
+
+public class RPyCExample {
+    public static void main(String[] args) {
+        // Start JVM with Python
+        JPype.startJVM();
+
+        // Import RPyC
+        PyObject rpyc = PyModule.import_("rpyc");
+        PyObject classic = rpyc.getAttr("classic");
+
+        // Connect
+        PyObject conn = classic.invoke("connect", "localhost", 18812);
+
+        // Use remote math
+        PyObject modules = conn.getAttr("modules");
+        PyObject math = modules.getAttr("math");
+        PyObject result = math.invoke("sqrt", 16);
+
+        System.out.println("sqrt(16) = " + result);  // 4.0
+
+        conn.invoke("close");
+        JPype.shutdownJVM();
+    }
+}
+```
+
+### Rust (PyO3)
+
+```rust
+use pyo3::prelude::*;
+
+fn main() -> PyResult<()> {
+    Python::with_gil(|py| {
+        // Import rpyc
+        let rpyc = py.import("rpyc")?;
+        let classic = rpyc.getattr("classic")?;
+
+        // Connect
+        let conn = classic.call_method1("connect", ("localhost", 18812))?;
+
+        // Access remote math
+        let modules = conn.getattr("modules")?;
+        let math = modules.getattr("math")?;
+        let result: f64 = math.call_method1("sqrt", (16,))?.extract()?;
+
+        println!("sqrt(16) = {}", result);  // 4.0
+
+        conn.call_method0("close")?;
+        Ok(())
+    })
+}
+```
+
+### Ruby (PyCall.rb)
+
+```ruby
+require 'pycall'
+
+# Import rpyc
+rpyc = PyCall.import_module('rpyc')
+
+# Connect
+conn = rpyc.classic.connect('localhost', 18812)
+
+# Use remote math
+math = conn.modules.math
+result = math.sqrt(16)
+puts "sqrt(16) = #{result}"  # 4.0
+
+conn.close()
+```
+
+## Tier 2: Medium Confidence (Likely Works)
+
+### Go (go-python3)
+
+```go
+package main
+
+import (
+    "fmt"
+    python "github.com/DataDog/go-python3"
+)
+
+func main() {
+    python.Py_Initialize()
+    defer python.Py_Finalize()
+
+    // Import rpyc
+    rpyc := python.PyImport_ImportModule("rpyc")
+    classic := rpyc.GetAttrString("classic")
+
+    // Connect - Note: GIL management required
+    args := python.PyTuple_New(2)
+    python.PyTuple_SetItem(args, 0, python.PyUnicode_FromString("localhost"))
+    python.PyTuple_SetItem(args, 1, python.PyLong_FromLong(18812))
+
+    conn := classic.CallMethodObjArgs("connect", args)
+
+    // Use remote math
+    modules := conn.GetAttrString("modules")
+    math := modules.GetAttrString("math")
+
+    sqrtArgs := python.PyTuple_New(1)
+    python.PyTuple_SetItem(sqrtArgs, 0, python.PyLong_FromLong(16))
+    result := math.CallMethodObjArgs("sqrt", sqrtArgs)
+
+    fmt.Printf("sqrt(16) = %v\n", python.PyFloat_AsDouble(result))
+
+    conn.CallMethodObjArgs("close", nil)
+}
+```
+
+### GraalVM Polyglot (Java + Python)
+
+```java
+import org.graalvm.polyglot.*;
+
+public class GraalRPyCExample {
+    public static void main(String[] args) {
+        try (Context context = Context.newBuilder("python")
+                .allowAllAccess(true)
+                .build()) {
+
+            // Execute Python code that uses RPyC
+            Value result = context.eval("python", """
+                import rpyc
+                conn = rpyc.classic.connect('localhost', 18812)
+                result = conn.modules.math.sqrt(16)
+                conn.close()
+                result
+            """);
+
+            System.out.println("sqrt(16) = " + result.asDouble());
+        }
+    }
+}
+```
+
+## Tier 3: Low Confidence (Challenging)
+
+### Lua
+
+Lua bridges typically embed Lua in Python, not the reverse. To use RPyC from Lua, you'd need:
+
+1. **lunatic-python** (limited bi-directional support)
+2. Custom FFI to CPython (significant effort)
+3. Subprocess approach (defeats purpose of live proxies)
+
+### Node.js
+
+Node.js options typically use subprocess communication:
+
+```javascript
+// This defeats the purpose of RPyC's live proxies
+const { spawn } = require('child_process');
+const python = spawn('python', ['-c', `
+import rpyc
+conn = rpyc.classic.connect('localhost', 18812)
+print(conn.modules.math.sqrt(16))
+`]);
+```
+
+For true integration, consider [edge-py](https://github.com/nicola/edge-py) but it has limitations.
+
+## Architecture Decision
+
+### When to Use Each Approach
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Prolog + Python | Janus + RPyC (this project) |
+| .NET + Python | Python.NET + RPyC |
+| Java + Python | JPype + RPyC |
+| Rust + Python | PyO3 + RPyC |
+| Ruby + Python | PyCall.rb + RPyC |
+| Go + Python | Consider gRPC instead |
+| Node.js + Python | Consider gRPC or HTTP instead |
+| Lua + Python | Consider embedding Lua in Python |
+
+### Alternative: gRPC for Non-Python Languages
+
+For languages without good CPython embedding, consider:
+
+1. **Generate gRPC stubs** from Python services
+2. **Polyglot support** out of the box
+3. **Better tooling** for non-Python clients
+4. **Trade-off**: No live proxies, requires proto definitions
+
+## Implementation Priority
+
+Based on ecosystem maturity and use cases:
+
+1. **Prolog (Janus)** - ✅ Done
+2. **C# (Python.NET)** - High value, .NET ecosystem is large
+3. **Java (JPype)** - Enterprise adoption potential
+4. **Rust (PyO3)** - Growing systems programming use
+5. **Ruby (PyCall.rb)** - Rails/web development niche
+
+## References
+
+- [Python.NET Documentation](https://pythonnet.github.io/pythonnet/dotnet.html)
+- [JPype User Guide](https://jpype.readthedocs.io/en/latest/userguide.html)
+- [PyO3 User Guide](https://pyo3.rs/main/python-from-rust)
+- [PyCall.rb GitHub](https://github.com/red-data-tools/pycall.rb)
+- [GraalPy Interoperability](https://github.com/oracle/graalpython/blob/master/docs/user/Interoperability.md)
+- [Cgo and Python - Datadog](https://www.datadoghq.com/blog/engineering/cgo-and-python/)
+- [lupa PyPI](https://pypi.org/project/lupa/)
+
+## Next Steps
+
+To test a new language bridge:
+
+1. Install the bridge package (e.g., `pip install jpype1` for Java-side, Maven for Java)
+2. Install RPyC: `pip install rpyc`
+3. Start a test server: `python examples/rpyc-integration/rpyc_server.py`
+4. Write bridge code using patterns above
+5. Test connection and remote calls
+6. Document any quirks or limitations

--- a/examples/rpyc-integration/README.md
+++ b/examples/rpyc-integration/README.md
@@ -1,0 +1,81 @@
+# RPyC Integration Example
+
+This example demonstrates using RPyC for network-based RPC communication between Prolog and Python through UnifyWeaver's glue system.
+
+## Overview
+
+RPyC (Remote Python Call) provides live object proxies over the network, filling the gap between:
+- **Pipe transport**: Serialized data, same machine
+- **HTTP transport**: Serialized data, network
+- **Janus**: Live objects, in-process only
+- **RPyC**: Live objects, network-capable
+
+## Quick Start
+
+### 1. Install RPyC
+
+```bash
+pip install rpyc
+```
+
+### 2. Start the Server
+
+```bash
+python rpyc_server.py
+```
+
+You should see:
+```
+UnifyWeaver RPyC Demo Server
+Listening on port 18812
+Press Ctrl+C to stop
+```
+
+### 3. Run the Demo
+
+In a new terminal:
+
+```bash
+swipl rpyc_demo.pl
+```
+
+```prolog
+?- run_demo.
+```
+
+## Demo Features
+
+1. **Code Generation** - Generate client wrappers and service code
+2. **Connection Test** - Connect to RPyC server
+3. **Remote Computation** - Execute math and code remotely
+4. **Proxy Layers** - Explore the four proxy layers
+5. **Transport Comparison** - Understand when to use RPyC
+
+## Proxy Layers
+
+The RPyC transport provides four proxy layers:
+
+| Layer | Property | Use Case |
+|-------|----------|----------|
+| `root` | Direct exposed_ access | Simple RPC calls |
+| `wrapped_root` | Safe attribute access | Prevent accidental execution |
+| `auto_root` | Automatic wrapping | General use |
+| `smart_root` | Local-class-aware | Code generation |
+
+## Security Modes
+
+- **unsecured**: Development only (shown in this demo)
+- **ssh**: SSH tunnel (recommended for production)
+- **ssl**: SSL/TLS with certificates
+
+For production use, always use `ssh` or `ssl` modes.
+
+## Files
+
+- `rpyc_demo.pl` - Prolog demo script
+- `rpyc_server.py` - Python RPyC server
+
+## Related Documentation
+
+- [RPYC Transport Proposal](../../docs/proposals/RPYC_TRANSPORT_PROPOSAL.md)
+- [Chapter 21: Janus Integration](../../education/book-07-cross-target-glue/21_janus_integration.md)

--- a/examples/rpyc-integration/rpyc_demo.pl
+++ b/examples/rpyc-integration/rpyc_demo.pl
@@ -1,0 +1,216 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% rpyc_demo.pl - RPyC Network-Based Python Integration Demo
+%
+% This example demonstrates using RPyC for network-based RPC
+% communication between Prolog and Python, integrated with
+% UnifyWeaver's glue system.
+%
+% Prerequisites:
+%   1. Start the RPyC server first:
+%      python rpyc_server.py
+%
+%   2. Then run this demo:
+%      ?- [rpyc_demo].
+%      ?- run_demo.
+
+:- use_module(library(janus)).
+:- use_module('../../src/unifyweaver/glue/rpyc_glue').
+
+%% ============================================
+%% Demo 1: Code Generation (No Server Needed)
+%% ============================================
+
+demo_code_generation :-
+    format('~n=== Demo 1: Code Generation ===~n'),
+    format('(Does not require running server)~n~n'),
+
+    % Generate client wrapper
+    format('1.1 Generating client wrapper:~n'),
+    generate_rpyc_client([
+        exposed(sqrt_wrapper/2, [module(math), function(sqrt)])
+    ], [host('localhost'), security(unsecured)], ClientCode),
+    format('~w~n', [ClientCode]),
+
+    % Generate service
+    format('~n1.2 Generating RPyC service:~n'),
+    generate_rpyc_service([
+        exposed(transform_data/2, [input(list), output(list)]),
+        exposed(predict/2, [input(dict), output(float)])
+    ], [service_name('MLService'), imports([numpy])], ServiceCode),
+    format('~w~n', [ServiceCode]).
+
+%% ============================================
+%% Demo 2: Connection (Requires Server)
+%% ============================================
+
+demo_connection :-
+    format('~n=== Demo 2: Connection Test ===~n'),
+
+    format('2.1 Connecting to localhost:18812 (unsecured)...~n'),
+    catch(
+        (   rpyc_connect('localhost', [
+                security(unsecured),
+                acknowledge_risk(true),
+                remote_port(18812)
+            ], Proxy),
+            format('    Connected successfully!~n'),
+
+            % Get modules access
+            format('2.2 Testing module access:~n'),
+            rpyc_import(Proxy, sys, Sys),
+            py_call(Sys:version, PyVersion),
+            format('    Remote Python version: ~w~n', [PyVersion]),
+
+            % Disconnect
+            format('2.3 Disconnecting...~n'),
+            rpyc_disconnect(Proxy),
+            format('    Disconnected.~n')
+        ),
+        Error,
+        (   format('~n    Connection failed: ~w~n', [Error]),
+            format('~n    Make sure the RPyC server is running:~n'),
+            format('      python rpyc_server.py~n')
+        )
+    ).
+
+%% ============================================
+%% Demo 3: Remote Computation
+%% ============================================
+
+demo_remote_computation :-
+    format('~n=== Demo 3: Remote Computation ===~n'),
+
+    catch(
+        (   rpyc_connect('localhost', [
+                security(unsecured),
+                acknowledge_risk(true)
+            ], Proxy),
+
+            % Math operations
+            format('3.1 Remote math operations:~n'),
+            rpyc_import(Proxy, math, Math),
+            py_call(Math:sqrt(16), Sqrt16),
+            format('    math.sqrt(16) = ~w~n', [Sqrt16]),
+
+            py_call(Math:factorial(10), Fact10),
+            format('    math.factorial(10) = ~w~n', [Fact10]),
+
+            % Remote code execution
+            format('~n3.2 Remote code execution:~n'),
+            rpyc_exec(Proxy, "
+result = sum(range(1, 101))
+squares = [x**2 for x in range(1, 11)]
+", NS),
+            py_call(NS:get('result'), SumResult),
+            format('    sum(1..100) = ~w~n', [SumResult]),
+
+            rpyc_disconnect(Proxy)
+        ),
+        Error,
+        (   format('    Error: ~w~n', [Error]),
+            format('    Start server with: python rpyc_server.py~n')
+        )
+    ).
+
+%% ============================================
+%% Demo 4: Proxy Layers
+%% ============================================
+
+demo_proxy_layers :-
+    format('~n=== Demo 4: Proxy Layers ===~n'),
+
+    catch(
+        (   rpyc_connect('localhost', [
+                security(unsecured),
+                acknowledge_risk(true)
+            ], Proxy),
+
+            % Layer 1: Root
+            format('4.1 Layer 1 (root) - Direct method access:~n'),
+            rpyc_root(Proxy, Root),
+            format('    Root proxy obtained~n'),
+
+            % Layer 2: Wrapped Root
+            format('4.2 Layer 2 (wrapped_root) - Safe attribute access:~n'),
+            rpyc_wrapped_root(Proxy, WrappedRoot),
+            format('    WrappedRoot proxy obtained~n'),
+
+            % Layer 3: Auto Root
+            format('4.3 Layer 3 (auto_root) - Automatic wrapping:~n'),
+            rpyc_auto_root(Proxy, AutoRoot),
+            format('    AutoRoot proxy obtained~n'),
+
+            % Layer 4: Smart Root
+            format('4.4 Layer 4 (smart_root) - Local-class-aware:~n'),
+            rpyc_smart_root(Proxy, SmartRoot),
+            format('    SmartRoot proxy obtained~n'),
+
+            rpyc_disconnect(Proxy)
+        ),
+        Error,
+        format('    Skipped (server not available): ~w~n', [Error])
+    ).
+
+%% ============================================
+%% Demo 5: Transport Comparison
+%% ============================================
+
+demo_transport_comparison :-
+    format('~n=== Demo 5: Transport Comparison ===~n'),
+    format('~n'),
+    format('Transport     | Location   | Objects      | Use Case~n'),
+    format('--------------|------------|--------------|------------------------~n'),
+    format('pipe          | Same host  | Serialized   | Process isolation~n'),
+    format('http          | Network    | Serialized   | REST APIs~n'),
+    format('janus         | In-process | Live (share) | NumPy, ML, tight integ~n'),
+    format('rpyc          | Network    | Live (proxy) | Remote compute, distrib~n'),
+    format('~n'),
+    format('RPyC fills the gap of "network + live objects".~n'),
+    format('Use RPyC when you need remote machine access with~n'),
+    format('the convenience of live object proxies.~n').
+
+%% ============================================
+%% Main Demo Runner
+%% ============================================
+
+run_demo :-
+    format('~n========================================~n'),
+    format('RPyC Network-Based Python Integration Demo~n'),
+    format('========================================~n'),
+
+    % Check Janus availability
+    (   current_module(janus)
+    ->  format('Janus available: yes~n'),
+        demo_code_generation,
+        demo_connection,
+        demo_remote_computation,
+        demo_proxy_layers,
+        demo_transport_comparison
+    ;   format('Janus not available.~n'),
+        format('Only code generation demos will run.~n'),
+        demo_code_generation,
+        demo_transport_comparison
+    ),
+
+    format('~n========================================~n'),
+    format('Demo complete!~n'),
+    format('========================================~n').
+
+%% ============================================
+%% Server Setup Helper
+%% ============================================
+
+%% generate_server
+%  Generate a server script file in the current directory.
+generate_server :-
+    generate_rpyc_server([
+        output_file('rpyc_server.py'),
+        service_name('DemoService')
+    ], Script),
+    format('Generated: rpyc_server.py~n'),
+    format('Run it with: python rpyc_server.py~n').
+
+% Auto-run message on load
+:- initialization(format('~nRPyC demo loaded.~nRun ?- run_demo. to start.~nRun ?- generate_server. to create a server script.~n')).

--- a/examples/rpyc-integration/rpyc_server.py
+++ b/examples/rpyc-integration/rpyc_server.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+RPyC Server for UnifyWeaver Integration Demo
+
+This server provides a basic RPyC endpoint for testing
+the UnifyWeaver RPyC transport.
+
+Usage:
+    python rpyc_server.py [--port PORT]
+
+Then run the Prolog demo:
+    swipl rpyc_demo.pl
+    ?- run_demo.
+"""
+
+import rpyc
+from rpyc.utils.server import ThreadedServer
+from rpyc.core.service import ClassicService
+import sys
+import os
+import argparse
+
+
+class DemoService(ClassicService):
+    """Demo RPyC service for UnifyWeaver integration testing."""
+
+    def on_connect(self, conn):
+        print(f"Client connected from {conn._config}")
+        self._setup_environment()
+
+    def on_disconnect(self, conn):
+        print("Client disconnected")
+
+    def _setup_environment(self):
+        """Setup demo environment."""
+        # Add current directory to path for dict_wrapper if available
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        sys.path.insert(0, script_dir)
+
+        # Try to find and add UnifyWeaver's rpyc module
+        # Navigate up to find src/unifyweaver/glue/rpyc
+        potential_paths = [
+            os.path.join(script_dir, '../../src/unifyweaver/glue/rpyc'),
+            os.path.join(script_dir, '../../src'),
+        ]
+
+        for path in potential_paths:
+            abs_path = os.path.abspath(path)
+            if os.path.exists(abs_path):
+                sys.path.insert(0, abs_path)
+                print(f"Added path: {abs_path}")
+
+        # Import dict_wrapper if available
+        try:
+            import dict_wrapper
+            print("+ dict_wrapper loaded")
+        except ImportError:
+            print("- dict_wrapper not available (optional)")
+
+    # Example exposed methods for testing
+    def exposed_echo(self, message):
+        """Echo a message back."""
+        return f"Echo: {message}"
+
+    def exposed_add(self, a, b):
+        """Add two numbers."""
+        return a + b
+
+    def exposed_compute_stats(self, numbers):
+        """Compute basic statistics for a list of numbers."""
+        if not numbers:
+            return {"error": "empty list"}
+        return {
+            "count": len(numbers),
+            "sum": sum(numbers),
+            "mean": sum(numbers) / len(numbers),
+            "min": min(numbers),
+            "max": max(numbers),
+        }
+
+
+def start_server(port=18812):
+    """Start the RPyC demo server."""
+    print("=" * 50)
+    print("UnifyWeaver RPyC Demo Server")
+    print("=" * 50)
+    print()
+    print("WARNING: This server uses UNSECURED mode!")
+    print("Only use for development and testing.")
+    print()
+    print(f"Listening on port {port}")
+    print("Press Ctrl+C to stop")
+    print()
+    print("Connect from Prolog with:")
+    print("  ?- rpyc_connect('localhost', [")
+    print("         security(unsecured),")
+    print("         acknowledge_risk(true)")
+    print("     ], Proxy).")
+    print()
+    print("=" * 50)
+
+    server = ThreadedServer(
+        DemoService,
+        port=port,
+        protocol_config={"allow_all_attrs": True}
+    )
+
+    try:
+        server.start()
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='UnifyWeaver RPyC Demo Server')
+    parser.add_argument('--port', type=int, default=18812,
+                       help='Server port (default: 18812)')
+
+    args = parser.parse_args()
+    start_server(args.port)

--- a/examples/rpyc-integration/test_connection.pl
+++ b/examples/rpyc-integration/test_connection.pl
@@ -1,0 +1,30 @@
+% test_connection.pl - Test RPyC connection from Prolog
+:- use_module('../../src/unifyweaver/glue/rpyc_glue').
+
+test_connection :-
+    format('Testing RPyC connection from Prolog...~n'),
+    catch(
+        (   rpyc_connect(localhost, [
+                security(unsecured),
+                acknowledge_risk(true),
+                remote_port(18812)
+            ], Proxy),
+            format('Connected to RPyC server.~n'),
+
+            % Test module access
+            rpyc_import(Proxy, math, Math),
+            py_call(Math:sqrt(25), Sqrt),
+            format('math.sqrt(25) = ~w~n', [Sqrt]),
+
+            % Test proxy layers
+            rpyc_root(Proxy, Root),
+            format('Root proxy obtained: ~w~n', [Root]),
+
+            rpyc_disconnect(Proxy),
+            format('Disconnected successfully.~n')
+        ),
+        Error,
+        format('Error: ~w~n', [Error])
+    ).
+
+:- initialization(test_connection).

--- a/src/unifyweaver/glue/rpyc/__init__.py
+++ b/src/unifyweaver/glue/rpyc/__init__.py
@@ -1,0 +1,125 @@
+"""
+UnifyWeaver RPyC Transport Module
+
+Provides network-based RPC with live object proxies through RPyC,
+enabling transparent remote Python execution from Prolog.
+
+Proxy Layers:
+    - root: Layer 1 - Direct exposed_ method access
+    - wrapped_root: Layer 2 - Safe attribute access
+    - auto_root: Layer 3 - Automatic wrapping
+    - smart_root: Layer 4 - Local-class-aware wrapping
+
+Security Modes:
+    - ssh: SSH tunnel (recommended for production)
+    - ssl: SSL/TLS with certificates
+    - unsecured: Plain TCP (development only)
+
+Example:
+    from unifyweaver.glue.rpyc import create_ssh_bridge
+
+    bridge = create_ssh_bridge('server.example.com', user='deploy')
+    with bridge.secure_connection() as proxy:
+        result = proxy.modules.numpy.array([1, 2, 3])
+        print(proxy.root.exposed_compute(result))
+"""
+
+from .remote_execution import (
+    # Main classes
+    ConfigurableRPyCBridge,
+    SecureRPyCProxy,
+    SecurityError,
+
+    # Proxy layers
+    RootProxy,
+    ClientModuleWrapper,
+    ClientModuleAdapter,
+    AutoWrapProxy,
+    SmartAutoWrapProxy,
+
+    # Local utilities
+    LocalMethods,
+    DictWrapper,
+
+    # Async support
+    AsyncResult,
+    async_call,
+
+    # Factory functions
+    create_ssh_bridge,
+    create_ssl_bridge,
+    create_unsecured_bridge,
+
+    # Server generation
+    generate_rpyc_server_script,
+
+    # Utility functions
+    is_rpyc_proxy,
+    is_simple_type,
+    setup_logging,
+)
+
+from .dict_wrapper import (
+    DictWrapper,
+    mkDictWrapper,
+    wrapped_exec,
+    call_function,
+    call_with_args,
+    call_with_kwargs,
+    call_with_mixed_args,
+    call_and_wrap,
+    wrap,
+    get_dict_value,
+    set_dict_value,
+    BoundCallable,
+)
+
+__all__ = [
+    # Main classes
+    'ConfigurableRPyCBridge',
+    'SecureRPyCProxy',
+    'SecurityError',
+
+    # Proxy layers
+    'RootProxy',
+    'ClientModuleWrapper',
+    'ClientModuleAdapter',
+    'AutoWrapProxy',
+    'SmartAutoWrapProxy',
+
+    # Local utilities
+    'LocalMethods',
+    'DictWrapper',
+
+    # Async support
+    'AsyncResult',
+    'async_call',
+
+    # Factory functions
+    'create_ssh_bridge',
+    'create_ssl_bridge',
+    'create_unsecured_bridge',
+
+    # Server generation
+    'generate_rpyc_server_script',
+
+    # Utility functions
+    'is_rpyc_proxy',
+    'is_simple_type',
+    'setup_logging',
+
+    # Dict wrapper utilities
+    'mkDictWrapper',
+    'wrapped_exec',
+    'call_function',
+    'call_with_args',
+    'call_with_kwargs',
+    'call_with_mixed_args',
+    'call_and_wrap',
+    'wrap',
+    'get_dict_value',
+    'set_dict_value',
+    'BoundCallable',
+]
+
+__version__ = '0.1.0'

--- a/src/unifyweaver/glue/rpyc/dict_wrapper.py
+++ b/src/unifyweaver/glue/rpyc/dict_wrapper.py
@@ -1,0 +1,265 @@
+class DictWrapper:
+    def __init__(self, arg=None,**args):
+        if arg is None:
+            self.dict = dict(**args)
+        else:
+            self.dict=arg
+            self.dict.update(dict(**args))
+    
+    def get(self, key, default=None):  
+        return self.dict.get(key, default)
+    
+    def update(self, other):
+        # Handle different types of input
+        if hasattr(other, 'dict'):  # Another DictWrapper
+            self.dict.update(other.dict)
+        else:  # Assume it's a dictionary-like object
+            self.dict.update(other)
+    def set(self,key,value):
+        self.update({key:value})
+    def update_kv(self, key, value):
+        # Alternative method for single key-value updates
+        self.dict[key] = value
+    
+    def update_pairs(self, **kwargs):
+        # Alternative method using keyword arguments
+        self.dict.update(kwargs)
+    
+    def __repr__(self):
+        return f"DictWrapper({self.dict})"
+
+def mkDictWrapper(**args):
+    return DictWrapper(**args)
+def wrapped_exec(code, initial_vars=None):
+    """
+    Execute Python code and return results in a DictWrapper.
+    
+    Args:
+        code: Python code string to execute
+        initial_vars: Optional dictionary of initial variables
+    
+    Returns:
+        DictWrapper containing all variables from the execution
+    """
+    # Create execution namespace
+    if isinstance(initial_vars,DictWrapper):
+        initial_vars=initial_vars.dict
+        
+    namespace = {} if initial_vars is None else initial_vars
+    
+    # Execute the code in the namespace
+    exec(code, globals(), namespace)
+    
+    # Return wrapped results
+    return DictWrapper(namespace)
+def call_in_namespace(func=None, ns={}, f_name="func", r_name="result", args=[], kwargs={}):
+    #if ns is None:
+    #    ns = {}  # Ensuring a fresh dictionary per function cal    
+    #elif not isinstance(ns,dict):
+    #    args_out = [ns] + list(args)
+    #    ns={}
+    #if func is not None:
+    #    ns.update({f_name:func})  # Store function reference in namespace
+    if isinstance(ns,DictWrapper):
+        ns=ns.dict
+    if func is not None:
+        if callable(func):
+            ns[f_name]=func
+        elif isinstance(func,dict):
+            if ns is None:
+                ns=func
+                func = None
+            elif isinstance(ns,dict):
+                ns.update(func)
+        elif isinstance(func, str):
+            f_name=func
+            func=None
+    ns[r_name] = ns[f_name](*args,**kwargs)  # Directly call and store result
+    
+    return ns[r_name]  # Retrieve the computed result
+    
+def wrapped_call(func=None, ns=None, f_name="func", r_name="result"):
+    if isinstance(func, dict):  
+        if ns is None:  
+            ns = func  # If no namespace was provided, use the dictionary itself
+            func = None
+        else:  
+            ns.update(func)  # If ns exists, merge the dictionaries
+            func = none
+    if ns is None:
+        ns={}
+    
+    return lambda *args, **kwargs: call_in_namespace(func=func, ns=ns, f_name=f_name, r_name=r_name, args=args, kwargs=kwargs)
+
+
+def wrapped_exec_with_globals(code, use_globals=True):
+    """
+    Alternative version that can optionally include global variables.
+    """
+    if use_globals:
+        # Use current globals as the execution environment
+        local_vars = {}
+        exec(code, globals(), local_vars)
+        return DictWrapper(local_vars)
+    else:
+        # Clean environment
+        namespace = {}
+        exec(code, {}, namespace)
+        return DictWrapper(namespace)
+def call_function(func, *args, **kwargs):
+    """
+    Wrapper to call any Python callable object.
+    This bypasses potential issues with __call__ in Janus.
+    """
+    return func(*args, **kwargs)
+def call_with_args(func, args_list):
+    """
+    Call a function with arguments from a list, expanding them as positional arguments.
+    
+    Args:
+        func: The callable function
+        args_list: List of arguments to expand and pass to the function
+    
+    Returns:
+        Result of the function call
+    """
+    return func(*args_list)
+
+def call_with_kwargs(func, kwargs_dict):
+    """
+    Call a function with keyword arguments from a dictionary.
+    
+    Args:
+        func: The callable function  
+        kwargs_dict: Dictionary of keyword arguments
+    
+    Returns:
+        Result of the function call
+    """
+    return func(**kwargs_dict)
+
+def call_with_mixed_args(func, args_list=None, kwargs_dict=None):
+    """
+    Call a function with both positional and keyword arguments.
+    
+    Args:
+        func: The callable function
+        args_list: List of positional arguments (optional)
+        kwargs_dict: Dictionary of keyword arguments (optional)
+    
+    Returns:
+        Result of the function call
+    """
+    args = args_list or []
+    kwargs = kwargs_dict or {}
+    return func(*args, **kwargs)
+def wrap(d):
+    if isinstance(d,DictWrapper):
+        return d
+    else:
+        return DictWrapper(d)
+def get_dict_value(d, key, default=None):
+    return d.get(key, default)
+    
+def set_dict_value(d, key, value):
+    out=wrap(d)
+    out.set(key,value)
+    return out
+def getattr_wrapped(obj,key):
+    value=getattr(obj,key)
+    if isinstance(value,dict):
+        value=wrap(value)
+    return value
+class BoundCallable:
+    def __init__(self, func, context, func_name=None):
+        self.func = func
+        self.context = context
+        self.name = func_name or getattr(func, '__name__', 'anonymous')
+    
+    def __call__(self, *args, **kwargs):
+        try:
+            return self.func(self.context, *args, **kwargs)
+        except Exception as e:
+            raise RuntimeError(f"Error in {self.name}: {e}") from e
+    
+    def __repr__(self):
+        return f"BoundCallable({self.name}, context={type(self.context).__name__})"
+
+import inspect
+import sys
+
+def get_module_classes(module=None):
+    """
+    Get all classes defined in a module.
+    
+    Args:
+        module: Module object (defaults to current module)
+    
+    Returns:
+        Dictionary mapping class names to class objects
+    """
+    if module is None:
+        module = sys.modules[__name__]
+    
+    # Get classes defined in this module (not imported ones)
+    classes = {}
+    for name, obj in inspect.getmembers(module, inspect.isclass):
+        if obj.__module__ == module.__name__:
+            classes[name] = obj
+    
+    return classes
+
+def get_class_constructor(class_name, module=None):
+    """
+    Get a specific class constructor by name.
+    
+    Args:
+        class_name: Name of the class
+        module: Module object (defaults to current module)
+    
+    Returns:
+        Class constructor or None if not found
+    """
+    classes = get_module_classes(module) # Inherits current module default
+    return classes.get(class_name)
+
+def get_all_constructors(module=None):
+    """
+    Get all class constructors as a dictionary.
+    Same as get_module_classes but more explicit naming.
+    """
+    return get_module_classes(module)
+
+def create_constructor_factory(module=None):
+    """
+    Create a factory function that returns constructors by name.
+    
+    Returns:
+        Function that takes class_name and returns constructor
+    """
+    classes = get_module_classes(module)
+    return lambda class_name: classes.get(class_name)
+def get_current_module():
+    """Get reference to current module."""
+    return sys.modules[__name__]
+def call_and_wrap(func, *args, **kwargs):
+    """
+    Call a Python function and automatically wrap dictionary results.
+    
+    This solves the problem where Python functions return dictionaries
+    that lose their object behavior when passed to Prolog.
+    
+    Args:
+        func: The Python function to call
+        *args: Positional arguments for the function
+        **kwargs: Keyword arguments for the function
+    
+    Returns:
+        - DictWrapper if result is a dict
+        - Original result otherwise
+    """
+    result = func(*args, **kwargs)
+    if isinstance(result, dict):
+        return DictWrapper(result)
+    return result
+    

--- a/src/unifyweaver/glue/rpyc/remote_execution.py
+++ b/src/unifyweaver/glue/rpyc/remote_execution.py
@@ -1,0 +1,880 @@
+"""
+remote_execution.py - RPyC Remote Execution for UnifyWeaver
+
+Adapted from JanusBridge project by John William Creighton (s243a)
+
+Provides network-based RPC with live object proxies through RPyC,
+supporting SSH/SSL/unsecured connection modes and four proxy layers.
+"""
+
+import rpyc
+import subprocess
+import time
+import getpass
+import os
+import stat
+import pathlib
+import traceback
+import types
+import logging
+from contextlib import contextmanager
+from typing import Optional, Dict, Any, Callable
+
+# UnifyWeaver logger
+logger = logging.getLogger("unifyweaver.rpyc")
+
+
+def setup_logging(level=logging.INFO, format_str=None):
+    """
+    Configure logging for unifyweaver.rpyc module.
+
+    Args:
+        level: Logging level (default: INFO)
+        format_str: Custom format string for log messages
+    """
+    format_str = format_str or "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    logging.basicConfig(level=level, format=format_str)
+    logger.setLevel(level)
+
+
+# Import DictWrapper from local module
+try:
+    from .dict_wrapper import DictWrapper, wrapped_exec, call_function
+except ImportError:
+    from dict_wrapper import DictWrapper, wrapped_exec, call_function
+
+
+class ConfigurableRPyCBridge:
+    """
+    RPyC bridge with configurable security tunneling.
+
+    Supports three connection modes:
+    - ssh: SSH tunnel (recommended for production)
+    - ssl: SSL/TLS with certificates
+    - unsecured: Plain TCP (development only)
+    """
+
+    def __init__(self, host: str, tunnel_type: str = 'ssh',
+                 acknowledge_risk: bool = False, **kwargs):
+        """
+        Initialize RPyC bridge.
+
+        Args:
+            host: Remote host address
+            tunnel_type: Connection security mode ('ssh', 'ssl', 'unsecured')
+            acknowledge_risk: Required for unsecured connections
+            **kwargs: Additional configuration options
+        """
+        self.host = host
+        self.tunnel_type = tunnel_type
+        self.connection = None
+        self.ssh_process = None
+        self.acknowledge_risk = acknowledge_risk
+        self.config = self._setup_config(**kwargs)
+
+        # Security check for unsecured connections
+        if tunnel_type == 'unsecured':
+            self._validate_unsecured_connection()
+
+    def _setup_config(self, **kwargs) -> Dict[str, Any]:
+        """Setup configuration based on tunnel type."""
+        config = {
+            'remote_port': kwargs.get('remote_port', 18812),
+            'local_port': kwargs.get('local_port', 18813),
+        }
+
+        if self.tunnel_type == 'ssh':
+            config.update({
+                'ssh_user': kwargs.get('ssh_user', getpass.getuser()),
+                'ssh_password': kwargs.get('ssh_password'),
+                'ssh_port': kwargs.get('ssh_port', 22),
+                'ssh_key': kwargs.get('ssh_key'),
+            })
+        elif self.tunnel_type == 'ssl':
+            config.update({
+                'keyfile': kwargs.get('keyfile', 'client.key'),
+                'certfile': kwargs.get('certfile', 'client.cert'),
+                'ca_certs': kwargs.get('ca_certs', 'ca.cert')
+            })
+
+        return config
+
+    def _validate_unsecured_connection(self):
+        """Validate that unsecured connection is explicitly acknowledged."""
+        if not self.acknowledge_risk:
+            raise SecurityError(
+                "Unsecured connections require acknowledge_risk=True. "
+                "This mode should only be used for development or isolated environments."
+            )
+
+        logger.warning(
+            "UNSECURED CONNECTION: Data transmitted in plain text. "
+            "Only use for development or trusted networks."
+        )
+
+    @contextmanager
+    def secure_connection(self):
+        """Context manager for secure RPyC connections."""
+        try:
+            if self.tunnel_type == 'ssh':
+                with self._ssh_tunnel():
+                    yield self._connect_via_tunnel()
+            elif self.tunnel_type == 'ssl':
+                yield self._connect_ssl()
+            elif self.tunnel_type == 'unsecured':
+                yield self._connect_unsecured()
+            else:
+                raise ValueError(f"Unknown tunnel type: {self.tunnel_type}")
+        finally:
+            self._cleanup()
+
+    def connect(self) -> 'SecureRPyCProxy':
+        """
+        Establish connection without context manager.
+
+        Returns:
+            SecureRPyCProxy: Connected proxy object
+
+        Note: Caller is responsible for calling close() when done.
+        """
+        if self.tunnel_type == 'ssh':
+            self._start_ssh_tunnel()
+            return self._connect_via_tunnel()
+        elif self.tunnel_type == 'ssl':
+            return self._connect_ssl()
+        elif self.tunnel_type == 'unsecured':
+            return self._connect_unsecured()
+        else:
+            raise ValueError(f"Unknown tunnel type: {self.tunnel_type}")
+
+    def _start_ssh_tunnel(self):
+        """Start SSH tunnel without context manager."""
+        ssh_user = self.config['ssh_user']
+        ssh_port = self.config['ssh_port']
+        local_port = self.config['local_port']
+        remote_port = self.config['remote_port']
+
+        ssh_cmd = [
+            'ssh', '-L', f'{local_port}:localhost:{remote_port}',
+            '-p', str(ssh_port),
+            '-N',
+            f'{ssh_user}@{self.host}'
+        ]
+
+        # Add SSH key if specified
+        if self.config.get('ssh_key'):
+            ssh_cmd.extend(['-i', self.config['ssh_key']])
+
+        # Add password via sshpass if specified
+        if self.config.get('ssh_password'):
+            ssh_cmd = ['sshpass', '-p', self.config['ssh_password']] + ssh_cmd
+
+        logger.info(f"Creating SSH tunnel: {ssh_user}@{self.host}:{ssh_port}")
+
+        self.ssh_process = subprocess.Popen(
+            ssh_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        time.sleep(3)
+
+        if self.ssh_process.poll() is not None:
+            stderr = self.ssh_process.stderr.read().decode()
+            raise ConnectionError(f"SSH tunnel failed: {stderr}")
+
+        logger.info("SSH tunnel established")
+
+    @contextmanager
+    def _ssh_tunnel(self):
+        """Create SSH tunnel for secure RPyC connection."""
+        try:
+            self._start_ssh_tunnel()
+            yield
+        finally:
+            if self.ssh_process:
+                self.ssh_process.terminate()
+                self.ssh_process.wait()
+                logger.info("SSH tunnel closed")
+
+    def _connect_via_tunnel(self) -> 'SecureRPyCProxy':
+        """Connect to RPyC server via SSH tunnel."""
+        local_port = self.config['local_port']
+        logger.info(f"Connecting to RPyC via tunnel (localhost:{local_port})")
+
+        conn = rpyc.connect('localhost', local_port)
+        return SecureRPyCProxy(conn, self.tunnel_type, self.config)
+
+    def _connect_ssl(self) -> 'SecureRPyCProxy':
+        """Connect to RPyC server via SSL/TLS."""
+        logger.info(f"Connecting to RPyC via SSL ({self.host})")
+
+        conn = rpyc.ssl_connect(
+            self.host,
+            self.config['remote_port'],
+            keyfile=self.config['keyfile'],
+            certfile=self.config['certfile'],
+            ca_certs=self.config['ca_certs']
+        )
+        return SecureRPyCProxy(conn, self.tunnel_type, self.config)
+
+    def _connect_unsecured(self) -> 'SecureRPyCProxy':
+        """Connect to RPyC server without security."""
+        remote_port = self.config['remote_port']
+        logger.warning(f"Connecting UNSECURED to {self.host}:{remote_port}")
+
+        try:
+            conn = rpyc.classic.connect(self.host, port=remote_port)
+            logger.info("TCP connection established")
+            return SecureRPyCProxy(conn, self.tunnel_type, self.config)
+        except Exception as e:
+            error_msg = (
+                f"Failed to connect to RPyC server at {self.host}:{remote_port}.\n"
+                "Ensure the server is running."
+            )
+            raise ConnectionError(error_msg) from e
+
+    def _cleanup(self):
+        """Cleanup resources."""
+        if self.ssh_process:
+            try:
+                self.ssh_process.terminate()
+                self.ssh_process.wait(timeout=3)
+            except Exception as e:
+                logger.warning(f"SSH cleanup warning: {e}")
+            self.ssh_process = None
+
+        if self.connection:
+            try:
+                self.connection.close()
+            except Exception:
+                pass
+            self.connection = None
+
+
+class SecurityError(Exception):
+    """Raised when security requirements are not met."""
+    pass
+
+
+class LocalMethods:
+    """Client-side methods that can use remote or local execution."""
+
+    def __init__(self, proxy: 'SecureRPyCProxy'):
+        self._proxy = proxy
+
+    def wrapped_exec(self, code: str, initial_vars: Optional[Dict] = None) -> DictWrapper:
+        """
+        Execute Python code remotely, returning results in a DictWrapper.
+
+        Args:
+            code: Python code string to execute
+            initial_vars: Optional initial variables dictionary
+
+        Returns:
+            DictWrapper containing execution namespace
+        """
+        try:
+            remote_dict_wrapper = self._proxy.conn.modules['dict_wrapper']
+            result = remote_dict_wrapper.wrapped_exec(code, initial_vars)
+            return DictWrapper(result.dict if hasattr(result, 'dict') else result)
+        except Exception:
+            return self._basic_remote_exec(code, initial_vars)
+
+    def _basic_remote_exec(self, code: str, initial_vars: Optional[Dict] = None) -> DictWrapper:
+        """Basic remote code execution without dict_wrapper."""
+        namespace = initial_vars or {}
+        remote_builtins = self._proxy.conn.modules.builtins
+        remote_builtins.exec(code, remote_builtins.__dict__, namespace)
+        return DictWrapper(namespace)
+
+    def call_function(self, func: Callable, *args, **kwargs):
+        """Call a function (remote or local) with arguments."""
+        return func(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        """Route to remote exposed methods if not found locally."""
+        if hasattr(self._proxy.conn.root, 'exposed_' + name):
+            def remote_method(*args, **kwargs):
+                return getattr(self._proxy.conn.root, 'exposed_' + name)(*args, **kwargs)
+            return remote_method
+        raise AttributeError(f"No local or remote method named '{name}'")
+
+
+# =============================================================================
+# Proxy Layer 1: RootProxy - Direct exposed_ method access
+# =============================================================================
+
+class RootProxy:
+    """
+    Layer 1: Direct access to exposed_ methods on the remote server.
+
+    Use for simple RPC calls where you know the method name.
+    """
+
+    def __init__(self, parent_proxy: 'SecureRPyCProxy'):
+        self._parent_proxy = parent_proxy
+
+    def __getattr__(self, name: str):
+        exposed_name = 'exposed_' + name
+        proxy = self._parent_proxy
+
+        if hasattr(proxy.conn.root, exposed_name):
+            def remote_method(*args, **kwargs):
+                result = getattr(proxy.conn.root, exposed_name)(*args, **kwargs)
+                logger.debug(f"{exposed_name}({args}, {kwargs}) -> {result}")
+                return result
+            return remote_method
+
+        # Fallback to local_methods
+        if hasattr(proxy.local_methods, name):
+            return getattr(proxy.local_methods, name)
+
+        raise AttributeError(f"No remote or local method named '{name}'")
+
+
+# =============================================================================
+# Proxy Layer 2: ClientModuleWrapper - Safe attribute access
+# =============================================================================
+
+class ClientModuleAdapter:
+    """Client-side adapter for remote module proxies."""
+
+    def __init__(self, remote_proxy):
+        self._remote = remote_proxy
+
+    def __getattr__(self, name: str):
+        result = getattr(self._remote, name)
+        return ClientModuleWrapper(result, name)
+
+
+class ClientModuleWrapper:
+    """
+    Layer 2: Safe attribute access wrapper.
+
+    Prevents accidental execution by wrapping all attribute access.
+    Use when you need to navigate remote objects safely.
+    """
+
+    def __init__(self, remote_proxy, display_name: Optional[str] = None):
+        object.__setattr__(self, '_proxy', remote_proxy)
+        object.__setattr__(self, '_display_name',
+                          display_name or self._get_default_name(remote_proxy))
+
+    def _get_default_name(self, obj) -> str:
+        if hasattr(obj, '__name__'):
+            return obj.__name__
+        if hasattr(obj, '__class__'):
+            return obj.__class__.__name__
+        return str(type(obj))
+
+    def __getattr__(self, name: str):
+        _proxy = object.__getattribute__(self, '_proxy')
+        unwrapped = getattr(_proxy, name)
+        return ClientModuleWrapper(unwrapped, getattr(unwrapped, '__name__', name))
+
+    def __call__(self, *args, **kwargs):
+        _proxy = object.__getattribute__(self, '_proxy')
+        result = _proxy(*args, **kwargs)
+        return ClientModuleWrapper(result)
+
+    def __str__(self):
+        _display_name = object.__getattribute__(self, '_display_name')
+        _proxy = object.__getattribute__(self, '_proxy')
+        return f"<ClientModuleWrapper for '{_display_name}' [{type(_proxy).__name__}]>"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+# =============================================================================
+# Proxy Layer 3: AutoWrapProxy - Automatic wrapping
+# =============================================================================
+
+def is_rpyc_proxy(obj) -> bool:
+    """Check if an object is an RPyC proxy (netref)."""
+    if hasattr(obj, '__class__') and getattr(obj.__class__, '__module__', '').startswith('rpyc.core.netref'):
+        return True
+    try:
+        if isinstance(obj, rpyc.core.netref.BaseNetref):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def is_simple_type(obj) -> bool:
+    """Check if object is a simple type that doesn't need wrapping."""
+    return isinstance(obj, (int, float, str, bytes, bool, type(None), list, dict, tuple, set))
+
+
+def is_routing_remote_method(obj) -> bool:
+    """Detect if obj is a local routing function from RootProxy."""
+    return (
+        type(obj) is types.FunctionType and
+        getattr(obj, '__name__', '') == 'remote_method' and
+        'RootProxy.__getattr__' in getattr(obj, '__qualname__', '')
+    )
+
+
+class AutoWrapProxy:
+    """
+    Layer 3: Automatically wraps RPyC proxies for better usability.
+
+    General-purpose proxy that automatically wraps remote objects
+    to provide consistent access patterns.
+    """
+
+    def __init__(self, remote_proxy, name: Optional[str] = None,
+                 pre_should_wrap: Optional[Callable] = None,
+                 post_should_wrap: Optional[Callable] = None):
+        object.__setattr__(self, '_remote', remote_proxy)
+        object.__setattr__(self, '_name', name or self._get_safe_name(remote_proxy))
+        object.__setattr__(self, 'pre_should_wrap', pre_should_wrap or (lambda x: False))
+        object.__setattr__(self, 'post_should_wrap', post_should_wrap or (lambda x, y: y))
+
+    def _get_safe_name(self, obj) -> str:
+        """Safely get a name for the object."""
+        try:
+            if hasattr(obj, '__name__'):
+                return obj.__name__
+            elif hasattr(obj, '__class__'):
+                return obj.__class__.__name__
+            else:
+                return str(type(obj).__name__)
+        except Exception:
+            return 'UnknownProxy'
+
+    def __getattr__(self, name: str):
+        if name == '__call__':
+            return object.__getattribute__(self, '__call__')
+
+        _remote = object.__getattribute__(self, '_remote')
+        attr = getattr(_remote, name)
+
+        if self.should_wrap(attr):
+            _name = object.__getattribute__(self, '_name')
+            return self.wrap(attr, _name)
+        return attr
+
+    def __call__(self, *args, **kwargs):
+        _remote = object.__getattribute__(self, '_remote')
+        result = _remote(*args, **kwargs)
+
+        if self.should_wrap(result):
+            return self.wrap(result)
+        return result
+
+    def should_wrap(self, obj) -> bool:
+        """Determine if object should be wrapped."""
+        pre_should_wrap = object.__getattribute__(self, 'pre_should_wrap')
+        post_should_wrap = object.__getattribute__(self, 'post_should_wrap')
+
+        wrap_value = False
+
+        if pre_should_wrap(obj):
+            wrap_value = True
+        elif is_rpyc_proxy(obj) and not is_simple_type(obj):
+            wrap_value = True
+        elif is_routing_remote_method(obj):
+            wrap_value = True
+
+        return post_should_wrap(obj, wrap_value)
+
+    def wrap(self, obj, name: Optional[str] = None):
+        """Create a new wrapped instance."""
+        if name is None:
+            name = self._get_safe_name(obj)
+        return self.__class__(obj, name)
+
+
+# =============================================================================
+# Proxy Layer 4: SmartAutoWrapProxy - Local-class-aware wrapping
+# =============================================================================
+
+class SmartAutoWrapProxy(AutoWrapProxy):
+    """
+    Layer 4: Smart proxy that only wraps when class isn't available locally.
+
+    Useful for code generation scenarios where you want to use local
+    classes when available but proxy remote ones.
+    """
+
+    def __init__(self, remote_proxy, name: Optional[str] = None,
+                 connection=None):
+        super().__init__(remote_proxy, name)
+        object.__setattr__(self, '_connection', connection)
+        object.__setattr__(self, '_local_class', self._check_local_class())
+
+    def _check_local_class(self):
+        """Check if the remote object's class exists locally."""
+        try:
+            _remote = object.__getattribute__(self, '_remote')
+            remote_class = getattr(_remote, '__class__', None)
+            if not remote_class:
+                return None
+
+            remote_class_name = getattr(remote_class, '__name__', None)
+            remote_module_name = getattr(remote_class, '__module__', None)
+
+            if not (remote_class_name and remote_module_name):
+                return None
+
+            import importlib
+            try:
+                module = importlib.import_module(remote_module_name)
+                return getattr(module, remote_class_name, None)
+            except (ImportError, AttributeError):
+                return None
+        except Exception:
+            return None
+
+    def should_wrap(self, obj) -> bool:
+        """Override to consider local class availability."""
+        _local_class = object.__getattribute__(self, '_local_class')
+        if _local_class is not None:
+            try:
+                if isinstance(obj, _local_class):
+                    return False
+            except Exception:
+                pass
+        return super().should_wrap(obj)
+
+    def get_wrapped_smartly(self, module_name: str):
+        """Get a module with smart wrapping based on local availability."""
+        _connection = object.__getattribute__(self, '_connection')
+        if _connection:
+            checker = self._create_class_checker()
+            module = _connection.root.exposed_import_with_smart_wrap(
+                module_name,
+                checker
+            )
+            if self.should_wrap(module):
+                return self.wrap(module, module_name)
+            return module
+        return None
+
+    def _create_class_checker(self) -> Callable:
+        """Create a function for server callback to check local class availability."""
+        def check_class_locally(class_info):
+            import importlib
+            try:
+                module = importlib.import_module(class_info['module'])
+                return hasattr(module, class_info['name'])
+            except ImportError:
+                return False
+        return check_class_locally
+
+    def __getattr__(self, name: str):
+        if name == "import_with_smart_wrap":
+            return self.get_wrapped_smartly
+        return super().__getattr__(name)
+
+
+# =============================================================================
+# SecureRPyCProxy - Main proxy class with all layers
+# =============================================================================
+
+class SecureRPyCProxy:
+    """
+    Main proxy for RPyC connections with four access layers.
+
+    Properties:
+        root: Layer 1 - Direct exposed_ method access
+        wrapped_root: Layer 2 - Safe attribute access
+        auto_root: Layer 3 - Automatic wrapping
+        smart_root: Layer 4 - Local-class-aware wrapping
+        modules: Direct access to remote Python modules
+    """
+
+    def __init__(self, rpyc_connection, tunnel_type: str, config: Optional[Dict] = None):
+        self.conn = rpyc_connection
+        self.tunnel_type = tunnel_type
+        self.config = config or {}
+        self.local_methods = LocalMethods(self)
+        self._validate_connection()
+
+    def _validate_connection(self):
+        """Validate the RPyC connection is working."""
+        try:
+            if not hasattr(self.conn, 'modules'):
+                raise AttributeError("Not a valid RPyC connection")
+
+            # Test basic connection
+            _ = self.conn.modules.sys
+            logger.info("RPyC connection validated")
+
+            # Check for dict_wrapper availability
+            try:
+                _ = self.conn.modules['dict_wrapper']
+                logger.debug("dict_wrapper available remotely")
+            except Exception:
+                logger.debug("dict_wrapper not available remotely")
+
+        except Exception as e:
+            logger.error(f"RPyC connection validation failed: {e}")
+            raise
+
+    @property
+    def root(self) -> RootProxy:
+        """Layer 1: Direct exposed_ method access."""
+        return RootProxy(self)
+
+    @property
+    def wrapped_root(self) -> ClientModuleAdapter:
+        """Layer 2: Safe attribute access wrapper."""
+        return ClientModuleAdapter(self.root)
+
+    @property
+    def auto_root(self) -> AutoWrapProxy:
+        """Layer 3: Automatic wrapping proxy."""
+        return AutoWrapProxy(self.root)
+
+    @property
+    def smart_root(self) -> SmartAutoWrapProxy:
+        """Layer 4: Smart local-class-aware proxy."""
+        return SmartAutoWrapProxy(self.root, connection=self.conn)
+
+    @property
+    def modules(self):
+        """Direct access to remote Python modules."""
+        if not hasattr(self.conn, 'modules'):
+            raise AttributeError("No RPyC server connection")
+        return self.conn.modules
+
+    def get_module(self, full_name: str):
+        """Import a module on the remote server."""
+        remote_importlib = self.conn.modules.importlib
+        return remote_importlib.import_module(full_name)
+
+    def close(self):
+        """Close the RPyC connection."""
+        if self.conn:
+            self.conn.close()
+
+
+# =============================================================================
+# Async Support
+# =============================================================================
+
+class AsyncResult:
+    """
+    Wrapper for RPyC async results.
+
+    Provides a consistent interface for async operations.
+    """
+
+    def __init__(self, async_result):
+        self._result = async_result
+
+    @property
+    def ready(self) -> bool:
+        """Check if the result is ready."""
+        return self._result.ready
+
+    def wait(self, timeout: Optional[float] = None):
+        """Wait for the result to be ready."""
+        self._result.wait(timeout)
+
+    @property
+    def value(self):
+        """Get the result value (blocks if not ready)."""
+        return self._result.value
+
+    @property
+    def error(self):
+        """Get any error that occurred."""
+        return self._result.error
+
+
+def async_call(proxy: SecureRPyCProxy, module_name: str,
+               func_name: str, args: tuple = (), kwargs: dict = None) -> AsyncResult:
+    """
+    Make an asynchronous call to a remote function.
+
+    Args:
+        proxy: SecureRPyCProxy connection
+        module_name: Name of the remote module
+        func_name: Name of the function to call
+        args: Positional arguments
+        kwargs: Keyword arguments
+
+    Returns:
+        AsyncResult that can be awaited
+    """
+    kwargs = kwargs or {}
+    module = proxy.get_module(module_name)
+    func = getattr(module, func_name)
+
+    # RPyC async wrapper
+    async_func = rpyc.async_(func)
+    result = async_func(*args, **kwargs)
+
+    return AsyncResult(result)
+
+
+# =============================================================================
+# Factory Functions
+# =============================================================================
+
+def create_ssh_bridge(host: str, user: Optional[str] = None,
+                      password: Optional[str] = None, **kwargs) -> ConfigurableRPyCBridge:
+    """
+    Create SSH-tunneled RPyC bridge (recommended for production).
+
+    Args:
+        host: Remote host address
+        user: SSH username (default: current user)
+        password: SSH password (optional, prefer key-based auth)
+        **kwargs: Additional options (ssh_port, ssh_key, remote_port, etc.)
+    """
+    config = {'ssh_user': user or getpass.getuser()}
+    if password:
+        config['ssh_password'] = password
+    config.update(kwargs)
+    return ConfigurableRPyCBridge(host, tunnel_type='ssh', **config)
+
+
+def create_ssl_bridge(host: str, keyfile: Optional[str] = None,
+                      certfile: Optional[str] = None,
+                      ca_certs: Optional[str] = None, **kwargs) -> ConfigurableRPyCBridge:
+    """
+    Create SSL/TLS RPyC bridge.
+
+    Args:
+        host: Remote host address
+        keyfile: Path to client key file
+        certfile: Path to client certificate file
+        ca_certs: Path to CA certificates file
+    """
+    config = {}
+    if keyfile:
+        config['keyfile'] = keyfile
+    if certfile:
+        config['certfile'] = certfile
+    if ca_certs:
+        config['ca_certs'] = ca_certs
+    config.update(kwargs)
+    return ConfigurableRPyCBridge(host, tunnel_type='ssl', **config)
+
+
+def create_unsecured_bridge(host: str, acknowledge_risk: bool = False,
+                           **kwargs) -> ConfigurableRPyCBridge:
+    """
+    Create unsecured RPyC bridge (development/isolated environments only).
+
+    Args:
+        host: Remote host address
+        acknowledge_risk: Must be True to use unsecured connections
+
+    Warning:
+        Only use for development, testing, or isolated virtual machines.
+        Data is transmitted in plain text with no authentication.
+    """
+    return ConfigurableRPyCBridge(
+        host,
+        tunnel_type='unsecured',
+        acknowledge_risk=acknowledge_risk,
+        **kwargs
+    )
+
+
+# =============================================================================
+# Server Generation
+# =============================================================================
+
+def generate_rpyc_server_script(output_file: str = 'rpyc_server.py',
+                                service_name: str = 'UnifyWeaverService') -> str:
+    """
+    Generate an RPyC server setup script.
+
+    Args:
+        output_file: Output file path
+        service_name: Name for the generated service class
+
+    Returns:
+        Path to generated file
+    """
+    server_script = f'''#!/usr/bin/env python3
+"""
+RPyC Server for UnifyWeaver Remote Integration
+Generated by UnifyWeaver RPyC Transport
+"""
+
+import rpyc
+from rpyc.utils.server import ThreadedServer
+from rpyc.core.service import ClassicService
+import sys
+import os
+
+
+class {service_name}(ClassicService):
+    """RPyC service with UnifyWeaver integration."""
+
+    def on_connect(self, conn):
+        print(f"Client connected")
+        self._setup_environment()
+
+    def on_disconnect(self, conn):
+        print("Client disconnected")
+
+    def _setup_environment(self):
+        """Setup environment on the server."""
+        # Add paths for UnifyWeaver modules
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Try to import dict_wrapper
+        try:
+            import dict_wrapper
+            print("+ dict_wrapper loaded")
+        except ImportError as e:
+            print(f"- dict_wrapper not found: {{e}}")
+
+
+def start_server(port: int = 18812, mode: str = 'unsecured'):
+    """Start RPyC server."""
+    print("=" * 50)
+    print(f"Starting {{mode.upper()}} RPyC server on port {{port}}")
+    print("=" * 50)
+
+    if mode == 'unsecured':
+        print("WARNING: This server provides UNSECURED access!")
+        print("Only use for development or isolated environments.")
+
+    server = ThreadedServer(
+        {service_name},
+        port=port,
+        protocol_config={{"allow_all_attrs": True}}
+    )
+    print(f"RPyC server listening on port {{port}}")
+    print("Press Ctrl+C to stop")
+
+    try:
+        server.start()
+    except KeyboardInterrupt:
+        print("\\nStopping server...")
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='UnifyWeaver RPyC Server')
+    parser.add_argument('--mode', choices=['unsecured', 'ssl'], default='unsecured',
+                       help='Server security mode')
+    parser.add_argument('--port', type=int, default=18812,
+                       help='Server port (default: 18812)')
+
+    args = parser.parse_args()
+    start_server(args.port, args.mode)
+'''
+
+    pathlib.Path(output_file).write_text(server_script, encoding='utf-8')
+
+    # Make executable on Unix-like systems
+    try:
+        pathlib.Path(output_file).chmod(stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
+    except Exception:
+        pass
+
+    logger.info(f"RPyC server script generated: {output_file}")
+    return output_file

--- a/src/unifyweaver/glue/rpyc_glue.pl
+++ b/src/unifyweaver/glue/rpyc_glue.pl
@@ -1,0 +1,571 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% rpyc_glue.pl - Network-Based Python Communication via RPyC
+%
+% This module provides glue code for network-based RPC communication
+% between Prolog and Python using RPyC (Remote Python Call).
+%
+% Unlike pipe-based communication, RPyC provides:
+% - Live object proxies over the network
+% - Bidirectional calls between client and server
+% - Full module access on remote machines
+% - SSH/SSL/unsecured security modes
+%
+% Unlike Janus (in-process), RPyC enables:
+% - Remote machine access
+% - Process isolation
+% - Language-agnostic client connections
+%
+% Four Proxy Layers:
+% - root: Direct exposed_ method access (simple RPC)
+% - wrapped_root: Safe attribute access (prevent accidental execution)
+% - auto_root: Automatic wrapping (general use)
+% - smart_root: Local-class-aware wrapping (code generation)
+%
+% Requirements:
+% - Python 3.8+ with rpyc package
+% - Janus for Prolog-Python bridge (or external process)
+% - For SSH: ssh command and optionally sshpass
+% - For SSL: valid certificates
+%
+% Usage:
+%   ?- rpyc_connect('localhost', [security(unsecured), acknowledge_risk(true)], Proxy).
+%   ?- rpyc_call(Proxy, math, sqrt, [16], Result).
+%   ?- rpyc_disconnect(Proxy).
+
+:- module(rpyc_glue, [
+    % Connection management
+    rpyc_connect/3,           % +Host, +Options, -Proxy
+    rpyc_disconnect/1,        % +Proxy
+    rpyc_with_connection/3,   % +Host, +Options, :Goal
+
+    % Remote execution (sync)
+    rpyc_call/5,              % +Proxy, +Module, +Function, +Args, -Result
+    rpyc_exec/3,              % +Proxy, +Code, -Namespace
+
+    % Remote execution (async)
+    rpyc_async_call/5,        % +Proxy, +Module, +Function, +Args, -AsyncResult
+    rpyc_await/2,             % +AsyncResult, -Result
+    rpyc_ready/1,             % +AsyncResult (succeeds if ready)
+
+    % Module access
+    rpyc_import/3,            % +Proxy, +ModuleName, -ModuleRef
+    rpyc_get_module/3,        % +Proxy, +FullModuleName, -ModuleRef
+
+    % Proxy layers
+    rpyc_root/2,              % +Proxy, -RootProxy
+    rpyc_wrapped_root/2,      % +Proxy, -WrappedRoot
+    rpyc_auto_root/2,         % +Proxy, -AutoRoot
+    rpyc_smart_root/2,        % +Proxy, -SmartRoot
+
+    % Code generation
+    generate_rpyc_client/3,   % +Predicates, +Options, -Code
+    generate_rpyc_service/3,  % +Predicates, +Options, -ServiceCode
+    generate_rpyc_server/2,   % +Options, -ServerScript
+
+    % Transport registration
+    rpyc_transport_type/1,
+
+    % Testing
+    test_rpyc_glue/0
+]).
+
+:- use_module(library(lists)).
+
+% Conditionally load Janus if available
+:- catch(use_module(library(janus)), _, true).
+
+%% ============================================
+%% Transport Registration
+%% ============================================
+
+%% rpyc_transport_type(-Type)
+%  Register RPyC as a transport type.
+rpyc_transport_type(rpyc).
+
+%% ============================================
+%% Connection Management
+%% ============================================
+
+%% rpyc_connect(+Host, +Options, -Proxy)
+%  Connect to an RPyC server.
+%
+%  Options:
+%    security(Mode) - One of: ssh, ssl, unsecured
+%    remote_port(Port) - Server port (default: 18812)
+%    acknowledge_risk(Bool) - Required for unsecured connections
+%
+%  SSH-specific options:
+%    ssh_user(User) - SSH username
+%    ssh_port(Port) - SSH port (default: 22)
+%    ssh_key(Path) - Path to SSH key file
+%
+%  SSL-specific options:
+%    keyfile(Path) - Client key file
+%    certfile(Path) - Client certificate file
+%    ca_certs(Path) - CA certificates file
+%
+%  Example:
+%    ?- rpyc_connect('localhost', [security(unsecured), acknowledge_risk(true)], Proxy).
+%
+rpyc_connect(Host, Options, Proxy) :-
+    atom(Host),
+    is_list(Options),
+    option(security(Security), Options, unsecured),
+    validate_security_mode(Security, Options),
+    create_bridge(Host, Security, Options, Bridge),
+    connect_bridge(Bridge, Proxy).
+
+%% validate_security_mode(+Security, +Options)
+%  Validate that security requirements are met.
+validate_security_mode(unsecured, Options) :-
+    !,
+    (   option(acknowledge_risk(true), Options)
+    ->  true
+    ;   throw(error(security_error('Unsecured connections require acknowledge_risk(true)'), _))
+    ).
+validate_security_mode(ssh, _) :- !.
+validate_security_mode(ssl, _) :- !.
+validate_security_mode(Mode, _) :-
+    throw(error(domain_error(security_mode, Mode), _)).
+
+%% create_bridge(+Host, +Security, +Options, -Bridge)
+%  Create an RPyC bridge via Janus.
+create_bridge(Host, Security, Options, Bridge) :-
+    janus_available,
+    !,
+    janus_add_rpyc_path,
+    atom_string(Host, HostStr),
+    atom_string(Security, SecStr),
+    build_py_bridge_call(HostStr, SecStr, Options, Bridge).
+create_bridge(_, _, _, _) :-
+    throw(error(janus_not_available, 'RPyC glue requires Janus for Python bridging')).
+
+%% build_py_bridge_call(+HostStr, +SecStr, +Options, -Bridge)
+%  Build the Python bridge call with options.
+build_py_bridge_call(HostStr, SecStr, Options, Bridge) :-
+    % Extract commonly used options
+    option(remote_port(Port), Options, 18812),
+    option(acknowledge_risk(AckRisk), Options, false),
+    py_call(
+        'unifyweaver.glue.rpyc':'ConfigurableRPyCBridge'(
+            HostStr,
+            tunnel_type=SecStr,
+            remote_port=Port,
+            acknowledge_risk=AckRisk
+        ),
+        Bridge
+    ).
+
+%% build_bridge_options(+Options, -BridgeOpts)
+%  Convert Prolog options to Python kwargs dictionary.
+build_bridge_options(Options, BridgeOpts) :-
+    findall(Key=Value, (
+        member(Opt, Options),
+        option_to_python(Opt, Key, Value)
+    ), Pairs),
+    dict_create(BridgeOpts, _, Pairs).
+
+option_to_python(remote_port(P), remote_port, P) :- !.
+option_to_python(local_port(P), local_port, P) :- !.
+option_to_python(ssh_user(U), ssh_user, U) :- atom(U), !.
+option_to_python(ssh_port(P), ssh_port, P) :- !.
+option_to_python(ssh_key(K), ssh_key, K) :- atom(K), !.
+option_to_python(keyfile(F), keyfile, F) :- atom(F), !.
+option_to_python(certfile(F), certfile, F) :- atom(F), !.
+option_to_python(ca_certs(F), ca_certs, F) :- atom(F), !.
+option_to_python(acknowledge_risk(B), acknowledge_risk, B) :- !.
+option_to_python(_, _, _) :- fail.
+
+%% connect_bridge(+Bridge, -Proxy)
+%  Establish connection using the bridge.
+connect_bridge(Bridge, Proxy) :-
+    py_call(Bridge:connect(), Proxy).
+
+%% rpyc_disconnect(+Proxy)
+%  Disconnect from an RPyC server.
+rpyc_disconnect(Proxy) :-
+    catch(
+        py_call(Proxy:close(), _),
+        _,
+        true
+    ).
+
+%% rpyc_with_connection(+Host, +Options, :Goal)
+%  Execute Goal with an RPyC connection, ensuring cleanup.
+%
+%  Example:
+%    ?- rpyc_with_connection('localhost',
+%           [security(unsecured), acknowledge_risk(true)],
+%           rpyc_call(Proxy, math, sqrt, [16], R)).
+%
+:- meta_predicate rpyc_with_connection(+, +, 0).
+rpyc_with_connection(Host, Options, Goal) :-
+    setup_call_cleanup(
+        rpyc_connect(Host, Options, Proxy),
+        call(Goal, Proxy),
+        rpyc_disconnect(Proxy)
+    ).
+
+%% ============================================
+%% Path Management
+%% ============================================
+
+%% janus_add_rpyc_path
+%  Add the UnifyWeaver RPyC module path to Python.
+janus_add_rpyc_path :-
+    % Try multiple approaches to find the src directory
+    (   % Method 1: From source_file
+        source_file(rpyc_glue:_, SrcFile),
+        file_directory_name(SrcFile, GlueDir),
+        file_directory_name(GlueDir, UnifyWeaverDir),
+        file_directory_name(UnifyWeaverDir, SrcDir),
+        py_add_lib_dir(SrcDir)
+    ;   % Method 2: From working directory
+        working_directory(Cwd, Cwd),
+        atomic_list_concat([Cwd, '/src'], SrcPath),
+        exists_directory(SrcPath),
+        py_add_lib_dir(SrcPath)
+    ;   % Method 3: Just add 'src' relative path
+        py_add_lib_dir(src)
+    ),
+    !.  % Succeed once
+
+%% ============================================
+%% Remote Execution (Sync)
+%% ============================================
+
+%% rpyc_call(+Proxy, +Module, +Function, +Args, -Result)
+%  Call a Python function on the remote server.
+%
+%  Example:
+%    ?- rpyc_connect(..., Proxy),
+%       rpyc_call(Proxy, math, sqrt, [16], Result).
+%    Result = 4.0.
+%
+rpyc_call(Proxy, Module, Function, Args, Result) :-
+    atom(Module),
+    atom(Function),
+    is_list(Args),
+    rpyc_get_module(Proxy, Module, ModRef),
+    py_call(ModRef:Function, TempArgs),
+    apply_args(TempArgs, Args, CallResult),
+    Result = CallResult.
+
+%% Helper to apply args - simplified approach
+apply_args(Func, [], Result) :-
+    !,
+    py_call(Func, Result).
+apply_args(Func, Args, Result) :-
+    FuncWithArgs =.. [call, Func | Args],
+    py_call(FuncWithArgs, Result).
+
+%% rpyc_exec(+Proxy, +Code, -Namespace)
+%  Execute Python code on the remote server.
+%
+%  Example:
+%    ?- rpyc_exec(Proxy, "x = 42\ny = x * 2", NS),
+%       rpyc_get_var(NS, y, Y).
+%    Y = 84.
+%
+rpyc_exec(Proxy, Code, Namespace) :-
+    string(Code),
+    py_call(Proxy:local_methods:wrapped_exec(Code), Namespace).
+
+%% ============================================
+%% Remote Execution (Async)
+%% ============================================
+
+%% rpyc_async_call(+Proxy, +Module, +Function, +Args, -AsyncResult)
+%  Make an asynchronous call to a remote function.
+%
+%  Example:
+%    ?- rpyc_async_call(Proxy, ml, train_model, [Data], Future),
+%       do_other_work,
+%       rpyc_await(Future, Model).
+%
+rpyc_async_call(Proxy, Module, Function, Args, AsyncResult) :-
+    atom(Module),
+    atom(Function),
+    is_list(Args),
+    atom_string(Module, ModStr),
+    atom_string(Function, FuncStr),
+    py_call(
+        'unifyweaver.glue.rpyc':async_call(Proxy, ModStr, FuncStr, Args),
+        AsyncResult
+    ).
+
+%% rpyc_await(+AsyncResult, -Result)
+%  Wait for and get the result of an async call.
+rpyc_await(AsyncResult, Result) :-
+    py_call(AsyncResult:value, Result).
+
+%% rpyc_ready(+AsyncResult)
+%  Succeeds if the async result is ready.
+rpyc_ready(AsyncResult) :-
+    py_call(AsyncResult:ready, true).
+
+%% ============================================
+%% Module Access
+%% ============================================
+
+%% rpyc_import(+Proxy, +ModuleName, -ModuleRef)
+%  Import a module on the remote server.
+%
+%  Example:
+%    ?- rpyc_import(Proxy, numpy, NP),
+%       py_call(NP:array([1,2,3]), Arr).
+%
+rpyc_import(Proxy, ModuleName, ModuleRef) :-
+    atom(ModuleName),
+    py_call(Proxy:modules:ModuleName, ModuleRef).
+
+%% rpyc_get_module(+Proxy, +FullModuleName, -ModuleRef)
+%  Get a module by its full dotted name.
+%
+%  Example:
+%    ?- rpyc_get_module(Proxy, 'numpy.linalg', LinAlg).
+%
+rpyc_get_module(Proxy, FullModuleName, ModuleRef) :-
+    atom(FullModuleName),
+    atom_string(FullModuleName, NameStr),
+    py_call(Proxy:get_module(NameStr), ModuleRef).
+
+%% ============================================
+%% Proxy Layers
+%% ============================================
+
+%% rpyc_root(+Proxy, -RootProxy)
+%  Get Layer 1 proxy: Direct exposed_ method access.
+%
+%  Use for simple RPC calls where you know the method name.
+%
+%  Example:
+%    ?- rpyc_root(Proxy, Root),
+%       py_call(Root:compute([1,2,3]), Result).
+%
+rpyc_root(Proxy, RootProxy) :-
+    py_call(Proxy:root, RootProxy).
+
+%% rpyc_wrapped_root(+Proxy, -WrappedRoot)
+%  Get Layer 2 proxy: Safe attribute access.
+%
+%  Prevents accidental execution by wrapping all attribute access.
+%
+rpyc_wrapped_root(Proxy, WrappedRoot) :-
+    py_call(Proxy:wrapped_root, WrappedRoot).
+
+%% rpyc_auto_root(+Proxy, -AutoRoot)
+%  Get Layer 3 proxy: Automatic wrapping.
+%
+%  General-purpose proxy that automatically wraps remote objects.
+%
+rpyc_auto_root(Proxy, AutoRoot) :-
+    py_call(Proxy:auto_root, AutoRoot).
+
+%% rpyc_smart_root(+Proxy, -SmartRoot)
+%  Get Layer 4 proxy: Local-class-aware wrapping.
+%
+%  Only wraps when the class isn't available locally.
+%  Useful for code generation scenarios.
+%
+rpyc_smart_root(Proxy, SmartRoot) :-
+    py_call(Proxy:smart_root, SmartRoot).
+
+%% ============================================
+%% Code Generation
+%% ============================================
+
+%% generate_rpyc_client(+Predicates, +Options, -Code)
+%  Generate Prolog client code for RPyC calls.
+%
+%  Example:
+%    ?- generate_rpyc_client([
+%           exposed(compute/2, [module(mymodule)])
+%       ], [host('server.local')], Code).
+%
+generate_rpyc_client(Predicates, Options, Code) :-
+    option(host(Host), Options, localhost),
+    option(security(Security), Options, unsecured),
+    findall(PredCode, (
+        member(exposed(Pred/Arity, PredOpts), Predicates),
+        generate_client_predicate(Pred, Arity, Host, Security, PredOpts, PredCode)
+    ), PredCodes),
+    atomic_list_concat(PredCodes, '\n\n', Code).
+
+generate_client_predicate(Pred, Arity, Host, Security, PredOpts, Code) :-
+    option(module(Module), PredOpts, builtins),
+    option(function(Function), PredOpts, Pred),
+    InputArity is Arity - 1,
+    generate_arg_list(InputArity, ArgList),
+    format(atom(Line1), '% RPyC wrapper for ~w/~w', [Pred, Arity]),
+    format(atom(Line2), '% Calls ~w.~w on ~w', [Module, Function, Host]),
+    format(atom(Line3), '~w(~w, Result) :-', [Pred, ArgList]),
+    format(atom(Line4), '    rpyc_connect(~q, [security(~w), acknowledge_risk(true)], Proxy),', [Host, Security]),
+    format(atom(Line5), '    rpyc_call(Proxy, ~w, ~w, [~w], Result),', [Module, Function, ArgList]),
+    Line6 = '    rpyc_disconnect(Proxy).',
+    atomic_list_concat([Line1, Line2, Line3, Line4, Line5, Line6], '\n', Code).
+
+generate_arg_list(0, '') :- !.
+generate_arg_list(1, 'Arg1') :- !.
+generate_arg_list(N, ArgList) :-
+    N > 1,
+    findall(Arg, (
+        between(1, N, I),
+        format(atom(Arg), 'Arg~w', [I])
+    ), Args),
+    atomic_list_concat(Args, ', ', ArgList).
+
+%% generate_rpyc_service(+Predicates, +Options, -ServiceCode)
+%  Generate Python RPyC service code from predicate declarations.
+%
+%  Example:
+%    ?- generate_rpyc_service([
+%           exposed(transform_data/2, [input(list), output(list)]),
+%           exposed(predict/2, [input(dict), output(float)])
+%       ], [service_name('MLService')], ServiceCode).
+%
+generate_rpyc_service(Predicates, Options, ServiceCode) :-
+    option(service_name(ServiceName), Options, 'GeneratedService'),
+    option(imports(Imports), Options, []),
+    generate_imports(Imports, ImportCode),
+    findall(MethodCode, (
+        member(exposed(Pred/_, PredOpts), Predicates),
+        generate_exposed_method(Pred, PredOpts, MethodCode)
+    ), MethodCodes),
+    atomic_list_concat(MethodCodes, '\n\n', MethodsCode),
+    format(atom(Header), '#!/usr/bin/env python3\n"""\nGenerated RPyC Service: ~w\nGenerated by UnifyWeaver\n"""', [ServiceName]),
+    format(atom(ClassDef), 'class ~w(rpyc.Service):\n    ALIASES = [~q]', [ServiceName, ServiceName]),
+    format(atom(MainBlock), 'if __name__ == "__main__":\n    server = ThreadedServer(~w, port=18812)\n    print("Starting ~w on port 18812...")\n    server.start()', [ServiceName, ServiceName]),
+    atomic_list_concat([
+        Header,
+        '',
+        'import rpyc',
+        'from rpyc.utils.server import ThreadedServer',
+        ImportCode,
+        '',
+        ClassDef,
+        '',
+        MethodsCode,
+        '',
+        MainBlock
+    ], '\n', ServiceCode).
+
+generate_imports([], '') :- !.
+generate_imports(Imports, ImportCode) :-
+    findall(Line, (
+        member(Imp, Imports),
+        format(atom(Line), 'import ~w', [Imp])
+    ), Lines),
+    atomic_list_concat(Lines, '\n', ImportCode).
+
+generate_exposed_method(Pred, Options, Code) :-
+    option(input(_), Options, any),
+    option(output(_), Options, any),
+    format(atom(Def), '    def exposed_~w(self, *args, **kwargs):', [Pred]),
+    format(atom(Doc), '        """Auto-generated exposed method for ~w"""', [Pred]),
+    format(atom(Todo), '        # TODO: Implement ~w logic', [Pred]),
+    format(atom(Raise), '        raise NotImplementedError("~w not yet implemented")', [Pred]),
+    atomic_list_concat([Def, Doc, Todo, Raise], '\n', Code).
+
+%% generate_rpyc_server(+Options, -ServerScript)
+%  Generate a complete RPyC server startup script.
+%
+%  Example:
+%    ?- generate_rpyc_server([output_file('my_server.py')], Script),
+%       write(Script).
+%
+generate_rpyc_server(Options, ServerScript) :-
+    option(service_name(ServiceName), Options, 'UnifyWeaverService'),
+    option(output_file(OutputFile), Options, 'rpyc_server.py'),
+    (   janus_available
+    ->  py_call(
+            'unifyweaver.glue.rpyc':generate_rpyc_server_script(OutputFile, ServiceName),
+            ServerScript
+        )
+    ;   format(atom(Comment), '# RPyC Server Script\n# Run: python ~w', [OutputFile]),
+        format(atom(ClassDef), 'class ~w(ClassicService):\n    pass', [ServiceName]),
+        format(atom(MainBlock), 'if __name__ == "__main__":\n    server = ThreadedServer(~w, port=18812)\n    print("Starting server on port 18812...")\n    server.start()', [ServiceName]),
+        atomic_list_concat([
+            Comment,
+            '',
+            'import rpyc',
+            'from rpyc.utils.server import ThreadedServer',
+            'from rpyc.core.service import ClassicService',
+            '',
+            ClassDef,
+            '',
+            MainBlock
+        ], '\n', ServerScript)
+    ).
+
+%% ============================================
+%% Testing
+%% ============================================
+
+%% test_rpyc_glue
+%  Run basic tests for RPyC glue functionality.
+test_rpyc_glue :-
+    format('~n=== RPyC Glue Tests ===~n'),
+
+    % Test 1: Transport registration
+    format('1. Transport registration: '),
+    (   rpyc_transport_type(rpyc)
+    ->  format('PASS~n')
+    ;   format('FAIL~n')
+    ),
+
+    % Test 2: Code generation (doesn't require connection)
+    format('2. Client code generation: '),
+    (   generate_rpyc_client([
+            exposed(compute/2, [module(math), function(sqrt)])
+        ], [host('localhost')], ClientCode),
+        ClientCode \= ''
+    ->  format('PASS~n')
+    ;   format('FAIL~n')
+    ),
+
+    % Test 3: Service code generation
+    format('3. Service code generation: '),
+    (   generate_rpyc_service([
+            exposed(transform/2, [input(list), output(list)])
+        ], [service_name('TestService')], ServiceCode),
+        ServiceCode \= ''
+    ->  format('PASS~n')
+    ;   format('FAIL~n')
+    ),
+
+    % Test 4: Janus availability check
+    format('4. Janus availability: '),
+    (   janus_available
+    ->  format('PASS (available)~n')
+    ;   format('SKIP (not available)~n')
+    ),
+
+    format('=== Tests Complete ===~n').
+
+%% ============================================
+%% Option Helper
+%% ============================================
+
+%% option(+Term, +Options, +Default)
+%  Get option value with default.
+option(Term, Options, _Default) :-
+    member(Term, Options),
+    !.
+option(Term, _Options, Default) :-
+    Term =.. [_Name, Default],
+    !.
+option(Term, _Options, _Default) :-
+    Term =.. [Name, _],
+    throw(error(existence_error(option, Name), _)).
+
+%% janus_available
+%  Check if Janus is available.
+janus_available :-
+    catch(
+        current_module(janus),
+        _,
+        fail
+    ).


### PR DESCRIPTION
  ## Summary

  Adds RPyC as a new transport type for the cross-target glue system, enabling network-based RPC with live object proxies from Prolog via Janus.

  - **Python module** (`src/unifyweaver/glue/rpyc/`): Connection management (SSH/SSL/unsecured), four proxy layers, async support
  - **Prolog glue** (`rpyc_glue.pl`): `rpyc_connect/3`, `rpyc_call/5`, proxy accessors, code generation
  - **Examples**: Demo scripts and test server
  - **Research**: Language compatibility analysis (C#, Java, Rust, Ruby can also use RPyC via their Python bridges)

  ## Test plan

  - [x] Python module imports and bridge creation tested
  - [x] Prolog built-in tests pass (`test_rpyc_glue/0`)
  - [x] Full round-trip tested: Prolog → Janus → RPyC → Remote Python → Result
  - [x] All four proxy layers verified

  � Generated with [Claude Code](https://claude.com/claude-code)