### PR TITLE
Add LINQ-style TransitiveClosure for C# Native Target

### DIFF
--- a/src/unifyweaver/targets/csharp_native_runtime/LinqRecursive.cs
+++ b/src/unifyweaver/targets/csharp_native_runtime/LinqRecursive.cs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2025 UnifyWeaver Contributors
+//
+// LinqRecursive - LINQ-style extension methods for recursive queries
+// Uses semi-naive iteration for efficient fixpoint computation
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UnifyWeaver.Native
+{
+    /// <summary>
+    /// Provides LINQ-style extension methods for recursive query patterns.
+    /// These methods use semi-naive iteration internally for efficient
+    /// fixpoint computation while preserving familiar LINQ semantics.
+    /// </summary>
+    public static class LinqRecursive
+    {
+        /// <summary>
+        /// Computes the transitive closure of a relation using semi-naive iteration.
+        ///
+        /// Example - ancestor/2:
+        ///   ancestor(X,Y) :- parent(X,Y).
+        ///   ancestor(X,Z) :- parent(X,Y), ancestor(Y,Z).
+        ///
+        /// Usage:
+        ///   ParentStream().TransitiveClosure(
+        ///       parents => parents,
+        ///       (ancestor, parents) => parents
+        ///           .Where(p => p.Item2 == ancestor.Item1)
+        ///           .Select(p => (p.Item1, ancestor.Item2))
+        ///   )
+        /// </summary>
+        /// <typeparam name="T">The tuple type of the relation</typeparam>
+        /// <param name="baseRelation">The base relation (e.g., parent facts)</param>
+        /// <param name="seedSelector">Function to derive initial results from base relation</param>
+        /// <param name="expandStep">Function that joins delta tuples with base relation to produce new tuples</param>
+        /// <returns>All tuples in the transitive closure</returns>
+        public static IEnumerable<T> TransitiveClosure<T>(
+            this IEnumerable<T> baseRelation,
+            Func<IEnumerable<T>, IEnumerable<T>> seedSelector,
+            Func<T, IEnumerable<T>, IEnumerable<T>> expandStep)
+        {
+            // Materialize base relation to avoid multiple enumeration
+            var baseList = baseRelation.ToList();
+            var seen = new HashSet<T>();
+            var delta = new List<T>();
+
+            // Seed from base case
+            foreach (var item in seedSelector(baseList))
+            {
+                if (seen.Add(item))
+                {
+                    delta.Add(item);
+                    yield return item;
+                }
+            }
+
+            // Semi-naive iteration: only process new delta tuples
+            while (delta.Count > 0)
+            {
+                var newDelta = new List<T>();
+                foreach (var d in delta)
+                {
+                    foreach (var result in expandStep(d, baseList))
+                    {
+                        if (seen.Add(result))
+                        {
+                            newDelta.Add(result);
+                            yield return result;
+                        }
+                    }
+                }
+                delta = newDelta;
+            }
+        }
+
+        /// <summary>
+        /// Simplified transitive closure for common pattern where seed is the base relation itself.
+        ///
+        /// Usage:
+        ///   ParentStream().TransitiveClosure(
+        ///       (ancestor, parents) => parents
+        ///           .Where(p => p.Item2 == ancestor.Item1)
+        ///           .Select(p => (p.Item1, ancestor.Item2))
+        ///   )
+        /// </summary>
+        public static IEnumerable<T> TransitiveClosure<T>(
+            this IEnumerable<T> baseRelation,
+            Func<T, IEnumerable<T>, IEnumerable<T>> expandStep)
+        {
+            return baseRelation.TransitiveClosure(seed => seed, expandStep);
+        }
+
+        /// <summary>
+        /// Safe recursive join that prevents stack overflow by using iteration.
+        /// Similar to LINQ Join but safe for self-referential queries.
+        ///
+        /// Example - reachable/2:
+        ///   edge(a, b). edge(b, c). edge(c, d).
+        ///   reachable(X, Y) :- edge(X, Y).
+        ///   reachable(X, Z) :- edge(X, Y), reachable(Y, Z).
+        ///
+        /// Usage:
+        ///   EdgeStream().SafeRecursiveJoin(
+        ///       edges => edges,                           // seed
+        ///       (reachable, edges) => edges               // expand
+        ///           .Where(e => e.Item2 == reachable.Item1)
+        ///           .Select(e => (e.Item1, reachable.Item2)),
+        ///       result => result                          // project
+        ///   )
+        /// </summary>
+        public static IEnumerable<TResult> SafeRecursiveJoin<TBase, TResult>(
+            this IEnumerable<TBase> baseRelation,
+            Func<IEnumerable<TBase>, IEnumerable<TResult>> seedSelector,
+            Func<TResult, IEnumerable<TBase>, IEnumerable<TResult>> expandStep,
+            Func<TResult, TResult> resultSelector)
+        {
+            var baseList = baseRelation.ToList();
+            var seen = new HashSet<TResult>();
+            var delta = new List<TResult>();
+
+            // Seed
+            foreach (var item in seedSelector(baseList))
+            {
+                var result = resultSelector(item);
+                if (seen.Add(result))
+                {
+                    delta.Add(result);
+                    yield return result;
+                }
+            }
+
+            // Iterate
+            while (delta.Count > 0)
+            {
+                var newDelta = new List<TResult>();
+                foreach (var d in delta)
+                {
+                    foreach (var item in expandStep(d, baseList))
+                    {
+                        var result = resultSelector(item);
+                        if (seen.Add(result))
+                        {
+                            newDelta.Add(result);
+                            yield return result;
+                        }
+                    }
+                }
+                delta = newDelta;
+            }
+        }
+
+        /// <summary>
+        /// Computes fixpoint of an expansion function starting from a seed.
+        /// Most general form - use when TransitiveClosure pattern doesn't fit.
+        ///
+        /// Usage:
+        ///   LinqRecursive.Fixpoint(
+        ///       initialFacts,
+        ///       current => DeriveNewFacts(current, baseData)
+        ///   )
+        /// </summary>
+        public static IEnumerable<T> Fixpoint<T>(
+            IEnumerable<T> seed,
+            Func<IEnumerable<T>, IEnumerable<T>> expand)
+        {
+            var seen = new HashSet<T>();
+            var delta = new List<T>();
+
+            foreach (var item in seed)
+            {
+                if (seen.Add(item))
+                {
+                    delta.Add(item);
+                    yield return item;
+                }
+            }
+
+            while (delta.Count > 0)
+            {
+                var newDelta = new List<T>();
+                foreach (var item in expand(delta))
+                {
+                    if (seen.Add(item))
+                    {
+                        newDelta.Add(item);
+                        yield return item;
+                    }
+                }
+                delta = newDelta;
+            }
+        }
+
+        /// <summary>
+        /// Memoized version of TransitiveClosure that caches results for repeated calls.
+        /// Thread-safe for concurrent access.
+        /// </summary>
+        public static Func<IEnumerable<T>> MemoizedTransitiveClosure<T>(
+            Func<IEnumerable<T>> baseRelationFactory,
+            Func<IEnumerable<T>, IEnumerable<T>> seedSelector,
+            Func<T, IEnumerable<T>, IEnumerable<T>> expandStep)
+        {
+            List<T>? cached = null;
+            object lockObj = new object();
+
+            return () =>
+            {
+                if (cached != null) return cached;
+
+                lock (lockObj)
+                {
+                    if (cached != null) return cached;
+                    cached = baseRelationFactory()
+                        .TransitiveClosure(seedSelector, expandStep)
+                        .ToList();
+                    return cached;
+                }
+            };
+        }
+    }
+}

