### PR TITLE
feat: Add rdf repair tools for Pearltrees from zip and HTML exports

### DIFF
--- a/scripts/repair_from_html_export.py
+++ b/scripts/repair_from_html_export.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""
+Repair/augment JSONL data from Pearltrees HTML (Netscape bookmark) exports.
+
+HTML exports contain:
+- Folder hierarchy (<H3> tags for trees)
+- PagePearls (<A TARGET="_BLANK"> with external URLs but NO pearl_uri)
+- AliasPearls (<A HREF="pearltrees.com/..."> with full Pearltrees URI)
+
+This script can:
+1. Extract AliasPearls with their full URIs
+2. Build folder hierarchy (child folder names under each parent)
+3. Match PagePearls by URL to find their pearl_uri from existing JSONL/RDF
+
+Usage:
+    # Extract what's available and compare with existing JSONL
+    python3 scripts/repair_from_html_export.py \
+        --html-export "context/PT/pearltrees_export_s243a_grous_2026-01-05.html" \
+        --compare reports/pearltrees_targets_repaired.jsonl \
+        --output /tmp/html_export_analysis.jsonl
+
+    # Just analyze the HTML export structure
+    python3 scripts/repair_from_html_export.py \
+        --html-export "context/PT/pearltrees_export_s243a_grous_2026-01-05.html" \
+        --analyze
+"""
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Set
+from html.parser import HTMLParser
+from dataclasses import dataclass, field
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BookmarkItem:
+    """Represents an item from the HTML export."""
+    title: str
+    url: str
+    add_date: str = ""
+    is_folder: bool = False
+    is_pearltrees_link: bool = False
+    parent_path: List[str] = field(default_factory=list)
+
+    @property
+    def pearltrees_uri(self) -> Optional[str]:
+        """Extract Pearltrees URI if this is a Pearltrees link."""
+        if self.is_pearltrees_link and 'pearltrees.com' in self.url:
+            return self.url
+        return None
+
+    @property
+    def tree_id(self) -> Optional[str]:
+        """Extract tree ID from Pearltrees URI."""
+        if not self.pearltrees_uri:
+            return None
+        match = re.search(r'/id(\d+)(?:/|$)', self.pearltrees_uri)
+        return match.group(1) if match else None
+
+
+class HierarchyBuilder:
+    """Builds hybrid hierarchy with title paths and partial ID paths."""
+
+    def __init__(self):
+        # Map folder title to known tree ID (from AliasPearls)
+        self.title_to_id: Dict[str, str] = {}
+        # Map full title path tuple to known tree ID
+        self.path_to_id: Dict[Tuple[str, ...], str] = {}
+
+    def register_known_id(self, title: str, tree_id: str, parent_path: List[str] = None):
+        """Register a known title -> tree_id mapping."""
+        self.title_to_id[title] = tree_id
+        if parent_path is not None:
+            full_path = tuple(parent_path + [title])
+            self.path_to_id[full_path] = tree_id
+
+    def build_id_path_pattern(self, title_path: List[str]) -> str:
+        """Build materialized ID path with regex for unknown parts.
+
+        Args:
+            title_path: List of folder titles from root to current
+
+        Returns:
+            Pattern like '/10311468/[^/]+/[^/]+/2492215'
+        """
+        parts = []
+        for i, title in enumerate(title_path):
+            # Try exact path match first
+            path_tuple = tuple(title_path[:i+1])
+            if path_tuple in self.path_to_id:
+                parts.append(self.path_to_id[path_tuple])
+            # Fall back to title-only match
+            elif title in self.title_to_id:
+                parts.append(self.title_to_id[title])
+            else:
+                # Unknown - use regex pattern
+                parts.append('[^/]+')
+
+        return '/' + '/'.join(parts) if parts else '/'
+
+    def get_known_id(self, title: str, parent_path: List[str] = None) -> Optional[str]:
+        """Get known ID for a title, preferring path-specific match."""
+        if parent_path is not None:
+            full_path = tuple(parent_path + [title])
+            if full_path in self.path_to_id:
+                return self.path_to_id[full_path]
+        return self.title_to_id.get(title)
+
+
+class NetscapeBookmarkParser(HTMLParser):
+    """Parser for Netscape bookmark HTML format."""
+
+    def __init__(self):
+        super().__init__()
+        self.items: List[BookmarkItem] = []
+        self.folders: List[BookmarkItem] = []
+        self.folder_stack: List[str] = []  # Current path of folder names
+        self.current_attrs: Dict = {}
+        self.in_h3 = False
+        self.in_a = False
+        self.current_text = ""
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+
+        if tag == 'h3':
+            self.in_h3 = True
+            self.current_attrs = attrs_dict
+            self.current_text = ""
+        elif tag == 'a':
+            self.in_a = True
+            self.current_attrs = attrs_dict
+            self.current_text = ""
+        elif tag == 'dl':
+            # Entering a new folder's content
+            pass
+
+    def handle_endtag(self, tag):
+        if tag == 'h3' and self.in_h3:
+            # Folder/Tree
+            folder = BookmarkItem(
+                title=self.current_text.strip(),
+                url="",
+                add_date=self.current_attrs.get('add_date', ''),
+                is_folder=True,
+                parent_path=self.folder_stack.copy()
+            )
+            self.folders.append(folder)
+            self.folder_stack.append(folder.title)
+            self.in_h3 = False
+
+        elif tag == 'a' and self.in_a:
+            # Bookmark link
+            url = self.current_attrs.get('href', '')
+            is_pt = 'pearltrees.com' in url and 'TARGET' not in str(self.current_attrs).upper()
+
+            # Check if it's a Pearltrees internal link (no TARGET="_BLANK")
+            has_target_blank = self.current_attrs.get('target', '').upper() == '_BLANK'
+            is_pt = 'pearltrees.com' in url and not has_target_blank
+
+            item = BookmarkItem(
+                title=self.current_text.strip(),
+                url=url,
+                add_date=self.current_attrs.get('add_date', ''),
+                is_folder=False,
+                is_pearltrees_link=is_pt,
+                parent_path=self.folder_stack.copy()
+            )
+            self.items.append(item)
+            self.in_a = False
+
+        elif tag == 'dl':
+            # Exiting a folder
+            if self.folder_stack:
+                self.folder_stack.pop()
+
+    def handle_data(self, data):
+        if self.in_h3 or self.in_a:
+            self.current_text += data
+
+
+def parse_html_export(html_path: Path) -> Tuple[List[BookmarkItem], List[BookmarkItem]]:
+    """Parse HTML export file.
+
+    Returns:
+        (items, folders): Lists of bookmark items and folders
+    """
+    content = html_path.read_text(encoding='utf-8', errors='ignore')
+
+    parser = NetscapeBookmarkParser()
+    parser.feed(content)
+
+    return parser.items, parser.folders
+
+
+def load_existing_jsonl(jsonl_path: Path) -> Tuple[Dict[str, Dict], Dict[str, Dict]]:
+    """Load existing JSONL and build indices.
+
+    Returns:
+        (by_url, by_uri): Indices for lookup by URL and URI
+    """
+    by_url = {}  # source URL -> entry
+    by_uri = {}  # pearltrees URI -> entry
+
+    if not jsonl_path.exists():
+        return by_url, by_uri
+
+    with open(jsonl_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            try:
+                entry = json.loads(line.strip())
+            except json.JSONDecodeError:
+                continue
+
+            # Index by URL (for PagePearls)
+            url = entry.get('url', '')
+            if url and url != 'null':
+                by_url[url] = entry
+
+            # Index by URI (for trees and pearls)
+            uri = entry.get('uri') or entry.get('pearl_uri', '')
+            if uri:
+                by_uri[uri] = entry
+
+    return by_url, by_uri
+
+
+def analyze_export(items: List[BookmarkItem], folders: List[BookmarkItem]):
+    """Print analysis of the HTML export."""
+
+    pt_links = [i for i in items if i.is_pearltrees_link]
+    external_links = [i for i in items if not i.is_pearltrees_link]
+
+    print(f"\n=== HTML Export Analysis ===")
+    print(f"Total folders (Trees):     {len(folders)}")
+    print(f"Total bookmarks:           {len(items)}")
+    print(f"  - Pearltrees links:      {len(pt_links)} (have URI)")
+    print(f"  - External links:        {len(external_links)} (no pearl_uri)")
+
+    # Show folder depth distribution
+    max_depth = max((len(f.parent_path) for f in folders), default=0)
+    print(f"\nMax folder depth: {max_depth}")
+
+    # Show sample Pearltrees links
+    if pt_links:
+        print(f"\nSample Pearltrees links (AliasPearls):")
+        for item in pt_links[:5]:
+            path = " > ".join(item.parent_path[-3:]) if item.parent_path else "(root)"
+            print(f"  - {item.title}")
+            print(f"    URI: {item.url}")
+            print(f"    Path: {path}")
+
+    # Show top-level folders
+    top_folders = [f for f in folders if len(f.parent_path) == 0]
+    if top_folders:
+        print(f"\nTop-level folders ({len(top_folders)}):")
+        for f in top_folders[:10]:
+            print(f"  - {f.title}")
+        if len(top_folders) > 10:
+            print(f"  ... and {len(top_folders) - 10} more")
+
+
+def match_with_existing(
+    items: List[BookmarkItem],
+    folders: List[BookmarkItem],
+    by_url: Dict[str, Dict],
+    by_uri: Dict[str, Dict]
+) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+    """Match HTML export items with existing JSONL data.
+
+    Returns:
+        (matched_items, unmatched_items, alias_pearls_with_uri)
+    """
+    matched = []
+    unmatched = []
+    alias_pearls = []
+
+    for item in items:
+        if item.is_pearltrees_link:
+            # This is an AliasPearl with full URI
+            alias_entry = {
+                'type': 'AliasPearl',
+                'raw_title': item.title,
+                'alias_target_uri': item.url,
+                'parent_path': item.parent_path,
+                '_source': 'html_export'
+            }
+
+            # Check if target exists in JSONL
+            if item.url in by_uri:
+                alias_entry['_target_exists'] = True
+                alias_entry['_target_type'] = by_uri[item.url].get('type')
+            else:
+                alias_entry['_target_exists'] = False
+
+            alias_pearls.append(alias_entry)
+        else:
+            # External link - try to match by URL
+            if item.url in by_url:
+                existing = by_url[item.url]
+                matched.append({
+                    'html_title': item.title,
+                    'html_parent_path': item.parent_path,
+                    'existing_entry': existing
+                })
+            else:
+                unmatched.append({
+                    'title': item.title,
+                    'url': item.url,
+                    'parent_path': item.parent_path,
+                    '_source': 'html_export'
+                })
+
+    return matched, unmatched, alias_pearls
+
+
+def build_hierarchy_with_patterns(
+    items: List[BookmarkItem],
+    folders: List[BookmarkItem],
+    existing_by_uri: Dict[str, Dict] = None
+) -> Tuple[HierarchyBuilder, List[Dict]]:
+    """Build hierarchy with title paths and ID path patterns.
+
+    Uses AliasPearls to learn title->ID mappings, then generates
+    entries with hybrid paths for all folders.
+
+    Returns:
+        (hierarchy_builder, folder_entries)
+    """
+    hierarchy = HierarchyBuilder()
+
+    # First pass: learn ID mappings from AliasPearls (items pointing to PT)
+    for item in items:
+        if item.is_pearltrees_link and item.tree_id:
+            # This AliasPearl tells us the ID of the tree it points to
+            hierarchy.register_known_id(
+                title=item.title,
+                tree_id=item.tree_id,
+                parent_path=item.parent_path
+            )
+
+    # Also learn from existing JSONL if provided
+    if existing_by_uri:
+        for uri, entry in existing_by_uri.items():
+            title = entry.get('raw_title', '')
+            tree_id = entry.get('tree_id', '')
+            if title and tree_id:
+                hierarchy.title_to_id[title] = tree_id
+
+    # Second pass: generate folder entries with hybrid paths
+    folder_entries = []
+    for folder in folders:
+        full_path = folder.parent_path + [folder.title]
+        id_pattern = hierarchy.build_id_path_pattern(full_path)
+        known_id = hierarchy.get_known_id(folder.title, folder.parent_path)
+
+        entry = {
+            'type': 'Tree',
+            'raw_title': folder.title,
+            'title_path': full_path,
+            'id_path_pattern': id_pattern,
+            '_source': 'html_export',
+        }
+
+        if known_id:
+            entry['tree_id'] = known_id
+            entry['_id_source'] = 'alias_pearl'
+        else:
+            entry['_needs_id'] = True
+
+        # Count known vs unknown parts
+        parts = id_pattern.split('/')[1:]  # Skip empty first part
+        known_count = sum(1 for p in parts if p != '[^/]+')
+        entry['_known_ids'] = known_count
+        entry['_unknown_ids'] = len(parts) - known_count
+
+        folder_entries.append(entry)
+
+    return hierarchy, folder_entries
+
+
+def generate_target_text_with_pattern(entry: Dict) -> str:
+    """Generate target_text using title path and ID pattern.
+
+    Format:
+        /id_pattern
+        - title1
+          - title2
+            - title3
+    """
+    title_path = entry.get('title_path', [])
+    id_pattern = entry.get('id_path_pattern', '')
+
+    lines = [id_pattern]
+    for i, title in enumerate(title_path):
+        indent = '  ' * i
+        lines.append(f"{indent}- {title}")
+
+    return '\n'.join(lines)
+
+
+def extract_missing_trees(alias_pearls: List[Dict]) -> List[Dict]:
+    """Extract unique missing trees from AliasPearls that target non-existent entries.
+
+    Returns list of Tree entries that can be added to JSONL.
+    """
+    seen_uris = set()
+    missing_trees = []
+
+    for alias in alias_pearls:
+        if alias.get('_target_exists'):
+            continue
+
+        uri = alias.get('alias_target_uri', '')
+        if not uri or uri in seen_uris:
+            continue
+
+        # Skip placeholder/broken links
+        if '/id' not in uri or uri == 'https://www.pearltrees.com/ooops':
+            continue
+
+        seen_uris.add(uri)
+
+        # Parse URI to extract tree info
+        # Format: https://www.pearltrees.com/[t/]account/tree-name/id12345
+        match = re.match(
+            r'https://www\.pearltrees\.com/(?:t/)?([^/]+)/(?:([^/]+)/)?id(\d+)',
+            uri
+        )
+
+        if not match:
+            continue
+
+        account = match.group(1)
+        tree_name = match.group(2) or ''
+        tree_id = match.group(3)
+
+        tree_entry = {
+            'type': 'Tree',
+            'raw_title': alias.get('raw_title', tree_name),
+            'tree_id': tree_id,
+            'uri': uri,
+            'account': account,
+            '_source': 'html_export_alias_target',
+            '_discovered_from_path': alias.get('parent_path', [])
+        }
+
+        missing_trees.append(tree_entry)
+
+    return missing_trees
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse Pearltrees HTML exports")
+    parser.add_argument("--html-export", type=Path, required=True,
+                       help="Path to HTML export file")
+    parser.add_argument("--compare", type=Path, default=None,
+                       help="Compare with existing JSONL")
+    parser.add_argument("--output", type=Path, default=None,
+                       help="Output JSONL file for extracted/matched data")
+    parser.add_argument("--extract-missing-trees", type=Path, default=None,
+                       help="Extract missing trees from AliasPearls to JSONL")
+    parser.add_argument("--build-hierarchy", type=Path, default=None,
+                       help="Build hybrid hierarchy with title paths and ID patterns")
+    parser.add_argument("--analyze", action="store_true",
+                       help="Just analyze the export structure")
+
+    args = parser.parse_args()
+
+    if not args.html_export.exists():
+        logger.error(f"HTML file not found: {args.html_export}")
+        return 1
+
+    logger.info(f"Parsing: {args.html_export}")
+    items, folders = parse_html_export(args.html_export)
+
+    logger.info(f"Found {len(items)} items, {len(folders)} folders")
+
+    if args.analyze:
+        analyze_export(items, folders)
+        return 0
+
+    # Compare with existing JSONL
+    if args.compare:
+        by_url, by_uri = load_existing_jsonl(args.compare)
+        logger.info(f"Loaded {len(by_url)} URLs, {len(by_uri)} URIs from {args.compare}")
+
+        matched, unmatched, alias_pearls = match_with_existing(
+            items, folders, by_url, by_uri)
+
+        print(f"\n=== Comparison Results ===")
+        print(f"PagePearls matched by URL:    {len(matched)}")
+        print(f"PagePearls unmatched:         {len(unmatched)}")
+        print(f"AliasPearls with URI:         {len(alias_pearls)}")
+
+        # Check alias targets
+        targets_exist = sum(1 for a in alias_pearls if a.get('_target_exists'))
+        print(f"  - Target exists in JSONL:   {targets_exist}")
+        print(f"  - Target missing:           {len(alias_pearls) - targets_exist}")
+
+        # Write output if requested
+        if args.output:
+            all_entries = alias_pearls + unmatched
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            with open(args.output, 'w', encoding='utf-8') as f:
+                for entry in all_entries:
+                    f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+            logger.info(f"Wrote {len(all_entries)} entries to {args.output}")
+
+        # Show sample unmatched
+        if unmatched:
+            print(f"\nSample unmatched PagePearls:")
+            for item in unmatched[:5]:
+                path = " > ".join(item['parent_path'][-3:]) if item['parent_path'] else "(root)"
+                print(f"  - {item['title']}")
+                print(f"    URL: {item['url'][:80]}...")
+                print(f"    Path: {path}")
+
+        # Extract missing trees if requested
+        if args.extract_missing_trees:
+            missing_trees = extract_missing_trees(alias_pearls)
+            args.extract_missing_trees.parent.mkdir(parents=True, exist_ok=True)
+            with open(args.extract_missing_trees, 'w', encoding='utf-8') as f:
+                for tree in missing_trees:
+                    f.write(json.dumps(tree, ensure_ascii=False) + '\n')
+            print(f"\n=== Missing Trees Extracted ===")
+            print(f"Wrote {len(missing_trees)} missing trees to {args.extract_missing_trees}")
+
+            # Show sample
+            if missing_trees:
+                print(f"\nSample missing trees:")
+                for tree in missing_trees[:10]:
+                    print(f"  - {tree['raw_title']} ({tree['account']})")
+                    print(f"    URI: {tree['uri']}")
+
+        # Build hybrid hierarchy if requested
+        if args.build_hierarchy:
+            hierarchy, folder_entries = build_hierarchy_with_patterns(
+                items, folders, by_uri)
+
+            # Add target_text to each entry
+            for entry in folder_entries:
+                entry['target_text'] = generate_target_text_with_pattern(entry)
+
+            # Write output
+            args.build_hierarchy.parent.mkdir(parents=True, exist_ok=True)
+            with open(args.build_hierarchy, 'w', encoding='utf-8') as f:
+                for entry in folder_entries:
+                    f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+            # Stats
+            known_count = sum(1 for e in folder_entries if not e.get('_needs_id'))
+            unknown_count = sum(1 for e in folder_entries if e.get('_needs_id'))
+            fully_resolved = sum(1 for e in folder_entries if e.get('_unknown_ids', 0) == 0)
+
+            print(f"\n=== Hybrid Hierarchy Built ===")
+            print(f"Total folders:           {len(folder_entries)}")
+            print(f"With known tree_id:      {known_count}")
+            print(f"Without tree_id:         {unknown_count}")
+            print(f"Fully resolved ID paths: {fully_resolved}")
+            print(f"Output: {args.build_hierarchy}")
+
+            # Show samples at different resolution levels
+            print(f"\nSample entries:")
+            # Fully resolved
+            resolved = [e for e in folder_entries if e.get('_unknown_ids', 0) == 0][:2]
+            if resolved:
+                print(f"\n  Fully resolved ({len([e for e in folder_entries if e.get('_unknown_ids', 0) == 0])}):")
+                for e in resolved:
+                    print(f"    {e['raw_title']}")
+                    print(f"      ID pattern: {e['id_path_pattern']}")
+
+            # Partially resolved
+            partial = [e for e in folder_entries
+                      if 0 < e.get('_unknown_ids', 0) < len(e.get('title_path', []))][:2]
+            if partial:
+                print(f"\n  Partially resolved ({len([e for e in folder_entries if 0 < e.get('_unknown_ids', 0) < len(e.get('title_path', []))])}):")
+                for e in partial:
+                    print(f"    {e['raw_title']}")
+                    print(f"      ID pattern: {e['id_path_pattern']}")
+                    print(f"      Title path: {' > '.join(e['title_path'][-4:])}")
+
+            # Unresolved
+            unresolved = [e for e in folder_entries
+                         if e.get('_unknown_ids', 0) == len(e.get('title_path', []))][:2]
+            if unresolved:
+                print(f"\n  Unresolved ({len([e for e in folder_entries if e.get('_unknown_ids', 0) == len(e.get('title_path', []))])}):")
+                for e in unresolved:
+                    print(f"    {e['raw_title']}")
+                    print(f"      Title path: {' > '.join(e['title_path'][-4:])}")
+
+    else:
+        analyze_export(items, folders)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repair_from_zip_export.py
+++ b/scripts/repair_from_zip_export.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Repair JSONL data from Pearltrees zip exports.
+
+Pearltrees zip exports contain:
+- HTML files for each PagePearl (with PT link and source URL)
+- Subdirectories for child Trees
+
+This script parses the export folder structure to generate JSONL entries
+for trees and pearls that may be missing from the RDF export.
+
+Usage:
+    # Extract repairs to separate file
+    python3 scripts/repair_from_zip_export.py \
+        --export-dir "context/PT/Zip_Exports/Academic disciplines" \
+        --root-uri "https://www.pearltrees.com/s243a/academic-disciplines/id53344165" \
+        --account s243a \
+        --output data/repair_academic_disciplines.jsonl
+
+    # Compare with existing JSONL (report what's missing)
+    python3 scripts/repair_from_zip_export.py \
+        --export-dir "context/PT/Zip_Exports/Academic disciplines" \
+        --root-uri "https://www.pearltrees.com/s243a/academic-disciplines/id53344165" \
+        --account s243a \
+        --compare data/pearltrees_all.jsonl \
+        --output /tmp/missing_items.jsonl
+
+    # Auto-merge repairs into existing JSONL
+    python3 scripts/repair_from_zip_export.py \
+        --export-dir "context/PT/Zip_Exports/Academic disciplines" \
+        --root-uri "https://www.pearltrees.com/s243a/academic-disciplines/id53344165" \
+        --account s243a \
+        --merge-into data/pearltrees_all.jsonl
+"""
+
+import argparse
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from datetime import date
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def extract_pearl_data_from_html(html_file: Path) -> Optional[Dict]:
+    """Extract pearl data from an HTML export file.
+
+    Returns dict with:
+        - title: Pearl title
+        - pearl_uri: Full Pearltrees URI (with item ID)
+        - parent_tree_uri: Parent tree URI (extracted from pearl URI)
+        - source_url: The URL the pearl points to
+        - item_id: The pearl's item ID
+    """
+    try:
+        content = html_file.read_text(encoding='utf-8', errors='ignore')
+    except Exception as e:
+        logger.warning(f"Could not read {html_file}: {e}")
+        return None
+
+    # Extract title from <title> tag
+    title_match = re.search(r'<title>([^<]+)</title>', content)
+    title = title_match.group(1).strip() if title_match else html_file.stem
+
+    # Extract Pearltrees item link from see-medal div
+    # Format: data-pt-skip="true"href="https://www.pearltrees.com/account/tree-name/id123/item456"
+    pt_link_match = re.search(
+        r'data-pt-skip="true"href="(https://www\.pearltrees\.com/[^"]+/item\d+)"', content)
+
+    if not pt_link_match:
+        # Try standard href format
+        pt_link_match = re.search(
+            r'href="(https://www\.pearltrees\.com/[^"]+/item\d+)"', content)
+
+    if not pt_link_match:
+        logger.debug(f"No PT link found in {html_file.name}")
+        return None
+
+    pearl_uri = pt_link_match.group(1)
+
+    # Extract item ID and parent tree URI from pearl URI
+    # e.g., .../scientific-disciplines/id72963112/item556601870
+    item_match = re.search(r'(/item\d+)$', pearl_uri)
+    item_id = item_match.group(1).replace('/item', '') if item_match else None
+
+    # Parent tree URI is everything before /item...
+    parent_tree_uri = pearl_uri.rsplit('/item', 1)[0] if '/item' in pearl_uri else None
+
+    # Extract source URL (the actual webpage) from author-medal div
+    # Format: <div class="author-medal"><a href="URL"
+    source_match = re.search(r'<div class="author-medal"><a href="([^"]+)"', content)
+    if not source_match:
+        # Try: <a class="relative-url" href="URL"
+        source_match = re.search(r'class="relative-url" href="([^"]+)"', content)
+
+    source_url = source_match.group(1) if source_match else None
+
+    return {
+        'title': title,
+        'pearl_uri': pearl_uri,
+        'parent_tree_uri': parent_tree_uri,
+        'source_url': source_url,
+        'item_id': item_id
+    }
+
+
+def parse_export_folder(
+    export_dir: Path,
+    parent_tree_uri: str,
+    account: str,
+    depth: int = 0
+) -> Tuple[List[Dict], List[Dict]]:
+    """Recursively parse export folder to extract trees and pearls.
+
+    Args:
+        export_dir: Path to export folder
+        parent_tree_uri: URI of the parent tree (used as cluster_id for this folder's items)
+        account: Account name
+        depth: Current recursion depth (for logging)
+
+    Returns:
+        (trees, pearls): Lists of tree and pearl dicts
+    """
+    trees = []
+    pearls = []
+
+    indent = "  " * depth
+    logger.info(f"{indent}Parsing: {export_dir.name}")
+
+    # Process HTML files (PagePearls)
+    html_files = [f for f in export_dir.iterdir()
+                  if f.suffix == '.html' and 'Zone.Identifier' not in f.name]
+
+    # Track the actual tree URI discovered from pearl URIs
+    # (all pearls in a folder should have the same parent tree URI)
+    discovered_tree_uri = None
+
+    for html_file in html_files:
+        pearl_data = extract_pearl_data_from_html(html_file)
+        if pearl_data:
+            # Use the parent_tree_uri from the pearl itself (contains actual tree ID)
+            actual_parent = pearl_data.get('parent_tree_uri') or parent_tree_uri
+
+            # Track discovered URI for this folder
+            if pearl_data.get('parent_tree_uri') and not discovered_tree_uri:
+                discovered_tree_uri = pearl_data['parent_tree_uri']
+
+            # Build PagePearl entry
+            pearl_entry = {
+                'type': 'PagePearl',
+                'raw_title': pearl_data['title'],
+                'query': pearl_data['title'],
+                'cluster_id': actual_parent,
+                'pearl_id': f"item{pearl_data['item_id']}" if pearl_data['item_id'] else '',
+                'pearl_uri': pearl_data['pearl_uri'],
+                'parent_tree_uri': actual_parent,
+                'account': account,
+                'url': pearl_data['source_url'] or '',
+                '_source': 'zip_export',
+                '_source_file': str(html_file.relative_to(export_dir.parent.parent))
+            }
+            pearls.append(pearl_entry)
+
+    logger.info(f"{indent}  Found {len(html_files)} HTML files -> {len(pearls)} pearls")
+    if discovered_tree_uri:
+        logger.info(f"{indent}  Discovered tree URI: {discovered_tree_uri}")
+
+    # Process subdirectories (child Trees)
+    subdirs = [d for d in export_dir.iterdir() if d.is_dir()]
+
+    for subdir in subdirs:
+        # First, peek into the subdir to find the tree URI from its pearl files
+        subdir_tree_uri = None
+        for html_file in subdir.glob("*.html"):
+            if 'Zone.Identifier' in str(html_file):
+                continue
+            pearl_data = extract_pearl_data_from_html(html_file)
+            if pearl_data and pearl_data.get('parent_tree_uri'):
+                subdir_tree_uri = pearl_data['parent_tree_uri']
+                break
+
+        # Extract tree_id from discovered URI
+        tree_id = None
+        if subdir_tree_uri:
+            # URI format: .../tree-name/id12345
+            id_match = re.search(r'/id(\d+)$', subdir_tree_uri)
+            tree_id = id_match.group(1) if id_match else None
+
+        # Create Tree entry with discovered URI
+        tree_entry = {
+            'type': 'Tree',
+            'raw_title': subdir.name,
+            'cluster_id': discovered_tree_uri or parent_tree_uri,
+            'account': account,
+            '_source': 'zip_export',
+            '_source_folder': str(subdir.relative_to(export_dir.parent.parent)),
+        }
+
+        if subdir_tree_uri:
+            tree_entry['uri'] = subdir_tree_uri
+            tree_entry['tree_id'] = tree_id
+        else:
+            tree_entry['_needs_uri'] = True
+
+        trees.append(tree_entry)
+
+        # Recursively process child folder with discovered URI
+        child_trees, child_pearls = parse_export_folder(
+            subdir,
+            subdir_tree_uri or f"{parent_tree_uri}/{subdir.name.lower().replace(' ', '-')}",
+            account,
+            depth + 1
+        )
+
+        trees.extend(child_trees)
+        pearls.extend(child_pearls)
+
+    return trees, pearls
+
+
+def generate_target_text(pearl: Dict, parent_title: str = "") -> str:
+    """Generate target_text for embedding (simplified version)."""
+    title = pearl.get('raw_title', '')
+    if parent_title:
+        return f"- {parent_title}\n  - {title}"
+    return f"- {title}"
+
+
+def load_existing_data(jsonl_path: Path) -> Tuple[Dict[str, Dict], Dict[str, Dict], set]:
+    """Load existing JSONL and build indices.
+
+    Returns:
+        (pearl_by_uri, tree_by_uri, all_uris): Indices for quick lookup
+    """
+    pearl_by_uri = {}
+    tree_by_uri = {}
+    all_uris = set()
+
+    if not jsonl_path.exists():
+        logger.warning(f"JSONL file not found: {jsonl_path}")
+        return pearl_by_uri, tree_by_uri, all_uris
+
+    with open(jsonl_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            try:
+                entry = json.loads(line.strip())
+            except json.JSONDecodeError:
+                continue
+
+            entry_type = entry.get('type', '')
+
+            if entry_type == 'Tree':
+                uri = entry.get('uri', '')
+                if uri:
+                    tree_by_uri[uri] = entry
+                    all_uris.add(uri)
+            elif entry_type in ('PagePearl', 'RefPearl', 'AliasPearl'):
+                uri = entry.get('pearl_uri', '')
+                if uri:
+                    pearl_by_uri[uri] = entry
+                    all_uris.add(uri)
+
+    logger.info(f"Loaded {len(tree_by_uri)} trees, {len(pearl_by_uri)} pearls from {jsonl_path}")
+    return pearl_by_uri, tree_by_uri, all_uris
+
+
+def compare_with_existing(
+    extracted_trees: List[Dict],
+    extracted_pearls: List[Dict],
+    pearl_by_uri: Dict[str, Dict],
+    tree_by_uri: Dict[str, Dict]
+) -> Tuple[List[Dict], List[Dict], List[Dict], List[Dict]]:
+    """Compare extracted data with existing JSONL.
+
+    Returns:
+        (missing_trees, missing_pearls, existing_trees, existing_pearls)
+    """
+    missing_trees = []
+    missing_pearls = []
+    existing_trees = []
+    existing_pearls = []
+
+    for tree in extracted_trees:
+        uri = tree.get('uri', '')
+        if uri and uri in tree_by_uri:
+            existing_trees.append(tree)
+        else:
+            missing_trees.append(tree)
+
+    for pearl in extracted_pearls:
+        uri = pearl.get('pearl_uri', '')
+        if uri and uri in pearl_by_uri:
+            existing_pearls.append(pearl)
+        else:
+            missing_pearls.append(pearl)
+
+    return missing_trees, missing_pearls, existing_trees, existing_pearls
+
+
+def merge_into_jsonl(
+    jsonl_path: Path,
+    new_entries: List[Dict],
+    backup: bool = True
+) -> int:
+    """Merge new entries into existing JSONL file.
+
+    Args:
+        jsonl_path: Path to existing JSONL
+        new_entries: New entries to add
+        backup: Whether to create .bak backup
+
+    Returns:
+        Number of entries added
+    """
+    if not new_entries:
+        logger.info("No new entries to merge")
+        return 0
+
+    # Create backup
+    if backup and jsonl_path.exists():
+        backup_path = jsonl_path.with_suffix('.jsonl.bak')
+        import shutil
+        shutil.copy(jsonl_path, backup_path)
+        logger.info(f"Created backup: {backup_path}")
+
+    # Append new entries
+    with open(jsonl_path, 'a', encoding='utf-8') as f:
+        for entry in new_entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+    logger.info(f"Merged {len(new_entries)} entries into {jsonl_path}")
+    return len(new_entries)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Repair JSONL from Pearltrees zip exports")
+    parser.add_argument("--export-dir", type=Path, required=True,
+                       help="Path to zip export folder")
+    parser.add_argument("--root-uri", type=str, required=True,
+                       help="URI of the root tree (e.g., https://www.pearltrees.com/s243a/tree/id123)")
+    parser.add_argument("--account", type=str, required=True,
+                       help="Account name")
+    parser.add_argument("--output", type=Path, default=None,
+                       help="Output JSONL file (required unless --merge-into)")
+    parser.add_argument("--compare", type=Path, default=None,
+                       help="Compare with existing JSONL and report what's missing")
+    parser.add_argument("--merge-into", type=Path, default=None,
+                       help="Auto-merge repairs directly into this JSONL file")
+    parser.add_argument("--no-backup", action="store_true",
+                       help="Skip backup when using --merge-into")
+    parser.add_argument("--parent-title", type=str, default="",
+                       help="Title of parent tree (for target_text generation)")
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.output and not args.merge_into:
+        parser.error("Either --output or --merge-into is required")
+
+    if not args.export_dir.exists():
+        logger.error(f"Export directory not found: {args.export_dir}")
+        return 1
+
+    logger.info(f"Parsing export: {args.export_dir}")
+    logger.info(f"Root URI: {args.root_uri}")
+
+    # Parse the export folder
+    trees, pearls = parse_export_folder(
+        args.export_dir, args.root_uri, args.account)
+
+    logger.info(f"\nExtracted from zip export:")
+    logger.info(f"  Trees: {len(trees)}")
+    logger.info(f"  Pearls: {len(pearls)}")
+
+    # Add target_text to pearls
+    for pearl in pearls:
+        pearl['target_text'] = generate_target_text(pearl, args.parent_title)
+
+    # Compare mode: check what's missing from existing JSONL
+    compare_jsonl = args.compare or args.merge_into
+    if compare_jsonl:
+        pearl_by_uri, tree_by_uri, all_uris = load_existing_data(compare_jsonl)
+
+        missing_trees, missing_pearls, existing_trees, existing_pearls = \
+            compare_with_existing(trees, pearls, pearl_by_uri, tree_by_uri)
+
+        print(f"\n=== Comparison with {compare_jsonl.name} ===")
+        print(f"Trees in zip export:  {len(trees)}")
+        print(f"  - Already in JSONL: {len(existing_trees)}")
+        print(f"  - Missing (NEW):    {len(missing_trees)}")
+        print(f"Pearls in zip export: {len(pearls)}")
+        print(f"  - Already in JSONL: {len(existing_pearls)}")
+        print(f"  - Missing (NEW):    {len(missing_pearls)}")
+
+        # Show sample of missing items
+        if missing_trees:
+            print(f"\nMissing trees:")
+            for tree in missing_trees[:10]:
+                uri = tree.get('uri', '(no URI)')
+                print(f"  - {tree['raw_title']}: {uri}")
+            if len(missing_trees) > 10:
+                print(f"  ... and {len(missing_trees) - 10} more")
+
+        if missing_pearls:
+            print(f"\nMissing pearls (sample):")
+            for pearl in missing_pearls[:10]:
+                print(f"  - {pearl['raw_title']}")
+            if len(missing_pearls) > 10:
+                print(f"  ... and {len(missing_pearls) - 10} more")
+
+        # Only output missing entries
+        all_entries = missing_trees + missing_pearls
+    else:
+        all_entries = trees + pearls
+
+    # Handle merge mode
+    if args.merge_into:
+        if not all_entries:
+            print("\nNo new entries to merge - JSONL is already complete!")
+            return 0
+
+        merged_count = merge_into_jsonl(
+            args.merge_into, all_entries, backup=not args.no_backup)
+        print(f"\n=== Merge Complete ===")
+        print(f"Added {merged_count} entries to {args.merge_into}")
+        return 0
+
+    # Write output file
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, 'w', encoding='utf-8') as f:
+            for entry in all_entries:
+                f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+        logger.info(f"Wrote {len(all_entries)} entries to {args.output}")
+
+    # Summary
+    print(f"\n=== Repair Summary ===")
+    print(f"Export folder: {args.export_dir}")
+    print(f"Root tree: {args.root_uri}")
+    print(f"Trees found: {len(trees)}")
+    print(f"Pearls found: {len(pearls)}")
+    if args.output:
+        print(f"Output: {args.output}")
+
+    if trees:
+        print(f"\nChild trees discovered:")
+        for tree in trees[:5]:
+            uri = tree.get('uri', '(needs URI)')
+            print(f"  - {tree['raw_title']}: {uri}")
+        if len(trees) > 5:
+            print(f"  ... and {len(trees) - 5} more")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/suggest_hierarchy_repairs.py
+++ b/scripts/suggest_hierarchy_repairs.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+Auto-suggest hierarchy repairs for orphaned trees.
+
+Finds orphaned trees (those with account root as cluster_id) that have
+same-account AliasPearls pointing to them. These AliasPearls indicate
+where the tree should logically be placed in the hierarchy.
+
+Usage:
+    python3 scripts/suggest_hierarchy_repairs.py \
+        --input reports/pearltrees_targets_combined.jsonl \
+        --output data/hierarchy_repairs_suggested.json \
+        --account s243a
+"""
+
+import argparse
+import json
+import logging
+import re
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Dict, List, Set, Any, Optional
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def extract_account_from_uri(uri: str) -> Optional[str]:
+    """Extract account name from Pearltrees URI."""
+    # Handle both /s243a/ and /t/s243a/ formats
+    match = re.search(r'pearltrees\.com/(?:t/)?([^/]+)/', uri)
+    return match.group(1) if match else None
+
+
+def is_orphan(entry: Dict, primary_account: str) -> bool:
+    """Check if a tree is orphaned (cluster_id is account root)."""
+    if entry.get('type') != 'Tree':
+        return False
+
+    cluster_id = entry.get('cluster_id', '')
+    # Orphan if cluster_id is just the account root (no tree path)
+    # e.g., "https://www.pearltrees.com/s243a" vs "https://www.pearltrees.com/s243a/folder/id123"
+
+    # Check if cluster_id is account root (ends with account name, no further path)
+    if cluster_id.rstrip('/').endswith(f'/{primary_account}'):
+        return True
+    if cluster_id.rstrip('/').endswith(f'.com/{primary_account}'):
+        return True
+
+    return False
+
+
+def find_alias_links(jsonl_file: Path, primary_account: str) -> Dict[str, List[Dict]]:
+    """
+    Find all AliasPearls that link to trees, grouped by target URI.
+
+    Returns: {target_tree_uri: [list of AliasPearl info]}
+    """
+    alias_links = defaultdict(list)
+
+    # First pass: build set of trees owned by primary account
+    primary_tree_uris = set()
+    with open(jsonl_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            entry = json.loads(line)
+            if entry.get('type') == 'Tree' and entry.get('account') == primary_account:
+                uri = entry.get('uri')
+                if uri:
+                    primary_tree_uris.add(uri)
+
+    logger.info(f"Found {len(primary_tree_uris)} trees owned by {primary_account}")
+
+    # Second pass: find AliasPearls pointing to primary account trees
+    with open(jsonl_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            entry = json.loads(line)
+
+            if entry.get('type') != 'AliasPearl':
+                continue
+
+            target_uri = entry.get('alias_target_uri')
+            if not target_uri:
+                continue
+
+            # Get the parent tree where this alias lives
+            parent_tree_uri = entry.get('parent_tree_uri', entry.get('cluster_id', ''))
+            alias_account = entry.get('account', '')
+
+            # Only consider aliases owned by primary account pointing to primary account trees
+            if alias_account == primary_account and target_uri in primary_tree_uris:
+                alias_links[target_uri].append({
+                    'alias_uri': entry.get('pearl_uri', ''),
+                    'alias_title': entry.get('raw_title'),
+                    'parent_tree_uri': parent_tree_uri,
+                    'account': alias_account,
+                    'pearl_type': 'AliasPearl'
+                })
+
+    return alias_links
+
+
+def find_crossaccount_alias_links(jsonl_file: Path, primary_accounts: Set[str]) -> Dict[str, List[Dict]]:
+    """
+    Find AliasPearls from user accounts pointing to external account trees.
+
+    This helps place external account trees in the user's hierarchy based on
+    where the user has referenced them via AliasPearls. When multiple AliasPearls
+    point to the same external tree, we can pick the best semantic fit.
+
+    Returns: {target_tree_uri: [list of AliasPearl info]}
+    """
+    alias_links = defaultdict(list)
+
+    with open(jsonl_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            entry = json.loads(line)
+
+            if entry.get('type') != 'AliasPearl':
+                continue
+
+            target_uri = entry.get('alias_target_uri')
+            if not target_uri:
+                continue
+
+            pearl_account = entry.get('account', '')
+            target_account = extract_account_from_uri(target_uri)
+
+            # Only consider AliasPearls from user's accounts pointing to external trees
+            if pearl_account in primary_accounts and target_account and target_account not in primary_accounts:
+                parent_tree_uri = entry.get('parent_tree_uri', entry.get('cluster_id', ''))
+                alias_links[target_uri].append({
+                    'pearl_uri': entry.get('pearl_uri', ''),
+                    'pearl_title': entry.get('raw_title'),
+                    'parent_tree_uri': parent_tree_uri,
+                    'account': pearl_account,
+                    'pearl_type': 'AliasPearl'
+                })
+
+    return alias_links
+
+
+def suggest_repairs(jsonl_file: Path, primary_account: str,
+                    existing_repairs: Optional[Path] = None,
+                    additional_accounts: Optional[Set[str]] = None) -> Dict[str, Dict]:
+    """
+    Suggest hierarchy repairs for orphaned trees.
+
+    For same-account orphans: Uses AliasPearls to find where they should be placed.
+    For external account orphans: Uses RefPearls from user's accounts to find
+    the best semantic fit in the user's hierarchy.
+
+    Args:
+        jsonl_file: Input JSONL with trees and pearls
+        primary_account: Main user account
+        existing_repairs: Path to existing repairs file to skip
+        additional_accounts: Other user accounts (e.g., s243a_groups) to include
+
+    Returns: {tree_uri: {parent_uri, source, confidence, notes}}
+    """
+    # Build set of all user accounts
+    user_accounts = {primary_account}
+    if additional_accounts:
+        user_accounts.update(additional_accounts)
+
+    # Load existing repairs to skip
+    existing = set()
+    if existing_repairs and existing_repairs.exists():
+        with open(existing_repairs, 'r') as f:
+            data = json.load(f)
+            if 'repairs' in data:
+                existing = set(data['repairs'].keys())
+            else:
+                existing = set(k for k in data.keys() if not k.startswith('_'))
+        logger.info(f"Loaded {len(existing)} existing repairs to skip")
+
+    # Find all alias links (same-account)
+    alias_links = find_alias_links(jsonl_file, primary_account)
+    logger.info(f"Found {len(alias_links)} trees with same-account AliasPearl links")
+
+    # Find cross-account AliasPearl links
+    crossaccount_links = find_crossaccount_alias_links(jsonl_file, user_accounts)
+    logger.info(f"Found {len(crossaccount_links)} external trees with AliasPearl links from user accounts")
+
+    # Build tree lookup
+    trees = {}
+    same_account_orphans = []
+    external_orphans = []
+
+    with open(jsonl_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            entry = json.loads(line)
+            if entry.get('type') == 'Tree':
+                uri = entry.get('uri')
+                trees[uri] = entry
+                tree_account = entry.get('account', '')
+
+                if uri in existing:
+                    continue
+
+                # Categorize orphans
+                if tree_account in user_accounts:
+                    if is_orphan(entry, primary_account):
+                        same_account_orphans.append(entry)
+                else:
+                    # External tree - check if we have AliasPearl links to it
+                    if uri in crossaccount_links:
+                        external_orphans.append(entry)
+
+    logger.info(f"Found {len(same_account_orphans)} same-account orphans")
+    logger.info(f"Found {len(external_orphans)} external orphans with AliasPearl links")
+
+    suggestions = {}
+
+    # Process same-account orphans using AliasPearl links
+    for orphan in same_account_orphans:
+        uri = orphan.get('uri')
+
+        if uri not in alias_links:
+            continue
+
+        links = alias_links[uri]
+        best_parent = None
+        best_confidence = 0
+
+        for link in links:
+            parent_uri = link['parent_tree_uri']
+
+            if parent_uri not in trees:
+                continue
+
+            parent_entry = trees[parent_uri]
+
+            # Higher confidence if parent has a real hierarchy
+            if not is_orphan(parent_entry, primary_account):
+                confidence = 0.9
+            else:
+                confidence = 0.5
+
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_parent = {
+                    'parent_uri': parent_uri,
+                    'parent_title': parent_entry.get('raw_title'),
+                    'pearl_title': link.get('alias_title') or link.get('pearl_title'),
+                    'pearl_type': link.get('pearl_type', 'AliasPearl'),
+                    'confidence': confidence
+                }
+
+        if best_parent:
+            suggestions[uri] = {
+                'parent_uri': best_parent['parent_uri'],
+                'source': 'semantic',
+                'date': str(date.today()),
+                'confidence': best_parent['confidence'],
+                'notes': f"{best_parent['pearl_type']} '{best_parent['pearl_title']}' in '{best_parent['parent_title']}' points to this tree"
+            }
+
+    # Process external orphans using AliasPearl links (crossing account boundaries)
+    for orphan in external_orphans:
+        uri = orphan.get('uri')
+        orphan_account = orphan.get('account', '')
+
+        links = crossaccount_links.get(uri, [])
+        best_parent = None
+        best_confidence = 0
+
+        for link in links:
+            parent_uri = link['parent_tree_uri']
+
+            if parent_uri not in trees:
+                continue
+
+            parent_entry = trees[parent_uri]
+
+            # For external trees, confidence based on parent's hierarchy status
+            if not is_orphan(parent_entry, primary_account):
+                confidence = 0.8  # Slightly lower than same-account
+            else:
+                confidence = 0.4
+
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_parent = {
+                    'parent_uri': parent_uri,
+                    'parent_title': parent_entry.get('raw_title'),
+                    'pearl_title': link.get('pearl_title'),
+                    'pearl_type': 'AliasPearl',
+                    'confidence': confidence
+                }
+
+        if best_parent:
+            suggestions[uri] = {
+                'parent_uri': best_parent['parent_uri'],
+                'source': 'semantic-crossaccount',
+                'date': str(date.today()),
+                'confidence': best_parent['confidence'],
+                'notes': f"AliasPearl '{best_parent['pearl_title']}' in '{best_parent['parent_title']}' references this {orphan_account} tree"
+            }
+
+    return suggestions
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Suggest hierarchy repairs for orphaned trees")
+    parser.add_argument("--input", type=Path, required=True, help="Input JSONL file")
+    parser.add_argument("--output", type=Path, required=True, help="Output suggestions JSON file")
+    parser.add_argument("--account", type=str, required=True, help="Primary account name")
+    parser.add_argument("--additional-accounts", type=str, nargs='*', default=[],
+                       help="Additional user accounts (e.g., s243a_groups)")
+    parser.add_argument("--existing", type=Path, default=None,
+                       help="Existing repairs file to skip")
+    parser.add_argument("--min-confidence", type=float, default=0.0,
+                       help="Minimum confidence threshold (0-1)")
+    parser.add_argument("--merge", action="store_true",
+                       help="Merge suggestions into existing repairs file")
+
+    args = parser.parse_args()
+
+    additional = set(args.additional_accounts) if args.additional_accounts else None
+    suggestions = suggest_repairs(args.input, args.account, args.existing, additional)
+
+    # Filter by confidence
+    if args.min_confidence > 0:
+        suggestions = {k: v for k, v in suggestions.items()
+                      if v.get('confidence', 0) >= args.min_confidence}
+
+    logger.info(f"Generated {len(suggestions)} repair suggestions")
+
+    # Count by source type
+    same_account = sum(1 for s in suggestions.values() if s.get('source') == 'semantic')
+    cross_account = sum(1 for s in suggestions.values() if s.get('source') == 'semantic-crossaccount')
+    logger.info(f"  Same-account repairs: {same_account}")
+    logger.info(f"  Cross-account repairs: {cross_account}")
+
+    # Output format
+    output_data = {
+        "_meta": {
+            "description": "Auto-suggested hierarchy repairs from AliasPearl and RefPearl analysis",
+            "format_version": "1.1",
+            "generated": str(date.today()),
+            "source_file": str(args.input),
+            "primary_account": args.account,
+            "additional_accounts": args.additional_accounts or []
+        },
+        "repairs": suggestions
+    }
+
+    # Merge with existing if requested
+    if args.merge and args.existing and args.existing.exists():
+        with open(args.existing, 'r') as f:
+            existing_data = json.load(f)
+
+        if 'repairs' in existing_data:
+            # Add new suggestions, don't overwrite existing
+            for uri, repair in suggestions.items():
+                if uri not in existing_data['repairs']:
+                    existing_data['repairs'][uri] = repair
+            output_data = existing_data
+            logger.info(f"Merged with existing repairs")
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(output_data, f, indent=2, ensure_ascii=False)
+
+    logger.info(f"Wrote suggestions to {args.output}")
+
+    # Print summary
+    if suggestions:
+        print(f"\n=== Top suggestions (by confidence) ===")
+        sorted_suggestions = sorted(suggestions.items(),
+                                   key=lambda x: x[1].get('confidence', 0),
+                                   reverse=True)
+        for uri, info in sorted_suggestions[:10]:
+            tree_id = uri.split('/')[-1]
+            parent_id = info['parent_uri'].split('/')[-1]
+            print(f"  {tree_id} -> {parent_id} (conf={info['confidence']:.1f})")
+            print(f"    {info['notes']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  ## Summary

  Add tools to repair incomplete RDF export data using Pearltrees zip and HTML exports. RDF exports often have missing children - trees exist but their contents weren't exported. These new scripts extract the missing data from alternative export formats.

  ## New Scripts

  ### `repair_from_zip_export.py`
  Parses zip export folders containing HTML files for each PagePearl:
  - Extracts full pearl URIs from HTML (`see-medal` div)
  - Extracts source URLs (`author-medal` div)
  - Discovers parent tree URIs embedded in pearl URLs
  - Supports `--compare` mode to see what's missing
  - Supports `--merge-into` mode to auto-merge with backup

  ### `repair_from_html_export.py`
  Parses Netscape bookmark HTML exports:
  - Extracts folder hierarchy from nested `<DL>` tags
  - Extracts AliasPearl targets (links with full Pearltrees URIs)
  - Builds hybrid title+ID path patterns for semantic matching
  - Supports `--build-hierarchy` to generate entries with regex patterns for unknown IDs

  ### `suggest_hierarchy_repairs.py`
  Auto-suggests hierarchy fixes using AliasPearl cross-references.

  ## Other Changes

  - **Cross-account disambiguation**: AliasPearls pointing to other accounts now show `account:title` (e.g., `vijayau:science`)
  - **Documentation**: Added "Repairing Incomplete Data" section to workflow docs

  ## Example Usage

  ```bash
  # Repair from zip export
  python3 scripts/repair_from_zip_export.py \
      --export-dir "context/PT/Zip_Exports/Academic disciplines" \
      --root-uri "https://www.pearltrees.com/s243a/academic-disciplines/id53344165" \
      --account s243a \
      --merge-into reports/pearltrees_targets_repaired.jsonl

  # Analyze HTML export and extract missing trees
  python3 scripts/repair_from_html_export.py \
      --html-export "context/PT/pearltrees_export_s243a_2026-01-05.html" \
      --compare reports/pearltrees_targets_repaired.jsonl \
      --extract-missing-trees /tmp/missing_trees.jsonl

  Key Insight

  Even without complete IDs, the title hierarchy provides semantic meaning for embeddings. The hybrid format uses regex patterns ([^/]+) for unknown IDs while preserving the full title path - semantically close is often good enough for discovery and matching.