### PR TITLE
feat: Add declarative mind map layout DSL with multi-target compilation

### DIFF
--- a/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
+++ b/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,491 @@
+# Implementation Plan: Declarative Mind Map Layout System
+
+## Overview
+
+This document outlines the phased implementation of the declarative mind map layout system. The plan prioritizes layout optimization as the first target, building foundation infrastructure, and progressively adding targets and features.
+
+## Phase 1: Core DSL Foundation
+
+### 1.1 Create Base Module Structure
+
+**File:** `src/unifyweaver/mindmap/mindmap_dsl.pl`
+
+```prolog
+:- module(mindmap_dsl, [...]).
+
+% Dynamic predicates for node/edge storage
+:- dynamic mindmap_node/2.
+:- dynamic mindmap_edge/3.
+:- dynamic mindmap_spec/2.
+:- dynamic mindmap_constraint/2.
+:- dynamic mindmap_preference/2.
+:- dynamic mindmap_layout/2.
+:- dynamic mindmap_pipeline/2.
+:- dynamic mindmap_style/2.
+:- dynamic mindmap_theme/2.
+```
+
+**Tasks:**
+- [ ] Define core predicates for node and edge declaration
+- [ ] Implement specification predicates with validation
+- [ ] Add constraint and preference storage
+- [ ] Create management predicates (declare_*, clear_*)
+
+### 1.2 Integrate with Component Registry
+
+**File:** `src/unifyweaver/mindmap/mindmap_components.pl`
+
+**Tasks:**
+- [ ] Define `mindmap_layout` category
+- [ ] Define `mindmap_optimizer` category
+- [ ] Define `mindmap_renderer` category
+- [ ] Register default implementations
+
+### 1.3 Create Intermediate Representation
+
+**File:** `src/unifyweaver/mindmap/mindmap_ir.pl`
+
+**Tasks:**
+- [ ] Define normalized graph structure
+- [ ] Implement spec-to-IR transformation
+- [ ] Add attribute extraction and normalization
+- [ ] Handle implicit edges from `parent()` properties
+
+## Phase 2: Layout Optimization Target (Priority)
+
+### 2.1 Port Existing Python Algorithms
+
+**Reference:** `scripts/generate_mindmap.py` (force-directed, radial)
+
+**File:** `src/unifyweaver/mindmap/layout/force_directed.pl`
+
+```prolog
+%% compute_force_layout(+Nodes, +Edges, +Options, -Positions)
+% Pure Prolog implementation with binding to Python for computation
+```
+
+**Tasks:**
+- [ ] Extract algorithm parameters from existing Python
+- [ ] Create Prolog interface predicates
+- [ ] Add Python bindings for heavy computation
+- [ ] Implement fallback pure-Prolog version for small graphs
+
+### 2.2 Port Optimization Algorithms
+
+**Reference:** `scripts/generate_mindmap.py` (overlap removal, crossing minimization)
+
+**Files:**
+- `src/unifyweaver/mindmap/optimize/overlap_removal.pl`
+- `src/unifyweaver/mindmap/optimize/crossing_minimization.pl`
+
+**Tasks:**
+- [ ] Create overlap detection predicates
+- [ ] Implement push-apart algorithm
+- [ ] Create edge crossing detection
+- [ ] Implement angular adjustment optimizer
+- [ ] Add Python bindings for O(n²) operations
+
+### 2.3 Create Layout Pipeline
+
+**File:** `src/unifyweaver/mindmap/layout_pipeline.pl`
+
+```prolog
+%% execute_pipeline(+Graph, +Pipeline, -Result)
+% Execute a sequence of layout and optimization stages
+```
+
+**Tasks:**
+- [ ] Implement stage sequencing
+- [ ] Add intermediate result passing
+- [ ] Create convergence detection
+- [ ] Add progress reporting hooks
+
+## Phase 3: First Output Targets
+
+### 3.1 SVG Renderer
+
+**File:** `src/unifyweaver/mindmap/render/svg_renderer.pl`
+
+**Tasks:**
+- [ ] Port rendering logic from `render_mindmap.py`
+- [ ] Create SVG element generation predicates
+- [ ] Implement node shape rendering (ellipse, rectangle, diamond)
+- [ ] Implement edge rendering (straight, bezier)
+- [ ] Add style application
+- [ ] Generate complete SVG document
+
+### 3.2 Native Format Export (.smmx, .mm)
+
+**File:** `src/unifyweaver/mindmap/render/native_format_renderer.pl`
+
+**Tasks:**
+- [ ] Port XML generation from `export_mindmap.py`
+- [ ] Create format-specific structure generation
+- [ ] Map positions to native format coordinates
+- [ ] Preserve styling information
+
+### 3.3 Interactive Graph Component
+
+**File:** `src/unifyweaver/mindmap/render/graph_interactive_renderer.pl`
+
+**Tasks:**
+- [ ] Extend existing `graph_generator.pl` patterns
+- [ ] Add mind map-specific node types
+- [ ] Create layout preset export
+- [ ] Generate React/TypeScript component
+
+## Phase 4: Custom Component Integration
+
+### 4.1 Leverage Existing Custom Components
+
+UnifyWeaver already has `custom_<target>.pl` modules for 25+ targets. The mind map
+system should leverage these existing components.
+
+**Existing modules to use:**
+- `targets/go_runtime/custom_go.pl` - Custom Go code injection
+- `targets/python_runtime/custom_python.pl` - Custom Python code
+- `targets/typescript_runtime/custom_typescript.pl` - Custom TypeScript
+- ... and 20+ more
+
+**Tasks:**
+- [ ] Document how to use existing custom components for layouts
+- [ ] Create example custom layout using `custom_python`
+- [ ] Create example custom optimizer using `custom_go`
+- [ ] Add `component(Name)` reference syntax to mind map specs
+
+### 4.2 Mind Map-Specific Custom Components
+
+**Files:**
+- `src/unifyweaver/mindmap/custom_mindmap_layout.pl`
+- `src/unifyweaver/mindmap/custom_mindmap_optimizer.pl`
+
+```prolog
+% Follow existing pattern from custom_go.pl / custom_python.pl
+:- module(custom_mindmap_layout, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+```
+
+**Tasks:**
+- [ ] Create mind map layout component type (delegates to target custom components)
+- [ ] Create mind map optimizer component type
+- [ ] Register with component registry on initialization
+- [ ] Add validation for mind map-specific options
+
+### 4.3 Binding Integration
+
+**File:** `src/unifyweaver/bindings/python_mindmap_bindings.pl`
+
+```prolog
+declare_binding(python, force_layout/3, 'mindmap.layout.force_directed',
+    [graph_dict, options_dict], [positions_dict],
+    [import('unifyweaver.mindmap.layout')]).
+```
+
+**Tasks:**
+- [ ] Define bindings for built-in layout algorithms
+- [ ] Define bindings for optimization passes
+- [ ] Create Python implementation module
+- [ ] Add NumPy/SciPy acceleration
+
+## Phase 5: Styling System
+
+### 5.1 Style Resolution
+
+**File:** `src/unifyweaver/mindmap/styling/style_resolver.pl`
+
+**Tasks:**
+- [ ] Implement selector matching
+- [ ] Create property cascading (theme → type → node)
+- [ ] Add computed style calculation
+- [ ] Support CSS custom properties
+
+### 5.2 Theme System
+
+**File:** `src/unifyweaver/mindmap/styling/theme_system.pl`
+
+**Tasks:**
+- [ ] Define built-in themes
+- [ ] Create theme application predicates
+- [ ] Add theme inheritance/extension
+- [ ] Support user-defined themes
+
+## Phase 6: Additional Targets
+
+### 6.1 GraphViz Export
+
+**File:** `src/unifyweaver/mindmap/render/graphviz_renderer.pl`
+
+**Tasks:**
+- [ ] Generate DOT format output
+- [ ] Map styles to GraphViz attributes
+- [ ] Support multiple GraphViz layouts
+- [ ] Add subgraph/cluster support
+
+### 6.2 D3.js Component
+
+**File:** `src/unifyweaver/mindmap/render/d3_renderer.pl`
+
+**Tasks:**
+- [ ] Generate D3.js force simulation code
+- [ ] Add interactive features (drag, zoom, pan)
+- [ ] Create animation support
+- [ ] Generate React wrapper component
+
+### 6.3 Additional Native Formats (.mm, .vue)
+
+**File:** `src/unifyweaver/mindmap/render/mm_renderer.pl`
+
+**Tasks:**
+- [ ] Generate .mm XML format
+- [ ] Map styling to native properties
+- [ ] Support icons and links
+
+## Phase 7: Interactive Features (Future GUI)
+
+This phase leverages UnifyWeaver's existing GUI infrastructure:
+
+**Existing modules to build on:**
+- `react_generator.pl` - React component generation
+- `interaction_generator.pl` - Tooltips, pan, zoom, drag handlers
+- `data_binding_generator.pl` - Real-time data sync
+- `animation_generator.pl` - Animation system
+- `graph_generator.pl` - Interactive graph visualization
+
+**Existing examples:**
+- `examples/storybook-react/` - React component examples
+- `Interactions.tsx` - Tooltip, PanZoomCanvas patterns
+- `Performance.tsx` - VirtualList for large datasets
+
+### 7.1 Event Model (extend interaction_generator.pl)
+
+**File:** `src/unifyweaver/mindmap/interaction/mindmap_interaction.pl`
+
+```prolog
+% Using existing interaction_generator.pl patterns
+tooltip_spec(mindmap_nodes, [
+    position(node_center),
+    delay(200),
+    content([field(label), field(link)])
+]).
+
+selection_spec(mindmap_nodes, [
+    mode(single),
+    method(click),
+    on_select(follow_link)
+]).
+
+drag_spec(mindmap_nodes, [
+    enabled(true),
+    mode(node_move),
+    update_layout(true)
+]).
+```
+
+**Tasks:**
+- [ ] Extend `interaction_generator.pl` with mind map-specific modes
+- [ ] Add `generate_mindmap_interaction/2` predicate
+- [ ] Integrate with existing event handler patterns
+- [ ] Add gesture support using existing patterns
+
+### 7.2 Viewport Management (extend zoom/pan patterns)
+
+**File:** `src/unifyweaver/mindmap/interaction/mindmap_viewport.pl`
+
+```prolog
+% Using existing zoom_spec/2 and drag_spec/2 patterns
+zoom_spec(mindmap_view, [
+    enabled(true),
+    min_scale(0.1),
+    max_scale(5.0),
+    step(0.1),
+    controls([zoom_in, zoom_out, zoom_fit, reset])
+]).
+
+drag_spec(mindmap_view, [
+    enabled(true),
+    mode(pan),
+    inertia(true),
+    bounds(auto)
+]).
+```
+
+**Tasks:**
+- [ ] Use existing `generate_zoom_controls/2`
+- [ ] Use existing `generate_pan_handler/2`
+- [ ] Add fit-to-content calculation for mind maps
+- [ ] Integrate with layout system for bounds
+
+### 7.3 Hyperlink Navigation (extend selection patterns)
+
+**File:** `src/unifyweaver/mindmap/interaction/mindmap_navigation.pl`
+
+**Tasks:**
+- [ ] Extend `selection_spec/2` with `on_select(follow_link)`
+- [ ] Use existing tooltip system for link previews
+- [ ] Add smooth scroll animation using `animation_generator.pl`
+- [ ] Support both external URLs and internal node links
+
+## File Structure
+
+```
+src/unifyweaver/mindmap/
+├── mindmap_dsl.pl              # Core DSL module
+├── mindmap_components.pl       # Component registry integration
+├── mindmap_ir.pl               # Intermediate representation
+│
+├── layout/
+│   ├── layout_interface.pl     # Layout algorithm interface
+│   ├── radial.pl               # Radial layout
+│   ├── force_directed.pl       # Force-directed layout
+│   ├── hierarchical.pl         # Tree layout
+│   └── layout_pipeline.pl      # Pipeline execution
+│
+├── optimize/
+│   ├── optimizer_interface.pl  # Optimizer interface
+│   ├── overlap_removal.pl      # Overlap removal
+│   ├── crossing_minimization.pl# Edge crossing minimization
+│   └── spacing.pl              # Spacing adjustment
+│
+├── render/
+│   ├── renderer_interface.pl   # Renderer interface
+│   ├── svg_renderer.pl         # SVG output
+│   ├── smmx_renderer.pl        # .smmx format
+│   ├── graph_interactive_renderer.pl  # Interactive React
+│   ├── graphviz_renderer.pl    # DOT format
+│   ├── d3_renderer.pl          # D3.js
+│   └── mm_renderer.pl          # .mm format
+│
+├── styling/
+│   ├── style_resolver.pl       # Style resolution
+│   └── theme_system.pl         # Theme management
+│
+├── interaction/
+│   ├── event_model.pl          # Event handling
+│   ├── viewport.pl             # Pan/zoom
+│   └── navigation.pl           # Link navigation
+│
+└── bindings/
+    ├── python_layout.py        # Python layout implementations
+    └── typescript/             # TypeScript implementations
+        ├── package.json
+        └── src/
+            └── layout.ts
+```
+
+## Milestones
+
+### Milestone 1: Minimal Viable DSL
+- Core DSL predicates working
+- Can define nodes and edges
+- Basic spec validation
+
+### Milestone 2: Layout Optimization Working
+- Force-directed layout functional
+- Overlap removal working
+- Can process existing mind map data
+
+### Milestone 3: First Output Target
+- SVG rendering complete
+- Styles applied correctly
+- Matches quality of existing `render_mindmap.py`
+
+### Milestone 4: Multi-Target Support
+- 3+ output targets working
+- Binding integration complete
+- Pipeline execution reliable
+
+### Milestone 5: Interactive Foundation
+- Event model defined
+- Basic pan/zoom working
+- Link navigation functional
+
+## Testing Strategy
+
+### Unit Tests
+
+```prolog
+% test/mindmap/mindmap_dsl_test.pl
+:- begin_tests(mindmap_dsl).
+
+test(node_declaration) :-
+    clear_mindmap,
+    declare_mindmap_node(test, [label("Test")]),
+    mindmap_node(test, Props),
+    member(label("Test"), Props).
+
+test(implicit_edge_creation) :-
+    clear_mindmap,
+    declare_mindmap_node(parent, [label("Parent")]),
+    declare_mindmap_node(child, [label("Child"), parent(parent)]),
+    mindmap_edge(parent, child, _).
+
+:- end_tests(mindmap_dsl).
+```
+
+### Integration Tests
+
+- Process existing mind map files (.smmx, .mm) through pipeline
+- Compare output with existing Python tools
+- Validate against multiple targets
+
+### Visual Regression Tests
+
+- Generate reference images
+- Compare new outputs pixel-by-pixel
+- Flag layout differences for review
+
+## Dependencies
+
+### Existing Modules to Integrate
+
+- `component_registry.pl` - Component management
+- `binding_registry.pl` - Target bindings
+- `target_registry.pl` - Target capabilities
+- `layout_generator.pl` - Layout patterns (for web targets)
+- `graph_generator.pl` - Graph visualization patterns
+
+### External Dependencies
+
+**Python:**
+- NumPy (array operations)
+- SciPy (optimization)
+- svgwrite (SVG generation)
+
+**JavaScript/TypeScript:**
+- Graph visualization libraries (for interactive output)
+- D3.js (data visualization)
+- React (component framework)
+
+## Risk Mitigation
+
+### Performance Risk
+
+**Risk:** Layout optimization too slow for large mind maps
+
+**Mitigation:**
+- Use Python/NumPy for heavy computation via bindings
+- Implement spatial indexing (R-trees) for collision detection
+- Add progressive refinement with early termination
+
+### Compatibility Risk
+
+**Risk:** Output doesn't match existing tool quality
+
+**Mitigation:**
+- Port existing algorithms faithfully before optimizing
+- Create comparison test suite
+- Allow fallback to existing Python tools
+
+### Complexity Risk
+
+**Risk:** DSL becomes too complex to use
+
+**Mitigation:**
+- Progressive enhancement approach (simple → complex)
+- Sensible defaults for all options
+- Comprehensive examples and documentation

--- a/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
+++ b/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
@@ -26,30 +26,30 @@ This document outlines the phased implementation of the declarative mind map lay
 ```
 
 **Tasks:**
-- [ ] Define core predicates for node and edge declaration
-- [ ] Implement specification predicates with validation
-- [ ] Add constraint and preference storage
-- [ ] Create management predicates (declare_*, clear_*)
+- [x] Define core predicates for node and edge declaration
+- [x] Implement specification predicates with validation
+- [x] Add constraint and preference storage
+- [x] Create management predicates (declare_*, clear_*)
 
 ### 1.2 Integrate with Component Registry
 
 **File:** `src/unifyweaver/mindmap/mindmap_components.pl`
 
 **Tasks:**
-- [ ] Define `mindmap_layout` category
-- [ ] Define `mindmap_optimizer` category
-- [ ] Define `mindmap_renderer` category
-- [ ] Register default implementations
+- [x] Define `mindmap_layout` category
+- [x] Define `mindmap_optimizer` category
+- [x] Define `mindmap_renderer` category
+- [x] Register default implementations
 
 ### 1.3 Create Intermediate Representation
 
 **File:** `src/unifyweaver/mindmap/mindmap_ir.pl`
 
 **Tasks:**
-- [ ] Define normalized graph structure
-- [ ] Implement spec-to-IR transformation
-- [ ] Add attribute extraction and normalization
-- [ ] Handle implicit edges from `parent()` properties
+- [x] Define normalized graph structure
+- [x] Implement spec-to-IR transformation
+- [x] Add attribute extraction and normalization
+- [x] Handle implicit edges from `parent()` properties
 
 ## Phase 2: Layout Optimization Target (Priority)
 
@@ -65,10 +65,10 @@ This document outlines the phased implementation of the declarative mind map lay
 ```
 
 **Tasks:**
-- [ ] Extract algorithm parameters from existing Python
-- [ ] Create Prolog interface predicates
+- [x] Extract algorithm parameters from existing Python
+- [x] Create Prolog interface predicates
 - [ ] Add Python bindings for heavy computation
-- [ ] Implement fallback pure-Prolog version for small graphs
+- [x] Implement fallback pure-Prolog version for small graphs
 
 ### 2.2 Port Optimization Algorithms
 
@@ -79,8 +79,8 @@ This document outlines the phased implementation of the declarative mind map lay
 - `src/unifyweaver/mindmap/optimize/crossing_minimization.pl`
 
 **Tasks:**
-- [ ] Create overlap detection predicates
-- [ ] Implement push-apart algorithm
+- [x] Create overlap detection predicates
+- [x] Implement push-apart algorithm
 - [ ] Create edge crossing detection
 - [ ] Implement angular adjustment optimizer
 - [ ] Add Python bindings for O(n²) operations
