### PR TITLE
feat: Integrate fuzzy logic boost with bookmark filing (all modes)

### DIFF
--- a/education/book-13-semantic-search/16_bookmark_filing.md
+++ b/education/book-13-semantic-search/16_bookmark_filing.md
@@ -72,6 +72,45 @@ python3 scripts/bookmark_filing_assistant.py \
 ./scripts/launch_bookmark_filing_agent.sh "Optional bookmark title"
 ```
 
+## Fuzzy Boost
+
+Fuzzy logic boosting allows fine-tuning candidate rankings with term matching:
+
+### CLI Options
+```bash
+python3 scripts/bookmark_filing_assistant.py \
+  --bookmark "bash reduce function" \
+  --boost-or "bash:0.9,shell:0.5,scripting:0.3" \
+  --filter "in_subtree:Unix" \
+  --blend-alpha 0.8
+```
+
+| Option | Description |
+|--------|-------------|
+| `--boost-and` | AND boost - all terms must match (product t-norm) |
+| `--boost-or` | OR boost - any term can match (distributed OR) |
+| `--filter` | Filter by predicate (e.g., `in_subtree:Unix`, `is_type:tree`) |
+| `--blend-alpha` | Blend weight 0-1 (default 0.7, higher = more boost influence) |
+
+### Interactive Commands
+In interactive mode (`--interactive`):
+- `boost bash:0.9,shell:0.5` - Set OR boost
+- `boost-and python:0.9` - Set AND boost
+- `filter in_subtree:Unix` - Add filter
+- `clear` - Clear all boosts/filters
+- `status` - Show current settings
+
+### API Mode
+```bash
+# Start REST API server
+python3 scripts/api_bookmark_filing_server.py --port 5000
+
+# Query with fuzzy boost
+curl -X POST http://localhost:5000/api/candidates \
+  -H "Content-Type: application/json" \
+  -d '{"bookmark_title": "bash tutorial", "boost_or": "bash:0.9"}'
+```
+
 ## MCP Integration
 
 An MCP server exposes these tools:
@@ -82,8 +121,11 @@ python3 scripts/mcp_bookmark_filing_server.py
 ```
 
 Tools exposed:
-- `get_filing_candidates` - Semantic search candidates
-- `file_bookmark` - Full LLM recommendation
+- `get_filing_candidates` - Semantic search candidates (with fuzzy boost support)
+- `get_dual_objective_candidates` - Dual-objective scoring
+- `file_bookmark` - Full LLM recommendation (with fuzzy boost support)
+
+All tools support fuzzy boost parameters: `boost_and`, `boost_or`, `filters`, `blend_alpha`.
 
 ## Decision Process
 
@@ -109,8 +151,10 @@ The LLM sees the merged tree and considers:
 | File | Purpose |
 |------|---------|
 | `scripts/infer_pearltrees_federated.py` | Semantic search |
-| `scripts/bookmark_filing_assistant.py` | LLM-assisted filing |
+| `scripts/bookmark_filing_assistant.py` | LLM-assisted filing (CLI + interactive) |
 | `scripts/mcp_bookmark_filing_server.py` | MCP server |
+| `scripts/api_bookmark_filing_server.py` | REST API server |
+| `scripts/fuzzy_boost.py` | Fuzzy logic boost module |
 | `scripts/launch_bookmark_filing_agent.sh` | Claude launcher |
 | `skills/skill_bookmark_filing.md` | Skill documentation |
 | `docs/ai-skills/bookmark-filing-agent.md` | Agent role |

--- a/education/book-13-semantic-search/README.md
+++ b/education/book-13-semantic-search/README.md
@@ -148,6 +148,21 @@ This book covers building intelligent semantic agents using UnifyWeaver's Python
 - MCP server for tool integration
 - Slash command `/file-bookmark` for quick filing
 
