### PR TITLE
feat: Add mindmap index store with pluggable backends and link tools

### DIFF
--- a/scripts/mindmap/add_relative_links.py
+++ b/scripts/mindmap/add_relative_links.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Add relative links (cloudmapref) to mindmap files using the index.
+
+For each Pearltrees URL in a mindmap, looks up the corresponding local
+mindmap file and adds a cloudmapref attribute for local navigation.
+
+Usage:
+    python3 add_relative_links.py mindmap.smmx --index index.json
+    python3 add_relative_links.py mindmap.smmx --index index.json --dry-run
+    python3 add_relative_links.py output/mindmaps_curated/*.smmx --index index.json
+"""
+
+import argparse
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Optional, Tuple
+from xml.etree import ElementTree as ET
+
+# Add parent to path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+from index_store import create_index_store, IndexStore
+
+
+def extract_tree_id_from_url(url: str) -> Optional[str]:
+    """Extract tree ID from Pearltrees URL.
+
+    Patterns:
+    - https://www.pearltrees.com/user/slug/id{tree_id}
+    - https://www.pearltrees.com/user/slug/id{tree_id}/item{pearl_id}
+
+    Returns:
+        Tree ID string or None if not a tree URL
+    """
+    if not url or 'pearltrees.com' not in url:
+        return None
+
+    # Match /id{digits} pattern (tree ID)
+    match = re.search(r'/id(\d+)(?:/|$)', url)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def compute_relative_path(source_path: str, target_path: str, base_dir: str) -> str:
+    """Compute relative path from source mindmap to target mindmap.
+
+    Args:
+        source_path: Path to source .smmx file (absolute or relative to base_dir)
+        target_path: Path to target .smmx file (relative to base_dir from index)
+        base_dir: Base directory for the index
+
+    Returns:
+        Relative path from source to target (e.g., '../sibling/target.smmx')
+    """
+    # Make both paths absolute
+    if not os.path.isabs(source_path):
+        source_abs = os.path.join(base_dir, source_path)
+    else:
+        source_abs = source_path
+
+    target_abs = os.path.join(base_dir, target_path)
+
+    # Get directories
+    source_dir = os.path.dirname(source_abs)
+    target_dir = os.path.dirname(target_abs)
+    target_filename = os.path.basename(target_abs)
+
+    # Compute relative path from source dir to target dir
+    rel_dir = os.path.relpath(target_dir, source_dir)
+
+    # Combine with filename
+    if rel_dir == '.':
+        return target_filename
+    else:
+        return os.path.join(rel_dir, target_filename)
+
+
+def extract_tree_id_from_filename(filename: str) -> Optional[str]:
+    """Extract tree ID from mindmap filename like 'id75009241.smmx'."""
+    match = re.match(r'^id(\d+)\.smmx$', os.path.basename(filename))
+    if match:
+        return match.group(1)
+    return None
+
+
+def process_mindmap(
+    smmx_path: str,
+    store: IndexStore,
+    dry_run: bool = False,
+    verbose: bool = False
+) -> Tuple[int, int]:
+    """Process a mindmap file and add cloudmapref links.
+
+    Args:
+        smmx_path: Path to .smmx file
+        store: Index store for looking up mindmap paths
+        dry_run: If True, don't save changes
+        verbose: If True, print each link added
+
+    Returns:
+        Tuple of (links_found, links_added)
+    """
+    smmx_path = os.path.abspath(smmx_path)
+    base_dir = store.base_dir
+
+    # Get this mindmap's tree ID to avoid self-links
+    self_tree_id = extract_tree_id_from_filename(smmx_path)
+
+    if not base_dir:
+        print(f"Warning: No base_dir in index, using mindmap directory", file=sys.stderr)
+        base_dir = os.path.dirname(smmx_path)
+
+    # Read the smmx file (it's a ZIP)
+    try:
+        with zipfile.ZipFile(smmx_path, 'r') as zf:
+            xml_content = zf.read('document/mindmap.xml').decode('utf-8')
+    except (zipfile.BadZipFile, KeyError) as e:
+        print(f"Error reading {smmx_path}: {e}", file=sys.stderr)
+        return (0, 0)
+
+    # Parse XML
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError as e:
+        print(f"Error parsing XML in {smmx_path}: {e}", file=sys.stderr)
+        return (0, 0)
+
+    # Find the source path relative to base_dir
+    try:
+        source_rel = os.path.relpath(smmx_path, base_dir)
+    except ValueError:
+        # Different drives on Windows
+        source_rel = smmx_path
+
+    links_found = 0
+    links_added = 0
+
+    # Process all link elements
+    for link in root.iter('link'):
+        urllink = link.get('urllink')
+        if not urllink:
+            continue
+
+        tree_id = extract_tree_id_from_url(urllink)
+        if not tree_id:
+            continue
+
+        links_found += 1
+
+        # Skip self-links
+        if tree_id == self_tree_id:
+            continue
+
+        # Skip if already has cloudmapref
+        if link.get('cloudmapref'):
+            continue
+
+        # Look up in index
+        target_path = store.get(tree_id)
+        if not target_path:
+            if verbose:
+                print(f"  Tree {tree_id} not in index", file=sys.stderr)
+            continue
+
+        # Compute relative path
+        rel_path = compute_relative_path(source_rel, target_path, base_dir)
+
+        # Add cloudmapref
+        link.set('cloudmapref', rel_path)
+        links_added += 1
+
+        if verbose:
+            print(f"  Added: {tree_id} -> {rel_path}")
+
+    if links_added > 0 and not dry_run:
+        # Write back to smmx
+        # Preserve XML declaration
+        xml_output = ET.tostring(root, encoding='unicode')
+        xml_output = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE simplemind-mindmaps>\n' + xml_output
+
+        with zipfile.ZipFile(smmx_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr('document/mindmap.xml', xml_output.encode('utf-8'))
+
+    return (links_found, links_added)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Add relative links (cloudmapref) to mindmap files'
+    )
+    parser.add_argument('files', nargs='+', help='Mindmap files to process')
+    parser.add_argument('--index', '-i', required=True,
+                       help='Path to index file (JSON, TSV, or SQLite)')
+    parser.add_argument('--dry-run', '-n', action='store_true',
+                       help='Show what would be done without making changes')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                       help='Print each link added')
+    parser.add_argument('--cache', action='store_true',
+                       help='Cache index in memory (faster for many files)')
+
+    args = parser.parse_args()
+
+    # Load index
+    store = create_index_store(args.index, cache=args.cache)
+    print(f"Loaded index with {store.count()} entries", file=sys.stderr)
+
+    if not store.base_dir:
+        print("Warning: Index has no base_dir set", file=sys.stderr)
+
+    total_found = 0
+    total_added = 0
+    files_modified = 0
+
+    for filepath in args.files:
+        if not os.path.exists(filepath):
+            print(f"File not found: {filepath}", file=sys.stderr)
+            continue
+
+        if args.verbose:
+            print(f"Processing: {filepath}")
+
+        found, added = process_mindmap(
+            filepath, store,
+            dry_run=args.dry_run,
+            verbose=args.verbose
+        )
+
+        total_found += found
+        total_added += added
+        if added > 0:
+            files_modified += 1
+
+    action = "Would add" if args.dry_run else "Added"
+    print(f"\n{action} {total_added} cloudmapref links ({total_found} Pearltrees links found)")
+    print(f"Files {'that would be ' if args.dry_run else ''}modified: {files_modified}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/mindmap/build_index.py
+++ b/scripts/mindmap/build_index.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Build an index of mindmap files mapping tree IDs to file paths.
+
+This index enables:
+- Relative linking between mindmaps without full recursive regeneration
+- Avoiding AI calls for human-readable names on reruns
+- Fast lookup of existing mindmaps by tree ID
+
+Usage:
+    python3 build_index.py <mindmap_dir> [output_file]
+    python3 build_index.py output/mindmaps_curated output/mindmaps_curated/index.json
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Optional, Dict
+
+
+def extract_tree_id(filename: str) -> Optional[str]:
+    """Extract tree ID from filename.
+
+    Supported patterns:
+    - id{number}.smmx -> returns the number
+    - sha_{hash}.smmx -> returns sha_{hash}
+    - {alphanumeric}.smmx -> returns the stem if long enough
+    """
+    stem = Path(filename).stem
+
+    # Numeric ID: id{number}
+    match = re.match(r'^id(\d+)$', stem)
+    if match:
+        return match.group(1)
+
+    # Synthetic ID: sha_{hash}
+    match = re.match(r'^(sha_[a-f0-9]+)$', stem)
+    if match:
+        return match.group(1)
+
+    # Other alphanumeric patterns (synthetic IDs from old format)
+    if re.match(r'^[a-z0-9]+$', stem) and len(stem) > 5:
+        return stem
+
+    return None
+
+
+def build_index(search_dir: str) -> Dict[str, str]:
+    """Build index mapping tree_id -> relative path.
+
+    Args:
+        search_dir: Directory to search for .smmx files
+
+    Returns:
+        Dict mapping tree IDs to relative file paths
+    """
+    index = {}
+    base = Path(search_dir)
+
+    for smmx_file in base.rglob("*.smmx"):
+        tree_id = extract_tree_id(smmx_file.name)
+        if tree_id:
+            # Store relative path from base
+            rel_path = str(smmx_file.relative_to(base))
+            index[tree_id] = rel_path
+
+    return index
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: build_index.py <mindmap_dir> [output_file]", file=sys.stderr)
+        print("       build_index.py output/mindmaps_curated index.json", file=sys.stderr)
+        sys.exit(1)
+
+    search_dir = sys.argv[1]
+    output_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+    if not os.path.isdir(search_dir):
+        print(f"Error: {search_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    index = build_index(search_dir)
+
+    result = {
+        "base_dir": os.path.abspath(search_dir),
+        "count": len(index),
+        "index": index
+    }
+
+    if output_file:
+        with open(output_file, 'w') as f:
+            json.dump(result, f, indent=2)
+        print(f"Written {len(index)} entries to {output_file}", file=sys.stderr)
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mindmap/build_reverse_index.py
+++ b/scripts/mindmap/build_reverse_index.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Build a reverse index of mindmap links (backlinks).
+
+Scans all mindmaps and records which mindmaps link to each other.
+Useful for updating links when a mindmap is renamed or moved.
+
+Usage:
+    python3 build_reverse_index.py <mindmap_dir> [output_file]
+    python3 build_reverse_index.py output/mindmaps_curated backlinks.json
+    python3 build_reverse_index.py output/mindmaps_curated backlinks.tsv
+"""
+
+import argparse
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Optional
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, str(Path(__file__).parent))
+from index_store import ReverseIndex
+
+
+def extract_tree_id_from_url(url: str) -> Optional[str]:
+    """Extract tree ID from Pearltrees URL."""
+    if not url or 'pearltrees.com' not in url:
+        return None
+    match = re.search(r'/id(\d+)(?:/|$)', url)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_tree_id_from_cloudmapref(ref: str) -> Optional[str]:
+    """Extract tree ID from cloudmapref path like '../folder/id12345.smmx'."""
+    match = re.search(r'id(\d+)\.smmx$', ref)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_tree_id_from_filename(filename: str) -> Optional[str]:
+    """Extract tree ID from mindmap filename."""
+    match = re.match(r'^id(\d+)\.smmx$', os.path.basename(filename))
+    if match:
+        return match.group(1)
+    return None
+
+
+def scan_mindmap_links(smmx_path: str) -> set:
+    """Scan a mindmap and return all tree IDs it links to.
+
+    Checks both urllink (Pearltrees URLs) and cloudmapref (local links).
+    """
+    linked_ids = set()
+
+    try:
+        with zipfile.ZipFile(smmx_path, 'r') as zf:
+            xml_content = zf.read('document/mindmap.xml').decode('utf-8')
+    except (zipfile.BadZipFile, KeyError):
+        return linked_ids
+
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError:
+        return linked_ids
+
+    for link in root.iter('link'):
+        # Check urllink
+        urllink = link.get('urllink')
+        if urllink:
+            tree_id = extract_tree_id_from_url(urllink)
+            if tree_id:
+                linked_ids.add(tree_id)
+
+        # Check cloudmapref
+        cloudmapref = link.get('cloudmapref')
+        if cloudmapref:
+            tree_id = extract_tree_id_from_cloudmapref(cloudmapref)
+            if tree_id:
+                linked_ids.add(tree_id)
+
+    return linked_ids
+
+
+def build_reverse_index(mindmap_dir: str, verbose: bool = False) -> ReverseIndex:
+    """Build reverse index from all mindmaps in directory.
+
+    Args:
+        mindmap_dir: Directory containing .smmx files
+        verbose: Print progress
+
+    Returns:
+        ReverseIndex with all backlinks
+    """
+    reverse = ReverseIndex()
+    base = Path(mindmap_dir)
+
+    smmx_files = list(base.rglob("*.smmx"))
+    total = len(smmx_files)
+
+    for i, smmx_file in enumerate(smmx_files):
+        source_id = extract_tree_id_from_filename(str(smmx_file))
+        if not source_id:
+            continue
+
+        if verbose and (i % 500 == 0 or i == total - 1):
+            print(f"Scanning {i+1}/{total}...", file=sys.stderr)
+
+        linked_ids = scan_mindmap_links(str(smmx_file))
+
+        # Remove self-links
+        linked_ids.discard(source_id)
+
+        for target_id in linked_ids:
+            reverse.add_link(source_id, target_id)
+
+    return reverse
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Build reverse index of mindmap links (backlinks)'
+    )
+    parser.add_argument('mindmap_dir', help='Directory containing .smmx files')
+    parser.add_argument('output', nargs='?', help='Output file (JSON or TSV)')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                       help='Print progress')
+
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.mindmap_dir):
+        print(f"Error: {args.mindmap_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    reverse = build_reverse_index(args.mindmap_dir, verbose=args.verbose)
+
+    # Count stats
+    total_links = sum(len(sources) for _, sources in reverse.items())
+    targets_with_backlinks = sum(1 for _ in reverse.items())
+
+    print(f"Found {total_links} links to {targets_with_backlinks} targets", file=sys.stderr)
+
+    if args.output:
+        ext = Path(args.output).suffix.lower()
+        if ext == '.tsv':
+            reverse.save_tsv(args.output)
+        else:
+            reverse.save_json(args.output)
+        print(f"Saved to {args.output}", file=sys.stderr)
+    else:
+        # Print summary
+        print("\nTop 10 most linked-to mindmaps:")
+        items = [(target, sources) for target, sources in reverse.items()]
+        items.sort(key=lambda x: len(x[1]), reverse=True)
+        for target, sources in items[:10]:
+            print(f"  {target}: {len(sources)} backlinks")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/mindmap/index_store.py
+++ b/scripts/mindmap/index_store.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""
+Mindmap index store abstraction layer.
+
+Design principles:
+- Storage backend and caching are orthogonal concerns
+- Any storage format can be a "database" (text, JSON, SQLite, etc.)
+- CachedStore wraps any backend with in-memory caching
+
+Storage backends:
+- JSONStore: JSON file
+- SQLiteStore: SQLite database
+- TSVStore: Tab-separated text file (awk-friendly)
+
+Caching:
+- CachedStore: Wraps any store with in-memory cache
+
+Usage:
+    from index_store import create_index_store
+
+    # Auto-selects backend based on file extension
+    store = create_index_store("index.json")           # JSON
+    store = create_index_store("index.db")             # SQLite
+    store = create_index_store("index.tsv")            # TSV (awk-friendly)
+    store = create_index_store("index.db", cache=True) # SQLite with cache
+
+    # Lookup
+    path = store.get("75009241")
+    abs_path = store.resolve_path("75009241")
+"""
+
+import json
+import os
+import sqlite3
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Dict, Iterator, Optional, Tuple
+
+
+class IndexStore(ABC):
+    """Abstract base class for mindmap index storage."""
+
+    @abstractmethod
+    def get(self, tree_id: str) -> Optional[str]:
+        """Get mindmap path by tree ID."""
+        pass
+
+    @abstractmethod
+    def contains(self, tree_id: str) -> bool:
+        """Check if tree ID exists in index."""
+        pass
+
+    @abstractmethod
+    def set(self, tree_id: str, path: str) -> None:
+        """Set/update a tree ID -> path mapping."""
+        pass
+
+    @abstractmethod
+    def delete(self, tree_id: str) -> bool:
+        """Delete a mapping. Returns True if existed."""
+        pass
+
+    @abstractmethod
+    def items(self) -> Iterator[Tuple[str, str]]:
+        """Iterate over all (tree_id, path) pairs."""
+        pass
+
+    @abstractmethod
+    def count(self) -> int:
+        """Return number of entries."""
+        pass
+
+    @property
+    @abstractmethod
+    def base_dir(self) -> Optional[str]:
+        """Return base directory for relative paths."""
+        pass
+
+    def resolve_path(self, tree_id: str) -> Optional[str]:
+        """Get absolute path for a tree ID."""
+        rel_path = self.get(tree_id)
+        if rel_path and self.base_dir:
+            return os.path.join(self.base_dir, rel_path)
+        return rel_path
+
+
+class CachedStore(IndexStore):
+    """Wrapper that adds in-memory caching to any store."""
+
+    def __init__(self, backend: IndexStore, preload: bool = True):
+        """
+        Args:
+            backend: Underlying storage backend
+            preload: If True, load entire index into cache on init
+        """
+        self._backend = backend
+        self._cache: Dict[str, str] = {}
+        self._fully_loaded = False
+
+        if preload:
+            self._load_all()
+
+    def _load_all(self) -> None:
+        """Load entire index into cache."""
+        self._cache = dict(self._backend.items())
+        self._fully_loaded = True
+
+    def get(self, tree_id: str) -> Optional[str]:
+        if tree_id in self._cache:
+            return self._cache[tree_id]
+        if self._fully_loaded:
+            return None
+        # Cache miss - fetch from backend
+        path = self._backend.get(tree_id)
+        if path:
+            self._cache[tree_id] = path
+        return path
+
+    def contains(self, tree_id: str) -> bool:
+        if tree_id in self._cache:
+            return True
+        if self._fully_loaded:
+            return False
+        return self._backend.contains(tree_id)
+
+    def set(self, tree_id: str, path: str) -> None:
+        self._cache[tree_id] = path
+        self._backend.set(tree_id, path)
+
+    def delete(self, tree_id: str) -> bool:
+        self._cache.pop(tree_id, None)
+        return self._backend.delete(tree_id)
+
+    def items(self) -> Iterator[Tuple[str, str]]:
+        if self._fully_loaded:
+            return iter(self._cache.items())
+        return self._backend.items()
+
+    def count(self) -> int:
+        if self._fully_loaded:
+            return len(self._cache)
+        return self._backend.count()
+
+    @property
+    def base_dir(self) -> Optional[str]:
+        return self._backend.base_dir
+
+    def invalidate(self, tree_id: str = None) -> None:
+        """Invalidate cache entry or entire cache."""
+        if tree_id:
+            self._cache.pop(tree_id, None)
+        else:
+            self._cache.clear()
+            self._fully_loaded = False
+
+
+class JSONStore(IndexStore):
+    """JSON file storage."""
+
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+        self._base_dir: Optional[str] = None
+        self._index: Dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.filepath):
+            with open(self.filepath, 'r') as f:
+                data = json.load(f)
+                self._base_dir = data.get("base_dir")
+                self._index = data.get("index", {})
+
+    def _save(self) -> None:
+        data = {
+            "base_dir": self._base_dir,
+            "count": len(self._index),
+            "index": self._index
+        }
+        with open(self.filepath, 'w') as f:
+            json.dump(data, f, indent=2)
+
+    def get(self, tree_id: str) -> Optional[str]:
+        return self._index.get(tree_id)
+
+    def contains(self, tree_id: str) -> bool:
+        return tree_id in self._index
+
+    def set(self, tree_id: str, path: str) -> None:
+        self._index[tree_id] = path
+        self._save()
+
+    def delete(self, tree_id: str) -> bool:
+        if tree_id in self._index:
+            del self._index[tree_id]
+            self._save()
+            return True
+        return False
+
+    def items(self) -> Iterator[Tuple[str, str]]:
+        return iter(self._index.items())
+
+    def count(self) -> int:
+        return len(self._index)
+
+    @property
+    def base_dir(self) -> Optional[str]:
+        return self._base_dir
+
+    @base_dir.setter
+    def base_dir(self, value: str) -> None:
+        self._base_dir = value
+        self._save()
+
+
+class TSVStore(IndexStore):
+    """Tab-separated text file storage (awk-friendly).
+
+    Format:
+        # base_dir: /path/to/mindmaps
+        tree_id<TAB>path
+        75009241<TAB>id75009241.smmx
+    """
+
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+        self._base_dir: Optional[str] = None
+        self._index: Dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.filepath):
+            with open(self.filepath, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("# base_dir:"):
+                        self._base_dir = line.split(":", 1)[1].strip()
+                    elif line and not line.startswith("#"):
+                        parts = line.split("\t", 1)
+                        if len(parts) == 2:
+                            self._index[parts[0]] = parts[1]
+
+    def _save(self) -> None:
+        with open(self.filepath, 'w') as f:
+            if self._base_dir:
+                f.write(f"# base_dir: {self._base_dir}\n")
+            for tree_id, path in sorted(self._index.items()):
+                f.write(f"{tree_id}\t{path}\n")
+
+    def get(self, tree_id: str) -> Optional[str]:
+        return self._index.get(tree_id)
+
+    def contains(self, tree_id: str) -> bool:
+        return tree_id in self._index
+
+    def set(self, tree_id: str, path: str) -> None:
+        self._index[tree_id] = path
+        self._save()
+
+    def delete(self, tree_id: str) -> bool:
+        if tree_id in self._index:
+            del self._index[tree_id]
+            self._save()
+            return True
+        return False
+
+    def items(self) -> Iterator[Tuple[str, str]]:
+        return iter(self._index.items())
+
+    def count(self) -> int:
+        return len(self._index)
+
+    @property
+    def base_dir(self) -> Optional[str]:
+        return self._base_dir
+
+    @base_dir.setter
+    def base_dir(self, value: str) -> None:
+        self._base_dir = value
+        self._save()
+
+
+class SQLiteStore(IndexStore):
+    """SQLite database storage."""
+
+    def __init__(self, filepath: str):
+        self.filepath = filepath
+        self._conn = sqlite3.connect(filepath)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cursor = self._conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS mindmap_index (
+                tree_id TEXT PRIMARY KEY,
+                path TEXT NOT NULL
+            )
+        ''')
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )
+        ''')
+        self._conn.commit()
+
+    def get(self, tree_id: str) -> Optional[str]:
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'SELECT path FROM mindmap_index WHERE tree_id = ?',
+            (tree_id,)
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    def contains(self, tree_id: str) -> bool:
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'SELECT 1 FROM mindmap_index WHERE tree_id = ?',
+            (tree_id,)
+        )
+        return cursor.fetchone() is not None
+
+    def set(self, tree_id: str, path: str) -> None:
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'INSERT OR REPLACE INTO mindmap_index (tree_id, path) VALUES (?, ?)',
+            (tree_id, path)
+        )
+        self._conn.commit()
+
+    def delete(self, tree_id: str) -> bool:
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'DELETE FROM mindmap_index WHERE tree_id = ?',
+            (tree_id,)
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def items(self) -> Iterator[Tuple[str, str]]:
+        cursor = self._conn.cursor()
+        cursor.execute('SELECT tree_id, path FROM mindmap_index')
+        return iter(cursor.fetchall())
+
+    def count(self) -> int:
+        cursor = self._conn.cursor()
+        cursor.execute('SELECT COUNT(*) FROM mindmap_index')
+        return cursor.fetchone()[0]
+
+    @property
+    def base_dir(self) -> Optional[str]:
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'SELECT value FROM metadata WHERE key = ?',
+            ('base_dir',)
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    @base_dir.setter
+    def base_dir(self, value: str) -> None:
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)',
+            ('base_dir', value)
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+def create_index_store(filepath: str, cache: bool = False) -> IndexStore:
+    """Factory function to create appropriate index store.
+
+    Selects backend based on file extension:
+    - .json -> JSONStore
+    - .tsv, .txt -> TSVStore (awk-friendly)
+    - .db, .sqlite -> SQLiteStore
+
+    Args:
+        filepath: Path to index file
+        cache: If True, wrap with CachedStore
+
+    Returns:
+        IndexStore instance
+    """
+    ext = Path(filepath).suffix.lower()
+
+    if ext == '.json':
+        store = JSONStore(filepath)
+    elif ext in ('.tsv', '.txt'):
+        store = TSVStore(filepath)
+    elif ext in ('.db', '.sqlite', '.sqlite3'):
+        store = SQLiteStore(filepath)
+    else:
+        # Default to JSON
+        store = JSONStore(filepath)
+
+    if cache:
+        store = CachedStore(store)
+
+    return store
+
+
+class ReverseIndex:
+    """Tracks which mindmaps link to each mindmap (backlinks).
+
+    Usage:
+        reverse = ReverseIndex()
+        reverse.add_link("75009241", "10388356")  # 75009241 links to 10388356
+        backlinks = reverse.get_backlinks("10388356")  # -> ["75009241"]
+    """
+
+    def __init__(self):
+        self._links: Dict[str, set] = {}  # target -> set of sources
+
+    def add_link(self, source_id: str, target_id: str) -> None:
+        """Record that source links to target."""
+        if target_id not in self._links:
+            self._links[target_id] = set()
+        self._links[target_id].add(source_id)
+
+    def get_backlinks(self, tree_id: str) -> list:
+        """Get all mindmaps that link to this tree."""
+        return list(self._links.get(tree_id, set()))
+
+    def count_backlinks(self, tree_id: str) -> int:
+        """Count how many mindmaps link to this tree."""
+        return len(self._links.get(tree_id, set()))
+
+    def items(self) -> Iterator[Tuple[str, list]]:
+        """Iterate over (target_id, [source_ids])."""
+        for target, sources in self._links.items():
+            yield (target, list(sources))
+
+    def save_json(self, filepath: str) -> None:
+        """Save reverse index to JSON file."""
+        data = {
+            target: list(sources)
+            for target, sources in self._links.items()
+        }
+        with open(filepath, 'w') as f:
+            json.dump(data, f, indent=2)
+
+    def load_json(self, filepath: str) -> None:
+        """Load reverse index from JSON file."""
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+        self._links = {k: set(v) for k, v in data.items()}
+
+    def save_tsv(self, filepath: str) -> None:
+        """Save reverse index to TSV file (awk-friendly)."""
+        with open(filepath, 'w') as f:
+            for target, sources in sorted(self._links.items()):
+                # Format: target_id<TAB>source1,source2,source3
+                f.write(f"{target}\t{','.join(sorted(sources))}\n")
+
+    def load_tsv(self, filepath: str) -> None:
+        """Load reverse index from TSV file."""
+        self._links = {}
+        with open(filepath, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    parts = line.split('\t', 1)
+                    if len(parts) == 2:
+                        target, sources = parts
+                        self._links[target] = set(sources.split(','))
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: index_store.py <index_file> [tree_id]")
+        print("       index_store.py index.json 75009241")
+        print("       index_store.py index.tsv   # awk-friendly format")
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+    store = create_index_store(filepath)
+
+    if len(sys.argv) > 2:
+        tree_id = sys.argv[2]
+        path = store.get(tree_id)
+        if path:
+            print(f"{tree_id} -> {path}")
+            abs_path = store.resolve_path(tree_id)
+            if abs_path:
+                print(f"Absolute: {abs_path}")
+        else:
+            print(f"Tree {tree_id} not found")
+            sys.exit(1)
+    else:
+        print(f"Index: {filepath}")
+        print(f"Count: {store.count()}")
+        print(f"Base dir: {store.base_dir}")


### PR DESCRIPTION
  ## Summary
  Add `scripts/mindmap/` folder with index storage abstractions and link management tools.

  ## Features
  - **Pluggable storage backends**: JSON, TSV (awk-friendly), SQLite
  - **Orthogonal caching**: CachedStore wrapper for any backend
  - **Forward index**: tree_id -> mindmap path lookup
  - **Reverse index**: Track backlinks for rename/move updates
  - **Link updater**: Add cloudmapref using the index

  ## Use Cases
  - Relative linking without full recursive regeneration
  - Update links when mindmaps are renamed/moved
  - Avoid AI calls for human-readable names on reruns

  🤖 Generated with [Claude Code](https://claude.com/claude-code)