### PR TITLE
Cross-Target Glue Integration for Mind Map DSL

### DIFF
--- a/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
+++ b/docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md
@@ -67,7 +67,7 @@ This document outlines the phased implementation of the declarative mind map lay
 **Tasks:**
 - [x] Extract algorithm parameters from existing Python
 - [x] Create Prolog interface predicates
-- [ ] Add Python bindings for heavy computation
+- [x] Add Python bindings for heavy computation (via cross-target glue)
 - [x] Implement fallback pure-Prolog version for small graphs
 
 ### 2.2 Port Optimization Algorithms
@@ -194,6 +194,7 @@ declare_binding(python, force_layout/3, 'mindmap.layout.force_directed',
 - [x] Define bindings for optimization passes
 - [x] Create Python implementation module (`scripts/unifyweaver/mindmap/`)
 - [x] Add NumPy/SciPy acceleration
+- [x] Add JSON Lines I/O for cross-target glue (`scripts/unifyweaver/mindmap/io.py`)
 
 ## Phase 5: Styling System
 

--- a/scripts/unifyweaver/mindmap/__init__.py
+++ b/scripts/unifyweaver/mindmap/__init__.py
@@ -8,10 +8,14 @@ Mind map layout, optimization, and rendering implementations.
 
 These modules provide NumPy/SciPy-accelerated implementations of
 layout algorithms and optimization passes for mind map visualization.
+
+The io module provides JSON Lines I/O for cross-target communication
+with the Prolog DSL via pipes.
 """
 
 from . import layout
 from . import optimize
 from . import render
+from . import io
 
-__all__ = ['layout', 'optimize', 'render']
+__all__ = ['layout', 'optimize', 'render', 'io']

--- a/scripts/unifyweaver/mindmap/io.py
+++ b/scripts/unifyweaver/mindmap/io.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Copyright (c) 2025 John William Creighton (s243a)
+#
+# JSON Lines I/O for Mind Map Objects
+#
+# Provides streaming I/O for mindmap data using JSON Lines format,
+# enabling cross-target communication with Prolog via pipes.
+
+"""
+JSON Lines I/O for mindmap objects.
+
+This module provides readers and writers for mindmap data in JSON Lines format,
+supporting streaming communication with the Prolog DSL via Unix pipes.
+
+Usage:
+    from unifyweaver.mindmap.io import read_nodes, write_positions
+
+    # Read nodes from stdin
+    for node in read_nodes(sys.stdin):
+        process(node)
+
+    # Write positions to stdout
+    write_positions(positions, sys.stdout)
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field, asdict
+from typing import (
+    Dict, List, Tuple, Optional, Any, Iterator,
+    TextIO, Union, Protocol, TypeVar, Generic
+)
+
+
+# ============================================================================
+# DATA CLASSES
+# ============================================================================
+
+@dataclass
+class MindmapNode:
+    """A mind map node."""
+    id: str
+    label: str = ""
+    node_type: str = "default"
+    parent: Optional[str] = None
+    link: Optional[str] = None
+    cluster: Optional[str] = None
+    props: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "type": "node",
+            "id": self.id,
+            "label": self.label,
+            "node_type": self.node_type,
+            "parent": self.parent,
+            "link": self.link,
+            "cluster": self.cluster,
+            "props": self.props
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'MindmapNode':
+        """Create from JSON dict."""
+        return cls(
+            id=d["id"],
+            label=d.get("label", ""),
+            node_type=d.get("node_type", "default"),
+            parent=d.get("parent"),
+            link=d.get("link"),
+            cluster=d.get("cluster"),
+            props=d.get("props", {})
+        )
+
+
+@dataclass
+class MindmapEdge:
+    """A mind map edge."""
+    from_id: str
+    to_id: str
+    edge_type: str = "default"
+    weight: float = 1.0
+    label: Optional[str] = None
+    props: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "type": "edge",
+            "from": self.from_id,
+            "to": self.to_id,
+            "edge_type": self.edge_type,
+            "weight": self.weight,
+            "label": self.label,
+            "props": self.props
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'MindmapEdge':
+        """Create from JSON dict."""
+        return cls(
+            from_id=d["from"],
+            to_id=d["to"],
+            edge_type=d.get("edge_type", "default"),
+            weight=d.get("weight", 1.0),
+            label=d.get("label"),
+            props=d.get("props", {})
+        )
+
+
+@dataclass
+class MindmapPosition:
+    """A node position."""
+    id: str
+    x: float
+    y: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "type": "position",
+            "id": self.id,
+            "x": self.x,
+            "y": self.y
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'MindmapPosition':
+        """Create from JSON dict."""
+        return cls(
+            id=d["id"],
+            x=d["x"],
+            y=d["y"]
+        )
+
+
+@dataclass
+class MindmapGraph:
+    """A complete mind map graph."""
+    id: str
+    nodes: List[MindmapNode] = field(default_factory=list)
+    edges: List[MindmapEdge] = field(default_factory=list)
+    positions: List[MindmapPosition] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "type": "graph",
+            "id": self.id,
+            "nodes": [n.to_dict() for n in self.nodes],
+            "edges": [e.to_dict() for e in self.edges],
+            "positions": [p.to_dict() for p in self.positions]
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'MindmapGraph':
+        """Create from JSON dict."""
+        return cls(
+            id=d["id"],
+            nodes=[MindmapNode.from_dict(n) for n in d.get("nodes", [])],
+            edges=[MindmapEdge.from_dict(e) for e in d.get("edges", [])],
+            positions=[MindmapPosition.from_dict(p) for p in d.get("positions", [])]
+        )
+
+
+# Type for any mindmap object
+MindmapObject = Union[MindmapNode, MindmapEdge, MindmapPosition, MindmapGraph]
+
+
+# ============================================================================
+# PROTOCOL ABSTRACTION
+# ============================================================================
+
+class MindmapProtocol(Protocol):
+    """Protocol interface for mindmap data serialization."""
+
+    def read(self, stream: TextIO) -> Iterator[MindmapObject]:
+        """Read objects from stream."""
+        ...
+
+    def write(self, obj: MindmapObject, stream: TextIO) -> None:
+        """Write object to stream."""
+        ...
+
+
+class JsonLinesProtocol:
+    """JSON Lines protocol implementation."""
+
+    def read(self, stream: TextIO) -> Iterator[MindmapObject]:
+        """Read mindmap objects from JSON Lines stream."""
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                obj = json.loads(line)
+                obj_type = obj.get("type")
+
+                if obj_type == "node":
+                    yield MindmapNode.from_dict(obj)
+                elif obj_type == "edge":
+                    yield MindmapEdge.from_dict(obj)
+                elif obj_type == "position":
+                    yield MindmapPosition.from_dict(obj)
+                elif obj_type == "graph":
+                    yield MindmapGraph.from_dict(obj)
+            except json.JSONDecodeError:
+                continue
+
+    def write(self, obj: MindmapObject, stream: TextIO) -> None:
+        """Write mindmap object as JSON line."""
+        json_str = json.dumps(obj.to_dict(), ensure_ascii=False)
+        print(json_str, file=stream)
+
+
+# Default protocol instance
+DEFAULT_PROTOCOL = JsonLinesProtocol()
+
+
+# ============================================================================
+# READER FUNCTIONS
+# ============================================================================
+
+def read_jsonl(stream: TextIO = sys.stdin) -> Iterator[Dict[str, Any]]:
+    """Read raw JSON objects from JSON Lines stream."""
+    for line in stream:
+        line = line.strip()
+        if line:
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def read_objects(stream: TextIO = sys.stdin) -> Iterator[MindmapObject]:
+    """Read typed mindmap objects from JSON Lines stream."""
+    yield from DEFAULT_PROTOCOL.read(stream)
+
+
+def read_nodes(stream: TextIO = sys.stdin) -> Iterator[MindmapNode]:
+    """Read only node objects from stream."""
+    for obj in read_objects(stream):
+        if isinstance(obj, MindmapNode):
+            yield obj
+
+
+def read_edges(stream: TextIO = sys.stdin) -> Iterator[MindmapEdge]:
+    """Read only edge objects from stream."""
+    for obj in read_objects(stream):
+        if isinstance(obj, MindmapEdge):
+            yield obj
+
+
+def read_positions(stream: TextIO = sys.stdin) -> Iterator[MindmapPosition]:
+    """Read only position objects from stream."""
+    for obj in read_objects(stream):
+        if isinstance(obj, MindmapPosition):
+            yield obj
+
+
+def read_positions_dict(stream: TextIO = sys.stdin) -> Dict[str, Tuple[float, float]]:
+    """Read positions as dict {id: (x, y)}."""
+    return {pos.id: (pos.x, pos.y) for pos in read_positions(stream)}
+
+
+def read_graph(stream: TextIO = sys.stdin) -> Optional[MindmapGraph]:
+    """Read a complete graph object from stream."""
+    for obj in read_objects(stream):
+        if isinstance(obj, MindmapGraph):
+            return obj
+    return None
+
+
+def read_all(stream: TextIO = sys.stdin) -> Tuple[
+    List[MindmapNode], List[MindmapEdge], List[MindmapPosition]
+]:
+    """Read all objects, grouped by type."""
+    nodes = []
+    edges = []
+    positions = []
+
+    for obj in read_objects(stream):
+        if isinstance(obj, MindmapNode):
+            nodes.append(obj)
+        elif isinstance(obj, MindmapEdge):
+            edges.append(obj)
+        elif isinstance(obj, MindmapPosition):
+            positions.append(obj)
+
+    return nodes, edges, positions
+
+
+# ============================================================================
+# WRITER FUNCTIONS
+# ============================================================================
+
+def write_jsonl(obj: Dict[str, Any], stream: TextIO = sys.stdout) -> None:
+    """Write a JSON object as a single line."""
+    print(json.dumps(obj, ensure_ascii=False), file=stream)
+
+
+def write_object(obj: MindmapObject, stream: TextIO = sys.stdout) -> None:
+    """Write a mindmap object as JSON line."""
+    DEFAULT_PROTOCOL.write(obj, stream)
+
+
+def write_node(node: MindmapNode, stream: TextIO = sys.stdout) -> None:
+    """Write a node object."""
+    write_object(node, stream)
+
+
+def write_edge(edge: MindmapEdge, stream: TextIO = sys.stdout) -> None:
+    """Write an edge object."""
+    write_object(edge, stream)
+
+
+def write_position(
+    node_id: str, x: float, y: float, stream: TextIO = sys.stdout
+) -> None:
+    """Write a position object."""
+    pos = MindmapPosition(id=node_id, x=x, y=y)
+    write_object(pos, stream)
+
+
+def write_positions(
+    positions: Dict[str, Tuple[float, float]],
+    stream: TextIO = sys.stdout
+) -> None:
+    """Write positions dict as JSON Lines."""
+    for node_id, (x, y) in positions.items():
+        write_position(node_id, x, y, stream)
+
+
+def write_graph(graph: MindmapGraph, stream: TextIO = sys.stdout) -> None:
+    """Write a complete graph object."""
+    write_object(graph, stream)
+
+
+# ============================================================================
+# CONVENIENCE FUNCTIONS FOR LAYOUT/OPTIMIZER INTEGRATION
+# ============================================================================
+
+def positions_from_dict(d: Dict[str, Any]) -> Dict[str, Tuple[float, float]]:
+    """Convert JSON dict to positions dict."""
+    positions = d.get("positions", {})
+    return {k: tuple(v) for k, v in positions.items()}
+
+
+def positions_to_list(
+    positions: Dict[str, Tuple[float, float]]
+) -> List[Dict[str, Any]]:
+    """Convert positions dict to list of position dicts."""
+    return [
+        {"type": "position", "id": k, "x": v[0], "y": v[1]}
+        for k, v in positions.items()
+    ]
+
+
+def graph_from_dict(d: Dict[str, Any]) -> Tuple[
+    Dict[str, Dict[str, Any]],  # nodes: {id: props}
+    List[Tuple[str, str]],      # edges: [(from, to)]
+    Dict[str, Any]              # options
+]:
+    """
+    Convert JSON graph dict to layout-friendly format.
+
+    Returns:
+        nodes: {id: {label, type, ...}}
+        edges: [(from_id, to_id)]
+        options: layout options
+    """
+    nodes = {}
+    for n in d.get("nodes", []):
+        node_id = n.get("id")
+        if node_id:
+            nodes[node_id] = n.get("props", {})
+            nodes[node_id]["label"] = n.get("label", "")
+            nodes[node_id]["type"] = n.get("node_type", "default")
+
+    edges = []
+    for e in d.get("edges", []):
+        from_id = e.get("from")
+        to_id = e.get("to")
+        if from_id and to_id:
+            edges.append((from_id, to_id))
+
+    options = d.get("options", {})
+
+    return nodes, edges, options
+
+
+# ============================================================================
+# MAIN ENTRY POINT (for testing)
+# ============================================================================
+
+def main():
+    """Test JSON Lines I/O by echoing input."""
+    import sys
+
+    print("Reading mindmap objects from stdin...", file=sys.stderr)
+
+    nodes, edges, positions = read_all(sys.stdin)
+
+    print(f"Read {len(nodes)} nodes, {len(edges)} edges, {len(positions)} positions",
+          file=sys.stderr)
+
+    # Echo back
+    for node in nodes:
+        write_object(node)
+    for edge in edges:
+        write_object(edge)
+    for pos in positions:
+        write_object(pos)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unifyweaver/mindmap/glue/mindmap_glue.pl
+++ b/src/unifyweaver/mindmap/glue/mindmap_glue.pl
@@ -1,0 +1,559 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% mindmap_glue.pl - Cross-Target Glue Integration for Mind Map DSL
+%
+% Integrates the mindmap DSL with UnifyWeaver's cross-target glue system,
+% enabling seamless communication between Prolog (DSL) and Python (computation).
+%
+% Key concepts:
+% - Prolog handles DSL definition and orchestration
+% - Python handles heavy computation (layout, optimization)
+% - Data flows via JSON Lines over pipes
+%
+% Usage:
+%   ?- declare_mindmap_target(force_layout, python).
+%   ?- execute_mindmap_pipeline(my_map, Positions).
+
+:- module(mindmap_glue, [
+    % Target declarations
+    declare_mindmap_target/2,       % declare_mindmap_target(+Predicate, +Target)
+    declare_mindmap_target/3,       % declare_mindmap_target(+Predicate, +Target, +Options)
+    get_mindmap_target/2,           % get_mindmap_target(+Predicate, -Target)
+
+    % Pipeline execution
+    execute_mindmap_pipeline/2,     % execute_mindmap_pipeline(+MapId, -Result)
+    execute_mindmap_pipeline/3,     % execute_mindmap_pipeline(+MapId, +Options, -Result)
+
+    % Stage execution
+    execute_layout_stage/4,         % execute_layout_stage(+Graph, +Algorithm, +Options, -Positions)
+    execute_optimize_stage/4,       % execute_optimize_stage(+Positions, +Optimizer, +Options, -NewPositions)
+
+    % Glue code generation
+    generate_mindmap_glue/3,        % generate_mindmap_glue(+Stage, +Target, -GlueCode)
+    generate_pipeline_glue/3,       % generate_pipeline_glue(+Pipeline, +Options, -Script)
+
+    % Protocol handling
+    create_mindmap_pipe/3,          % create_mindmap_pipe(+Direction, +Protocol, -Pipe)
+    send_mindmap_data/3,            % send_mindmap_data(+Pipe, +Data, +Protocol)
+    receive_mindmap_data/3,         % receive_mindmap_data(+Pipe, -Data, +Protocol)
+
+    % Testing
+    test_mindmap_glue/0
+]).
+
+:- use_module(library(lists)).
+:- use_module(library(process)).
+
+% Load serializer
+:- use_module('../serialization/mindmap_serializer').
+
+% ============================================================================
+% TARGET DECLARATIONS
+% ============================================================================
+
+:- dynamic mindmap_target/3.  % mindmap_target(Predicate, Target, Options)
+
+% Default target mappings - Python for heavy computation
+mindmap_target(force_layout, python, [
+    module('unifyweaver.mindmap.layout.force_directed'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+mindmap_target(radial_layout, python, [
+    module('unifyweaver.mindmap.layout.radial'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+mindmap_target(hierarchical_layout, python, [
+    module('unifyweaver.mindmap.layout.hierarchical'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+mindmap_target(overlap_removal, python, [
+    module('unifyweaver.mindmap.optimize.overlap_removal'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+mindmap_target(crossing_minimization, python, [
+    module('unifyweaver.mindmap.optimize.crossing_minimization'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+mindmap_target(spacing, python, [
+    module('unifyweaver.mindmap.optimize.spacing'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+mindmap_target(centering, python, [
+    module('unifyweaver.mindmap.optimize.centering'),
+    function(compute),
+    location(local_process),
+    transport(pipe),
+    format(jsonl)
+]).
+
+%% declare_mindmap_target(+Predicate, +Target)
+declare_mindmap_target(Predicate, Target) :-
+    declare_mindmap_target(Predicate, Target, []).
+
+%% declare_mindmap_target(+Predicate, +Target, +Options)
+declare_mindmap_target(Predicate, Target, Options) :-
+    retractall(mindmap_target(Predicate, _, _)),
+    assertz(mindmap_target(Predicate, Target, Options)).
+
+%% get_mindmap_target(+Predicate, -TargetInfo)
+get_mindmap_target(Predicate, target(Target, Options)) :-
+    mindmap_target(Predicate, Target, Options).
+
+% ============================================================================
+% PIPELINE EXECUTION
+% ============================================================================
+
+%% execute_mindmap_pipeline(+MapId, -Result)
+%  Execute the default pipeline for a mindmap.
+%
+execute_mindmap_pipeline(MapId, Result) :-
+    execute_mindmap_pipeline(MapId, [], Result).
+
+%% execute_mindmap_pipeline(+MapId, +Options, -Result)
+execute_mindmap_pipeline(MapId, Options, Result) :-
+    % Get graph data
+    get_mindmap_graph(MapId, Graph),
+
+    % Determine pipeline stages
+    (   member(pipeline(Stages), Options)
+    ->  true
+    ;   Stages = [force_layout, overlap_removal, centering]  % Default pipeline
+    ),
+
+    % Execute stages
+    execute_stages(Graph, Stages, Options, Result).
+
+execute_stages(Graph, [], _Options, graph_result(Graph, [])).
+execute_stages(Graph, [Stage | Rest], Options, Result) :-
+    execute_stage(Graph, Stage, Options, StageResult),
+    (   StageResult = positions(Positions)
+    ->  execute_stages_with_positions(Graph, Rest, Positions, Options, Result)
+    ;   execute_stages(Graph, Rest, Options, Result)
+    ).
+
+execute_stages_with_positions(Graph, [], Positions, _Options, graph_result(Graph, Positions)).
+execute_stages_with_positions(Graph, [Stage | Rest], Positions, Options, Result) :-
+    execute_optimize_stage(Positions, Stage, Options, NewPositions),
+    execute_stages_with_positions(Graph, Rest, NewPositions, Options, Result).
+
+%% execute_stage(+Graph, +Stage, +Options, -Result)
+execute_stage(Graph, Stage, Options, Result) :-
+    get_mindmap_target(Stage, target(Target, TargetOpts)),
+    (   Target == python
+    ->  execute_python_stage(Graph, Stage, TargetOpts, Options, Result)
+    ;   Target == prolog
+    ->  execute_prolog_stage(Graph, Stage, Options, Result)
+    ;   format(user_error, 'Unknown target: ~w~n', [Target]),
+        fail
+    ).
+
+% ============================================================================
+% STAGE EXECUTION
+% ============================================================================
+
+%% execute_layout_stage(+Graph, +Algorithm, +Options, -Positions)
+execute_layout_stage(Graph, Algorithm, Options, Positions) :-
+    get_mindmap_target(Algorithm, target(Target, TargetOpts)),
+    (   Target == python
+    ->  execute_python_layout(Graph, Algorithm, TargetOpts, Options, Positions)
+    ;   execute_prolog_layout(Graph, Algorithm, Options, Positions)
+    ).
+
+%% execute_optimize_stage(+Positions, +Optimizer, +Options, -NewPositions)
+execute_optimize_stage(Positions, Optimizer, Options, NewPositions) :-
+    get_mindmap_target(Optimizer, target(Target, TargetOpts)),
+    (   Target == python
+    ->  execute_python_optimizer(Positions, Optimizer, TargetOpts, Options, NewPositions)
+    ;   execute_prolog_optimizer(Positions, Optimizer, Options, NewPositions)
+    ).
+
+% ============================================================================
+% PYTHON STAGE EXECUTION
+% ============================================================================
+
+%% execute_python_stage(+Graph, +Stage, +TargetOpts, +Options, -Result)
+execute_python_stage(Graph, Stage, TargetOpts, Options, Result) :-
+    % Generate Python command
+    member(module(Module), TargetOpts),
+    member(function(Function), TargetOpts),
+
+    % Serialize graph to JSON Lines
+    serialize_graph_for_python(Graph, Options, InputData),
+
+    % Build Python command
+    format(atom(PythonCode),
+        'import sys; import json; from ~w import ~w; data = json.loads(sys.stdin.read()); result = ~w(data); print(json.dumps(result))',
+        [Module, Function, Function]),
+
+    % Execute via pipe
+    process_create(path(python3), ['-c', PythonCode],
+        [stdin(pipe(In)), stdout(pipe(Out)), stderr(null)]),
+
+    % Send input
+    format(In, '~w~n', [InputData]),
+    close(In),
+
+    % Read output
+    read_string(Out, _, OutputStr),
+    close(Out),
+
+    % Parse result
+    atom_json_dict(OutputStr, ResultDict, []),
+    parse_python_result(Stage, ResultDict, Result).
+
+execute_python_layout(Graph, _Algorithm, TargetOpts, Options, Positions) :-
+    member(module(Module), TargetOpts),
+
+    % Prepare graph data
+    Graph = graph(_Id, Nodes, Edges, _),
+    serialize_graph_dict(Nodes, Edges, Options, GraphDict),
+
+    % Build Python script
+    format(atom(Script),
+'import sys, json
+from ~w import compute
+data = json.loads(sys.stdin.read())
+positions = compute(data["nodes"], data["edges"], data.get("options", {}))
+result = [{"type": "position", "id": k, "x": v[0], "y": v[1]} for k, v in positions.items()]
+for r in result:
+    print(json.dumps(r))
+', [Module]),
+
+    % Execute
+    execute_python_script(Script, GraphDict, OutputLines),
+
+    % Parse positions
+    parse_position_lines(OutputLines, Positions).
+
+execute_python_optimizer(Positions, _Optimizer, TargetOpts, Options, NewPositions) :-
+    member(module(Module), TargetOpts),
+
+    % Prepare positions dict
+    positions_to_dict(Positions, PosDict),
+    merge_options(Options, PosDict, InputDict),
+
+    % Build Python script
+    format(atom(Script),
+'import sys, json
+from ~w import compute
+data = json.loads(sys.stdin.read())
+positions = {k: tuple(v) for k, v in data["positions"].items()}
+options = {k: v for k, v in data.items() if k != "positions"}
+new_positions = compute(positions, **options)
+result = [{"type": "position", "id": k, "x": v[0], "y": v[1]} for k, v in new_positions.items()]
+for r in result:
+    print(json.dumps(r))
+', [Module]),
+
+    % Execute
+    execute_python_script(Script, InputDict, OutputLines),
+
+    % Parse positions
+    parse_position_lines(OutputLines, NewPositions).
+
+execute_python_script(Script, InputDict, OutputLines) :-
+    % Convert dict to JSON
+    with_output_to(string(InputJson), json_write(current_output, InputDict, [width(0)])),
+
+    % Execute Python
+    process_create(path(python3), ['-c', Script],
+        [stdin(pipe(In)), stdout(pipe(Out)), stderr(null)]),
+
+    format(In, '~w', [InputJson]),
+    close(In),
+
+    read_string(Out, _, OutputStr),
+    close(Out),
+
+    split_string(OutputStr, "\n", "\r\t ", OutputLines0),
+    exclude(=(""), OutputLines0, OutputLines).
+
+% ============================================================================
+% PROLOG STAGE EXECUTION (FALLBACK)
+% ============================================================================
+
+execute_prolog_stage(Graph, Stage, Options, Result) :-
+    format(user_error, 'Prolog fallback for ~w not implemented~n', [Stage]),
+    Result = error(not_implemented, Stage).
+
+execute_prolog_layout(_Graph, Algorithm, _Options, []) :-
+    format(user_error, 'Prolog layout ~w not implemented~n', [Algorithm]).
+
+execute_prolog_optimizer(Positions, Optimizer, _Options, Positions) :-
+    format(user_error, 'Prolog optimizer ~w not implemented~n', [Optimizer]).
+
+% ============================================================================
+% GLUE CODE GENERATION
+% ============================================================================
+
+%% generate_mindmap_glue(+Stage, +Target, -GlueCode)
+%  Generate glue code for a mindmap pipeline stage.
+%
+generate_mindmap_glue(layout(Algorithm), python, GlueCode) :-
+    get_mindmap_target(Algorithm, target(python, TargetOpts)),
+    member(module(Module), TargetOpts),
+    format(atom(GlueCode),
+'#!/usr/bin/env python3
+"""Mindmap layout glue - ~w"""
+import sys
+import json
+from ~w import compute
+
+def main():
+    data = json.loads(sys.stdin.read())
+    nodes = data.get("nodes", [])
+    edges = data.get("edges", [])
+    options = data.get("options", {})
+
+    # Convert nodes to graph structure
+    graph = {}
+    for n in nodes:
+        graph[n["id"]] = n
+
+    # Convert edges to adjacency
+    adj = {}
+    for e in edges:
+        adj.setdefault(e["from"], []).append(e["to"])
+
+    # Compute layout
+    positions = compute(graph, adj, options)
+
+    # Output as JSON Lines
+    for node_id, (x, y) in positions.items():
+        print(json.dumps({"type": "position", "id": node_id, "x": x, "y": y}))
+
+if __name__ == "__main__":
+    main()
+', [Algorithm, Module]).
+
+generate_mindmap_glue(optimize(Optimizer), python, GlueCode) :-
+    get_mindmap_target(Optimizer, target(python, TargetOpts)),
+    member(module(Module), TargetOpts),
+    format(atom(GlueCode),
+'#!/usr/bin/env python3
+"""Mindmap optimizer glue - ~w"""
+import sys
+import json
+from ~w import compute
+
+def main():
+    # Read positions from stdin (JSON Lines)
+    positions = {}
+    for line in sys.stdin:
+        obj = json.loads(line.strip())
+        if obj.get("type") == "position":
+            positions[obj["id"]] = (obj["x"], obj["y"])
+
+    # Run optimizer
+    new_positions = compute(positions)
+
+    # Output as JSON Lines
+    for node_id, (x, y) in new_positions.items():
+        print(json.dumps({"type": "position", "id": node_id, "x": x, "y": y}))
+
+if __name__ == "__main__":
+    main()
+', [Optimizer, Module]).
+
+%% generate_pipeline_glue(+Pipeline, +Options, -Script)
+%  Generate a complete pipeline script.
+%
+generate_pipeline_glue(Pipeline, Options, Script) :-
+    findall(StageScript,
+        (   member(Stage, Pipeline),
+            generate_stage_command(Stage, Options, StageScript)
+        ),
+        StageScripts),
+    atomic_list_concat(StageScripts, ' | ', PipelineCmd),
+    format(atom(Script),
+'#!/bin/bash
+# Mindmap pipeline: ~w
+# Generated by UnifyWeaver mindmap_glue
+
+~w
+', [Pipeline, PipelineCmd]).
+
+generate_stage_command(layout(Algorithm), _Options, Cmd) :-
+    get_mindmap_target(Algorithm, target(python, TargetOpts)),
+    member(module(Module), TargetOpts),
+    format(atom(Cmd), 'python3 -c "from ~w import compute; import sys,json; d=json.load(sys.stdin); print(json.dumps(compute(d)))"', [Module]).
+
+generate_stage_command(optimize(Optimizer), _Options, Cmd) :-
+    get_mindmap_target(Optimizer, target(python, TargetOpts)),
+    member(module(Module), TargetOpts),
+    format(atom(Cmd), 'python3 -c "from ~w import compute; import sys,json; d=json.load(sys.stdin); print(json.dumps(compute(d)))"', [Module]).
+
+% ============================================================================
+% PROTOCOL HANDLING
+% ============================================================================
+
+%% create_mindmap_pipe(+Direction, +Protocol, -Pipe)
+create_mindmap_pipe(input, jsonl, pipe(stdin, jsonl, [])).
+create_mindmap_pipe(output, jsonl, pipe(stdout, jsonl, [])).
+
+%% send_mindmap_data(+Pipe, +Data, +Protocol)
+send_mindmap_data(pipe(Stream, jsonl, _), Data, jsonl) :-
+    (   is_list(Data)
+    ->  forall(member(Item, Data),
+            (   serialize_object(Item, Dict),
+                dict_to_json_line(Dict, Line),
+                writeln(Stream, Line)
+            ))
+    ;   serialize_object(Data, Dict),
+        dict_to_json_line(Dict, Line),
+        writeln(Stream, Line)
+    ).
+
+%% receive_mindmap_data(+Pipe, -Data, +Protocol)
+receive_mindmap_data(pipe(Stream, jsonl, _), Data, jsonl) :-
+    read_mindmap_jsonl(Stream, Data).
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+get_mindmap_graph(MapId, graph(MapId, Nodes, Edges, [])) :-
+    % This would normally query the mindmap DSL
+    % For now, just return empty if not found
+    findall(node(Id, Props), mindmap_dsl:mindmap_node(Id, Props), Nodes),
+    findall(edge(F, T, P), mindmap_dsl:mindmap_edge(F, T, P), Edges).
+
+serialize_graph_for_python(graph(_Id, Nodes, Edges, _), _Options, JsonStr) :-
+    serialize_graph_dict(Nodes, Edges, [], Dict),
+    with_output_to(string(JsonStr), json_write(current_output, Dict, [width(0)])).
+
+serialize_graph_dict(Nodes, Edges, Options, Dict) :-
+    maplist(node_to_dict, Nodes, NodeDicts),
+    maplist(edge_to_dict, Edges, EdgeDicts),
+    Dict = json{nodes: NodeDicts, edges: EdgeDicts, options: Options}.
+
+node_to_dict(node(Id, Props), json{id: Id, props: PropsDict}) :-
+    props_to_dict(Props, PropsDict).
+
+edge_to_dict(edge(From, To, Props), json{from: From, to: To, props: PropsDict}) :-
+    props_to_dict(Props, PropsDict).
+
+positions_to_dict(Positions, json{positions: PosDict}) :-
+    findall(Id-[X, Y], member(position(Id, X, Y), Positions), Pairs),
+    dict_create(PosDict, json, Pairs).
+
+merge_options(Options, BaseDict, MergedDict) :-
+    findall(Key-Value, member(Key=Value, Options), Pairs),
+    dict_create(OptsDict, json, Pairs),
+    put_dict(OptsDict, BaseDict, MergedDict).
+
+parse_position_lines(Lines, Positions) :-
+    findall(position(Id, X, Y),
+        (   member(Line, Lines),
+            Line \== "",
+            atom_json_dict(Line, Dict, []),
+            Dict.type == "position",
+            Id = Dict.id,
+            X = Dict.x,
+            Y = Dict.y
+        ),
+        Positions).
+
+parse_python_result(Stage, ResultDict, positions(Positions)) :-
+    is_list(ResultDict),
+    !,
+    findall(position(Id, X, Y),
+        (   member(P, ResultDict),
+            P.type == "position",
+            Id = P.id,
+            X = P.x,
+            Y = P.y
+        ),
+        Positions).
+parse_python_result(Stage, ResultDict, error(Stage, ResultDict)).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_mindmap_glue :-
+    format('~n=== Mind Map Glue Tests ===~n~n'),
+
+    % Test 1: Target declarations exist
+    format('Test 1: Default target declarations...~n'),
+    (   get_mindmap_target(force_layout, target(python, Opts)),
+        member(module(_), Opts)
+    ->  format('  PASS: force_layout target declared~n')
+    ;   format('  FAIL: force_layout target missing~n')
+    ),
+
+    % Test 2: Custom target declaration
+    format('~nTest 2: Custom target declaration...~n'),
+    declare_mindmap_target(custom_layout, python, [module('custom.layout'), function(run)]),
+    (   get_mindmap_target(custom_layout, target(python, CustomOpts)),
+        member(module('custom.layout'), CustomOpts)
+    ->  format('  PASS: Custom target declared~n')
+    ;   format('  FAIL: Custom target declaration failed~n')
+    ),
+
+    % Test 3: Generate layout glue code
+    format('~nTest 3: Generate layout glue code...~n'),
+    generate_mindmap_glue(layout(force_layout), python, GlueCode),
+    (   sub_atom(GlueCode, _, _, _, 'force_directed'),
+        sub_atom(GlueCode, _, _, _, 'json.dumps')
+    ->  format('  PASS: Glue code generated~n')
+    ;   format('  FAIL: Glue code generation failed~n')
+    ),
+
+    % Test 4: Generate optimizer glue code
+    format('~nTest 4: Generate optimizer glue code...~n'),
+    generate_mindmap_glue(optimize(overlap_removal), python, OptGlue),
+    (   sub_atom(OptGlue, _, _, _, 'overlap_removal'),
+        sub_atom(OptGlue, _, _, _, 'compute')
+    ->  format('  PASS: Optimizer glue generated~n')
+    ;   format('  FAIL: Optimizer glue generation failed~n')
+    ),
+
+    % Test 5: Serialization utilities
+    format('~nTest 5: Serialization utilities...~n'),
+    TestNodes = [node(a, [label("A")]), node(b, [label("B")])],
+    TestEdges = [edge(a, b, [])],
+    serialize_graph_dict(TestNodes, TestEdges, [], Dict),
+    (   is_dict(Dict),
+        length(Dict.nodes, 2)
+    ->  format('  PASS: Graph serialization works~n')
+    ;   format('  FAIL: Graph serialization failed~n')
+    ),
+
+    % Cleanup
+    retractall(mindmap_target(custom_layout, _, _)),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('Mind map glue module loaded~n', [])
+), now).

--- a/src/unifyweaver/mindmap/glue/mindmap_glue.pl
+++ b/src/unifyweaver/mindmap/glue/mindmap_glue.pl
@@ -3,25 +3,37 @@
 %
 % mindmap_glue.pl - Cross-Target Glue Integration for Mind Map DSL
 %
-% Integrates the mindmap DSL with UnifyWeaver's cross-target glue system,
-% enabling seamless communication between Prolog (DSL) and Python (computation).
+% Integrates with the UnifyWeaver glue system for cross-target execution:
 %
-% Key concepts:
-% - Prolog handles DSL definition and orchestration
-% - Python handles heavy computation (layout, optimization)
-% - Data flows via JSON Lines over pipes
+% 1. Target is Python → Generate pure Python code
+% 2. Target is Prolog (SWI) → Use janus_glue for in-process Python calls
+% 3. Target is Prolog (GNU/other) → Use pipe_glue with jsonL serialization
+%
+% This module delegates to the existing glue infrastructure:
+% - janus_glue.pl: In-process Python↔Prolog via Janus
+% - pipe_glue.pl: Subprocess communication via pipes
+% - shell_glue.pl: Shell script execution
 %
 % Usage:
-%   ?- declare_mindmap_target(force_layout, python).
+%   ?- mindmap_janus_available.  % Check if Janus can be used for mindmaps
 %   ?- execute_mindmap_pipeline(my_map, Positions).
+%   ?- generate_mindmap_python(my_map, [layout(force)], PythonCode).
 
 :- module(mindmap_glue, [
+    % Janus availability (delegated to janus_glue)
+    mindmap_janus_available/0,      % mindmap_janus_available - true if Janus is usable
+    mindmap_janus_available/1,      % mindmap_janus_available(-Info)
+    check_mindmap_packages/1,       % check_mindmap_packages(-Available)
+
     % Target declarations
     declare_mindmap_target/2,       % declare_mindmap_target(+Predicate, +Target)
     declare_mindmap_target/3,       % declare_mindmap_target(+Predicate, +Target, +Options)
     get_mindmap_target/2,           % get_mindmap_target(+Predicate, -Target)
 
-    % Pipeline execution
+    % Transport selection
+    select_transport/3,             % select_transport(+Predicate, +Options, -Transport)
+
+    % Pipeline execution (Prolog runtime)
     execute_mindmap_pipeline/2,     % execute_mindmap_pipeline(+MapId, -Result)
     execute_mindmap_pipeline/3,     % execute_mindmap_pipeline(+MapId, +Options, -Result)
 
@@ -29,24 +41,70 @@
     execute_layout_stage/4,         % execute_layout_stage(+Graph, +Algorithm, +Options, -Positions)
     execute_optimize_stage/4,       % execute_optimize_stage(+Positions, +Optimizer, +Options, -NewPositions)
 
-    % Glue code generation
+    % Python code generation (when target is Python)
+    generate_mindmap_python/3,      % generate_mindmap_python(+MapId, +Options, -PythonCode)
+    generate_layout_python/3,       % generate_layout_python(+Algorithm, +Options, -Code)
+    generate_optimizer_python/3,    % generate_optimizer_python(+Optimizer, +Options, -Code)
+    generate_pipeline_python/3,     % generate_pipeline_python(+Pipeline, +Options, -Code)
+
+    % Glue code generation (for cross-target)
     generate_mindmap_glue/3,        % generate_mindmap_glue(+Stage, +Target, -GlueCode)
     generate_pipeline_glue/3,       % generate_pipeline_glue(+Pipeline, +Options, -Script)
-
-    % Protocol handling
-    create_mindmap_pipe/3,          % create_mindmap_pipe(+Direction, +Protocol, -Pipe)
-    send_mindmap_data/3,            % send_mindmap_data(+Pipe, +Data, +Protocol)
-    receive_mindmap_data/3,         % receive_mindmap_data(+Pipe, -Data, +Protocol)
 
     % Testing
     test_mindmap_glue/0
 ]).
 
 :- use_module(library(lists)).
-:- use_module(library(process)).
+
+% Conditionally load process library (not available in all Prologs)
+:- catch(use_module(library(process)), _, true).
+
+% Load existing glue infrastructure
+:- catch(use_module('../../glue/janus_glue'), _, true).
+:- catch(use_module('../../glue/pipe_glue'), _, true).
 
 % Load serializer
 :- use_module('../serialization/mindmap_serializer').
+
+% ============================================================================
+% JANUS AVAILABILITY (DELEGATED TO JANUS_GLUE)
+% ============================================================================
+
+%% mindmap_janus_available
+%  True if Janus is available for mindmap operations.
+%  Delegates to janus_glue:janus_available/0.
+%
+mindmap_janus_available :-
+    catch(janus_glue:janus_available, _, fail).
+
+%% mindmap_janus_available(-Info)
+%  Check Janus availability and return info.
+%  Delegates to janus_glue:janus_available/1.
+%
+mindmap_janus_available(Info) :-
+    catch(janus_glue:janus_available(Info), _, fail).
+
+%% check_mindmap_packages(-Available)
+%  Check if required mindmap Python packages are available via Janus.
+%  Only meaningful when Janus is available.
+%
+check_mindmap_packages(true) :-
+    mindmap_janus_available,
+    check_package_via_janus('unifyweaver.mindmap.layout'),
+    check_package_via_janus('unifyweaver.mindmap.optimize'),
+    !.
+check_mindmap_packages(false).
+
+%% check_package_via_janus(+Package)
+%  Check if a Python package is importable via Janus.
+%
+check_package_via_janus(Package) :-
+    catch(
+        janus_glue:janus_import_module(Package, _),
+        _,
+        fail
+    ).
 
 % ============================================================================
 % TARGET DECLARATIONS
@@ -55,60 +113,50 @@
 :- dynamic mindmap_target/3.  % mindmap_target(Predicate, Target, Options)
 
 % Default target mappings - Python for heavy computation
+% Transport will be determined at runtime based on Janus availability
 mindmap_target(force_layout, python, [
     module('unifyweaver.mindmap.layout.force_directed'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
 ]).
 
 mindmap_target(radial_layout, python, [
     module('unifyweaver.mindmap.layout.radial'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
 ]).
 
 mindmap_target(hierarchical_layout, python, [
     module('unifyweaver.mindmap.layout.hierarchical'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
+]).
+
+mindmap_target(grid_layout, python, [
+    module('unifyweaver.mindmap.layout.grid'),
+    function(compute)
+]).
+
+mindmap_target(circular_layout, python, [
+    module('unifyweaver.mindmap.layout.circular'),
+    function(compute)
 ]).
 
 mindmap_target(overlap_removal, python, [
     module('unifyweaver.mindmap.optimize.overlap_removal'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
 ]).
 
 mindmap_target(crossing_minimization, python, [
     module('unifyweaver.mindmap.optimize.crossing_minimization'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
 ]).
 
 mindmap_target(spacing, python, [
     module('unifyweaver.mindmap.optimize.spacing'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
 ]).
 
 mindmap_target(centering, python, [
     module('unifyweaver.mindmap.optimize.centering'),
-    function(compute),
-    location(local_process),
-    transport(pipe),
-    format(jsonl)
+    function(compute)
 ]).
 
 %% declare_mindmap_target(+Predicate, +Target)
@@ -125,12 +173,47 @@ get_mindmap_target(Predicate, target(Target, Options)) :-
     mindmap_target(Predicate, Target, Options).
 
 % ============================================================================
-% PIPELINE EXECUTION
+% TRANSPORT SELECTION
+% ============================================================================
+
+%% select_transport(+Predicate, +Options, -Transport)
+%  Select the best transport mechanism for calling Python from Prolog.
+%
+%  Transport options:
+%  - janus: In-process via Janus (SWI-Prolog only, fastest)
+%  - pipe: Subprocess via Unix pipes with jsonL
+%  - socket: Network socket (for remote/distributed)
+%
+%  Selection is delegated to the glue infrastructure where possible.
+%  Janus is preferred when:
+%  - Running on SWI-Prolog (janus_glue reports available)
+%  - Required mindmap Python packages are importable
+%
+select_transport(_Predicate, Options, Transport) :-
+    % Check if transport is explicitly specified
+    member(transport(Transport), Options),
+    !.
+select_transport(Predicate, _Options, Transport) :-
+    % Auto-select based on runtime
+    auto_select_transport(Predicate, Transport).
+
+%% auto_select_transport(+Predicate, -Transport)
+%  Auto-select transport based on runtime capabilities.
+%
+auto_select_transport(_Predicate, janus) :-
+    % Use Janus if available and mindmap packages are accessible
+    mindmap_janus_available,
+    check_mindmap_packages(true),
+    !.
+auto_select_transport(_Predicate, pipe) :-
+    % Fallback to pipe for any Prolog implementation
+    !.
+
+% ============================================================================
+% PIPELINE EXECUTION (PROLOG RUNTIME)
 % ============================================================================
 
 %% execute_mindmap_pipeline(+MapId, -Result)
-%  Execute the default pipeline for a mindmap.
-%
 execute_mindmap_pipeline(MapId, Result) :-
     execute_mindmap_pipeline(MapId, [], Result).
 
@@ -142,7 +225,7 @@ execute_mindmap_pipeline(MapId, Options, Result) :-
     % Determine pipeline stages
     (   member(pipeline(Stages), Options)
     ->  true
-    ;   Stages = [force_layout, overlap_removal, centering]  % Default pipeline
+    ;   Stages = [force_layout, overlap_removal, centering]
     ),
 
     % Execute stages
@@ -163,124 +246,115 @@ execute_stages_with_positions(Graph, [Stage | Rest], Positions, Options, Result)
 
 %% execute_stage(+Graph, +Stage, +Options, -Result)
 execute_stage(Graph, Stage, Options, Result) :-
-    get_mindmap_target(Stage, target(Target, TargetOpts)),
-    (   Target == python
-    ->  execute_python_stage(Graph, Stage, TargetOpts, Options, Result)
-    ;   Target == prolog
-    ->  execute_prolog_stage(Graph, Stage, Options, Result)
-    ;   format(user_error, 'Unknown target: ~w~n', [Target]),
+    get_mindmap_target(Stage, target(python, TargetOpts)),
+    select_transport(Stage, Options, Transport),
+    (   Transport == janus
+    ->  execute_janus_stage(Graph, Stage, TargetOpts, Options, Result)
+    ;   Transport == pipe
+    ->  execute_pipe_stage(Graph, Stage, TargetOpts, Options, Result)
+    ;   format(user_error, 'Unknown transport: ~w~n', [Transport]),
         fail
     ).
 
 % ============================================================================
-% STAGE EXECUTION
+% JANUS EXECUTION (IN-PROCESS VIA JANUS_GLUE)
 % ============================================================================
+%
+% Uses janus_glue:janus_call_python/4 for in-process Python calls.
+% This provides:
+% - Zero serialization overhead for compatible types
+% - Direct function calls without process spawning
+% - Shared memory for large data structures
+%
 
-%% execute_layout_stage(+Graph, +Algorithm, +Options, -Positions)
-execute_layout_stage(Graph, Algorithm, Options, Positions) :-
-    get_mindmap_target(Algorithm, target(Target, TargetOpts)),
-    (   Target == python
-    ->  execute_python_layout(Graph, Algorithm, TargetOpts, Options, Positions)
-    ;   execute_prolog_layout(Graph, Algorithm, Options, Positions)
-    ).
-
-%% execute_optimize_stage(+Positions, +Optimizer, +Options, -NewPositions)
-execute_optimize_stage(Positions, Optimizer, Options, NewPositions) :-
-    get_mindmap_target(Optimizer, target(Target, TargetOpts)),
-    (   Target == python
-    ->  execute_python_optimizer(Positions, Optimizer, TargetOpts, Options, NewPositions)
-    ;   execute_prolog_optimizer(Positions, Optimizer, Options, NewPositions)
-    ).
-
-% ============================================================================
-% PYTHON STAGE EXECUTION
-% ============================================================================
-
-%% execute_python_stage(+Graph, +Stage, +TargetOpts, +Options, -Result)
-execute_python_stage(Graph, Stage, TargetOpts, Options, Result) :-
-    % Generate Python command
+execute_janus_stage(Graph, _Stage, TargetOpts, Options, positions(Positions)) :-
     member(module(Module), TargetOpts),
     member(function(Function), TargetOpts),
 
-    % Serialize graph to JSON Lines
-    serialize_graph_for_python(Graph, Options, InputData),
+    % Convert graph to arguments list
+    graph_to_janus_args(Graph, Options, Args),
 
-    % Build Python command
-    format(atom(PythonCode),
-        'import sys; import json; from ~w import ~w; data = json.loads(sys.stdin.read()); result = ~w(data); print(json.dumps(result))',
-        [Module, Function, Function]),
+    % Call Python via janus_glue
+    catch(
+        (   janus_glue:janus_call_python(Module, Function, Args, PyResult),
+            py_result_to_positions(PyResult, Positions)
+        ),
+        Error,
+        (   format(user_error, 'Janus error: ~w~n', [Error]),
+            Positions = []
+        )
+    ).
 
-    % Execute via pipe
-    process_create(path(python3), ['-c', PythonCode],
-        [stdin(pipe(In)), stdout(pipe(Out)), stderr(null)]),
-
-    % Send input
-    format(In, '~w~n', [InputData]),
-    close(In),
-
-    % Read output
-    read_string(Out, _, OutputStr),
-    close(Out),
-
-    % Parse result
-    atom_json_dict(OutputStr, ResultDict, []),
-    parse_python_result(Stage, ResultDict, Result).
-
-execute_python_layout(Graph, _Algorithm, TargetOpts, Options, Positions) :-
+execute_janus_layout(Graph, _Algorithm, TargetOpts, Options, Positions) :-
     member(module(Module), TargetOpts),
 
-    % Prepare graph data
     Graph = graph(_Id, Nodes, Edges, _),
-    serialize_graph_dict(Nodes, Edges, Options, GraphDict),
+    nodes_to_py_dict(Nodes, NodesDict),
+    edges_to_py_list(Edges, EdgesList),
+    options_to_py_dict(Options, OptsDict),
+
+    % Call module.compute(nodes, edges, options) via janus_glue
+    catch(
+        (   janus_glue:janus_call_python(Module, compute, [NodesDict, EdgesList, OptsDict], PyResult),
+            py_result_to_positions(PyResult, Positions)
+        ),
+        _,
+        Positions = []
+    ).
+
+execute_janus_optimizer(Positions, _Optimizer, TargetOpts, Options, NewPositions) :-
+    member(module(Module), TargetOpts),
+
+    positions_to_py_dict(Positions, PosDict),
+    options_to_py_dict(Options, OptsDict),
+
+    % Call module.compute(positions, options) via janus_glue
+    catch(
+        (   janus_glue:janus_call_python(Module, compute, [PosDict, OptsDict], PyResult),
+            py_result_to_positions(PyResult, NewPositions)
+        ),
+        _,
+        NewPositions = Positions
+    ).
+
+%% graph_to_janus_args(+Graph, +Options, -Args)
+%  Convert graph and options to Janus-compatible argument list.
+%
+graph_to_janus_args(Graph, Options, [NodesDict, EdgesList, OptsDict]) :-
+    Graph = graph(_Id, Nodes, Edges, _),
+    nodes_to_py_dict(Nodes, NodesDict),
+    edges_to_py_list(Edges, EdgesList),
+    options_to_py_dict(Options, OptsDict).
+
+% ============================================================================
+% PIPE EXECUTION (SUBPROCESS)
+% ============================================================================
+
+execute_pipe_stage(Graph, Stage, TargetOpts, Options, positions(Positions)) :-
+    member(module(Module), TargetOpts),
+
+    % Serialize graph to JSON
+    serialize_graph_for_python(Graph, Options, InputJson),
 
     % Build Python script
     format(atom(Script),
 'import sys, json
 from ~w import compute
 data = json.loads(sys.stdin.read())
-positions = compute(data["nodes"], data["edges"], data.get("options", {}))
-result = [{"type": "position", "id": k, "x": v[0], "y": v[1]} for k, v in positions.items()]
-for r in result:
-    print(json.dumps(r))
-', [Module]),
+nodes = {n["id"]: n.get("props", {}) for n in data.get("nodes", [])}
+edges = [(e["from"], e["to"]) for e in data.get("edges", [])]
+options = data.get("options", {})
+result = compute(nodes, edges, options) if "nodes" in data else compute(data.get("positions", {}), **options)
+for node_id, pos in result.items():
+    print(json.dumps({"type": "position", "id": node_id, "x": pos[0], "y": pos[1]}))', [Module]),
 
-    % Execute
-    execute_python_script(Script, GraphDict, OutputLines),
+    % Execute via pipe
+    execute_python_script(Script, InputJson, OutputLines),
 
     % Parse positions
     parse_position_lines(OutputLines, Positions).
 
-execute_python_optimizer(Positions, _Optimizer, TargetOpts, Options, NewPositions) :-
-    member(module(Module), TargetOpts),
-
-    % Prepare positions dict
-    positions_to_dict(Positions, PosDict),
-    merge_options(Options, PosDict, InputDict),
-
-    % Build Python script
-    format(atom(Script),
-'import sys, json
-from ~w import compute
-data = json.loads(sys.stdin.read())
-positions = {k: tuple(v) for k, v in data["positions"].items()}
-options = {k: v for k, v in data.items() if k != "positions"}
-new_positions = compute(positions, **options)
-result = [{"type": "position", "id": k, "x": v[0], "y": v[1]} for k, v in new_positions.items()]
-for r in result:
-    print(json.dumps(r))
-', [Module]),
-
-    % Execute
-    execute_python_script(Script, InputDict, OutputLines),
-
-    % Parse positions
-    parse_position_lines(OutputLines, NewPositions).
-
-execute_python_script(Script, InputDict, OutputLines) :-
-    % Convert dict to JSON
-    with_output_to(string(InputJson), json_write(current_output, InputDict, [width(0)])),
-
-    % Execute Python
+execute_python_script(Script, InputJson, OutputLines) :-
     process_create(path(python3), ['-c', Script],
         [stdin(pipe(In)), stdout(pipe(Out)), stderr(null)]),
 
@@ -294,26 +368,181 @@ execute_python_script(Script, InputDict, OutputLines) :-
     exclude(=(""), OutputLines0, OutputLines).
 
 % ============================================================================
-% PROLOG STAGE EXECUTION (FALLBACK)
+% STAGE EXECUTION DISPATCH
 % ============================================================================
 
-execute_prolog_stage(Graph, Stage, Options, Result) :-
-    format(user_error, 'Prolog fallback for ~w not implemented~n', [Stage]),
-    Result = error(not_implemented, Stage).
+%% execute_layout_stage(+Graph, +Algorithm, +Options, -Positions)
+execute_layout_stage(Graph, Algorithm, Options, Positions) :-
+    get_mindmap_target(Algorithm, target(python, TargetOpts)),
+    select_transport(Algorithm, Options, Transport),
+    (   Transport == janus
+    ->  execute_janus_layout(Graph, Algorithm, TargetOpts, Options, Positions)
+    ;   execute_pipe_layout(Graph, Algorithm, TargetOpts, Options, Positions)
+    ).
 
-execute_prolog_layout(_Graph, Algorithm, _Options, []) :-
-    format(user_error, 'Prolog layout ~w not implemented~n', [Algorithm]).
+execute_pipe_layout(Graph, _Algorithm, TargetOpts, Options, Positions) :-
+    member(module(Module), TargetOpts),
 
-execute_prolog_optimizer(Positions, Optimizer, _Options, Positions) :-
-    format(user_error, 'Prolog optimizer ~w not implemented~n', [Optimizer]).
+    Graph = graph(_Id, Nodes, Edges, _),
+    serialize_graph_dict(Nodes, Edges, Options, GraphDict),
+    with_output_to(string(InputJson), json_write(current_output, GraphDict, [width(0)])),
+
+    format(atom(Script),
+'import sys, json
+from ~w import compute
+data = json.loads(sys.stdin.read())
+nodes = {n["id"]: n.get("props", {}) for n in data.get("nodes", [])}
+edges = [(e["from"], e["to"]) for e in data.get("edges", [])]
+options = data.get("options", {})
+result = compute(nodes, edges, options)
+for node_id, pos in result.items():
+    print(json.dumps({"type": "position", "id": node_id, "x": pos[0], "y": pos[1]}))', [Module]),
+
+    execute_python_script(Script, InputJson, OutputLines),
+    parse_position_lines(OutputLines, Positions).
+
+%% execute_optimize_stage(+Positions, +Optimizer, +Options, -NewPositions)
+execute_optimize_stage(Positions, Optimizer, Options, NewPositions) :-
+    get_mindmap_target(Optimizer, target(python, TargetOpts)),
+    select_transport(Optimizer, Options, Transport),
+    (   Transport == janus
+    ->  execute_janus_optimizer(Positions, Optimizer, TargetOpts, Options, NewPositions)
+    ;   execute_pipe_optimizer(Positions, Optimizer, TargetOpts, Options, NewPositions)
+    ).
+
+execute_pipe_optimizer(Positions, _Optimizer, TargetOpts, Options, NewPositions) :-
+    member(module(Module), TargetOpts),
+
+    positions_to_dict(Positions, PosDict),
+    merge_options(Options, PosDict, InputDict),
+    with_output_to(string(InputJson), json_write(current_output, InputDict, [width(0)])),
+
+    format(atom(Script),
+'import sys, json
+from ~w import compute
+data = json.loads(sys.stdin.read())
+positions = {k: tuple(v) for k, v in data["positions"].items()}
+options = {k: v for k, v in data.items() if k != "positions"}
+result = compute(positions, **options)
+for node_id, pos in result.items():
+    print(json.dumps({"type": "position", "id": node_id, "x": pos[0], "y": pos[1]}))', [Module]),
+
+    execute_python_script(Script, InputJson, OutputLines),
+    parse_position_lines(OutputLines, NewPositions).
 
 % ============================================================================
-% GLUE CODE GENERATION
+% PYTHON CODE GENERATION (WHEN TARGET IS PYTHON)
+% ============================================================================
+
+%% generate_mindmap_python(+MapId, +Options, -PythonCode)
+%  Generate standalone Python code for mindmap processing.
+%  Used when the overall target is Python (not Prolog calling Python).
+%
+generate_mindmap_python(MapId, Options, PythonCode) :-
+    % Determine pipeline
+    (   member(pipeline(Stages), Options)
+    ->  true
+    ;   Stages = [force_layout, overlap_removal, centering]
+    ),
+
+    % Generate imports
+    generate_imports(Stages, Imports),
+
+    % Generate pipeline code
+    generate_pipeline_python(Stages, Options, PipelineCode),
+
+    % Assemble
+    format(atom(PythonCode),
+'#!/usr/bin/env python3
+"""
+Mind Map Pipeline: ~w
+Generated by UnifyWeaver mindmap_glue
+"""
+
+~w
+
+from unifyweaver.mindmap.io import read_graph, write_positions
+
+def process_mindmap(graph):
+    """Process a mindmap graph through the pipeline."""
+    nodes = {n.id: {"label": n.label, "type": n.node_type} for n in graph.nodes}
+    edges = [(e.from_id, e.to_id) for e in graph.edges]
+
+~w
+
+    return positions
+
+def main():
+    import sys
+    graph = read_graph(sys.stdin)
+    if graph:
+        positions = process_mindmap(graph)
+        write_positions(positions, sys.stdout)
+
+if __name__ == "__main__":
+    main()
+', [MapId, Imports, PipelineCode]).
+
+generate_imports(Stages, Imports) :-
+    findall(Import,
+        (   member(Stage, Stages),
+            get_mindmap_target(Stage, target(python, Opts)),
+            member(module(Mod), Opts),
+            format(atom(Import), 'from ~w import compute as ~w_compute', [Mod, Stage])
+        ),
+        ImportList),
+    atomic_list_concat(ImportList, '\n', Imports).
+
+%% generate_layout_python(+Algorithm, +Options, -Code)
+generate_layout_python(Algorithm, _Options, Code) :-
+    get_mindmap_target(Algorithm, target(python, Opts)),
+    member(module(Module), Opts),
+    format(atom(Code),
+'from ~w import compute as layout_compute
+
+def compute_layout(nodes, edges, options=None):
+    """Compute layout positions for nodes."""
+    return layout_compute(nodes, edges, options or {})
+', [Module]).
+
+%% generate_optimizer_python(+Optimizer, +Options, -Code)
+generate_optimizer_python(Optimizer, _Options, Code) :-
+    get_mindmap_target(Optimizer, target(python, Opts)),
+    member(module(Module), Opts),
+    format(atom(Code),
+'from ~w import compute as optimize_compute
+
+def optimize_positions(positions, options=None):
+    """Optimize node positions."""
+    return optimize_compute(positions, **(options or {}))
+', [Module]).
+
+%% generate_pipeline_python(+Pipeline, +Options, -Code)
+generate_pipeline_python(Pipeline, _Options, Code) :-
+    generate_pipeline_steps(Pipeline, 1, StepsCode),
+    format(atom(Code),
+'    # Pipeline execution
+~w', [StepsCode]).
+
+generate_pipeline_steps([], _, '').
+generate_pipeline_steps([Stage | Rest], N, Code) :-
+    (   N == 1
+    ->  % First stage is layout
+        format(atom(StepCode),
+'    positions = ~w_compute(nodes, edges, {})~n', [Stage])
+    ;   % Subsequent stages are optimizers
+        format(atom(StepCode),
+'    positions = ~w_compute(positions)~n', [Stage])
+    ),
+    N1 is N + 1,
+    generate_pipeline_steps(Rest, N1, RestCode),
+    atom_concat(StepCode, RestCode, Code).
+
+% ============================================================================
+% GLUE CODE GENERATION (FOR SHELL SCRIPTS)
 % ============================================================================
 
 %% generate_mindmap_glue(+Stage, +Target, -GlueCode)
-%  Generate glue code for a mindmap pipeline stage.
-%
 generate_mindmap_glue(layout(Algorithm), python, GlueCode) :-
     get_mindmap_target(Algorithm, target(python, TargetOpts)),
     member(module(Module), TargetOpts),
@@ -323,29 +552,20 @@ generate_mindmap_glue(layout(Algorithm), python, GlueCode) :-
 import sys
 import json
 from ~w import compute
+from unifyweaver.mindmap.io import read_graph, write_positions
 
 def main():
-    data = json.loads(sys.stdin.read())
-    nodes = data.get("nodes", [])
-    edges = data.get("edges", [])
-    options = data.get("options", {})
+    graph = read_graph(sys.stdin)
+    if not graph:
+        data = json.loads(sys.stdin.read())
+        nodes = {n["id"]: n.get("props", {}) for n in data.get("nodes", [])}
+        edges = [(e["from"], e["to"]) for e in data.get("edges", [])]
+    else:
+        nodes = {n.id: {"label": n.label} for n in graph.nodes}
+        edges = [(e.from_id, e.to_id) for e in graph.edges]
 
-    # Convert nodes to graph structure
-    graph = {}
-    for n in nodes:
-        graph[n["id"]] = n
-
-    # Convert edges to adjacency
-    adj = {}
-    for e in edges:
-        adj.setdefault(e["from"], []).append(e["to"])
-
-    # Compute layout
-    positions = compute(graph, adj, options)
-
-    # Output as JSON Lines
-    for node_id, (x, y) in positions.items():
-        print(json.dumps({"type": "position", "id": node_id, "x": x, "y": y}))
+    positions = compute(nodes, edges, {})
+    write_positions(positions)
 
 if __name__ == "__main__":
     main()
@@ -358,38 +578,30 @@ generate_mindmap_glue(optimize(Optimizer), python, GlueCode) :-
 '#!/usr/bin/env python3
 """Mindmap optimizer glue - ~w"""
 import sys
-import json
 from ~w import compute
+from unifyweaver.mindmap.io import read_positions_dict, write_positions
 
 def main():
-    # Read positions from stdin (JSON Lines)
-    positions = {}
-    for line in sys.stdin:
-        obj = json.loads(line.strip())
-        if obj.get("type") == "position":
-            positions[obj["id"]] = (obj["x"], obj["y"])
-
-    # Run optimizer
+    positions = read_positions_dict(sys.stdin)
     new_positions = compute(positions)
-
-    # Output as JSON Lines
-    for node_id, (x, y) in new_positions.items():
-        print(json.dumps({"type": "position", "id": node_id, "x": x, "y": y}))
+    write_positions(new_positions)
 
 if __name__ == "__main__":
     main()
 ', [Optimizer, Module]).
 
 %% generate_pipeline_glue(+Pipeline, +Options, -Script)
-%  Generate a complete pipeline script.
-%
-generate_pipeline_glue(Pipeline, Options, Script) :-
-    findall(StageScript,
+generate_pipeline_glue(Pipeline, _Options, Script) :-
+    findall(Cmd,
         (   member(Stage, Pipeline),
-            generate_stage_command(Stage, Options, StageScript)
+            get_mindmap_target(Stage, target(python, Opts)),
+            member(module(Mod), Opts),
+            format(atom(Cmd),
+                'python3 -c "from ~w import compute; from unifyweaver.mindmap.io import *; import sys,json; exec(open(\\'glue_~w.py\\').read())"',
+                [Mod, Stage])
         ),
-        StageScripts),
-    atomic_list_concat(StageScripts, ' | ', PipelineCmd),
+        Cmds),
+    atomic_list_concat(Cmds, ' | ', PipelineCmd),
     format(atom(Script),
 '#!/bin/bash
 # Mindmap pipeline: ~w
@@ -398,48 +610,11 @@ generate_pipeline_glue(Pipeline, Options, Script) :-
 ~w
 ', [Pipeline, PipelineCmd]).
 
-generate_stage_command(layout(Algorithm), _Options, Cmd) :-
-    get_mindmap_target(Algorithm, target(python, TargetOpts)),
-    member(module(Module), TargetOpts),
-    format(atom(Cmd), 'python3 -c "from ~w import compute; import sys,json; d=json.load(sys.stdin); print(json.dumps(compute(d)))"', [Module]).
-
-generate_stage_command(optimize(Optimizer), _Options, Cmd) :-
-    get_mindmap_target(Optimizer, target(python, TargetOpts)),
-    member(module(Module), TargetOpts),
-    format(atom(Cmd), 'python3 -c "from ~w import compute; import sys,json; d=json.load(sys.stdin); print(json.dumps(compute(d)))"', [Module]).
-
-% ============================================================================
-% PROTOCOL HANDLING
-% ============================================================================
-
-%% create_mindmap_pipe(+Direction, +Protocol, -Pipe)
-create_mindmap_pipe(input, jsonl, pipe(stdin, jsonl, [])).
-create_mindmap_pipe(output, jsonl, pipe(stdout, jsonl, [])).
-
-%% send_mindmap_data(+Pipe, +Data, +Protocol)
-send_mindmap_data(pipe(Stream, jsonl, _), Data, jsonl) :-
-    (   is_list(Data)
-    ->  forall(member(Item, Data),
-            (   serialize_object(Item, Dict),
-                dict_to_json_line(Dict, Line),
-                writeln(Stream, Line)
-            ))
-    ;   serialize_object(Data, Dict),
-        dict_to_json_line(Dict, Line),
-        writeln(Stream, Line)
-    ).
-
-%% receive_mindmap_data(+Pipe, -Data, +Protocol)
-receive_mindmap_data(pipe(Stream, jsonl, _), Data, jsonl) :-
-    read_mindmap_jsonl(Stream, Data).
-
 % ============================================================================
 % UTILITIES
 % ============================================================================
 
 get_mindmap_graph(MapId, graph(MapId, Nodes, Edges, [])) :-
-    % This would normally query the mindmap DSL
-    % For now, just return empty if not found
     findall(node(Id, Props), mindmap_dsl:mindmap_node(Id, Props), Nodes),
     findall(edge(F, T, P), mindmap_dsl:mindmap_edge(F, T, P), Edges).
 
@@ -479,18 +654,38 @@ parse_position_lines(Lines, Positions) :-
         ),
         Positions).
 
-parse_python_result(Stage, ResultDict, positions(Positions)) :-
-    is_list(ResultDict),
-    !,
+% Janus-specific conversions
+graph_to_py_dict(graph(_Id, Nodes, Edges, _), _Options, PyDict) :-
+    nodes_to_py_dict(Nodes, NodesDict),
+    edges_to_py_list(Edges, EdgesList),
+    PyDict = py{nodes: NodesDict, edges: EdgesList}.
+
+nodes_to_py_dict(Nodes, Dict) :-
+    findall(Id-Props,
+        (member(node(Id, PropList), Nodes), props_to_py(PropList, Props)),
+        Pairs),
+    dict_create(Dict, py, Pairs).
+
+edges_to_py_list(Edges, List) :-
+    findall([From, To], member(edge(From, To, _), Edges), List).
+
+options_to_py_dict(Options, Dict) :-
+    findall(Key-Value, member(Key=Value, Options), Pairs),
+    dict_create(Dict, py, Pairs).
+
+positions_to_py_dict(Positions, Dict) :-
+    findall(Id-[X, Y], member(position(Id, X, Y), Positions), Pairs),
+    dict_create(Dict, py, Pairs).
+
+props_to_py(PropList, Props) :-
+    findall(Key-Value, (member(Prop, PropList), Prop =.. [Key, Value]), Pairs),
+    dict_create(Props, py, Pairs).
+
+py_result_to_positions(PyResult, Positions) :-
+    dict_pairs(PyResult, _, Pairs),
     findall(position(Id, X, Y),
-        (   member(P, ResultDict),
-            P.type == "position",
-            Id = P.id,
-            X = P.x,
-            Y = P.y
-        ),
+        (member(Id-[X, Y], Pairs)),
         Positions).
-parse_python_result(Stage, ResultDict, error(Stage, ResultDict)).
 
 % ============================================================================
 % TESTING
@@ -499,54 +694,68 @@ parse_python_result(Stage, ResultDict, error(Stage, ResultDict)).
 test_mindmap_glue :-
     format('~n=== Mind Map Glue Tests ===~n~n'),
 
-    % Test 1: Target declarations exist
-    format('Test 1: Default target declarations...~n'),
+    % Test 1: Janus availability check (delegated to janus_glue)
+    format('Test 1: Janus availability (via janus_glue)...~n'),
+    (   mindmap_janus_available(Info)
+    ->  format('  Janus available: ~w~n', [Info])
+    ;   format('  Janus not available (will use pipe transport)~n')
+    ),
+
+    % Test 2: Mindmap packages check
+    format('~nTest 2: Mindmap packages availability...~n'),
+    check_mindmap_packages(PkgAvail),
+    format('  Mindmap packages available: ~w~n', [PkgAvail]),
+
+    % Test 3: Transport selection
+    format('~nTest 3: Transport selection...~n'),
+    select_transport(force_layout, [], Transport),
+    format('  Selected transport: ~w~n', [Transport]),
+    (   member(Transport, [janus, pipe, socket])
+    ->  format('  PASS: Valid transport selected~n')
+    ;   format('  FAIL: Invalid transport~n')
+    ),
+
+    % Test 4: Target declarations
+    format('~nTest 4: Target declarations...~n'),
     (   get_mindmap_target(force_layout, target(python, Opts)),
         member(module(_), Opts)
-    ->  format('  PASS: force_layout target declared~n')
+    ->  format('  PASS: force_layout target exists~n')
     ;   format('  FAIL: force_layout target missing~n')
     ),
 
-    % Test 2: Custom target declaration
-    format('~nTest 2: Custom target declaration...~n'),
-    declare_mindmap_target(custom_layout, python, [module('custom.layout'), function(run)]),
-    (   get_mindmap_target(custom_layout, target(python, CustomOpts)),
-        member(module('custom.layout'), CustomOpts)
-    ->  format('  PASS: Custom target declared~n')
-    ;   format('  FAIL: Custom target declaration failed~n')
+    % Test 5: Python code generation
+    format('~nTest 5: Python code generation...~n'),
+    generate_layout_python(force_layout, [], PyCode),
+    (   sub_atom(PyCode, _, _, _, 'force_directed'),
+        sub_atom(PyCode, _, _, _, 'compute')
+    ->  format('  PASS: Python code generated~n')
+    ;   format('  FAIL: Python code generation failed~n')
     ),
 
-    % Test 3: Generate layout glue code
-    format('~nTest 3: Generate layout glue code...~n'),
+    % Test 6: Pipeline Python generation
+    format('~nTest 6: Pipeline Python generation...~n'),
+    generate_mindmap_python(test_map, [pipeline([force_layout, overlap_removal])], FullPyCode),
+    (   sub_atom(FullPyCode, _, _, _, 'def process_mindmap'),
+        sub_atom(FullPyCode, _, _, _, 'force_layout_compute')
+    ->  format('  PASS: Full pipeline code generated~n')
+    ;   format('  FAIL: Pipeline code generation failed~n')
+    ),
+
+    % Test 7: Glue code generation
+    format('~nTest 7: Glue code generation...~n'),
     generate_mindmap_glue(layout(force_layout), python, GlueCode),
-    (   sub_atom(GlueCode, _, _, _, 'force_directed'),
-        sub_atom(GlueCode, _, _, _, 'json.dumps')
-    ->  format('  PASS: Glue code generated~n')
-    ;   format('  FAIL: Glue code generation failed~n')
+    (   sub_atom(GlueCode, _, _, _, 'read_graph'),
+        sub_atom(GlueCode, _, _, _, 'write_positions')
+    ->  format('  PASS: Glue code uses io module~n')
+    ;   format('  FAIL: Glue code missing io module~n')
     ),
 
-    % Test 4: Generate optimizer glue code
-    format('~nTest 4: Generate optimizer glue code...~n'),
-    generate_mindmap_glue(optimize(overlap_removal), python, OptGlue),
-    (   sub_atom(OptGlue, _, _, _, 'overlap_removal'),
-        sub_atom(OptGlue, _, _, _, 'compute')
-    ->  format('  PASS: Optimizer glue generated~n')
-    ;   format('  FAIL: Optimizer glue generation failed~n')
+    % Test 8: Integration with janus_glue
+    format('~nTest 8: Integration with janus_glue...~n'),
+    (   catch(current_module(janus_glue), _, fail)
+    ->  format('  PASS: janus_glue module accessible~n')
+    ;   format('  INFO: janus_glue module not loaded (normal if not SWI-Prolog)~n')
     ),
-
-    % Test 5: Serialization utilities
-    format('~nTest 5: Serialization utilities...~n'),
-    TestNodes = [node(a, [label("A")]), node(b, [label("B")])],
-    TestEdges = [edge(a, b, [])],
-    serialize_graph_dict(TestNodes, TestEdges, [], Dict),
-    (   is_dict(Dict),
-        length(Dict.nodes, 2)
-    ->  format('  PASS: Graph serialization works~n')
-    ;   format('  FAIL: Graph serialization failed~n')
-    ),
-
-    % Cleanup
-    retractall(mindmap_target(custom_layout, _, _)),
 
     format('~n=== Tests Complete ===~n').
 
@@ -555,5 +764,8 @@ test_mindmap_glue :-
 % ============================================================================
 
 :- initialization((
-    format('Mind map glue module loaded~n', [])
+    (   mindmap_janus_available(Info)
+    ->  format('Mind map glue loaded (Janus: ~w)~n', [Info])
+    ;   format('Mind map glue loaded (using pipe transport)~n')
+    )
 ), now).

--- a/src/unifyweaver/mindmap/serialization/mindmap_serializer.pl
+++ b/src/unifyweaver/mindmap/serialization/mindmap_serializer.pl
@@ -1,0 +1,799 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% mindmap_serializer.pl - JSON Lines Serialization for Mind Map DSL Objects
+%
+% Provides serialization/deserialization of mindmap objects (nodes, edges,
+% positions, styles) to/from JSON Lines format for cross-target communication.
+%
+% This module follows the pipe_glue.pl patterns and integrates with the
+% cross-target glue system, enabling mindmap data to flow between Prolog,
+% Python, and other targets.
+%
+% Usage:
+%   ?- serialize_mindmap_nodes(Nodes, JsonL).
+%   ?- deserialize_mindmap_nodes(JsonL, Nodes).
+%   ?- generate_mindmap_reader(python, Code).
+
+:- module(mindmap_serializer, [
+    % Object serialization (Prolog → JSON)
+    serialize_node/2,               % serialize_node(+Node, -JsonDict)
+    serialize_edge/2,               % serialize_edge(+Edge, -JsonDict)
+    serialize_position/2,           % serialize_position(+Position, -JsonDict)
+    serialize_style/2,              % serialize_style(+Style, -JsonDict)
+
+    % Batch serialization
+    serialize_mindmap_nodes/2,      % serialize_mindmap_nodes(+Nodes, -JsonL)
+    serialize_mindmap_edges/2,      % serialize_mindmap_edges(+Edges, -JsonL)
+    serialize_mindmap_positions/2,  % serialize_mindmap_positions(+Positions, -JsonL)
+    serialize_mindmap_graph/2,      % serialize_mindmap_graph(+Graph, -JsonL)
+
+    % Object deserialization (JSON → Prolog)
+    deserialize_node/2,             % deserialize_node(+JsonDict, -Node)
+    deserialize_edge/2,             % deserialize_edge(+JsonDict, -Edge)
+    deserialize_position/2,         % deserialize_position(+JsonDict, -Position)
+
+    % Batch deserialization
+    deserialize_mindmap_nodes/2,    % deserialize_mindmap_nodes(+JsonL, -Nodes)
+    deserialize_mindmap_edges/2,    % deserialize_mindmap_edges(+JsonL, -Edges)
+    deserialize_mindmap_graph/2,    % deserialize_mindmap_graph(+JsonL, -Graph)
+
+    % Stream I/O
+    write_mindmap_jsonl/2,          % write_mindmap_jsonl(+Stream, +Objects)
+    read_mindmap_jsonl/2,           % read_mindmap_jsonl(+Stream, -Objects)
+
+    % Code generation for other targets
+    generate_mindmap_reader/2,      % generate_mindmap_reader(+Target, -Code)
+    generate_mindmap_writer/2,      % generate_mindmap_writer(+Target, -Code)
+
+    % Protocol abstraction
+    mindmap_protocol/2,             % mindmap_protocol(+ProtocolName, -Spec)
+    register_mindmap_protocol/2,    % register_mindmap_protocol(+Name, +Spec)
+
+    % Testing
+    test_mindmap_serializer/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% JSON LINES FORMAT SPECIFICATION
+% ============================================================================
+%
+% Each mindmap object is serialized as a single JSON line with a "type" field:
+%
+% Node:
+%   {"type":"node","id":"n1","label":"Topic","node_type":"root","props":{...}}
+%
+% Edge:
+%   {"type":"edge","from":"n1","to":"n2","edge_type":"parent","props":{...}}
+%
+% Position:
+%   {"type":"position","id":"n1","x":100.5,"y":200.3}
+%
+% Style:
+%   {"type":"style","selector":"root","properties":{"fill":"#4a90d9",...}}
+%
+% Graph (compound object):
+%   {"type":"graph","id":"map1","nodes":[...],"edges":[...],"positions":[...]}
+%
+% ============================================================================
+
+% ============================================================================
+% PROTOCOL REGISTRY
+% ============================================================================
+
+:- dynamic mindmap_protocol/2.
+
+% Default protocol: JSON Lines
+mindmap_protocol(jsonl, protocol{
+    name: jsonl,
+    description: "JSON Lines - one JSON object per line",
+    mime_type: "application/x-ndjson",
+    file_extension: ".jsonl",
+    record_delimiter: "\n",
+    supports_streaming: true,
+    supports_nested: true
+}).
+
+% TSV protocol (flat records only)
+mindmap_protocol(tsv, protocol{
+    name: tsv,
+    description: "Tab-separated values",
+    mime_type: "text/tab-separated-values",
+    file_extension: ".tsv",
+    record_delimiter: "\n",
+    field_delimiter: "\t",
+    supports_streaming: true,
+    supports_nested: false
+}).
+
+%% register_mindmap_protocol(+Name, +Spec)
+register_mindmap_protocol(Name, Spec) :-
+    retractall(mindmap_protocol(Name, _)),
+    assertz(mindmap_protocol(Name, Spec)).
+
+% ============================================================================
+% NODE SERIALIZATION
+% ============================================================================
+
+%% serialize_node(+Node, -JsonDict)
+%  Convert a mindmap node to a JSON-compatible dict.
+%
+serialize_node(node(Id, Props), JsonDict) :-
+    % Extract standard properties
+    (member(label(Label), Props) -> true ; Label = ""),
+    (member(type(NodeType), Props) -> true ; NodeType = default),
+    (member(parent(Parent), Props) -> true ; Parent = null),
+    (member(link(Link), Props) -> true ; Link = null),
+    (member(cluster(Cluster), Props) -> true ; Cluster = null),
+
+    % Collect remaining properties
+    exclude(is_standard_node_prop, Props, ExtraProps),
+    props_to_dict(ExtraProps, ExtraDict),
+
+    % Build JSON dict
+    JsonDict = json{
+        type: node,
+        id: Id,
+        label: Label,
+        node_type: NodeType,
+        parent: Parent,
+        link: Link,
+        cluster: Cluster,
+        props: ExtraDict
+    }.
+
+is_standard_node_prop(label(_)).
+is_standard_node_prop(type(_)).
+is_standard_node_prop(parent(_)).
+is_standard_node_prop(link(_)).
+is_standard_node_prop(cluster(_)).
+
+%% deserialize_node(+JsonDict, -Node)
+deserialize_node(JsonDict, node(Id, Props)) :-
+    Id = JsonDict.id,
+    Label = JsonDict.label,
+    NodeType = JsonDict.node_type,
+    Parent = JsonDict.parent,
+    Link = JsonDict.link,
+    Cluster = JsonDict.cluster,
+
+    % Build properties list
+    Props0 = [label(Label), type(NodeType)],
+    (Parent \== null -> Props1 = [parent(Parent) | Props0] ; Props1 = Props0),
+    (Link \== null -> Props2 = [link(Link) | Props1] ; Props2 = Props1),
+    (Cluster \== null -> Props3 = [cluster(Cluster) | Props2] ; Props3 = Props2),
+
+    % Add extra props
+    (   get_dict(props, JsonDict, ExtraDict),
+        is_dict(ExtraDict)
+    ->  dict_to_props(ExtraDict, ExtraProps),
+        append(Props3, ExtraProps, Props)
+    ;   Props = Props3
+    ).
+
+% ============================================================================
+% EDGE SERIALIZATION
+% ============================================================================
+
+%% serialize_edge(+Edge, -JsonDict)
+serialize_edge(edge(From, To, Props), JsonDict) :-
+    (member(type(EdgeType), Props) -> true ; EdgeType = default),
+    (member(weight(Weight), Props) -> true ; Weight = 1),
+    (member(label(Label), Props) -> true ; Label = null),
+
+    exclude(is_standard_edge_prop, Props, ExtraProps),
+    props_to_dict(ExtraProps, ExtraDict),
+
+    JsonDict = json{
+        type: edge,
+        from: From,
+        to: To,
+        edge_type: EdgeType,
+        weight: Weight,
+        label: Label,
+        props: ExtraDict
+    }.
+
+is_standard_edge_prop(type(_)).
+is_standard_edge_prop(weight(_)).
+is_standard_edge_prop(label(_)).
+
+%% deserialize_edge(+JsonDict, -Edge)
+deserialize_edge(JsonDict, edge(From, To, Props)) :-
+    From = JsonDict.from,
+    To = JsonDict.to,
+    EdgeType = JsonDict.edge_type,
+    Weight = JsonDict.weight,
+    Label = JsonDict.label,
+
+    Props0 = [type(EdgeType), weight(Weight)],
+    (Label \== null -> Props1 = [label(Label) | Props0] ; Props1 = Props0),
+
+    (   get_dict(props, JsonDict, ExtraDict),
+        is_dict(ExtraDict)
+    ->  dict_to_props(ExtraDict, ExtraProps),
+        append(Props1, ExtraProps, Props)
+    ;   Props = Props1
+    ).
+
+% ============================================================================
+% POSITION SERIALIZATION
+% ============================================================================
+
+%% serialize_position(+Position, -JsonDict)
+serialize_position(position(Id, X, Y), JsonDict) :-
+    JsonDict = json{
+        type: position,
+        id: Id,
+        x: X,
+        y: Y
+    }.
+
+%% deserialize_position(+JsonDict, -Position)
+deserialize_position(JsonDict, position(Id, X, Y)) :-
+    Id = JsonDict.id,
+    X = JsonDict.x,
+    Y = JsonDict.y.
+
+% ============================================================================
+% STYLE SERIALIZATION
+% ============================================================================
+
+%% serialize_style(+Style, -JsonDict)
+serialize_style(style(Selector, Properties), JsonDict) :-
+    props_to_dict(Properties, PropsDict),
+    JsonDict = json{
+        type: style,
+        selector: Selector,
+        properties: PropsDict
+    }.
+
+% ============================================================================
+% BATCH SERIALIZATION
+% ============================================================================
+
+%% serialize_mindmap_nodes(+Nodes, -JsonL)
+%  Serialize a list of nodes to JSON Lines string.
+%
+serialize_mindmap_nodes(Nodes, JsonL) :-
+    maplist(serialize_node, Nodes, JsonDicts),
+    maplist(dict_to_json_line, JsonDicts, Lines),
+    atomic_list_concat(Lines, '\n', JsonL).
+
+%% serialize_mindmap_edges(+Edges, -JsonL)
+serialize_mindmap_edges(Edges, JsonL) :-
+    maplist(serialize_edge, Edges, JsonDicts),
+    maplist(dict_to_json_line, JsonDicts, Lines),
+    atomic_list_concat(Lines, '\n', JsonL).
+
+%% serialize_mindmap_positions(+Positions, -JsonL)
+serialize_mindmap_positions(Positions, JsonL) :-
+    maplist(serialize_position, Positions, JsonDicts),
+    maplist(dict_to_json_line, JsonDicts, Lines),
+    atomic_list_concat(Lines, '\n', JsonL).
+
+%% serialize_mindmap_graph(+Graph, -JsonL)
+%  Serialize a complete graph structure.
+%  Graph = graph(Id, Nodes, Edges, Positions)
+%
+serialize_mindmap_graph(graph(Id, Nodes, Edges, Positions), JsonL) :-
+    maplist(serialize_node, Nodes, NodeDicts),
+    maplist(serialize_edge, Edges, EdgeDicts),
+    maplist(serialize_position, Positions, PosDicts),
+
+    GraphDict = json{
+        type: graph,
+        id: Id,
+        nodes: NodeDicts,
+        edges: EdgeDicts,
+        positions: PosDicts
+    },
+
+    dict_to_json_line(GraphDict, JsonL).
+
+% ============================================================================
+% BATCH DESERIALIZATION
+% ============================================================================
+
+%% deserialize_mindmap_nodes(+JsonL, -Nodes)
+deserialize_mindmap_nodes(JsonL, Nodes) :-
+    split_json_lines(JsonL, Lines),
+    maplist(json_line_to_dict, Lines, Dicts),
+    include(is_node_dict, Dicts, NodeDicts),
+    maplist(deserialize_node, NodeDicts, Nodes).
+
+%% deserialize_mindmap_edges(+JsonL, -Edges)
+deserialize_mindmap_edges(JsonL, Edges) :-
+    split_json_lines(JsonL, Lines),
+    maplist(json_line_to_dict, Lines, Dicts),
+    include(is_edge_dict, Dicts, EdgeDicts),
+    maplist(deserialize_edge, EdgeDicts, Edges).
+
+%% deserialize_mindmap_graph(+JsonL, -Graph)
+deserialize_mindmap_graph(JsonL, graph(Id, Nodes, Edges, Positions)) :-
+    json_line_to_dict(JsonL, Dict),
+    Dict.type == graph,
+    Id = Dict.id,
+    maplist(deserialize_node, Dict.nodes, Nodes),
+    maplist(deserialize_edge, Dict.edges, Edges),
+    maplist(deserialize_position, Dict.positions, Positions).
+
+is_node_dict(Dict) :- Dict.type == node.
+is_edge_dict(Dict) :- Dict.type == edge.
+
+% ============================================================================
+% STREAM I/O
+% ============================================================================
+
+%% write_mindmap_jsonl(+Stream, +Objects)
+%  Write mindmap objects to a stream as JSON Lines.
+%
+write_mindmap_jsonl(Stream, Objects) :-
+    forall(
+        member(Obj, Objects),
+        (   serialize_object(Obj, Dict),
+            dict_to_json_line(Dict, Line),
+            writeln(Stream, Line)
+        )
+    ).
+
+serialize_object(node(Id, Props), Dict) :- serialize_node(node(Id, Props), Dict).
+serialize_object(edge(F, T, P), Dict) :- serialize_edge(edge(F, T, P), Dict).
+serialize_object(position(I, X, Y), Dict) :- serialize_position(position(I, X, Y), Dict).
+
+%% read_mindmap_jsonl(+Stream, -Objects)
+%  Read mindmap objects from a JSON Lines stream.
+%
+read_mindmap_jsonl(Stream, Objects) :-
+    read_all_lines(Stream, Lines),
+    maplist(json_line_to_dict, Lines, Dicts),
+    maplist(deserialize_object, Dicts, Objects).
+
+deserialize_object(Dict, node(Id, Props)) :-
+    Dict.type == node, !,
+    deserialize_node(Dict, node(Id, Props)).
+deserialize_object(Dict, edge(F, T, P)) :-
+    Dict.type == edge, !,
+    deserialize_edge(Dict, edge(F, T, P)).
+deserialize_object(Dict, position(I, X, Y)) :-
+    Dict.type == position, !,
+    deserialize_position(Dict, position(I, X, Y)).
+
+read_all_lines(Stream, Lines) :-
+    read_line_to_string(Stream, Line),
+    (   Line == end_of_file
+    ->  Lines = []
+    ;   Lines = [Line | Rest],
+        read_all_lines(Stream, Rest)
+    ).
+
+% ============================================================================
+% CODE GENERATION FOR OTHER TARGETS
+% ============================================================================
+
+%% generate_mindmap_reader(+Target, -Code)
+%  Generate code to read mindmap JSON Lines in the target language.
+%
+generate_mindmap_reader(python, Code) :-
+    Code = '
+import json
+import sys
+from dataclasses import dataclass
+from typing import List, Optional, Dict, Any
+
+@dataclass
+class MindmapNode:
+    id: str
+    label: str
+    node_type: str = "default"
+    parent: Optional[str] = None
+    link: Optional[str] = None
+    cluster: Optional[str] = None
+    props: Dict[str, Any] = None
+
+@dataclass
+class MindmapEdge:
+    from_id: str
+    to_id: str
+    edge_type: str = "default"
+    weight: float = 1.0
+    label: Optional[str] = None
+    props: Dict[str, Any] = None
+
+@dataclass
+class MindmapPosition:
+    id: str
+    x: float
+    y: float
+
+def read_mindmap_jsonl(stream=sys.stdin):
+    """Read mindmap objects from JSON Lines stream."""
+    for line in stream:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        obj_type = obj.get("type")
+
+        if obj_type == "node":
+            yield MindmapNode(
+                id=obj["id"],
+                label=obj.get("label", ""),
+                node_type=obj.get("node_type", "default"),
+                parent=obj.get("parent"),
+                link=obj.get("link"),
+                cluster=obj.get("cluster"),
+                props=obj.get("props", {})
+            )
+        elif obj_type == "edge":
+            yield MindmapEdge(
+                from_id=obj["from"],
+                to_id=obj["to"],
+                edge_type=obj.get("edge_type", "default"),
+                weight=obj.get("weight", 1.0),
+                label=obj.get("label"),
+                props=obj.get("props", {})
+            )
+        elif obj_type == "position":
+            yield MindmapPosition(
+                id=obj["id"],
+                x=obj["x"],
+                y=obj["y"]
+            )
+'.
+
+generate_mindmap_reader(go, Code) :-
+    Code = '
+package mindmap
+
+import (
+    "bufio"
+    "encoding/json"
+    "io"
+)
+
+type MindmapNode struct {
+    ID       string                 `json:"id"`
+    Label    string                 `json:"label"`
+    NodeType string                 `json:"node_type"`
+    Parent   *string                `json:"parent,omitempty"`
+    Link     *string                `json:"link,omitempty"`
+    Cluster  *string                `json:"cluster,omitempty"`
+    Props    map[string]interface{} `json:"props,omitempty"`
+}
+
+type MindmapEdge struct {
+    From     string                 `json:"from"`
+    To       string                 `json:"to"`
+    EdgeType string                 `json:"edge_type"`
+    Weight   float64                `json:"weight"`
+    Label    *string                `json:"label,omitempty"`
+    Props    map[string]interface{} `json:"props,omitempty"`
+}
+
+type MindmapPosition struct {
+    ID string  `json:"id"`
+    X  float64 `json:"x"`
+    Y  float64 `json:"y"`
+}
+
+func ReadMindmapJSONL(reader io.Reader) (<-chan interface{}, <-chan error) {
+    objects := make(chan interface{})
+    errors := make(chan error, 1)
+
+    go func() {
+        defer close(objects)
+        defer close(errors)
+
+        scanner := bufio.NewScanner(reader)
+        for scanner.Scan() {
+            line := scanner.Bytes()
+            if len(line) == 0 {
+                continue
+            }
+
+            var raw map[string]interface{}
+            if err := json.Unmarshal(line, &raw); err != nil {
+                errors <- err
+                return
+            }
+
+            switch raw["type"] {
+            case "node":
+                var node MindmapNode
+                json.Unmarshal(line, &node)
+                objects <- node
+            case "edge":
+                var edge MindmapEdge
+                json.Unmarshal(line, &edge)
+                objects <- edge
+            case "position":
+                var pos MindmapPosition
+                json.Unmarshal(line, &pos)
+                objects <- pos
+            }
+        }
+    }()
+
+    return objects, errors
+}
+'.
+
+generate_mindmap_reader(typescript, Code) :-
+    Code = '
+interface MindmapNode {
+    type: "node";
+    id: string;
+    label: string;
+    node_type: string;
+    parent?: string;
+    link?: string;
+    cluster?: string;
+    props?: Record<string, unknown>;
+}
+
+interface MindmapEdge {
+    type: "edge";
+    from: string;
+    to: string;
+    edge_type: string;
+    weight: number;
+    label?: string;
+    props?: Record<string, unknown>;
+}
+
+interface MindmapPosition {
+    type: "position";
+    id: string;
+    x: number;
+    y: number;
+}
+
+type MindmapObject = MindmapNode | MindmapEdge | MindmapPosition;
+
+function* readMindmapJSONL(lines: string[]): Generator<MindmapObject> {
+    for (const line of lines) {
+        if (!line.trim()) continue;
+        const obj = JSON.parse(line) as MindmapObject;
+        yield obj;
+    }
+}
+
+async function* readMindmapStream(
+    reader: ReadableStreamDefaultReader<Uint8Array>
+): AsyncGenerator<MindmapObject> {
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+            if (line.trim()) {
+                yield JSON.parse(line) as MindmapObject;
+            }
+        }
+    }
+}
+'.
+
+%% generate_mindmap_writer(+Target, -Code)
+%  Generate code to write mindmap JSON Lines in the target language.
+%
+generate_mindmap_writer(python, Code) :-
+    Code = '
+import json
+import sys
+
+def write_node(node, stream=sys.stdout):
+    """Write a MindmapNode as JSON Line."""
+    obj = {
+        "type": "node",
+        "id": node.id,
+        "label": node.label,
+        "node_type": node.node_type,
+        "parent": node.parent,
+        "link": node.link,
+        "cluster": node.cluster,
+        "props": node.props or {}
+    }
+    print(json.dumps(obj, ensure_ascii=False), file=stream)
+
+def write_edge(edge, stream=sys.stdout):
+    """Write a MindmapEdge as JSON Line."""
+    obj = {
+        "type": "edge",
+        "from": edge.from_id,
+        "to": edge.to_id,
+        "edge_type": edge.edge_type,
+        "weight": edge.weight,
+        "label": edge.label,
+        "props": edge.props or {}
+    }
+    print(json.dumps(obj, ensure_ascii=False), file=stream)
+
+def write_position(pos, stream=sys.stdout):
+    """Write a MindmapPosition as JSON Line."""
+    obj = {
+        "type": "position",
+        "id": pos.id,
+        "x": pos.x,
+        "y": pos.y
+    }
+    print(json.dumps(obj, ensure_ascii=False), file=stream)
+
+def write_positions(positions, stream=sys.stdout):
+    """Write position dict {id: (x, y)} as JSON Lines."""
+    for node_id, (x, y) in positions.items():
+        obj = {"type": "position", "id": node_id, "x": x, "y": y}
+        print(json.dumps(obj), file=stream)
+'.
+
+generate_mindmap_writer(go, Code) :-
+    Code = '
+package mindmap
+
+import (
+    "encoding/json"
+    "io"
+)
+
+func WriteNode(w io.Writer, node MindmapNode) error {
+    node.Props["type"] = "node"
+    return json.NewEncoder(w).Encode(node)
+}
+
+func WriteEdge(w io.Writer, edge MindmapEdge) error {
+    return json.NewEncoder(w).Encode(struct {
+        Type string `json:"type"`
+        MindmapEdge
+    }{"edge", edge})
+}
+
+func WritePosition(w io.Writer, pos MindmapPosition) error {
+    return json.NewEncoder(w).Encode(struct {
+        Type string `json:"type"`
+        MindmapPosition
+    }{"position", pos})
+}
+'.
+
+% ============================================================================
+% UTILITIES
+% ============================================================================
+
+%% props_to_dict(+Props, -Dict)
+%  Convert a list of Prop(Value) terms to a dict.
+%
+props_to_dict([], json{}).
+props_to_dict(Props, Dict) :-
+    Props \== [],
+    findall(Key-Value, (member(Prop, Props), Prop =.. [Key, Value]), Pairs),
+    dict_create(Dict, json, Pairs).
+
+%% dict_to_props(+Dict, -Props)
+%  Convert a dict to a list of Prop(Value) terms.
+%
+dict_to_props(Dict, Props) :-
+    dict_pairs(Dict, _, Pairs),
+    findall(Prop, (member(Key-Value, Pairs), Prop =.. [Key, Value]), Props).
+
+%% dict_to_json_line(+Dict, -JsonLine)
+%  Convert a dict to a JSON string (single line).
+%
+dict_to_json_line(Dict, JsonLine) :-
+    % Use SWI-Prolog's json_write
+    with_output_to(string(JsonLine),
+        json_write(current_output, Dict, [width(0)])
+    ).
+
+%% json_line_to_dict(+JsonLine, -Dict)
+%  Parse a JSON string to a dict.
+%
+json_line_to_dict(JsonLine, Dict) :-
+    atom_string(JsonAtom, JsonLine),
+    atom_json_dict(JsonAtom, Dict, []).
+
+%% split_json_lines(+JsonL, -Lines)
+%  Split JSON Lines string into individual lines.
+%
+split_json_lines(JsonL, Lines) :-
+    split_string(JsonL, "\n", "\r\t ", Lines0),
+    exclude(=(""), Lines0, Lines).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_mindmap_serializer :-
+    format('~n=== Mind Map Serializer Tests ===~n~n'),
+
+    % Test 1: Serialize node
+    format('Test 1: Serialize node...~n'),
+    TestNode = node(n1, [label("Test Node"), type(root), parent(null), link("http://example.com")]),
+    serialize_node(TestNode, NodeDict),
+    (   NodeDict.id == n1,
+        NodeDict.label == "Test Node",
+        NodeDict.node_type == root
+    ->  format('  PASS: Node serialized correctly~n')
+    ;   format('  FAIL: Node serialization incorrect~n')
+    ),
+
+    % Test 2: Deserialize node
+    format('~nTest 2: Deserialize node...~n'),
+    deserialize_node(NodeDict, DeserializedNode),
+    DeserializedNode = node(DId, DProps),
+    (   DId == n1,
+        member(label("Test Node"), DProps)
+    ->  format('  PASS: Node deserialized correctly~n')
+    ;   format('  FAIL: Node deserialization incorrect~n')
+    ),
+
+    % Test 3: Serialize edge
+    format('~nTest 3: Serialize edge...~n'),
+    TestEdge = edge(n1, n2, [type(strong), weight(2)]),
+    serialize_edge(TestEdge, EdgeDict),
+    (   EdgeDict.from == n1,
+        EdgeDict.to == n2,
+        EdgeDict.edge_type == strong
+    ->  format('  PASS: Edge serialized correctly~n')
+    ;   format('  FAIL: Edge serialization incorrect~n')
+    ),
+
+    % Test 4: Serialize position
+    format('~nTest 4: Serialize position...~n'),
+    TestPos = position(n1, 100.5, 200.3),
+    serialize_position(TestPos, PosDict),
+    (   PosDict.id == n1,
+        PosDict.x =:= 100.5,
+        PosDict.y =:= 200.3
+    ->  format('  PASS: Position serialized correctly~n')
+    ;   format('  FAIL: Position serialization incorrect~n')
+    ),
+
+    % Test 5: Batch serialize nodes
+    format('~nTest 5: Batch serialize nodes to JSON Lines...~n'),
+    Nodes = [
+        node(a, [label("A"), type(root)]),
+        node(b, [label("B"), type(branch)])
+    ],
+    serialize_mindmap_nodes(Nodes, JsonL),
+    (   sub_string(JsonL, _, _, _, "\"id\":\"a\""),
+        sub_string(JsonL, _, _, _, "\"id\":\"b\"")
+    ->  format('  PASS: Batch serialization works~n')
+    ;   format('  FAIL: Batch serialization failed~n')
+    ),
+
+    % Test 6: Generate Python reader
+    format('~nTest 6: Generate Python reader code...~n'),
+    generate_mindmap_reader(python, PyCode),
+    (   sub_string(PyCode, _, _, _, "MindmapNode"),
+        sub_string(PyCode, _, _, _, "read_mindmap_jsonl")
+    ->  format('  PASS: Python reader generated~n')
+    ;   format('  FAIL: Python reader generation failed~n')
+    ),
+
+    % Test 7: Protocol registry
+    format('~nTest 7: Protocol registry...~n'),
+    mindmap_protocol(jsonl, JsonlSpec),
+    (   JsonlSpec.supports_streaming == true
+    ->  format('  PASS: jsonL protocol registered~n')
+    ;   format('  FAIL: Protocol not found~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('Mind map serializer module loaded~n', [])
+), now).


### PR DESCRIPTION
## Summary

Integrates the mind map DSL with UnifyWeaver's cross-target glue infrastructure, enabling seamless Prolog-Python communication for layout algorithms and optimization passes.

**Key Features:**
- JSON Lines serialization for mindmap objects (nodes, edges, positions)
- Protocol-agnostic I/O with pluggable data formats
- Automatic transport selection (Janus in-process vs pipe subprocess)
- Python dataclasses matching Prolog structures for first-class object support
- Integration with existing `janus_glue.pl` infrastructure

## Changes

### New Files

| File | Description |
|------|-------------|
| `src/unifyweaver/mindmap/serialization/mindmap_serializer.pl` | JSON Lines serialization with protocol registry |
| `src/unifyweaver/mindmap/glue/mindmap_glue.pl` | Cross-target dispatch and Python code generation |
| `scripts/unifyweaver/mindmap/io.py` | Python dataclasses and streaming I/O |

### Modified Files

| File | Description |
|------|-------------|
| `scripts/unifyweaver/mindmap/__init__.py` | Added `io` module to exports |
| `docs/design/mindmap_declarative_targets/IMPLEMENTATION_PLAN.md` | Added glue architecture docs |

## Architecture

### Transport Selection

The glue automatically selects the optimal transport:

1. **Janus Transport** (preferred when available)
   - In-process Python calls via SWI-Prolog's Janus library
   - Zero serialization overhead
   - Requires: SWI-Prolog, Janus, mindmap Python packages

2. **Pipe Transport** (fallback)
   - Subprocess communication via Unix pipes
   - JSON Lines encoding for streaming data
   - Works with any Prolog implementation

### Module Integration

```
mindmap_glue.pl
    ├── delegates to → janus_glue.pl (in-process)
    └── delegates to → pipe_glue.pl (subprocess)
                           └── uses → mindmap_serializer.pl (JSON Lines)
                                          └── parsed by → io.py (Python)
```

### JSON Lines Protocol

Mindmap objects are serialized as typed JSON objects:

```json
{"type": "node", "id": "root", "label": "Main Topic", "node_type": "root"}
{"type": "edge", "from": "root", "to": "child1", "edge_type": "default"}
{"type": "position", "id": "root", "x": 0.0, "y": 0.0}
```

## Usage Examples

### Prolog (executing pipeline)

```prolog
% Check if Janus is available for mindmaps
?- mindmap_janus_available(Info).
Info = janus('3.11.0').

% Execute a layout pipeline (auto-selects transport)
?- execute_mindmap_pipeline(my_map,
       [pipeline([force_layout, overlap_removal])],
       Result).

% Generate standalone Python code
?- generate_mindmap_python(my_map, [], PythonCode).
```

### Python (streaming I/O)

```python
from unifyweaver.mindmap.io import read_graph, write_positions

# Read graph from stdin (from Prolog via pipe)
graph = read_graph(sys.stdin)

# Process nodes
positions = compute_layout(graph.nodes, graph.edges)

# Write positions back (to Prolog via pipe)
write_positions(positions, sys.stdout)
```

## Test Plan

- [ ] Verify `mindmap_janus_available/0` correctly detects Janus on SWI-Prolog
- [ ] Verify fallback to pipe transport on GNU Prolog
- [ ] Test JSON Lines serialization round-trip for all object types
- [ ] Test Python `io.py` reading/writing with sample data
- [ ] Run `test_mindmap_glue/0` predicate
- [ ] Verify pipeline execution with both transports

## Related

- Continues work from PR #540 (mindmap enhancements)
- Uses existing `janus_glue.pl` infrastructure
- Implements task from IMPLEMENTATION_PLAN.md Phase 4.3

---

Generated with [Claude Code](https://claude.com/claude-code)
