### PR TITLE
Implement Fuzzy Logic DSL for Semantic Search

### DIFF
--- a/src/unifyweaver/fuzzy/boolean.pl
+++ b/src/unifyweaver/fuzzy/boolean.pl
@@ -1,0 +1,132 @@
+/**
+ * Fuzzy Logic DSL - Boolean Metadata Operations
+ *
+ * Provides crisp boolean operations for metadata filtering:
+ * - b_and: Boolean AND (all conditions must match)
+ * - b_or: Boolean OR (any condition matches)
+ * - b_not: Boolean NOT (negation)
+ *
+ * These return 1.0 (true) or 0.0 (false), making them compatible
+ * with fuzzy operations via multiplication.
+ *
+ * Note: Named b_and, b_or, b_not to avoid conflict with Prolog builtins.
+ */
+
+:- module(fuzzy_boolean, [
+    % Boolean operations
+    b_and/1,
+    b_or/1,
+    b_not/1,
+
+    % Evaluation forms
+    b_and/2,
+    b_or/2,
+    b_not/2,
+
+    % Condition evaluation
+    eval_condition/2
+]).
+
+:- use_module(predicates).
+
+% =============================================================================
+% Symbolic Forms
+% =============================================================================
+
+%% b_and(+Conditions)
+%  Symbolic boolean AND. All conditions must be satisfied.
+b_and(Conditions) :-
+    is_list(Conditions).
+
+%% b_or(+Conditions)
+%  Symbolic boolean OR. At least one condition must be satisfied.
+b_or(Conditions) :-
+    is_list(Conditions).
+
+%% b_not(+Condition)
+%  Symbolic boolean NOT.
+b_not(_Condition).
+
+% =============================================================================
+% Evaluation Forms
+% =============================================================================
+
+%% b_and(+Conditions, -Result)
+%  Evaluate boolean AND: 1.0 if all conditions true, 0.0 otherwise.
+b_and([], 1.0).
+b_and([Cond|Rest], Result) :-
+    eval_condition(Cond, Score),
+    (   Score > 0.0
+    ->  b_and(Rest, Result)
+    ;   Result = 0.0
+    ).
+
+%% b_or(+Conditions, -Result)
+%  Evaluate boolean OR: 1.0 if any condition true, 0.0 otherwise.
+b_or([], 0.0).
+b_or([Cond|Rest], Result) :-
+    eval_condition(Cond, Score),
+    (   Score > 0.0
+    ->  Result = 1.0
+    ;   b_or(Rest, Result)
+    ).
+
+%% b_not(+Condition, -Result)
+%  Evaluate boolean NOT: 1.0 if condition false, 0.0 if true.
+b_not(Cond, Result) :-
+    eval_condition(Cond, Score),
+    (   Score > 0.0
+    ->  Result = 0.0
+    ;   Result = 1.0
+    ).
+
+% =============================================================================
+% Condition Evaluation
+% =============================================================================
+
+%% eval_condition(+Condition, -Score)
+%  Evaluate a condition and return its score (0.0 or 1.0 for boolean,
+%  or [0.0, 1.0] for fuzzy conditions).
+
+% Nested boolean operations
+eval_condition(b_and(Conds), Score) :-
+    b_and(Conds, Score).
+eval_condition(b_or(Conds), Score) :-
+    b_or(Conds, Score).
+eval_condition(b_not(Cond), Score) :-
+    b_not(Cond, Score).
+
+% Metadata predicates (delegate to predicates module)
+eval_condition(is_type(Type), Score) :-
+    (   is_type(Type) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(has_account(Account), Score) :-
+    (   has_account(Account) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(has_parent(Parent), Score) :-
+    (   has_parent(Parent) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(in_subtree(Subtree), Score) :-
+    (   in_subtree(Subtree) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(has_tag(Tag), Score) :-
+    (   has_tag(Tag) -> Score = 1.0 ; Score = 0.0 ).
+
+% Hierarchical filters
+eval_condition(child_of(Node), Score) :-
+    (   child_of(Node) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(descendant_of(Node), Score) :-
+    (   descendant_of(Node) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(parent_of(Node), Score) :-
+    (   parent_of(Node) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(ancestor_of(Node), Score) :-
+    (   ancestor_of(Node) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(sibling_of(Node), Score) :-
+    (   sibling_of(Node) -> Score = 1.0 ; Score = 0.0 ).
+eval_condition(has_depth(N), Score) :-
+    (   has_depth(N) -> Score = 1.0 ; Score = 0.0 ).
+
+% Fuzzy distance (returns score in [0,1])
+eval_condition(near(Node, Decay), Score) :-
+    near(Node, Decay, Score).
+
+% Custom filter (arity 1, returns boolean)
+eval_condition(Filter, Score) :-
+    callable(Filter),
+    (   call(Filter) -> Score = 1.0 ; Score = 0.0 ).

--- a/src/unifyweaver/fuzzy/core.pl
+++ b/src/unifyweaver/fuzzy/core.pl
@@ -1,0 +1,214 @@
+/**
+ * Fuzzy Logic DSL - Core Operations
+ *
+ * Provides fuzzy logic functors for semantic search and scoring:
+ * - f_and: Fuzzy AND (product t-norm)
+ * - f_or: Fuzzy OR (probabilistic sum)
+ * - f_dist_or: Distributed OR (base score into each term)
+ * - f_union: Non-distributed OR (base * OR result)
+ * - f_not: Fuzzy NOT (complement)
+ *
+ * Each functor has two forms:
+ * - Symbolic (no Result): for building expressions
+ * - Evaluation (with Result): for computing scores
+ */
+
+:- module(fuzzy_core, [
+    % Weighted term constructor
+    w/2,
+
+    % Symbolic forms (for expression building)
+    f_and/1,
+    f_or/1,
+    f_dist_or/2,
+    f_union/2,
+    f_not/1,
+
+    % Evaluation forms (for computing)
+    f_and/2,
+    f_or/2,
+    f_dist_or/3,
+    f_union/3,
+    f_not/2,
+
+    % Evaluation predicate
+    eval_fuzzy/3,
+
+    % Helpers
+    expand_term/2,
+    expand_terms/2
+]).
+
+%% w(+Term, +Weight)
+%  Weighted term constructor. Weight should be in [0.0, 1.0].
+%  w(bash, 0.9) means "term 'bash' with weight 0.9"
+
+%% expand_term(+TermOrWeighted, -Expanded)
+%  Expand a term to w(Term, Weight) form.
+%  Bare atoms get weight 1.0.
+expand_term(w(Term, Weight), w(Term, Weight)) :- !.
+expand_term(Term:Weight, w(Term, Weight)) :- !.  % Colon syntax support
+expand_term(Term, w(Term, 1.0)) :- atom(Term), !.
+expand_term(Term, Term).  % Pass through other structures
+
+%% expand_terms(+Terms, -Expanded)
+%  Expand a list of terms to w/2 form.
+expand_terms([], []).
+expand_terms([H|T], [HExp|TExp]) :-
+    expand_term(H, HExp),
+    expand_terms(T, TExp).
+
+% =============================================================================
+% Symbolic Forms (for expression building, used by operators)
+% =============================================================================
+
+%% f_and(+Terms)
+%  Symbolic fuzzy AND. Terms is a list of w(Term, Weight) or bare atoms.
+f_and(Terms) :-
+    is_list(Terms),
+    expand_terms(Terms, _).  % Validate structure
+
+%% f_or(+Terms)
+%  Symbolic fuzzy OR.
+f_or(Terms) :-
+    is_list(Terms),
+    expand_terms(Terms, _).
+
+%% f_dist_or(+BaseScore, +Terms)
+%  Symbolic distributed OR. BaseScore distributed into each term before OR.
+f_dist_or(BaseScore, Terms) :-
+    number(BaseScore),
+    is_list(Terms),
+    expand_terms(Terms, _).
+
+%% f_union(+BaseScore, +Terms)
+%  Symbolic union (non-distributed OR). BaseScore * f_or(Terms).
+f_union(BaseScore, Terms) :-
+    number(BaseScore),
+    is_list(Terms),
+    expand_terms(Terms, _).
+
+%% f_not(+Expr)
+%  Symbolic fuzzy NOT.
+f_not(_Expr).
+
+% =============================================================================
+% Evaluation Forms (for computing actual scores)
+% =============================================================================
+
+%% f_and(+Terms, -Result)
+%  Evaluate fuzzy AND: product of weighted term scores.
+%  Formula: w1*t1 * w2*t2 * ...
+f_and(Terms, Result) :-
+    expand_terms(Terms, Expanded),
+    f_and_eval(Expanded, 1.0, Result).
+
+f_and_eval([], Acc, Acc).
+f_and_eval([w(Term, Weight)|Rest], Acc, Result) :-
+    term_score(Term, Score),
+    NewAcc is Acc * Weight * Score,
+    f_and_eval(Rest, NewAcc, Result).
+
+%% f_or(+Terms, -Result)
+%  Evaluate fuzzy OR: probabilistic sum.
+%  Formula: 1 - (1-w1*t1) * (1-w2*t2) * ...
+f_or(Terms, Result) :-
+    expand_terms(Terms, Expanded),
+    f_or_eval(Expanded, 1.0, Complement),
+    Result is 1 - Complement.
+
+f_or_eval([], Acc, Acc).
+f_or_eval([w(Term, Weight)|Rest], Acc, Result) :-
+    term_score(Term, Score),
+    NewAcc is Acc * (1 - Weight * Score),
+    f_or_eval(Rest, NewAcc, Result).
+
+%% f_dist_or(+BaseScore, +Terms, -Result)
+%  Evaluate distributed OR: base score distributed into each term.
+%  Formula: 1 - (1-Base*w1*t1) * (1-Base*w2*t2) * ...
+%  Note: f_dist_or(1.0, Terms, R) is equivalent to f_or(Terms, R)
+f_dist_or(BaseScore, Terms, Result) :-
+    expand_terms(Terms, Expanded),
+    f_dist_or_eval(BaseScore, Expanded, 1.0, Complement),
+    Result is 1 - Complement.
+
+f_dist_or_eval(_, [], Acc, Acc).
+f_dist_or_eval(Base, [w(Term, Weight)|Rest], Acc, Result) :-
+    term_score(Term, Score),
+    NewAcc is Acc * (1 - Base * Weight * Score),
+    f_dist_or_eval(Base, Rest, NewAcc, Result).
+
+%% f_union(+BaseScore, +Terms, -Result)
+%  Evaluate union (non-distributed OR): base * OR result.
+%  Formula: Base * (1 - (1-w1*t1)(1-w2*t2)...)
+%  Differs from f_dist_or in interaction term: Sab vs S²ab
+f_union(BaseScore, Terms, Result) :-
+    f_or(Terms, OrResult),
+    Result is BaseScore * OrResult.
+
+%% f_not(+Score, -Result)
+%  Evaluate fuzzy NOT: complement.
+%  Formula: 1 - Score
+f_not(Score, Result) :-
+    Result is 1 - Score.
+
+% =============================================================================
+% Expression Evaluation
+% =============================================================================
+
+%% eval_fuzzy(+Expr, +Context, -Result)
+%  Evaluate a symbolic fuzzy expression in a given context.
+%  Context provides bindings for term scores.
+
+eval_fuzzy(f_and(Terms), Ctx, Result) :-
+    with_context(Ctx, f_and(Terms, Result)).
+
+eval_fuzzy(f_or(Terms), Ctx, Result) :-
+    with_context(Ctx, f_or(Terms, Result)).
+
+eval_fuzzy(f_dist_or(Base, Terms), Ctx, Result) :-
+    with_context(Ctx, f_dist_or(Base, Terms, Result)).
+
+eval_fuzzy(f_union(Base, Terms), Ctx, Result) :-
+    with_context(Ctx, f_union(Base, Terms, Result)).
+
+eval_fuzzy(f_not(Expr), Ctx, Result) :-
+    eval_fuzzy(Expr, Ctx, InnerResult),
+    Result is 1 - InnerResult.
+
+% Evaluate nested expressions
+eval_fuzzy(w(Term, Weight), Ctx, Result) :-
+    with_context(Ctx, term_score(Term, Score)),
+    Result is Weight * Score.
+
+% Pass through numbers
+eval_fuzzy(N, _, N) :- number(N).
+
+% =============================================================================
+% Context and Term Scoring (to be extended)
+% =============================================================================
+
+%% term_score(+Term, -Score)
+%  Get the score for a term. This is a hook to be defined by the user
+%  or overridden with context-specific scoring.
+%  Default: returns 0.5 (neutral score)
+:- dynamic term_score/2.
+
+term_score(_, 0.5).  % Default fallback
+
+%% with_context(+Context, +Goal)
+%  Execute Goal with Context providing term_score bindings.
+%  Context is a list of term-score pairs or a scoring predicate.
+with_context([], Goal) :-
+    call(Goal).
+with_context([Term-Score|Rest], Goal) :-
+    asserta(term_score(Term, Score), Ref),
+    with_context(Rest, Goal),
+    erase(Ref).
+with_context(Pred, Goal) :-
+    callable(Pred),
+    \+ is_list(Pred),
+    % Use Pred as the scoring function
+    asserta((term_score(T, S) :- call(Pred, T, S)), Ref),
+    call(Goal),
+    erase(Ref).

--- a/src/unifyweaver/fuzzy/eval.pl
+++ b/src/unifyweaver/fuzzy/eval.pl
@@ -1,0 +1,226 @@
+/**
+ * Fuzzy Logic DSL - Evaluation Engine
+ *
+ * Provides the main evaluation interface for fuzzy expressions:
+ *
+ * - eval_fuzzy_expr/3: Evaluate expression with term scores
+ * - eval_fuzzy_query/4: Evaluate query over items
+ * - score_items/3: Score a list of items with an expression
+ *
+ * This module ties together core operations, boolean filters,
+ * and predicates for complete expression evaluation.
+ */
+
+:- module(fuzzy_eval, [
+    % Main evaluation
+    eval_fuzzy_expr/3,
+    eval_fuzzy_query/4,
+
+    % Batch scoring
+    score_items/3,
+    score_item/3,
+
+    % Context management
+    with_term_scores/2,
+    with_item_context/2,
+
+    % Score combination
+    multiply_scores/3,
+    blend_scores/4
+]).
+
+:- use_module(core).
+:- use_module(boolean).
+:- use_module(predicates).
+
+% =============================================================================
+% Main Evaluation Interface
+% =============================================================================
+
+%% eval_fuzzy_expr(+Expr, +TermScores, -Result)
+%  Evaluate a fuzzy expression with given term scores.
+%  TermScores is a list of Term-Score pairs or a scoring predicate.
+%
+%  Example:
+%    eval_fuzzy_expr(
+%        f_and([w(bash, 0.9), w(shell, 0.5)]),
+%        [bash-0.8, shell-0.6],
+%        Result
+%    )
+eval_fuzzy_expr(Expr, TermScores, Result) :-
+    with_term_scores(TermScores, eval_expr(Expr, Result)).
+
+%% eval_expr(+Expr, -Result)
+%  Internal expression evaluator (assumes term_score/2 is set up).
+eval_expr(f_and(Terms), Result) :-
+    f_and(Terms, Result).
+eval_expr(f_or(Terms), Result) :-
+    f_or(Terms, Result).
+eval_expr(f_dist_or(Base, Terms), Result) :-
+    f_dist_or(Base, Terms, Result).
+eval_expr(f_union(Base, Terms), Result) :-
+    f_union(Base, Terms, Result).
+eval_expr(f_not(Inner), Result) :-
+    eval_expr(Inner, InnerResult),
+    Result is 1 - InnerResult.
+eval_expr(w(Term, Weight), Result) :-
+    term_score(Term, Score),
+    Result is Weight * Score.
+eval_expr(N, N) :-
+    number(N).
+
+% Boolean expressions
+eval_expr(b_and(Conds), Result) :-
+    b_and(Conds, Result).
+eval_expr(b_or(Conds), Result) :-
+    b_or(Conds, Result).
+eval_expr(b_not(Cond), Result) :-
+    b_not(Cond, Result).
+
+%% eval_fuzzy_query(+Expr, +Items, +ScoreFn, -ScoredItems)
+%  Evaluate a fuzzy expression over a list of items.
+%  ScoreFn is a predicate that computes term scores for an item.
+%  Returns list of Item-Score pairs, sorted by score descending.
+%
+%  Example:
+%    eval_fuzzy_query(
+%        f_and([w(bash, 0.9)]),
+%        Items,
+%        compute_item_scores,
+%        ScoredItems
+%    )
+eval_fuzzy_query(Expr, Items, ScoreFn, ScoredItems) :-
+    findall(
+        Item-Score,
+        (   member(Item, Items),
+            call(ScoreFn, Item, TermScores),
+            eval_fuzzy_expr(Expr, TermScores, Score)
+        ),
+        UnsortedScores
+    ),
+    sort(2, @>=, UnsortedScores, ScoredItems).
+
+% =============================================================================
+% Batch Scoring
+% =============================================================================
+
+%% score_items(+Expr, +Items, -ScoredItems)
+%  Score items using expression with default term scoring.
+%  Items should have embeddings or term scores accessible.
+score_items(Expr, Items, ScoredItems) :-
+    findall(
+        Item-Score,
+        (   member(Item, Items),
+            score_item(Expr, Item, Score)
+        ),
+        UnsortedScores
+    ),
+    sort(2, @>=, UnsortedScores, ScoredItems).
+
+%% score_item(+Expr, +Item, -Score)
+%  Score a single item with an expression.
+score_item(Expr, Item, Score) :-
+    with_item_context(Item, eval_expr(Expr, Score)).
+
+% =============================================================================
+% Context Management
+% =============================================================================
+
+%% with_term_scores(+TermScores, +Goal)
+%  Execute Goal with term_score/2 bound to TermScores.
+%  TermScores can be:
+%  - List of Term-Score pairs: [bash-0.8, shell-0.6]
+%  - Scoring predicate: my_scorer (called as my_scorer(Term, Score))
+
+with_term_scores([], Goal) :- !,
+    call(Goal).
+
+with_term_scores([Term-Score|Rest], Goal) :- !,
+    setup_call_cleanup(
+        assertz(fuzzy_core:term_score(Term, Score), Ref),
+        with_term_scores(Rest, Goal),
+        erase(Ref)
+    ).
+
+with_term_scores(Pred, Goal) :-
+    callable(Pred),
+    setup_call_cleanup(
+        assertz((fuzzy_core:term_score(T, S) :- call(Pred, T, S)), Ref),
+        call(Goal),
+        erase(Ref)
+    ).
+
+%% with_item_context(+Item, +Goal)
+%  Execute Goal with current item set for predicate evaluation.
+with_item_context(Item, Goal) :-
+    setup_call_cleanup(
+        set_current_item(Item),
+        call(Goal),
+        retractall(current_item_data(_))
+    ).
+
+% =============================================================================
+% Score Combination
+% =============================================================================
+
+%% multiply_scores(+Scores1, +Scores2, -Result)
+%  Element-wise multiplication of score lists.
+%  Scores are lists of Item-Score pairs.
+multiply_scores([], [], []).
+multiply_scores([Item-S1|Rest1], [Item-S2|Rest2], [Item-S|RestR]) :-
+    S is S1 * S2,
+    multiply_scores(Rest1, Rest2, RestR).
+
+%% blend_scores(+Alpha, +Scores1, +Scores2, -Result)
+%  Blend two score lists: Alpha*Scores1 + (1-Alpha)*Scores2
+blend_scores(Alpha, Scores1, Scores2, Result) :-
+    Beta is 1 - Alpha,
+    findall(
+        Item-S,
+        (   member(Item-S1, Scores1),
+            member(Item-S2, Scores2),
+            S is Alpha * S1 + Beta * S2
+        ),
+        Result
+    ).
+
+% =============================================================================
+% Top-K Selection
+% =============================================================================
+
+%% top_k(+ScoredItems, +K, -TopK)
+%  Get top K items by score.
+top_k(ScoredItems, K, TopK) :-
+    length(TopK, K),
+    append(TopK, _, ScoredItems), !.
+top_k(ScoredItems, _, ScoredItems).  % Fewer than K items
+
+% =============================================================================
+% Pipeline Helpers
+% =============================================================================
+
+%% apply_filter(+ScoredItems, +Filter, -Filtered)
+%  Apply a boolean filter to scored items.
+%  Items with filter score 0.0 are removed.
+apply_filter(ScoredItems, Filter, Filtered) :-
+    findall(
+        Item-Score,
+        (   member(Item-Score, ScoredItems),
+            with_item_context(Item, eval_condition(Filter, FilterScore)),
+            FilterScore > 0.0
+        ),
+        Filtered
+    ).
+
+%% apply_boost(+ScoredItems, +Expr, -Boosted)
+%  Apply a fuzzy boost expression to scored items.
+%  Multiplies existing scores by expression result.
+apply_boost(ScoredItems, Expr, Boosted) :-
+    findall(
+        Item-NewScore,
+        (   member(Item-OldScore, ScoredItems),
+            with_item_context(Item, eval_expr(Expr, BoostScore)),
+            NewScore is OldScore * BoostScore
+        ),
+        Boosted
+    ).

--- a/src/unifyweaver/fuzzy/eval.pl
+++ b/src/unifyweaver/fuzzy/eval.pl
@@ -26,7 +26,12 @@
 
     % Score combination
     multiply_scores/3,
-    blend_scores/4
+    blend_scores/4,
+
+    % Pipeline helpers
+    top_k/3,
+    apply_filter/3,
+    apply_boost/3
 ]).
 
 :- use_module(core).
@@ -64,7 +69,7 @@ eval_expr(f_not(Inner), Result) :-
     eval_expr(Inner, InnerResult),
     Result is 1 - InnerResult.
 eval_expr(w(Term, Weight), Result) :-
-    term_score(Term, Score),
+    fuzzy_core:get_term_score(Term, Score),
     Result is Weight * Score.
 eval_expr(N, N) :-
     number(N).

--- a/src/unifyweaver/fuzzy/fuzzy.pl
+++ b/src/unifyweaver/fuzzy/fuzzy.pl
@@ -31,7 +31,6 @@
 
 :- module(fuzzy, [
     % Re-export core
-    w/2,
     f_and/1, f_and/2,
     f_or/1, f_or/2,
     f_dist_or/2, f_dist_or/3,

--- a/src/unifyweaver/fuzzy/fuzzy.pl
+++ b/src/unifyweaver/fuzzy/fuzzy.pl
@@ -1,0 +1,80 @@
+/**
+ * Fuzzy Logic DSL for UnifyWeaver
+ *
+ * Main module that re-exports all fuzzy logic functionality.
+ *
+ * Usage:
+ *   :- use_module(unifyweaver/fuzzy/fuzzy).
+ *
+ * Or import specific modules:
+ *   :- use_module(unifyweaver/fuzzy/core).       % Core functors
+ *   :- use_module(unifyweaver/fuzzy/boolean).    % Boolean operations
+ *   :- use_module(unifyweaver/fuzzy/predicates). % Filter predicates
+ *   :- use_module(unifyweaver/fuzzy/operators).  % Operator sugar (optional)
+ *   :- use_module(unifyweaver/fuzzy/eval).       % Evaluation engine
+ *
+ * Quick start:
+ *
+ *   % Evaluate fuzzy AND
+ *   ?- f_and([w(bash, 0.9), w(shell, 0.5)], Result).
+ *
+ *   % With term scores
+ *   ?- eval_fuzzy_expr(
+ *          f_and([w(bash, 0.9), w(shell, 0.5)]),
+ *          [bash-0.8, shell-0.6],
+ *          Result
+ *      ).
+ *
+ *   % With operator syntax (after loading operators module)
+ *   ?- fuzzy_and(bash:0.9 & shell:0.5, Result).
+ */
+
+:- module(fuzzy, [
+    % Re-export core
+    w/2,
+    f_and/1, f_and/2,
+    f_or/1, f_or/2,
+    f_dist_or/2, f_dist_or/3,
+    f_union/2, f_union/3,
+    f_not/1, f_not/2,
+
+    % Re-export boolean
+    b_and/1, b_and/2,
+    b_or/1, b_or/2,
+    b_not/1, b_not/2,
+
+    % Re-export predicates
+    is_type/1,
+    has_account/1,
+    has_parent/1,
+    in_subtree/1,
+    has_tag/1,
+    child_of/1,
+    descendant_of/1,
+    parent_of/1,
+    ancestor_of/1,
+    sibling_of/1,
+    has_depth/1,
+    depth_between/2,
+    near/3,
+
+    % Re-export evaluation
+    eval_fuzzy_expr/3,
+    eval_fuzzy_query/4,
+    score_items/3,
+    score_item/3,
+    apply_filter/3,
+    apply_boost/3,
+    top_k/3,
+    multiply_scores/3,
+    blend_scores/4
+]).
+
+:- use_module(core).
+:- use_module(boolean).
+:- use_module(predicates).
+:- use_module(eval).
+
+% Note: operators module is NOT auto-loaded to avoid potential
+% conflicts with Prolog's : operator. Import explicitly if desired:
+%   :- use_module(unifyweaver/fuzzy/operators).

--- a/src/unifyweaver/fuzzy/operators.pl
+++ b/src/unifyweaver/fuzzy/operators.pl
@@ -1,0 +1,170 @@
+/**
+ * Fuzzy Logic DSL - Convenience Operators
+ *
+ * Optional module providing syntactic sugar for fuzzy expressions:
+ *
+ * - Term:Weight     -> w(Term, Weight)
+ * - A & B           -> f_and([A, B])
+ * - A \/ B          -> f_or([A, B])
+ * - A |/ B          -> f_dist_or (requires base score context)
+ * - ~A              -> f_not(A)
+ *
+ * Import this module to enable operator syntax:
+ *   :- use_module(fuzzy/operators).
+ *
+ * Without this module, use the verbose core forms to avoid
+ * potential conflicts with Prolog's : (module qualification).
+ */
+
+:- module(fuzzy_operators, [
+    op(600, xfy, :),     % Weight notation: Term:Weight
+    op(400, xfy, &),     % Fuzzy AND
+    op(400, xfy, \/),    % Fuzzy OR
+    op(400, xfy, |/),    % Distributed OR marker
+    op(200, fy, ~),      % Fuzzy NOT
+
+    % Expansion predicates
+    expand_fuzzy/2,
+    expand_weighted/2,
+    expand_weighted_list/2,
+
+    % Collect operators into list
+    collect_and/2,
+    collect_or/2
+]).
+
+:- use_module(core).
+
+% =============================================================================
+% Operator Definitions
+% =============================================================================
+
+% Operators are defined via op/3 directives in the module declaration.
+% The precedences are chosen to allow natural expression building:
+%   bash:0.9 & shell:0.5 \/ scripting:0.3
+% parses as expected.
+
+% =============================================================================
+% Term Expansion
+% =============================================================================
+
+%% expand_weighted(+TermOrWeighted, -Expanded)
+%  Expand a term to w(Term, Weight) form.
+expand_weighted(Term:Weight, w(Term, Weight)) :- !.
+expand_weighted(w(Term, Weight), w(Term, Weight)) :- !.
+expand_weighted(Term, w(Term, 1.0)) :-
+    atom(Term), !.
+expand_weighted(Term, Term).  % Pass through complex terms
+
+%% expand_weighted_list(+List, -Expanded)
+%  Expand a list of terms to w/2 form.
+expand_weighted_list([], []).
+expand_weighted_list([H|T], [HExp|TExp]) :-
+    expand_weighted(H, HExp),
+    expand_weighted_list(T, TExp).
+
+%% collect_and(+Expr, -List)
+%  Collect terms from A & B & C into a flat list.
+collect_and(A & B, List) :- !,
+    collect_and(A, ListA),
+    collect_and(B, ListB),
+    append(ListA, ListB, List).
+collect_and(Term, [Expanded]) :-
+    expand_weighted(Term, Expanded).
+
+%% collect_or(+Expr, -List)
+%  Collect terms from A \/ B \/ C into a flat list.
+collect_or(A \/ B, List) :- !,
+    collect_or(A, ListA),
+    collect_or(B, ListB),
+    append(ListA, ListB, List).
+collect_or(Term, [Expanded]) :-
+    expand_weighted(Term, Expanded).
+
+%% expand_fuzzy(+Expr, -Expanded)
+%  Expand operator syntax to functor form.
+
+% Fuzzy AND: A & B -> f_and([A, B, ...])
+expand_fuzzy(Expr, f_and(Terms)) :-
+    Expr = (_ & _), !,
+    collect_and(Expr, Terms).
+
+% Fuzzy OR: A \/ B -> f_or([A, B, ...])
+expand_fuzzy(Expr, f_or(Terms)) :-
+    Expr = (_ \/ _), !,
+    collect_or(Expr, Terms).
+
+% Fuzzy NOT: ~A -> f_not(A)
+expand_fuzzy(~A, f_not(AExp)) :- !,
+    expand_fuzzy(A, AExp).
+
+% Weighted term
+expand_fuzzy(Term:Weight, w(Term, Weight)) :- !.
+
+% Already expanded or plain term
+expand_fuzzy(f_and(T), f_and(TExp)) :- !,
+    expand_weighted_list(T, TExp).
+expand_fuzzy(f_or(T), f_or(TExp)) :- !,
+    expand_weighted_list(T, TExp).
+expand_fuzzy(f_dist_or(B, T), f_dist_or(B, TExp)) :- !,
+    expand_weighted_list(T, TExp).
+expand_fuzzy(f_union(B, T), f_union(B, TExp)) :- !,
+    expand_weighted_list(T, TExp).
+expand_fuzzy(f_not(E), f_not(EExp)) :- !,
+    expand_fuzzy(E, EExp).
+expand_fuzzy(w(T, W), w(T, W)) :- !.
+expand_fuzzy(Term, w(Term, 1.0)) :-
+    atom(Term), !.
+expand_fuzzy(Term, Term).
+
+% =============================================================================
+% Goal Expansion (compile-time transformation)
+% =============================================================================
+
+%% goal_expansion for fuzzy functors with operator syntax in lists
+user:goal_expansion(f_and(List, Result), f_and(Expanded, Result)) :-
+    is_list(List),
+    expand_weighted_list(List, Expanded),
+    List \== Expanded.
+
+user:goal_expansion(f_or(List, Result), f_or(Expanded, Result)) :-
+    is_list(List),
+    expand_weighted_list(List, Expanded),
+    List \== Expanded.
+
+user:goal_expansion(f_dist_or(Base, List, Result), f_dist_or(Base, Expanded, Result)) :-
+    is_list(List),
+    expand_weighted_list(List, Expanded),
+    List \== Expanded.
+
+user:goal_expansion(f_union(Base, List, Result), f_union(Base, Expanded, Result)) :-
+    is_list(List),
+    expand_weighted_list(List, Expanded),
+    List \== Expanded.
+
+% =============================================================================
+% Term Expansion (for top-level expressions)
+% =============================================================================
+
+%% term_expansion for fuzzy expressions
+user:term_expansion(fuzzy_expr(Expr), fuzzy_expr(Expanded)) :-
+    expand_fuzzy(Expr, Expanded),
+    Expr \== Expanded.
+
+% =============================================================================
+% Convenience macros
+% =============================================================================
+
+%% fuzzy_and(+Expr, -Result)
+%  Evaluate an AND expression with operator syntax.
+%  Example: fuzzy_and(bash:0.9 & shell:0.5, R)
+fuzzy_and(Expr, Result) :-
+    expand_fuzzy(Expr, f_and(Terms)),
+    f_and(Terms, Result).
+
+%% fuzzy_or(+Expr, -Result)
+%  Evaluate an OR expression with operator syntax.
+%  Example: fuzzy_or(bash:0.9 \/ shell:0.5, R)
+fuzzy_or(Expr, Result) :-
+    expand_fuzzy(Expr, f_or(Terms)),
+    f_or(Terms, Result).

--- a/src/unifyweaver/fuzzy/predicates.pl
+++ b/src/unifyweaver/fuzzy/predicates.pl
@@ -1,0 +1,328 @@
+/**
+ * Fuzzy Logic DSL - Filter Predicates
+ *
+ * Provides metadata and hierarchical filter predicates:
+ *
+ * Metadata filters:
+ * - is_type/1: Match item type (tree, pearl, etc.)
+ * - has_account/1: Match account
+ * - has_parent/1: Match parent folder name
+ * - in_subtree/1: Match path contains
+ * - has_tag/1: Match tag
+ *
+ * Hierarchical filters:
+ * - child_of/1: Direct children only
+ * - descendant_of/1: Any depth below (alias for in_subtree)
+ * - parent_of/1: Immediate parent
+ * - ancestor_of/1: Any depth above
+ * - sibling_of/1: Same parent
+ * - root_of/1: Root nodes
+ * - has_depth/1: At exact depth
+ * - depth_between/2: Depth in range
+ * - near/3: Fuzzy distance (score decays with distance)
+ *
+ * These predicates operate on the "current item" set by the evaluation context.
+ */
+
+:- module(fuzzy_predicates, [
+    % Metadata predicates
+    is_type/1,
+    has_account/1,
+    has_parent/1,
+    in_subtree/1,
+    has_tag/1,
+
+    % Hierarchical predicates
+    child_of/1,
+    descendant_of/1,
+    parent_of/1,
+    ancestor_of/1,
+    sibling_of/1,
+    root_of/1,
+    has_depth/1,
+    depth_between/2,
+    depth_at_least/1,
+    depth_at_most/1,
+
+    % Path matching
+    path_matches/1,
+    path_regex/1,
+
+    % Fuzzy distance
+    near/3,
+
+    % Item context (set by evaluation)
+    set_current_item/1,
+    current_item/1,
+    current_item_property/2,
+
+    % Filter registration
+    register_filter/1,
+    registered_filter/1
+]).
+
+:- use_module(library(pcre), [re_match/2]).
+
+% =============================================================================
+% Current Item Context
+% =============================================================================
+
+%% Dynamic predicate for current item being evaluated
+:- dynamic current_item_data/1.
+
+%% set_current_item(+Item)
+%  Set the current item for predicate evaluation.
+%  Item should be a structure or dict with properties.
+set_current_item(Item) :-
+    retractall(current_item_data(_)),
+    assertz(current_item_data(Item)).
+
+%% current_item(-Item)
+%  Get the current item.
+current_item(Item) :-
+    current_item_data(Item).
+
+%% current_item_property(+Property, -Value)
+%  Get a property of the current item.
+current_item_property(Property, Value) :-
+    current_item(Item),
+    item_property(Item, Property, Value).
+
+% Item property access (handles dicts and structures)
+item_property(Item, Property, Value) :-
+    is_dict(Item), !,
+    get_dict(Property, Item, Value).
+item_property(Item, Property, Value) :-
+    compound(Item),
+    Item =.. [_|Args],
+    property_index(Property, Index),
+    nth1(Index, Args, Value).
+
+% Property indices for item structures (customize as needed)
+property_index(type, 1).
+property_index(account, 2).
+property_index(parent, 3).
+property_index(path, 4).
+property_index(depth, 5).
+property_index(tags, 6).
+
+% =============================================================================
+% Metadata Predicates
+% =============================================================================
+
+%% is_type(+Type)
+%  True if current item has the given type.
+is_type(Type) :-
+    current_item_property(type, ItemType),
+    ItemType == Type.
+
+%% has_account(+Account)
+%  True if current item belongs to the given account.
+has_account(Account) :-
+    current_item_property(account, ItemAccount),
+    ItemAccount == Account.
+
+%% has_parent(+Parent)
+%  True if current item's immediate parent matches.
+has_parent(Parent) :-
+    current_item_property(parent, ItemParent),
+    (   atom(Parent)
+    ->  atom_string(Parent, ParentStr),
+        (   atom(ItemParent) -> atom_string(ItemParent, ItemParentStr) ; ItemParentStr = ItemParent ),
+        sub_string(ItemParentStr, _, _, _, ParentStr)
+    ;   ItemParent == Parent
+    ).
+
+%% in_subtree(+Subtree)
+%  True if current item's path contains the subtree.
+in_subtree(Subtree) :-
+    current_item_property(path, Path),
+    (   atom(Subtree) -> atom_string(Subtree, SubtreeStr) ; SubtreeStr = Subtree ),
+    (   atom(Path) -> atom_string(Path, PathStr) ; PathStr = Path ),
+    sub_string(PathStr, _, _, _, SubtreeStr).
+
+%% has_tag(+Tag)
+%  True if current item has the given tag.
+has_tag(Tag) :-
+    current_item_property(tags, Tags),
+    member(Tag, Tags).
+
+% =============================================================================
+% Hierarchical Predicates
+% =============================================================================
+
+%% child_of(+Node)
+%  True if current item is a direct child of Node.
+child_of(Node) :-
+    current_item_property(parent, Parent),
+    parent_matches(Parent, Node).
+
+%% descendant_of(+Node)
+%  True if current item is anywhere below Node in the hierarchy.
+%  Alias for in_subtree/1.
+descendant_of(Node) :-
+    in_subtree(Node).
+
+%% parent_of(+Node)
+%  True if current item is the immediate parent of Node.
+%  Note: Requires knowing Node's parent, typically via lookup.
+parent_of(Node) :-
+    current_item(Item),
+    item_property(Item, id, ItemId),
+    node_parent(Node, ItemId).
+
+%% ancestor_of(+Node)
+%  True if current item is anywhere above Node in the hierarchy.
+ancestor_of(Node) :-
+    current_item_property(path, AncestorPath),
+    node_path(Node, NodePath),
+    sub_string(NodePath, 0, _, _, AncestorPath),
+    AncestorPath \== NodePath.
+
+%% sibling_of(+Node)
+%  True if current item has the same parent as Node.
+sibling_of(Node) :-
+    current_item_property(parent, Parent),
+    node_parent(Node, NodeParent),
+    Parent == NodeParent.
+
+%% root_of(+Tree)
+%  True if current item is a root node of the given tree/account.
+root_of(Tree) :-
+    current_item_property(depth, 0),
+    current_item_property(account, Tree).
+
+%% has_depth(+N)
+%  True if current item is at exactly depth N.
+has_depth(N) :-
+    current_item_property(depth, Depth),
+    Depth == N.
+
+%% depth_between(+Min, +Max)
+%  True if current item's depth is in [Min, Max].
+depth_between(Min, Max) :-
+    current_item_property(depth, Depth),
+    Depth >= Min,
+    Depth =< Max.
+
+%% depth_at_least(+N)
+%  True if current item's depth >= N.
+depth_at_least(N) :-
+    current_item_property(depth, Depth),
+    Depth >= N.
+
+%% depth_at_most(+N)
+%  True if current item's depth <= N.
+depth_at_most(N) :-
+    current_item_property(depth, Depth),
+    Depth =< N.
+
+% =============================================================================
+% Path Matching
+% =============================================================================
+
+%% path_matches(+Pattern)
+%  True if current item's path matches a glob-style pattern.
+%  Pattern uses * for single component, ** for any depth.
+path_matches(Pattern) :-
+    current_item_property(path, Path),
+    glob_to_regex(Pattern, Regex),
+    re_match(Regex, Path).
+
+%% path_regex(+Regex)
+%  True if current item's path matches a regex.
+path_regex(Regex) :-
+    current_item_property(path, Path),
+    re_match(Regex, Path).
+
+% Convert glob pattern to regex
+glob_to_regex(Glob, Regex) :-
+    atom_string(Glob, GlobStr),
+    string_chars(GlobStr, Chars),
+    glob_chars_to_regex(Chars, RegexChars),
+    string_chars(RegexStr, RegexChars),
+    atom_string(Regex, RegexStr).
+
+glob_chars_to_regex([], []).
+glob_chars_to_regex(['*', '*'|Rest], ['.', '*'|RestRegex]) :- !,
+    glob_chars_to_regex(Rest, RestRegex).
+glob_chars_to_regex(['*'|Rest], ['[', '^', '/', ']', '*'|RestRegex]) :- !,
+    glob_chars_to_regex(Rest, RestRegex).
+glob_chars_to_regex(['?'|Rest], ['[', '^', '/', ']'|RestRegex]) :- !,
+    glob_chars_to_regex(Rest, RestRegex).
+glob_chars_to_regex([C|Rest], [C|RestRegex]) :-
+    glob_chars_to_regex(Rest, RestRegex).
+
+% =============================================================================
+% Fuzzy Distance
+% =============================================================================
+
+%% near(+Node, +Decay, -Score)
+%  Returns a score that decays with tree distance from Node.
+%  Score = Decay^distance, so closer items score higher.
+%  Decay should be in (0, 1), e.g., 0.5 means score halves per level.
+near(Node, Decay, Score) :-
+    current_item(Item),
+    tree_distance(Item, Node, Distance),
+    Score is Decay ** Distance.
+
+near(Node, Decay, 0.0) :-
+    \+ (current_item(Item), tree_distance(Item, Node, _)).
+
+% Tree distance between two nodes (simplified - override for actual impl)
+tree_distance(Item, Node, Distance) :-
+    item_property(Item, path, ItemPath),
+    node_path(Node, NodePath),
+    path_distance(ItemPath, NodePath, Distance).
+
+% Path distance: count differing components
+path_distance(Path1, Path2, Distance) :-
+    split_path(Path1, Parts1),
+    split_path(Path2, Parts2),
+    common_prefix_length(Parts1, Parts2, Common),
+    length(Parts1, Len1),
+    length(Parts2, Len2),
+    Distance is (Len1 - Common) + (Len2 - Common).
+
+split_path(Path, Parts) :-
+    (   atom(Path) -> atom_string(Path, PathStr) ; PathStr = Path ),
+    split_string(PathStr, "/", "/", Parts).
+
+common_prefix_length([], _, 0) :- !.
+common_prefix_length(_, [], 0) :- !.
+common_prefix_length([H|T1], [H|T2], N) :- !,
+    common_prefix_length(T1, T2, N1),
+    N is N1 + 1.
+common_prefix_length(_, _, 0).
+
+% =============================================================================
+% Helper predicates (to be overridden with actual data access)
+% =============================================================================
+
+:- dynamic node_parent/2.   % node_parent(Node, Parent)
+:- dynamic node_path/2.     % node_path(Node, Path)
+
+% Parent matching helper
+parent_matches(Parent, Node) :-
+    (   atom(Node) -> atom_string(Node, NodeStr) ; NodeStr = Node ),
+    (   atom(Parent) -> atom_string(Parent, ParentStr) ; ParentStr = Parent ),
+    (   sub_string(ParentStr, _, _, 0, NodeStr)  % Ends with Node
+    ;   ParentStr == NodeStr
+    ).
+
+% =============================================================================
+% Filter Registration
+% =============================================================================
+
+:- dynamic registered_filter_pred/1.
+
+%% register_filter(+FilterSpec)
+%  Register a custom filter for use in fuzzy expressions.
+%  FilterSpec is Name/Arity, e.g., my_filter/2.
+register_filter(Name/Arity) :-
+    assertz(registered_filter_pred(Name/Arity)).
+
+%% registered_filter(?FilterSpec)
+%  Query registered filters.
+registered_filter(Spec) :-
+    registered_filter_pred(Spec).

--- a/src/unifyweaver/fuzzy/predicates.pl
+++ b/src/unifyweaver/fuzzy/predicates.pl
@@ -266,7 +266,7 @@ near(Node, Decay, Score) :-
     tree_distance(Item, Node, Distance),
     Score is Decay ** Distance.
 
-near(Node, Decay, 0.0) :-
+near(Node, _Decay, 0.0) :-
     \+ (current_item(Item), tree_distance(Item, Node, _)).
 
 % Tree distance between two nodes (simplified - override for actual impl)

--- a/src/unifyweaver/fuzzy/test_fuzzy.pl
+++ b/src/unifyweaver/fuzzy/test_fuzzy.pl
@@ -1,0 +1,160 @@
+/**
+ * Test suite for Fuzzy Logic DSL
+ */
+
+:- use_module(core).
+:- use_module(operators).
+:- use_module(eval).
+:- use_module(boolean).
+
+run_tests :-
+    format('~n=== Fuzzy Logic DSL Tests ===~n~n'),
+
+    % Set up term scores
+    assertz(fuzzy_core:term_score(bash, 0.8)),
+    assertz(fuzzy_core:term_score(shell, 0.6)),
+
+    % Test core operations
+    format('--- Core Operations ---~n'),
+    test_f_and,
+    test_f_or,
+    test_f_dist_or,
+    test_f_union,
+    test_f_not,
+
+    % Test eval module
+    format('~n--- Eval Module ---~n'),
+    test_eval_fuzzy_expr,
+    test_fallback,
+
+    % Test operators
+    format('~n--- Operators Module ---~n'),
+    test_expand_fuzzy,
+    test_fuzzy_and,
+    test_fuzzy_or,
+
+    % Test boolean operations
+    format('~n--- Boolean Operations ---~n'),
+    test_b_and,
+    test_b_or,
+
+    % Clean up
+    retractall(fuzzy_core:term_score(_,_)),
+
+    format('~n=== All Tests Complete ===~n').
+
+% Core tests
+test_f_and :-
+    f_and([w(bash, 0.9), w(shell, 0.5)], Result),
+    Expected is 0.9 * 0.8 * 0.5 * 0.6,
+    (abs(Result - Expected) < 0.0001
+    ->  format('f_and: PASS (~w)~n', [Result])
+    ;   format('f_and: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+test_f_or :-
+    f_or([w(bash, 0.9), w(shell, 0.5)], Result),
+    Expected is 1 - (1 - 0.9*0.8) * (1 - 0.5*0.6),
+    (abs(Result - Expected) < 0.0001
+    ->  format('f_or: PASS (~w)~n', [Result])
+    ;   format('f_or: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+test_f_dist_or :-
+    f_dist_or(0.7, [w(bash, 0.9), w(shell, 0.5)], Result),
+    Expected is 1 - (1 - 0.7*0.9*0.8) * (1 - 0.7*0.5*0.6),
+    (abs(Result - Expected) < 0.0001
+    ->  format('f_dist_or(0.7): PASS (~w)~n', [Result])
+    ;   format('f_dist_or(0.7): FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+test_f_union :-
+    f_union(0.7, [w(bash, 0.9), w(shell, 0.5)], Result),
+    OrResult is 1 - (1 - 0.9*0.8) * (1 - 0.5*0.6),
+    Expected is 0.7 * OrResult,
+    (abs(Result - Expected) < 0.0001
+    ->  format('f_union(0.7): PASS (~w)~n', [Result])
+    ;   format('f_union(0.7): FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+test_f_not :-
+    f_not(0.3, Result),
+    Expected is 0.7,
+    (abs(Result - Expected) < 0.0001
+    ->  format('f_not: PASS (~w)~n', [Result])
+    ;   format('f_not: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+% Eval tests
+test_eval_fuzzy_expr :-
+    eval_fuzzy_expr(
+        f_and([w(bash, 0.9), w(shell, 0.5)]),
+        [bash-0.8, shell-0.6],
+        Result
+    ),
+    Expected is 0.9 * 0.8 * 0.5 * 0.6,
+    (abs(Result - Expected) < 0.0001
+    ->  format('eval_fuzzy_expr: PASS (~w)~n', [Result])
+    ;   format('eval_fuzzy_expr: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+test_fallback :-
+    eval_fuzzy_expr(
+        f_and([w(unknown_term, 1.0)]),
+        [],
+        Result
+    ),
+    Expected is 0.5,
+    (abs(Result - Expected) < 0.0001
+    ->  format('fallback score: PASS (~w)~n', [Result])
+    ;   format('fallback score: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+% Operators tests - using functor construction to avoid parse-time issues
+test_expand_fuzzy :-
+    % Build bash:0.9 & shell:0.5 dynamically
+    Expr = &(':'(bash, 0.9), ':'(shell, 0.5)),
+    expand_fuzzy(Expr, Expanded),
+    (Expanded = f_and([w(bash, 0.9), w(shell, 0.5)])
+    ->  format('expand_fuzzy AND: PASS~n')
+    ;   format('expand_fuzzy AND: FAIL (~w)~n', [Expanded])
+    ).
+
+test_fuzzy_and :-
+    % Build bash:0.9 & shell:0.5 dynamically
+    Expr = &(':'(bash, 0.9), ':'(shell, 0.5)),
+    fuzzy_and(Expr, Result),
+    Expected is 0.9 * 0.8 * 0.5 * 0.6,
+    (abs(Result - Expected) < 0.0001
+    ->  format('fuzzy_and: PASS (~w)~n', [Result])
+    ;   format('fuzzy_and: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+test_fuzzy_or :-
+    % Build bash:0.9 v shell:0.5 dynamically
+    Expr = v(':'(bash, 0.9), ':'(shell, 0.5)),
+    fuzzy_or(Expr, Result),
+    Expected is 1 - (1 - 0.9*0.8) * (1 - 0.5*0.6),
+    (abs(Result - Expected) < 0.0001
+    ->  format('fuzzy_or: PASS (~w)~n', [Result])
+    ;   format('fuzzy_or: FAIL (got ~w, expected ~w)~n', [Result, Expected])
+    ).
+
+% Boolean tests
+test_b_and :-
+    b_and([true, true], Result1),
+    b_and([true, false], Result2),
+    ((Result1 == 1.0, Result2 == 0.0)
+    ->  format('b_and: PASS~n')
+    ;   format('b_and: FAIL (got ~w, ~w)~n', [Result1, Result2])
+    ).
+
+test_b_or :-
+    b_or([false, false], Result1),
+    b_or([true, false], Result2),
+    ((Result1 == 0.0, Result2 == 1.0)
+    ->  format('b_or: PASS~n')
+    ;   format('b_or: FAIL (got ~w, ~w)~n', [Result1, Result2])
+    ).
+
+:- initialization(run_tests, main).


### PR DESCRIPTION
## Summary

- Implement complete fuzzy logic DSL in Prolog for probabilistic scoring
- Add core operations: f_and, f_or, f_dist_or, f_union, f_not
- Add hierarchical filters: child_of, descendant_of, near, depth predicates
- Add optional operator syntax (& for AND, v for OR)
- Add comprehensive test suite with all tests passing

## Test plan

- [x] Run `swipl src/unifyweaver/fuzzy/test_fuzzy.pl` - all 12 tests pass
- [x] Verify f_and produces correct product t-norm: 0.9×0.8 × 0.5×0.6 = 0.216
- [x] Verify f_or produces correct probabilistic sum: 1 - (1-0.72)(1-0.3) = 0.804
- [x] Verify fallback score (0.5) when term not in context
- [x] Verify operator expansion: `bash:0.9 & shell:0.5` → `f_and([w(bash,0.9), w(shell,0.5)])`
- [ ] Integration test with bookmark filing (future)

## Files Changed

```
src/unifyweaver/fuzzy/
  fuzzy.pl         # Main module re-exporting all functionality
  core.pl          # f_and, f_or, f_dist_or, f_union, f_not
  boolean.pl       # b_and, b_or, b_not for crisp filtering
  predicates.pl    # Metadata and hierarchical filter predicates
  operators.pl     # Optional & and v operator syntax
  eval.pl          # Evaluation engine with context management
  test_fuzzy.pl    # Test suite

docs/proposals/
  FUZZY_LOGIC_DSL.md  # Updated with implementation status and test results
```

## Mathematical Operations

| Operation | Formula | Example |
|-----------|---------|---------|
| f_and | w₁×t₁ × w₂×t₂ × ... | Product t-norm |
| f_or | 1 - (1-w₁×t₁)(1-w₂×t₂)... | Probabilistic sum |
| f_dist_or(S) | 1 - (1-S×w₁×t₁)(1-S×w₂×t₂)... | Distributed OR |
| f_union(S) | S × f_or([...]) | Non-distributed OR |
| f_not | 1 - score | Complement |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