@@ -95,10 +95,10 @@ This document outlines the phased implementation of the declarative mind map lay
 ```
 
 **Tasks:**
-- [ ] Implement stage sequencing
-- [ ] Add intermediate result passing
-- [ ] Create convergence detection
-- [ ] Add progress reporting hooks
+- [x] Implement stage sequencing
+- [x] Add intermediate result passing
+- [x] Create convergence detection
+- [x] Add progress reporting hooks
 
 ## Phase 3: First Output Targets
 
@@ -107,12 +107,12 @@ This document outlines the phased implementation of the declarative mind map lay
 **File:** `src/unifyweaver/mindmap/render/svg_renderer.pl`
 
 **Tasks:**
-- [ ] Port rendering logic from `render_mindmap.py`
-- [ ] Create SVG element generation predicates
-- [ ] Implement node shape rendering (ellipse, rectangle, diamond)
-- [ ] Implement edge rendering (straight, bezier)
-- [ ] Add style application
-- [ ] Generate complete SVG document
+- [x] Port rendering logic from `render_mindmap.py`
+- [x] Create SVG element generation predicates
+- [x] Implement node shape rendering (ellipse, rectangle, diamond)
+- [x] Implement edge rendering (straight, bezier)
+- [x] Add style application
+- [x] Generate complete SVG document
 
 ### 3.2 Native Format Export (.smmx, .mm)
 

--- a/docs/design/mindmap_declarative_targets/PHILOSOPHY.md
+++ b/docs/design/mindmap_declarative_targets/PHILOSOPHY.md
@@ -1,0 +1,278 @@
+# Design Philosophy: Declarative Mind Map Layout System
+
+## Core Principle: Separation of Concerns
+
+The declarative mind map system separates **what** from **how**:
+
+1. **Specification** - What the mind map contains and how it should behave
+2. **Layout Algorithm** - How nodes are positioned (force-directed, radial, etc.)
+3. **Rendering Target** - How the result is output (SVG, Canvas, interactive graphs, etc.)
+4. **Optimization** - How the layout is refined (crossing minimization, overlap removal)
+
+Each concern is independently composable and replaceable.
+
+## Design Principles
+
+### 1. Declarative Over Imperative
+
+Describe the desired outcome, not the steps to achieve it:
+
+```prolog
+% Good: Declarative specification
+mindmap_node(root, [label("Central Topic"), style(hub)]).
+mindmap_node(child1, [label("Branch A"), parent(root)]).
+mindmap_constraint(no_overlap, [min_distance(20)]).
+mindmap_layout(force_directed, [iterations(300)]).
+
+% Bad: Imperative positioning
+set_node_position(root, 400, 300).
+set_node_position(child1, 600, 200).
+```
+
+### 2. Composable Components
+
+Systems should be built from small, reusable pieces:
+
+```prolog
+% Layout algorithms are components
+:- register_component_type(layout, force_directed, force_directed_layout, []).
+:- register_component_type(layout, radial, radial_layout, []).
+:- register_component_type(layout, hierarchical, hierarchical_layout, []).
+
+% Optimizers are components
+:- register_component_type(optimizer, overlap_removal, overlap_optimizer, []).
+:- register_component_type(optimizer, crossing_minimization, crossing_optimizer, []).
+
+% Renderers are components
+:- register_component_type(renderer, svg, svg_renderer, []).
+:- register_component_type(renderer, canvas, canvas_renderer, []).
+:- register_component_type(renderer, graph_interactive, graph_interactive_renderer, []).
+```
+
+### 3. Target Independence
+
+The same specification should compile to multiple targets:
+
+```prolog
+% Single specification
+mindmap_spec(my_map, [
+    nodes([root, a, b, c]),
+    layout(force_directed),
+    theme(dark)
+]).
+
+% Multiple targets
+?- compile_mindmap(my_map, svg, SVGCode).
+?- compile_mindmap(my_map, graph_interactive, InteractiveCode).
+?- compile_mindmap(my_map, smmx, SMMXCode).
+?- compile_mindmap(my_map, graphviz, DotCode).
+```
+
+### 4. Binding-Based Extension
+
+New targets are added through bindings, not code changes:
+
+```prolog
+% Bind layout operations to target implementations
+declare_binding(python, compute_forces/3, 'layout.compute_forces',
+    [nodes, edges, params], [positions],
+    [import('mindmap.layout')]).
+
+declare_binding(javascript, compute_forces/3, 'computeForces',
+    [nodes, edges, params], [positions],
+    [import('layout-engine')]).
+```
+
+### 5. Constraint Satisfaction
+
+Layout is framed as constraint satisfaction, not procedural positioning:
+
+```prolog
+% Hard constraints (must satisfy)
+mindmap_constraint(hierarchy, [child_further_from_center]).
+mindmap_constraint(no_overlap, [min_distance(NodeRadius * 2)]).
+
+% Soft constraints (optimize for)
+mindmap_preference(minimize_crossings, [weight(0.8)]).
+mindmap_preference(angular_balance, [weight(0.5)]).
+mindmap_preference(radial_alignment, [weight(0.3)]).
+```
+
+### 6. Progressive Enhancement
+
+Start simple, add complexity as needed:
+
+```prolog
+% Level 1: Basic specification (uses all defaults)
+mindmap(my_map, [nodes([a, b, c]), edges([a-b, b-c])]).
+
+% Level 2: With layout preference
+mindmap(my_map, [nodes([...]), layout(radial)]).
+
+% Level 3: With customization
+mindmap(my_map, [nodes([...]), layout(radial),
+    options([iterations(500), min_distance(50)])]).
+
+% Level 4: With optimization pipeline
+mindmap(my_map, [nodes([...]),
+    pipeline([radial_init, force_refine, crossing_minimize])]).
+```
+
+### 7. Semantic Preservation
+
+Meaning travels through the pipeline:
+
+```prolog
+% Semantic annotations
+mindmap_node(topic, [
+    label("Machine Learning"),
+    semantic_type(concept),
+    importance(high),
+    cluster(ai_topics)
+]).
+
+% Semantics inform layout
+layout_hint(cluster(ai_topics), [group_nearby]).
+layout_hint(importance(high), [larger_node, central_position]).
+```
+
+## Architectural Layers
+
+```
++------------------------------------------------------------------+
+|                    User Specification (DSL)                       |
+|  mindmap_node/2, mindmap_edge/3, mindmap_spec/2, constraints     |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                    Intermediate Representation                    |
+|  Normalized graph structure with attributes and constraints       |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                    Layout Engine (Pluggable)                      |
+|  Force-directed, Radial, Hierarchical, Custom algorithms          |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                    Optimization Pipeline                          |
+|  Overlap removal, Crossing minimization, Spacing adjustment       |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                    Target Binding Layer                           |
+|  Maps operations to target-specific implementations               |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|                    Code Generator                                 |
+|  SVG, Canvas, interactive graphs, native formats (.smmx, .mm), etc. |
++------------------------------------------------------------------+
+```
+
+## Integration with Existing Systems
+
+### Component Registry Integration
+
+Layout algorithms, optimizers, and renderers register as components:
+
+```prolog
+:- define_category(mindmap_layout, "Layout algorithms", []).
+:- define_category(mindmap_optimizer, "Layout optimizers", []).
+:- define_category(mindmap_renderer, "Output renderers", []).
+```
+
+### Binding Registry Integration
+
+Target-specific operations use the binding system:
+
+```prolog
+% Abstract operation
+compute_node_positions(Graph, Layout, Positions).
+
+% Bound to targets
+declare_binding(python, compute_node_positions/3, ...).
+declare_binding(javascript, compute_node_positions/3, ...).
+```
+
+### Target Registry Integration
+
+Mind map targets register with capabilities:
+
+```prolog
+register_target(svg, graphics, [static, vector, pan, zoom]).
+register_target(canvas, graphics, [dynamic, raster, pan, zoom, interaction]).
+register_target(graph_interactive, graph_viz, [dynamic, interaction, layout_algorithms]).
+register_target(smmx, mindmap, [native, editable, collaboration]).
+register_target(mm, mindmap, [native, editable, folding]).
+```
+
+## Future GUI Considerations
+
+The architecture builds on UnifyWeaver's existing GUI infrastructure:
+
+**Existing modules to leverage:**
+- `react_generator.pl` (1,004 lines) - React component generation
+- `interaction_generator.pl` (1,111 lines) - Tooltips, pan, zoom, drag
+- `data_binding_generator.pl` (989 lines) - Real-time data sync
+- `animation_generator.pl` + `animation_presets.pl` (28,879 lines) - Animations
+- `graph_generator.pl` (803 lines) - Interactive graph visualization
+
+### Canvas Drawing
+Uses existing `react_generator.pl` patterns:
+- `ui_component/2` for component definition
+- `generate_react_component/2` for code generation
+
+### Pan and Zoom
+Uses existing `interaction_generator.pl` patterns:
+- `zoom_spec/2` for zoom configuration
+- `drag_spec/2` with `mode(pan)` for panning
+- `generate_zoom_controls/2`, `generate_pan_handler/2`
+
+### Hyperlink Following
+Uses existing interaction patterns:
+- `tooltip_spec/2` for hover previews
+- `selection_spec/2` with `on_select(follow_link)`
+
+```prolog
+% Using existing interaction_generator.pl patterns
+zoom_spec(mindmap_view, [
+    enabled(true),
+    min_scale(0.1),
+    max_scale(5.0),
+    controls([zoom_in, zoom_out, zoom_fit, reset])
+]).
+
+drag_spec(mindmap_view, [
+    enabled(true),
+    mode(pan),
+    inertia(true)
+]).
+
+tooltip_spec(mindmap_nodes, [
+    position(node_center),
+    delay(200),
+    content([field(label), field(link)])
+]).
+
+selection_spec(mindmap_nodes, [
+    mode(single),
+    method(click),
+    on_select(follow_link)
+]).
+```
+
+## Guiding Questions
+
+When extending the system, ask:
+
+1. **Is this declarative?** Can it be specified without describing execution?
+2. **Is this composable?** Can it be combined with other components?
+3. **Is this target-independent?** Does it make sense across multiple outputs?
+4. **Does it use bindings?** Is the implementation pluggable?
+5. **Does it preserve semantics?** Does meaning flow through the pipeline?

--- a/docs/design/mindmap_declarative_targets/PROPOSAL.md
+++ b/docs/design/mindmap_declarative_targets/PROPOSAL.md
@@ -1,0 +1,352 @@
+# Proposal: Declarative Mind Map Layout System
+
+## Executive Summary
+
+This proposal introduces a declarative system for generating mind map layouts across multiple targets. The system preserves existing Python tools (`export_mindmap.py`, `render_mindmap.py`, `generate_mindmap.py`) while adding a composable Prolog DSL that compiles to various output formats, starting with layout optimization.
+
+## Motivation
+
+### Current State
+
+UnifyWeaver has powerful mind mapping tools:
+- **Export**: Convert between mind map formats (.smmx, .mm, .vue, .opml, .graphml)
+- **Render**: Generate SVG, PNG with customizable styling
+- **Generate**: Procedural generation with force-directed layout and optimization
+
+However, these tools are:
+- **Imperative**: Python scripts that execute steps sequentially
+- **Monolithic**: Each script handles the full pipeline
+- **Single-target**: Each output requires separate code paths
+
+### Proposed State
+
+A declarative system where:
+- **Specification is separate from execution**: Define *what* you want, not *how* to get it
+- **Components are composable**: Mix and match layouts, optimizers, and renderers
+- **Targets are pluggable**: Same spec compiles to SVG, interactive graphs, native formats, etc.
+- **Custom functions extend the system**: Users add algorithms without modifying core code
+
+## Key Features
+
+### 1. Declarative Mind Map DSL
+
+Following the patterns from `layout_generator.pl`:
+
+```prolog
+% Define structure (similar to graph_node/2 pattern)
+mindmap_node(root, [label("Project Plan"), type(root)]).
+mindmap_node(phase1, [label("Research"), parent(root)]).
+mindmap_node(phase2, [label("Development"), parent(root)]).
+
+% Define layout (following declare_layout/3 pattern)
+declare_mindmap_layout(project_map, force_directed, [
+    iterations(300),
+    min_distance(50),
+    theme(dark)
+]).
+
+% Generate to any target
+?- generate_mindmap_svg(project_map, SVGCode).
+?- generate_mindmap_jsx(project_map, ReactComponent).
+```
+
+### 2. Layout Optimization Pipeline
+
+Build multi-stage optimization as composable pipeline:
+
+```prolog
+mindmap_pipeline(production, [
+    stage(radial, [level_spacing(120)]),      % Initial layout
+    stage(force_directed, [iterations(200)]), % Physics refinement
+    optimize(overlap_removal, []),             % Remove overlaps
+    optimize(crossing_minimization, [])        % Clean up crossings
+]).
+```
+
+### 3. Custom Function System
+
+Leverages UnifyWeaver's existing **custom component system** (`custom_<target>.pl`
+modules for 25+ targets):
+
+```prolog
+% Use existing custom_python for a layout algorithm
+declare_component(source, embedding_layout, custom_python, [
+    code("
+        from sklearn.manifold import TSNE
+        positions = TSNE(n_components=2).fit_transform(embeddings)
+        return {n: (x,y) for n,(x,y) in zip(nodes, positions)}
+    "),
+    imports(["sklearn.manifold"])
+]).
+
+% Use existing custom_go for fast overlap removal
+declare_component(source, fast_overlap, custom_go, [
+    code("
+        tree := rtree.New()
+        for _, n := range nodes { tree.Insert(n.Bounds(), n) }
+        return resolveOverlaps(tree, nodes)
+    "),
+    imports(["github.com/dhconnelly/rtreego"])
+]).
+
+% Reference custom components in mind map spec
+declare_mindmap_layout(custom_map, component(embedding_layout), [
+    pipeline([
+        stage(component(embedding_layout), []),
+        optimize(component(fast_overlap), [])
+    ])
+]).
+```
+
+**Existing custom component modules:**
+- `targets/go_runtime/custom_go.pl`
+- `targets/python_runtime/custom_python.pl`
+- `targets/typescript_runtime/custom_typescript.pl`
+- ... and 20+ more targets
+
+### 4. Component Registry Integration
+
+All algorithms register as queryable components:
+
+```prolog
+% Built-in layouts
+:- register_component_type(mindmap_layout, radial, radial_layout_module, [...]).
+:- register_component_type(mindmap_layout, force_directed, force_module, [...]).
+
+% User custom layouts also registered
+?- list_components(mindmap_layout, All).
+% All = [radial, force_directed, hierarchical, spiral, embedding_layout, ...]
+```
+
+### 5. Binding-Based Target Support
+
+New targets added via bindings, not code changes:
+
+```prolog
+% Python target for NumPy-accelerated layout
+declare_binding(python, force_layout/3, 'mindmap.layout.force_directed',
+    [graph, options], [positions], [import('unifyweaver.mindmap')]).
+
+% JavaScript target for browser execution
+declare_binding(javascript, force_layout/3, 'computeForceLayout',
+    [graph, options], [positions], [import('@unifyweaver/layout')]).
+```
+
+### 6. Constraint-Based Layout
+
+Frame layout as constraint satisfaction:
+
+```prolog
+% Hard constraints (must satisfy)
+mindmap_constraint(no_overlap, [min_distance(20)]).
+mindmap_constraint(hierarchy, [child_further_from_root]).
+
+% Soft preferences (optimize for)
+mindmap_preference(minimize_crossings, [weight(0.8)]).
+mindmap_preference(angular_balance, [weight(0.5)]).
+```
+
+## Relation to Existing Tools
+
+| Existing Tool | Preserved? | Integration |
+|---------------|------------|-------------|
+| `export_mindmap.py` | Yes | Can use DSL renderers internally |
+| `render_mindmap.py` | Yes | SVG renderer ports its logic |
+| `generate_mindmap.py` | Yes | Algorithms become DSL components |
+
+The existing tools remain as standalone scripts. The DSL provides an alternative declarative interface that can eventually wrap or replace them.
+
+## Output Targets
+
+### Phase 1 (Layout Optimization Focus)
+- **Internal positions**: Compute optimized (x, y) coordinates
+- **SVG**: Static vector output
+- **Native formats**: .smmx, .mm with computed positions
+
+### Phase 2 (Interactive)
+- **Graph visualization libraries**: React components with interaction
+- **Force simulation**: Animated layout with D3-style physics
+
+### Phase 3 (Export Formats)
+- **GraphViz (DOT)**: For external rendering
+- **Various mind map formats**: .mm, .vue, .opml, .graphml
+- **Text-based diagrams**: Mermaid, PlantUML
+
+### Future (GUI Integration)
+- **HTML Canvas**: With pan/zoom/hyperlinks
+- **WebGL**: For large graphs
+- **Native GUI**: Platform-specific rendering
+
+## API Alignment with layout_generator.pl
+
+The mind map DSL follows established patterns from the existing layout system:
+
+| Existing API | Mind Map Equivalent |
+|--------------|---------------------|
+| `declare_layout/3` | `declare_mindmap_layout/3` |
+| `layout/3` | `mindmap_layout/3` |
+| `generate_layout_css/2` | `generate_mindmap_svg/2` |
+| `generate_layout_jsx/2` | `generate_mindmap_jsx/2` |
+| `style/2` | `mindmap_style/2` |
+| `theme/2` | `mindmap_theme/2` |
+| `has_layout/1` | `has_mindmap_layout/1` |
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    User Specification                        │
+│  mindmap_node/2, declare_mindmap_layout/3, mindmap_style/2  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                 Intermediate Representation                  │
+│  Normalized graph with attributes, constraints, preferences  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Component Registry + Custom Functions           │
+│  Built-in + user-defined layouts, optimizers, renderers     │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Layout Pipeline                           │
+│  Sequential execution of layout stages and optimizers       │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Binding Layer (Target Resolution)               │
+│  Maps operations to Python/JavaScript/Prolog implementations │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Code Generator                            │
+│  SVG, interactive graphs, native formats, DOT, etc.         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Future: GUI Capabilities
+
+The architecture builds on UnifyWeaver's existing GUI infrastructure:
+
+**Existing generators to leverage:**
+- `react_generator.pl` - React component generation
+- `interaction_generator.pl` - Tooltips, pan, zoom, drag handlers
+- `data_binding_generator.pl` - Real-time data sync
+- `animation_generator.pl` + `animation_presets.pl` - Animation library
+- `graph_generator.pl` - Interactive graph visualization
+
+### Canvas Drawing (using existing patterns)
+```prolog
+% Following react_generator.pl patterns
+ui_component(mindmap_canvas, [
+    type(visualization),
+    title("Mind Map"),
+    width(1920), height(1080),
+    theme(dark),
+    render_quality(high)
+]).
+
+?- generate_react_component(mindmap_canvas, ReactCode).
+```
+
+### Pan and Zoom (using interaction_generator.pl)
+```prolog
+% Following existing zoom_spec/2 and pan patterns
+zoom_spec(mindmap_view, [
+    enabled(true),
+    min_scale(0.1),
+    max_scale(5.0),
+    step(0.1),
+    controls([zoom_in, zoom_out, zoom_fit, reset])
+]).
+
+drag_spec(mindmap_view, [
+    enabled(true),
+    mode(pan),
+    inertia(true)
+]).
+
+?- generate_zoom_controls(mindmap_view, ZoomJSX).
+?- generate_pan_handler(mindmap_view, PanHandler).
+```
+
+### Hyperlink Navigation (using interaction patterns)
+```prolog
+mindmap_node(docs, [
+    label("Documentation"),
+    link("https://docs.example.com"),
+    link_style(underline)
+]).
+
+% Following existing tooltip_spec/2 pattern
+tooltip_spec(mindmap_nodes, [
+    position(node_center),
+    offset(0, -10),
+    delay(200),
+    content([field(label), field(link)])
+]).
+
+% Following existing selection patterns
+selection_spec(mindmap_nodes, [
+    mode(single),
+    method(click),
+    on_select(follow_link)
+]).
+```
+
+## Benefits
+
+### For Users
+- **Simpler specification**: Describe the result, not the process
+- **Consistent interface**: Same DSL for all targets
+- **Customizable**: Add custom algorithms without forking
+
+### For Developers
+- **Modular codebase**: Each component is isolated
+- **Testable**: Pure functions, clear interfaces
+- **Extensible**: New targets without touching existing code
+
+### For the Project
+- **Unified approach**: Aligns with existing declarative systems
+- **Reuses infrastructure**: Component registry, bindings, targets
+- **Future-proof**: GUI features build on same foundation
+
+## Implementation Phases
+
+1. **Core DSL**: Node/edge/spec predicates, basic validation
+2. **Layout Optimization**: Port force-directed, overlap removal, crossing minimization
+3. **First Targets**: SVG renderer, native format export
+4. **Custom Functions**: Extension mechanism for all component types
+5. **Additional Targets**: Interactive graphs, DOT, text diagrams
+6. **Interactivity**: Event model, viewport, navigation
+
+## Related Documents
+
+- [PHILOSOPHY.md](./PHILOSOPHY.md) - Design principles and architectural decisions
+- [SPECIFICATION.md](./SPECIFICATION.md) - Complete DSL reference
+- [IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md) - Detailed implementation roadmap
+
+## Success Criteria
+
+1. **Functional parity**: DSL can produce output matching existing Python tools
+2. **Multi-target**: Same spec generates valid SVG, native formats, and interactive output
+3. **Custom functions work**: Users can add layouts/optimizers without core changes
+4. **Performance acceptable**: Large mind maps (500+ nodes) optimize in reasonable time
+5. **Integration clean**: Uses existing component/binding/target registries
+
+## Conclusion
+
+This proposal extends UnifyWeaver's declarative approach to mind map generation. By separating specification from execution and making all components pluggable, we create a flexible system that:
+
+- Preserves existing tool functionality
+- Enables multi-target output from single specifications
+- Allows user customization through the custom function system
+- Prepares for future GUI integration with canvas, pan/zoom, and hyperlinks
+
+The phased implementation minimizes risk while delivering incremental value, starting with the most requested feature: layout optimization.

--- a/docs/design/mindmap_declarative_targets/SPECIFICATION.md
+++ b/docs/design/mindmap_declarative_targets/SPECIFICATION.md
@@ -1,0 +1,810 @@
+# Mind Map DSL Specification
+
+## Overview
+
+This specification defines a declarative domain-specific language (DSL) for mind map layout and visualization. The DSL is implemented in Prolog and generates code for multiple targets.
+
+The API follows patterns established in `layout_generator.pl` and `graph_generator.pl` for consistency with existing UnifyWeaver declarative systems.
+
+## Module Structure
+
+```prolog
+:- module(mindmap_dsl, [
+    % Node and edge definition
+    mindmap_node/2,           % mindmap_node(+Id, +Properties)
+    mindmap_edge/3,           % mindmap_edge(+From, +To, +Properties)
+
+    % Specification
+    mindmap_spec/2,           % mindmap_spec(+Name, +Config)
+
+    % Constraints and preferences
+    mindmap_constraint/2,     % mindmap_constraint(+Type, +Options)
+    mindmap_preference/2,     % mindmap_preference(+Type, +Options)
+
+    % Layout configuration
+    mindmap_layout/2,         % mindmap_layout(+Algorithm, +Options)
+    mindmap_pipeline/2,       % mindmap_pipeline(+Name, +Stages)
+
+    % Styling
+    mindmap_style/2,          % mindmap_style(+Selector, +Properties)
+    mindmap_theme/2,          % mindmap_theme(+Name, +Properties)
+
+    % Code generation
+    compile_mindmap/3,        % compile_mindmap(+Name, +Target, -Code)
+    compile_mindmap/4,        % compile_mindmap(+Name, +Target, +Options, -Code)
+
+    % Management
+    declare_mindmap_node/2,
+    declare_mindmap_edge/3,
+    clear_mindmap/0,
+    clear_mindmap/1
+]).
+```
+
+## Core Predicates
+
+### Node Definition
+
+```prolog
+%% mindmap_node(+Id, +Properties)
+%
+% Define a mind map node.
+%
+% Properties:
+%   label(Text)           - Display text
+%   parent(ParentId)      - Parent node (creates implicit edge)
+%   type(Type)            - Node type (root, branch, leaf, hub)
+%   style(StyleName)      - Reference to style definition
+%   color(Color)          - Node color (hex or name)
+%   shape(Shape)          - Node shape (ellipse, rectangle, diamond, half_round)
+%   size(Width, Height)   - Node dimensions
+%   icon(IconRef)         - Icon reference
+%   link(URL)             - External hyperlink
+%   link_node(NodeId)     - Internal link to another node
+%   data(Key, Value)      - Custom metadata
+%   cluster(ClusterId)    - Cluster membership for grouping
+%   importance(Level)     - Importance level (low, medium, high)
+%   position(X, Y)        - Initial/fixed position (optional)
+
+% Examples:
+mindmap_node(root, [
+    label("Central Topic"),
+    type(root),
+    style(hub_style),
+    importance(high)
+]).
+
+mindmap_node(branch1, [
+    label("First Branch"),
+    parent(root),
+    type(branch),
+    color('#7c3aed')
+]).
+
+mindmap_node(leaf1, [
+    label("Detail Item"),
+    parent(branch1),
+    type(leaf),
+    link("https://example.com/detail")
+]).
+```
+
+### Edge Definition
+
+```prolog
+%% mindmap_edge(+From, +To, +Properties)
+%
+% Define an explicit edge between nodes.
+% Note: parent(X) in node properties creates implicit edges.
+%
+% Properties:
+%   label(Text)           - Edge label
+%   style(StyleName)      - Reference to edge style
+%   weight(N)             - Edge weight for layout algorithms
+%   type(Type)            - Edge type (parent, sibling, cross_reference)
+%   curve(CurveType)      - bezier, straight, orthogonal
+%   color(Color)          - Edge color
+%   width(N)              - Line width
+%   arrow(ArrowSpec)      - Arrow configuration (none, end, both)
+
+% Examples:
+mindmap_edge(branch1, branch2, [
+    type(cross_reference),
+    label("related to"),
+    style(dashed)
+]).
+
+mindmap_edge(root, overview, [
+    type(parent),
+    weight(2),
+    curve(bezier)
+]).
+```
+
+### Mind Map Specification
+
+```prolog
+%% mindmap_spec(+Name, +Config)
+%
+% Define a complete mind map specification.
+%
+% Config options:
+%   title(Text)           - Map title
+%   description(Text)     - Map description
+%   nodes(NodeList)       - Explicit node list (optional, defaults to all)
+%   root(NodeId)          - Root node identifier
+%   layout(Algorithm)     - Layout algorithm
+%   theme(ThemeName)      - Theme to apply
+%   constraints(List)     - Constraint specifications
+%   preferences(List)     - Optimization preferences
+%   pipeline(Stages)      - Processing pipeline
+
+% Example:
+mindmap_spec(my_project_map, [
+    title("Project Overview"),
+    description("Main concepts and relationships"),
+    root(central),
+    layout(force_directed),
+    theme(dark),
+    constraints([
+        no_overlap(min_distance(30)),
+        hierarchy(child_further)
+    ]),
+    preferences([
+        minimize_crossings(weight(0.8)),
+        angular_balance(weight(0.5))
+    ])
+]).
+```
+
+## Layout System
+
+### Layout Algorithms
+
+```prolog
+%% mindmap_layout(+Algorithm, +Options)
+%
+% Configure layout algorithm.
+%
+% Algorithms:
+%   radial          - Radial/circular layout from root
+%   force_directed  - Physics-based force simulation
+%   hierarchical    - Tree-like hierarchical layout
+%   cose            - Compound Spring Embedder (force-based)
+%   grid            - Grid-based layout
+%   concentric      - Concentric circles by attribute
+%   custom(Module)  - Custom algorithm implementation
+
+% Algorithm-specific options:
+
+% radial options:
+%   level_spacing(N)      - Distance between levels
+%   angular_width(Deg)    - Angular span in degrees
+%   start_angle(Deg)      - Starting angle
+%   clockwise(Bool)       - Direction of layout
+
+% force_directed options:
+%   iterations(N)         - Number of simulation iterations
+%   repulsion_strength(N) - Node repulsion force
+%   attraction_strength(N)- Edge attraction force
+%   damping(N)            - Velocity damping factor
+%   min_distance(N)       - Minimum node distance
+
+% hierarchical options:
+%   direction(Dir)        - top_down, bottom_up, left_right, right_left
+%   level_sep(N)          - Separation between levels
+%   node_sep(N)           - Separation between siblings
+
+% Examples:
+mindmap_layout(radial, [
+    level_spacing(150),
+    angular_width(360),
+    start_angle(0)
+]).
+
+mindmap_layout(force_directed, [
+    iterations(300),
+    repulsion_strength(100000),
+    min_distance(120)
+]).
+```
+
+### Layout Pipeline
+
+```prolog
+%% mindmap_pipeline(+Name, +Stages)
+%
+% Define a multi-stage layout pipeline.
+%
+% Each stage is a term: stage(Algorithm, Options)
+% Or an optimizer: optimize(Type, Options)
+
+% Example:
+mindmap_pipeline(production_pipeline, [
+    % Stage 1: Initial radial layout
+    stage(radial, [level_spacing(100)]),
+
+    % Stage 2: Force refinement
+    stage(force_directed, [
+        iterations(200),
+        preserve_hierarchy(true)
+    ]),
+
+    % Stage 3: Overlap removal
+    optimize(overlap_removal, [
+        min_distance(30),
+        method(push_apart)
+    ]),
+
+    % Stage 4: Crossing minimization
+    optimize(crossing_minimization, [
+        passes(50),
+        method(angular_adjustment)
+    ]),
+
+    % Stage 5: Final spacing
+    optimize(spacing, [
+        uniform(false),
+        density_aware(true)
+    ])
+]).
+```
+
+## Constraints and Preferences
+
+### Hard Constraints
+
+```prolog
+%% mindmap_constraint(+Type, +Options)
+%
+% Define hard constraints that must be satisfied.
+%
+% Types:
+%   no_overlap            - Nodes must not overlap
+%   hierarchy             - Parent-child positioning rules
+%   boundary              - Stay within bounds
+%   fixed_position        - Some nodes have fixed positions
+%   cluster_proximity     - Cluster members stay together
+%   level_alignment       - Nodes at same depth align
+
+% Examples:
+mindmap_constraint(no_overlap, [
+    min_distance(20),
+    include_labels(true)
+]).
+
+mindmap_constraint(hierarchy, [
+    rule(child_further_from_root),
+    min_parent_child_distance(50)
+]).
+
+mindmap_constraint(boundary, [
+    width(2000),
+    height(1500),
+    margin(50)
+]).
+```
+
+### Soft Preferences
+
+```prolog
+%% mindmap_preference(+Type, +Options)
+%
+% Define soft preferences for optimization.
+%
+% Types:
+%   minimize_crossings    - Reduce edge crossings
+%   angular_balance       - Even angular distribution
+%   radial_alignment      - Maintain radial structure
+%   compact               - Minimize total area
+%   symmetry              - Prefer symmetric layouts
+%   cluster_cohesion      - Keep clusters together
+
+% Examples:
+mindmap_preference(minimize_crossings, [
+    weight(0.8),
+    method(hierarchical_priority)
+]).
+
+mindmap_preference(angular_balance, [
+    weight(0.5),
+    per_level(true)
+]).
+
+mindmap_preference(compact, [
+    weight(0.3),
+    aspect_ratio(16/9)
+]).
+```
+
+## Styling System
+
+### Style Definitions
+
+```prolog
+%% mindmap_style(+Selector, +Properties)
+%
+% Define styles for nodes and edges.
+%
+% Selectors:
+%   node                  - All nodes
+%   node(Type)            - Nodes of specific type
+%   node(id(Id))          - Specific node
+%   edge                  - All edges
+%   edge(Type)            - Edges of specific type
+%   label                 - All labels
+%   .class_name           - Class-based selection
+
+% Node properties:
+%   fill(Color)           - Background color
+%   stroke(Color)         - Border color
+%   stroke_width(N)       - Border width
+%   shape(Shape)          - Node shape
+%   width(N), height(N)   - Dimensions
+%   font_size(N)          - Label font size
+%   font_family(Name)     - Label font
+%   font_weight(Weight)   - Label font weight
+%   opacity(N)            - Node opacity
+%   shadow(ShadowSpec)    - Drop shadow
+
+% Edge properties:
+%   stroke(Color)         - Line color
+%   stroke_width(N)       - Line width
+%   stroke_dasharray(Pat) - Dash pattern
+%   curve(Type)           - Curve type
+%   arrow_end(Spec)       - End arrow
+%   arrow_start(Spec)     - Start arrow
+
+% Examples:
+mindmap_style(node, [
+    fill('#2a2a4a'),
+    stroke('#7c3aed'),
+    stroke_width(2),
+    font_size(14),
+    font_family('Inter, sans-serif')
+]).
+
+mindmap_style(node(root), [
+    fill('#7c3aed'),
+    font_size(18),
+    font_weight(bold),
+    shadow(offset(2, 2), blur(4), color('rgba(0,0,0,0.3)'))
+]).
+
+mindmap_style(node(leaf), [
+    shape(ellipse),
+    opacity(0.9)
+]).
+
+mindmap_style(edge, [
+    stroke('#00d4ff'),
+    stroke_width(2),
+    curve(bezier)
+]).
+
+mindmap_style(edge(cross_reference), [
+    stroke('#888888'),
+    stroke_dasharray('5,5'),
+    arrow_end(triangle)
+]).
+```
+
+### Themes
+
+```prolog
+%% mindmap_theme(+Name, +Properties)
+%
+% Define complete themes.
+%
+% Properties define CSS custom properties / theme variables.
+
+mindmap_theme(dark, [
+    background('#1a1a2e'),
+    surface('#2a2a4a'),
+    text('#e0e0e0'),
+    text_secondary('#888888'),
+    accent('#7c3aed'),
+    accent_secondary('#00d4ff'),
+    node_fill('#2a2a4a'),
+    node_stroke('#7c3aed'),
+    edge_color('#00d4ff'),
+    shadow_color('rgba(0,0,0,0.3)')
+]).
+
+mindmap_theme(light, [
+    background('#f8fafc'),
+    surface('#ffffff'),
+    text('#1e293b'),
+    text_secondary('#64748b'),
+    accent('#7c3aed'),
+    accent_secondary('#00d4ff'),
+    node_fill('#ffffff'),
+    node_stroke('#7c3aed'),
+    edge_color('#7c3aed'),
+    shadow_color('rgba(0,0,0,0.1)')
+]).
+
+mindmap_theme(nature, [
+    background('#1a2f1a'),
+    surface('#2d4a2d'),
+    text('#d4e6d4'),
+    accent('#4ade80'),
+    node_fill('#2d4a2d'),
+    node_stroke('#4ade80'),
+    edge_color('#86efac')
+]).
+```
+
+## Target Code Generation
+
+### Supported Targets
+
+```prolog
+% Target capabilities
+mindmap_target(svg, [
+    static(true),
+    vector(true),
+    interactive(false),
+    capabilities([pan, zoom, export_png, export_pdf])
+]).
+
+mindmap_target(canvas, [
+    static(false),
+    vector(false),
+    interactive(true),
+    capabilities([pan, zoom, click, hover, animation])
+]).
+
+mindmap_target(graph_interactive, [
+    static(false),
+    vector(true),
+    interactive(true),
+    capabilities([pan, zoom, click, hover, drag, layout_algorithms])
+]).
+
+mindmap_target(smmx, [
+    format(smmx),
+    native(true),
+    editable(true),
+    capabilities([manual_edit, collaboration])
+]).
+
+mindmap_target(mm, [
+    format(mm),
+    native(true),
+    editable(true),
+    capabilities([manual_edit, folding])
+]).
+
+mindmap_target(graphviz, [
+    format(dot),
+    static(true),
+    capabilities([multiple_layouts, export_formats])
+]).
+
+mindmap_target(d3, [
+    static(false),
+    interactive(true),
+    capabilities([pan, zoom, force_simulation, transitions])
+]).
+```
+
+### Code Generation
+
+```prolog
+%% compile_mindmap(+Name, +Target, -Code)
+%% compile_mindmap(+Name, +Target, +Options, -Code)
+%
+% Generate target-specific code from mind map specification.
+%
+% Options:
+%   embed_data(Bool)      - Embed node/edge data in output
+%   minify(Bool)          - Minify output code
+%   include_styles(Bool)  - Include style definitions
+%   include_interactions(Bool) - Include interaction handlers
+%   export_format(Format) - For targets with multiple outputs
+
+% Example usage:
+?- mindmap_spec(my_map, Config),
+   compile_mindmap(my_map, svg, SVGCode).
+
+?- compile_mindmap(my_map, graph_interactive, [
+       embed_data(true),
+       include_interactions(true)
+   ], ReactComponent).
+
+?- compile_mindmap(my_map, smmx, SMMXContent).
+```
+
+## Component Registration
+
+### Layout Algorithm Components
+
+```prolog
+% Register layout algorithms as components
+:- define_category(mindmap_layout, "Mind map layout algorithms", [
+    required_interface([
+        compute_positions/3   % compute_positions(+Graph, +Options, -Positions)
+    ])
+]).
+
+:- register_component_type(mindmap_layout, radial, radial_layout_module, [
+    description("Radial layout from central root"),
+    options([level_spacing, angular_width, start_angle, clockwise])
+]).
+
+:- register_component_type(mindmap_layout, force_directed, force_layout_module, [
+    description("Force-directed physics simulation"),
+    options([iterations, repulsion_strength, attraction_strength, damping])
+]).
+```
+
+### Optimizer Components
+
+```prolog
+% Register optimizers as components
+:- define_category(mindmap_optimizer, "Layout optimization passes", [
+    required_interface([
+        optimize_layout/3     % optimize_layout(+Positions, +Options, -NewPositions)
+    ])
+]).
+
+:- register_component_type(mindmap_optimizer, overlap_removal, overlap_optimizer_module, [
+    description("Remove node overlaps"),
+    options([min_distance, method, iterations])
+]).
+
+:- register_component_type(mindmap_optimizer, crossing_minimization, crossing_optimizer_module, [
+    description("Minimize edge crossings"),
+    options([passes, method, preserve_hierarchy])
+]).
+```
+
+### Renderer Components
+
+```prolog
+% Register renderers as components
+:- define_category(mindmap_renderer, "Output renderers", [
+    required_interface([
+        render/3              % render(+Graph, +Positions, -Output)
+    ])
+]).
+
+:- register_component_type(mindmap_renderer, svg, svg_renderer_module, [
+    description("Static SVG output"),
+    capabilities([vector, export])
+]).
+
+:- register_component_type(mindmap_renderer, canvas, canvas_renderer_module, [
+    description("HTML5 Canvas output"),
+    capabilities([raster, animation, interaction])
+]).
+
+:- register_component_type(mindmap_renderer, graph_interactive, graph_interactive_renderer, [
+    description("Interactive graph React component"),
+    capabilities([vector, interaction, builtin_layouts])
+]).
+```
+
+## Custom Functions
+
+The DSL integrates with UnifyWeaver's existing **custom component system**, which
+provides `custom_<target>.pl` modules for 25+ target languages. Each module follows
+the component interface pattern:
+
+**Existing Custom Component Modules:**
+- `targets/go_runtime/custom_go.pl`
+- `targets/python_runtime/custom_python.pl`
+- `targets/bash_runtime/custom_bash.pl`
+- `targets/typescript_runtime/custom_typescript.pl`
+- ... and 20+ more targets
+
+### Custom Component Interface
+
+Each custom component module implements:
+
+```prolog
+:- module(custom_<target>, [
+    type_info/1,           % Metadata about the component type
+    validate_config/1,     % Validate configuration options
+    init_component/2,      % Initialize component (if needed)
+    invoke_component/4,    % Runtime invocation (optional)
+    compile_component/4    % Compile to target code
+]).
+```
+
+### Using Custom Components
+
+Declare custom components with inline target code:
+
+```prolog
+% Custom Python layout algorithm
+declare_component(source, embedding_layout, custom_python, [
+    code("
+        import numpy as np
+        from sklearn.manifold import TSNE
+
+        positions = TSNE(n_components=2).fit_transform(embeddings)
+        return {node: (x, y) for node, (x, y) in zip(nodes, positions)}
+    "),
+    imports(["numpy", "sklearn.manifold"])
+]).
+
+% Custom Go optimizer
+declare_component(source, fast_overlap_removal, custom_go, [
+    code("
+        // Use spatial indexing for O(n log n) overlap detection
+        tree := rtree.New()
+        for _, node := range nodes {
+            tree.Insert(node.Bounds(), node)
+        }
+        return resolveOverlaps(tree, nodes)
+    "),
+    imports(["github.com/dhconnelly/rtreego"])
+]).
+
+% Custom TypeScript renderer
+declare_component(source, canvas_renderer, custom_typescript, [
+    code("
+        const ctx = canvas.getContext('2d');
+        nodes.forEach(node => {
+            ctx.beginPath();
+            ctx.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
+            ctx.fill();
+        });
+        return canvas.toDataURL();
+    "),
+    imports([])
+]).
+```
+
+### Mind Map Custom Components
+
+For mind map-specific custom functions, we extend the pattern:
+
+```prolog
+%% Custom layout using existing custom_python
+declare_component(source, spiral_layout, custom_python, [
+    code("
+        import math
+        positions = {}
+        for i, node in enumerate(nodes):
+            angle = i * 0.5
+            radius = 50 + i * 10
+            positions[node] = (
+                center_x + radius * math.cos(angle),
+                center_y + radius * math.sin(angle)
+            )
+        return positions
+    "),
+    imports(["math"])
+]).
+
+% Use in mind map spec
+mindmap_spec(my_map, [
+    layout(component(spiral_layout)),  % Reference component by name
+    ...
+]).
+```
+
+### Custom Mind Map Component Types
+
+New component types for mind map operations (following the existing pattern):
+
+```prolog
+% File: src/unifyweaver/mindmap/custom_mindmap_layout.pl
+:- module(custom_mindmap_layout, [
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    invoke_component/4,
+    compile_component/4
+]).
+
+:- use_module('../../core/component_registry').
+
+type_info(info(
+    name('Custom Mind Map Layout'),
+    version('1.0.0'),
+    description('Custom layout algorithm for mind maps')
+)).
+
+validate_config(Config) :-
+    member(algorithm(Alg), Config), atom(Alg).
+
+compile_component(Name, Config, Options, Code) :-
+    member(algorithm(Alg), Config),
+    member(target(Target), Options),
+    % Delegate to target-specific custom component
+    compile_for_target(Target, Name, Alg, Config, Code).
+
+:- initialization((
+    register_component_type(mindmap_layout, custom, custom_mindmap_layout, [
+        description("Custom Mind Map Layout Algorithm")
+    ])
+), now).
+```
+
+### Integration Pattern
+
+The mind map DSL leverages existing custom components:
+
+1. **Reuse existing `custom_<target>` modules** for target-specific code
+2. **Register mind map component types** following the same interface
+3. **Reference components by name** in mind map specs
+
+```prolog
+% Register a custom layout that uses custom_python internally
+declare_component(source, my_layout, custom_python, [
+    code("..."),
+    imports([...])
+]).
+
+% Use in mind map (references the component)
+mindmap_spec(example, [
+    layout(component(my_layout)),
+    pipeline([
+        stage(component(my_layout), []),
+        optimize(overlap_removal, [])
+    ])
+]).
+```
+
+## Binding Integration
+
+### Target Bindings
+
+```prolog
+% Bind layout computation to Python (for NumPy/SciPy)
+declare_binding(python, compute_force_layout/4, 'mindmap_layout.force_directed',
+    [nodes, edges, options], [positions],
+    [import('unifyweaver.mindmap.layout'),
+     pure, deterministic]).
+
+% Bind to JavaScript (for browser execution)
+declare_binding(javascript, compute_force_layout/4, 'computeForceLayout',
+    [nodes, edges, options], [positions],
+    [import('@unifyweaver/mindmap-layout'),
+     async]).
+
+% Bind SVG generation
+declare_binding(python, render_svg/3, 'mindmap_render.to_svg',
+    [graph, positions], [svg_string],
+    [import('unifyweaver.mindmap.render')]).
+```
+
+## Example: Complete Mind Map
+
+```prolog
+% Nodes
+mindmap_node(ai, [label("Artificial Intelligence"), type(root), importance(high)]).
+mindmap_node(ml, [label("Machine Learning"), parent(ai), cluster(learning)]).
+mindmap_node(dl, [label("Deep Learning"), parent(ml), cluster(learning)]).
+mindmap_node(rl, [label("Reinforcement Learning"), parent(ml), cluster(learning)]).
+mindmap_node(nlp, [label("Natural Language Processing"), parent(ai), cluster(language)]).
+mindmap_node(cv, [label("Computer Vision"), parent(ai), cluster(perception)]).
+mindmap_node(transformers, [label("Transformers"), parent(dl), link_node(nlp)]).
+mindmap_node(cnn, [label("CNN"), parent(dl), link_node(cv)]).
+
+% Cross-references
+mindmap_edge(transformers, nlp, [type(cross_reference), label("revolutionized")]).
+mindmap_edge(cnn, cv, [type(cross_reference), label("core of")]).
+
+% Specification
+mindmap_spec(ai_overview, [
+    title("AI Overview"),
+    root(ai),
+    layout(force_directed),
+    theme(dark),
+    pipeline([
+        stage(radial, [level_spacing(120)]),
+        stage(force_directed, [iterations(200)]),
+        optimize(overlap_removal, []),
+        optimize(crossing_minimization, [passes(30)])
+    ])
+]).
+
+% Generate outputs
+?- compile_mindmap(ai_overview, svg, SVG).
+?- compile_mindmap(ai_overview, graph_interactive, ReactCode).
+```

--- a/src/unifyweaver/mindmap/layout/force_directed.pl
+++ b/src/unifyweaver/mindmap/layout/force_directed.pl
@@ -1,0 +1,466 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% force_directed.pl - Force-Directed Layout Algorithm for Mind Maps
+%
+% Implements a force-directed physics simulation for laying out mind maps.
+% Nodes repel each other while edges act as springs pulling connected nodes together.
+%
+% Forces:
+% - Repulsion: Nodes push apart (inverse square law)
+% - Attraction: Connected nodes pull together (spring force)
+% - Damping: Velocities decay over time
+%
+% Based on algorithms from generate_simplemind_map.py
+
+:- module(mindmap_layout_force, [
+    % Component interface
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    compute_layout/3,
+
+    % Direct API
+    force_directed_layout/4,        % force_directed_layout(+IR, +Options, -Positions, -Stats)
+    force_directed_optimize/4,      % force_directed_optimize(+InitialPos, +Edges, +Options, -Positions)
+    compute_forces/5                % compute_forces(+Positions, +Edges, +Options, -Forces, -MaxForce)
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% COMPONENT INTERFACE
+% ============================================================================
+
+%% type_info(-Info)
+%
+%  Component type information.
+%
+type_info(info{
+    name: force_directed,
+    category: mindmap_layout,
+    description: "Force-directed physics simulation layout",
+    version: "1.0.0",
+    parameters: [
+        iterations - "Number of simulation iterations (default 300)",
+        repulsion - "Repulsion force strength (default 100000)",
+        attraction - "Attraction force to connected nodes (default 0.001)",
+        min_distance - "Minimum distance between nodes (default 120)",
+        damping - "Velocity damping factor 0-1 (default 0.8)",
+        max_velocity - "Maximum velocity per step (default 150)",
+        convergence_threshold - "Stop when max movement below this (default 0.5)",
+        initial_layout - "Initial layout: radial, random, grid (default radial)"
+    ]
+}).
+
+%% validate_config(+Config)
+%
+%  Validate layout configuration.
+%
+validate_config(Config) :-
+    is_list(Config),
+    (   member(iterations(I), Config)
+    ->  integer(I), I > 0
+    ;   true
+    ),
+    (   member(repulsion(R), Config)
+    ->  number(R), R > 0
+    ;   true
+    ),
+    (   member(damping(D), Config)
+    ->  number(D), D >= 0, D =< 1
+    ;   true
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  Initialize the component (no-op for force layout).
+%
+init_component(_Name, _Config).
+
+%% compute_layout(+Graph, +Options, -Positions)
+%
+%  Main entry point for component invocation.
+%
+compute_layout(graph(Nodes, Edges, RootId), Options, Positions) :-
+    IR = ir(Nodes, Edges, RootId),
+    force_directed_layout(IR, Options, Positions, _Stats).
+
+% ============================================================================
+% FORCE-DIRECTED LAYOUT ALGORITHM
+% ============================================================================
+
+%% force_directed_layout(+IR, +Options, -Positions, -Stats)
+%
+%  Compute force-directed layout.
+%
+%  @param IR        term - ir(Nodes, Edges, RootId)
+%  @param Options   list - layout options
+%  @param Positions list - list of position(Id, X, Y)
+%  @param Stats     dict - layout statistics
+%
+force_directed_layout(IR, Options, Positions, Stats) :-
+    extract_ir_data(IR, Nodes, Edges, RootId),
+
+    % Get options
+    option_or_default(iterations, Options, 300, MaxIterations),
+    option_or_default(initial_layout, Options, radial, InitialLayout),
+
+    % Generate initial positions
+    generate_initial_positions(Nodes, RootId, InitialLayout, Options, InitialPositions),
+
+    % Build edge list for physics
+    build_edge_pairs(Edges, EdgePairs),
+
+    % Run force-directed optimization
+    force_directed_optimize(InitialPositions, EdgePairs, Options, Positions, IterationsUsed, Converged),
+
+    % Statistics
+    length(Nodes, NumNodes),
+    Stats = stats{
+        nodes: NumNodes,
+        iterations_used: IterationsUsed,
+        iterations_max: MaxIterations,
+        converged: Converged
+    }.
+
+%% extract_ir_data(+IR, -Nodes, -Edges, -RootId)
+extract_ir_data(ir(Nodes, Edges, RootId), Nodes, Edges, RootId) :- !.
+extract_ir_data(mindmap_ir(_, graph(Nodes, Edges, RootId), _, _, _), Nodes, Edges, RootId) :- !.
+extract_ir_data(graph(Nodes, Edges, RootId), Nodes, Edges, RootId).
+
+%% generate_initial_positions(+Nodes, +RootId, +Layout, +Options, -Positions)
+%
+%  Generate initial node positions.
+%
+generate_initial_positions(Nodes, RootId, radial, Options, Positions) :-
+    !,
+    option_or_default(center_x, Options, 500, CX),
+    option_or_default(center_y, Options, 500, CY),
+    length(Nodes, N),
+    (   N =< 1
+    ->  Nodes = [node(Id, _)],
+        Positions = [pos(Id, CX, CY, 0, 0)]
+    ;   % Place root at center, others in circle
+        Radius = 200,
+        N1 is N - 1,
+        AngleStep is 2 * pi / max(1, N1),
+        generate_circle_positions(Nodes, RootId, CX, CY, Radius, 0, AngleStep, Positions)
+    ).
+
+generate_initial_positions(Nodes, _RootId, random, Options, Positions) :-
+    !,
+    option_or_default(center_x, Options, 500, CX),
+    option_or_default(center_y, Options, 500, CY),
+    option_or_default(spread, Options, 400, Spread),
+    generate_random_positions(Nodes, CX, CY, Spread, Positions).
+
+generate_initial_positions(Nodes, _RootId, grid, Options, Positions) :-
+    !,
+    option_or_default(center_x, Options, 500, CX),
+    option_or_default(center_y, Options, 500, CY),
+    option_or_default(grid_spacing, Options, 100, Spacing),
+    generate_grid_positions(Nodes, CX, CY, Spacing, Positions).
+
+generate_initial_positions(Nodes, RootId, _, Options, Positions) :-
+    % Default to radial
+    generate_initial_positions(Nodes, RootId, radial, Options, Positions).
+
+generate_circle_positions([], _, _, _, _, _, _, []).
+generate_circle_positions([node(Id, _) | Rest], RootId, CX, CY, R, Angle, Step, [pos(Id, X, Y, 0, 0) | RestPos]) :-
+    (   Id == RootId
+    ->  X = CX, Y = CY, NextAngle = Angle
+    ;   X is CX + R * cos(Angle),
+        Y is CY + R * sin(Angle),
+        NextAngle is Angle + Step
+    ),
+    generate_circle_positions(Rest, RootId, CX, CY, R, NextAngle, Step, RestPos).
+
+generate_random_positions([], _, _, _, []).
+generate_random_positions([node(Id, _) | Rest], CX, CY, Spread, [pos(Id, X, Y, 0, 0) | RestPos]) :-
+    random(R1), random(R2),
+    X is CX + (R1 - 0.5) * Spread,
+    Y is CY + (R2 - 0.5) * Spread,
+    generate_random_positions(Rest, CX, CY, Spread, RestPos).
+
+generate_grid_positions(Nodes, CX, CY, Spacing, Positions) :-
+    length(Nodes, N),
+    GridSize is ceiling(sqrt(N)),
+    Offset is (GridSize - 1) * Spacing / 2,
+    generate_grid_impl(Nodes, CX, CY, Spacing, Offset, 0, 0, GridSize, Positions).
+
+generate_grid_impl([], _, _, _, _, _, _, _, []).
+generate_grid_impl([node(Id, _) | Rest], CX, CY, Spacing, Offset, Row, Col, GridSize, [pos(Id, X, Y, 0, 0) | RestPos]) :-
+    X is CX + Col * Spacing - Offset,
+    Y is CY + Row * Spacing - Offset,
+    NextCol is (Col + 1) mod GridSize,
+    (   NextCol =:= 0
+    ->  NextRow is Row + 1
+    ;   NextRow = Row
+    ),
+    generate_grid_impl(Rest, CX, CY, Spacing, Offset, NextRow, NextCol, GridSize, RestPos).
+
+%% build_edge_pairs(+Edges, -Pairs)
+%
+%  Extract From-To pairs from edges.
+%
+build_edge_pairs(Edges, Pairs) :-
+    findall(From-To, member(edge(From, To, _), Edges), Pairs).
+
+%% force_directed_optimize(+InitialPos, +EdgePairs, +Options, -Positions, -IterationsUsed, -Converged)
+%
+%  Run force-directed optimization.
+%
+force_directed_optimize(InitialPos, EdgePairs, Options, FinalPositions, IterationsUsed, Converged) :-
+    option_or_default(iterations, Options, 300, MaxIterations),
+    option_or_default(convergence_threshold, Options, 0.5, Threshold),
+
+    % Build connected pairs set for fast lookup
+    findall(P, (member(A-B, EdgePairs), (P = A-B ; P = B-A)), AllPairs),
+    list_to_set(AllPairs, ConnectedSet),
+
+    % Run simulation
+    simulate_loop(InitialPos, EdgePairs, ConnectedSet, Options, MaxIterations, Threshold,
+                  0, FinalPosWithVel, IterationsUsed, Converged),
+
+    % Strip velocities from result
+    findall(position(Id, X, Y),
+            member(pos(Id, X, Y, _, _), FinalPosWithVel),
+            FinalPositions).
+
+simulate_loop(Positions, _, _, _, MaxIter, _, Iter, Positions, Iter, false) :-
+    Iter >= MaxIter,
+    !.
+simulate_loop(Positions, EdgePairs, ConnectedSet, Options, MaxIter, Threshold, Iter, FinalPos, IterUsed, Converged) :-
+    % Compute forces
+    compute_forces(Positions, EdgePairs, ConnectedSet, Options, Forces),
+
+    % Update positions
+    update_positions(Positions, Forces, Options, NewPositions, MaxMovement),
+
+    % Check convergence
+    NextIter is Iter + 1,
+    (   MaxMovement < Threshold
+    ->  FinalPos = NewPositions,
+        IterUsed = NextIter,
+        Converged = true
+    ;   simulate_loop(NewPositions, EdgePairs, ConnectedSet, Options, MaxIter, Threshold,
+                      NextIter, FinalPos, IterUsed, Converged)
+    ).
+
+%% compute_forces(+Positions, +EdgePairs, +ConnectedSet, +Options, -Forces)
+%
+%  Compute forces for all nodes.
+%
+%  @param Positions    list - list of pos(Id, X, Y, VX, VY)
+%  @param EdgePairs    list - list of From-To pairs
+%  @param ConnectedSet set  - set of connected pairs for fast lookup
+%  @param Options      list - force parameters
+%  @param Forces       list - list of force(Id, FX, FY)
+%
+compute_forces(Positions, EdgePairs, ConnectedSet, Options, Forces) :-
+    option_or_default(repulsion, Options, 100000, Repulsion),
+    option_or_default(attraction, Options, 0.001, Attraction),
+    option_or_default(min_distance, Options, 120, MinDist),
+
+    % Compute repulsion between all pairs
+    findall(force(Id, FX, FY),
+            (member(pos(Id, _, _, _, _), Positions),
+             compute_node_forces(Id, Positions, EdgePairs, ConnectedSet,
+                                Repulsion, Attraction, MinDist, FX, FY)),
+            Forces).
+
+compute_node_forces(Id, Positions, EdgePairs, ConnectedSet, Repulsion, Attraction, MinDist, FX, FY) :-
+    member(pos(Id, X, Y, _, _), Positions),
+
+    % Repulsion from all other nodes
+    findall(fx(RFX, RFY),
+            (member(pos(OtherId, OX, OY, _, _), Positions),
+             OtherId \== Id,
+             compute_repulsion(X, Y, OX, OY, Id, OtherId, ConnectedSet, Repulsion, MinDist, RFX, RFY)),
+            RepulsionForces),
+    sum_forces(RepulsionForces, RepFX, RepFY),
+
+    % Attraction to connected nodes (parents/children)
+    findall(fx(AFX, AFY),
+            (member(From-To, EdgePairs),
+             (   (From == Id, member(pos(To, OX, OY, _, _), Positions))
+             ;   (To == Id, member(pos(From, OX, OY, _, _), Positions))
+             ),
+             compute_attraction(X, Y, OX, OY, Attraction, AFX, AFY)),
+            AttractionForces),
+    sum_forces(AttractionForces, AttrFX, AttrFY),
+
+    FX is RepFX + AttrFX,
+    FY is RepFY + AttrFY.
+
+compute_repulsion(X1, Y1, X2, Y2, Id1, Id2, ConnectedSet, Repulsion, MinDist, FX, FY) :-
+    DX is X2 - X1,
+    DY is Y2 - Y1,
+    DistSq is DX*DX + DY*DY + 1,  % +1 to avoid division by zero
+    Dist is sqrt(DistSq),
+
+    % Only apply repulsion within range
+    (   Dist < MinDist * 5
+    ->  % Connected nodes repel less
+        (   (member(Id1-Id2, ConnectedSet) ; member(Id2-Id1, ConnectedSet))
+        ->  ConnectionFactor = 0.3
+        ;   ConnectionFactor = 1.5
+        ),
+        % Inverse square repulsion
+        ForceMag is (Repulsion * ConnectionFactor) / (DistSq + 100),
+        % Extra boost when overlapping
+        (   Dist < MinDist
+        ->  ForceMag2 is ForceMag * 3
+        ;   ForceMag2 = ForceMag
+        ),
+        (   Dist > 0.1
+        ->  FX is -(DX / Dist) * ForceMag2,
+            FY is -(DY / Dist) * ForceMag2
+        ;   FX = 0, FY = 0
+        )
+    ;   FX = 0, FY = 0
+    ).
+
+compute_attraction(X1, Y1, X2, Y2, Attraction, FX, FY) :-
+    DX is X2 - X1,
+    DY is Y2 - Y1,
+    Dist is sqrt(DX*DX + DY*DY),
+
+    % Only attract when far apart
+    IdealDist = 100,
+    (   Dist > IdealDist
+    ->  ForceMag is (Dist - IdealDist) * Attraction,
+        (   Dist > IdealDist * 2
+        ->  ForceMag2 is ForceMag * 2
+        ;   ForceMag2 = ForceMag
+        ),
+        (   Dist > 0.1
+        ->  FX is (DX / Dist) * ForceMag2,
+            FY is (DY / Dist) * ForceMag2
+        ;   FX = 0, FY = 0
+        )
+    ;   FX = 0, FY = 0
+    ).
+
+sum_forces([], 0, 0).
+sum_forces([fx(FX, FY) | Rest], TotalFX, TotalFY) :-
+    sum_forces(Rest, RestFX, RestFY),
+    TotalFX is FX + RestFX,
+    TotalFY is FY + RestFY.
+
+%% update_positions(+Positions, +Forces, +Options, -NewPositions, -MaxMovement)
+%
+%  Update positions based on forces and velocities.
+%
+update_positions(Positions, Forces, Options, NewPositions, MaxMovement) :-
+    option_or_default(damping, Options, 0.8, Damping),
+    option_or_default(max_velocity, Options, 150, MaxVel),
+
+    findall(Movement,
+            (member(pos(Id, _, _, _, _), Positions),
+             member(force(Id, _, _), Forces),
+             update_single_position(Id, Positions, Forces, Damping, MaxVel, _, Movement)),
+            Movements),
+
+    findall(pos(Id, NX, NY, NVX, NVY),
+            (member(pos(Id, _, _, _, _), Positions),
+             update_single_position(Id, Positions, Forces, Damping, MaxVel,
+                                   pos(Id, NX, NY, NVX, NVY), _)),
+            NewPositions),
+
+    (   Movements = []
+    ->  MaxMovement = 0
+    ;   max_list(Movements, MaxMovement)
+    ).
+
+update_single_position(Id, Positions, Forces, Damping, MaxVel, pos(Id, NX, NY, NVX, NVY), Movement) :-
+    member(pos(Id, X, Y, VX, VY), Positions),
+    member(force(Id, FX, FY), Forces),
+
+    % Update velocity with damping
+    VX1 is (VX + FX) * Damping,
+    VY1 is (VY + FY) * Damping,
+
+    % Limit velocity
+    VelMag is sqrt(VX1*VX1 + VY1*VY1),
+    (   VelMag > MaxVel
+    ->  NVX is VX1 * MaxVel / VelMag,
+        NVY is VY1 * MaxVel / VelMag
+    ;   NVX = VX1, NVY = VY1
+    ),
+
+    % Update position
+    NX is X + NVX,
+    NY is Y + NVY,
+
+    Movement is max(abs(NVX), abs(NVY)).
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+option_or_default(Key, Options, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+pi is 3.14159265358979.
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_force_directed :-
+    format('~n=== Force-Directed Layout Tests ===~n~n'),
+
+    % Test data
+    Nodes = [
+        node(root, [label("Root")]),
+        node(a, [label("A")]),
+        node(b, [label("B")]),
+        node(c, [label("C")])
+    ],
+    Edges = [
+        edge(root, a, []),
+        edge(root, b, []),
+        edge(a, c, [])
+    ],
+
+    % Test 1: Compute layout
+    format('Test 1: Compute force-directed layout...~n'),
+    compute_layout(graph(Nodes, Edges, root), [iterations(50)], Positions),
+    length(Positions, NumPos),
+    (   NumPos =:= 4
+    ->  format('  PASS: Generated ~w positions~n', [NumPos])
+    ;   format('  FAIL: Expected 4 positions, got ~w~n', [NumPos])
+    ),
+
+    % Test 2: All nodes have valid positions
+    format('~nTest 2: All nodes positioned...~n'),
+    (   forall(member(node(Id, _), Nodes), member(position(Id, _, _), Positions))
+    ->  format('  PASS: All nodes have positions~n')
+    ;   format('  FAIL: Some nodes missing positions~n')
+    ),
+
+    % Test 3: No overlapping (approximate check)
+    format('~nTest 3: Checking node separation...~n'),
+    findall(Dist,
+            (member(position(Id1, X1, Y1), Positions),
+             member(position(Id2, X2, Y2), Positions),
+             Id1 @< Id2,
+             Dist is sqrt((X2-X1)^2 + (Y2-Y1)^2)),
+            Distances),
+    min_list(Distances, MinDist),
+    (   MinDist > 50
+    ->  format('  PASS: Minimum distance ~2f > 50~n', [MinDist])
+    ;   format('  WARN: Minimum distance ~2f may indicate overlap~n', [MinDist])
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+:- initialization((
+    format('Force-directed layout module loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/layout/layout_pipeline.pl
+++ b/src/unifyweaver/mindmap/layout/layout_pipeline.pl
@@ -1,0 +1,494 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% layout_pipeline.pl - Mind Map Layout Pipeline
+%
+% Orchestrates the execution of layout stages and optimization passes.
+% A pipeline consists of:
+%   - Initial layout stage (radial, force_directed, hierarchical)
+%   - Optional refinement stages
+%   - Optimization passes (overlap removal, crossing minimization)
+%
+% Usage:
+%   mindmap_pipeline(my_pipeline, [
+%       stage(radial, [level_spacing(120)]),
+%       stage(force_directed, [iterations(100)]),
+%       optimize(overlap_removal, [min_distance(50)])
+%   ]).
+%
+%   ?- execute_pipeline(my_pipeline, Graph, FinalPositions).
+
+:- module(mindmap_layout_pipeline, [
+    % Pipeline execution
+    execute_pipeline/3,             % execute_pipeline(+Graph, +Pipeline, -Positions)
+    execute_pipeline/4,             % execute_pipeline(+Graph, +Pipeline, +Options, -Result)
+
+    % Stage execution
+    execute_stage/4,                % execute_stage(+Stage, +Graph, +Positions, -NewPositions)
+    execute_optimizer/3,            % execute_optimizer(+Optimizer, +Positions, -NewPositions)
+
+    % Pipeline building
+    build_default_pipeline/2,       % build_default_pipeline(+Options, -Pipeline)
+    validate_pipeline/1,            % validate_pipeline(+Pipeline)
+
+    % Progress reporting
+    pipeline_progress/2,            % pipeline_progress(+Stage, +Progress) - hook for progress
+
+    % Testing
+    test_layout_pipeline/0
+]).
+
+:- use_module(library(lists)).
+
+% Load layout modules if available
+:- if(exists_source(library('./radial'))).
+:- use_module('./radial').
+:- endif.
+:- if(exists_source(library('./force_directed'))).
+:- use_module('./force_directed').
+:- endif.
+:- if(exists_source(library('../optimize/overlap_removal'))).
+:- use_module('../optimize/overlap_removal').
+:- endif.
+
+% ============================================================================
+% PIPELINE EXECUTION
+% ============================================================================
+
+%% execute_pipeline(+Graph, +Pipeline, -Positions)
+%
+%  Execute a layout pipeline on a graph.
+%
+%  @param Graph     term - graph(Nodes, Edges, RootId)
+%  @param Pipeline  list - list of stage() and optimize() terms
+%  @param Positions list - final node positions
+%
+execute_pipeline(Graph, Pipeline, Positions) :-
+    execute_pipeline(Graph, Pipeline, [], result(Positions, _)).
+
+%% execute_pipeline(+Graph, +Pipeline, +Options, -Result)
+%
+%  Execute a pipeline with options and detailed result.
+%
+%  Options:
+%    - report_progress(Bool) - call pipeline_progress/2 hook
+%    - collect_stats(Bool)   - collect statistics from each stage
+%
+%  @param Graph    term - graph structure
+%  @param Pipeline list - pipeline stages
+%  @param Options  list - execution options
+%  @param Result   term - result(Positions, Stats)
+%
+execute_pipeline(Graph, Pipeline, Options, result(FinalPositions, Stats)) :-
+    % Validate pipeline
+    (   validate_pipeline(Pipeline)
+    ->  true
+    ;   format('Warning: Invalid pipeline structure~n', [])
+    ),
+
+    option_or_default(report_progress, Options, false, ReportProgress),
+    option_or_default(collect_stats, Options, true, CollectStats),
+
+    % Initialize with empty positions
+    InitialPositions = [],
+
+    % Execute each stage
+    execute_stages(Pipeline, Graph, InitialPositions, Options, ReportProgress, CollectStats,
+                   FinalPositions, StageStats),
+
+    % Aggregate statistics
+    Stats = pipeline_stats{
+        stages_executed: StageStats,
+        total_stages: Pipeline
+    }.
+
+execute_stages([], _Graph, Positions, _Options, _Report, _Collect, Positions, []).
+execute_stages([Stage | Rest], Graph, Positions, Options, Report, Collect, FinalPositions, [StageStat | RestStats]) :-
+    % Report progress if enabled
+    (   Report == true
+    ->  pipeline_progress(Stage, starting)
+    ;   true
+    ),
+
+    % Execute the stage
+    execute_single_stage(Stage, Graph, Positions, NewPositions, StageStat),
+
+    % Report completion
+    (   Report == true
+    ->  pipeline_progress(Stage, completed)
+    ;   true
+    ),
+
+    % Continue with rest of pipeline
+    execute_stages(Rest, Graph, NewPositions, Options, Report, Collect, FinalPositions, RestStats).
+
+%% execute_single_stage(+Stage, +Graph, +Positions, -NewPositions, -Stats)
+%
+%  Execute a single pipeline stage.
+%
+execute_single_stage(stage(Algorithm, StageOptions), Graph, _Positions, NewPositions, Stats) :-
+    !,
+    execute_stage(Algorithm, Graph, StageOptions, NewPositions),
+    Stats = stage_stat{type: layout, algorithm: Algorithm, status: completed}.
+
+execute_single_stage(optimize(Optimizer, OptOptions), _Graph, Positions, NewPositions, Stats) :-
+    !,
+    execute_optimizer_stage(Optimizer, Positions, OptOptions, NewPositions),
+    Stats = stage_stat{type: optimizer, algorithm: Optimizer, status: completed}.
+
+execute_single_stage(Unknown, _Graph, Positions, Positions, Stats) :-
+    format('Warning: Unknown pipeline stage: ~w~n', [Unknown]),
+    Stats = stage_stat{type: unknown, algorithm: Unknown, status: skipped}.
+
+%% execute_stage(+Algorithm, +Graph, +Options, -Positions)
+%
+%  Execute a layout algorithm stage.
+%
+execute_stage(radial, Graph, Options, Positions) :-
+    !,
+    (   catch(mindmap_layout_radial:compute_layout(Graph, Options, Positions), _, fail)
+    ->  true
+    ;   compute_radial_fallback(Graph, Options, Positions)
+    ).
+
+execute_stage(force_directed, Graph, Options, Positions) :-
+    !,
+    (   catch(mindmap_layout_force:compute_layout(Graph, Options, Positions), _, fail)
+    ->  true
+    ;   compute_force_fallback(Graph, Options, Positions)
+    ).
+
+execute_stage(hierarchical, Graph, Options, Positions) :-
+    !,
+    compute_hierarchical_fallback(Graph, Options, Positions).
+
+execute_stage(Algorithm, _Graph, _Options, []) :-
+    format('Error: Unknown layout algorithm: ~w~n', [Algorithm]).
+
+%% execute_optimizer(+Optimizer, +Positions, -NewPositions)
+%
+%  Execute an optimization pass.
+%
+execute_optimizer(Optimizer, Positions, NewPositions) :-
+    execute_optimizer_stage(Optimizer, Positions, [], NewPositions).
+
+execute_optimizer_stage(overlap_removal, Positions, Options, NewPositions) :-
+    !,
+    (   catch(mindmap_opt_overlap:optimize(Positions, Options, NewPositions), _, fail)
+    ->  true
+    ;   overlap_removal_fallback(Positions, Options, NewPositions)
+    ).
+
+execute_optimizer_stage(crossing_minimization, Positions, _Options, Positions) :-
+    !,
+    format('Note: Crossing minimization not yet implemented~n', []).
+
+execute_optimizer_stage(spacing_adjustment, Positions, _Options, Positions) :-
+    !,
+    format('Note: Spacing adjustment not yet implemented~n', []).
+
+execute_optimizer_stage(Optimizer, Positions, _Options, Positions) :-
+    format('Warning: Unknown optimizer: ~w~n', [Optimizer]).
+
+% ============================================================================
+% FALLBACK IMPLEMENTATIONS
+% ============================================================================
+
+%% compute_radial_fallback(+Graph, +Options, -Positions)
+%
+%  Basic radial layout fallback.
+%
+compute_radial_fallback(graph(Nodes, _Edges, RootId), Options, Positions) :-
+    option_or_default(center_x, Options, 500, CX),
+    option_or_default(center_y, Options, 500, CY),
+    option_or_default(base_radius, Options, 150, R),
+
+    length(Nodes, N),
+    (   N =:= 0
+    ->  Positions = []
+    ;   N =:= 1
+    ->  Nodes = [node(Id, _)],
+        Positions = [position(Id, CX, CY)]
+    ;   % Place root at center, others in circle
+        AngleStep is 2 * pi / max(1, N - 1),
+        place_nodes_circle(Nodes, RootId, CX, CY, R, 0, AngleStep, Positions)
+    ).
+
+place_nodes_circle([], _, _, _, _, _, _, []).
+place_nodes_circle([node(Id, _) | Rest], RootId, CX, CY, R, Angle, Step, [position(Id, X, Y) | RestPos]) :-
+    (   Id == RootId
+    ->  X = CX, Y = CY, NextAngle = Angle
+    ;   X is CX + R * cos(Angle),
+        Y is CY + R * sin(Angle),
+        NextAngle is Angle + Step
+    ),
+    place_nodes_circle(Rest, RootId, CX, CY, R, NextAngle, Step, RestPos).
+
+%% compute_force_fallback(+Graph, +Options, -Positions)
+%
+%  Force-directed fallback (uses radial then basic spreading).
+%
+compute_force_fallback(Graph, Options, Positions) :-
+    % Start with radial
+    compute_radial_fallback(Graph, Options, RadialPositions),
+    % Apply basic overlap removal
+    overlap_removal_fallback(RadialPositions, Options, Positions).
+
+%% compute_hierarchical_fallback(+Graph, +Options, -Positions)
+%
+%  Hierarchical layout fallback.
+%
+compute_hierarchical_fallback(graph(Nodes, Edges, RootId), Options, Positions) :-
+    option_or_default(level_spacing, Options, 100, LevelSpacing),
+    option_or_default(sibling_spacing, Options, 80, SiblingSpacing),
+    option_or_default(center_x, Options, 500, CX),
+    option_or_default(start_y, Options, 50, StartY),
+
+    % Build children map
+    findall(Parent-Children,
+            setof(Child, member(edge(Parent, Child, _), Edges), Children),
+            ChildrenMap),
+
+    % Position recursively
+    hierarchical_position(RootId, ChildrenMap, CX, StartY, LevelSpacing, SiblingSpacing, [], Positions).
+
+hierarchical_position(NodeId, ChildrenMap, X, Y, LevelSpacing, SiblingSpacing, AccIn, AccOut) :-
+    AccMid = [position(NodeId, X, Y) | AccIn],
+
+    % Get children
+    (   member(NodeId-Children, ChildrenMap)
+    ->  true
+    ;   Children = []
+    ),
+
+    % Position children
+    length(Children, NumChildren),
+    (   NumChildren > 0
+    ->  ChildY is Y + LevelSpacing,
+        TotalWidth is (NumChildren - 1) * SiblingSpacing,
+        StartX is X - TotalWidth / 2,
+        position_children_hierarchical(Children, ChildrenMap, StartX, ChildY,
+                                       LevelSpacing, SiblingSpacing, AccMid, AccOut)
+    ;   AccOut = AccMid
+    ).
+
+position_children_hierarchical([], _, _, _, _, _, Acc, Acc).
+position_children_hierarchical([Child | Rest], ChildrenMap, X, Y, LevelSpacing, SiblingSpacing, AccIn, AccOut) :-
+    hierarchical_position(Child, ChildrenMap, X, Y, LevelSpacing, SiblingSpacing, AccIn, AccMid),
+    NextX is X + SiblingSpacing,
+    position_children_hierarchical(Rest, ChildrenMap, NextX, Y, LevelSpacing, SiblingSpacing, AccMid, AccOut).
+
+%% overlap_removal_fallback(+Positions, +Options, -NewPositions)
+%
+%  Basic overlap removal fallback.
+%
+overlap_removal_fallback(Positions, Options, NewPositions) :-
+    option_or_default(min_distance, Options, 50, MinDist),
+    option_or_default(iterations, Options, 50, MaxIter),
+
+    overlap_removal_loop(Positions, MinDist, MaxIter, 0, NewPositions).
+
+overlap_removal_loop(Positions, _, MaxIter, Iter, Positions) :-
+    Iter >= MaxIter,
+    !.
+overlap_removal_loop(Positions, MinDist, MaxIter, Iter, FinalPositions) :-
+    % Find overlapping pairs
+    findall(overlap(Id1, Id2),
+            (member(position(Id1, X1, Y1), Positions),
+             member(position(Id2, X2, Y2), Positions),
+             Id1 @< Id2,
+             Dist is sqrt((X2-X1)^2 + (Y2-Y1)^2),
+             Dist < MinDist),
+            Overlaps),
+
+    (   Overlaps = []
+    ->  FinalPositions = Positions
+    ;   % Push overlapping nodes apart
+        push_apart(Positions, Overlaps, MinDist, NewPositions),
+        NextIter is Iter + 1,
+        overlap_removal_loop(NewPositions, MinDist, MaxIter, NextIter, FinalPositions)
+    ).
+
+push_apart(Positions, [], _, Positions).
+push_apart(Positions, [overlap(Id1, Id2) | Rest], MinDist, FinalPositions) :-
+    member(position(Id1, X1, Y1), Positions),
+    member(position(Id2, X2, Y2), Positions),
+
+    DX is X2 - X1,
+    DY is Y2 - Y1,
+    Dist is sqrt(DX*DX + DY*DY),
+
+    (   Dist < 0.1
+    ->  % Same position - push in random direction
+        random(R),
+        Angle is R * 2 * pi,
+        PushX is MinDist * 0.5 * cos(Angle),
+        PushY is MinDist * 0.5 * sin(Angle)
+    ;   % Push along line
+        Overlap is (MinDist - Dist) / 2,
+        PushX is (DX / Dist) * Overlap,
+        PushY is (DY / Dist) * Overlap
+    ),
+
+    % Update positions
+    select(position(Id1, X1, Y1), Positions, Rest1),
+    select(position(Id2, X2, Y2), Rest1, Rest2),
+    NX1 is X1 - PushX, NY1 is Y1 - PushY,
+    NX2 is X2 + PushX, NY2 is Y2 + PushY,
+    NewPositions = [position(Id1, NX1, NY1), position(Id2, NX2, NY2) | Rest2],
+
+    push_apart(NewPositions, Rest, MinDist, FinalPositions).
+
+% ============================================================================
+% PIPELINE BUILDING
+% ============================================================================
+
+%% build_default_pipeline(+Options, -Pipeline)
+%
+%  Build a default pipeline based on options.
+%
+%  Options:
+%    - layout(Algorithm)       - initial layout algorithm
+%    - optimize(Bool)          - whether to add optimization passes
+%    - quality(fast|balanced|high) - quality preset
+%
+build_default_pipeline(Options, Pipeline) :-
+    option_or_default(layout, Options, radial, Layout),
+    option_or_default(quality, Options, balanced, Quality),
+
+    % Base layout stage
+    (   Quality == fast
+    ->  LayoutOptions = []
+    ;   Quality == balanced
+    ->  LayoutOptions = [iterations(100)]
+    ;   LayoutOptions = [iterations(300)]
+    ),
+    LayoutStage = stage(Layout, LayoutOptions),
+
+    % Optimization stages based on quality
+    (   Quality == fast
+    ->  OptStages = []
+    ;   Quality == balanced
+    ->  OptStages = [optimize(overlap_removal, [iterations(50)])]
+    ;   OptStages = [
+            stage(force_directed, [iterations(100)]),
+            optimize(overlap_removal, [iterations(100)])
+        ]
+    ),
+
+    append([LayoutStage], OptStages, Pipeline).
+
+%% validate_pipeline(+Pipeline)
+%
+%  Validate pipeline structure.
+%
+validate_pipeline(Pipeline) :-
+    is_list(Pipeline),
+    forall(member(Stage, Pipeline), valid_stage(Stage)).
+
+valid_stage(stage(Algorithm, Options)) :-
+    atom(Algorithm),
+    is_list(Options).
+valid_stage(optimize(Optimizer, Options)) :-
+    atom(Optimizer),
+    is_list(Options).
+
+% ============================================================================
+% PROGRESS REPORTING
+% ============================================================================
+
+%% pipeline_progress(+Stage, +Status)
+%
+%  Hook for reporting pipeline progress.
+%  Override in application code to handle progress events.
+%
+pipeline_progress(Stage, Status) :-
+    format('Pipeline: ~w - ~w~n', [Stage, Status]).
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+option_or_default(Key, Options, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+pi is 3.14159265358979.
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_layout_pipeline :-
+    format('~n=== Layout Pipeline Tests ===~n~n'),
+
+    % Test data
+    Graph = graph(
+        [node(root, [label("Root")]),
+         node(a, [label("A")]),
+         node(b, [label("B")]),
+         node(c, [label("C")])],
+        [edge(root, a, []),
+         edge(root, b, []),
+         edge(a, c, [])],
+        root
+    ),
+
+    % Test 1: Simple pipeline
+    format('Test 1: Simple radial pipeline...~n'),
+    Pipeline1 = [stage(radial, [])],
+    execute_pipeline(Graph, Pipeline1, Positions1),
+    length(Positions1, NumPos1),
+    (   NumPos1 =:= 4
+    ->  format('  PASS: Generated ~w positions~n', [NumPos1])
+    ;   format('  FAIL: Expected 4 positions, got ~w~n', [NumPos1])
+    ),
+
+    % Test 2: Pipeline with optimization
+    format('~nTest 2: Pipeline with overlap removal...~n'),
+    Pipeline2 = [
+        stage(radial, [base_radius(30)]),  % Small radius to force overlaps
+        optimize(overlap_removal, [min_distance(50)])
+    ],
+    execute_pipeline(Graph, Pipeline2, Positions2),
+    findall(Dist,
+            (member(position(Id1, X1, Y1), Positions2),
+             member(position(Id2, X2, Y2), Positions2),
+             Id1 @< Id2,
+             Dist is sqrt((X2-X1)^2 + (Y2-Y1)^2)),
+            Distances),
+    min_list(Distances, MinDist),
+    (   MinDist >= 49
+    ->  format('  PASS: Minimum distance ~2f >= 50~n', [MinDist])
+    ;   format('  WARN: Minimum distance ~2f < 50~n', [MinDist])
+    ),
+
+    % Test 3: Default pipeline builder
+    format('~nTest 3: Default pipeline (balanced)...~n'),
+    build_default_pipeline([quality(balanced)], DefaultPipeline),
+    length(DefaultPipeline, NumStages),
+    (   NumStages >= 2
+    ->  format('  PASS: Built ~w-stage pipeline~n', [NumStages])
+    ;   format('  WARN: Expected 2+ stages, got ~w~n', [NumStages])
+    ),
+
+    % Test 4: Hierarchical layout
+    format('~nTest 4: Hierarchical layout...~n'),
+    Pipeline4 = [stage(hierarchical, [level_spacing(80)])],
+    execute_pipeline(Graph, Pipeline4, Positions4),
+    % Check that children are below parent
+    member(position(root, _, RY), Positions4),
+    member(position(a, _, AY), Positions4),
+    (   AY > RY
+    ->  format('  PASS: Child below parent (y: ~2f > ~2f)~n', [AY, RY])
+    ;   format('  FAIL: Child not below parent~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+:- initialization((
+    format('Layout pipeline module loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/layout/radial.pl
+++ b/src/unifyweaver/mindmap/layout/radial.pl
@@ -1,0 +1,345 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% radial.pl - Radial Layout Algorithm for Mind Maps
+%
+% Implements a radial/circular layout where the root node is at the center
+% and child nodes are placed in concentric circles around it.
+%
+% The algorithm:
+% 1. Place root at center
+% 2. For each level, calculate radius needed to maintain minimum spacing
+% 3. Position children in their parent's angular sector
+%
+% Based on algorithms from generate_simplemind_map.py
+
+:- module(mindmap_layout_radial, [
+    % Component interface
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    compute_layout/3,
+
+    % Direct API
+    radial_layout/4,                % radial_layout(+IR, +Options, -Positions, -Stats)
+    count_nodes_per_level/3,        % count_nodes_per_level(+IR, +RootId, -LevelCounts)
+    compute_level_radii/3           % compute_level_radii(+LevelCounts, +Options, -Radii)
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% COMPONENT INTERFACE
+% ============================================================================
+
+%% type_info(-Info)
+%
+%  Component type information.
+%
+type_info(info{
+    name: radial,
+    category: mindmap_layout,
+    description: "Radial layout with root at center",
+    version: "1.0.0",
+    parameters: [
+        center_x - "X coordinate of center (default 500)",
+        center_y - "Y coordinate of center (default 500)",
+        base_radius - "Base radius for first level (default 150)",
+        min_spacing - "Minimum spacing between nodes (default 80)",
+        level_growth - "How radius grows per level: linear, sqrt, log (default linear)"
+    ]
+}).
+
+%% validate_config(+Config)
+%
+%  Validate layout configuration.
+%
+validate_config(Config) :-
+    is_list(Config),
+    (   member(center_x(X), Config)
+    ->  number(X)
+    ;   true
+    ),
+    (   member(center_y(Y), Config)
+    ->  number(Y)
+    ;   true
+    ),
+    (   member(base_radius(R), Config)
+    ->  number(R), R > 0
+    ;   true
+    ),
+    (   member(min_spacing(S), Config)
+    ->  number(S), S > 0
+    ;   true
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  Initialize the component (no-op for radial layout).
+%
+init_component(_Name, _Config).
+
+%% compute_layout(+Graph, +Options, -Positions)
+%
+%  Main entry point for component invocation.
+%
+%  @param Graph     term - graph(Nodes, Edges, RootId)
+%  @param Options   list - layout options
+%  @param Positions list - list of position(Id, X, Y) terms
+%
+compute_layout(graph(Nodes, Edges, RootId), Options, Positions) :-
+    % Build minimal IR for internal use
+    IR = ir(Nodes, Edges, RootId),
+    radial_layout(IR, Options, Positions, _Stats).
+
+% ============================================================================
+% RADIAL LAYOUT ALGORITHM
+% ============================================================================
+
+%% radial_layout(+IR, +Options, -Positions, -Stats)
+%
+%  Compute radial layout positions.
+%
+%  @param IR        term - ir(Nodes, Edges, RootId) or mindmap_ir term
+%  @param Options   list - layout options
+%  @param Positions list - list of position(Id, X, Y)
+%  @param Stats     dict - layout statistics
+%
+radial_layout(IR, Options, Positions, Stats) :-
+    % Extract graph data
+    extract_ir_data(IR, Nodes, Edges, RootId),
+
+    % Get options with defaults
+    option_or_default(center_x, Options, 500, CenterX),
+    option_or_default(center_y, Options, 500, CenterY),
+    option_or_default(base_radius, Options, 150, BaseRadius),
+    option_or_default(min_spacing, Options, 80, MinSpacing),
+
+    % Build adjacency for children lookup
+    build_children_map(Edges, ChildrenMap),
+
+    % Count nodes at each level
+    count_nodes_per_level_impl(RootId, ChildrenMap, 0, [], LevelCounts),
+
+    % Compute radius for each level
+    compute_level_radii(LevelCounts, [base_radius(BaseRadius), min_spacing(MinSpacing)], LevelRadii),
+
+    % Position nodes recursively
+    position_nodes(RootId, ChildrenMap, CenterX, CenterY, LevelRadii,
+                   0, 0, 2*pi, [], Positions),
+
+    % Compute statistics
+    length(Nodes, NumNodes),
+    length(Positions, NumPositioned),
+    (   LevelRadii = [_ | _]
+    ->  last(LevelRadii, _-MaxRadius)
+    ;   MaxRadius = 0
+    ),
+    Stats = stats{
+        nodes_total: NumNodes,
+        nodes_positioned: NumPositioned,
+        max_radius: MaxRadius,
+        levels: LevelCounts
+    }.
+
+%% extract_ir_data(+IR, -Nodes, -Edges, -RootId)
+%
+%  Extract nodes, edges, and root from IR structure.
+%
+extract_ir_data(ir(Nodes, Edges, RootId), Nodes, Edges, RootId) :- !.
+extract_ir_data(mindmap_ir(_, graph(Nodes, Edges, RootId), _, _, _), Nodes, Edges, RootId) :- !.
+extract_ir_data(graph(Nodes, Edges, RootId), Nodes, Edges, RootId).
+
+%% build_children_map(+Edges, -ChildrenMap)
+%
+%  Build a map from parent ID to list of children IDs.
+%
+build_children_map(Edges, ChildrenMap) :-
+    findall(Parent-Children,
+            (setof(Child, member(edge(Parent, Child, _), Edges), Children)),
+            Pairs),
+    ChildrenMap = Pairs.
+
+get_children(Id, ChildrenMap, Children) :-
+    (   member(Id-Children, ChildrenMap)
+    ->  true
+    ;   Children = []
+    ).
+
+%% count_nodes_per_level(+IR, +RootId, -LevelCounts)
+%
+%  Count how many nodes are at each depth level.
+%
+%  @param IR          term - IR structure
+%  @param RootId      atom - root node ID
+%  @param LevelCounts list - list of Level-Count pairs
+%
+count_nodes_per_level(IR, RootId, LevelCounts) :-
+    extract_ir_data(IR, _Nodes, Edges, _),
+    build_children_map(Edges, ChildrenMap),
+    count_nodes_per_level_impl(RootId, ChildrenMap, 0, [], LevelCounts).
+
+count_nodes_per_level_impl(NodeId, ChildrenMap, Level, AccIn, AccOut) :-
+    % Increment count for this level
+    (   select(Level-Count, AccIn, AccRest)
+    ->  NewCount is Count + 1,
+        Acc1 = [Level-NewCount | AccRest]
+    ;   Acc1 = [Level-1 | AccIn]
+    ),
+    % Process children
+    get_children(NodeId, ChildrenMap, Children),
+    ChildLevel is Level + 1,
+    foldl(count_child(ChildrenMap, ChildLevel), Children, Acc1, AccOut).
+
+count_child(ChildrenMap, Level, ChildId, AccIn, AccOut) :-
+    count_nodes_per_level_impl(ChildId, ChildrenMap, Level, AccIn, AccOut).
+
+%% compute_level_radii(+LevelCounts, +Options, -Radii)
+%
+%  Compute the radius for each level to maintain minimum spacing.
+%
+%  Formula: radius = max(base_radius, n_nodes * min_spacing / (2 * pi))
+%
+%  @param LevelCounts list - list of Level-Count pairs
+%  @param Options     list - options including base_radius, min_spacing
+%  @param Radii       list - list of Level-Radius pairs
+%
+compute_level_radii(LevelCounts, Options, Radii) :-
+    option_or_default(base_radius, Options, 150, BaseRadius),
+    option_or_default(min_spacing, Options, 80, MinSpacing),
+
+    % Sort by level
+    msort(LevelCounts, SortedCounts),
+
+    % Compute cumulative radius
+    compute_radii_impl(SortedCounts, BaseRadius, MinSpacing, 0, [], Radii).
+
+compute_radii_impl([], _, _, _, Acc, Radii) :-
+    reverse(Acc, Radii).
+compute_radii_impl([Level-Count | Rest], BaseRadius, MinSpacing, CumulativeR, Acc, Radii) :-
+    (   Level =:= 0
+    ->  % Root is at center
+        LevelRadius = 0,
+        NewCumulative = 0
+    ;   % Calculate radius needed for this level's circumference
+        % circumference = 2 * pi * r, spacing = circumference / n_nodes
+        % So r = n_nodes * spacing / (2 * pi)
+        Pi is 3.14159265358979,
+        NeededRadius is max(BaseRadius, Count * MinSpacing / (2 * Pi)),
+        NewCumulative is CumulativeR + NeededRadius,
+        LevelRadius = NewCumulative
+    ),
+    compute_radii_impl(Rest, BaseRadius, MinSpacing, NewCumulative, [Level-LevelRadius | Acc], Radii).
+
+%% position_nodes(+NodeId, +ChildrenMap, +CX, +CY, +Radii, +Level, +AngleStart, +AngleSpan, +AccIn, -AccOut)
+%
+%  Recursively position nodes.
+%
+position_nodes(NodeId, ChildrenMap, CX, CY, Radii, Level, AngleStart, AngleSpan, AccIn, AccOut) :-
+    % Get radius for this level
+    (   member(Level-Radius, Radii)
+    ->  true
+    ;   Radius = 0
+    ),
+
+    % Compute position
+    (   Level =:= 0
+    ->  X = CX, Y = CY
+    ;   % Position at this level's radius within the angular sector
+        AngleMid is AngleStart + AngleSpan / 2,
+        X is CX + Radius * cos(AngleMid),
+        Y is CY + Radius * sin(AngleMid)
+    ),
+
+    Acc1 = [position(NodeId, X, Y) | AccIn],
+
+    % Position children
+    get_children(NodeId, ChildrenMap, Children),
+    length(Children, NumChildren),
+    (   NumChildren > 0
+    ->  ChildLevel is Level + 1,
+        ChildAngleSpan is AngleSpan / NumChildren,
+        position_children(Children, ChildrenMap, CX, CY, Radii, ChildLevel,
+                         AngleStart, ChildAngleSpan, Acc1, AccOut)
+    ;   AccOut = Acc1
+    ).
+
+position_children([], _, _, _, _, _, _, _, Acc, Acc).
+position_children([Child | Rest], ChildrenMap, CX, CY, Radii, Level, AngleStart, AngleSpan, AccIn, AccOut) :-
+    position_nodes(Child, ChildrenMap, CX, CY, Radii, Level, AngleStart, AngleSpan, AccIn, Acc1),
+    NextAngleStart is AngleStart + AngleSpan,
+    position_children(Rest, ChildrenMap, CX, CY, Radii, Level, NextAngleStart, AngleSpan, Acc1, AccOut).
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+%% option_or_default(+Key, +Options, +Default, -Value)
+%
+%  Get option value or default.
+%
+option_or_default(Key, Options, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+% Math constants
+pi is 3.14159265358979.
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_radial_layout :-
+    format('~n=== Radial Layout Tests ===~n~n'),
+
+    % Test data
+    Nodes = [
+        node(root, [label("Root")]),
+        node(a, [label("A")]),
+        node(b, [label("B")]),
+        node(c, [label("C")]),
+        node(d, [label("D")])
+    ],
+    Edges = [
+        edge(root, a, []),
+        edge(root, b, []),
+        edge(a, c, []),
+        edge(a, d, [])
+    ],
+
+    % Test 1: Compute layout
+    format('Test 1: Compute radial layout...~n'),
+    compute_layout(graph(Nodes, Edges, root), [], Positions),
+    length(Positions, NumPos),
+    (   NumPos =:= 5
+    ->  format('  PASS: Generated ~w positions~n', [NumPos])
+    ;   format('  FAIL: Expected 5 positions, got ~w~n', [NumPos])
+    ),
+
+    % Test 2: Root at center
+    format('~nTest 2: Root at center...~n'),
+    member(position(root, RX, RY), Positions),
+    (   RX =:= 500, RY =:= 500
+    ->  format('  PASS: Root at (500, 500)~n')
+    ;   format('  FAIL: Root at (~w, ~w)~n', [RX, RY])
+    ),
+
+    % Test 3: Children positioned
+    format('~nTest 3: Children positioned around root...~n'),
+    member(position(a, AX, AY), Positions),
+    member(position(b, BX, BY), Positions),
+    DistA is sqrt((AX-500)^2 + (AY-500)^2),
+    DistB is sqrt((BX-500)^2 + (BY-500)^2),
+    (   DistA > 100, DistB > 100
+    ->  format('  PASS: Children at radius ~2f, ~2f~n', [DistA, DistB])
+    ;   format('  FAIL: Children too close to center~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+:- initialization((
+    format('Radial layout module loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/mindmap_components.pl
+++ b/src/unifyweaver/mindmap/mindmap_components.pl
@@ -1,0 +1,451 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% mindmap_components.pl - Mind Map Component Registry Integration
+%
+% This module integrates the mind map system with UnifyWeaver's component
+% registry, defining categories and registering built-in components.
+%
+% Categories:
+%   - mindmap_layout    - Layout algorithms (radial, force_directed, etc.)
+%   - mindmap_optimizer - Layout optimizers (overlap_removal, crossing_min, etc.)
+%   - mindmap_renderer  - Output renderers (svg, smmx, graph_interactive, etc.)
+
+:- module(mindmap_components, [
+    % Category definitions
+    define_mindmap_categories/0,
+
+    % Component registration
+    register_mindmap_layout/3,      % register_mindmap_layout(+Name, +Module, +Options)
+    register_mindmap_optimizer/3,   % register_mindmap_optimizer(+Name, +Module, +Options)
+    register_mindmap_renderer/3,    % register_mindmap_renderer(+Name, +Module, +Options)
+
+    % Query predicates
+    list_mindmap_layouts/1,         % list_mindmap_layouts(-Layouts)
+    list_mindmap_optimizers/1,      % list_mindmap_optimizers(-Optimizers)
+    list_mindmap_renderers/1,       % list_mindmap_renderers(-Renderers)
+
+    % Component invocation
+    invoke_layout/4,                % invoke_layout(+Name, +Graph, +Options, -Positions)
+    invoke_optimizer/4,             % invoke_optimizer(+Name, +Positions, +Options, -OptimizedPositions)
+    invoke_renderer/4,              % invoke_renderer(+Name, +Data, +Options, -Output)
+
+    % Initialization
+    init_mindmap_components/0,
+
+    % Testing
+    test_mindmap_components/0
+]).
+
+:- use_module(library(lists)).
+
+% Conditionally load component_registry if available
+:- if(exists_source(library('../../core/component_registry'))).
+:- use_module('../core/component_registry').
+:- endif.
+
+% ============================================================================
+% CATEGORY DEFINITIONS
+% ============================================================================
+
+%% define_mindmap_categories
+%
+%  Define the mind map component categories.
+%  This should be called during module initialization.
+%
+define_mindmap_categories :-
+    % Define layout category
+    (   catch(define_category(mindmap_layout,
+            "Mind map layout algorithms",
+            [requires_compilation(false), singleton(false)]), _, true)
+    ->  true ; true),
+
+    % Define optimizer category
+    (   catch(define_category(mindmap_optimizer,
+            "Layout optimization passes",
+            [requires_compilation(false), singleton(false)]), _, true)
+    ->  true ; true),
+
+    % Define renderer category
+    (   catch(define_category(mindmap_renderer,
+            "Output format renderers",
+            [requires_compilation(true), singleton(false)]), _, true)
+    ->  true ; true).
+
+% ============================================================================
+% COMPONENT REGISTRATION
+% ============================================================================
+
+%% register_mindmap_layout(+Name, +Module, +Options)
+%
+%  Register a layout algorithm component.
+%
+%  The Module should export:
+%    - type_info(-Info)
+%    - validate_config(+Config)
+%    - init_component(+Name, +Config)
+%    - compute_layout(+Graph, +Options, -Positions)
+%
+%  Options:
+%    - description(Text)  - Human-readable description
+%    - parameters(List)   - Configurable parameters
+%    - complexity(Big-O)  - Algorithmic complexity
+%
+register_mindmap_layout(Name, Module, Options) :-
+    atom(Name),
+    atom(Module),
+    is_list(Options),
+    (   catch(register_component_type(mindmap_layout, Name, Module, Options), _, fail)
+    ->  true
+    ;   % Fallback: store locally if component_registry not available
+        assertz(local_layout(Name, Module, Options))
+    ).
+
+%% register_mindmap_optimizer(+Name, +Module, +Options)
+%
+%  Register a layout optimizer component.
+%
+%  The Module should export:
+%    - type_info(-Info)
+%    - validate_config(+Config)
+%    - init_component(+Name, +Config)
+%    - optimize(+Positions, +Graph, +Options, -OptimizedPositions)
+%
+register_mindmap_optimizer(Name, Module, Options) :-
+    atom(Name),
+    atom(Module),
+    is_list(Options),
+    (   catch(register_component_type(mindmap_optimizer, Name, Module, Options), _, fail)
+    ->  true
+    ;   assertz(local_optimizer(Name, Module, Options))
+    ).
+
+%% register_mindmap_renderer(+Name, +Module, +Options)
+%
+%  Register an output renderer component.
+%
+%  The Module should export:
+%    - type_info(-Info)
+%    - validate_config(+Config)
+%    - init_component(+Name, +Config)
+%    - compile_component(+Name, +Config, +Options, -Code)
+%    - render(+Graph, +Positions, +Options, -Output)
+%
+register_mindmap_renderer(Name, Module, Options) :-
+    atom(Name),
+    atom(Module),
+    is_list(Options),
+    (   catch(register_component_type(mindmap_renderer, Name, Module, Options), _, fail)
+    ->  true
+    ;   assertz(local_renderer(Name, Module, Options))
+    ).
+
+% Local storage for when component_registry is not available
+:- dynamic local_layout/3.
+:- dynamic local_optimizer/3.
+:- dynamic local_renderer/3.
+
+% ============================================================================
+% QUERY PREDICATES
+% ============================================================================
+
+%% list_mindmap_layouts(-Layouts)
+%
+%  Get list of all registered layout algorithms.
+%
+list_mindmap_layouts(Layouts) :-
+    (   catch(list_types(mindmap_layout, Layouts), _, fail)
+    ->  true
+    ;   findall(Name, local_layout(Name, _, _), Layouts)
+    ).
+
+%% list_mindmap_optimizers(-Optimizers)
+%
+%  Get list of all registered optimizers.
+%
+list_mindmap_optimizers(Optimizers) :-
+    (   catch(list_types(mindmap_optimizer, Optimizers), _, fail)
+    ->  true
+    ;   findall(Name, local_optimizer(Name, _, _), Optimizers)
+    ).
+
+%% list_mindmap_renderers(-Renderers)
+%
+%  Get list of all registered renderers.
+%
+list_mindmap_renderers(Renderers) :-
+    (   catch(list_types(mindmap_renderer, Renderers), _, fail)
+    ->  true
+    ;   findall(Name, local_renderer(Name, _, _), Renderers)
+    ).
+
+% ============================================================================
+% COMPONENT INVOCATION
+% ============================================================================
+
+%% invoke_layout(+Name, +Graph, +Options, -Positions)
+%
+%  Invoke a layout algorithm by name.
+%
+%  @param Name      atom - registered layout name
+%  @param Graph     term - graph(Nodes, Edges) structure
+%  @param Options   list - algorithm options
+%  @param Positions list - list of position(Id, X, Y) terms
+%
+invoke_layout(Name, Graph, Options, Positions) :-
+    get_layout_module(Name, Module),
+    !,
+    Module:compute_layout(Graph, Options, Positions).
+invoke_layout(Name, _Graph, _Options, []) :-
+    format('Error: Layout algorithm ~w not found~n', [Name]).
+
+%% invoke_optimizer(+Name, +Positions, +Options, -OptimizedPositions)
+%
+%  Invoke a layout optimizer by name.
+%
+invoke_optimizer(Name, Positions, Options, OptimizedPositions) :-
+    get_optimizer_module(Name, Module),
+    !,
+    Module:optimize(Positions, Options, OptimizedPositions).
+invoke_optimizer(Name, Positions, _Options, Positions) :-
+    format('Warning: Optimizer ~w not found, returning unchanged positions~n', [Name]).
+
+%% invoke_renderer(+Name, +Data, +Options, -Output)
+%
+%  Invoke a renderer by name.
+%
+%  @param Name    atom - registered renderer name
+%  @param Data    term - render_data(Graph, Positions, Styles)
+%  @param Options list - renderer options
+%  @param Output  term - rendered output (format depends on renderer)
+%
+invoke_renderer(Name, Data, Options, Output) :-
+    get_renderer_module(Name, Module),
+    !,
+    Module:render(Data, Options, Output).
+invoke_renderer(Name, _Data, _Options, '') :-
+    format('Error: Renderer ~w not found~n', [Name]).
+
+% Helper predicates to get module for a component
+get_layout_module(Name, Module) :-
+    (   catch(component_type(mindmap_layout, Name, Module, _), _, fail)
+    ->  true
+    ;   local_layout(Name, Module, _)
+    ).
+
+get_optimizer_module(Name, Module) :-
+    (   catch(component_type(mindmap_optimizer, Name, Module, _), _, fail)
+    ->  true
+    ;   local_optimizer(Name, Module, _)
+    ).
+
+get_renderer_module(Name, Module) :-
+    (   catch(component_type(mindmap_renderer, Name, Module, _), _, fail)
+    ->  true
+    ;   local_renderer(Name, Module, _)
+    ).
+
+% ============================================================================
+% BUILT-IN COMPONENT REGISTRATION
+% ============================================================================
+
+%% register_builtin_layouts
+%
+%  Register the built-in layout algorithms.
+%
+register_builtin_layouts :-
+    % Radial layout
+    register_mindmap_layout(radial, mindmap_layout_radial, [
+        description("Radial layout with root at center"),
+        parameters([
+            center(X, Y) - "Center point (default 500, 500)",
+            base_radius(R) - "Base radius for first level (default 150)",
+            min_spacing(S) - "Minimum spacing between nodes (default 80)"
+        ]),
+        complexity("O(n)")
+    ]),
+
+    % Force-directed layout
+    register_mindmap_layout(force_directed, mindmap_layout_force, [
+        description("Force-directed physics simulation"),
+        parameters([
+            iterations(N) - "Number of simulation iterations (default 300)",
+            repulsion(R) - "Repulsion force strength (default 100000)",
+            attraction(A) - "Attraction force to parent (default 0.001)",
+            min_distance(D) - "Minimum distance between nodes (default 120)",
+            damping(D) - "Velocity damping factor (default 0.8)"
+        ]),
+        complexity("O(n² × iterations)")
+    ]),
+
+    % Hierarchical layout
+    register_mindmap_layout(hierarchical, mindmap_layout_hierarchical, [
+        description("Tree-like hierarchical layout"),
+        parameters([
+            level_spacing(S) - "Vertical spacing between levels (default 100)",
+            sibling_spacing(S) - "Horizontal spacing between siblings (default 50)",
+            direction(D) - "Layout direction: top_down, left_right (default top_down)"
+        ]),
+        complexity("O(n)")
+    ]).
+
+%% register_builtin_optimizers
+%
+%  Register the built-in layout optimizers.
+%
+register_builtin_optimizers :-
+    % Overlap removal
+    register_mindmap_optimizer(overlap_removal, mindmap_opt_overlap, [
+        description("Remove overlapping nodes"),
+        parameters([
+            min_distance(D) - "Minimum distance between node centers (default 50)",
+            iterations(N) - "Maximum iterations (default 100)"
+        ]),
+        complexity("O(n²)")
+    ]),
+
+    % Crossing minimization
+    register_mindmap_optimizer(crossing_minimization, mindmap_opt_crossing, [
+        description("Minimize edge crossings"),
+        parameters([
+            max_swaps(N) - "Maximum swap operations (default 1000)",
+            temperature(T) - "Simulated annealing temperature (default 1.0)"
+        ]),
+        complexity("O(e² + n×e)")
+    ]),
+
+    % Spacing adjustment
+    register_mindmap_optimizer(spacing_adjustment, mindmap_opt_spacing, [
+        description("Adjust spacing for visual balance"),
+        parameters([
+            target_density(D) - "Target node density (default 0.3)",
+            preserve_structure(B) - "Preserve relative positions (default true)"
+        ]),
+        complexity("O(n)")
+    ]).
+
+%% register_builtin_renderers
+%
+%  Register the built-in output renderers.
+%
+register_builtin_renderers :-
+    % SVG renderer
+    register_mindmap_renderer(svg, mindmap_render_svg, [
+        description("Static SVG output"),
+        parameters([
+            width(W) - "SVG width (default 1000)",
+            height(H) - "SVG height (default 800)",
+            node_shape(S) - "Node shape: ellipse, rectangle, diamond",
+            edge_style(S) - "Edge style: straight, bezier, orthogonal"
+        ]),
+        file_extension(".svg"),
+        mime_type("image/svg+xml")
+    ]),
+
+    % Native format renderer (.smmx)
+    register_mindmap_renderer(smmx, mindmap_render_smmx, [
+        description("Native .smmx format"),
+        parameters([
+            include_positions(B) - "Include computed positions (default true)",
+            compression(B) - "ZIP compress output (default true)"
+        ]),
+        file_extension(".smmx"),
+        mime_type("application/zip")
+    ]),
+
+    % Native format renderer (.mm)
+    register_mindmap_renderer(mm, mindmap_render_mm, [
+        description("Native .mm format"),
+        parameters([
+            include_positions(B) - "Include computed positions (default true)"
+        ]),
+        file_extension(".mm"),
+        mime_type("application/xml")
+    ]),
+
+    % Interactive graph renderer
+    register_mindmap_renderer(graph_interactive, mindmap_render_interactive, [
+        description("Interactive React component"),
+        parameters([
+            library(L) - "Graph library to use (default auto)",
+            include_controls(B) - "Include zoom/pan controls (default true)",
+            enable_editing(B) - "Allow node editing (default false)"
+        ]),
+        file_extension(".tsx"),
+        mime_type("text/typescript")
+    ]),
+
+    % GraphViz DOT renderer
+    register_mindmap_renderer(graphviz, mindmap_render_graphviz, [
+        description("GraphViz DOT format"),
+        parameters([
+            layout_engine(E) - "GraphViz engine: dot, neato, fdp, etc.",
+            rankdir(D) - "Rank direction: TB, LR, BT, RL"
+        ]),
+        file_extension(".dot"),
+        mime_type("text/vnd.graphviz")
+    ]).
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+%% init_mindmap_components
+%
+%  Initialize the mind map component system.
+%  Defines categories and registers built-in components.
+%
+init_mindmap_components :-
+    define_mindmap_categories,
+    register_builtin_layouts,
+    register_builtin_optimizers,
+    register_builtin_renderers,
+    format('Mind map components initialized~n', []).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_mindmap_components :-
+    format('~n=== Mind Map Components Tests ===~n~n'),
+
+    % Initialize
+    init_mindmap_components,
+
+    % Test 1: List layouts
+    format('Test 1: List layouts...~n'),
+    list_mindmap_layouts(Layouts),
+    format('  Layouts: ~w~n', [Layouts]),
+    (   member(radial, Layouts)
+    ->  format('  PASS: radial layout registered~n')
+    ;   format('  FAIL: radial layout not found~n')
+    ),
+
+    % Test 2: List optimizers
+    format('~nTest 2: List optimizers...~n'),
+    list_mindmap_optimizers(Optimizers),
+    format('  Optimizers: ~w~n', [Optimizers]),
+    (   member(overlap_removal, Optimizers)
+    ->  format('  PASS: overlap_removal registered~n')
+    ;   format('  FAIL: overlap_removal not found~n')
+    ),
+
+    % Test 3: List renderers
+    format('~nTest 3: List renderers...~n'),
+    list_mindmap_renderers(Renderers),
+    format('  Renderers: ~w~n', [Renderers]),
+    (   member(svg, Renderers)
+    ->  format('  PASS: svg renderer registered~n')
+    ;   format('  FAIL: svg renderer not found~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% MODULE INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    % Delay initialization to allow component_registry to load first
+    init_mindmap_components
+), now).

--- a/src/unifyweaver/mindmap/mindmap_dsl.pl
+++ b/src/unifyweaver/mindmap/mindmap_dsl.pl
@@ -1,0 +1,587 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% mindmap_dsl.pl - Declarative Mind Map Layout DSL
+%
+% This module provides a declarative domain-specific language for specifying
+% mind map structure, layout, and styling that compiles to multiple targets.
+%
+% Usage:
+%   % Define nodes
+%   mindmap_node(root, [label("Central Topic"), type(root)]).
+%   mindmap_node(child1, [label("Branch A"), parent(root)]).
+%
+%   % Define layout
+%   declare_mindmap_layout(my_map, force_directed, [
+%       iterations(300),
+%       min_distance(50)
+%   ]).
+%
+%   % Generate output
+%   ?- generate_mindmap_svg(my_map, SVG).
+%   ?- generate_mindmap_positions(my_map, Positions).
+
+:- module(mindmap_dsl, [
+    % Node and edge declaration
+    mindmap_node/2,                 % mindmap_node(+Id, +Properties)
+    mindmap_edge/3,                 % mindmap_edge(+From, +To, +Properties)
+
+    % Specification predicates
+    mindmap_spec/2,                 % mindmap_spec(+Name, +Options)
+
+    % Constraint and preference predicates
+    mindmap_constraint/2,           % mindmap_constraint(+Type, +Options)
+    mindmap_preference/2,           % mindmap_preference(+Type, +Options)
+
+    % Layout predicates
+    mindmap_layout/2,               % mindmap_layout(+Name, +Options)
+    declare_mindmap_layout/3,       % declare_mindmap_layout(+Name, +Algorithm, +Options)
+
+    % Pipeline predicates
+    mindmap_pipeline/2,             % mindmap_pipeline(+Name, +Stages)
+
+    % Style and theme predicates
+    mindmap_style/2,                % mindmap_style(+Selector, +Properties)
+    mindmap_theme/2,                % mindmap_theme(+Name, +Properties)
+
+    % Management predicates
+    declare_mindmap_node/2,         % declare_mindmap_node(+Id, +Properties)
+    declare_mindmap_edge/3,         % declare_mindmap_edge(+From, +To, +Properties)
+    declare_mindmap_spec/2,         % declare_mindmap_spec(+Name, +Options)
+    clear_mindmap/0,                % clear_mindmap - clears all mindmap data
+    clear_mindmap/1,                % clear_mindmap(+Name) - clears specific mindmap
+
+    % Query predicates
+    has_mindmap_layout/1,           % has_mindmap_layout(+Name)
+    get_mindmap_nodes/2,            % get_mindmap_nodes(+SpecName, -Nodes)
+    get_mindmap_edges/2,            % get_mindmap_edges(+SpecName, -Edges)
+    get_mindmap_root/2,             % get_mindmap_root(+SpecName, -RootId)
+
+    % Generation predicates (high-level)
+    generate_mindmap_positions/2,   % generate_mindmap_positions(+Name, -Positions)
+    generate_mindmap_svg/2,         % generate_mindmap_svg(+Name, -SVG)
+    generate_mindmap_svg/3,         % generate_mindmap_svg(+Name, +Options, -SVG)
+    compile_mindmap/3,              % compile_mindmap(+Name, +Target, -Code)
+
+    % Testing
+    test_mindmap_dsl/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% DYNAMIC PREDICATES
+% ============================================================================
+
+:- dynamic mindmap_node/2.          % mindmap_node(Id, Properties)
+:- dynamic mindmap_edge/3.          % mindmap_edge(From, To, Properties)
+:- dynamic mindmap_spec/2.          % mindmap_spec(Name, Options)
+:- dynamic mindmap_constraint/2.    % mindmap_constraint(Type, Options)
+:- dynamic mindmap_preference/2.    % mindmap_preference(Type, Options)
+:- dynamic mindmap_layout/2.        % mindmap_layout(Name, Options)
+:- dynamic mindmap_pipeline/2.      % mindmap_pipeline(Name, Stages)
+:- dynamic mindmap_style/2.         % mindmap_style(Selector, Properties)
+:- dynamic mindmap_theme/2.         % mindmap_theme(Name, Properties)
+
+% Allow discontiguous definitions for user convenience
+:- discontiguous mindmap_node/2.
+:- discontiguous mindmap_edge/3.
+:- discontiguous mindmap_spec/2.
+:- discontiguous mindmap_constraint/2.
+:- discontiguous mindmap_preference/2.
+:- discontiguous mindmap_layout/2.
+:- discontiguous mindmap_style/2.
+:- discontiguous mindmap_theme/2.
+
+% ============================================================================
+% MANAGEMENT PREDICATES
+% ============================================================================
+
+%% declare_mindmap_node(+Id, +Properties)
+%
+%  Declare a mind map node with given properties.
+%
+%  Properties:
+%    - label(Text)      - Display text for the node
+%    - parent(ParentId) - Parent node (creates implicit edge)
+%    - type(Type)       - Node type: root, branch, leaf, hub
+%    - link(URL)        - Hyperlink associated with node
+%    - style(Style)     - Node style reference
+%    - cluster(Name)    - Cluster grouping
+%    - importance(Level)- Importance: high, medium, low
+%    - position(X, Y)   - Fixed position (optional)
+%
+%  @param Id         atom - unique node identifier
+%  @param Properties list - node properties
+%
+declare_mindmap_node(Id, Properties) :-
+    atom(Id),
+    is_list(Properties),
+    % Remove existing node if any
+    retractall(mindmap_node(Id, _)),
+    % Add node
+    assertz(mindmap_node(Id, Properties)),
+    % Create implicit edge from parent if specified
+    (   member(parent(ParentId), Properties)
+    ->  declare_mindmap_edge(ParentId, Id, [implicit(true)])
+    ;   true
+    ).
+
+%% declare_mindmap_edge(+From, +To, +Properties)
+%
+%  Declare an edge between two nodes.
+%
+%  Properties:
+%    - weight(W)      - Edge weight for layout
+%    - style(Style)   - Edge style: straight, bezier, orthogonal
+%    - label(Text)    - Edge label
+%    - implicit(Bool) - Whether edge was auto-created from parent()
+%
+%  @param From       atom - source node id
+%  @param To         atom - target node id
+%  @param Properties list - edge properties
+%
+declare_mindmap_edge(From, To, Properties) :-
+    atom(From),
+    atom(To),
+    is_list(Properties),
+    % Remove existing edge if any (prevent duplicates)
+    retractall(mindmap_edge(From, To, _)),
+    assertz(mindmap_edge(From, To, Properties)).
+
+%% declare_mindmap_spec(+Name, +Options)
+%
+%  Declare a complete mind map specification.
+%
+%  Options:
+%    - nodes(List)          - List of node ids or inline node specs
+%    - edges(List)          - List of From-To pairs
+%    - layout(Algorithm)    - Layout algorithm to use
+%    - theme(ThemeName)     - Theme to apply
+%    - constraints(List)    - Layout constraints
+%    - preferences(List)    - Layout preferences
+%    - pipeline(List)       - Processing pipeline stages
+%
+%  @param Name    atom - specification name
+%  @param Options list - specification options
+%
+declare_mindmap_spec(Name, Options) :-
+    atom(Name),
+    is_list(Options),
+    retractall(mindmap_spec(Name, _)),
+    assertz(mindmap_spec(Name, Options)),
+    % Process inline node/edge definitions if present
+    process_spec_nodes(Name, Options),
+    process_spec_edges(Name, Options).
+
+%% declare_mindmap_layout(+Name, +Algorithm, +Options)
+%
+%  Declare a layout configuration.
+%
+%  Algorithms:
+%    - radial           - Radial/circular layout from center
+%    - force_directed   - Force-directed physics simulation
+%    - hierarchical     - Tree-like hierarchical layout
+%    - spiral           - Spiral pattern from center
+%
+%  Options vary by algorithm but common ones include:
+%    - iterations(N)    - Number of iterations for iterative layouts
+%    - min_distance(D)  - Minimum distance between nodes
+%    - center(X, Y)     - Center point
+%    - theme(Theme)     - Visual theme
+%
+%  @param Name      atom - layout name
+%  @param Algorithm atom - layout algorithm
+%  @param Options   list - algorithm-specific options
+%
+declare_mindmap_layout(Name, Algorithm, Options) :-
+    atom(Name),
+    atom(Algorithm),
+    is_list(Options),
+    FullOptions = [algorithm(Algorithm) | Options],
+    retractall(mindmap_layout(Name, _)),
+    assertz(mindmap_layout(Name, FullOptions)).
+
+%% clear_mindmap
+%
+%  Clear all mind map data from dynamic storage.
+%
+clear_mindmap :-
+    retractall(mindmap_node(_, _)),
+    retractall(mindmap_edge(_, _, _)),
+    retractall(mindmap_spec(_, _)),
+    retractall(mindmap_constraint(_, _)),
+    retractall(mindmap_preference(_, _)),
+    retractall(mindmap_layout(_, _)),
+    retractall(mindmap_pipeline(_, _)),
+    retractall(mindmap_style(_, _)),
+    retractall(mindmap_theme(_, _)).
+
+%% clear_mindmap(+Name)
+%
+%  Clear a specific mind map specification and its associated data.
+%
+clear_mindmap(Name) :-
+    atom(Name),
+    retractall(mindmap_spec(Name, _)),
+    retractall(mindmap_layout(Name, _)),
+    retractall(mindmap_pipeline(Name, _)).
+
+% ============================================================================
+% QUERY PREDICATES
+% ============================================================================
+
+%% has_mindmap_layout(+Name)
+%
+%  Check if a mind map layout exists.
+%
+has_mindmap_layout(Name) :-
+    mindmap_layout(Name, _).
+
+%% get_mindmap_nodes(+SpecName, -Nodes)
+%
+%  Get all nodes for a mind map specification.
+%  Returns list of node(Id, Properties) terms.
+%
+get_mindmap_nodes(SpecName, Nodes) :-
+    mindmap_spec(SpecName, Options),
+    (   member(nodes(NodeIds), Options)
+    ->  findall(node(Id, Props),
+                (member(Id, NodeIds), mindmap_node(Id, Props)),
+                Nodes)
+    ;   % If no nodes specified, get all declared nodes
+        findall(node(Id, Props), mindmap_node(Id, Props), Nodes)
+    ).
+
+%% get_mindmap_edges(+SpecName, -Edges)
+%
+%  Get all edges for a mind map specification.
+%  Returns list of edge(From, To, Properties) terms.
+%
+get_mindmap_edges(SpecName, Edges) :-
+    (   mindmap_spec(SpecName, Options),
+        member(edges(EdgeList), Options)
+    ->  findall(edge(F, T, Props),
+                (member(F-T, EdgeList), mindmap_edge(F, T, Props)),
+                Edges)
+    ;   % If no edges specified, get all declared edges
+        findall(edge(F, T, Props), mindmap_edge(F, T, Props), Edges)
+    ).
+
+%% get_mindmap_root(+SpecName, -RootId)
+%
+%  Find the root node of a mind map.
+%  Root is defined as a node with type(root) or no parent.
+%
+get_mindmap_root(SpecName, RootId) :-
+    get_mindmap_nodes(SpecName, Nodes),
+    (   % First try to find explicit root
+        member(node(RootId, Props), Nodes),
+        member(type(root), Props)
+    ->  true
+    ;   % Otherwise find node with no incoming edges
+        member(node(RootId, _), Nodes),
+        \+ mindmap_edge(_, RootId, _)
+    ).
+
+% ============================================================================
+% HELPER PREDICATES
+% ============================================================================
+
+%% process_spec_nodes(+Name, +Options)
+%
+%  Process inline node definitions from a spec.
+%
+process_spec_nodes(_Name, Options) :-
+    (   member(nodes(NodeList), Options)
+    ->  maplist(ensure_node_exists, NodeList)
+    ;   true
+    ).
+
+ensure_node_exists(Id) :-
+    atom(Id),
+    !,
+    (   mindmap_node(Id, _)
+    ->  true
+    ;   declare_mindmap_node(Id, [])
+    ).
+ensure_node_exists(node(Id, Props)) :-
+    declare_mindmap_node(Id, Props).
+
+%% process_spec_edges(+Name, +Options)
+%
+%  Process inline edge definitions from a spec.
+%
+process_spec_edges(_Name, Options) :-
+    (   member(edges(EdgeList), Options)
+    ->  maplist(ensure_edge_exists, EdgeList)
+    ;   true
+    ).
+
+ensure_edge_exists(From-To) :-
+    (   mindmap_edge(From, To, _)
+    ->  true
+    ;   declare_mindmap_edge(From, To, [])
+    ).
+
+% ============================================================================
+% GENERATION PREDICATES (STUBS - implemented in render modules)
+% ============================================================================
+
+%% generate_mindmap_positions(+Name, -Positions)
+%
+%  Generate node positions using the configured layout algorithm.
+%  Returns list of position(Id, X, Y) terms.
+%
+%  This is a high-level predicate that:
+%  1. Retrieves the layout configuration
+%  2. Builds the intermediate representation
+%  3. Executes the layout algorithm
+%  4. Returns positioned nodes
+%
+generate_mindmap_positions(Name, Positions) :-
+    (   mindmap_layout(Name, LayoutOptions)
+    ->  true
+    ;   LayoutOptions = [algorithm(radial)]  % Default layout
+    ),
+    get_mindmap_nodes(Name, Nodes),
+    get_mindmap_edges(Name, Edges),
+    member(algorithm(Algorithm), LayoutOptions),
+    % Call appropriate layout algorithm
+    compute_layout(Algorithm, Nodes, Edges, LayoutOptions, Positions).
+
+%% compute_layout(+Algorithm, +Nodes, +Edges, +Options, -Positions)
+%
+%  Dispatch to appropriate layout algorithm.
+%  Default implementation provides basic radial layout.
+%
+compute_layout(radial, Nodes, _Edges, Options, Positions) :-
+    !,
+    compute_radial_layout(Nodes, Options, Positions).
+compute_layout(force_directed, Nodes, Edges, Options, Positions) :-
+    !,
+    compute_force_directed_layout(Nodes, Edges, Options, Positions).
+compute_layout(hierarchical, Nodes, Edges, Options, Positions) :-
+    !,
+    compute_hierarchical_layout(Nodes, Edges, Options, Positions).
+compute_layout(Algorithm, _Nodes, _Edges, _Options, []) :-
+    format('Warning: Unknown layout algorithm: ~w~n', [Algorithm]).
+
+%% compute_radial_layout(+Nodes, +Options, -Positions)
+%
+%  Basic radial layout: root at center, children in circles.
+%
+compute_radial_layout(Nodes, Options, Positions) :-
+    % Get center point
+    (member(center(CX, CY), Options) -> true ; CX = 500, CY = 500),
+    (member(base_radius(R), Options) -> true ; R = 150),
+    length(Nodes, N),
+    (   N =:= 0
+    ->  Positions = []
+    ;   N =:= 1
+    ->  Nodes = [node(Id, _)],
+        Positions = [position(Id, CX, CY)]
+    ;   % Place first node at center, others in circle
+        Nodes = [node(RootId, _) | RestNodes],
+        length(RestNodes, NumRest),
+        AngleStep is 2 * pi / max(1, NumRest),
+        compute_circle_positions(RestNodes, CX, CY, R, 0, AngleStep, RestPositions),
+        Positions = [position(RootId, CX, CY) | RestPositions]
+    ).
+
+compute_circle_positions([], _, _, _, _, _, []).
+compute_circle_positions([node(Id, _) | Rest], CX, CY, R, Angle, Step, [position(Id, X, Y) | RestPos]) :-
+    X is CX + R * cos(Angle),
+    Y is CY + R * sin(Angle),
+    NextAngle is Angle + Step,
+    compute_circle_positions(Rest, CX, CY, R, NextAngle, Step, RestPos).
+
+%% compute_force_directed_layout(+Nodes, +Edges, +Options, -Positions)
+%
+%  Force-directed layout stub - full implementation in layout/force_directed.pl
+%
+compute_force_directed_layout(Nodes, _Edges, Options, Positions) :-
+    % Fallback to radial for now
+    compute_radial_layout(Nodes, Options, Positions).
+
+%% compute_hierarchical_layout(+Nodes, +Edges, +Options, -Positions)
+%
+%  Hierarchical tree layout stub - full implementation in layout/hierarchical.pl
+%
+compute_hierarchical_layout(Nodes, _Edges, Options, Positions) :-
+    % Fallback to radial for now
+    compute_radial_layout(Nodes, Options, Positions).
+
+%% generate_mindmap_svg(+Name, -SVG)
+%
+%  Generate SVG output for a mind map.
+%
+generate_mindmap_svg(Name, SVG) :-
+    generate_mindmap_svg(Name, [], SVG).
+
+%% generate_mindmap_svg(+Name, +Options, -SVG)
+%
+%  Generate SVG output with options.
+%
+%  Options:
+%    - width(W)        - SVG width
+%    - height(H)       - SVG height
+%    - background(C)   - Background color
+%    - node_shape(S)   - Default node shape: ellipse, rectangle, diamond
+%    - edge_style(S)   - Default edge style: straight, bezier
+%
+generate_mindmap_svg(Name, Options, SVG) :-
+    generate_mindmap_positions(Name, Positions),
+    get_mindmap_nodes(Name, Nodes),
+    get_mindmap_edges(Name, Edges),
+    (member(width(W), Options) -> true ; W = 1000),
+    (member(height(H), Options) -> true ; H = 800),
+    generate_svg_document(W, H, Nodes, Edges, Positions, Options, SVG).
+
+%% generate_svg_document(+W, +H, +Nodes, +Edges, +Positions, +Options, -SVG)
+%
+%  Generate complete SVG document.
+%
+generate_svg_document(W, H, Nodes, Edges, Positions, Options, SVG) :-
+    % Build position lookup
+    findall(Id-pos(X,Y), member(position(Id, X, Y), Positions), PosLookup),
+    % Generate edges first (underneath nodes)
+    generate_svg_edges(Edges, PosLookup, EdgesSVG),
+    % Generate nodes
+    generate_svg_nodes(Nodes, PosLookup, Options, NodesSVG),
+    % Combine into document
+    (member(background(BG), Options) -> true ; BG = '#ffffff'),
+    format(atom(SVG),
+        '<svg xmlns="http://www.w3.org/2000/svg" width="~w" height="~w" viewBox="0 0 ~w ~w">~n  <rect width="100%" height="100%" fill="~w"/>~n  <g class="edges">~n~w  </g>~n  <g class="nodes">~n~w  </g>~n</svg>',
+        [W, H, W, H, BG, EdgesSVG, NodesSVG]).
+
+generate_svg_edges([], _, '').
+generate_svg_edges([edge(From, To, _Props) | Rest], PosLookup, SVG) :-
+    (   member(From-pos(X1, Y1), PosLookup),
+        member(To-pos(X2, Y2), PosLookup)
+    ->  format(atom(EdgeSVG), '    <line x1="~2f" y1="~2f" x2="~2f" y2="~2f" stroke="#666" stroke-width="2"/>~n', [X1, Y1, X2, Y2])
+    ;   EdgeSVG = ''
+    ),
+    generate_svg_edges(Rest, PosLookup, RestSVG),
+    atom_concat(EdgeSVG, RestSVG, SVG).
+
+generate_svg_nodes([], _, _, '').
+generate_svg_nodes([node(Id, Props) | Rest], PosLookup, Options, SVG) :-
+    (   member(Id-pos(X, Y), PosLookup)
+    ->  (member(label(Label), Props) -> true ; atom_string(Id, Label)),
+        (member(node_radius(R), Options) -> true ; R = 40),
+        format(atom(NodeSVG), '    <g class="node" data-id="~w">~n      <ellipse cx="~2f" cy="~2f" rx="~w" ry="~w" fill="#4a90d9" stroke="#2c5a8c" stroke-width="2"/>~n      <text x="~2f" y="~2f" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="12">~w</text>~n    </g>~n', [Id, X, Y, R, R, X, Y, Label])
+    ;   NodeSVG = ''
+    ),
+    generate_svg_nodes(Rest, PosLookup, Options, RestSVG),
+    atom_concat(NodeSVG, RestSVG, SVG).
+
+%% compile_mindmap(+Name, +Target, -Code)
+%
+%  Compile a mind map to target format.
+%
+%  Targets:
+%    - svg              - Static SVG
+%    - smmx             - .smmx format
+%    - mm               - .mm format
+%    - graph_interactive - Interactive graph component
+%    - graphviz         - DOT format
+%    - positions        - Just node positions
+%
+compile_mindmap(Name, svg, Code) :-
+    !,
+    generate_mindmap_svg(Name, Code).
+compile_mindmap(Name, positions, Code) :-
+    !,
+    generate_mindmap_positions(Name, Code).
+compile_mindmap(Name, Target, _Code) :-
+    format('Error: Target ~w not yet implemented for mind map ~w~n', [Target, Name]),
+    fail.
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_mindmap_dsl :-
+    format('~n=== Mind Map DSL Tests ===~n~n'),
+
+    % Setup
+    clear_mindmap,
+
+    % Test 1: Node declaration
+    format('Test 1: Node declaration...~n'),
+    declare_mindmap_node(root, [label("Central Topic"), type(root)]),
+    declare_mindmap_node(child1, [label("Branch A"), parent(root)]),
+    declare_mindmap_node(child2, [label("Branch B"), parent(root)]),
+    (   mindmap_node(root, RootProps),
+        member(label("Central Topic"), RootProps)
+    ->  format('  PASS: Root node declared~n')
+    ;   format('  FAIL: Root node not found~n')
+    ),
+
+    % Test 2: Implicit edge creation
+    format('~nTest 2: Implicit edge creation...~n'),
+    (   mindmap_edge(root, child1, _)
+    ->  format('  PASS: Implicit edge created~n')
+    ;   format('  FAIL: Implicit edge not found~n')
+    ),
+
+    % Test 3: Spec declaration
+    format('~nTest 3: Spec declaration...~n'),
+    declare_mindmap_spec(test_map, [
+        nodes([root, child1, child2]),
+        layout(radial)
+    ]),
+    (   mindmap_spec(test_map, _)
+    ->  format('  PASS: Spec declared~n')
+    ;   format('  FAIL: Spec not found~n')
+    ),
+
+    % Test 4: Layout declaration
+    format('~nTest 4: Layout declaration...~n'),
+    declare_mindmap_layout(test_map, force_directed, [
+        iterations(100),
+        min_distance(50)
+    ]),
+    (   has_mindmap_layout(test_map)
+    ->  format('  PASS: Layout declared~n')
+    ;   format('  FAIL: Layout not found~n')
+    ),
+
+    % Test 5: Position generation
+    format('~nTest 5: Position generation...~n'),
+    generate_mindmap_positions(test_map, Positions),
+    length(Positions, NumPos),
+    (   NumPos > 0
+    ->  format('  PASS: Generated ~w positions~n', [NumPos])
+    ;   format('  FAIL: No positions generated~n')
+    ),
+
+    % Test 6: SVG generation
+    format('~nTest 6: SVG generation...~n'),
+    generate_mindmap_svg(test_map, SVG),
+    (   sub_atom(SVG, _, _, _, '<svg')
+    ->  format('  PASS: SVG generated~n')
+    ;   format('  FAIL: Invalid SVG~n')
+    ),
+
+    % Test 7: Get root node
+    format('~nTest 7: Get root node...~n'),
+    (   get_mindmap_root(test_map, RootId),
+        RootId == root
+    ->  format('  PASS: Root is ~w~n', [RootId])
+    ;   format('  FAIL: Could not find root~n')
+    ),
+
+    % Cleanup
+    clear_mindmap,
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% MODULE INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('Mind Map DSL module loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/mindmap_ir.pl
+++ b/src/unifyweaver/mindmap/mindmap_ir.pl
@@ -1,0 +1,680 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% mindmap_ir.pl - Mind Map Intermediate Representation
+%
+% This module provides a normalized intermediate representation for mind maps
+% that can be processed by layout algorithms and rendered to various targets.
+%
+% The IR separates the graph structure from layout and styling concerns,
+% enabling pipeline processing and target-independent transformations.
+%
+% IR Structure:
+%   mindmap_ir(
+%       Name,
+%       Graph = graph(Nodes, Edges, Root),
+%       Attributes = attrs(NodeAttrs, EdgeAttrs, GlobalAttrs),
+%       Constraints = [constraint(Type, Options), ...],
+%       Preferences = [preference(Type, Weight, Options), ...]
+%   )
+
+:- module(mindmap_ir, [
+    % IR construction
+    build_ir/2,                     % build_ir(+SpecName, -IR)
+    build_ir_from_nodes/3,          % build_ir_from_nodes(+Nodes, +Edges, -IR)
+
+    % IR access
+    ir_name/2,                      % ir_name(+IR, -Name)
+    ir_graph/2,                     % ir_graph(+IR, -Graph)
+    ir_nodes/2,                     % ir_nodes(+IR, -Nodes)
+    ir_edges/2,                     % ir_edges(+IR, -Edges)
+    ir_root/2,                      % ir_root(+IR, -RootId)
+    ir_attributes/2,                % ir_attributes(+IR, -Attributes)
+    ir_constraints/2,               % ir_constraints(+IR, -Constraints)
+    ir_preferences/2,               % ir_preferences(+IR, -Preferences)
+
+    % Node access
+    ir_node/3,                      % ir_node(+IR, +Id, -NodeData)
+    ir_node_attr/4,                 % ir_node_attr(+IR, +Id, +AttrName, -Value)
+    ir_node_label/3,                % ir_node_label(+IR, +Id, -Label)
+    ir_node_type/3,                 % ir_node_type(+IR, +Id, -Type)
+
+    % Edge access
+    ir_edge/4,                      % ir_edge(+IR, +From, +To, -EdgeData)
+    ir_children/3,                  % ir_children(+IR, +Id, -Children)
+    ir_parent/3,                    % ir_parent(+IR, +Id, -Parent)
+    ir_descendants/3,               % ir_descendants(+IR, +Id, -Descendants)
+    ir_ancestors/3,                 % ir_ancestors(+IR, +Id, -Ancestors)
+
+    % Tree traversal
+    ir_traverse_preorder/3,         % ir_traverse_preorder(+IR, +RootId, -OrderedIds)
+    ir_traverse_postorder/3,        % ir_traverse_postorder(+IR, +RootId, -OrderedIds)
+    ir_traverse_levelorder/3,       % ir_traverse_levelorder(+IR, +RootId, -OrderedIds)
+    ir_depth/3,                     % ir_depth(+IR, +Id, -Depth)
+    ir_max_depth/2,                 % ir_max_depth(+IR, -MaxDepth)
+
+    % IR transformation
+    ir_add_positions/3,             % ir_add_positions(+IR, +Positions, -NewIR)
+    ir_get_positions/2,             % ir_get_positions(+IR, -Positions)
+    ir_update_node_attr/5,          % ir_update_node_attr(+IR, +Id, +Attr, +Value, -NewIR)
+
+    % Validation
+    validate_ir/1,                  % validate_ir(+IR)
+    ir_is_tree/1,                   % ir_is_tree(+IR) - true if IR forms a tree
+    ir_is_connected/1,              % ir_is_connected(+IR) - true if graph is connected
+
+    % Conversion
+    ir_to_dict/2,                   % ir_to_dict(+IR, -Dict) - for JSON/Python interop
+    dict_to_ir/2,                   % dict_to_ir(+Dict, -IR)
+
+    % Testing
+    test_mindmap_ir/0
+]).
+
+:- use_module(library(lists)).
+
+% Conditionally load mindmap_dsl
+:- if(exists_source(library('./mindmap_dsl'))).
+:- use_module('./mindmap_dsl').
+:- endif.
+
+% ============================================================================
+% IR STRUCTURE
+% ============================================================================
+
+% IR term structure:
+% mindmap_ir(Name, Graph, Attributes, Constraints, Preferences)
+%
+% Where:
+%   Name = atom
+%   Graph = graph(Nodes, Edges, RootId)
+%     Nodes = [node(Id, Props), ...]
+%     Edges = [edge(From, To, Props), ...]
+%     RootId = atom
+%   Attributes = attrs(NodeAttrs, EdgeAttrs, GlobalAttrs)
+%     NodeAttrs = [Id-AttrDict, ...]
+%     EdgeAttrs = [(From,To)-AttrDict, ...]
+%     GlobalAttrs = AttrDict
+%   Constraints = [constraint(Type, Options), ...]
+%   Preferences = [preference(Type, Weight, Options), ...]
+
+% ============================================================================
+% IR CONSTRUCTION
+% ============================================================================
+
+%% build_ir(+SpecName, -IR)
+%
+%  Build intermediate representation from a mind map specification.
+%
+%  @param SpecName atom - name of the mind map specification
+%  @param IR       term - constructed IR
+%
+build_ir(SpecName, IR) :-
+    % Get nodes and edges from DSL
+    (   catch(get_mindmap_nodes(SpecName, RawNodes), _, fail)
+    ->  true
+    ;   RawNodes = []
+    ),
+    (   catch(get_mindmap_edges(SpecName, RawEdges), _, fail)
+    ->  true
+    ;   RawEdges = []
+    ),
+    % Find root
+    find_root(RawNodes, RawEdges, RootId),
+    % Build graph structure
+    Graph = graph(RawNodes, RawEdges, RootId),
+    % Extract attributes
+    extract_all_attributes(RawNodes, RawEdges, Attributes),
+    % Get constraints and preferences
+    collect_constraints(SpecName, Constraints),
+    collect_preferences(SpecName, Preferences),
+    % Construct IR
+    IR = mindmap_ir(SpecName, Graph, Attributes, Constraints, Preferences).
+
+%% build_ir_from_nodes(+Nodes, +Edges, -IR)
+%
+%  Build IR from explicit node and edge lists.
+%
+%  @param Nodes list - list of node(Id, Props) terms
+%  @param Edges list - list of edge(From, To, Props) terms
+%  @param IR    term - constructed IR
+%
+build_ir_from_nodes(Nodes, Edges, IR) :-
+    find_root(Nodes, Edges, RootId),
+    Graph = graph(Nodes, Edges, RootId),
+    extract_all_attributes(Nodes, Edges, Attributes),
+    IR = mindmap_ir(anonymous, Graph, Attributes, [], []).
+
+%% find_root(+Nodes, +Edges, -RootId)
+%
+%  Find the root node of the graph.
+%  Root is either marked with type(root) or has no incoming edges.
+%
+find_root(Nodes, Edges, RootId) :-
+    % First look for explicit root
+    (   member(node(RootId, Props), Nodes),
+        member(type(root), Props)
+    ->  true
+    ;   % Find node with no incoming edges
+        member(node(RootId, _), Nodes),
+        \+ member(edge(_, RootId, _), Edges)
+    ->  true
+    ;   % Fallback to first node
+        Nodes = [node(RootId, _) | _]
+    ->  true
+    ;   RootId = none
+    ).
+
+%% extract_all_attributes(+Nodes, +Edges, -Attributes)
+%
+%  Extract and normalize attributes from nodes and edges.
+%
+extract_all_attributes(Nodes, Edges, attrs(NodeAttrs, EdgeAttrs, GlobalAttrs)) :-
+    % Node attributes
+    findall(Id-AttrDict,
+            (member(node(Id, Props), Nodes),
+             props_to_dict(Props, AttrDict)),
+            NodeAttrs),
+    % Edge attributes
+    findall((From,To)-AttrDict,
+            (member(edge(From, To, Props), Edges),
+             props_to_dict(Props, AttrDict)),
+            EdgeAttrs),
+    % Global attributes (empty for now)
+    GlobalAttrs = global{}.
+
+%% props_to_dict(+Props, -Dict)
+%
+%  Convert property list to dictionary.
+%
+props_to_dict(Props, Dict) :-
+    findall(Key-Value, (member(Prop, Props), prop_kv(Prop, Key, Value)), Pairs),
+    dict_create(Dict, attr, Pairs).
+
+prop_kv(label(V), label, V) :- !.
+prop_kv(type(V), type, V) :- !.
+prop_kv(parent(V), parent, V) :- !.
+prop_kv(link(V), link, V) :- !.
+prop_kv(style(V), style, V) :- !.
+prop_kv(cluster(V), cluster, V) :- !.
+prop_kv(importance(V), importance, V) :- !.
+prop_kv(position(X, Y), position, pos(X, Y)) :- !.
+prop_kv(x(V), x, V) :- !.
+prop_kv(y(V), y, V) :- !.
+prop_kv(weight(V), weight, V) :- !.
+prop_kv(implicit(V), implicit, V) :- !.
+prop_kv(Term, Key, Value) :-
+    Term =.. [Key, Value].
+
+%% collect_constraints(+SpecName, -Constraints)
+%
+%  Collect all constraints for a specification.
+%
+collect_constraints(_SpecName, Constraints) :-
+    findall(constraint(Type, Opts),
+            mindmap_constraint(Type, Opts),
+            Constraints).
+
+%% collect_preferences(+SpecName, -Preferences)
+%
+%  Collect all preferences for a specification.
+%
+collect_preferences(_SpecName, Preferences) :-
+    findall(preference(Type, Weight, Opts),
+            (mindmap_preference(Type, Opts),
+             (member(weight(Weight), Opts) -> true ; Weight = 1.0)),
+            Preferences).
+
+% ============================================================================
+% IR ACCESS
+% ============================================================================
+
+%% ir_name(+IR, -Name)
+ir_name(mindmap_ir(Name, _, _, _, _), Name).
+
+%% ir_graph(+IR, -Graph)
+ir_graph(mindmap_ir(_, Graph, _, _, _), Graph).
+
+%% ir_nodes(+IR, -Nodes)
+ir_nodes(mindmap_ir(_, graph(Nodes, _, _), _, _, _), Nodes).
+
+%% ir_edges(+IR, -Edges)
+ir_edges(mindmap_ir(_, graph(_, Edges, _), _, _, _), Edges).
+
+%% ir_root(+IR, -RootId)
+ir_root(mindmap_ir(_, graph(_, _, RootId), _, _, _), RootId).
+
+%% ir_attributes(+IR, -Attributes)
+ir_attributes(mindmap_ir(_, _, Attributes, _, _), Attributes).
+
+%% ir_constraints(+IR, -Constraints)
+ir_constraints(mindmap_ir(_, _, _, Constraints, _), Constraints).
+
+%% ir_preferences(+IR, -Preferences)
+ir_preferences(mindmap_ir(_, _, _, _, Preferences), Preferences).
+
+% ============================================================================
+% NODE ACCESS
+% ============================================================================
+
+%% ir_node(+IR, +Id, -NodeData)
+%
+%  Get node data by id.
+%
+ir_node(IR, Id, NodeData) :-
+    ir_nodes(IR, Nodes),
+    member(node(Id, Props), Nodes),
+    NodeData = node(Id, Props).
+
+%% ir_node_attr(+IR, +Id, +AttrName, -Value)
+%
+%  Get a specific attribute of a node.
+%
+ir_node_attr(IR, Id, AttrName, Value) :-
+    ir_attributes(IR, attrs(NodeAttrs, _, _)),
+    member(Id-AttrDict, NodeAttrs),
+    get_dict(AttrName, AttrDict, Value).
+
+%% ir_node_label(+IR, +Id, -Label)
+%
+%  Get the label of a node.
+%
+ir_node_label(IR, Id, Label) :-
+    (   ir_node_attr(IR, Id, label, Label)
+    ->  true
+    ;   atom_string(Id, Label)
+    ).
+
+%% ir_node_type(+IR, +Id, -Type)
+%
+%  Get the type of a node.
+%
+ir_node_type(IR, Id, Type) :-
+    (   ir_node_attr(IR, Id, type, Type)
+    ->  true
+    ;   Type = default
+    ).
+
+% ============================================================================
+% EDGE ACCESS
+% ============================================================================
+
+%% ir_edge(+IR, +From, +To, -EdgeData)
+%
+%  Get edge data.
+%
+ir_edge(IR, From, To, EdgeData) :-
+    ir_edges(IR, Edges),
+    member(edge(From, To, Props), Edges),
+    EdgeData = edge(From, To, Props).
+
+%% ir_children(+IR, +Id, -Children)
+%
+%  Get immediate children of a node.
+%
+ir_children(IR, Id, Children) :-
+    ir_edges(IR, Edges),
+    findall(ChildId, member(edge(Id, ChildId, _), Edges), Children).
+
+%% ir_parent(+IR, +Id, -Parent)
+%
+%  Get parent of a node (fails if root).
+%
+ir_parent(IR, Id, Parent) :-
+    ir_edges(IR, Edges),
+    member(edge(Parent, Id, _), Edges),
+    !.
+
+%% ir_descendants(+IR, +Id, -Descendants)
+%
+%  Get all descendants of a node.
+%
+ir_descendants(IR, Id, Descendants) :-
+    ir_children(IR, Id, Children),
+    (   Children = []
+    ->  Descendants = []
+    ;   findall(Desc, (member(C, Children), ir_descendants(IR, C, ChildDesc),
+                       (Desc = C ; member(Desc, ChildDesc))), Descendants)
+    ).
+
+%% ir_ancestors(+IR, +Id, -Ancestors)
+%
+%  Get all ancestors of a node (path to root).
+%
+ir_ancestors(IR, Id, Ancestors) :-
+    (   ir_parent(IR, Id, Parent)
+    ->  ir_ancestors(IR, Parent, ParentAncestors),
+        Ancestors = [Parent | ParentAncestors]
+    ;   Ancestors = []
+    ).
+
+% ============================================================================
+% TREE TRAVERSAL
+% ============================================================================
+
+%% ir_traverse_preorder(+IR, +RootId, -OrderedIds)
+%
+%  Pre-order traversal: visit node before children.
+%
+ir_traverse_preorder(IR, RootId, OrderedIds) :-
+    ir_children(IR, RootId, Children),
+    findall(ChildOrder,
+            (member(C, Children), ir_traverse_preorder(IR, C, ChildOrder)),
+            ChildOrders),
+    append(ChildOrders, FlatChildren),
+    OrderedIds = [RootId | FlatChildren].
+
+%% ir_traverse_postorder(+IR, +RootId, -OrderedIds)
+%
+%  Post-order traversal: visit children before node.
+%
+ir_traverse_postorder(IR, RootId, OrderedIds) :-
+    ir_children(IR, RootId, Children),
+    findall(ChildOrder,
+            (member(C, Children), ir_traverse_postorder(IR, C, ChildOrder)),
+            ChildOrders),
+    append(ChildOrders, FlatChildren),
+    append(FlatChildren, [RootId], OrderedIds).
+
+%% ir_traverse_levelorder(+IR, +RootId, -OrderedIds)
+%
+%  Level-order (breadth-first) traversal.
+%
+ir_traverse_levelorder(IR, RootId, OrderedIds) :-
+    levelorder_queue(IR, [RootId], OrderedIds).
+
+levelorder_queue(_, [], []) :- !.
+levelorder_queue(IR, [Id | Rest], [Id | OrderedIds]) :-
+    ir_children(IR, Id, Children),
+    append(Rest, Children, NewQueue),
+    levelorder_queue(IR, NewQueue, OrderedIds).
+
+%% ir_depth(+IR, +Id, -Depth)
+%
+%  Get depth of a node (root = 0).
+%
+ir_depth(IR, Id, Depth) :-
+    ir_root(IR, RootId),
+    (   Id == RootId
+    ->  Depth = 0
+    ;   ir_ancestors(IR, Id, Ancestors),
+        length(Ancestors, Depth)
+    ).
+
+%% ir_max_depth(+IR, -MaxDepth)
+%
+%  Get maximum depth of the tree.
+%
+ir_max_depth(IR, MaxDepth) :-
+    ir_nodes(IR, Nodes),
+    findall(D, (member(node(Id, _), Nodes), ir_depth(IR, Id, D)), Depths),
+    (   Depths = []
+    ->  MaxDepth = 0
+    ;   max_list(Depths, MaxDepth)
+    ).
+
+% ============================================================================
+% IR TRANSFORMATION
+% ============================================================================
+
+%% ir_add_positions(+IR, +Positions, -NewIR)
+%
+%  Add computed positions to the IR.
+%  Positions is a list of position(Id, X, Y) terms.
+%
+ir_add_positions(mindmap_ir(Name, Graph, attrs(NodeAttrs, EdgeAttrs, GlobalAttrs), Constraints, Preferences),
+                 Positions,
+                 mindmap_ir(Name, Graph, attrs(NewNodeAttrs, EdgeAttrs, GlobalAttrs), Constraints, Preferences)) :-
+    update_node_positions(NodeAttrs, Positions, NewNodeAttrs).
+
+update_node_positions([], _, []).
+update_node_positions([Id-AttrDict | Rest], Positions, [Id-NewAttrDict | NewRest]) :-
+    (   member(position(Id, X, Y), Positions)
+    ->  put_dict([x-X, y-Y], AttrDict, NewAttrDict)
+    ;   NewAttrDict = AttrDict
+    ),
+    update_node_positions(Rest, Positions, NewRest).
+
+%% ir_get_positions(+IR, -Positions)
+%
+%  Extract positions from IR.
+%
+ir_get_positions(IR, Positions) :-
+    ir_attributes(IR, attrs(NodeAttrs, _, _)),
+    findall(position(Id, X, Y),
+            (member(Id-AttrDict, NodeAttrs),
+             get_dict(x, AttrDict, X),
+             get_dict(y, AttrDict, Y)),
+            Positions).
+
+%% ir_update_node_attr(+IR, +Id, +Attr, +Value, -NewIR)
+%
+%  Update a specific node attribute.
+%
+ir_update_node_attr(mindmap_ir(Name, Graph, attrs(NodeAttrs, EdgeAttrs, GlobalAttrs), C, P),
+                    Id, Attr, Value,
+                    mindmap_ir(Name, Graph, attrs(NewNodeAttrs, EdgeAttrs, GlobalAttrs), C, P)) :-
+    update_single_attr(NodeAttrs, Id, Attr, Value, NewNodeAttrs).
+
+update_single_attr([], _, _, _, []).
+update_single_attr([Id-AttrDict | Rest], Id, Attr, Value, [Id-NewAttrDict | Rest]) :-
+    !,
+    put_dict(Attr, AttrDict, Value, NewAttrDict).
+update_single_attr([Other | Rest], Id, Attr, Value, [Other | NewRest]) :-
+    update_single_attr(Rest, Id, Attr, Value, NewRest).
+
+% ============================================================================
+% VALIDATION
+% ============================================================================
+
+%% validate_ir(+IR)
+%
+%  Validate IR structure.
+%
+validate_ir(IR) :-
+    IR = mindmap_ir(Name, Graph, Attributes, Constraints, Preferences),
+    atom(Name),
+    Graph = graph(Nodes, Edges, RootId),
+    is_list(Nodes),
+    is_list(Edges),
+    atom(RootId),
+    Attributes = attrs(NodeAttrs, EdgeAttrs, _GlobalAttrs),
+    is_list(NodeAttrs),
+    is_list(EdgeAttrs),
+    is_list(Constraints),
+    is_list(Preferences),
+    % Verify root exists
+    (   RootId == none
+    ->  true
+    ;   member(node(RootId, _), Nodes)
+    ).
+
+%% ir_is_tree(+IR)
+%
+%  Check if the IR forms a valid tree (single root, no cycles).
+%
+ir_is_tree(IR) :-
+    ir_root(IR, RootId),
+    RootId \== none,
+    ir_nodes(IR, Nodes),
+    % Every non-root node has exactly one parent
+    forall((member(node(Id, _), Nodes), Id \== RootId),
+           (findall(P, ir_edge(IR, P, Id, _), Parents),
+            length(Parents, 1))),
+    % No cycles (all nodes reachable from root)
+    ir_traverse_preorder(IR, RootId, Reachable),
+    length(Nodes, N),
+    length(Reachable, N).
+
+%% ir_is_connected(+IR)
+%
+%  Check if all nodes are connected.
+%
+ir_is_connected(IR) :-
+    ir_root(IR, RootId),
+    RootId \== none,
+    ir_nodes(IR, Nodes),
+    ir_traverse_preorder(IR, RootId, Reachable),
+    length(Nodes, N),
+    length(Reachable, N).
+
+% ============================================================================
+% CONVERSION
+% ============================================================================
+
+%% ir_to_dict(+IR, -Dict)
+%
+%  Convert IR to dictionary for JSON/Python interop.
+%
+ir_to_dict(IR, Dict) :-
+    ir_name(IR, Name),
+    ir_nodes(IR, Nodes),
+    ir_edges(IR, Edges),
+    ir_root(IR, RootId),
+    % Convert nodes
+    findall(NodeDict,
+            (member(node(Id, Props), Nodes),
+             props_to_dict(Props, AttrDict),
+             NodeDict = node{id: Id, attrs: AttrDict}),
+            NodeDicts),
+    % Convert edges
+    findall(EdgeDict,
+            (member(edge(From, To, Props), Edges),
+             props_to_dict(Props, AttrDict),
+             EdgeDict = edge{from: From, to: To, attrs: AttrDict}),
+            EdgeDicts),
+    Dict = mindmap{
+        name: Name,
+        root: RootId,
+        nodes: NodeDicts,
+        edges: EdgeDicts
+    }.
+
+%% dict_to_ir(+Dict, -IR)
+%
+%  Convert dictionary to IR.
+%
+dict_to_ir(Dict, IR) :-
+    get_dict(name, Dict, Name),
+    get_dict(nodes, Dict, NodeDicts),
+    get_dict(edges, Dict, EdgeDicts),
+    get_dict(root, Dict, RootId),
+    % Convert nodes
+    findall(node(Id, Props),
+            (member(NodeDict, NodeDicts),
+             get_dict(id, NodeDict, Id),
+             (get_dict(attrs, NodeDict, AttrDict) -> dict_to_props(AttrDict, Props) ; Props = [])),
+            Nodes),
+    % Convert edges
+    findall(edge(From, To, Props),
+            (member(EdgeDict, EdgeDicts),
+             get_dict(from, EdgeDict, From),
+             get_dict(to, EdgeDict, To),
+             (get_dict(attrs, EdgeDict, AttrDict) -> dict_to_props(AttrDict, Props) ; Props = [])),
+            Edges),
+    build_ir_from_nodes(Nodes, Edges, BaseIR),
+    % Override name and root
+    BaseIR = mindmap_ir(_, Graph, Attrs, Cons, Prefs),
+    Graph = graph(N, E, _),
+    IR = mindmap_ir(Name, graph(N, E, RootId), Attrs, Cons, Prefs).
+
+dict_to_props(AttrDict, Props) :-
+    dict_pairs(AttrDict, _, Pairs),
+    findall(Prop, (member(Key-Value, Pairs), Prop =.. [Key, Value]), Props).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_mindmap_ir :-
+    format('~n=== Mind Map IR Tests ===~n~n'),
+
+    % Create test data
+    TestNodes = [
+        node(root, [label("Root"), type(root)]),
+        node(a, [label("A"), parent(root)]),
+        node(b, [label("B"), parent(root)]),
+        node(c, [label("C"), parent(a)])
+    ],
+    TestEdges = [
+        edge(root, a, []),
+        edge(root, b, []),
+        edge(a, c, [])
+    ],
+
+    % Test 1: Build IR
+    format('Test 1: Build IR from nodes...~n'),
+    build_ir_from_nodes(TestNodes, TestEdges, IR),
+    (   validate_ir(IR)
+    ->  format('  PASS: IR built and valid~n')
+    ;   format('  FAIL: IR invalid~n')
+    ),
+
+    % Test 2: Access root
+    format('~nTest 2: Access root...~n'),
+    ir_root(IR, RootId),
+    (   RootId == root
+    ->  format('  PASS: Root is ~w~n', [RootId])
+    ;   format('  FAIL: Expected root, got ~w~n', [RootId])
+    ),
+
+    % Test 3: Get children
+    format('~nTest 3: Get children...~n'),
+    ir_children(IR, root, RootChildren),
+    (   length(RootChildren, 2)
+    ->  format('  PASS: Root has 2 children: ~w~n', [RootChildren])
+    ;   format('  FAIL: Expected 2 children, got ~w~n', [RootChildren])
+    ),
+
+    % Test 4: Traverse preorder
+    format('~nTest 4: Preorder traversal...~n'),
+    ir_traverse_preorder(IR, root, PreOrder),
+    format('  Order: ~w~n', [PreOrder]),
+    (   PreOrder = [root | _]
+    ->  format('  PASS: Preorder starts with root~n')
+    ;   format('  FAIL: Invalid preorder~n')
+    ),
+
+    % Test 5: Tree check
+    format('~nTest 5: Tree check...~n'),
+    (   ir_is_tree(IR)
+    ->  format('  PASS: IR is a valid tree~n')
+    ;   format('  FAIL: IR is not a tree~n')
+    ),
+
+    % Test 6: Depth calculation
+    format('~nTest 6: Depth calculation...~n'),
+    ir_depth(IR, c, DepthC),
+    (   DepthC =:= 2
+    ->  format('  PASS: Depth of c is ~w~n', [DepthC])
+    ;   format('  FAIL: Expected depth 2, got ~w~n', [DepthC])
+    ),
+
+    % Test 7: Add positions
+    format('~nTest 7: Add positions...~n'),
+    Positions = [position(root, 100, 100), position(a, 150, 200), position(b, 50, 200), position(c, 175, 300)],
+    ir_add_positions(IR, Positions, IRWithPos),
+    ir_get_positions(IRWithPos, RetrievedPos),
+    length(RetrievedPos, NumPos),
+    (   NumPos =:= 4
+    ->  format('  PASS: ~w positions stored and retrieved~n', [NumPos])
+    ;   format('  FAIL: Expected 4 positions, got ~w~n', [NumPos])
+    ),
+
+    % Test 8: Convert to dict
+    format('~nTest 8: Convert to dict...~n'),
+    ir_to_dict(IR, Dict),
+    (   is_dict(Dict)
+    ->  format('  PASS: Converted to dict~n')
+    ;   format('  FAIL: Conversion failed~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% MODULE INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('Mind Map IR module loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/optimize/overlap_removal.pl
+++ b/src/unifyweaver/mindmap/optimize/overlap_removal.pl
@@ -1,0 +1,292 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% overlap_removal.pl - Overlap Removal Optimizer for Mind Maps
+%
+% Removes overlapping nodes by pushing them apart while preserving
+% the overall layout structure.
+%
+% Algorithm:
+% 1. Detect overlapping node pairs
+% 2. Compute push vectors to separate them
+% 3. Apply forces iteratively until no overlaps remain
+
+:- module(mindmap_opt_overlap, [
+    % Component interface
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    optimize/3,
+
+    % Direct API
+    remove_overlaps/4,              % remove_overlaps(+Positions, +Options, -NewPositions, -Stats)
+    detect_overlaps/3,              % detect_overlaps(+Positions, +MinDist, -Overlaps)
+    compute_separation_vector/5     % compute_separation_vector(+P1, +P2, +MinDist, -DX, -DY)
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% COMPONENT INTERFACE
+% ============================================================================
+
+%% type_info(-Info)
+%
+%  Component type information.
+%
+type_info(info{
+    name: overlap_removal,
+    category: mindmap_optimizer,
+    description: "Remove overlapping nodes by pushing them apart",
+    version: "1.0.0",
+    parameters: [
+        min_distance - "Minimum distance between node centers (default 50)",
+        iterations - "Maximum iterations (default 100)",
+        step_size - "How much to move per iteration (default 0.5)",
+        preserve_root - "Keep root node fixed (default true)"
+    ]
+}).
+
+%% validate_config(+Config)
+%
+%  Validate optimizer configuration.
+%
+validate_config(Config) :-
+    is_list(Config),
+    (   member(min_distance(D), Config)
+    ->  number(D), D > 0
+    ;   true
+    ),
+    (   member(iterations(I), Config)
+    ->  integer(I), I > 0
+    ;   true
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  Initialize the component.
+%
+init_component(_Name, _Config).
+
+%% optimize(+Positions, +Options, -OptimizedPositions)
+%
+%  Main entry point for component invocation.
+%
+optimize(Positions, Options, OptimizedPositions) :-
+    remove_overlaps(Positions, Options, OptimizedPositions, _Stats).
+
+% ============================================================================
+% OVERLAP REMOVAL ALGORITHM
+% ============================================================================
+
+%% remove_overlaps(+Positions, +Options, -NewPositions, -Stats)
+%
+%  Remove overlaps from node positions.
+%
+%  @param Positions    list - list of position(Id, X, Y)
+%  @param Options      list - optimizer options
+%  @param NewPositions list - positions with overlaps removed
+%  @param Stats        dict - optimization statistics
+%
+remove_overlaps(Positions, Options, NewPositions, Stats) :-
+    option_or_default(min_distance, Options, 50, MinDist),
+    option_or_default(iterations, Options, 100, MaxIterations),
+    option_or_default(step_size, Options, 0.5, StepSize),
+    option_or_default(preserve_root, Options, true, PreserveRoot),
+
+    % Find root if we need to preserve it
+    (   PreserveRoot == true,
+        Positions = [position(RootId, _, _) | _]
+    ->  FixedNodes = [RootId]
+    ;   FixedNodes = []
+    ),
+
+    % Run iterative overlap removal
+    overlap_removal_loop(Positions, MinDist, StepSize, FixedNodes, MaxIterations, 0,
+                         NewPositions, IterationsUsed, OverlapsRemoved),
+
+    Stats = stats{
+        iterations_used: IterationsUsed,
+        iterations_max: MaxIterations,
+        overlaps_removed: OverlapsRemoved,
+        min_distance: MinDist
+    }.
+
+overlap_removal_loop(Positions, _, _, _, MaxIter, Iter, Positions, Iter, 0) :-
+    Iter >= MaxIter,
+    !.
+overlap_removal_loop(Positions, MinDist, StepSize, FixedNodes, MaxIter, Iter, FinalPositions, IterUsed, TotalRemoved) :-
+    % Detect current overlaps
+    detect_overlaps(Positions, MinDist, Overlaps),
+
+    (   Overlaps = []
+    ->  % No overlaps, we're done
+        FinalPositions = Positions,
+        IterUsed = Iter,
+        TotalRemoved = 0
+    ;   % Apply separation
+        length(Overlaps, NumOverlaps),
+        apply_separations(Positions, Overlaps, MinDist, StepSize, FixedNodes, NewPositions),
+        NextIter is Iter + 1,
+        overlap_removal_loop(NewPositions, MinDist, StepSize, FixedNodes, MaxIter, NextIter,
+                            FinalPositions, IterUsed, RestRemoved),
+        TotalRemoved is NumOverlaps + RestRemoved
+    ).
+
+%% detect_overlaps(+Positions, +MinDist, -Overlaps)
+%
+%  Find all overlapping node pairs.
+%
+%  @param Positions list - list of position(Id, X, Y)
+%  @param MinDist   number - minimum distance threshold
+%  @param Overlaps  list - list of overlap(Id1, Id2, Dist, DX, DY)
+%
+detect_overlaps(Positions, MinDist, Overlaps) :-
+    findall(overlap(Id1, Id2, Dist, DX, DY),
+            (member(position(Id1, X1, Y1), Positions),
+             member(position(Id2, X2, Y2), Positions),
+             Id1 @< Id2,  % Avoid duplicates
+             DX is X2 - X1,
+             DY is Y2 - Y1,
+             Dist is sqrt(DX*DX + DY*DY),
+             Dist < MinDist),
+            Overlaps).
+
+%% compute_separation_vector(+X1, +Y1, +X2, +Y2, +MinDist, -SepX, -SepY)
+%
+%  Compute vector to separate two overlapping nodes.
+%
+compute_separation_vector(X1, Y1, X2, Y2, MinDist, SepX, SepY) :-
+    DX is X2 - X1,
+    DY is Y2 - Y1,
+    Dist is sqrt(DX*DX + DY*DY),
+
+    (   Dist < 0.1
+    ->  % Nodes at same position - push in random direction
+        random(R),
+        Angle is R * 2 * pi,
+        SepX is MinDist * cos(Angle),
+        SepY is MinDist * sin(Angle)
+    ;   % Push apart along connecting line
+        Overlap is MinDist - Dist,
+        SepX is (DX / Dist) * Overlap,
+        SepY is (DY / Dist) * Overlap
+    ).
+
+%% apply_separations(+Positions, +Overlaps, +MinDist, +StepSize, +FixedNodes, -NewPositions)
+%
+%  Apply separation forces for all overlaps.
+%
+apply_separations(Positions, Overlaps, MinDist, StepSize, FixedNodes, NewPositions) :-
+    % Accumulate displacement for each node
+    findall(Id-disp(0, 0), member(position(Id, _, _), Positions), InitDisp),
+    accumulate_displacements(Overlaps, MinDist, StepSize, InitDisp, FinalDisp),
+
+    % Apply displacements
+    findall(position(Id, NX, NY),
+            (member(position(Id, X, Y), Positions),
+             (   member(Id, FixedNodes)
+             ->  NX = X, NY = Y  % Don't move fixed nodes
+             ;   member(Id-disp(DispX, DispY), FinalDisp),
+                 NX is X + DispX,
+                 NY is Y + DispY
+             )),
+            NewPositions).
+
+accumulate_displacements([], _, _, Disp, Disp).
+accumulate_displacements([overlap(Id1, Id2, Dist, DX, DY) | Rest], MinDist, StepSize, DispIn, DispOut) :-
+    % Compute separation amount
+    (   Dist < 0.1
+    ->  % At same position - use random direction
+        random(R),
+        Angle is R * 2 * pi,
+        SepX is MinDist * StepSize * cos(Angle),
+        SepY is MinDist * StepSize * sin(Angle)
+    ;   Overlap is MinDist - Dist,
+        SepX is (DX / Dist) * Overlap * StepSize,
+        SepY is (DY / Dist) * Overlap * StepSize
+    ),
+
+    % Each node moves half the separation
+    HalfSepX is SepX / 2,
+    HalfSepY is SepY / 2,
+
+    % Update displacements for both nodes
+    update_displacement(Id1, -HalfSepX, -HalfSepY, DispIn, Disp1),
+    update_displacement(Id2, HalfSepX, HalfSepY, Disp1, Disp2),
+
+    accumulate_displacements(Rest, MinDist, StepSize, Disp2, DispOut).
+
+update_displacement(Id, AddX, AddY, DispIn, DispOut) :-
+    (   select(Id-disp(OldX, OldY), DispIn, Rest)
+    ->  NewX is OldX + AddX,
+        NewY is OldY + AddY,
+        DispOut = [Id-disp(NewX, NewY) | Rest]
+    ;   DispOut = [Id-disp(AddX, AddY) | DispIn]
+    ).
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+option_or_default(Key, Options, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+pi is 3.14159265358979.
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_overlap_removal :-
+    format('~n=== Overlap Removal Tests ===~n~n'),
+
+    % Test 1: Detect overlaps
+    format('Test 1: Detect overlaps...~n'),
+    TestPositions = [
+        position(a, 100, 100),
+        position(b, 120, 100),  % 20 units from a
+        position(c, 200, 200),  % Far from others
+        position(d, 105, 105)   % ~7 units from a
+    ],
+    detect_overlaps(TestPositions, 50, Overlaps),
+    length(Overlaps, NumOverlaps),
+    (   NumOverlaps > 0
+    ->  format('  PASS: Detected ~w overlaps~n', [NumOverlaps])
+    ;   format('  FAIL: No overlaps detected~n')
+    ),
+
+    % Test 2: Remove overlaps
+    format('~nTest 2: Remove overlaps...~n'),
+    remove_overlaps(TestPositions, [min_distance(50)], NewPositions, Stats),
+    detect_overlaps(NewPositions, 50, RemainingOverlaps),
+    (   RemainingOverlaps = []
+    ->  format('  PASS: All overlaps removed~n')
+    ;   length(RemainingOverlaps, Remaining),
+        format('  FAIL: ~w overlaps remain~n', [Remaining])
+    ),
+    format('  Stats: ~w~n', [Stats]),
+
+    % Test 3: Minimum distances maintained
+    format('~nTest 3: Minimum distances...~n'),
+    findall(Dist,
+            (member(position(Id1, X1, Y1), NewPositions),
+             member(position(Id2, X2, Y2), NewPositions),
+             Id1 @< Id2,
+             Dist is sqrt((X2-X1)^2 + (Y2-Y1)^2)),
+            Distances),
+    min_list(Distances, MinActual),
+    (   MinActual >= 49.9  % Allow small floating point error
+    ->  format('  PASS: Minimum distance ~2f >= 50~n', [MinActual])
+    ;   format('  FAIL: Minimum distance ~2f < 50~n', [MinActual])
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+:- initialization((
+    format('Overlap removal optimizer loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/render/svg_renderer.pl
+++ b/src/unifyweaver/mindmap/render/svg_renderer.pl
@@ -1,0 +1,478 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% svg_renderer.pl - SVG Renderer for Mind Maps
+%
+% Generates static SVG output from positioned mind map data.
+% Supports various node shapes, edge styles, and theming.
+%
+% Usage:
+%   ?- render_mindmap_svg(Nodes, Edges, Positions, Options, SVG).
+
+:- module(mindmap_render_svg, [
+    % Component interface
+    type_info/1,
+    validate_config/1,
+    init_component/2,
+    compile_component/4,
+    render/3,
+
+    % Direct API
+    render_mindmap_svg/5,           % render_mindmap_svg(+Nodes, +Edges, +Positions, +Options, -SVG)
+    render_node_svg/4,              % render_node_svg(+Node, +Position, +Options, -SVGElement)
+    render_edge_svg/5,              % render_edge_svg(+Edge, +Pos1, +Pos2, +Options, -SVGElement)
+
+    % Style helpers
+    node_style/3,                   % node_style(+NodeType, +Theme, -StyleAttrs)
+    edge_style/3,                   % edge_style(+EdgeType, +Theme, -StyleAttrs)
+
+    % Testing
+    test_svg_renderer/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% COMPONENT INTERFACE
+% ============================================================================
+
+%% type_info(-Info)
+%
+%  Component type information.
+%
+type_info(info{
+    name: svg,
+    category: mindmap_renderer,
+    description: "Static SVG output renderer",
+    version: "1.0.0",
+    file_extension: ".svg",
+    mime_type: "image/svg+xml",
+    parameters: [
+        width - "SVG width in pixels (default 1000)",
+        height - "SVG height in pixels (default 800)",
+        background - "Background color (default #ffffff)",
+        node_shape - "Node shape: ellipse, rectangle, diamond (default ellipse)",
+        edge_style - "Edge style: straight, bezier (default straight)",
+        theme - "Color theme: light, dark, colorful (default light)",
+        include_labels - "Include text labels (default true)",
+        font_family - "Font family (default sans-serif)",
+        font_size - "Base font size (default 12)"
+    ]
+}).
+
+%% validate_config(+Config)
+%
+%  Validate renderer configuration.
+%
+validate_config(Config) :-
+    is_list(Config),
+    (   member(width(W), Config)
+    ->  integer(W), W > 0
+    ;   true
+    ),
+    (   member(height(H), Config)
+    ->  integer(H), H > 0
+    ;   true
+    ).
+
+%% init_component(+Name, +Config)
+%
+%  Initialize the renderer.
+%
+init_component(_Name, _Config).
+
+%% compile_component(+Name, +Config, +Options, -Code)
+%
+%  Compile renderer to code (returns SVG template).
+%
+compile_component(_Name, _Config, _Options, Code) :-
+    Code = '<!-- SVG Mind Map Template -->'.
+
+%% render(+Data, +Options, -Output)
+%
+%  Main render entry point.
+%
+%  @param Data    term - render_data(Nodes, Edges, Positions, Styles)
+%  @param Options list - render options
+%  @param Output  atom - SVG string
+%
+render(render_data(Nodes, Edges, Positions, _Styles), Options, Output) :-
+    render_mindmap_svg(Nodes, Edges, Positions, Options, Output).
+
+% ============================================================================
+% SVG RENDERING
+% ============================================================================
+
+%% render_mindmap_svg(+Nodes, +Edges, +Positions, +Options, -SVG)
+%
+%  Render a complete mind map to SVG.
+%
+%  @param Nodes     list - list of node(Id, Props)
+%  @param Edges     list - list of edge(From, To, Props)
+%  @param Positions list - list of position(Id, X, Y)
+%  @param Options   list - rendering options
+%  @param SVG       atom - complete SVG document
+%
+render_mindmap_svg(Nodes, Edges, Positions, Options, SVG) :-
+    % Get options with defaults
+    option_or_default(width, Options, 1000, Width),
+    option_or_default(height, Options, 800, Height),
+    option_or_default(background, Options, '#ffffff', Background),
+    option_or_default(theme, Options, light, Theme),
+    option_or_default(margin, Options, 50, Margin),
+
+    % Auto-calculate viewBox if positions exceed default
+    calculate_viewbox(Positions, Margin, VBX, VBY, VBW, VBH),
+
+    % Build position lookup
+    build_position_lookup(Positions, PosLookup),
+
+    % Render edges (underneath nodes)
+    render_edges_svg(Edges, PosLookup, Options, Theme, EdgesContent),
+
+    % Render nodes
+    render_nodes_svg(Nodes, PosLookup, Options, Theme, NodesContent),
+
+    % Build complete SVG document
+    format(atom(SVG),
+'<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="~w" height="~w"
+     viewBox="~w ~w ~w ~w">
+  <defs>
+    <style>
+      .node-label { font-family: sans-serif; pointer-events: none; }
+      .node { cursor: pointer; }
+      .edge { fill: none; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="100%" height="100%" fill="~w"/>
+
+  <!-- Edges -->
+  <g class="edges">
+~w  </g>
+
+  <!-- Nodes -->
+  <g class="nodes">
+~w  </g>
+</svg>',
+        [Width, Height, VBX, VBY, VBW, VBH, Background, EdgesContent, NodesContent]).
+
+%% calculate_viewbox(+Positions, +Margin, -X, -Y, -W, -H)
+%
+%  Calculate viewBox to fit all nodes.
+%
+calculate_viewbox([], _, 0, 0, 1000, 800) :- !.
+calculate_viewbox(Positions, Margin, X, Y, W, H) :-
+    findall(PX, member(position(_, PX, _), Positions), Xs),
+    findall(PY, member(position(_, _, PY), Positions), Ys),
+    min_list(Xs, MinX),
+    max_list(Xs, MaxX),
+    min_list(Ys, MinY),
+    max_list(Ys, MaxY),
+    X is MinX - Margin,
+    Y is MinY - Margin,
+    W is MaxX - MinX + 2 * Margin,
+    H is MaxY - MinY + 2 * Margin.
+
+%% build_position_lookup(+Positions, -Lookup)
+%
+%  Build position lookup map.
+%
+build_position_lookup(Positions, Lookup) :-
+    findall(Id-pos(X, Y), member(position(Id, X, Y), Positions), Lookup).
+
+get_position(Id, Lookup, X, Y) :-
+    member(Id-pos(X, Y), Lookup),
+    !.
+get_position(_, _, 0, 0).
+
+% ============================================================================
+% NODE RENDERING
+% ============================================================================
+
+%% render_nodes_svg(+Nodes, +PosLookup, +Options, +Theme, -Content)
+%
+%  Render all nodes to SVG elements.
+%
+render_nodes_svg([], _, _, _, '').
+render_nodes_svg([node(Id, Props) | Rest], PosLookup, Options, Theme, Content) :-
+    get_position(Id, PosLookup, X, Y),
+    render_node_svg(node(Id, Props), pos(X, Y), Options, Theme, NodeSVG),
+    render_nodes_svg(Rest, PosLookup, Options, Theme, RestSVG),
+    atom_concat(NodeSVG, RestSVG, Content).
+
+%% render_node_svg(+Node, +Position, +Options, +Theme, -SVGElement)
+%
+%  Render a single node to SVG.
+%
+render_node_svg(node(Id, Props), pos(X, Y), Options, Theme, SVGElement) :-
+    % Get node properties
+    (member(label(Label), Props) -> true ; atom_string(Id, Label)),
+    (member(type(NodeType), Props) -> true ; NodeType = default),
+
+    % Get style
+    node_style(NodeType, Theme, StyleAttrs),
+    option_or_default(node_shape, Options, ellipse, Shape),
+    option_or_default(node_radius, Options, 40, Radius),
+    option_or_default(include_labels, Options, true, IncludeLabels),
+
+    % Get colors from style
+    member(fill(Fill), StyleAttrs),
+    member(stroke(Stroke), StyleAttrs),
+    member(stroke_width(StrokeWidth), StyleAttrs),
+    (member(text_color(TextColor), StyleAttrs) -> true ; TextColor = '#ffffff'),
+
+    % Render shape
+    render_shape(Shape, X, Y, Radius, Fill, Stroke, StrokeWidth, Id, ShapeSVG),
+
+    % Render label
+    (   IncludeLabels == true
+    ->  escape_xml(Label, EscapedLabel),
+        format(atom(LabelSVG),
+            '    <text x="~2f" y="~2f" text-anchor="middle" dominant-baseline="middle" fill="~w" class="node-label" font-size="12">~w</text>~n',
+            [X, Y, TextColor, EscapedLabel])
+    ;   LabelSVG = ''
+    ),
+
+    % Combine into group
+    format(atom(SVGElement),
+        '    <g class="node" data-id="~w">~n~w~w    </g>~n',
+        [Id, ShapeSVG, LabelSVG]).
+
+%% render_shape(+Shape, +X, +Y, +R, +Fill, +Stroke, +SW, +Id, -SVG)
+%
+%  Render a node shape.
+%
+render_shape(ellipse, X, Y, R, Fill, Stroke, SW, _Id, SVG) :-
+    !,
+    format(atom(SVG),
+        '      <ellipse cx="~2f" cy="~2f" rx="~w" ry="~w" fill="~w" stroke="~w" stroke-width="~w"/>~n',
+        [X, Y, R, R, Fill, Stroke, SW]).
+
+render_shape(rectangle, X, Y, R, Fill, Stroke, SW, _Id, SVG) :-
+    !,
+    W is R * 2,
+    H is R * 1.5,
+    RX is X - R,
+    RY is Y - H/2,
+    format(atom(SVG),
+        '      <rect x="~2f" y="~2f" width="~w" height="~2f" rx="5" fill="~w" stroke="~w" stroke-width="~w"/>~n',
+        [RX, RY, W, H, Fill, Stroke, SW]).
+
+render_shape(diamond, X, Y, R, Fill, Stroke, SW, _Id, SVG) :-
+    !,
+    % Diamond points
+    Top = [X, Y-R],
+    Right = [X+R, Y],
+    Bottom = [X, Y+R],
+    Left = [X-R, Y],
+    Top = [TX, TY], Right = [RiX, RiY], Bottom = [BX, BY], Left = [LX, LY],
+    format(atom(SVG),
+        '      <polygon points="~2f,~2f ~2f,~2f ~2f,~2f ~2f,~2f" fill="~w" stroke="~w" stroke-width="~w"/>~n',
+        [TX, TY, RiX, RiY, BX, BY, LX, LY, Fill, Stroke, SW]).
+
+render_shape(_, X, Y, R, Fill, Stroke, SW, Id, SVG) :-
+    % Default to ellipse
+    render_shape(ellipse, X, Y, R, Fill, Stroke, SW, Id, SVG).
+
+% ============================================================================
+% EDGE RENDERING
+% ============================================================================
+
+%% render_edges_svg(+Edges, +PosLookup, +Options, +Theme, -Content)
+%
+%  Render all edges to SVG elements.
+%
+render_edges_svg([], _, _, _, '').
+render_edges_svg([edge(From, To, Props) | Rest], PosLookup, Options, Theme, Content) :-
+    get_position(From, PosLookup, X1, Y1),
+    get_position(To, PosLookup, X2, Y2),
+    render_edge_svg(edge(From, To, Props), pos(X1, Y1), pos(X2, Y2), Options, Theme, EdgeSVG),
+    render_edges_svg(Rest, PosLookup, Options, Theme, RestSVG),
+    atom_concat(EdgeSVG, RestSVG, Content).
+
+%% render_edge_svg(+Edge, +Pos1, +Pos2, +Options, +Theme, -SVGElement)
+%
+%  Render a single edge to SVG.
+%
+render_edge_svg(edge(_From, _To, Props), pos(X1, Y1), pos(X2, Y2), Options, Theme, SVGElement) :-
+    % Get edge type
+    (member(type(EdgeType), Props) -> true ; EdgeType = default),
+
+    % Get style
+    edge_style(EdgeType, Theme, StyleAttrs),
+    option_or_default(edge_style, Options, straight, EdgeStyle),
+
+    member(stroke(Stroke), StyleAttrs),
+    member(stroke_width(StrokeWidth), StyleAttrs),
+
+    % Render based on style
+    render_edge_path(EdgeStyle, X1, Y1, X2, Y2, Stroke, StrokeWidth, SVGElement).
+
+%% render_edge_path(+Style, +X1, +Y1, +X2, +Y2, +Stroke, +SW, -SVG)
+%
+%  Render edge path based on style.
+%
+render_edge_path(straight, X1, Y1, X2, Y2, Stroke, SW, SVG) :-
+    !,
+    format(atom(SVG),
+        '    <line x1="~2f" y1="~2f" x2="~2f" y2="~2f" stroke="~w" stroke-width="~w" class="edge"/>~n',
+        [X1, Y1, X2, Y2, Stroke, SW]).
+
+render_edge_path(bezier, X1, Y1, X2, Y2, Stroke, SW, SVG) :-
+    !,
+    % Control points for smooth curve
+    MidX is (X1 + X2) / 2,
+    MidY is (Y1 + Y2) / 2,
+    DX is X2 - X1,
+    DY is Y2 - Y1,
+    % Perpendicular offset for control point
+    CX is MidX - DY * 0.2,
+    CY is MidY + DX * 0.2,
+    format(atom(SVG),
+        '    <path d="M ~2f ~2f Q ~2f ~2f ~2f ~2f" stroke="~w" stroke-width="~w" class="edge"/>~n',
+        [X1, Y1, CX, CY, X2, Y2, Stroke, SW]).
+
+render_edge_path(_, X1, Y1, X2, Y2, Stroke, SW, SVG) :-
+    % Default to straight
+    render_edge_path(straight, X1, Y1, X2, Y2, Stroke, SW, SVG).
+
+% ============================================================================
+% THEMES AND STYLES
+% ============================================================================
+
+%% node_style(+NodeType, +Theme, -StyleAttrs)
+%
+%  Get style attributes for a node type and theme.
+%
+node_style(root, light, [fill('#4a90d9'), stroke('#2c5a8c'), stroke_width(3), text_color('#ffffff')]) :- !.
+node_style(root, dark, [fill('#5a9ce9'), stroke('#3c6a9c'), stroke_width(3), text_color('#ffffff')]) :- !.
+node_style(hub, light, [fill('#6ab04c'), stroke('#4a904c'), stroke_width(2), text_color('#ffffff')]) :- !.
+node_style(hub, dark, [fill('#7ac05c'), stroke('#5aa05c'), stroke_width(2), text_color('#ffffff')]) :- !.
+node_style(branch, light, [fill('#f0932b'), stroke('#c07020'), stroke_width(2), text_color('#ffffff')]) :- !.
+node_style(branch, dark, [fill('#ffaa4b'), stroke('#d08030'), stroke_width(2), text_color('#000000')]) :- !.
+node_style(leaf, light, [fill('#eb4d4b'), stroke('#cb2d2b'), stroke_width(1), text_color('#ffffff')]) :- !.
+node_style(leaf, dark, [fill('#fb5d5b'), stroke('#db3d3b'), stroke_width(1), text_color('#ffffff')]) :- !.
+node_style(default, light, [fill('#4a90d9'), stroke('#2c5a8c'), stroke_width(2), text_color('#ffffff')]) :- !.
+node_style(default, dark, [fill('#5a9ce9'), stroke('#3c6a9c'), stroke_width(2), text_color('#ffffff')]) :- !.
+node_style(_, Theme, Style) :-
+    node_style(default, Theme, Style).
+
+%% edge_style(+EdgeType, +Theme, -StyleAttrs)
+%
+%  Get style attributes for an edge type and theme.
+%
+edge_style(default, light, [stroke('#666666'), stroke_width(2)]) :- !.
+edge_style(default, dark, [stroke('#999999'), stroke_width(2)]) :- !.
+edge_style(strong, light, [stroke('#333333'), stroke_width(3)]) :- !.
+edge_style(strong, dark, [stroke('#cccccc'), stroke_width(3)]) :- !.
+edge_style(weak, light, [stroke('#aaaaaa'), stroke_width(1)]) :- !.
+edge_style(weak, dark, [stroke('#666666'), stroke_width(1)]) :- !.
+edge_style(_, Theme, Style) :-
+    edge_style(default, Theme, Style).
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+option_or_default(Key, Options, Default, Value) :-
+    Term =.. [Key, Value],
+    (   member(Term, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+%% escape_xml(+Text, -Escaped)
+%
+%  Escape special XML characters.
+%
+escape_xml(Text, Escaped) :-
+    atom_string(Text, Str),
+    escape_xml_chars(Str, EscStr),
+    atom_string(Escaped, EscStr).
+
+escape_xml_chars([], []).
+escape_xml_chars([C | Rest], Escaped) :-
+    escape_char(C, EscC),
+    escape_xml_chars(Rest, RestEsc),
+    append(EscC, RestEsc, Escaped).
+
+escape_char(0'<, "&lt;") :- !.
+escape_char(0'>, "&gt;") :- !.
+escape_char(0'&, "&amp;") :- !.
+escape_char(0'", "&quot;") :- !.
+escape_char(0'', "&#39;") :- !.
+escape_char(C, [C]).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_svg_renderer :-
+    format('~n=== SVG Renderer Tests ===~n~n'),
+
+    % Test data
+    Nodes = [
+        node(root, [label("Central Topic"), type(root)]),
+        node(a, [label("Branch A"), type(branch)]),
+        node(b, [label("Branch B"), type(branch)]),
+        node(c, [label("Leaf C"), type(leaf)])
+    ],
+    Edges = [
+        edge(root, a, []),
+        edge(root, b, []),
+        edge(a, c, [])
+    ],
+    Positions = [
+        position(root, 500, 400),
+        position(a, 350, 550),
+        position(b, 650, 550),
+        position(c, 300, 700)
+    ],
+
+    % Test 1: Basic rendering
+    format('Test 1: Basic SVG rendering...~n'),
+    render_mindmap_svg(Nodes, Edges, Positions, [], SVG),
+    (   sub_atom(SVG, _, _, _, '<svg')
+    ->  format('  PASS: SVG document generated~n')
+    ;   format('  FAIL: Invalid SVG~n')
+    ),
+
+    % Test 2: Contains nodes
+    format('~nTest 2: Contains node elements...~n'),
+    (   sub_atom(SVG, _, _, _, 'class="node"')
+    ->  format('  PASS: Node elements present~n')
+    ;   format('  FAIL: No node elements~n')
+    ),
+
+    % Test 3: Contains edges
+    format('~nTest 3: Contains edge elements...~n'),
+    (   sub_atom(SVG, _, _, _, 'class="edge"')
+    ->  format('  PASS: Edge elements present~n')
+    ;   format('  FAIL: No edge elements~n')
+    ),
+
+    % Test 4: Dark theme
+    format('~nTest 4: Dark theme rendering...~n'),
+    render_mindmap_svg(Nodes, Edges, Positions, [theme(dark), background('#1a1a2e')], DarkSVG),
+    (   sub_atom(DarkSVG, _, _, _, '#1a1a2e')
+    ->  format('  PASS: Dark background applied~n')
+    ;   format('  FAIL: Theme not applied~n')
+    ),
+
+    % Test 5: Bezier edges
+    format('~nTest 5: Bezier edge style...~n'),
+    render_mindmap_svg(Nodes, Edges, Positions, [edge_style(bezier)], BezierSVG),
+    (   sub_atom(BezierSVG, _, _, _, '<path')
+    ->  format('  PASS: Bezier paths generated~n')
+    ;   format('  FAIL: No bezier paths~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+:- initialization((
+    format('SVG renderer module loaded~n', [])
+), now).


### PR DESCRIPTION
### Summary

This PR introduces a declarative Prolog DSL for specifying mind map structure, layout, and styling that compiles to multiple output targets. The system preserves existing Python mind mapping tools while providing a composable, target-independent specification layer.

### Key Features

- **Declarative DSL**: Specify mind maps using `mindmap_node/2`, `mindmap_edge/3`, and `declare_mindmap_layout/3`
- **Multiple Layout Algorithms**: Radial, force-directed, and hierarchical layouts
- **Optimization Pipeline**: Composable stages for overlap removal and layout refinement
- **SVG Rendering**: Full SVG output with node shapes, edge styles, and themes
- **Component Registry Integration**: Extensible via UnifyWeaver's component system

### Files Added

```
docs/design/mindmap_declarative_targets/
├── PROPOSAL.md              # Executive summary
├── PHILOSOPHY.md            # Design principles
├── SPECIFICATION.md         # Complete DSL reference
└── IMPLEMENTATION_PLAN.md   # Phased roadmap (updated with progress)

src/unifyweaver/mindmap/
├── mindmap_dsl.pl           # Core DSL predicates
├── mindmap_components.pl    # Component registry integration
├── mindmap_ir.pl            # Intermediate representation
├── layout/
│   ├── radial.pl            # Radial layout algorithm
│   ├── force_directed.pl    # Force-directed physics simulation
│   └── layout_pipeline.pl   # Pipeline orchestration
├── optimize/
│   └── overlap_removal.pl   # Overlap removal optimizer
└── render/
    └── svg_renderer.pl      # SVG output generation
```

### Usage Example

```prolog
% Define nodes
declare_mindmap_node(root, [label("Central Topic"), type(root)]).
declare_mindmap_node(a, [label("Branch A"), parent(root)]).
declare_mindmap_node(b, [label("Branch B"), parent(root)]).

% Define layout
declare_mindmap_layout(my_map, force_directed, [
    iterations(300),
    min_distance(50)
]).

% Generate SVG
?- generate_mindmap_svg(my_map, SVG).

% Or use pipeline
?- execute_pipeline(Graph, [
       stage(radial, []),
       optimize(overlap_removal, [min_distance(50)])
   ], Positions).
```

### Design Highlights

- **Separation of Concerns**: Specification, layout, optimization, and rendering are independent
- **Target Independence**: Same spec compiles to SVG, positions, or (future) native formats
- **Composable Pipeline**: Mix layout algorithms and optimizers in configurable stages
- **Progressive Enhancement**: Simple specs use defaults; complex specs add customization
- **Existing Tool Preservation**: Python tools remain available; DSL is an alternative interface

### Implementation Status

| Phase | Status | Notes |
|-------|--------|-------|
| Phase 1: Core DSL | ✅ Complete | All predicates implemented |
| Phase 2: Layout | ✅ Complete | Radial, force-directed, pipeline |
| Phase 3: SVG Renderer | ✅ Complete | Shapes, styles, themes |
| Phase 4: Custom Components | 🔲 Pending | Future work |
| Phase 5: Styling System | 🔲 Pending | Future work |
| Phase 6: Additional Targets | 🔲 Pending | .smmx, .mm, GraphViz |
| Phase 7: Interactive Features | 🔲 Pending | Pan, zoom, hyperlinks |

### Test Plan

- [ ] Load modules in SWI-Prolog without errors
- [ ] Run `test_mindmap_dsl/0` - node/edge declaration, SVG generation
- [ ] Run `test_mindmap_ir/0` - IR construction and traversal
- [ ] Run `test_layout_pipeline/0` - pipeline execution
- [ ] Run `test_svg_renderer/0` - SVG output validation
- [ ] Verify generated SVG renders correctly in browser
- [ ] Test with existing mind map data from Python tools

### Related Documents

- [PROPOSAL.md](docs/design/mindmap_declarative_targets/PROPOSAL.md) - Full proposal
- [SPECIFICATION.md](docs/design/mindmap_declarative_targets/SPECIFICATION.md) - DSL reference
- [IMPLEMENTATION_PLAN.md](docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md) - Roadmap

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
