### PR TITLE
feat: Add visual distinction for Trees vs Pearls (--tree-style, --pearl-style)

### DIFF
--- a/docs/MINDMAP_ROADMAP.md
+++ b/docs/MINDMAP_ROADMAP.md
@@ -76,11 +76,21 @@
 
 **Goal:** Visually differentiate folder nodes (Trees) from page nodes (Pearls).
 
+### 3.1 Shape-Based Distinction ✓
+
+Implemented via `--tree-style` and `--pearl-style` options:
+- [x] `--tree-style`: Set borderstyle for Tree (folder) nodes
+- [x] `--pearl-style`: Set borderstyle for Pearl (page/link) nodes
+- [x] Supported styles: half-round, ellipse, rectangle, diamond
+- [x] Default: no distinction (uses SimpleMind default)
+
+Example: `--tree-style rectangle --pearl-style ellipse`
+
 ### Design Options to Explore (with LLM assistance)
 
-#### Option A: Shape-Based
-- Trees: Rounded rectangle (current)
-- Pearls: Square, circle, or diamond
+#### Option A: Shape-Based ✓
+- Trees: Configurable (rectangle recommended)
+- Pearls: Configurable (ellipse recommended)
 
 #### Option B: Icon-Based
 - Folder icon embedded in Tree nodes

--- a/docs/SIMPLEMIND_GENERATOR.md
+++ b/docs/SIMPLEMIND_GENERATOR.md
@@ -51,6 +51,13 @@ python3 scripts/generate_simplemind_map.py \
     --cluster-url "..." \
     --output output/debug.smmx \
     --xml-only
+
+# Visual distinction: Trees as rectangles, Pearls as ellipses
+python3 scripts/generate_simplemind_map.py \
+    --cluster-url "..." \
+    --output output/styled.smmx \
+    --tree-style rectangle \
+    --pearl-style ellipse
 ```
 
 ## Options
@@ -70,6 +77,8 @@ python3 scripts/generate_simplemind_map.py \
 | `--minimize-crossings` | false | Apply edge crossing minimization after force-directed |
 | `--crossing-passes` | 10 | Max passes for crossing minimization |
 | `--no-scaling` | false | Disable node size scaling by descendant count |
+| `--tree-style` | None | Node shape for Tree items: half-round, ellipse, rectangle, diamond |
+| `--pearl-style` | None | Node shape for Pearl items: half-round, ellipse, rectangle, diamond |
 
 ## How It Works
 
@@ -288,6 +297,7 @@ The generated `.smmx` files can be:
 - [x] Sibling edge crossing detection (curved line heuristic)
 - [x] Image rendering (SVG/PNG) with straight and curved edges
 - [x] Per-node borderstyle support (half-round, ellipse, rectangle, diamond)
+- [x] Visual distinction: `--tree-style` and `--pearl-style` options
 - [ ] Time budget control (`--time-limit`)
 - [ ] Spatial indexing for O(n log n) crossing detection
 - [ ] Angular rebalancing based on subtree size


### PR DESCRIPTION
  ## Summary

  - Add `--tree-style` and `--pearl-style` options to visually distinguish folder nodes (Trees) from page/link nodes (Pearls)
  - Supported styles: half-round, ellipse, rectangle, diamond
  - Default behavior unchanged (no borderstyle written, SimpleMind uses half-round)

  ## Usage

  ```bash
  python3 scripts/generate_simplemind_map.py \
      --cluster-url "..." \
      --output output/styled.smmx \
      --tree-style rectangle \
      --pearl-style ellipse \
      --optimize

  Implementation

  - Add item_type field to MindMapNode to track Tree vs PagePearl
  - Write borderstyle attribute to XML based on item type when style options specified
  - Renderer already supports per-node borderstyle from Phase 1

  Test plan

  - Generate mindmap with mixed Trees and PagePearls
  - Verify Trees get sbsRectangle, Pearls get sbsEllipse
  - Verify default (no options) produces no borderstyle attributes
  - Render to SVG and confirm visual distinction
  - Test with --optimize to avoid overlaps

  🤖 Generated with https://claude.com/claude-code