### PR TITLE
feat(mindmap): Add component(Name) reference syntax for layouts

### DIFF
--- a/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
+++ b/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
@@ -154,7 +154,7 @@ system should leverage these existing components.
 - [x] Document how to use existing custom components for layouts
 - [x] Create example custom layout using `custom_python`
 - [x] Create example custom optimizer using `custom_go`
-- [ ] Add `component(Name)` reference syntax to mind map specs
+- [x] Add `component(Name)` reference syntax to mind map specs
 
 ### 4.2 Mind Map-Specific Custom Components
 

--- a/src/unifyweaver/mindmap/mindmap_components.pl
+++ b/src/unifyweaver/mindmap/mindmap_components.pl
@@ -25,6 +25,11 @@
     list_mindmap_optimizers/1,      % list_mindmap_optimizers(-Optimizers)
     list_mindmap_renderers/1,       % list_mindmap_renderers(-Renderers)
 
+    % Component existence checks (supports component(Name) syntax)
+    layout_exists/1,                % layout_exists(+NameOrComponent)
+    optimizer_exists/1,             % optimizer_exists(+NameOrComponent)
+    renderer_exists/1,              % renderer_exists(+NameOrComponent)
+
     % Component invocation
     invoke_layout/4,                % invoke_layout(+Name, +Graph, +Options, -Positions)
     invoke_optimizer/4,             % invoke_optimizer(+Name, +Positions, +Options, -OptimizedPositions)
@@ -148,6 +153,40 @@ register_mindmap_renderer(Name, Module, Options) :-
 % ============================================================================
 % QUERY PREDICATES
 % ============================================================================
+
+%% layout_exists(+Name)
+%
+%  Check if a layout component exists by name.
+%  Supports component(Name) syntax for explicit component references.
+%
+layout_exists(component(Name)) :-
+    !,
+    layout_exists(Name).
+layout_exists(Name) :-
+    atom(Name),
+    get_layout_module(Name, _).
+
+%% optimizer_exists(+Name)
+%
+%  Check if an optimizer component exists by name.
+%
+optimizer_exists(component(Name)) :-
+    !,
+    optimizer_exists(Name).
+optimizer_exists(Name) :-
+    atom(Name),
+    get_optimizer_module(Name, _).
+
+%% renderer_exists(+Name)
+%
+%  Check if a renderer component exists by name.
+%
+renderer_exists(component(Name)) :-
+    !,
+    renderer_exists(Name).
+renderer_exists(Name) :-
+    atom(Name),
+    get_renderer_module(Name, _).
 
 %% list_mindmap_layouts(-Layouts)
 %


### PR DESCRIPTION
## Summary

Adds support for referencing registered components by name in mindmap layout specifications, enabling pluggable custom implementations.

**Key Features:**
- New `component(Name)` syntax for layout algorithm specifications
- Automatic fallback to registered components for unknown algorithm names
- Helper predicates for checking component existence
- Completes the final task in IMPLEMENTATION_PLAN.md Phase 4.1

## Changes

### Modified Files

| File | Description |
|------|-------------|
| `src/unifyweaver/mindmap/mindmap_dsl.pl` | Add component dispatch to compute_layout/5 |
| `src/unifyweaver/mindmap/mindmap_components.pl` | Add existence check predicates |
| `docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md` | Mark task complete |

## Usage

### Before (built-in algorithms only)

```prolog
% Only built-in algorithms: radial, force_directed, hierarchical
declare_mindmap_layout(my_map, force_directed, [
    iterations(300)
]).
```

### After (component references)

```prolog
% Use a registered custom component
declare_mindmap_layout(my_map, component(my_custom_layout), [
    custom_param(value)
]).

% Built-in algorithms still work
declare_mindmap_layout(other_map, radial, []).

% Unknown atoms are also checked against registry
declare_mindmap_layout(third_map, my_registered_layout, []).
```

### Checking Component Availability

```prolog
?- layout_exists(component(my_layout)).
true.

?- optimizer_exists(overlap_removal).
true.

?- renderer_exists(component(custom_svg)).
false.
```

## Implementation Details

### compute_layout/5 dispatch order

1. `component(Name)` - Explicit component reference, invokes via registry
2. `radial` - Built-in radial layout
3. `force_directed` - Built-in force-directed layout
4. `hierarchical` - Built-in hierarchical layout
5. Any atom - Try registry lookup before failing
6. Unknown - Warning message, empty positions

### New Predicates

```prolog
% In mindmap_components.pl
layout_exists(+NameOrComponent)    % Check layout component exists
optimizer_exists(+NameOrComponent) % Check optimizer component exists
renderer_exists(+NameOrComponent)  % Check renderer component exists
```

## Test Plan

- [ ] Verify `component(Name)` syntax invokes registered layout
- [ ] Verify built-in algorithms still work (radial, force_directed, hierarchical)
- [ ] Verify unknown atoms are checked against registry
- [ ] Verify `layout_exists/1` returns correct results
- [ ] Verify error message for missing components

## Related

- Completes Phase 4.1 of IMPLEMENTATION_PLAN.md
- Builds on mindmap_components.pl component registry integration

---

Generated with [Claude Code](https://claude.com/claude-code)