--- a/src/unifyweaver/targets/csharp_native_runtime/UnifyWeaver.Native.csproj
+++ b/src/unifyweaver/targets/csharp_native_runtime/UnifyWeaver.Native.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
+    <RootNamespace>UnifyWeaver.Native</RootNamespace>
+    <PackageId>UnifyWeaver.Native</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>UnifyWeaver Contributors</Authors>
+    <Description>LINQ-style recursive query helpers for UnifyWeaver C# Native Target</Description>
+    <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Add a new `linq_recursive(true)` compilation option that generates cleaner recursive query code using a `TransitiveClosure` extension method, abstracting away the semi-naive iteration implementation details while preserving LINQ semantics.

## Changes

### New Files
- **`src/unifyweaver/targets/csharp_native_runtime/LinqRecursive.cs`** - Runtime helper library providing:
  - `TransitiveClosure<T>()` - Computes transitive closure with semi-naive iteration
  - `SafeRecursiveJoin<T>()` - Safe join for self-referential queries
  - `Fixpoint<T>()` - General fixpoint computation
  - `MemoizedTransitiveClosure<T>()` - Thread-safe cached version

- **`src/unifyweaver/targets/csharp_native_runtime/UnifyWeaver.Native.csproj`** - .NET 6.0 library package for the runtime helpers

### Modified Files
- **`src/unifyweaver/targets/csharp_native_target.pl`**:
  - Added `linq_recursive(true)` option support
  - Added `generate_recursive_stream_linq/7` for LINQ-style code generation
  - Fixed module qualification handling in `contains_recursive_call/3` and `body_goals/2`
  - Added `strip_module/2` helper for robust goal analysis
  - Added `test_linq_recursive_output/0` for comparing both styles
  - Exported new test predicate

- **`docs/targets/csharp-codegen.md`** - Added LINQ Recursive Style section

## Usage

```prolog
% Inline style (default) - generates explicit while loops
compile_predicate_to_csharp(ancestor/2, [], Code).

% LINQ style - generates TransitiveClosure calls
compile_predicate_to_csharp(ancestor/2, [linq_recursive(true)], Code).
```

## Generated Code Comparison

### Inline Style (default)
```csharp
while (delta.Count > 0)
{
    var newDelta = new List<(string, string)>();
    foreach (var d in delta)
    {
        foreach (var b in ParentStream())
        {
            if (b.Item2 == d.Item1)
            {
                var newItem = (b.Item1, d.Item2);
                if (seen.Add(newItem)) { newDelta.Add(newItem); yield return newItem; }
            }
        }
    }
    delta = newDelta;
}
```

### LINQ Style (`linq_recursive(true)`)
```csharp
using UnifyWeaver.Native;

_cache = ParentStream().TransitiveClosure(
    (d, baseRel) => baseRel
        .Where(b => b.Item2 == d.Item1)
        .Select(b => (b.Item1, d.Item2))
).ToList();
```

## Style Comparison

| Aspect | Inline Semi-Naive | LINQ TransitiveClosure |
|--------|-------------------|------------------------|
| Code readability | Explicit loops visible | Clean method call |
| Runtime dependency | None | `UnifyWeaver.Native` library |
| Customization | Full control | Abstracted |
| Generated code size | Larger | Smaller |

## Test Plan

- [x] `test_csharp_native_target/0` - All tests pass
- [x] `test_linq_recursive_output/0` - Both styles generate correctly
- [x] Module qualification fix verified (predicates asserted from different module contexts)

## Notes

- Both styles use semi-naive iteration internally for efficiency
- The LINQ style requires the `UnifyWeaver.Native` package or source reference
- No breaking changes to existing API
