### PR TITLE
feat: implement Phase 6 control generation system for declarative UI controls

### DIFF
--- a/docs/proposals/DECLARATIVE_LAYOUT_SYSTEM.md
+++ b/docs/proposals/DECLARATIVE_LAYOUT_SYSTEM.md
@@ -1,9 +1,9 @@
 # Declarative Layout and Styling System
 
-**Status:** Implemented (Phases 1-5 complete, Phase 6 pending)
+**Status:** Implemented (All 6 phases complete)
 **Author:** Claude Code
-**Date:** 2025-12-31
-**Tests:** 75 passing
+**Date:** 2026-01-01
+**Tests:** 99 passing
 
 ## Overview
 
@@ -409,12 +409,14 @@ This allows the same declarative specification to work across targets, using nat
 3. [x] Matplotlib uses native subplot system (not CSS layouts)
 4. [x] Add integration tests (75 tests passing)
 
-### Phase 6: Control Generation - PENDING
+### Phase 6: Control Generation - COMPLETE
 
-1. [ ] Implement `control/3` predicates
-2. [ ] Implement `control_panel/2`
-3. [ ] Generate React control components
-4. [ ] Wire controls to component state
+1. [x] Implement `control/3` predicates
+2. [x] Implement `control_panel/2`
+3. [x] Generate React control components (slider, select, checkbox, color_picker, number_input, text_input)
+4. [x] Wire controls to component state via `generate_wired_component/3`
+5. [x] Add TypeScript interface generation via `generate_prop_types/2`
+6. [x] Add 24 new tests (99 tests passing total)
 
 ## Generated Output Examples
 


### PR DESCRIPTION
  ## Summary
  - Implements Phase 6 of the Declarative Layout System: Control Generation
  - Adds declarative UI control system that generates React components from Prolog specifications
  - Completes all 6 phases of the layout system proposal

  ## Changes

  ### Control System
  - `control/3` predicate for defining UI controls (slider, select, checkbox, color_picker, number_input, text_input)
  - `control_panel/2` for grouping related controls
  - 11 default controls and 4 default control panels included

  ### Code Generation
  - `generate_control_jsx/2` - Individual control React JSX
  - `generate_control_panel_jsx/2` - Grouped control panels
  - `generate_control_state/2` - React useState hooks
  - `generate_control_css/2` - CSS styling with CSS custom properties

  ### Control Wiring
  - `wiring_spec/2` - Maps controls to visualization component props
  - `generate_wired_component/3` - Complete components with controls wired to state
  - `generate_prop_types/2` - TypeScript interface generation

  ## Test plan
  - [x] All 99 integration tests pass (24 new tests added)
  - [x] Control JSX generation verified for all 6 control types
  - [x] Wired component generation produces valid React code
  - [x] TypeScript interfaces correctly typed

  ```bash
  swipl -g "run_tests" -t halt tests/integration/glue/test_visualization_glue.pl
  # Results: 99/99 tests passed

  � Generated with https://claude.com/claude-code