### PR TITLE
perf(csharp-query-runtime): keep scan-index for tiny probes with cache reuse

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1827,7 +1827,7 @@ namespace UnifyWeaver.QueryRuntime
 
                         var otherNode = leftIsScan ? join.Right : join.Left;
 
-                        if (!scanIndexCached && !IsRecursiveProbe(otherNode))
+                        if (!scanIndexCached && _cacheContext is null && !IsRecursiveProbe(otherNode))
                         {
                             const int TinyProbeUpperBound = 64;
                             if (joinKeyCount == 1 &&


### PR DESCRIPTION
  - Updates ExecuteKeyJoin to only apply the “tiny probe” shortcut (skipping scan-index builds) when
    QueryExecutorOptions.ReuseCaches is off; when cache reuse is enabled, we now build the scan index so it can be
    reused across executions (src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs).
  - Adds regression test verify_tiny_probe_single_key_join_keeps_scan_index_with_cache_reuse to ensure KeyJoinScanIndex
    is used for a parameterized single-key join with a tiny probe when cache reuse is enabled (tests/core/
    test_csharp_query_target.pl).
  - Local: dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release
    succeeds (existing warnings unchanged).