### PR TITLE
perf(csharp-query-runtime): avoid partial scan-index inside fixpoints

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -2184,7 +2184,7 @@ namespace UnifyWeaver.QueryRuntime
                                                   TryEstimateRowUpperBound(join.Right, context, out var probeUpperBound) &&
                                                   probeUpperBound <= TinyProbeUpperBound;
 
-                                if (probeIsTiny && !joinIndexCached)
+                                if (probeIsTiny && !joinIndexCached && context.FixpointDepth == 0)
                                 {
                                     trace?.RecordStrategy(join, "KeyJoinScanIndexPartial");
                                     var probeSource = Evaluate(join.Right, context);
@@ -2352,7 +2352,7 @@ namespace UnifyWeaver.QueryRuntime
                                                   TryEstimateRowUpperBound(join.Left, context, out var probeUpperBound) &&
                                                   probeUpperBound <= TinyProbeUpperBound;
 
-                                if (probeIsTiny && !joinIndexCached)
+                                if (probeIsTiny && !joinIndexCached && context.FixpointDepth == 0)
                                 {
                                     trace?.RecordStrategy(join, "KeyJoinScanIndexPartial");
                                     var probeSource = Evaluate(join.Left, context);
@@ -2528,7 +2528,7 @@ namespace UnifyWeaver.QueryRuntime
                                               TryEstimateRowUpperBound(join.Left, context, out var probeUpperBound) &&
                                               probeUpperBound <= TinyProbeUpperBound;
 
-                             if (probeIsTiny && !joinIndexCached)
+                             if (probeIsTiny && !joinIndexCached && context.FixpointDepth == 0)
                              {
                                  trace?.RecordStrategy(join, "KeyJoinScanIndexPartial");
                                  var probeSource = Evaluate(join.Left, context);
@@ -2703,7 +2703,7 @@ namespace UnifyWeaver.QueryRuntime
                                               TryEstimateRowUpperBound(join.Right, context, out var probeUpperBound) &&
                                               probeUpperBound <= TinyProbeUpperBound;
 
-                             if (probeIsTiny && !joinIndexCached)
+                             if (probeIsTiny && !joinIndexCached && context.FixpointDepth == 0)
                              {
                                  trace?.RecordStrategy(join, "KeyJoinScanIndexPartial");
                                  var probeSource = Evaluate(join.Right, context);

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -1374,13 +1374,13 @@ verify_parameterized_recursive_multi_key_join_strategy_partial_index :-
         sub_term(recursive_ref{type:recursive_ref, predicate:predicate{name:test_group_reach_param, arity:3}, role:_, width:_}, Right)
     ),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
-    harness_source_with_strategy_flag(ModuleClass, [[alice, laptop]], 'KeyJoinScanIndexPartial', HarnessSource),
+    harness_source_with_strategy_flag(ModuleClass, [[alice, laptop]], 'KeyJoinScanIndex', HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
         ['alice,laptop,0',
          'alice,laptop,1',
          'alice,laptop,2',
          'alice,laptop,3',
-         'STRATEGY_USED:KeyJoinScanIndexPartial=true'],
+         'STRATEGY_USED:KeyJoinScanIndex=true'],
         [[alice, laptop]],
         HarnessSource).
 


### PR DESCRIPTION
  - Changes src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs to avoid the KeyJoinScanIndexPartial “tiny
    probe” path when executing inside fixpoints (context.FixpointDepth > 0), so recursive iterations prefer building the
    full scan join index once and reusing it.
  - Updates tests/core/test_csharp_query_target.pl to expect KeyJoinScanIndex (instead of KeyJoinScanIndexPartial) for
    the recursive multi-key join smoke case.
  - Local check: dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c
    Release succeeds (existing warnings unchanged).