### PR TITLE
feat: PyCall.rb (Ruby) bridge tested and working - all 6 bridges verified

### DIFF
--- a/docs/research/RPYC_LANGUAGE_COMPATIBILITY.md
+++ b/docs/research/RPYC_LANGUAGE_COMPATIBILITY.md
@@ -68,12 +68,12 @@ RPyC depends on **plumbum** (shell command toolkit). For RPyC classic mode (whic
 |----------|------------------|----------|------|------------------|-------|
 | **Prolog (SWI)** | [Janus](https://www.swi-prolog.org/pldoc/man?section=janus) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | This project |
 | **C#/F#** | [Python.NET](https://pythonnet.github.io/) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | .NET Core 9.0, math + NumPy |
-| **C#** | [CSnakes](https://tonybaloney.github.io/posts/embedding-python-in-dot-net-with-csnakes.html) | ✅ Yes | ✅ Yes | ✅ High | Newer, simpler API |
+| **C#** | [CSnakes](https://tonybaloney.github.io/posts/embedding-python-in-dot-net-with-csnakes.html) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | .NET 9, FromRedistributable |
 | **Java** | [JPype](https://github.com/jpype-project/jpype) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | Java 11, math + NumPy |
 | **Java** | [jpy](https://jpy.readthedocs.io/) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | Java 11, bi-directional |
 | **Java** | [GraalPy](https://github.com/oracle/graalpython) | ⚠️ GraalVM | ⚠️ Limited | ⚠️ Medium | May have C extension issues |
-| **Rust** | [PyO3](https://pyo3.rs/) | ✅ Yes | ✅ Yes | ✅ High | Very active, mature |
-| **Ruby** | [PyCall.rb](https://github.com/red-data-tools/pycall.rb) | ✅ Yes | ✅ Yes | ✅ High | v1.5.2 (May 2024) |
+| **Rust** | [PyO3](https://pyo3.rs/) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | PyO3 0.22, math + NumPy |
+| **Ruby** | [PyCall.rb](https://github.com/red-data-tools/pycall.rb) | ✅ Yes | ✅ Yes | ✅ **Tested & Working** | v1.5.2, math + NumPy |
 | **Go** | [go-python3](https://github.com/DataDog/go-python3) | ✅ Yes | ✅ Yes | ⚠️ Medium | GIL management complex |
 | **Go** | [go-embed-python](https://github.com/kluctl/go-embed-python) | ✅ Yes | ✅ Yes | ⚠️ Medium | No CGO, uses subprocess |
 | **Lua** | [lupa](https://github.com/scoder/lupa) | ❌ No* | ❌ No | ❌ Low | Lua embeds in Python, not reverse |
@@ -364,18 +364,20 @@ All the working variants run on or with CPython:
 
 ### Tested: Language Bridge Integration
 
-These bridges have been tested with RPyC (2025-12-27):
+These bridges have been tested with RPyC (2025-12-28):
 
 | Language | Bridge | Status | Test Results |
 |----------|--------|--------|--------------|
 | **.NET** | Python.NET | ✅ Verified | .NET Core 9.0, math.sqrt + numpy.mean |
-| **.NET** | CSnakes | ✅ Source gen verified | Compile-time wrappers work; runtime setup complex |
+| **.NET** | CSnakes | ✅ Verified | .NET 9, FromRedistributable + venv |
 | **Java** | JPype | ✅ Verified | Java 11, math.sqrt + numpy.mean |
 | **Java** | jpy | ✅ Verified | Java 11, bi-directional ArrayList demo |
+| **Rust** | PyO3 | ✅ Verified | PyO3 0.22, math.sqrt + numpy.mean |
+| **Ruby** | PyCall.rb | ✅ Verified | v1.5.2, math.sqrt + numpy.mean |
 | **Java** | GraalPy | ⏳ Untested | GraalVM-based, may have C extension issues |
 | **Java** | JNI + CPython | ⏳ Untested | Manual integration via Java Native Interface |
 
-See `examples/python-bridges/` for working examples.
+**All 6 primary bridges now verified working.** See `examples/python-bridges/` for working examples.
 
 ### Test Suite
 

--- a/examples/python-bridges/README.md
+++ b/examples/python-bridges/README.md
@@ -21,13 +21,13 @@ Each bridge embeds CPython and provides access to RPyC's live object proxies.
 | [JPype](jpype/) | JVM | ✅ Tested | Java projects needing NumPy/SciPy |
 | [jpy](jpy/) | JVM | ✅ Tested | Bi-directional Java↔Python |
 | [PyO3](pyo3/) | Rust | ✅ Tested | Systems programming with Python ML |
-| [PyCall.rb](pycall/) | Ruby | 🔬 Documented | Ruby/Rails with Python data science |
+| [PyCall.rb](pycall/) | Ruby | ✅ Tested | Ruby/Rails with Python data science |
 
 **Legend:** ✅ Tested and working | ⚠️ Partial (see notes) | 🔬 Documented (high confidence)
 
 **Notes:**
 - CSnakes: Uses `FromRedistributable` for cross-platform Python (auto-downloads ~60MB)
-- PyCall.rb: Well-documented pattern, not runtime-tested in this repo (Ruby environment required)
+- PyCall.rb: Requires `ruby-dev` package for native extension compilation
 
 ## Quick Start
 

--- a/examples/python-bridges/pycall/README.md
+++ b/examples/python-bridges/pycall/README.md
@@ -6,8 +6,8 @@ Use PyCall.rb to embed CPython in Ruby and access RPyC.
 
 | Feature | Status |
 |---------|--------|
-| PyCall.rb binding | ✅ Active, v1.5.2 (May 2024) |
-| RPyC access | 🔬 High confidence (untested) |
+| PyCall.rb binding | ✅ Active, v1.5.2 |
+| RPyC access | ✅ Tested and working |
 
 ## Overview
 
@@ -130,6 +130,13 @@ PyCall.rb automatically converts between Ruby and Python types:
 | Hash | dict |
 | true/false | True/False |
 | nil | None |
+
+**Note:** Remote Python objects (via RPyC) may need explicit conversion:
+```ruby
+# Python float from RPyC needs .to_f for Ruby numeric operations
+result = math.sqrt(16).to_f
+(result - 4.0).abs < 0.001  # Now works with Ruby's abs method
+```
 
 ## Advanced: Ruby Class Wrapper
 

--- a/examples/python-bridges/pycall/rpyc_client.rb
+++ b/examples/python-bridges/pycall/rpyc_client.rb
@@ -30,7 +30,7 @@ begin
   puts
   puts "Test 1: Remote math.sqrt"
   math = conn.modules.math
-  result = math.sqrt(16)
+  result = math.sqrt(16).to_f  # Convert Python float to Ruby float
   puts "  math.sqrt(16) = #{result}"
   raise "Expected 4.0" unless (result - 4.0).abs < 0.001
   puts "  ✓ Passed"
@@ -40,7 +40,7 @@ begin
   puts "Test 2: Remote numpy.mean"
   np = conn.modules.numpy
   arr = np.array([1, 2, 3, 4, 5])
-  mean = np.mean(arr)
+  mean = np.mean(arr).to_f  # Convert Python float to Ruby float
   puts "  numpy.mean([1,2,3,4,5]) = #{mean}"
   raise "Expected 3.0" unless (mean - 3.0).abs < 0.001
   puts "  ✓ Passed"


### PR DESCRIPTION
  ## Summary
  - Test and fix PyCall.rb (Ruby) bridge for RPyC integration
  - Update documentation to reflect all 6 bridges now verified working

  ## Changes

  ### PyCall.rb Fix
  - Add `.to_f` conversion for RPyC float objects before Ruby numeric operations
  - Remote Python floats don't have Ruby's `.abs` method directly

  **Root cause:** RPyC returns Python float proxy objects that need explicit conversion to Ruby floats for methods like `.abs`.

  ```ruby
  # Before (fails)
  result = math.sqrt(16)
  (result - 4.0).abs  # NoMethodError: undefined method `abs'

  # After (works)
  result = math.sqrt(16).to_f
  (result - 4.0).abs  # => 0.0

  Documentation Updates

  - examples/python-bridges/README.md: Mark PyCall.rb as ✅ Tested
  - examples/python-bridges/pycall/README.md: Add type conversion note
  - docs/research/RPYC_LANGUAGE_COMPATIBILITY.md: Update all bridge statuses

  Test Results

  PyCall.rb + RPyC Integration
  =============================
  Test 1: Remote math.sqrt
    math.sqrt(16) = 4.0
    ✓ Passed
  Test 2: Remote numpy.mean
    numpy.mean([1,2,3,4,5]) = 3.0
    ✓ Passed
  Test 3: Server Python version
    Server Python: 3.8.10
    ✓ Passed
  =============================
  All tests passed!

  All 6 Bridges Now Verified

  | Bridge     | Runtime | Status |
  |------------|---------|--------|
  | Python.NET | .NET    | ✅     |
  | CSnakes    | .NET    | ✅     |
  | JPype      | JVM     | ✅     |
  | jpy        | JVM     | ✅     |
  | PyO3       | Rust    | ✅     |
  | PyCall.rb  | Ruby    | ✅     |

  Prerequisites for Ruby Bridge

  - Ruby 2.7+ with ruby-dev package (for native extensions)
  - gem install pycall

  � Generated with https://claude.com/claude-code