### PR TITLE
Fix+Perf: param-seed multi-key joins + tiny-probe scan-index heuristic

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1627,9 +1627,8 @@ namespace UnifyWeaver.QueryRuntime
                             {
                                 useScanIndexStrategy = false;
                             }
-                            else if (joinKeyCount == 1 &&
-                                     TryEstimateRowUpperBound(otherNode, context, out var probeUpperBound) &&
-                                     probeUpperBound <= TinyProbeUpperBound)
+                            else if (TryEstimateRowUpperBound(otherNode, context, out var probeUpperBound) &&
+                                      probeUpperBound <= TinyProbeUpperBound)
                             {
                                 useScanIndexStrategy = false;
                                 forceBuildLeft = !leftIsScan;

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1177,16 +1177,18 @@ build_parameter_seed_node(HeadSpec, HeadArgs, Modes, param_seed{
     seed_var_map(HeadArgs, Positions, VarMap).
 
 seed_var_map(HeadArgs, Positions, VarMap) :-
-    findall(Var-Pos,
-        (   member(Pos, Positions),
-            nth0(Pos, HeadArgs, Var),
-            (   var(Var)
-            ->  true
-            ;   format(user_error, 'C# query target: input mode position must be a variable (~w).~n', [Var]),
-                fail
-            )
-        ),
-        VarMap).
+    seed_var_map_(Positions, HeadArgs, [], VarMapRev),
+    reverse(VarMapRev, VarMap).
+
+seed_var_map_([], _HeadArgs, Acc, Acc).
+seed_var_map_([Pos|Rest], HeadArgs, Acc, VarMap) :-
+    nth0(Pos, HeadArgs, Var),
+    (   var(Var)
+    ->  true
+    ;   format(user_error, 'C# query target: input mode position must be a variable (~w).~n', [Var]),
+        fail
+    ),
+    seed_var_map_(Rest, HeadArgs, [Var-Pos|Acc], VarMap).
 
 %% build_pipeline_seeded(+HeadSpec,+GroupSpecs,+HeadArgs,+Modes,+SeedOverride,+Terms,+Roles,...)
 %  If input modes are declared, start the pipeline from a param_seed node that


### PR DESCRIPTION
  - Fix: seed_var_map/3 no longer copies variables (via findall/3), so shared-variable join keys are inferred correctly for param_seed
    pipelines (src/unifyweaver/targets/csharp_target.pl:1179).
  - Test: add test_sale_item_param/3 (+,+,-) regression verifying multi-key join keys and runtime output (tests/core/
    test_csharp_query_target.pl:1198).
  - Perf: disable scan-index strategy for “tiny probe” joins even when key arity > 1 (src/unifyweaver/targets/csharp_query_runtime/
    QueryRuntime.cs:1625).

  Local Validation

  - Ran pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir (Join-Path $env:TEMP
    'uw_csharp_query_smoke_tinyprobe_multikey') (passes locally).
    (Avoid C:\tmp here; dotnet restore hit access-denied on .tmp files.)