### PR TITLE
Add recursion optimizations, aggregations, and JSON modes to Perl/Ruby targets

### DIFF
--- a/src/unifyweaver/targets/perl_target.pl
+++ b/src/unifyweaver/targets/perl_target.pl
@@ -77,8 +77,539 @@ compile_facts(Pred, _Arity, Clauses, Code) :-
 
 compile_rules(Pred, Arity, Clauses, IsRecursive, Code) :-
     (   IsRecursive == true
-    ->  compile_recursive_rules(Pred, Arity, Clauses, Code)
+    ->  % Check for tail recursion pattern first
+        (   can_compile_tail_recursion(Pred, Arity, Clauses)
+        ->  compile_tail_recursive_rules(Pred, Arity, Clauses, Code)
+        ;   can_compile_linear_recursion(Pred, Arity, Clauses)
+        ->  compile_linear_recursive_rules(Pred, Arity, Clauses, Code)
+        ;   compile_recursive_rules(Pred, Arity, Clauses, Code)
+        )
     ;   compile_nonrecursive_rules(Pred, Arity, Clauses, Code)
+    ).
+
+%% ============================================
+%% LINEAR RECURSION WITH MEMOIZATION
+%% ============================================
+
+%% can_compile_linear_recursion(+Pred, +Arity, +Clauses)
+%% Detect linear recursion pattern (recursive calls not in tail position,
+%% returns a computed value). Example: fibonacci, tree traversal.
+can_compile_linear_recursion(Pred, Arity, Clauses) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    % Must have base cases that set result directly
+    forall(member(BC, BaseClauses), is_value_base_case(BC)),
+    % Recursive clause should compute result from recursive calls
+    forall(member(RC, RecClauses), is_linear_recursive_clause(Pred, Arity, RC)).
+
+%% is_value_base_case(+Clause) - base case returns a constant or input value
+is_value_base_case(Head-true) :-
+    Head =.. [_|Args],
+    Args \= [],
+    last(Args, Result),
+    (number(Result) ; atom(Result) ; var(Result)), !.
+is_value_base_case(Head-Body) :-
+    Head =.. [_|Args],
+    Args \= [],
+    goals_to_list(Body, Goals),
+    forall(member(G, Goals), is_simple_condition(G)).
+
+%% is_linear_recursive_clause(+Pred, +Arity, +Clause)
+%% Check that recursive calls are not in tail position and result is computed
+is_linear_recursive_clause(Pred, Arity, _Head-Body) :-
+    goals_to_list(Body, Goals),
+    Goals \= [],
+    % Recursive call should NOT be last (not tail recursive)
+    last(Goals, LastGoal),
+    \+ (strip_module(LastGoal, _, G), functor(G, Pred, Arity)),
+    % Should have 'is' computation that uses recursive results
+    member(_ is _, Goals).
+
+%% compile_linear_recursive_rules(+Pred, +Arity, +Clauses, -Code)
+%% Generate memoized linear recursion with CPS
+compile_linear_recursive_rules(Pred, Arity, Clauses, Code) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+
+    % Generate parameter names (excluding result - last arg)
+    InputArity is Arity - 1,
+    numlist(1, InputArity, Indices),
+    maplist([I, Name]>>format(atom(Name), "$arg~w", [I]), Indices, ParamNames),
+    atomic_list_concat(ParamNames, ", ", ParamList),
+
+    % Generate memo key
+    format(string(MemoKey), "join('\\0', ~s)", [ParamList]),
+
+    % Compile base cases
+    compile_linear_base_cases(BaseClauses, ParamNames, BaseCaseCode),
+
+    % Compile recursive case
+    RecClauses = [RecClause|_],
+    compile_linear_recursive_case(RecClause, Pred, Arity, ParamNames, RecCaseCode),
+
+    format(string(Code),
+"{
+    my %%memo;
+    sub ~w {
+        my $callback = shift;
+        my (~s) = @_;
+        my $key = ~s;
+        if (exists $memo{$key}) {
+            return $callback->($memo{$key});
+        }
+~s
+~s
+    }
+}
+", [Pred, ParamList, MemoKey, BaseCaseCode, RecCaseCode]).
+
+%% compile_linear_base_cases(+BaseClauses, +ParamNames, -Code)
+compile_linear_base_cases([], _, "").
+compile_linear_base_cases([Clause|Rest], ParamNames, Code) :-
+    compile_linear_base_case(Clause, ParamNames, ClauseCode),
+    compile_linear_base_cases(Rest, ParamNames, RestCode),
+    format(string(Code), "~s~s", [ClauseCode, RestCode]).
+
+compile_linear_base_case(Head-_Body, ParamNames, Code) :-
+    Head =.. [_|Args],
+    % Get input args and result
+    append(InputArgs, [Result], Args),
+    % Build condition from input args
+    build_base_condition(InputArgs, ParamNames, Condition),
+    % Get result value
+    (   var(Result)
+    ->  % Result is bound to an input arg
+        (   nth1(Idx, InputArgs, RA), RA == Result
+        ->  nth1(Idx, ParamNames, ResultExpr)
+        ;   ResultExpr = "undef"
+        )
+    ;   format(string(ResultExpr), "~w", [Result])
+    ),
+    format(string(Code),
+"        if (~s) {
+            $memo{$key} = ~s;
+            return $callback->(~s);
+        }
+", [Condition, ResultExpr, ResultExpr]).
+
+build_base_condition([], [], "1").
+build_base_condition([Arg|Args], [Param|Params], Condition) :-
+    build_base_condition(Args, Params, RestCond),
+    (   number(Arg)
+    ->  format(string(ArgCond), "~s == ~w", [Param, Arg])
+    ;   atom(Arg)
+    ->  format(string(ArgCond), "~s eq '~w'", [Param, Arg])
+    ;   ArgCond = "1"
+    ),
+    (   RestCond == "1"
+    ->  Condition = ArgCond
+    ;   ArgCond == "1"
+    ->  Condition = RestCond
+    ;   format(string(Condition), "~s && ~s", [ArgCond, RestCond])
+    ).
+
+%% compile_linear_recursive_case(+Clause, +Pred, +Arity, +ParamNames, -Code)
+compile_linear_recursive_case(Head-Body, Pred, Arity, ParamNames, Code) :-
+    Head =.. [_|HeadArgs],
+    append(_, [ResultVar], HeadArgs),
+    goals_to_list(Body, Goals),
+
+    % Separate: conditions, computations, recursive calls, final computation
+    partition(is_recursive_goal(Pred, Arity), Goals, RecGoals, NonRecGoals),
+    partition(is_computation, NonRecGoals, Computations, _Conditions),
+
+    % Find the final result computation (ResultVar is ...)
+    find_final_expr(Computations, ResultVar, FinalExpr),
+
+    % Build computed vars for intermediate values
+    collect_linear_computed_vars(Computations, ResultVar, 0, ComputedVars),
+
+    % Generate pre-computations (before recursive calls)
+    compile_linear_pre_computations(Computations, ResultVar, HeadArgs, ParamNames, ComputedVars, PreCompCode),
+
+    % Generate nested recursive calls
+    compile_nested_recursive_calls(RecGoals, Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, ResultVar, RecCallCode),
+
+    format(string(Code), "~s~s", [PreCompCode, RecCallCode]).
+
+%% find_final_expr(+Computations, +ResultVar, -FinalExpr)
+find_final_expr([], _, 0).
+find_final_expr([RV is Expr|_], ResultVar, Expr) :-
+    RV == ResultVar, !.
+find_final_expr([_|Rest], ResultVar, Expr) :-
+    find_final_expr(Rest, ResultVar, Expr).
+
+is_computation(_ is _).
+
+collect_linear_computed_vars([], _, _, []).
+collect_linear_computed_vars([Var is _|Rest], ResultVar, Counter, Vars) :-
+    var(Var), Var \== ResultVar, !,
+    format(atom(Name), "$tmp~w", [Counter]),
+    Counter1 is Counter + 1,
+    collect_linear_computed_vars(Rest, ResultVar, Counter1, RestVars),
+    Vars = [Var-Name|RestVars].
+collect_linear_computed_vars([_|Rest], ResultVar, Counter, Vars) :-
+    collect_linear_computed_vars(Rest, ResultVar, Counter, Vars).
+
+compile_linear_pre_computations([], _, _, _, _, "").
+compile_linear_pre_computations([Var is Expr|Rest], ResultVar, HeadArgs, ParamNames, ComputedVars, Code) :-
+    var(Var), Var \== ResultVar, !,
+    get_var_name(Var, HeadArgs, ParamNames, ComputedVars, VarName),
+    compile_perl_expr_ext(Expr, HeadArgs, ParamNames, ComputedVars, ExprCode),
+    compile_linear_pre_computations(Rest, ResultVar, HeadArgs, ParamNames, ComputedVars, RestCode),
+    format(string(Code), "        my ~s = ~s;~n~s", [VarName, ExprCode, RestCode]).
+compile_linear_pre_computations([_|Rest], ResultVar, HeadArgs, ParamNames, ComputedVars, Code) :-
+    compile_linear_pre_computations(Rest, ResultVar, HeadArgs, ParamNames, ComputedVars, Code).
+
+%% compile_nested_recursive_calls(+RecGoals, +Pred, +HeadArgs, +ParamNames, +ComputedVars, +FinalExpr, +ResultVar, +Counter, -Code)
+compile_nested_recursive_calls(RecGoals, Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, ResultVar, Code) :-
+    compile_nested_recursive_calls_(RecGoals, Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, ResultVar, 0, Code).
+
+compile_nested_recursive_calls_([], _Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, _ResultVar, _Counter, Code) :-
+    compile_perl_expr_ext(FinalExpr, HeadArgs, ParamNames, ComputedVars, ExprCode),
+    format(string(Code),
+"            my $result = ~s;
+            $memo{$key} = $result;
+            $callback->($result);
+", [ExprCode]).
+
+compile_nested_recursive_calls_([RecGoal|Rest], Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, ResultVar, Counter, Code) :-
+    RecGoal =.. [_|RecArgs],
+    append(RecInputs, [RecResult], RecArgs),
+
+    % Compile arguments for recursive call
+    maplist(compile_rec_arg(HeadArgs, ParamNames, ComputedVars), RecInputs, ArgCodes),
+    atomic_list_concat(ArgCodes, ", ", ArgStr),
+
+    % Name for this recursive result (use counter for uniqueness)
+    format(atom(ResName), "$r~w", [Counter]),
+    NewComputedVars = [RecResult-ResName|ComputedVars],
+    NextCounter is Counter + 1,
+
+    % Compile inner nested calls or final computation
+    compile_nested_recursive_calls_(Rest, Pred, HeadArgs, ParamNames, NewComputedVars, FinalExpr, ResultVar, NextCounter, InnerCode),
+
+    format(string(Code),
+"        ~w(sub {
+            my (~s) = @_;
+~s
+        }, ~s);
+", [Pred, ResName, InnerCode, ArgStr]).
+
+compile_rec_arg(HeadArgs, ParamNames, ComputedVars, Arg, Code) :-
+    (   var(Arg)
+    ->  get_var_name(Arg, HeadArgs, ParamNames, ComputedVars, Code)
+    ;   number(Arg)
+    ->  format(string(Code), "~w", [Arg])
+    ;   format(string(Code), "'~w'", [Arg])
+    ).
+
+%% ============================================
+%% TAIL RECURSION DETECTION AND COMPILATION
+%% ============================================
+
+%% can_compile_tail_recursion(+Pred, +Arity, +Clauses)
+%% Check if this is a tail-recursive predicate that can be optimized to a loop.
+%% Pattern: base case returns accumulator, recursive case has recursive call last.
+%% Example: factorial(0, Acc, Acc). factorial(N, Acc, R) :- N1 is N-1, Acc1 is Acc*N, factorial(N1, Acc1, R).
+can_compile_tail_recursion(Pred, Arity, Clauses) :-
+    % Separate base and recursive cases
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    % All recursive clauses must have tail call
+    forall(member(Clause, RecClauses), is_tail_recursive_clause(Pred, Arity, Clause)),
+    % Base cases should unify result with accumulator (last two args same var)
+    forall(member(BaseClause, BaseClauses), is_accumulator_base_case(BaseClause)).
+
+%% is_tail_recursive_clause(+Pred, +Arity, +Clause)
+%% Check if the recursive call is in tail position (last goal in body)
+is_tail_recursive_clause(Pred, Arity, _Head-Body) :-
+    goals_to_list(Body, Goals),
+    Goals \= [],
+    last(Goals, LastGoal),
+    strip_module(LastGoal, _, G),
+    functor(G, Pred, Arity).
+
+%% is_accumulator_base_case(+Clause)
+%% Check if base case returns accumulator (last two args are same variable)
+is_accumulator_base_case(Head-true) :-
+    Head =.. [_|Args],
+    length(Args, Len),
+    Len >= 2,
+    append(_, [Acc, Result], Args),
+    Acc == Result, !.
+is_accumulator_base_case(Head-Body) :-
+    Head =.. [_|Args],
+    length(Args, Len),
+    Len >= 2,
+    append(_, [Acc, Result], Args),
+    Acc == Result,
+    % Body should be simple conditions
+    goals_to_list(Body, Goals),
+    forall(member(G, Goals), is_simple_condition(G)).
+
+%% is_simple_condition(+Goal)
+%% Check if goal is a simple condition (comparison, arithmetic)
+is_simple_condition(G) :-
+    functor(G, Op, 2),
+    member(Op, [=, ==, \=, \==, <, >, =<, >=, =:=, =\=, is]).
+
+%% compile_tail_recursive_rules(+Pred, +Arity, +Clauses, -Code)
+%% Compile tail recursion to an iterative loop
+compile_tail_recursive_rules(Pred, Arity, Clauses, Code) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+
+    % Generate parameter names
+    numlist(1, Arity, Indices),
+    maplist([I, Name]>>format(atom(Name), "$arg~w", [I]), Indices, ParamNames),
+    atomic_list_concat(ParamNames, ", ", ParamList),
+
+    % Find which arg is the accumulator (second to last in result position)
+    Arity >= 2,
+    AccIdx is Arity - 1,
+    _ResultIdx is Arity,  % ResultIdx not needed currently
+
+    % Generate base case condition
+    compile_tail_base_conditions(BaseClauses, AccIdx, BaseCondCode),
+
+    % Generate loop body from recursive clause
+    RecClauses = [RecClause|_],  % Use first recursive clause
+    compile_tail_loop_body(RecClause, Pred, Arity, ParamNames, LoopBodyCode),
+
+    % AccIdx and ResultIdx identify positions for base case check
+    % (AccParam and ResultParam not currently used in template)
+
+    format(string(Code),
+"sub ~w {
+    my $callback = shift;
+    my (~s) = @_;
+
+    # Tail recursion optimized to loop
+    while (1) {
+~s
+~s
+    }
+}
+", [Pred, ParamList, BaseCondCode, LoopBodyCode]).
+
+%% compile_tail_base_conditions(+BaseClauses, +AccIdx, -Code)
+compile_tail_base_conditions(BaseClauses, AccIdx, Code) :-
+    BaseClauses = [Head-Body|_],
+    Head =.. [_|Args],
+    % Find the base case condition (usually first arg == 0 or similar)
+    (   Body == true
+    ->  % Check first argument for base condition
+        Args = [FirstArg|_],
+        (   FirstArg == 0
+        ->  format(string(Code),
+"        if ($arg1 == 0) {
+            $callback->($arg~w);
+            return;
+        }", [AccIdx])
+        ;   FirstArg == []
+        ->  format(string(Code),
+"        if (!@{$arg1}) {
+            $callback->($arg~w);
+            return;
+        }", [AccIdx])
+        ;   format(string(Code),
+"        # Base case
+        if (defined $arg1 && $arg1 eq '~w') {
+            $callback->($arg~w);
+            return;
+        }", [FirstArg, AccIdx])
+        )
+    ;   % Has conditions in body
+        goals_to_list(Body, Goals),
+        compile_perl_conditions(Goals, CondCode),
+        format(string(Code),
+"        if (~s) {
+            $callback->($arg~w);
+            return;
+        }", [CondCode, AccIdx])
+    ).
+
+%% compile_perl_conditions(+Goals, -Code)
+compile_perl_conditions([], "1").
+compile_perl_conditions([Goal|Rest], Code) :-
+    compile_perl_condition(Goal, GoalCode),
+    compile_perl_conditions(Rest, RestCode),
+    (   RestCode == "1"
+    ->  Code = GoalCode
+    ;   format(string(Code), "~s && ~s", [GoalCode, RestCode])
+    ).
+
+compile_perl_condition(_ == Y, Code) :-
+    format(string(Code), "$arg1 == ~w", [Y]).
+compile_perl_condition(_ =:= Y, Code) :-
+    format(string(Code), "$arg1 == ~w", [Y]).
+compile_perl_condition(_ < Y, Code) :-
+    format(string(Code), "$arg1 < ~w", [Y]).
+compile_perl_condition(_ > Y, Code) :-
+    format(string(Code), "$arg1 > ~w", [Y]).
+compile_perl_condition(_ =< Y, Code) :-
+    format(string(Code), "$arg1 <= ~w", [Y]).
+compile_perl_condition(_ >= Y, Code) :-
+    format(string(Code), "$arg1 >= ~w", [Y]).
+compile_perl_condition(_, "1").
+
+%% compile_tail_loop_body(+RecClause, +Pred, +Arity, +ParamNames, -Code)
+compile_tail_loop_body(Head-Body, Pred, Arity, ParamNames, Code) :-
+    Head =.. [_|HeadArgs],
+    goals_to_list(Body, Goals),
+
+    % Separate the recursive call from other goals
+    partition(is_recursive_goal(Pred, Arity), Goals, [RecGoal|_], OtherGoals),
+    RecGoal =.. [_|RecArgs],
+
+    % Build a mapping of computed variables
+    collect_computed_vars(OtherGoals, 0, ComputedVars),
+
+    % Compile the intermediate computations with computed var tracking
+    compile_tail_computations(OtherGoals, HeadArgs, ParamNames, ComputedVars, CompCode),
+
+    % Generate the variable updates for next iteration
+    compile_tail_updates(RecArgs, HeadArgs, ParamNames, ComputedVars, UpdateCode),
+
+    format(string(Code), "~s~s", [CompCode, UpdateCode]).
+
+%% collect_computed_vars(+Goals, +Counter, -ComputedVars)
+%% Build a list of Var-Name pairs for computed variables
+collect_computed_vars([], _, []).
+collect_computed_vars([Var is _|Rest], Counter, [Var-Name|RestVars]) :-
+    var(Var), !,
+    format(atom(Name), "$tmp~w", [Counter]),
+    Counter1 is Counter + 1,
+    collect_computed_vars(Rest, Counter1, RestVars).
+collect_computed_vars([_|Rest], Counter, Vars) :-
+    collect_computed_vars(Rest, Counter, Vars).
+
+%% compile_tail_computations(+Goals, +HeadArgs, +ParamNames, +ComputedVars, -Code)
+compile_tail_computations([], _, _, _, "").
+compile_tail_computations([Goal|Rest], HeadArgs, ParamNames, ComputedVars, Code) :-
+    compile_tail_computation(Goal, HeadArgs, ParamNames, ComputedVars, GoalCode),
+    compile_tail_computations(Rest, HeadArgs, ParamNames, ComputedVars, RestCode),
+    format(string(Code), "~s~s", [GoalCode, RestCode]).
+
+compile_tail_computation(Var is Expr, HeadArgs, ParamNames, ComputedVars, Code) :-
+    var(Var), !,
+    % Find the variable name (check computed vars first, then head args)
+    get_var_name(Var, HeadArgs, ParamNames, ComputedVars, VarName),
+    compile_perl_expr_ext(Expr, HeadArgs, ParamNames, ComputedVars, ExprCode),
+    format(string(Code), "        my ~s = ~s;~n", [VarName, ExprCode]).
+compile_tail_computation(_, _, _, _, "").
+
+%% get_var_name(+Var, +HeadArgs, +ParamNames, +ComputedVars, -Name)
+get_var_name(Var, _, _, ComputedVars, Name) :-
+    member(V-Name, ComputedVars),
+    V == Var, !.
+get_var_name(Var, HeadArgs, ParamNames, _, Name) :-
+    nth1(Idx, HeadArgs, Arg),
+    Arg == Var, !,
+    nth1(Idx, ParamNames, Name).
+get_var_name(_, _, _, _, "$unknown").
+
+%% compile_perl_expr_ext - extended to handle computed vars
+compile_perl_expr_ext(Expr, HeadArgs, ParamNames, ComputedVars, Code) :-
+    var(Expr), !,
+    get_var_name(Expr, HeadArgs, ParamNames, ComputedVars, Code).
+compile_perl_expr_ext(N, _, _, _, Code) :-
+    number(N), !,
+    format(string(Code), "~w", [N]).
+compile_perl_expr_ext(Atom, _, _, _, Code) :-
+    atom(Atom), !,
+    format(string(Code), "'~w'", [Atom]).
+%% Handle X + (-Y) as X - Y (Prolog sometimes represents subtraction this way)
+compile_perl_expr_ext(X + Y, HeadArgs, ParamNames, ComputedVars, Code) :-
+    number(Y), Y < 0, !,
+    NegY is -Y,
+    compile_perl_expr_ext(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    format(string(Code), "(~s - ~w)", [XCode, NegY]).
+compile_perl_expr_ext(X + Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_perl_expr_ext(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_perl_expr_ext(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s + ~s)", [XCode, YCode]).
+compile_perl_expr_ext(X - Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_perl_expr_ext(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_perl_expr_ext(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s - ~s)", [XCode, YCode]).
+compile_perl_expr_ext(X * Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_perl_expr_ext(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_perl_expr_ext(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s * ~s)", [XCode, YCode]).
+compile_perl_expr_ext(X / Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_perl_expr_ext(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_perl_expr_ext(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s / ~s)", [XCode, YCode]).
+compile_perl_expr_ext(X, _, _, _, Code) :-
+    format(string(Code), "~w", [X]).
+
+%% compile_perl_expr(+Expr, +HeadArgs, +ParamNames, -Code)
+compile_perl_expr(Expr, HeadArgs, ParamNames, Code) :-
+    var(Expr), !,
+    get_perl_var_name(Expr, HeadArgs, ParamNames, Code).
+compile_perl_expr(N, _, _, Code) :-
+    number(N), !,
+    format(string(Code), "~w", [N]).
+compile_perl_expr(Atom, _, _, Code) :-
+    atom(Atom), !,
+    format(string(Code), "'~w'", [Atom]).
+compile_perl_expr(X + Y, HeadArgs, ParamNames, Code) :- !,
+    compile_perl_expr(X, HeadArgs, ParamNames, XCode),
+    compile_perl_expr(Y, HeadArgs, ParamNames, YCode),
+    format(string(Code), "(~s + ~s)", [XCode, YCode]).
+compile_perl_expr(X - Y, HeadArgs, ParamNames, Code) :- !,
+    compile_perl_expr(X, HeadArgs, ParamNames, XCode),
+    compile_perl_expr(Y, HeadArgs, ParamNames, YCode),
+    format(string(Code), "(~s - ~s)", [XCode, YCode]).
+compile_perl_expr(X * Y, HeadArgs, ParamNames, Code) :- !,
+    compile_perl_expr(X, HeadArgs, ParamNames, XCode),
+    compile_perl_expr(Y, HeadArgs, ParamNames, YCode),
+    format(string(Code), "(~s * ~s)", [XCode, YCode]).
+compile_perl_expr(X / Y, HeadArgs, ParamNames, Code) :- !,
+    compile_perl_expr(X, HeadArgs, ParamNames, XCode),
+    compile_perl_expr(Y, HeadArgs, ParamNames, YCode),
+    format(string(Code), "(~s / ~s)", [XCode, YCode]).
+compile_perl_expr(X, _, _, Code) :-
+    format(string(Code), "~w", [X]).
+
+%% get_perl_var_name(+Var, +HeadArgs, +ParamNames, -Name)
+get_perl_var_name(Var, HeadArgs, ParamNames, Name) :-
+    nth1(Idx, HeadArgs, Arg),
+    Arg == Var, !,
+    nth1(Idx, ParamNames, Name).
+get_perl_var_name(_, _, _, "$tmp").
+
+%% compile_tail_updates(+RecArgs, +HeadArgs, +ParamNames, +ComputedVars, -Code)
+compile_tail_updates(RecArgs, HeadArgs, ParamNames, ComputedVars, Code) :-
+    length(RecArgs, Len),
+    numlist(1, Len, Indices),
+    maplist(compile_single_update(HeadArgs, ParamNames, ComputedVars), Indices, RecArgs, UpdateCodes),
+    atomic_list_concat(UpdateCodes, "", Code).
+
+compile_single_update(HeadArgs, ParamNames, ComputedVars, Idx, RecArg, Code) :-
+    nth1(Idx, ParamNames, ParamName),
+    Len is Idx,  % Skip the result argument (last one)
+    length(ParamNames, TotalArgs),
+    (   Len == TotalArgs
+    ->  Code = ""  % Don't update result argument
+    ;   var(RecArg)
+    ->  % Find what this variable maps to - check computed vars first, then head args
+        (   member(V-ComputedName, ComputedVars), V == RecArg
+        ->  format(string(Code), "        ~s = ~s;~n", [ParamName, ComputedName])
+        ;   nth1(OldIdx, HeadArgs, OldArg), OldArg == RecArg
+        ->  nth1(OldIdx, ParamNames, OldName),
+            (   OldName == ParamName
+            ->  Code = ""  % No change needed
+            ;   format(string(Code), "        ~s = ~s;~n", [ParamName, OldName])
+            )
+        ;   % Unknown variable - shouldn't happen
+            format(string(Code), "        # ~s: unknown source~n", [ParamName])
+        )
+    ;   number(RecArg)
+    ->  format(string(Code), "        ~s = ~w;~n", [ParamName, RecArg])
+    ;   format(string(Code), "        ~s = '~w';~n", [ParamName, RecArg])
     ).
 
 %% Non-recursive rules use simple CPS

--- a/src/unifyweaver/targets/ruby_target.pl
+++ b/src/unifyweaver/targets/ruby_target.pl
@@ -77,8 +77,402 @@ compile_facts(Pred, _Arity, Clauses, Code) :-
 
 compile_rules(Pred, Arity, Clauses, IsRecursive, Code) :-
     (   IsRecursive == true
-    ->  compile_recursive_rules(Pred, Arity, Clauses, Code)
+    ->  % Check for tail recursion pattern first
+        (   can_compile_tail_recursion(Pred, Arity, Clauses)
+        ->  compile_tail_recursive_rules(Pred, Arity, Clauses, Code)
+        ;   can_compile_linear_recursion(Pred, Arity, Clauses)
+        ->  compile_linear_recursive_rules(Pred, Arity, Clauses, Code)
+        ;   compile_recursive_rules(Pred, Arity, Clauses, Code)
+        )
     ;   compile_nonrecursive_rules(Pred, Arity, Clauses, Code)
+    ).
+
+%% ============================================
+%% LINEAR RECURSION WITH MEMOIZATION
+%% ============================================
+
+can_compile_linear_recursion(Pred, Arity, Clauses) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    forall(member(BC, BaseClauses), is_value_base_case(BC)),
+    forall(member(RC, RecClauses), is_linear_recursive_clause(Pred, Arity, RC)).
+
+is_value_base_case(Head-true) :-
+    Head =.. [_|Args], Args \= [],
+    last(Args, Result),
+    (number(Result) ; atom(Result) ; var(Result)), !.
+is_value_base_case(Head-Body) :-
+    Head =.. [_|Args], Args \= [],
+    body_to_goals(Body, Goals),
+    forall(member(G, Goals), is_simple_condition(G)).
+
+is_linear_recursive_clause(Pred, Arity, _Head-Body) :-
+    body_to_goals(Body, Goals),
+    Goals \= [],
+    last(Goals, LastGoal),
+    \+ (strip_module(LastGoal, _, G), functor(G, Pred, Arity)),
+    member(_ is _, Goals).
+
+compile_linear_recursive_rules(Pred, Arity, Clauses, Code) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+
+    InputArity is Arity - 1,
+    numlist(1, InputArity, Indices),
+    maplist([I, Name]>>format(atom(Name), "arg~w", [I]), Indices, ParamNames),
+    atomic_list_concat(ParamNames, ", ", ParamList),
+
+    compile_ruby_linear_base_cases(BaseClauses, ParamNames, BaseCaseCode),
+
+    RecClauses = [RecClause|_],
+    compile_ruby_linear_recursive_case(RecClause, Pred, Arity, ParamNames, RecCaseCode),
+
+    format(string(Code),
+"def ~w(~s, &block)
+  @memo ||= {}
+  key = [~s]
+  if @memo.key?(key)
+    return block.call(@memo[key])
+  end
+
+~s
+~s
+end
+", [Pred, ParamList, ParamList, BaseCaseCode, RecCaseCode]).
+
+compile_ruby_linear_base_cases([], _, "").
+compile_ruby_linear_base_cases([Clause|Rest], ParamNames, Code) :-
+    compile_ruby_linear_base_case(Clause, ParamNames, ClauseCode),
+    compile_ruby_linear_base_cases(Rest, ParamNames, RestCode),
+    format(string(Code), "~s~s", [ClauseCode, RestCode]).
+
+compile_ruby_linear_base_case(Head-_Body, ParamNames, Code) :-
+    Head =.. [_|Args],
+    append(InputArgs, [Result], Args),
+    build_ruby_base_condition(InputArgs, ParamNames, Condition),
+    (   var(Result)
+    ->  (   nth1(Idx, InputArgs, RA), RA == Result
+        ->  nth1(Idx, ParamNames, ResultExpr)
+        ;   ResultExpr = "nil"
+        )
+    ;   format(string(ResultExpr), "~w", [Result])
+    ),
+    format(string(Code),
+"  if ~s
+    @memo[key] = ~s
+    return block.call(~s)
+  end
+", [Condition, ResultExpr, ResultExpr]).
+
+build_ruby_base_condition([], [], "true").
+build_ruby_base_condition([Arg|Args], [Param|Params], Condition) :-
+    build_ruby_base_condition(Args, Params, RestCond),
+    (   number(Arg) -> format(string(ArgCond), "~w == ~w", [Param, Arg])
+    ;   atom(Arg) -> format(string(ArgCond), "~w == '~w'", [Param, Arg])
+    ;   ArgCond = "true"
+    ),
+    (   RestCond == "true" -> Condition = ArgCond
+    ;   ArgCond == "true" -> Condition = RestCond
+    ;   format(string(Condition), "~s && ~s", [ArgCond, RestCond])
+    ).
+
+compile_ruby_linear_recursive_case(Head-Body, Pred, Arity, ParamNames, Code) :-
+    Head =.. [_|HeadArgs],
+    append(_, [ResultVar], HeadArgs),
+    body_to_goals(Body, Goals),
+
+    partition(goal_matches(Pred, Arity), Goals, RecGoals, NonRecGoals),
+    partition(is_ruby_computation, NonRecGoals, Computations, _Conditions),
+
+    find_ruby_final_expr(Computations, ResultVar, FinalExpr),
+    collect_ruby_computed_vars(Computations, ResultVar, 0, ComputedVars),
+    compile_ruby_linear_pre_computations(Computations, ResultVar, HeadArgs, ParamNames, ComputedVars, PreCompCode),
+    compile_ruby_nested_recursive_calls(RecGoals, Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, RecCallCode),
+
+    format(string(Code), "~s~s", [PreCompCode, RecCallCode]).
+
+is_ruby_computation(_ is _).
+
+find_ruby_final_expr([], _, 0).
+find_ruby_final_expr([RV is Expr|_], ResultVar, Expr) :- RV == ResultVar, !.
+find_ruby_final_expr([_|Rest], ResultVar, Expr) :- find_ruby_final_expr(Rest, ResultVar, Expr).
+
+collect_ruby_computed_vars([], _, _, []).
+collect_ruby_computed_vars([Var is _|Rest], ResultVar, Counter, Vars) :-
+    var(Var), Var \== ResultVar, !,
+    format(atom(Name), "tmp~w", [Counter]),
+    Counter1 is Counter + 1,
+    collect_ruby_computed_vars(Rest, ResultVar, Counter1, RestVars),
+    Vars = [Var-Name|RestVars].
+collect_ruby_computed_vars([_|Rest], ResultVar, Counter, Vars) :-
+    collect_ruby_computed_vars(Rest, ResultVar, Counter, Vars).
+
+compile_ruby_linear_pre_computations([], _, _, _, _, "").
+compile_ruby_linear_pre_computations([Var is Expr|Rest], ResultVar, HeadArgs, ParamNames, ComputedVars, Code) :-
+    var(Var), Var \== ResultVar, !,
+    get_ruby_var_name(Var, HeadArgs, ParamNames, ComputedVars, VarName),
+    compile_ruby_expr(Expr, HeadArgs, ParamNames, ComputedVars, ExprCode),
+    compile_ruby_linear_pre_computations(Rest, ResultVar, HeadArgs, ParamNames, ComputedVars, RestCode),
+    format(string(Code), "  ~s = ~s~n~s", [VarName, ExprCode, RestCode]).
+compile_ruby_linear_pre_computations([_|Rest], ResultVar, HeadArgs, ParamNames, ComputedVars, Code) :-
+    compile_ruby_linear_pre_computations(Rest, ResultVar, HeadArgs, ParamNames, ComputedVars, Code).
+
+compile_ruby_nested_recursive_calls(RecGoals, Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, Code) :-
+    compile_ruby_nested_recursive_calls_(RecGoals, Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, 0, Code).
+
+compile_ruby_nested_recursive_calls_([], _Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, _Counter, Code) :-
+    compile_ruby_expr(FinalExpr, HeadArgs, ParamNames, ComputedVars, ExprCode),
+    format(string(Code),
+"      result = ~s
+      @memo[key] = result
+      block.call(result)
+", [ExprCode]).
+
+compile_ruby_nested_recursive_calls_([RecGoal|Rest], Pred, HeadArgs, ParamNames, ComputedVars, FinalExpr, Counter, Code) :-
+    RecGoal =.. [_|RecArgs],
+    append(RecInputs, [RecResult], RecArgs),
+
+    maplist(compile_ruby_rec_arg(HeadArgs, ParamNames, ComputedVars), RecInputs, ArgCodes),
+    atomic_list_concat(ArgCodes, ", ", ArgStr),
+
+    format(atom(ResName), "r~w", [Counter]),
+    NewComputedVars = [RecResult-ResName|ComputedVars],
+    NextCounter is Counter + 1,
+
+    compile_ruby_nested_recursive_calls_(Rest, Pred, HeadArgs, ParamNames, NewComputedVars, FinalExpr, NextCounter, InnerCode),
+
+    format(string(Code),
+"  ~w(~s) do |~s|
+~s
+  end
+", [Pred, ArgStr, ResName, InnerCode]).
+
+compile_ruby_rec_arg(HeadArgs, ParamNames, ComputedVars, Arg, Code) :-
+    (   var(Arg) -> get_ruby_var_name(Arg, HeadArgs, ParamNames, ComputedVars, Code)
+    ;   number(Arg) -> format(string(Code), "~w", [Arg])
+    ;   format(string(Code), "'~w'", [Arg])
+    ).
+
+%% ============================================
+%% TAIL RECURSION DETECTION AND COMPILATION
+%% ============================================
+
+%% can_compile_tail_recursion(+Pred, +Arity, +Clauses)
+%% Check if this is a tail-recursive predicate that can be optimized to a loop.
+can_compile_tail_recursion(Pred, Arity, Clauses) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    forall(member(Clause, RecClauses), is_tail_recursive_clause(Pred, Arity, Clause)),
+    forall(member(BaseClause, BaseClauses), is_accumulator_base_case(BaseClause)).
+
+%% is_tail_recursive_clause(+Pred, +Arity, +Clause)
+is_tail_recursive_clause(Pred, Arity, _Head-Body) :-
+    body_to_goals(Body, Goals),
+    Goals \= [],
+    last(Goals, LastGoal),
+    strip_module(LastGoal, _, G),
+    functor(G, Pred, Arity).
+
+%% is_accumulator_base_case(+Clause)
+is_accumulator_base_case(Head-true) :-
+    Head =.. [_|Args],
+    length(Args, Len), Len >= 2,
+    append(_, [Acc, Result], Args),
+    Acc == Result, !.
+is_accumulator_base_case(Head-Body) :-
+    Head =.. [_|Args],
+    length(Args, Len), Len >= 2,
+    append(_, [Acc, Result], Args),
+    Acc == Result,
+    body_to_goals(Body, Goals),
+    forall(member(G, Goals), is_simple_condition(G)).
+
+is_simple_condition(G) :-
+    functor(G, Op, 2),
+    member(Op, [=, ==, \=, \==, <, >, =<, >=, =:=, =\=, is]).
+
+%% compile_tail_recursive_rules(+Pred, +Arity, +Clauses, -Code)
+compile_tail_recursive_rules(Pred, Arity, Clauses, Code) :-
+    partition(is_recursive_clause(Pred, Arity), Clauses, RecClauses, BaseClauses),
+
+    % Generate parameter names
+    numlist(1, Arity, Indices),
+    maplist([I, Name]>>format(atom(Name), "arg~w", [I]), Indices, ParamNames),
+    atomic_list_concat(ParamNames, ", ", ParamList),
+
+    % Find accumulator position
+    Arity >= 2,
+    AccIdx is Arity - 1,
+
+    % Generate base case condition
+    compile_tail_base_conditions(BaseClauses, AccIdx, ParamNames, BaseCondCode),
+
+    % Generate loop body from recursive clause
+    RecClauses = [RecClause|_],
+    compile_tail_loop_body(RecClause, Pred, Arity, ParamNames, LoopBodyCode),
+
+    format(string(Code),
+"def ~w(~s, &block)
+  # Tail recursion optimized to loop
+  loop do
+~s
+~s
+  end
+end
+", [Pred, ParamList, BaseCondCode, LoopBodyCode]).
+
+%% compile_tail_base_conditions(+BaseClauses, +AccIdx, +ParamNames, -Code)
+compile_tail_base_conditions(BaseClauses, AccIdx, ParamNames, Code) :-
+    BaseClauses = [Head-Body|_],
+    Head =.. [_|Args],
+    nth1(AccIdx, ParamNames, AccParam),
+    (   Body == true
+    ->  Args = [FirstArg|_],
+        (   FirstArg == 0
+        ->  format(string(Code),
+"    if arg1 == 0
+      block.call(~w)
+      break
+    end", [AccParam])
+        ;   FirstArg == []
+        ->  format(string(Code),
+"    if arg1.empty?
+      block.call(~w)
+      break
+    end", [AccParam])
+        ;   format(string(Code),
+"    if arg1 == ~w
+      block.call(~w)
+      break
+    end", [FirstArg, AccParam])
+        )
+    ;   body_to_goals(Body, Goals),
+        compile_ruby_conditions(Goals, ParamNames, CondCode),
+        format(string(Code),
+"    if ~s
+      block.call(~w)
+      break
+    end", [CondCode, AccParam])
+    ).
+
+compile_ruby_conditions([], _, "true").
+compile_ruby_conditions([Goal|Rest], ParamNames, Code) :-
+    compile_ruby_condition(Goal, ParamNames, GoalCode),
+    compile_ruby_conditions(Rest, ParamNames, RestCode),
+    (   RestCode == "true"
+    ->  Code = GoalCode
+    ;   format(string(Code), "~s && ~s", [GoalCode, RestCode])
+    ).
+
+compile_ruby_condition(_ == Y, _, Code) :- format(string(Code), "arg1 == ~w", [Y]).
+compile_ruby_condition(_ =:= Y, _, Code) :- format(string(Code), "arg1 == ~w", [Y]).
+compile_ruby_condition(_ < Y, _, Code) :- format(string(Code), "arg1 < ~w", [Y]).
+compile_ruby_condition(_ > Y, _, Code) :- format(string(Code), "arg1 > ~w", [Y]).
+compile_ruby_condition(_ =< Y, _, Code) :- format(string(Code), "arg1 <= ~w", [Y]).
+compile_ruby_condition(_ >= Y, _, Code) :- format(string(Code), "arg1 >= ~w", [Y]).
+compile_ruby_condition(_, _, "true").
+
+%% compile_tail_loop_body(+RecClause, +Pred, +Arity, +ParamNames, -Code)
+compile_tail_loop_body(Head-Body, Pred, Arity, ParamNames, Code) :-
+    Head =.. [_|HeadArgs],
+    body_to_goals(Body, Goals),
+    partition(goal_matches(Pred, Arity), Goals, [RecGoal|_], OtherGoals),
+    RecGoal =.. [_|RecArgs],
+
+    % Build computed variables mapping
+    collect_computed_vars(OtherGoals, 0, ComputedVars),
+
+    % Compile intermediate computations
+    compile_tail_computations(OtherGoals, HeadArgs, ParamNames, ComputedVars, CompCode),
+
+    % Generate variable updates
+    compile_tail_updates(RecArgs, HeadArgs, ParamNames, ComputedVars, UpdateCode),
+
+    format(string(Code), "~s~s", [CompCode, UpdateCode]).
+
+collect_computed_vars([], _, []).
+collect_computed_vars([Var is _|Rest], Counter, [Var-Name|RestVars]) :-
+    var(Var), !,
+    format(atom(Name), "tmp~w", [Counter]),
+    Counter1 is Counter + 1,
+    collect_computed_vars(Rest, Counter1, RestVars).
+collect_computed_vars([_|Rest], Counter, Vars) :-
+    collect_computed_vars(Rest, Counter, Vars).
+
+compile_tail_computations([], _, _, _, "").
+compile_tail_computations([Goal|Rest], HeadArgs, ParamNames, ComputedVars, Code) :-
+    compile_tail_computation(Goal, HeadArgs, ParamNames, ComputedVars, GoalCode),
+    compile_tail_computations(Rest, HeadArgs, ParamNames, ComputedVars, RestCode),
+    format(string(Code), "~s~s", [GoalCode, RestCode]).
+
+compile_tail_computation(Var is Expr, HeadArgs, ParamNames, ComputedVars, Code) :-
+    var(Var), !,
+    get_ruby_var_name(Var, HeadArgs, ParamNames, ComputedVars, VarName),
+    compile_ruby_expr(Expr, HeadArgs, ParamNames, ComputedVars, ExprCode),
+    format(string(Code), "    ~s = ~s~n", [VarName, ExprCode]).
+compile_tail_computation(_, _, _, _, "").
+
+get_ruby_var_name(Var, _, _, ComputedVars, Name) :-
+    member(V-Name, ComputedVars), V == Var, !.
+get_ruby_var_name(Var, HeadArgs, ParamNames, _, Name) :-
+    nth1(Idx, HeadArgs, Arg), Arg == Var, !,
+    nth1(Idx, ParamNames, Name).
+get_ruby_var_name(_, _, _, _, "unknown").
+
+compile_ruby_expr(Expr, HeadArgs, ParamNames, ComputedVars, Code) :-
+    var(Expr), !,
+    get_ruby_var_name(Expr, HeadArgs, ParamNames, ComputedVars, Code).
+compile_ruby_expr(N, _, _, _, Code) :- number(N), !, format(string(Code), "~w", [N]).
+compile_ruby_expr(Atom, _, _, _, Code) :- atom(Atom), !, format(string(Code), "'~w'", [Atom]).
+compile_ruby_expr(X + Y, HeadArgs, ParamNames, ComputedVars, Code) :-
+    number(Y), Y < 0, !,
+    NegY is -Y,
+    compile_ruby_expr(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    format(string(Code), "(~s - ~w)", [XCode, NegY]).
+compile_ruby_expr(X + Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_ruby_expr(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_ruby_expr(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s + ~s)", [XCode, YCode]).
+compile_ruby_expr(X - Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_ruby_expr(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_ruby_expr(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s - ~s)", [XCode, YCode]).
+compile_ruby_expr(X * Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_ruby_expr(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_ruby_expr(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s * ~s)", [XCode, YCode]).
+compile_ruby_expr(X / Y, HeadArgs, ParamNames, ComputedVars, Code) :- !,
+    compile_ruby_expr(X, HeadArgs, ParamNames, ComputedVars, XCode),
+    compile_ruby_expr(Y, HeadArgs, ParamNames, ComputedVars, YCode),
+    format(string(Code), "(~s / ~s)", [XCode, YCode]).
+compile_ruby_expr(X, _, _, _, Code) :- format(string(Code), "~w", [X]).
+
+compile_tail_updates(RecArgs, HeadArgs, ParamNames, ComputedVars, Code) :-
+    length(RecArgs, Len),
+    numlist(1, Len, Indices),
+    maplist(compile_ruby_single_update(HeadArgs, ParamNames, ComputedVars), Indices, RecArgs, UpdateCodes),
+    atomic_list_concat(UpdateCodes, "", Code).
+
+compile_ruby_single_update(HeadArgs, ParamNames, ComputedVars, Idx, RecArg, Code) :-
+    nth1(Idx, ParamNames, ParamName),
+    length(ParamNames, TotalArgs),
+    (   Idx == TotalArgs
+    ->  Code = ""  % Don't update result argument
+    ;   var(RecArg)
+    ->  (   member(V-ComputedName, ComputedVars), V == RecArg
+        ->  format(string(Code), "    ~s = ~s~n", [ParamName, ComputedName])
+        ;   nth1(OldIdx, HeadArgs, OldArg), OldArg == RecArg
+        ->  nth1(OldIdx, ParamNames, OldName),
+            (   OldName == ParamName
+            ->  Code = ""
+            ;   format(string(Code), "    ~s = ~s~n", [ParamName, OldName])
+            )
+        ;   Code = ""
+        )
+    ;   number(RecArg)
+    ->  format(string(Code), "    ~s = ~w~n", [ParamName, RecArg])
+    ;   format(string(Code), "    ~s = '~w'~n", [ParamName, RecArg])
     ).
 
 %% Non-recursive rules use nested blocks with yield


### PR DESCRIPTION
## Summary

- Add tail recursion optimization for accumulator-style predicates (factorial pattern)
- Add linear recursion with memoization for branching predicates (fibonacci pattern)
- Add aggregation support: count, sum, min, max, avg via `aggregate_all/3`
- Add `json_output` and `pipeline` options for JSON output and shell integration

## Details

### Tail Recursion Optimization
Predicates with accumulator patterns like:
```prolog
factorial(0, Acc, Acc).
factorial(N, Acc, Result) :- N1 is N-1, Acc1 is Acc*N, factorial(N1, Acc1, Result).
```
Now compile to efficient loops instead of recursive calls:
- Perl: `while (1) { ... }`
- Ruby: `loop do ... end`

### Linear Recursion with Memoization
Fibonacci-style predicates with multiple recursive calls get automatic memoization:
- Perl: `my %memo;` with closure scoping
- Ruby: `@memo ||= {}` instance variable

### Aggregations
`aggregate_all/3` with sum, count, min, max, avg templates:
```prolog
total(T) :- aggregate_all(sum(V), item(_, V), T).
```
Compiles to accumulator loops with appropriate init/update operations.

### JSON/Pipeline Modes
New options for `compile_predicate_to_perl/3` and `compile_predicate_to_ruby/3`:
- `json_output` - Generates `predicate_json` wrapper that outputs JSON array
- `pipeline` - Generates `run_pipeline` for Unix shell integration

## Test plan

- [x] Tail recursion generates loop structure (factorial)
- [x] Linear recursion includes memoization cache (fibonacci)
- [x] Aggregations produce correct accumulator code
- [x] JSON output adds `use JSON` / `require 'json'` and wrapper function
- [x] Pipeline mode generates executable entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