+### [Chapter 17: Fuzzy Logic DSL](17_fuzzy_logic_dsl.md)
+- Prolog-based fuzzy logic for probabilistic scoring
+- Core operations: f_and, f_or, f_dist_or, f_union, f_not
+- Optional operator syntax: `&` for AND, `v` for OR
+- Hierarchical filters: child_of, descendant_of, near
+- Mathematical foundations: product t-norm, probabilistic sum
+- Non-distributivity of fuzzy AND over OR
+
+### [Chapter 18: Fuzzy Logic Python Code Generation](18_fuzzy_python_codegen.md)
+- Compiling Prolog fuzzy expressions to Python
+- NumPy-based runtime with scalar and batch operations
+- Filter predicate translation to Python lambdas
+- Vectorized batch processing for efficiency
+- Bookmark filing integration example
+
 ## The Semantic Runtime
 
 The Python semantic runtime provides:
@@ -221,6 +236,10 @@ After completing this book, you'll be able to:
 - ✅ Tune HNSW M parameter for recall vs memory tradeoffs
 - ✅ Protect against adversarial nodes (outlier rejection, collision detection, trust)
 - ✅ Run comprehensive integration tests for all federation features
+- ✅ Use fuzzy logic DSL for probabilistic scoring and boosting
+- ✅ Combine fuzzy AND/OR with hierarchical filters
+- ✅ Compile fuzzy expressions to Python with NumPy vectorization
+- ✅ Use batch operations for efficient processing of large datasets
 
 ## Integration Tests
 

