### PR TITLE
feat(fuzzy): Add Python code generation for fuzzy logic DSL

### DIFF
--- a/docs/proposals/FUZZY_LOGIC_DSL.md
+++ b/docs/proposals/FUZZY_LOGIC_DSL.md
@@ -590,10 +590,15 @@ b_or: PASS
 
 ### Remaining Implementation
 
-#### Phase 2: Python Target
-1. Add fuzzy logic to UnifyWeaver's Python code generator
-2. Generate NumPy-based implementations
-3. Test with bookmark filing use case
+#### Phase 2: Python Target ✅ COMPLETE
+1. ✅ Add fuzzy logic to UnifyWeaver's Python code generator (`python_fuzzy_target.pl`)
+2. ✅ Generate NumPy-based implementations (`fuzzy_logic.py`)
+3. ✅ Test with bookmark filing use case (17 tests pass)
+
+Files added:
+- `src/unifyweaver/targets/python_fuzzy_target.pl` - Prolog code generator
+- `src/unifyweaver/targets/python_runtime/fuzzy_logic.py` - NumPy runtime
+- `src/unifyweaver/targets/python_runtime/test_fuzzy_logic.py` - Test suite
 
 #### Phase 3: SQL Target (Future)
 1. SQL compilation target for database queries

--- a/src/unifyweaver/targets/python_fuzzy_target.pl
+++ b/src/unifyweaver/targets/python_fuzzy_target.pl
@@ -1,0 +1,359 @@
+/**
+ * Python Fuzzy Logic Target
+ *
+ * Extends the Python code generator with fuzzy logic operations.
+ * Generates NumPy-based implementations for:
+ * - f_and: Fuzzy AND (product t-norm)
+ * - f_or: Fuzzy OR (probabilistic sum)
+ * - f_dist_or: Distributed OR
+ * - f_union: Non-distributed OR
+ * - f_not: Fuzzy NOT
+ *
+ * Usage in Prolog:
+ *   :- use_module(python_fuzzy_target).
+ *
+ *   % Compile a predicate that uses fuzzy logic
+ *   compile_fuzzy_to_python(my_search/2, [], Code).
+ */
+
+:- module(python_fuzzy_target, [
+    % Main compilation
+    compile_fuzzy_to_python/3,
+    compile_fuzzy_to_python/2,
+
+    % Goal translation (extends python_target)
+    translate_fuzzy_goal/2,
+
+    % Header/helper generation
+    fuzzy_header/1,
+    fuzzy_imports/1,
+
+    % Initialization
+    init_fuzzy_target/0
+]).
+
+:- use_module(python_target, [
+    compile_predicate_to_python/3,
+    init_python_target/0,
+    var_to_python/2
+]).
+
+% =============================================================================
+% Initialization
+% =============================================================================
+
+init_fuzzy_target :-
+    init_python_target.
+
+% =============================================================================
+% Main Compilation Interface
+% =============================================================================
+
+%% compile_fuzzy_to_python(+PredicateIndicator, +Options, -Code)
+%  Compile a predicate with fuzzy logic support to Python.
+compile_fuzzy_to_python(Pred/Arity, Options, Code) :-
+    compile_predicate_to_python(Pred/Arity, Options, BaseCode),
+    fuzzy_imports(Imports),
+    format(string(Code), "~w\n~w", [Imports, BaseCode]).
+
+%% compile_fuzzy_to_python(+PredicateIndicator, -Code)
+%  Compile with default options.
+compile_fuzzy_to_python(Pred/Arity, Code) :-
+    compile_fuzzy_to_python(Pred/Arity, [], Code).
+
+% =============================================================================
+% Fuzzy Header and Imports
+% =============================================================================
+
+fuzzy_imports(Imports) :-
+    Imports = "from unifyweaver.targets.python_runtime.fuzzy_logic import (
+    f_and, f_or, f_dist_or, f_union, f_not,
+    f_and_batch, f_or_batch, f_dist_or_batch, f_union_batch,
+    multiply_scores, blend_scores, top_k, apply_filter, apply_boost
+)
+import numpy as np
+".
+
+fuzzy_header(Header) :-
+    fuzzy_imports(Imports),
+    format(string(Header), "~w\n", [Imports]).
+
+% =============================================================================
+% Goal Translation for Fuzzy Operations
+% =============================================================================
+
+%% translate_fuzzy_goal(+Goal, -Code)
+%  Translate fuzzy logic goals to Python code.
+
+% f_and/2: Fuzzy AND
+% f_and([w(bash, 0.9), w(shell, 0.5)], Result)
+translate_fuzzy_goal(f_and(Terms, Result), Code) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_and(~w, _term_scores)\n",
+           [PyResult, PyTerms]).
+
+% f_or/2: Fuzzy OR
+translate_fuzzy_goal(f_or(Terms, Result), Code) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_or(~w, _term_scores)\n",
+           [PyResult, PyTerms]).
+
+% f_dist_or/3: Distributed OR with base score
+translate_fuzzy_goal(f_dist_or(BaseScore, Terms, Result), Code) :-
+    !,
+    var_to_python(BaseScore, PyBase),
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_dist_or(~w, ~w, _term_scores)\n",
+           [PyResult, PyBase, PyTerms]).
+
+% f_union/3: Non-distributed OR (union)
+translate_fuzzy_goal(f_union(BaseScore, Terms, Result), Code) :-
+    !,
+    var_to_python(BaseScore, PyBase),
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_union(~w, ~w, _term_scores)\n",
+           [PyResult, PyBase, PyTerms]).
+
+% f_not/2: Fuzzy NOT
+translate_fuzzy_goal(f_not(Score, Result), Code) :-
+    !,
+    var_to_python(Score, PyScore),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_not(~w)\n",
+           [PyResult, PyScore]).
+
+% eval_fuzzy_expr/3: Evaluate expression with term scores
+translate_fuzzy_goal(eval_fuzzy_expr(Expr, TermScores, Result), Code) :-
+    !,
+    translate_fuzzy_expr(Expr, PyExpr),
+    var_to_python(TermScores, PyScores),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    _term_scores = dict(~w)\n    ~w = ~w\n",
+           [PyScores, PyResult, PyExpr]).
+
+% multiply_scores/3: Element-wise score multiplication
+translate_fuzzy_goal(multiply_scores(Scores1, Scores2, Result), Code) :-
+    !,
+    var_to_python(Scores1, PyS1),
+    var_to_python(Scores2, PyS2),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = multiply_scores(np.array(~w), np.array(~w))\n",
+           [PyResult, PyS1, PyS2]).
+
+% blend_scores/4: Blend two score arrays
+translate_fuzzy_goal(blend_scores(Alpha, Scores1, Scores2, Result), Code) :-
+    !,
+    var_to_python(Alpha, PyAlpha),
+    var_to_python(Scores1, PyS1),
+    var_to_python(Scores2, PyS2),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = blend_scores(~w, np.array(~w), np.array(~w))\n",
+           [PyResult, PyAlpha, PyS1, PyS2]).
+
+% top_k/3: Get top K items by score
+translate_fuzzy_goal(top_k(ScoredItems, K, Result), Code) :-
+    !,
+    var_to_python(ScoredItems, PyItems),
+    var_to_python(K, PyK),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    _items, _scores = zip(*~w) if ~w else ([], [])\n    ~w = top_k(list(_items), np.array(_scores), ~w)\n",
+           [PyItems, PyItems, PyResult, PyK]).
+
+% apply_filter/3: Apply boolean filter
+translate_fuzzy_goal(apply_filter(ScoredItems, Filter, Result), Code) :-
+    !,
+    var_to_python(ScoredItems, PyItems),
+    translate_filter_predicate(Filter, PyFilter),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    _items, _scores = zip(*~w) if ~w else ([], [])\n    _filtered_items, _filtered_scores = apply_filter(list(_items), np.array(_scores), ~w)\n    ~w = list(zip(_filtered_items, _filtered_scores))\n",
+           [PyItems, PyItems, PyFilter, PyResult]).
+
+% apply_boost/3: Apply fuzzy boost
+translate_fuzzy_goal(apply_boost(ScoredItems, BoostExpr, Result), Code) :-
+    !,
+    var_to_python(ScoredItems, PyItems),
+    translate_boost_expr(BoostExpr, PyBoost),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    _items, _scores = zip(*~w) if ~w else ([], [])\n    _boosted = apply_boost(list(_items), np.array(_scores), ~w)\n    ~w = list(zip(_items, _boosted))\n",
+           [PyItems, PyItems, PyBoost, PyResult]).
+
+% =============================================================================
+% Batch Operations (for vectorized processing)
+% =============================================================================
+
+translate_fuzzy_goal(f_and_batch(Terms, TermScoresBatch, Result), Code) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(TermScoresBatch, PyScores),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_and_batch(~w, ~w)\n",
+           [PyResult, PyTerms, PyScores]).
+
+translate_fuzzy_goal(f_or_batch(Terms, TermScoresBatch, Result), Code) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(TermScoresBatch, PyScores),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_or_batch(~w, ~w)\n",
+           [PyResult, PyTerms, PyScores]).
+
+translate_fuzzy_goal(f_dist_or_batch(BaseScores, Terms, TermScoresBatch, Result), Code) :-
+    !,
+    var_to_python(BaseScores, PyBase),
+    translate_weighted_terms(Terms, PyTerms),
+    var_to_python(TermScoresBatch, PyScores),
+    var_to_python(Result, PyResult),
+    format(string(Code),
+           "    ~w = f_dist_or_batch(~w, ~w, ~w)\n",
+           [PyResult, PyBase, PyTerms, PyScores]).
+
+% =============================================================================
+% Helper Predicates
+% =============================================================================
+
+%% translate_weighted_terms(+Terms, -PyTerms)
+%  Convert Prolog weighted terms to Python list of tuples.
+%  w(bash, 0.9) -> ("bash", 0.9)
+translate_weighted_terms(Terms, PyTerms) :-
+    translate_terms_list(Terms, TermStrings),
+    atomic_list_concat(TermStrings, ', ', Joined),
+    format(string(PyTerms), "[~w]", [Joined]).
+
+translate_terms_list([], []).
+translate_terms_list([w(Term, Weight)|Rest], [PyTerm|PyRest]) :-
+    !,
+    format(string(PyTerm), "(\"~w\", ~w)", [Term, Weight]),
+    translate_terms_list(Rest, PyRest).
+translate_terms_list([Term:Weight|Rest], [PyTerm|PyRest]) :-
+    !,
+    format(string(PyTerm), "(\"~w\", ~w)", [Term, Weight]),
+    translate_terms_list(Rest, PyRest).
+translate_terms_list([Term|Rest], [PyTerm|PyRest]) :-
+    atom(Term),
+    !,
+    format(string(PyTerm), "(\"~w\", 1.0)", [Term]),
+    translate_terms_list(Rest, PyRest).
+
+%% translate_fuzzy_expr(+Expr, -PyExpr)
+%  Translate a fuzzy expression to Python.
+translate_fuzzy_expr(f_and(Terms), PyExpr) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    format(string(PyExpr), "f_and(~w, _term_scores)", [PyTerms]).
+translate_fuzzy_expr(f_or(Terms), PyExpr) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    format(string(PyExpr), "f_or(~w, _term_scores)", [PyTerms]).
+translate_fuzzy_expr(f_dist_or(Base, Terms), PyExpr) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    format(string(PyExpr), "f_dist_or(~w, ~w, _term_scores)", [Base, PyTerms]).
+translate_fuzzy_expr(f_union(Base, Terms), PyExpr) :-
+    !,
+    translate_weighted_terms(Terms, PyTerms),
+    format(string(PyExpr), "f_union(~w, ~w, _term_scores)", [Base, PyTerms]).
+translate_fuzzy_expr(f_not(Inner), PyExpr) :-
+    !,
+    translate_fuzzy_expr(Inner, PyInner),
+    format(string(PyExpr), "f_not(~w)", [PyInner]).
+translate_fuzzy_expr(Num, PyExpr) :-
+    number(Num),
+    !,
+    format(string(PyExpr), "~w", [Num]).
+
+%% translate_filter_predicate(+Filter, -PyFilter)
+%  Translate filter predicates to Python lambda.
+translate_filter_predicate(is_type(Type), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: item.get('type') == \"~w\"", [Type]).
+translate_filter_predicate(has_account(Account), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: item.get('account') == \"~w\"", [Account]).
+translate_filter_predicate(in_subtree(Subtree), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: \"~w\" in item.get('path', '')", [Subtree]).
+translate_filter_predicate(has_parent(Parent), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: \"~w\" in item.get('parent', '')", [Parent]).
+translate_filter_predicate(has_tag(Tag), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: \"~w\" in item.get('tags', [])", [Tag]).
+translate_filter_predicate(child_of(Node), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: item.get('parent', '').endswith(\"~w\")", [Node]).
+translate_filter_predicate(descendant_of(Node), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: \"~w\" in item.get('path', '')", [Node]).
+translate_filter_predicate(has_depth(N), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: item.get('depth') == ~w", [N]).
+translate_filter_predicate(depth_between(Min, Max), PyFilter) :-
+    !,
+    format(string(PyFilter), "lambda item: ~w <= item.get('depth', 0) <= ~w", [Min, Max]).
+translate_filter_predicate(not(Inner), PyFilter) :-
+    !,
+    translate_filter_predicate(Inner, PyInner),
+    format(string(PyFilter), "lambda item: not (~w)(item)", [PyInner]).
+translate_filter_predicate(Filter, PyFilter) :-
+    % Default: treat as a function name
+    format(string(PyFilter), "~w", [Filter]).
+
+%% translate_boost_expr(+BoostExpr, -PyBoost)
+%  Translate boost expressions to Python lambda.
+translate_boost_expr(near(Node, Decay), PyBoost) :-
+    !,
+    format(string(PyBoost),
+           "lambda item: ~w ** abs(item.get('depth', 0) - _find_depth(\"~w\"))",
+           [Decay, Node]).
+translate_boost_expr(Expr, PyBoost) :-
+    translate_fuzzy_expr(Expr, PyExpr),
+    format(string(PyBoost), "lambda item: ~w", [PyExpr]).
+
+% =============================================================================
+% Integration with python_target.pl
+% =============================================================================
+
+% Hook into python_target's translate_goal/2 for fuzzy operations
+:- multifile python_target:translate_goal/2.
+
+python_target:translate_goal(f_and(Terms, Result), Code) :-
+    translate_fuzzy_goal(f_and(Terms, Result), Code).
+python_target:translate_goal(f_or(Terms, Result), Code) :-
+    translate_fuzzy_goal(f_or(Terms, Result), Code).
+python_target:translate_goal(f_dist_or(Base, Terms, Result), Code) :-
+    translate_fuzzy_goal(f_dist_or(Base, Terms, Result), Code).
+python_target:translate_goal(f_union(Base, Terms, Result), Code) :-
+    translate_fuzzy_goal(f_union(Base, Terms, Result), Code).
+python_target:translate_goal(f_not(Score, Result), Code) :-
+    translate_fuzzy_goal(f_not(Score, Result), Code).
+python_target:translate_goal(eval_fuzzy_expr(E, S, R), Code) :-
+    translate_fuzzy_goal(eval_fuzzy_expr(E, S, R), Code).
+python_target:translate_goal(multiply_scores(A, B, R), Code) :-
+    translate_fuzzy_goal(multiply_scores(A, B, R), Code).
+python_target:translate_goal(blend_scores(A, S1, S2, R), Code) :-
+    translate_fuzzy_goal(blend_scores(A, S1, S2, R), Code).
+python_target:translate_goal(top_k(Items, K, R), Code) :-
+    translate_fuzzy_goal(top_k(Items, K, R), Code).
+python_target:translate_goal(apply_filter(Items, F, R), Code) :-
+    translate_fuzzy_goal(apply_filter(Items, F, R), Code).
+python_target:translate_goal(apply_boost(Items, B, R), Code) :-
+    translate_fuzzy_goal(apply_boost(Items, B, R), Code).

--- a/src/unifyweaver/targets/python_runtime/fuzzy_logic.py
+++ b/src/unifyweaver/targets/python_runtime/fuzzy_logic.py
@@ -1,0 +1,333 @@
+"""
+Fuzzy Logic Runtime for UnifyWeaver
+
+Provides NumPy-based implementations of fuzzy logic operations:
+- f_and: Fuzzy AND (product t-norm)
+- f_or: Fuzzy OR (probabilistic sum)
+- f_dist_or: Distributed OR (base score into each term)
+- f_union: Non-distributed OR (base * OR result)
+- f_not: Fuzzy NOT (complement)
+
+All operations work on both scalars and NumPy arrays for batch processing.
+"""
+
+from typing import List, Tuple, Union, Optional, Callable, Dict, Any
+import numpy as np
+
+# Type aliases
+Score = Union[float, np.ndarray]
+WeightedTerm = Tuple[str, float]  # (term, weight)
+TermScores = Dict[str, Score]  # term -> score mapping
+
+
+def f_and(terms: List[WeightedTerm], term_scores: TermScores,
+          default_score: float = 0.5) -> Score:
+    """
+    Fuzzy AND using product t-norm.
+
+    Formula: w1*t1 * w2*t2 * ...
+
+    Args:
+        terms: List of (term, weight) tuples
+        term_scores: Dictionary mapping terms to their scores
+        default_score: Score to use for unknown terms (default 0.5)
+
+    Returns:
+        Product of weighted term scores (scalar or array)
+
+    Example:
+        >>> f_and([('bash', 0.9), ('shell', 0.5)], {'bash': 0.8, 'shell': 0.6})
+        0.216  # 0.9*0.8 * 0.5*0.6
+    """
+    result = 1.0
+    for term, weight in terms:
+        score = term_scores.get(term, default_score)
+        result = result * (weight * score)
+    return result
+
+
+def f_or(terms: List[WeightedTerm], term_scores: TermScores,
+         default_score: float = 0.5) -> Score:
+    """
+    Fuzzy OR using probabilistic sum.
+
+    Formula: 1 - (1 - w1*t1) * (1 - w2*t2) * ...
+
+    Args:
+        terms: List of (term, weight) tuples
+        term_scores: Dictionary mapping terms to their scores
+        default_score: Score to use for unknown terms (default 0.5)
+
+    Returns:
+        Probabilistic sum of weighted term scores
+
+    Example:
+        >>> f_or([('bash', 0.9), ('shell', 0.5)], {'bash': 0.8, 'shell': 0.6})
+        0.804  # 1 - (1-0.72)(1-0.3)
+    """
+    complement = 1.0
+    for term, weight in terms:
+        score = term_scores.get(term, default_score)
+        complement = complement * (1 - weight * score)
+    return 1 - complement
+
+
+def f_dist_or(base_score: Score, terms: List[WeightedTerm],
+              term_scores: TermScores, default_score: float = 0.5) -> Score:
+    """
+    Distributed OR - base score distributed into each term before OR.
+
+    Formula: 1 - (1 - Base*w1*t1) * (1 - Base*w2*t2) * ...
+
+    Note: f_dist_or(1.0, terms, scores) is equivalent to f_or(terms, scores)
+
+    Args:
+        base_score: The base score to distribute into each term
+        terms: List of (term, weight) tuples
+        term_scores: Dictionary mapping terms to their scores
+        default_score: Score to use for unknown terms
+
+    Returns:
+        Distributed OR result
+
+    Example:
+        >>> f_dist_or(0.7, [('bash', 0.9), ('shell', 0.5)], {'bash': 0.8, 'shell': 0.6})
+        0.60816  # 1 - (1-0.7*0.72)(1-0.7*0.3)
+    """
+    complement = 1.0
+    for term, weight in terms:
+        score = term_scores.get(term, default_score)
+        complement = complement * (1 - base_score * weight * score)
+    return 1 - complement
+
+
+def f_union(base_score: Score, terms: List[WeightedTerm],
+            term_scores: TermScores, default_score: float = 0.5) -> Score:
+    """
+    Non-distributed OR (union) - base score multiplies the OR result.
+
+    Formula: Base * (1 - (1-w1*t1)(1-w2*t2)...)
+
+    The difference from f_dist_or is the interaction term:
+    - f_union: Sab (union)
+    - f_dist_or: S²ab (distributed)
+
+    Args:
+        base_score: The base score to multiply with OR result
+        terms: List of (term, weight) tuples
+        term_scores: Dictionary mapping terms to their scores
+        default_score: Score to use for unknown terms
+
+    Returns:
+        Base score times OR result
+
+    Example:
+        >>> f_union(0.7, [('bash', 0.9), ('shell', 0.5)], {'bash': 0.8, 'shell': 0.6})
+        0.5628  # 0.7 * 0.804
+    """
+    or_result = f_or(terms, term_scores, default_score)
+    return base_score * or_result
+
+
+def f_not(score: Score) -> Score:
+    """
+    Fuzzy NOT (complement).
+
+    Formula: 1 - score
+
+    Args:
+        score: The score to complement
+
+    Returns:
+        1 - score
+
+    Example:
+        >>> f_not(0.3)
+        0.7
+    """
+    return 1 - score
+
+
+# =============================================================================
+# NumPy Vectorized Versions (for batch processing)
+# =============================================================================
+
+def f_and_batch(terms: List[WeightedTerm],
+                term_scores_batch: Dict[str, np.ndarray],
+                default_score: float = 0.5) -> np.ndarray:
+    """
+    Batch fuzzy AND for multiple items simultaneously.
+
+    Args:
+        terms: List of (term, weight) tuples
+        term_scores_batch: Dict mapping terms to score arrays (one per item)
+        default_score: Score for unknown terms
+
+    Returns:
+        Array of AND results, one per item
+    """
+    # Determine batch size from first term
+    first_term = terms[0][0] if terms else None
+    if first_term and first_term in term_scores_batch:
+        result = np.ones(len(term_scores_batch[first_term]))
+    else:
+        return np.array([default_score])
+
+    for term, weight in terms:
+        scores = term_scores_batch.get(term, np.full(len(result), default_score))
+        result = result * (weight * scores)
+
+    return result
+
+
+def f_or_batch(terms: List[WeightedTerm],
+               term_scores_batch: Dict[str, np.ndarray],
+               default_score: float = 0.5) -> np.ndarray:
+    """
+    Batch fuzzy OR for multiple items simultaneously.
+
+    Args:
+        terms: List of (term, weight) tuples
+        term_scores_batch: Dict mapping terms to score arrays
+        default_score: Score for unknown terms
+
+    Returns:
+        Array of OR results, one per item
+    """
+    first_term = terms[0][0] if terms else None
+    if first_term and first_term in term_scores_batch:
+        complement = np.ones(len(term_scores_batch[first_term]))
+    else:
+        return np.array([1 - default_score])
+
+    for term, weight in terms:
+        scores = term_scores_batch.get(term, np.full(len(complement), default_score))
+        complement = complement * (1 - weight * scores)
+
+    return 1 - complement
+
+
+def f_dist_or_batch(base_scores: np.ndarray,
+                    terms: List[WeightedTerm],
+                    term_scores_batch: Dict[str, np.ndarray],
+                    default_score: float = 0.5) -> np.ndarray:
+    """
+    Batch distributed OR for multiple items.
+
+    Args:
+        base_scores: Array of base scores (one per item)
+        terms: List of (term, weight) tuples
+        term_scores_batch: Dict mapping terms to score arrays
+        default_score: Score for unknown terms
+
+    Returns:
+        Array of distributed OR results
+    """
+    complement = np.ones_like(base_scores)
+
+    for term, weight in terms:
+        scores = term_scores_batch.get(term, np.full_like(base_scores, default_score))
+        complement = complement * (1 - base_scores * weight * scores)
+
+    return 1 - complement
+
+
+def f_union_batch(base_scores: np.ndarray,
+                  terms: List[WeightedTerm],
+                  term_scores_batch: Dict[str, np.ndarray],
+                  default_score: float = 0.5) -> np.ndarray:
+    """
+    Batch non-distributed OR (union) for multiple items.
+
+    Args:
+        base_scores: Array of base scores
+        terms: List of (term, weight) tuples
+        term_scores_batch: Dict mapping terms to score arrays
+        default_score: Score for unknown terms
+
+    Returns:
+        Array of union results (base * OR)
+    """
+    or_result = f_or_batch(terms, term_scores_batch, default_score)
+    return base_scores * or_result
+
+
+# =============================================================================
+# Score Combination Utilities
+# =============================================================================
+
+def multiply_scores(scores1: np.ndarray, scores2: np.ndarray) -> np.ndarray:
+    """Element-wise multiplication of score arrays."""
+    return scores1 * scores2
+
+
+def blend_scores(alpha: float, scores1: np.ndarray,
+                 scores2: np.ndarray) -> np.ndarray:
+    """
+    Blend two score arrays: alpha*scores1 + (1-alpha)*scores2
+
+    Args:
+        alpha: Blend factor in [0, 1]
+        scores1: First score array
+        scores2: Second score array
+
+    Returns:
+        Blended scores
+    """
+    return alpha * scores1 + (1 - alpha) * scores2
+
+
+def top_k(items: List[Any], scores: np.ndarray, k: int) -> List[Tuple[Any, float]]:
+    """
+    Get top K items by score.
+
+    Args:
+        items: List of items
+        scores: Array of scores (same length as items)
+        k: Number of top items to return
+
+    Returns:
+        List of (item, score) tuples, sorted descending by score
+    """
+    indices = np.argsort(scores)[::-1][:k]
+    return [(items[i], float(scores[i])) for i in indices]
+
+
+# =============================================================================
+# Filter Predicates
+# =============================================================================
+
+def apply_filter(items: List[Any], scores: np.ndarray,
+                 filter_fn: Callable[[Any], bool]) -> Tuple[List[Any], np.ndarray]:
+    """
+    Apply a boolean filter to items, keeping only those that pass.
+
+    Args:
+        items: List of items
+        scores: Array of scores
+        filter_fn: Function that returns True for items to keep
+
+    Returns:
+        Tuple of (filtered_items, filtered_scores)
+    """
+    mask = np.array([filter_fn(item) for item in items])
+    filtered_items = [item for item, keep in zip(items, mask) if keep]
+    filtered_scores = scores[mask]
+    return filtered_items, filtered_scores
+
+
+def apply_boost(items: List[Any], scores: np.ndarray,
+                boost_fn: Callable[[Any], float]) -> np.ndarray:
+    """
+    Apply a fuzzy boost to scores based on item properties.
+
+    Args:
+        items: List of items
+        scores: Array of scores
+        boost_fn: Function that returns boost factor for each item
+
+    Returns:
+        Boosted scores (original * boost)
+    """
+    boosts = np.array([boost_fn(item) for item in items])
+    return scores * boosts

--- a/src/unifyweaver/targets/python_runtime/test_fuzzy_logic.py
+++ b/src/unifyweaver/targets/python_runtime/test_fuzzy_logic.py
@@ -1,0 +1,224 @@
+"""
+Test suite for fuzzy logic runtime.
+
+Demonstrates integration with bookmark filing use case.
+"""
+
+import unittest
+import numpy as np
+from fuzzy_logic import (
+    f_and, f_or, f_dist_or, f_union, f_not,
+    f_and_batch, f_or_batch, f_dist_or_batch, f_union_batch,
+    multiply_scores, blend_scores, top_k, apply_filter, apply_boost
+)
+
+
+class TestFuzzyLogicCore(unittest.TestCase):
+    """Test core fuzzy logic operations."""
+
+    def setUp(self):
+        self.term_scores = {'bash': 0.8, 'shell': 0.6, 'linux': 0.7}
+        self.terms = [('bash', 0.9), ('shell', 0.5)]
+
+    def test_f_and(self):
+        """Test fuzzy AND (product t-norm)."""
+        # 0.9*0.8 * 0.5*0.6 = 0.216
+        result = f_and(self.terms, self.term_scores)
+        self.assertAlmostEqual(result, 0.216, places=6)
+
+    def test_f_or(self):
+        """Test fuzzy OR (probabilistic sum)."""
+        # 1 - (1-0.72)(1-0.3) = 0.804
+        result = f_or(self.terms, self.term_scores)
+        self.assertAlmostEqual(result, 0.804, places=6)
+
+    def test_f_dist_or(self):
+        """Test distributed OR."""
+        # 1 - (1-0.7*0.72)(1-0.7*0.3) = 0.60816
+        result = f_dist_or(0.7, self.terms, self.term_scores)
+        self.assertAlmostEqual(result, 0.60816, places=5)
+
+    def test_f_union(self):
+        """Test non-distributed OR (union)."""
+        # 0.7 * 0.804 = 0.5628
+        result = f_union(0.7, self.terms, self.term_scores)
+        self.assertAlmostEqual(result, 0.5628, places=4)
+
+    def test_f_not(self):
+        """Test fuzzy NOT."""
+        self.assertAlmostEqual(f_not(0.3), 0.7)
+        self.assertAlmostEqual(f_not(0.0), 1.0)
+        self.assertAlmostEqual(f_not(1.0), 0.0)
+
+    def test_fallback_score(self):
+        """Test default score for unknown terms."""
+        result = f_and([('unknown', 1.0)], self.term_scores)
+        self.assertAlmostEqual(result, 0.5)  # Default fallback
+
+    def test_custom_fallback(self):
+        """Test custom fallback score."""
+        result = f_and([('unknown', 1.0)], self.term_scores, default_score=0.3)
+        self.assertAlmostEqual(result, 0.3)
+
+
+class TestBatchOperations(unittest.TestCase):
+    """Test vectorized batch operations."""
+
+    def setUp(self):
+        # Batch of 3 items
+        self.term_scores_batch = {
+            'bash': np.array([0.8, 0.5, 0.9]),
+            'shell': np.array([0.6, 0.7, 0.4])
+        }
+        self.terms = [('bash', 0.9), ('shell', 0.5)]
+
+    def test_f_and_batch(self):
+        """Test batch fuzzy AND."""
+        result = f_and_batch(self.terms, self.term_scores_batch)
+        expected = np.array([0.9*0.8*0.5*0.6, 0.9*0.5*0.5*0.7, 0.9*0.9*0.5*0.4])
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_f_or_batch(self):
+        """Test batch fuzzy OR."""
+        result = f_or_batch(self.terms, self.term_scores_batch)
+        # For first item: 1 - (1-0.72)(1-0.3) = 0.804
+        self.assertAlmostEqual(result[0], 0.804, places=4)
+
+    def test_f_dist_or_batch(self):
+        """Test batch distributed OR."""
+        base_scores = np.array([0.7, 0.8, 0.6])
+        result = f_dist_or_batch(base_scores, self.terms, self.term_scores_batch)
+        self.assertEqual(len(result), 3)
+
+
+class TestScoreCombination(unittest.TestCase):
+    """Test score combination utilities."""
+
+    def test_multiply_scores(self):
+        """Test element-wise multiplication."""
+        s1 = np.array([0.8, 0.5, 0.9])
+        s2 = np.array([0.5, 0.6, 0.7])
+        result = multiply_scores(s1, s2)
+        np.testing.assert_array_almost_equal(result, [0.4, 0.3, 0.63])
+
+    def test_blend_scores(self):
+        """Test score blending."""
+        s1 = np.array([0.8, 0.5])
+        s2 = np.array([0.4, 0.9])
+        result = blend_scores(0.6, s1, s2)
+        # 0.6*0.8 + 0.4*0.4 = 0.64, 0.6*0.5 + 0.4*0.9 = 0.66
+        np.testing.assert_array_almost_equal(result, [0.64, 0.66])
+
+    def test_top_k(self):
+        """Test top-k selection."""
+        items = ['a', 'b', 'c', 'd']
+        scores = np.array([0.2, 0.8, 0.5, 0.9])
+        top = top_k(items, scores, 2)
+        self.assertEqual(top[0][0], 'd')
+        self.assertEqual(top[1][0], 'b')
+
+
+class TestFiltersAndBoosts(unittest.TestCase):
+    """Test filter and boost operations."""
+
+    def test_apply_filter(self):
+        """Test boolean filtering."""
+        items = [
+            {'name': 'a', 'type': 'tree'},
+            {'name': 'b', 'type': 'pearl'},
+            {'name': 'c', 'type': 'tree'}
+        ]
+        scores = np.array([0.8, 0.9, 0.7])
+
+        filtered_items, filtered_scores = apply_filter(
+            items, scores,
+            lambda item: item['type'] == 'tree'
+        )
+
+        self.assertEqual(len(filtered_items), 2)
+        self.assertEqual(filtered_items[0]['name'], 'a')
+        self.assertEqual(filtered_items[1]['name'], 'c')
+
+    def test_apply_boost(self):
+        """Test fuzzy boosting."""
+        items = [
+            {'name': 'a', 'depth': 1},
+            {'name': 'b', 'depth': 3},
+            {'name': 'c', 'depth': 2}
+        ]
+        scores = np.array([0.8, 0.6, 0.7])
+
+        # Boost by inverse depth
+        boosted = apply_boost(
+            items, scores,
+            lambda item: 1.0 / item['depth']
+        )
+
+        self.assertAlmostEqual(boosted[0], 0.8)      # 0.8 * 1/1
+        self.assertAlmostEqual(boosted[1], 0.2)      # 0.6 * 1/3
+        self.assertAlmostEqual(boosted[2], 0.35)     # 0.7 * 1/2
+
+
+class TestBookmarkFilingIntegration(unittest.TestCase):
+    """Test bookmark filing use case with fuzzy logic."""
+
+    def test_semantic_search_with_boost(self):
+        """Simulate semantic search with fuzzy boosting."""
+        # Simulated semantic search results
+        items = [
+            {'id': 1, 'path': '/Unix/BASH/Scripts', 'type': 'tree', 'depth': 3},
+            {'id': 2, 'path': '/Unix/Shell/Tutorials', 'type': 'pearl', 'depth': 3},
+            {'id': 3, 'path': '/Programming/Python', 'type': 'tree', 'depth': 2},
+            {'id': 4, 'path': '/Unix/Linux/Kernel', 'type': 'tree', 'depth': 3},
+        ]
+        base_scores = np.array([0.7, 0.5, 0.3, 0.6])
+
+        # Term scores from query "bash scripting"
+        term_scores = {'bash': 0.9, 'scripting': 0.7, 'shell': 0.5}
+        terms = [('bash', 0.9), ('shell', 0.5)]
+
+        # Apply distributed OR boost
+        boosted = f_dist_or_batch(
+            base_scores,
+            terms,
+            {
+                'bash': np.array([0.9, 0.3, 0.1, 0.4]),  # Per-item bash relevance
+                'shell': np.array([0.5, 0.8, 0.1, 0.3])  # Per-item shell relevance
+            }
+        )
+
+        # Filter to trees only
+        tree_items, tree_scores = apply_filter(
+            items, boosted,
+            lambda item: item['type'] == 'tree'
+        )
+
+        # Get top 2
+        top = top_k(tree_items, tree_scores, 2)
+
+        self.assertEqual(len(top), 2)
+        # First result should be bash-related
+        self.assertIn('BASH', top[0][0]['path'])
+
+    def test_hierarchical_filtering(self):
+        """Test filtering by path hierarchy."""
+        items = [
+            {'id': 1, 'path': '/Unix/BASH/Scripts'},
+            {'id': 2, 'path': '/Unix/Shell/Tutorials'},
+            {'id': 3, 'path': '/Programming/Python'},
+        ]
+        scores = np.array([0.8, 0.7, 0.9])
+
+        # Filter to Unix subtree
+        filtered, _ = apply_filter(
+            items, scores,
+            lambda item: 'Unix' in item['path']
+        )
+
+        self.assertEqual(len(filtered), 2)
+        for item in filtered:
+            self.assertIn('Unix', item['path'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add Prolog module `python_fuzzy_target.pl` for generating Python code from fuzzy logic expressions
- Add NumPy-based Python runtime `fuzzy_logic.py` with scalar and batch operations
- Add comprehensive test suite with 17 tests including bookmark filing integration

## Test plan

- [x] Run `python3 -m unittest test_fuzzy_logic -v` in python_runtime/ - all 17 tests pass
- [x] Test core operations: f_and, f_or, f_dist_or, f_union, f_not
- [x] Test batch vectorized operations for efficient processing
- [x] Test score combination: multiply_scores, blend_scores, top_k
- [x] Test filter predicates: apply_filter, apply_boost
- [x] Test bookmark filing integration scenario

## Files Changed

```
src/unifyweaver/targets/
  python_fuzzy_target.pl    # Prolog code generator for fuzzy logic
  python_runtime/
    fuzzy_logic.py          # NumPy runtime implementation
    test_fuzzy_logic.py     # Test suite (17 tests)
```

## Code Generator Features

| Prolog Goal | Generated Python |
|-------------|------------------|
| `f_and([w(bash, 0.9)], R)` | `R = f_and([("bash", 0.9)], _term_scores)` |
| `f_or([w(bash, 0.9)], R)` | `R = f_or([("bash", 0.9)], _term_scores)` |
| `f_dist_or(0.7, Terms, R)` | `R = f_dist_or(0.7, terms, _term_scores)` |
| `apply_filter(Items, in_subtree("Unix"), R)` | `apply_filter(..., lambda item: "Unix" in item.get('path', ''))` |
| `top_k(Items, 10, R)` | `R = top_k(list(_items), np.array(_scores), 10)` |

## NumPy Operations

Both scalar and batch (vectorized) versions:

| Operation | Scalar | Batch |
|-----------|--------|-------|
| Fuzzy AND | `f_and()` | `f_and_batch()` |
| Fuzzy OR | `f_or()` | `f_or_batch()` |
| Distributed OR | `f_dist_or()` | `f_dist_or_batch()` |
| Union | `f_union()` | `f_union_batch()` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
