### PR TITLE
Perf: avoid scan-side hash builds for tiny probes

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1295,6 +1295,7 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             var joinKeyCount = join.LeftKeys.Count;
+            bool? forceBuildLeft = null;
 
             static bool TryGetPredicateScan(PlanNode node, out PredicateId predicate, out object[]? pattern)
             {
@@ -1555,6 +1556,7 @@ namespace UnifyWeaver.QueryRuntime
                                      probeUpperBound <= TinyProbeUpperBound)
                             {
                                 useScanIndexStrategy = false;
+                                forceBuildLeft = !leftIsScan;
                             }
                         }
                     }
@@ -2026,6 +2028,10 @@ namespace UnifyWeaver.QueryRuntime
             };
 
             var buildLeft = EstimateBuildCost(join.Left) < EstimateBuildCost(join.Right);
+            if (forceBuildLeft is not null)
+            {
+                buildLeft = forceBuildLeft.Value;
+            }
 
             static bool TryGetRecursiveRows(
                 PlanNode node,


### PR DESCRIPTION
  - Adjusts ExecuteKeyJoin in src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs to force hash-building on the
    non-scan (tiny probe) side when the scan-index strategy is intentionally disabled (tiny probe + no cached scan
    index), avoiding accidental per-join hash builds over full scans.
  - No semantic change; this is a join-strategy/perf tweak for “small probe x big scan” cases (common with parameter
    seeds).
  - Tests: pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir (Join-Path $env:TEMP
    'uw_cq_smoke_join_probe_subset') -ProjectFilter 'csharp_query_test_even_param_*'