--- a/scripts/api_bookmark_filing_server.py
+++ b/scripts/api_bookmark_filing_server.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+REST API Server for Bookmark Filing with Fuzzy Boost.
+
+Exposes bookmark filing as a REST API that can be consumed by any HTTP client.
+Supports fuzzy logic boosting for fine-tuning candidate rankings.
+
+Usage:
+    # Start the API server
+    python3 scripts/api_bookmark_filing_server.py
+
+    # With custom port
+    python3 scripts/api_bookmark_filing_server.py --port 8080
+
+Endpoints:
+    POST /api/candidates     - Get semantic search candidates
+    POST /api/file           - Get LLM filing recommendation
+    POST /api/dual-objective - Get dual-objective scored candidates
+    GET  /api/health         - Health check
+
+Example requests:
+    # Get candidates with fuzzy boost
+    curl -X POST http://localhost:5000/api/candidates \
+        -H "Content-Type: application/json" \
+        -d '{"bookmark_title": "bash scripting tutorial", "boost_or": "bash:0.9,shell:0.5"}'
+
+    # File a bookmark
+    curl -X POST http://localhost:5000/api/file \
+        -H "Content-Type: application/json" \
+        -d '{"bookmark_title": "Neural network tutorial", "provider": "claude"}'
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Check for flask
+try:
+    from flask import Flask, request, jsonify
+    HAS_FLASK = True
+except ImportError:
+    HAS_FLASK = False
+    print("Flask not installed. Run: pip install flask", file=sys.stderr)
+
+# Add paths
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Import our modules
+try:
+    from fuzzy_boost import boost_filing_candidates
+    HAS_FUZZY = True
+except ImportError:
+    HAS_FUZZY = False
+
+from bookmark_filing_assistant import (
+    file_bookmark,
+    get_semantic_candidates,
+    get_dual_objective_candidates,
+    rebuild_tree_output,
+    FilingResult
+)
+
+MODEL_PATH = Path("models/pearltrees_federated_single.pkl")
+DATA_PATH = Path("reports/pearltrees_targets_full_multi_account.jsonl")
+
+
+def create_app():
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    @app.route('/api/health', methods=['GET'])
+    def health():
+        """Health check endpoint."""
+        return jsonify({
+            "status": "healthy",
+            "fuzzy_boost_available": HAS_FUZZY,
+            "model_path": str(MODEL_PATH),
+            "model_exists": MODEL_PATH.exists()
+        })
+
+    @app.route('/api/candidates', methods=['POST'])
+    def get_candidates():
+        """
+        Get semantic search candidates for a bookmark.
+
+        Request body:
+            bookmark_title: str (required)
+            top_k: int (default: 10)
+            boost_and: str (optional) - AND boost spec
+            boost_or: str (optional) - OR boost spec
+            filters: list[str] (optional) - Filter specs
+            blend_alpha: float (default: 0.7)
+
+        Returns:
+            JSON with tree, candidates, and metadata
+        """
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No JSON body provided"}), 400
+
+        bookmark_title = data.get('bookmark_title', '')
+        if not bookmark_title:
+            return jsonify({"error": "bookmark_title is required"}), 400
+
+        top_k = data.get('top_k', 10)
+        boost_and = data.get('boost_and')
+        boost_or = data.get('boost_or')
+        filters = data.get('filters')
+        blend_alpha = data.get('blend_alpha', 0.7)
+
+        # Fetch more if fuzzy boost is requested
+        fetch_k = top_k * 2 if (boost_and or boost_or or filters) else top_k
+
+        try:
+            tree_output, candidates = get_semantic_candidates(
+                bookmark_title, MODEL_PATH, fetch_k,
+                tree_mode=True, data_path=DATA_PATH
+            )
+
+            # Apply fuzzy boost if requested
+            if HAS_FUZZY and candidates and (boost_and or boost_or or filters):
+                candidates = boost_filing_candidates(
+                    candidates,
+                    boost_and=boost_and,
+                    boost_or=boost_or,
+                    filters=filters,
+                    blend_alpha=blend_alpha,
+                    top_k=top_k
+                )
+                tree_output = rebuild_tree_output(candidates)
+            elif len(candidates) > top_k:
+                candidates = candidates[:top_k]
+
+            return jsonify({
+                "tree": tree_output,
+                "candidates": candidates,
+                "bookmark": bookmark_title,
+                "top_k": top_k,
+                "fuzzy_boost": {
+                    "enabled": HAS_FUZZY and bool(boost_and or boost_or or filters),
+                    "boost_and": boost_and,
+                    "boost_or": boost_or,
+                    "filters": filters,
+                    "blend_alpha": blend_alpha
+                } if (boost_and or boost_or or filters) else None
+            })
+
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+    @app.route('/api/dual-objective', methods=['POST'])
+    def get_dual_objective():
+        """
+        Get candidates using dual-objective scoring.
+
+        Request body:
+            bookmark_title: str (required)
+            top_k: int (default: 10)
+            alpha: float (default: 0.7) - Blend weight
+
+        Returns:
+            JSON with tree, candidates, and metadata
+        """
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No JSON body provided"}), 400
+
+        bookmark_title = data.get('bookmark_title', '')
+        if not bookmark_title:
+            return jsonify({"error": "bookmark_title is required"}), 400
+
+        top_k = data.get('top_k', 10)
+        alpha = data.get('alpha', 0.7)
+
+        try:
+            tree_output, candidates = get_dual_objective_candidates(
+                bookmark_title, top_k=top_k, alpha=alpha
+            )
+
+            return jsonify({
+                "tree": tree_output,
+                "candidates": candidates,
+                "bookmark": bookmark_title,
+                "alpha": alpha,
+                "top_k": top_k
+            })
+
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+    @app.route('/api/file', methods=['POST'])
+    def file_bookmark_endpoint():
+        """
+        Get LLM recommendation for where to file a bookmark.
+
+        Request body:
+            bookmark_title: str (required)
+            bookmark_url: str (optional)
+            provider: str (default: "claude") - claude, gemini, openai, ollama
+            top_k: int (default: 10)
+            boost_and: str (optional)
+            boost_or: str (optional)
+            filters: list[str] (optional)
+            blend_alpha: float (default: 0.7)
+
+        Returns:
+            JSON with selected folder and reasoning
+        """
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No JSON body provided"}), 400
+
+        bookmark_title = data.get('bookmark_title', '')
+        if not bookmark_title:
+            return jsonify({"error": "bookmark_title is required"}), 400
+
+        bookmark_url = data.get('bookmark_url')
+        provider = data.get('provider', 'claude')
+        top_k = data.get('top_k', 10)
+        boost_and = data.get('boost_and')
+        boost_or = data.get('boost_or')
+        filters = data.get('filters')
+        blend_alpha = data.get('blend_alpha', 0.7)
+
+        # Determine model based on provider
+        if provider == 'claude':
+            llm_model = 'sonnet'
+        elif provider == 'gemini':
+            llm_model = 'gemini-2.0-flash'
+        elif provider == 'openai':
+            llm_model = 'gpt-4o-mini'
+        else:
+            llm_model = 'llama3.1'
+
+        try:
+            result = file_bookmark(
+                bookmark_title,
+                bookmark_url,
+                model_path=MODEL_PATH,
+                data_path=DATA_PATH,
+                provider=provider,
+                llm_model=llm_model,
+                top_k=top_k,
+                boost_and=boost_and,
+                boost_or=boost_or,
+                filters=filters,
+                blend_alpha=blend_alpha
+            )
+
+            if result:
+                return jsonify({
+                    "selected_folder": result.selected_folder,
+                    "rank": result.rank,
+                    "score": result.score,
+                    "reasoning": result.reasoning,
+                    "tree_id": result.tree_id,
+                    "provider": result.provider,
+                    "model": result.model,
+                    "fuzzy_boost": {
+                        "boost_and": boost_and,
+                        "boost_or": boost_or,
+                        "filters": filters,
+                        "blend_alpha": blend_alpha
+                    } if (boost_and or boost_or or filters) else None
+                })
+            else:
+                return jsonify({"error": "Failed to get recommendation"}), 500
+
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+    @app.route('/api/boost/parse', methods=['POST'])
+    def parse_boost_spec():
+        """
+        Parse and validate a boost specification.
+
+        Request body:
+            spec: str - Boost spec to parse (e.g., "bash:0.9,shell:0.5")
+            mode: str (default: "dist_or") - and, or, dist_or, union
+
+        Returns:
+            JSON with parsed terms and weights
+        """
+        if not HAS_FUZZY:
+            return jsonify({"error": "Fuzzy boost module not available"}), 500
+
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No JSON body provided"}), 400
+
+        spec = data.get('spec', '')
+        mode = data.get('mode', 'dist_or')
+
+        try:
+            from fuzzy_boost import parse_boost_spec
+            result = parse_boost_spec(spec, mode)
+            return jsonify({
+                "terms": result.terms,
+                "mode": result.mode,
+                "base_weight": result.base_weight
+            })
+        except Exception as e:
+            return jsonify({"error": str(e)}), 400
+
+    return app
+
+
+def main():
+    """Run the API server."""
+    if not HAS_FLASK:
+        print("Flask required. Install with: pip install flask")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        description="REST API server for bookmark filing with fuzzy boost"
+    )
+    parser.add_argument("--host", type=str, default="127.0.0.1",
+                       help="Host to bind to (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=5000,
+                       help="Port to bind to (default: 5000)")
+    parser.add_argument("--debug", action="store_true",
+                       help="Enable debug mode")
+
+    args = parser.parse_args()
+
+    app = create_app()
+
+    print(f"Starting Bookmark Filing API Server...")
+    print(f"  Host: {args.host}")
+    print(f"  Port: {args.port}")
+    print(f"  Fuzzy Boost: {'enabled' if HAS_FUZZY else 'disabled'}")
+    print(f"  Model: {MODEL_PATH}")
+    print()
+    print("Endpoints:")
+    print("  POST /api/candidates     - Get semantic candidates")
+    print("  POST /api/file           - Get LLM recommendation")
+    print("  POST /api/dual-objective - Get dual-objective candidates")
+    print("  POST /api/boost/parse    - Parse boost spec")
+    print("  GET  /api/health         - Health check")
+    print()
+
+    app.run(host=args.host, port=args.port, debug=args.debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fuzzy_boost.py
+++ b/scripts/fuzzy_boost.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+Fuzzy Boost Module for Bookmark Filing.
+
+Integrates fuzzy logic operations with semantic search for bookmark filing.
+Supports term boosting, filtering, and score blending.
+
+Usage:
+    from fuzzy_boost import FuzzyBoostEngine, parse_boost_spec
+
+    engine = FuzzyBoostEngine()
+    boosted_scores = engine.apply_fuzzy_boost(
+        base_scores,
+        terms=[('bash', 0.9), ('shell', 0.5)],
+        term_scores={'bash': 0.8, 'shell': 0.6},
+        mode='dist_or'  # or 'and', 'or', 'union'
+    )
+"""
+
+import sys
+from pathlib import Path
+from typing import List, Tuple, Dict, Optional, Any, Union
+from dataclasses import dataclass, field
+import numpy as np
+
+# Add fuzzy logic runtime to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "unifyweaver" / "targets" / "python_runtime"))
+
+from fuzzy_logic import (
+    f_and, f_or, f_dist_or, f_union, f_not,
+    f_and_batch, f_or_batch, f_dist_or_batch, f_union_batch,
+    multiply_scores, blend_scores, top_k, apply_filter, apply_boost
+)
+
+
+@dataclass
+class BoostSpec:
+    """Specification for a fuzzy boost operation."""
+    terms: List[Tuple[str, float]]  # [(term, weight), ...]
+    mode: str = 'dist_or'  # 'and', 'or', 'dist_or', 'union'
+    base_weight: float = 1.0  # For dist_or and union modes
+
+
+@dataclass
+class FilterSpec:
+    """Specification for a filter predicate."""
+    predicate: str  # 'in_subtree', 'is_type', 'has_depth', etc.
+    value: Any  # The value to match
+
+
+@dataclass
+class FuzzyConfig:
+    """Configuration for fuzzy boost operations."""
+    boost_and: Optional[BoostSpec] = None  # AND boost terms
+    boost_or: Optional[BoostSpec] = None   # OR boost terms
+    filters: List[FilterSpec] = field(default_factory=list)
+    blend_alpha: float = 0.7  # Blend with original scores
+    default_term_score: float = 0.5  # Score for unknown terms
+
+
+def parse_boost_spec(spec_str: str, mode: str = 'dist_or') -> BoostSpec:
+    """
+    Parse a boost specification string into a BoostSpec.
+
+    Format: "term1:weight1,term2:weight2,..."
+
+    Examples:
+        "bash:0.9,shell:0.5" -> [('bash', 0.9), ('shell', 0.5)]
+        "python,machine_learning:0.8" -> [('python', 1.0), ('machine_learning', 0.8)]
+
+    Args:
+        spec_str: Comma-separated term:weight pairs
+        mode: Fuzzy operation mode ('and', 'or', 'dist_or', 'union')
+
+    Returns:
+        BoostSpec with parsed terms
+    """
+    terms = []
+    for part in spec_str.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        if ':' in part:
+            term, weight_str = part.rsplit(':', 1)
+            try:
+                weight = float(weight_str)
+            except ValueError:
+                weight = 1.0
+        else:
+            term = part
+            weight = 1.0
+        terms.append((term, weight))
+
+    return BoostSpec(terms=terms, mode=mode)
+
+
+def parse_filter_spec(spec_str: str) -> FilterSpec:
+    """
+    Parse a filter specification string.
+
+    Format: "predicate:value"
+
+    Examples:
+        "in_subtree:Unix" -> FilterSpec('in_subtree', 'Unix')
+        "is_type:tree" -> FilterSpec('is_type', 'tree')
+        "has_depth:3" -> FilterSpec('has_depth', 3)
+    """
+    if ':' not in spec_str:
+        return FilterSpec(predicate=spec_str, value=True)
+
+    predicate, value = spec_str.split(':', 1)
+
+    # Try to parse numeric values
+    try:
+        value = int(value)
+    except ValueError:
+        try:
+            value = float(value)
+        except ValueError:
+            pass  # Keep as string
+
+    return FilterSpec(predicate=predicate, value=value)
+
+
+class FuzzyBoostEngine:
+    """
+    Engine for applying fuzzy boost operations to bookmark candidates.
+
+    Supports:
+    - Term boosting (AND, OR, Distributed OR, Union)
+    - Filtering by predicates
+    - Score blending
+    - Batch processing
+    """
+
+    def __init__(self, config: Optional[FuzzyConfig] = None):
+        """Initialize with optional configuration."""
+        self.config = config or FuzzyConfig()
+
+    def compute_term_scores(
+        self,
+        candidates: List[dict],
+        terms: List[Tuple[str, float]],
+        text_field: str = 'title'
+    ) -> Dict[str, np.ndarray]:
+        """
+        Compute term relevance scores for each candidate.
+
+        Uses simple substring matching for now. Could be extended with:
+        - Fuzzy string matching
+        - Embedding similarity
+        - TF-IDF
+
+        Args:
+            candidates: List of candidate dicts
+            terms: List of (term, weight) tuples
+            text_field: Field to search in candidates
+
+        Returns:
+            Dict mapping terms to score arrays
+        """
+        n = len(candidates)
+        term_scores = {}
+
+        for term, _ in terms:
+            scores = np.zeros(n)
+            term_lower = term.lower()
+
+            for i, c in enumerate(candidates):
+                # Check title
+                title = str(c.get(text_field, '')).lower()
+                if term_lower in title:
+                    scores[i] = 1.0
+                    continue
+
+                # Check path
+                path = str(c.get('path', '')).lower()
+                if term_lower in path:
+                    scores[i] = 0.8  # Slightly lower for path match
+                    continue
+
+                # Default: use configured default
+                scores[i] = self.config.default_term_score
+
+            term_scores[term] = scores
+
+        return term_scores
+
+    def apply_fuzzy_boost(
+        self,
+        base_scores: np.ndarray,
+        terms: List[Tuple[str, float]],
+        term_scores: Dict[str, np.ndarray],
+        mode: str = 'dist_or'
+    ) -> np.ndarray:
+        """
+        Apply fuzzy boost to base scores.
+
+        Args:
+            base_scores: Original semantic search scores
+            terms: List of (term, weight) tuples
+            term_scores: Dict mapping terms to score arrays
+            mode: 'and', 'or', 'dist_or', 'union'
+
+        Returns:
+            Boosted scores
+        """
+        if mode == 'and':
+            boost = f_and_batch(terms, term_scores, self.config.default_term_score)
+            return base_scores * boost
+
+        elif mode == 'or':
+            boost = f_or_batch(terms, term_scores, self.config.default_term_score)
+            return base_scores * boost
+
+        elif mode == 'dist_or':
+            return f_dist_or_batch(
+                base_scores, terms, term_scores, self.config.default_term_score
+            )
+
+        elif mode == 'union':
+            return f_union_batch(
+                base_scores, terms, term_scores, self.config.default_term_score
+            )
+
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+
+    def apply_filter(
+        self,
+        candidates: List[dict],
+        scores: np.ndarray,
+        filter_spec: FilterSpec
+    ) -> Tuple[List[dict], np.ndarray]:
+        """
+        Apply a filter predicate to candidates.
+
+        Args:
+            candidates: List of candidate dicts
+            scores: Score array
+            filter_spec: Filter specification
+
+        Returns:
+            Tuple of (filtered_candidates, filtered_scores)
+        """
+        pred = filter_spec.predicate
+        val = filter_spec.value
+
+        if pred == 'in_subtree':
+            filter_fn = lambda c: str(val) in c.get('path', '')
+        elif pred == 'is_type':
+            filter_fn = lambda c: c.get('item_type') == val or c.get('type') == val
+        elif pred == 'has_depth':
+            filter_fn = lambda c: c.get('depth') == val
+        elif pred == 'depth_between':
+            min_d, max_d = val if isinstance(val, tuple) else (0, val)
+            filter_fn = lambda c: min_d <= c.get('depth', 0) <= max_d
+        elif pred == 'has_parent':
+            filter_fn = lambda c: str(val) in c.get('parent', '')
+        elif pred == 'not_in_subtree':
+            filter_fn = lambda c: str(val) not in c.get('path', '')
+        else:
+            # Unknown predicate, keep all
+            return candidates, scores
+
+        return apply_filter(candidates, scores, filter_fn)
+
+    def boost_candidates(
+        self,
+        candidates: List[dict],
+        boost_and: Optional[str] = None,
+        boost_or: Optional[str] = None,
+        filters: Optional[List[str]] = None,
+        blend_alpha: float = 0.7
+    ) -> List[dict]:
+        """
+        Apply fuzzy boost and filtering to candidates.
+
+        This is the main entry point for boosting candidates.
+
+        Args:
+            candidates: List of candidate dicts with 'score' field
+            boost_and: AND boost spec string (e.g., "bash:0.9,shell:0.5")
+            boost_or: OR boost spec string
+            filters: List of filter spec strings
+            blend_alpha: Blend weight (1.0 = full boost, 0.0 = original)
+
+        Returns:
+            Candidates with updated scores, re-sorted
+        """
+        if not candidates:
+            return candidates
+
+        # Extract original scores
+        original_scores = np.array([c.get('score', 0.0) for c in candidates])
+        boosted_scores = original_scores.copy()
+
+        # Apply AND boost
+        if boost_and:
+            spec = parse_boost_spec(boost_and, mode='and')
+            if spec.terms:
+                term_scores = self.compute_term_scores(candidates, spec.terms)
+                and_boost = f_and_batch(spec.terms, term_scores, self.config.default_term_score)
+                boosted_scores = boosted_scores * and_boost
+
+        # Apply OR boost (distributed)
+        if boost_or:
+            spec = parse_boost_spec(boost_or, mode='dist_or')
+            if spec.terms:
+                term_scores = self.compute_term_scores(candidates, spec.terms)
+                boosted_scores = f_dist_or_batch(
+                    boosted_scores, spec.terms, term_scores, self.config.default_term_score
+                )
+
+        # Blend with original
+        if blend_alpha < 1.0:
+            boosted_scores = blend_scores(blend_alpha, boosted_scores, original_scores)
+
+        # Apply filters
+        filtered_candidates = candidates
+        filtered_scores = boosted_scores
+
+        if filters:
+            for filter_str in filters:
+                filter_spec = parse_filter_spec(filter_str)
+                filtered_candidates, filtered_scores = self.apply_filter(
+                    filtered_candidates, filtered_scores, filter_spec
+                )
+
+        # Update scores in candidates and re-sort
+        result = []
+        for c, score in zip(filtered_candidates, filtered_scores):
+            c_copy = c.copy()
+            c_copy['score'] = float(score)
+            c_copy['original_score'] = c.get('score', 0.0)
+            result.append(c_copy)
+
+        # Sort by new score
+        result.sort(key=lambda x: x['score'], reverse=True)
+
+        # Update ranks
+        for i, c in enumerate(result):
+            c['rank'] = i + 1
+
+        return result
+
+
+def boost_filing_candidates(
+    candidates: List[dict],
+    boost_and: Optional[str] = None,
+    boost_or: Optional[str] = None,
+    filters: Optional[List[str]] = None,
+    blend_alpha: float = 0.7,
+    top_k: Optional[int] = None
+) -> List[dict]:
+    """
+    Convenience function to boost filing candidates.
+
+    Args:
+        candidates: List of candidate dicts from semantic search
+        boost_and: AND boost spec (e.g., "bash:0.9,python:0.5")
+        boost_or: OR boost spec
+        filters: List of filter specs (e.g., ["in_subtree:Unix", "is_type:tree"])
+        blend_alpha: Blend weight with original scores
+        top_k: Limit results to top K
+
+    Returns:
+        Boosted and filtered candidates
+    """
+    engine = FuzzyBoostEngine()
+    result = engine.boost_candidates(
+        candidates,
+        boost_and=boost_and,
+        boost_or=boost_or,
+        filters=filters,
+        blend_alpha=blend_alpha
+    )
+
+    if top_k:
+        result = result[:top_k]
+
+    return result
+
+
+# =============================================================================
+# CLI for testing
+# =============================================================================
+
+def main():
+    """Test the fuzzy boost module."""
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Test fuzzy boost module")
+    parser.add_argument("--candidates", type=str, help="JSON file with candidates")
+    parser.add_argument("--boost-and", type=str, help="AND boost spec")
+    parser.add_argument("--boost-or", type=str, help="OR boost spec")
+    parser.add_argument("--filter", type=str, action="append", help="Filter specs")
+    parser.add_argument("--alpha", type=float, default=0.7, help="Blend alpha")
+    parser.add_argument("--top-k", type=int, default=10, help="Top K results")
+
+    args = parser.parse_args()
+
+    # Load or create test candidates
+    if args.candidates:
+        with open(args.candidates) as f:
+            candidates = json.load(f)
+    else:
+        # Test data
+        candidates = [
+            {"title": "BASH Scripts", "path": "/Unix/BASH", "score": 0.8, "item_type": "tree"},
+            {"title": "Shell Scripting Guide", "path": "/Unix/Shell", "score": 0.7, "item_type": "tree"},
+            {"title": "Python Programming", "path": "/Programming/Python", "score": 0.6, "item_type": "tree"},
+            {"title": "Linux Kernel", "path": "/Unix/Linux", "score": 0.5, "item_type": "tree"},
+            {"title": "Machine Learning", "path": "/AI/ML", "score": 0.4, "item_type": "pearl"},
+        ]
+
+    print("Original candidates:")
+    for c in candidates:
+        print(f"  {c['title']}: {c['score']:.4f}")
+
+    # Apply boost
+    boosted = boost_filing_candidates(
+        candidates,
+        boost_and=args.boost_and,
+        boost_or=args.boost_or,
+        filters=args.filter,
+        blend_alpha=args.alpha,
+        top_k=args.top_k
+    )
+
+    print(f"\nBoosted candidates (alpha={args.alpha}):")
+    for c in boosted:
+        orig = c.get('original_score', c['score'])
+        print(f"  #{c['rank']} {c['title']}: {c['score']:.4f} (was {orig:.4f})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description

Adds fuzzy logic boosting to the bookmark filing assistant across all operation modes, allowing users to fine-tune candidate rankings with term matching and filtering.

### Features

**Fuzzy Boost Options:**
- `boost_and` - AND boost: all terms must match (product t-norm)
- `boost_or` - OR boost: any term can match (distributed OR)
- `filters` - Filter by predicates (e.g., `in_subtree:Unix`, `is_type:tree`)
- `blend_alpha` - Blend weight with original scores (0-1)

### Modes Implemented

#### 1. Headless CLI Mode
```bash
python3 scripts/bookmark_filing_assistant.py \
    --bookmark "bash scripting tutorial" \
    --boost-or "bash:0.9,shell:0.5" \
    --filter "in_subtree:Unix" \
    --blend-alpha 0.8
```

#### 2. Interactive Chat Mode
```bash
python3 scripts/bookmark_filing_assistant.py --interactive
```
Commands:
- `boost bash:0.9,shell:0.5` - Set OR boost
- `boost-and python:0.9` - Set AND boost
- `filter in_subtree:Unix` - Add filter
- `clear` - Clear all boosts/filters
- `status` - Show current settings

#### 3. MCP Server Mode
Updated tools with fuzzy boost parameters:
- `get_filing_candidates` - Added `boost_and`, `boost_or`, `filters`, `blend_alpha`
- `file_bookmark` - Added fuzzy boost parameters

#### 4. REST API Mode (New)
```bash
python3 scripts/api_bookmark_filing_server.py --port 5000
```

Endpoints:
| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/candidates` | POST | Get candidates with fuzzy boost |
| `/api/file` | POST | File bookmark with LLM + fuzzy boost |
| `/api/dual-objective` | POST | Dual-objective scoring |
| `/api/boost/parse` | POST | Parse/validate boost spec |
| `/api/health` | GET | Health check |

### New Files
- `scripts/fuzzy_boost.py` - Core fuzzy boost module with `FuzzyBoostEngine`
- `scripts/api_bookmark_filing_server.py` - Flask REST API server

### Modified Files
- `scripts/bookmark_filing_assistant.py` - Added CLI args and interactive commands
- `scripts/mcp_bookmark_filing_server.py` - Added fuzzy boost to MCP tools
- `education/book-13-semantic-search/16_bookmark_filing.md` - Added Fuzzy Boost docs
- `education/book-13-semantic-search/README.md` - Updated chapter list

### Example Usage

```bash
# Boost bash-related results, filter to Unix subtree
python3 scripts/bookmark_filing_assistant.py \
    --bookmark "bash-reduce function tutorial" \
    --boost-or "bash:0.9,shell:0.5,scripting:0.3" \
    --filter "in_subtree:Unix" \
    --provider claude

# API request with fuzzy boost
curl -X POST http://localhost:5000/api/candidates \
    -H "Content-Type: application/json" \
    -d '{
        "bookmark_title": "bash tutorial",
        "boost_or": "bash:0.9,shell:0.5",
        "filters": ["in_subtree:Unix"],
        "top_k": 10
    }'
```

### Testing

```bash
# Verify fuzzy boost module
PYTHONPATH="src:src/unifyweaver/targets/python_runtime" \
    python3 scripts/fuzzy_boost.py --boost-or "bash:0.9" --filter "in_subtree:Unix"

# Syntax check all files
python3 -m py_compile scripts/fuzzy_boost.py \
    scripts/bookmark_filing_assistant.py \
    scripts/mcp_bookmark_filing_server.py \
    scripts/api_bookmark_filing_server.py
```

### Related
- Builds on fuzzy logic DSL (Chapter 17) and Python codegen (Chapter 18)
- Uses `fuzzy_logic.py` runtime from `src/unifyweaver/targets/python_runtime/`
