### PR TITLE
fix(stream-compiler): avoid meta-call in goal readiness filter

### DIFF
--- a/src/unifyweaver/core/optimizer.pl
+++ b/src/unifyweaver/core/optimizer.pl
@@ -56,7 +56,7 @@ comma_list((A,B), [A|Rest]) :- comma_list(B, Rest).
 reorder_goals([], _, _, []).
 reorder_goals(Goals, BoundVars, Pred, [BestGoal|RestOptimized]) :-
     % 1. Identify candidate goals (dependencies satisfied)
-    include(is_ready(BoundVars), Goals, ReadyGoals),
+    ready_goals(BoundVars, Goals, ReadyGoals),
     
     (   ReadyGoals = []
     ->  % Fallback
@@ -78,6 +78,18 @@ reorder_goals(Goals, BoundVars, Pred, [BestGoal|RestOptimized]) :-
 % ============================================================================
 % DEPENDENCY CHECKING
 % ============================================================================
+
+%% ready_goals(+BoundVars:list, +Goals:list, -ReadyGoals:list) is det.
+%
+%  Filter the goals whose dependencies are satisfied given the currently bound
+%  variables.
+ready_goals(_BoundVars, [], []).
+ready_goals(BoundVars, [Goal|Rest], [Goal|ReadyRest]) :-
+    is_ready(BoundVars, Goal),
+    !,
+    ready_goals(BoundVars, Rest, ReadyRest).
+ready_goals(BoundVars, [_Goal|Rest], ReadyRest) :-
+    ready_goals(BoundVars, Rest, ReadyRest).
 
 %% is_ready(+BoundVars:list, +Goal) is semidet.
 %


### PR DESCRIPTION
  - Fixes CI failure Unknown procedure: optimizer:is_ready/2 during stream compiler goal reordering.
  - Replaces include(is_ready(BoundVars), Goals, ReadyGoals) with a deterministic local filter ready_goals/3, which
    calls is_ready/2 directly (no meta-call/module-qualification edge cases).
  - Change in src/unifyweaver/core/optimizer.pl.