### PR TITLE
Perf: prefer delta recursive refs in join ordering

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1710,8 +1710,14 @@ estimate_goal_row_count(relation, Term0, Arity, ConstArgs, Estimate) :-
         Pattern =.. [Pred|Args],
         aggregate_all(count, clause(user:Pattern, true), Estimate)
     ).
+estimate_goal_row_count(recursive(delta), _Term, _Arity, ConstArgs, Estimate) :-
+    !,
+    estimate_unknown_recursive_delta_rows(ConstArgs, Estimate).
 estimate_goal_row_count(recursive(_), _Term, _Arity, ConstArgs, Estimate) :-
     estimate_unknown_recursive_rows(ConstArgs, Estimate).
+estimate_goal_row_count(mutual(_, delta), _Term, _Arity, ConstArgs, Estimate) :-
+    !,
+    estimate_unknown_recursive_delta_rows(ConstArgs, Estimate).
 estimate_goal_row_count(mutual(_, _), _Term, _Arity, ConstArgs, Estimate) :-
     estimate_unknown_recursive_rows(ConstArgs, Estimate).
 
@@ -1719,6 +1725,10 @@ estimate_unknown_relation_rows(ConstArgs, Estimate) :-
     Base is 1000000000,
     Divisor is ConstArgs + 1,
     Estimate is Base // Divisor.
+
+estimate_unknown_recursive_delta_rows(ConstArgs, Estimate) :-
+    estimate_unknown_recursive_rows(ConstArgs, TotalEstimate),
+    Estimate is TotalEstimate // 2.
 
 estimate_unknown_recursive_rows(ConstArgs, Estimate) :-
     Base is 2000000000,


### PR DESCRIPTION
  - Improves recursive join ordering by treating delta recursive/cross refs as more selective than total, so order-free
    join reordering tends to scan/probe deltas first in semi-naive variants.
  - Adds a regression test ensuring the parameterized fib plan orders recursive refs as [delta, total] for each
    recursive variant.
  - Files: src/unifyweaver/targets/csharp_target.pl, tests/core/test_csharp_query_target.pl.