### PR TITLE
feat: Add --curated-folders for hierarchy-preserving folder organization

### DIFF
--- a/docs/proposals/CURATED_FOLDERS.md
+++ b/docs/proposals/CURATED_FOLDERS.md
@@ -169,22 +169,23 @@ This preserves navigation semantics while organizing files for manageability.
 
 ## Implementation Phases
 
-### Phase A: Design & Documentation (this PR)
-- [ ] Design document
-- [ ] Algorithm specification
-- [ ] Configuration options
+### Phase A: Design & Documentation ✓
+- [x] Design document
+- [x] Algorithm specification
+- [x] Configuration options
 
-### Phase B: Core Implementation
-- [ ] Build user hierarchy from JSONL
-- [ ] K-clustering of trees into folder groups
-- [ ] MST with fixed root
+### Phase B: Core Implementation ✓
+- [x] Build user hierarchy from JSONL
+- [x] K-clustering of trees into folder groups (kmeans, mst-cut)
+- [x] MST with fixed root
 
-### Phase C: Integration
-- [ ] `--curated-folders` flag in generate_simplemind_map.py
-- [ ] Folder naming options
-- [ ] Tests with real Pearltrees data
+### Phase C: Integration (In Progress)
+- [x] `--curated-folders` flag in generate_simplemind_map.py
+- [ ] LLM-generated folder names (currently `group_N`)
+- [ ] Performance optimization for large datasets
+- [ ] Tests with full Pearltrees data
 
-### Phase D: W Matrix Integration (Optional)
+### Phase D: W Matrix Integration (Future)
 - [ ] `--cluster-method per-folder` option
 - [ ] Folder-aligned W matrices in federated training
 

--- a/docs/proposals/CURATED_FOLDERS.md
+++ b/docs/proposals/CURATED_FOLDERS.md
@@ -188,18 +188,53 @@ This preserves navigation semantics while organizing files for manageability.
 - [ ] `--cluster-method per-folder` option
 - [ ] Folder-aligned W matrices in federated training
 
+## Design Decisions
+
+### Orphan Handling
+
+Trees not connected to the main hierarchy go to a separate `_orphans/` folder:
+
+```
+output/
+  root/
+    ...
+  _orphans/                      # Disconnected trees
+    id99999.smmx
+    id99998.smmx
+```
+
+This keeps the main hierarchy clean while preserving all data.
+
+### Cross-Account Mode
+
+Configurable via `--account-mode`:
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| **Primary account** | `--account-mode primary` | Start from designated primary account (default: first in dataset). Other accounts' trees accessed via cross-account links are included but hierarchy follows primary. |
+| **Unified root** | `--account-mode unified` | Single synthetic root with each account as top-level folder. |
+| **Per-account** | `--account-mode separate` | Separate output directories per account. |
+
+**Current embeddings context**: The hierarchical lists use `s243a` as the principal account, with the tree following links across accounts. This maps naturally to `--account-mode primary`.
+
+```bash
+# Default: primary account mode
+python3 scripts/generate_simplemind_map.py \
+    --curated-folders \
+    --primary-account s243a \
+    --output-dir output/
+
+# Unified: all accounts under one root
+python3 scripts/generate_simplemind_map.py \
+    --curated-folders \
+    --account-mode unified \
+    --output-dir output/
+```
+
 ## Open Questions
 
-1. **Orphan handling**: Trees not connected to main hierarchy
-   - Option: Separate "orphans" folder
-   - Option: Attach to nearest centroid
-
-2. **Folder naming**: Currently tree_id based
+1. **Folder naming**: Currently tree_id based
    - Future: LLM mnemonics, path abbreviations
-
-3. **Cross-account**: Multiple account roots
-   - Option: Separate curated hierarchies per account
-   - Option: Unified with account as top-level folders
 
 ## Related Documentation
 


### PR DESCRIPTION
  ## Summary
  - Implements `--curated-folders` option that preserves user's actual hierarchy root
  - K-clusters trees into folder groups by centroid similarity
  - MST determines folder hierarchy with user's root fixed at top
  - Orphan trees (disconnected from main hierarchy) go to `_orphans/` folder

  ## New CLI Options
  ```bash
  --curated-folders           # Enable curated folder organization
  --folder-count N            # Target folder groups (default: 100)
  --folder-method {kmeans,mst-cut}  # Clustering method
  --primary-account NAME      # Primary account for root selection

  Example Output

  output/
  ├── id2492215.smmx          # Root (user's actual root)
  ├── id2492371.smmx
  ├── group_2/
  │   ├── id2492377.smmx
  │   └── group_1/
  │       ├── id2492416.smmx
  │       └── id2492479.smmx

  Known Limitations

  - Folder names are group_N (LLM naming planned for future)
  - Performance needs optimization for 10k+ tree datasets

  Test plan

  - Unit tested individual functions (hierarchy, clustering, MST)
  - Integration test with small dataset (14 trees → 13 maps)
  - Full dataset testing (deferred - performance)

  🤖 Generated with https://claude.com/claude-code