### PR TITLE
feat(mindmap): Add semantic folder organization tools with LLM naming

### DIFF
--- a/scripts/mindmap/batch_rename_folders.py
+++ b/scripts/mindmap/batch_rename_folders.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""
+Batch rename mindmap folders using LLM-generated names.
+
+Renames folders from root to leaves, then updates all cloudmapref links.
+
+Usage:
+    # Dry run - show what would be renamed
+    python3 scripts/mindmap/batch_rename_folders.py \
+        --base-dir output/mindmaps_curated/ \
+        --dry-run --verbose
+
+    # Actually rename folders
+    python3 scripts/mindmap/batch_rename_folders.py \
+        --base-dir output/mindmaps_curated/
+
+    # With descriptions output
+    python3 scripts/mindmap/batch_rename_folders.py \
+        --base-dir output/mindmaps_curated/ \
+        --descriptions output/mindmaps_curated/folder_descriptions.json
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from xml.etree import ElementTree as ET
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from generate_mindmap import generate_folder_name_llm, sanitize_filename
+
+
+def get_folder_hierarchy(base_dir: Path) -> List[Tuple[int, Path]]:
+    """Get all folders sorted by depth (root first).
+
+    Returns list of (depth, folder_path) tuples.
+    """
+    folders = []
+    for root, dirs, files in os.walk(base_dir):
+        # Skip hidden directories
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+
+        root_path = Path(root)
+        # Only include folders that contain .smmx files (directly or in subdirs)
+        has_smmx = any(f.endswith('.smmx') for f in files)
+        has_smmx_subdir = any(
+            any(f.endswith('.smmx') for f in subfiles)
+            for _, _, subfiles in os.walk(root_path)
+        )
+
+        if has_smmx or has_smmx_subdir:
+            rel_path = root_path.relative_to(base_dir)
+            depth = len(rel_path.parts) if str(rel_path) != '.' else 0
+            if depth > 0:  # Skip base dir itself
+                folders.append((depth, root_path))
+
+    # Sort by depth (shallowest first)
+    folders.sort(key=lambda x: x[0])
+    return folders
+
+
+def get_trees_in_folder(folder: Path, embeddings_data: dict, index: dict) -> List[Dict]:
+    """Get tree items for a folder."""
+    tree_ids_list = list(embeddings_data['tree_ids'])
+    titles_list = list(embeddings_data['titles'])
+    id_to_idx = {str(tid): i for i, tid in enumerate(tree_ids_list)}
+
+    tree_items = []
+    for tree_id, rel_path in index.items():
+        # Check if this tree is in this folder
+        if tree_id not in id_to_idx:
+            continue
+        tree_folder = str(Path(rel_path).parent)
+        if tree_folder == str(folder.name) or rel_path.startswith(str(folder.name) + '/'):
+            idx = id_to_idx[tree_id]
+            tree_items.append({
+                "title": str(titles_list[idx]),
+                "path": rel_path,
+                "tree_id": tree_id
+            })
+
+    return tree_items
+
+
+def generate_folder_name(
+    folder: Path,
+    base_dir: Path,
+    embeddings_data: dict,
+    index: dict,
+    context_level: str = "jsonl",
+    with_descriptions: bool = False,
+    parent_name: str = None
+) -> Optional[Dict]:
+    """Generate a new name for a folder using LLM."""
+    # Get relative path for matching
+    rel_folder = folder.relative_to(base_dir)
+
+    # Find all trees in this folder (not subfolders)
+    tree_ids_list = list(embeddings_data['tree_ids'])
+    titles_list = list(embeddings_data['titles'])
+    id_to_idx = {str(tid): i for i, tid in enumerate(tree_ids_list)}
+
+    tree_items = []
+    for tree_id, rel_path in index.items():
+        if tree_id not in id_to_idx:
+            continue
+        # Check if directly in this folder (not subfolder)
+        tree_folder = str(Path(rel_path).parent)
+        if tree_folder == str(rel_folder):
+            idx = id_to_idx[tree_id]
+            tree_items.append({
+                "title": str(titles_list[idx]),
+                "path": rel_path,
+                "tree_id": tree_id
+            })
+
+    if not tree_items:
+        return None
+
+    # Generate name with parent context
+    result = generate_folder_name_llm(
+        tree_items,
+        context_level=context_level,
+        with_descriptions=with_descriptions,
+        parent_folder_path=parent_name
+    )
+
+    if with_descriptions and result:
+        return result
+    elif result:
+        return {"name": result}
+    return None
+
+
+def update_cloudmaprefs(
+    base_dir: Path,
+    path_mapping: Dict[str, str],
+    dry_run: bool = False,
+    verbose: bool = False
+) -> int:
+    """Update all cloudmapref attributes in all mindmaps.
+
+    Args:
+        base_dir: Base directory containing mindmaps
+        path_mapping: Dict of old_relative_path -> new_relative_path
+        dry_run: If True, don't actually modify files
+        verbose: Print detailed info
+
+    Returns:
+        Number of files modified
+    """
+    modified_count = 0
+
+    for smmx_file in base_dir.rglob("*.smmx"):
+        try:
+            # Read the zip file
+            with zipfile.ZipFile(smmx_file, 'r') as zf:
+                xml_content = zf.read('document.xml').decode('utf-8')
+
+            original_content = xml_content
+            modified = False
+
+            # Find all cloudmapref attributes
+            # Pattern: cloudmapref="some/path/file.smmx"
+            def replace_cloudmapref(match):
+                nonlocal modified
+                old_ref = match.group(1)
+
+                # Resolve the reference relative to this file's location
+                smmx_dir = smmx_file.parent
+                ref_path = (smmx_dir / old_ref).resolve()
+
+                try:
+                    old_rel = str(ref_path.relative_to(base_dir))
+                except ValueError:
+                    return match.group(0)  # Not under base_dir
+
+                # Check if this path needs updating
+                for old_path, new_path in path_mapping.items():
+                    if old_rel.startswith(old_path):
+                        # Replace the path portion
+                        new_rel = old_rel.replace(old_path, new_path, 1)
+                        # Compute new relative reference from this file
+                        new_ref_path = base_dir / new_rel
+                        new_ref = os.path.relpath(new_ref_path, smmx_dir)
+                        modified = True
+                        if verbose:
+                            print(f"    {old_ref} -> {new_ref}")
+                        return f'cloudmapref="{new_ref}"'
+
+                return match.group(0)
+
+            xml_content = re.sub(
+                r'cloudmapref="([^"]+)"',
+                replace_cloudmapref,
+                xml_content
+            )
+
+            if modified and xml_content != original_content:
+                modified_count += 1
+                if verbose:
+                    print(f"  Updating: {smmx_file.relative_to(base_dir)}")
+
+                if not dry_run:
+                    # Write back to the zip
+                    with zipfile.ZipFile(smmx_file, 'w', zipfile.ZIP_DEFLATED) as zf:
+                        zf.writestr('document.xml', xml_content.encode('utf-8'))
+
+        except Exception as e:
+            if verbose:
+                print(f"  Error processing {smmx_file}: {e}", file=sys.stderr)
+
+    return modified_count
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Batch rename mindmap folders using LLM",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument(
+        "--base-dir", "-d",
+        type=Path,
+        default=Path("output/mindmaps_curated"),
+        help="Base directory containing mindmaps"
+    )
+    parser.add_argument(
+        "--embeddings", "-e",
+        type=Path,
+        default=Path("models/dual_embeddings_combined_2026-01-02_trees_only.npz"),
+        help="Path to embeddings NPZ file"
+    )
+    parser.add_argument(
+        "--index", "-i",
+        type=Path,
+        default=Path("output/mindmaps_curated/index.json"),
+        help="Path to mindmap index"
+    )
+    parser.add_argument(
+        "--context-level", "-c",
+        choices=["titles", "paths", "jsonl"],
+        default="jsonl",
+        help="Context level for LLM naming"
+    )
+    parser.add_argument(
+        "--descriptions",
+        type=Path,
+        help="Output file for folder descriptions JSON"
+    )
+    parser.add_argument(
+        "--dry-run", "-n",
+        action="store_true",
+        help="Don't actually rename, just show what would happen"
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Verbose output"
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip folders that don't look like auto-generated names (id* pattern)"
+    )
+    parser.add_argument(
+        "--limit", "-l",
+        type=int,
+        default=0,
+        help="Limit number of folders to process (0 = all)"
+    )
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=0,
+        help="Only process folders at this depth (0 = all depths)"
+    )
+
+    args = parser.parse_args()
+
+    # Validate paths
+    if not args.base_dir.exists():
+        print(f"Error: Base directory not found: {args.base_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.embeddings.exists():
+        print(f"Error: Embeddings file not found: {args.embeddings}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.index.exists():
+        print(f"Error: Index file not found: {args.index}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load data
+    print("Loading embeddings...")
+    import numpy as np
+    embeddings_data = dict(np.load(args.embeddings, allow_pickle=True))
+
+    print("Loading index...")
+    with open(args.index) as f:
+        index_data = json.load(f)
+    index = index_data.get('index', index_data)
+
+    # Get folder hierarchy
+    print("Scanning folder hierarchy...")
+    folders = get_folder_hierarchy(args.base_dir)
+    print(f"Found {len(folders)} folders")
+
+    # Filter by depth if specified
+    if args.depth > 0:
+        folders = [(d, f) for d, f in folders if d == args.depth]
+        print(f"Filtered to {len(folders)} folders at depth {args.depth}")
+
+    # Limit if specified
+    if args.limit > 0:
+        folders = folders[:args.limit]
+        print(f"Limited to {len(folders)} folders")
+
+    # Track renames: old_path -> new_path (relative to base_dir)
+    path_mapping = {}
+    descriptions = {}
+
+    # Process folders from root to leaves
+    print("\nGenerating folder names...")
+    processed = 0
+    for depth, folder in folders:
+        rel_path = folder.relative_to(args.base_dir)
+
+        # Skip if not matching id* pattern (already renamed)
+        if args.skip_existing:
+            if not re.match(r'^id\d+', folder.name) and not any(
+                re.match(r'^id\d+', part) for part in rel_path.parts
+            ):
+                if args.verbose:
+                    print(f"  Skipping (already named): {rel_path}")
+                continue
+
+        # Get parent name for context
+        parent_name = None
+        if depth > 1:
+            parent_rel = str(rel_path.parent)
+            # Use renamed parent if available
+            parent_name = path_mapping.get(parent_rel, parent_rel)
+
+        # Generate new name
+        processed += 1
+        print(f"[{processed}/{len(folders)}] Processing: {rel_path}", end="", flush=True)
+
+        result = generate_folder_name(
+            folder,
+            args.base_dir,
+            embeddings_data,
+            index,
+            context_level=args.context_level,
+            with_descriptions=bool(args.descriptions),
+            parent_name=parent_name
+        )
+
+        if result is None:
+            print(f" -> (no trees)")
+            continue
+
+        new_name = result.get("name", folder.name)
+        if not new_name:
+            print(f" -> (no name generated)")
+            continue
+
+        # Sanitize the new name
+        new_name = sanitize_filename(new_name, max_length=40)
+
+        # Build new path
+        if depth == 1:
+            new_rel_path = new_name
+        else:
+            # Use renamed parent path
+            parent_rel = str(rel_path.parent)
+            new_parent = path_mapping.get(parent_rel, parent_rel)
+            new_rel_path = f"{new_parent}/{new_name}"
+
+        old_rel_path = str(rel_path)
+
+        if old_rel_path != new_rel_path:
+            path_mapping[old_rel_path] = new_rel_path
+            print(f" -> {new_name}")
+
+            if args.descriptions and 'short' in result:
+                descriptions[new_rel_path] = {
+                    "old_path": old_rel_path,
+                    "name": new_name,
+                    "short": result.get("short", ""),
+                    "medium": result.get("medium", ""),
+                    "long": result.get("long", "")
+                }
+        else:
+            print(f" -> (unchanged)")
+
+    print(f"\nFolders to rename: {len(path_mapping)}")
+
+    if not path_mapping:
+        print("No folders to rename.")
+        return
+
+    # Phase 1: Rename folders (in reverse depth order to avoid conflicts)
+    if not args.dry_run:
+        print("\nRenaming folders...")
+        # Sort by depth descending (deepest first) to avoid path conflicts
+        sorted_renames = sorted(
+            path_mapping.items(),
+            key=lambda x: x[0].count('/'),
+            reverse=True
+        )
+
+        for old_rel, new_rel in sorted_renames:
+            old_path = args.base_dir / old_rel
+            new_path = args.base_dir / new_rel
+
+            if old_path.exists():
+                # Ensure parent exists
+                new_path.parent.mkdir(parents=True, exist_ok=True)
+
+                if args.verbose:
+                    print(f"  Moving: {old_rel} -> {new_rel}")
+
+                shutil.move(str(old_path), str(new_path))
+
+    # Phase 2: Update cloudmapref links
+    print("\nUpdating cloudmapref links...")
+    modified = update_cloudmaprefs(
+        args.base_dir,
+        path_mapping,
+        dry_run=args.dry_run,
+        verbose=args.verbose
+    )
+    print(f"Modified {modified} mindmap files")
+
+    # Save descriptions
+    if args.descriptions and descriptions:
+        if not args.dry_run:
+            with open(args.descriptions, 'w') as f:
+                json.dump(descriptions, f, indent=2)
+            print(f"\nSaved descriptions to: {args.descriptions}")
+        else:
+            print(f"\nWould save {len(descriptions)} descriptions to: {args.descriptions}")
+
+    # Update index
+    if not args.dry_run:
+        print("\nUpdating index...")
+        new_index = {}
+        for tree_id, rel_path in index.items():
+            new_path = rel_path
+            for old_prefix, new_prefix in path_mapping.items():
+                if rel_path.startswith(old_prefix + '/') or rel_path.startswith(old_prefix):
+                    new_path = rel_path.replace(old_prefix, new_prefix, 1)
+                    break
+            new_index[tree_id] = new_path
+
+        index_data['index'] = new_index
+        with open(args.index, 'w') as f:
+            json.dump(index_data, f, indent=2)
+        print(f"Updated index: {args.index}")
+
+    print("\nDone!")
+    if args.dry_run:
+        print("(Dry run - no changes made)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mindmap/build_folder_projections.py
+++ b/scripts/mindmap/build_folder_projections.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+Build folder projections for mindmap organization suggestions.
+
+For each folder containing mindmaps, computes:
+1. Centroid: average of tree embeddings (for fast top-k filtering)
+2. W matrix: Procrustes projection (for precise fit scoring)
+
+The W matrix maps input embeddings to output embeddings via orthogonal
+transformation, capturing the folder's "semantic projection style".
+
+Usage:
+    # Full rebuild
+    python3 scripts/mindmap/build_folder_projections.py \
+        --embeddings models/dual_embeddings_combined_2026-01-02_trees_only.npz \
+        --index output/mindmaps_curated/index.json \
+        --output output/mindmaps_curated/folder_projections.db
+
+    # Incremental (only changed folders)
+    python3 scripts/mindmap/build_folder_projections.py \
+        --embeddings models/dual_embeddings_combined_2026-01-02_trees_only.npz \
+        --index output/mindmaps_curated/index.json \
+        --output output/mindmaps_curated/folder_projections.db \
+        --incremental
+
+    # Specific folders only
+    python3 scripts/mindmap/build_folder_projections.py \
+        --embeddings models/dual_embeddings_combined_2026-01-02_trees_only.npz \
+        --index output/mindmaps_curated/index.json \
+        --output output/mindmaps_curated/folder_projections.db \
+        --folders "Media_Reviews" "Economics"
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+try:
+    from scipy.linalg import orthogonal_procrustes
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+def create_db(db_path: Path) -> sqlite3.Connection:
+    """Create or open the folder projections database."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS folder_projections (
+            folder_path TEXT PRIMARY KEY,
+            centroid BLOB NOT NULL,
+            w_matrix BLOB NOT NULL,
+            n_trees INTEGER NOT NULL,
+            procrustes_scale REAL NOT NULL,
+            last_updated REAL NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+def get_folder_timestamps(conn: sqlite3.Connection) -> Dict[str, float]:
+    """Get last update timestamps for all folders."""
+    cursor = conn.execute("SELECT folder_path, last_updated FROM folder_projections")
+    return dict(cursor.fetchall())
+
+
+def save_projection(
+    conn: sqlite3.Connection,
+    folder_path: str,
+    centroid: np.ndarray,
+    w_matrix: np.ndarray,
+    n_trees: int,
+    scale: float
+):
+    """Save a folder projection to the database."""
+    conn.execute("""
+        INSERT OR REPLACE INTO folder_projections
+        (folder_path, centroid, w_matrix, n_trees, procrustes_scale, last_updated)
+        VALUES (?, ?, ?, ?, ?, ?)
+    """, (
+        folder_path,
+        centroid.astype(np.float32).tobytes(),
+        w_matrix.astype(np.float32).tobytes(),
+        n_trees,
+        scale,
+        time.time()
+    ))
+    conn.commit()
+
+
+def load_projection(conn: sqlite3.Connection, folder_path: str) -> Optional[Tuple[np.ndarray, np.ndarray, int, float]]:
+    """Load a folder projection from the database."""
+    cursor = conn.execute("""
+        SELECT centroid, w_matrix, n_trees, procrustes_scale
+        FROM folder_projections WHERE folder_path = ?
+    """, (folder_path,))
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    centroid = np.frombuffer(row[0], dtype=np.float32)
+    w_matrix = np.frombuffer(row[1], dtype=np.float32).reshape(768, 768)
+    return centroid, w_matrix, row[2], row[3]
+
+
+def load_all_centroids(conn: sqlite3.Connection) -> Tuple[List[str], np.ndarray]:
+    """Load all folder centroids for top-k filtering."""
+    cursor = conn.execute("SELECT folder_path, centroid FROM folder_projections ORDER BY folder_path")
+    rows = cursor.fetchall()
+    if not rows:
+        return [], np.array([])
+    folders = [r[0] for r in rows]
+    centroids = np.array([np.frombuffer(r[1], dtype=np.float32) for r in rows])
+    return folders, centroids
+
+
+def group_trees_by_folder(
+    index: Dict[str, str],
+    tree_ids: np.ndarray
+) -> Dict[str, List[int]]:
+    """Group tree indices by their folder path."""
+    # Build tree_id to index mapping
+    id_to_idx = {str(tid): i for i, tid in enumerate(tree_ids)}
+
+    # Group by folder
+    folder_trees = defaultdict(list)
+    for tree_id, rel_path in index.items():
+        if tree_id not in id_to_idx:
+            continue
+        # Extract folder from path (everything before the filename)
+        parts = rel_path.rsplit('/', 1)
+        folder = parts[0] if len(parts) > 1 else ""
+        folder_trees[folder].append(id_to_idx[tree_id])
+
+    return dict(folder_trees)
+
+
+def compute_procrustes(X: np.ndarray, Y: np.ndarray) -> Tuple[np.ndarray, float]:
+    """
+    Compute orthogonal Procrustes: find W that minimizes ||X @ W - Y||.
+
+    Returns:
+        W: 768x768 orthogonal matrix
+        scale: scaling factor
+    """
+    if not HAS_SCIPY:
+        # Fallback: simple SVD-based solution
+        M = X.T @ Y
+        U, _, Vt = np.linalg.svd(M)
+        W = U @ Vt
+        scale = 1.0
+    else:
+        W, scale = orthogonal_procrustes(X, Y)
+    return W, scale
+
+
+def build_folder_projection(
+    input_embs: np.ndarray,
+    output_embs: np.ndarray,
+    indices: List[int],
+    min_trees: int = 2
+) -> Optional[Tuple[np.ndarray, np.ndarray, float]]:
+    """
+    Build projection for a single folder.
+
+    Returns:
+        centroid: average input embedding
+        W: Procrustes transformation matrix
+        scale: Procrustes scale factor
+    """
+    if len(indices) < min_trees:
+        return None
+
+    X = input_embs[indices]  # n x 768
+    Y = output_embs[indices]  # n x 768
+
+    # Centroid is average of input embeddings
+    centroid = X.mean(axis=0)
+
+    # Procrustes: find W minimizing ||X @ W - Y||
+    W, scale = compute_procrustes(X, Y)
+
+    return centroid, W, scale
+
+
+def get_folder_mtime(base_dir: Path, folder: str) -> float:
+    """Get the newest modification time of any .smmx file in the folder."""
+    folder_path = base_dir / folder if folder else base_dir
+    if not folder_path.exists():
+        return 0.0
+
+    mtimes = [f.stat().st_mtime for f in folder_path.glob("*.smmx")]
+    return max(mtimes) if mtimes else 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build folder projections for mindmap organization",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument(
+        "--embeddings", "-e",
+        type=Path,
+        default=Path("models/dual_embeddings_combined_2026-01-02_trees_only.npz"),
+        help="Path to dual embeddings NPZ file"
+    )
+    parser.add_argument(
+        "--index", "-i",
+        type=Path,
+        default=Path("output/mindmaps_curated/index.json"),
+        help="Path to mindmap index JSON file"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        default=Path("output/mindmaps_curated/folder_projections.db"),
+        help="Output SQLite database path"
+    )
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Only update folders with changed files"
+    )
+    parser.add_argument(
+        "--folders", "-f",
+        nargs="+",
+        help="Only update specific folders (by name, not full path)"
+    )
+    parser.add_argument(
+        "--min-trees",
+        type=int,
+        default=2,
+        help="Minimum trees required to compute projection (default: 2)"
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Verbose output"
+    )
+
+    args = parser.parse_args()
+
+    # Check scipy
+    if not HAS_SCIPY:
+        print("Warning: scipy not available, using fallback Procrustes", file=sys.stderr)
+
+    # Load embeddings
+    print(f"Loading embeddings from {args.embeddings}...")
+    data = np.load(args.embeddings, allow_pickle=True)
+    input_embs = data['input_nomic']  # n x 768
+    output_embs = data['output_nomic']  # n x 768
+    tree_ids = data['tree_ids']
+    print(f"  Loaded {len(tree_ids)} trees with {input_embs.shape[1]}-dim embeddings")
+
+    # Load index
+    print(f"Loading index from {args.index}...")
+    with open(args.index) as f:
+        index_data = json.load(f)
+    index = index_data['index']
+    base_dir = Path(index_data.get('base_dir', args.index.parent))
+    print(f"  Index contains {len(index)} entries")
+
+    # Group by folder
+    folder_trees = group_trees_by_folder(index, tree_ids)
+    print(f"  Found {len(folder_trees)} folders with trees")
+
+    # Open/create database
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    conn = create_db(args.output)
+
+    # Get existing timestamps for incremental mode
+    existing_timestamps = get_folder_timestamps(conn) if args.incremental else {}
+
+    # Filter folders if specified
+    folders_to_process = list(folder_trees.keys())
+    if args.folders:
+        # Match by folder name (last component)
+        folder_names = set(args.folders)
+        folders_to_process = [
+            f for f in folders_to_process
+            if f.split('/')[-1] in folder_names or f in folder_names
+        ]
+        print(f"  Filtered to {len(folders_to_process)} specified folders")
+
+    # Process folders
+    updated = 0
+    skipped = 0
+    too_small = 0
+
+    start_time = time.time()
+
+    for folder in sorted(folders_to_process):
+        indices = folder_trees[folder]
+        display_name = folder if folder else "(root)"
+
+        # Check if update needed (incremental mode)
+        if args.incremental and folder in existing_timestamps:
+            folder_mtime = get_folder_mtime(base_dir, folder)
+            if folder_mtime <= existing_timestamps[folder]:
+                if args.verbose:
+                    print(f"  Skipping {display_name} (unchanged)")
+                skipped += 1
+                continue
+
+        # Compute projection
+        result = build_folder_projection(input_embs, output_embs, indices, args.min_trees)
+
+        if result is None:
+            if args.verbose:
+                print(f"  Skipping {display_name} (only {len(indices)} trees, need {args.min_trees})")
+            too_small += 1
+            continue
+
+        centroid, W, scale = result
+        save_projection(conn, folder, centroid, W, len(indices), scale)
+        updated += 1
+
+        if args.verbose:
+            print(f"  {display_name}: {len(indices)} trees, scale={scale:.4f}")
+
+    elapsed = time.time() - start_time
+
+    # Save metadata
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+        ("embedding_dim", str(input_embs.shape[1]))
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+        ("embeddings_file", str(args.embeddings))
+    )
+    conn.commit()
+    conn.close()
+
+    # Summary
+    print()
+    print(f"Completed in {elapsed:.2f}s")
+    print(f"  Updated: {updated} folders")
+    print(f"  Skipped (unchanged): {skipped} folders")
+    print(f"  Skipped (too small): {too_small} folders")
+    print(f"  Output: {args.output}")
+
+    # Show storage stats
+    db_size = args.output.stat().st_size
+    print(f"  Database size: {db_size / 1024 / 1024:.2f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mindmap/suggest_folder.py
+++ b/scripts/mindmap/suggest_folder.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+Suggest best folder for a mindmap based on semantic similarity.
+
+Uses a two-stage approach:
+1. Top-k centroid filtering (cheap): Find k nearest folder centroids
+2. Procrustes fit scoring (precise): Evaluate fit using folder's W matrix
+
+The final suggestion uses softmax over Procrustes fit scores.
+
+Usage:
+    # Suggest folder for a mindmap by tree ID
+    python3 scripts/mindmap/suggest_folder.py --tree-id 12345678
+
+    # Suggest folder for a mindmap by title
+    python3 scripts/mindmap/suggest_folder.py --title "Machine Learning Tutorial"
+
+    # Suggest folder with more candidates
+    python3 scripts/mindmap/suggest_folder.py --tree-id 12345678 --top-k 10
+
+    # Show detailed scores
+    python3 scripts/mindmap/suggest_folder.py --tree-id 12345678 --verbose
+
+    # Batch mode: check all mindmaps in a folder
+    python3 scripts/mindmap/suggest_folder.py --check-folder output/mindmaps_curated/Economics/
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+def load_centroids(conn: sqlite3.Connection) -> Tuple[List[str], np.ndarray]:
+    """Load all folder centroids for top-k filtering."""
+    cursor = conn.execute(
+        "SELECT folder_path, centroid FROM folder_projections ORDER BY folder_path"
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        return [], np.array([])
+    folders = [r[0] for r in rows]
+    centroids = np.array([np.frombuffer(r[1], dtype=np.float32) for r in rows])
+    return folders, centroids
+
+
+def load_w_matrix(conn: sqlite3.Connection, folder: str) -> Optional[np.ndarray]:
+    """Load W matrix for a specific folder."""
+    cursor = conn.execute(
+        "SELECT w_matrix FROM folder_projections WHERE folder_path = ?",
+        (folder,)
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    return np.frombuffer(row[0], dtype=np.float32).reshape(768, 768)
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Compute cosine similarity between two vectors."""
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-8))
+
+
+def cosine_similarity_batch(query: np.ndarray, matrix: np.ndarray) -> np.ndarray:
+    """Compute cosine similarity between query and each row in matrix."""
+    query_norm = query / (np.linalg.norm(query) + 1e-8)
+    matrix_norms = matrix / (np.linalg.norm(matrix, axis=1, keepdims=True) + 1e-8)
+    return matrix_norms @ query_norm
+
+
+def softmax(x: np.ndarray, temperature: float = 1.0) -> np.ndarray:
+    """Compute softmax with temperature."""
+    x_scaled = x / temperature
+    x_shifted = x_scaled - x_scaled.max()  # Numerical stability
+    exp_x = np.exp(x_shifted)
+    return exp_x / exp_x.sum()
+
+
+def get_embedding_for_tree(
+    tree_id: str,
+    embeddings_data: dict
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Get input and output embeddings for a tree ID."""
+    tree_ids = embeddings_data['tree_ids']
+    idx = None
+    for i, tid in enumerate(tree_ids):
+        if str(tid) == str(tree_id):
+            idx = i
+            break
+    if idx is None:
+        return None
+    return (
+        embeddings_data['input_nomic'][idx],
+        embeddings_data['output_nomic'][idx]
+    )
+
+
+def embed_title(title: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Embed a title using Nomic model."""
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
+    embedding = model.encode(title, convert_to_numpy=True)
+
+    # For a new title, input and output embeddings are the same
+    # (no hierarchy information yet)
+    return embedding, embedding
+
+
+def suggest_folder(
+    input_emb: np.ndarray,
+    output_emb: np.ndarray,
+    conn: sqlite3.Connection,
+    top_k: int = 5,
+    temperature: float = 0.1,
+    verbose: bool = False
+) -> List[Tuple[str, float, float]]:
+    """
+    Suggest best folder for a mindmap.
+
+    Args:
+        input_emb: Input embedding (768-dim)
+        output_emb: Output embedding (768-dim)
+        conn: Database connection
+        top_k: Number of candidates from centroid filtering
+        temperature: Softmax temperature (lower = sharper)
+        verbose: Print debug info
+
+    Returns:
+        List of (folder_path, probability, fit_score) tuples, sorted by probability
+    """
+    # Stage 1: Top-k centroid filtering
+    folders, centroids = load_centroids(conn)
+    if len(folders) == 0:
+        return []
+
+    centroid_sims = cosine_similarity_batch(input_emb, centroids)
+    top_k_indices = np.argsort(centroid_sims)[-top_k:][::-1]
+
+    if verbose:
+        print(f"Stage 1: Top-{top_k} by centroid similarity:")
+        for idx in top_k_indices:
+            print(f"  {folders[idx]}: {centroid_sims[idx]:.4f}")
+        print()
+
+    # Stage 2: Procrustes fit scoring
+    fit_scores = []
+    for idx in top_k_indices:
+        folder = folders[idx]
+        W = load_w_matrix(conn, folder)
+        if W is None:
+            fit_scores.append(-1.0)
+            continue
+
+        # Project input through folder's W matrix
+        projected = input_emb @ W
+
+        # Fit score is cosine similarity between projected and output
+        fit = cosine_similarity(projected, output_emb)
+        fit_scores.append(fit)
+
+    fit_scores = np.array(fit_scores)
+
+    if verbose:
+        print(f"Stage 2: Procrustes fit scores:")
+        for i, idx in enumerate(top_k_indices):
+            print(f"  {folders[idx]}: {fit_scores[i]:.4f}")
+        print()
+
+    # Softmax over fit scores
+    # Handle any negative scores by shifting
+    valid_mask = fit_scores >= 0
+    if not valid_mask.any():
+        return []
+
+    valid_scores = fit_scores[valid_mask]
+    valid_indices = top_k_indices[valid_mask]
+
+    probs = softmax(valid_scores, temperature)
+
+    if verbose:
+        print(f"Softmax probabilities (temperature={temperature}):")
+        for i, idx in enumerate(valid_indices):
+            print(f"  {folders[idx]}: {probs[i]:.4f}")
+        print()
+
+    # Build results
+    results = []
+    for i, idx in enumerate(valid_indices):
+        results.append((folders[idx], float(probs[i]), float(valid_scores[i])))
+
+    # Sort by probability (descending)
+    results.sort(key=lambda x: x[1], reverse=True)
+
+    return results
+
+
+def get_current_folder(tree_id: str, index: Dict[str, str]) -> Optional[str]:
+    """Get the current folder for a tree from the index."""
+    if tree_id not in index:
+        return None
+    rel_path = index[tree_id]
+    parts = rel_path.rsplit('/', 1)
+    return parts[0] if len(parts) > 1 else ""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Suggest best folder for a mindmap",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument(
+        "--tree-id", "-t",
+        help="Tree ID to suggest folder for"
+    )
+    parser.add_argument(
+        "--title",
+        help="Title to suggest folder for (embeds on the fly)"
+    )
+    parser.add_argument(
+        "--projections-db", "-p",
+        type=Path,
+        default=Path("output/mindmaps_curated/folder_projections.db"),
+        help="Path to folder projections database"
+    )
+    parser.add_argument(
+        "--embeddings", "-e",
+        type=Path,
+        default=Path("models/dual_embeddings_combined_2026-01-02_trees_only.npz"),
+        help="Path to dual embeddings NPZ file"
+    )
+    parser.add_argument(
+        "--index", "-i",
+        type=Path,
+        default=Path("output/mindmaps_curated/index.json"),
+        help="Path to mindmap index JSON file"
+    )
+    parser.add_argument(
+        "--top-k", "-k",
+        type=int,
+        default=5,
+        help="Number of candidates from centroid filtering (default: 5)"
+    )
+    parser.add_argument(
+        "--temperature", "-T",
+        type=float,
+        default=0.1,
+        help="Softmax temperature (default: 0.1, lower = sharper)"
+    )
+    parser.add_argument(
+        "--check-folder",
+        type=Path,
+        help="Check all mindmaps in a folder for misplacements"
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Probability threshold for misplacement warning (default: 0.5)"
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Verbose output"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON"
+    )
+
+    args = parser.parse_args()
+
+    # Validate inputs
+    if not args.tree_id and not args.title and not args.check_folder:
+        parser.error("Must specify --tree-id, --title, or --check-folder")
+
+    if not args.projections_db.exists():
+        print(f"Error: Projections database not found: {args.projections_db}", file=sys.stderr)
+        print("Run build_folder_projections.py first.", file=sys.stderr)
+        sys.exit(1)
+
+    # Open database
+    conn = sqlite3.connect(args.projections_db)
+
+    # Load embeddings if needed
+    embeddings_data = None
+    if args.tree_id or args.check_folder:
+        if not args.embeddings.exists():
+            print(f"Error: Embeddings file not found: {args.embeddings}", file=sys.stderr)
+            sys.exit(1)
+        embeddings_data = np.load(args.embeddings, allow_pickle=True)
+
+    # Load index if needed
+    index = None
+    if args.tree_id or args.check_folder:
+        if args.index.exists():
+            with open(args.index) as f:
+                index_data = json.load(f)
+            index = index_data['index']
+
+    # Single tree-id mode
+    if args.tree_id:
+        embs = get_embedding_for_tree(args.tree_id, embeddings_data)
+        if embs is None:
+            print(f"Error: Tree ID {args.tree_id} not found in embeddings", file=sys.stderr)
+            sys.exit(1)
+
+        input_emb, output_emb = embs
+        results = suggest_folder(
+            input_emb, output_emb, conn,
+            top_k=args.top_k,
+            temperature=args.temperature,
+            verbose=args.verbose
+        )
+
+        current_folder = get_current_folder(args.tree_id, index) if index else None
+
+        if args.json:
+            output = {
+                "tree_id": args.tree_id,
+                "current_folder": current_folder,
+                "suggestions": [
+                    {"folder": f, "probability": p, "fit_score": s}
+                    for f, p, s in results
+                ]
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            if current_folder is not None:
+                print(f"Tree ID: {args.tree_id}")
+                print(f"Current folder: {current_folder or '(root)'}")
+                print()
+
+            print("Suggested folders:")
+            for i, (folder, prob, score) in enumerate(results):
+                marker = " <-- current" if folder == current_folder else ""
+                display = folder if folder else "(root)"
+                print(f"  {i+1}. {display}: {prob:.1%} (fit={score:.4f}){marker}")
+
+    # Title mode
+    elif args.title:
+        print(f"Embedding title: {args.title}")
+        input_emb, output_emb = embed_title(args.title)
+
+        results = suggest_folder(
+            input_emb, output_emb, conn,
+            top_k=args.top_k,
+            temperature=args.temperature,
+            verbose=args.verbose
+        )
+
+        if args.json:
+            output = {
+                "title": args.title,
+                "suggestions": [
+                    {"folder": f, "probability": p, "fit_score": s}
+                    for f, p, s in results
+                ]
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print()
+            print("Suggested folders:")
+            for i, (folder, prob, score) in enumerate(results):
+                display = folder if folder else "(root)"
+                print(f"  {i+1}. {display}: {prob:.1%} (fit={score:.4f})")
+
+    # Check folder mode
+    elif args.check_folder:
+        import re
+
+        folder_path = args.check_folder
+        if not folder_path.exists():
+            print(f"Error: Folder not found: {folder_path}", file=sys.stderr)
+            sys.exit(1)
+
+        # Get relative folder path
+        base_dir = Path(index_data.get('base_dir', '')) if index else folder_path.parent
+        try:
+            rel_folder = str(folder_path.relative_to(base_dir))
+        except ValueError:
+            rel_folder = folder_path.name
+
+        # Find all mindmaps in folder
+        smmx_files = list(folder_path.glob("*.smmx"))
+        print(f"Checking {len(smmx_files)} mindmaps in {rel_folder}...")
+        print()
+
+        misplaced = []
+        for smmx in sorted(smmx_files):
+            # Extract tree ID from filename
+            match = re.search(r'id(\d+)\.smmx$', smmx.name)
+            if not match:
+                match = re.search(r'_(\d+)\.smmx$', smmx.name)
+            if not match:
+                continue
+
+            tree_id = match.group(1)
+            embs = get_embedding_for_tree(tree_id, embeddings_data)
+            if embs is None:
+                continue
+
+            input_emb, output_emb = embs
+            results = suggest_folder(
+                input_emb, output_emb, conn,
+                top_k=args.top_k,
+                temperature=args.temperature,
+                verbose=False
+            )
+
+            if not results:
+                continue
+
+            best_folder, best_prob, best_score = results[0]
+
+            # Check if current folder matches best suggestion
+            if best_folder != rel_folder and best_prob > args.threshold:
+                title = embeddings_data['titles'][
+                    list(embeddings_data['tree_ids']).index(tree_id)
+                ] if tree_id in list(embeddings_data['tree_ids']) else smmx.name
+
+                misplaced.append({
+                    "file": smmx.name,
+                    "tree_id": tree_id,
+                    "title": str(title),
+                    "suggested_folder": best_folder,
+                    "probability": best_prob,
+                    "fit_score": best_score
+                })
+
+        if args.json:
+            print(json.dumps({
+                "folder": rel_folder,
+                "total_checked": len(smmx_files),
+                "misplaced": misplaced
+            }, indent=2))
+        else:
+            if misplaced:
+                print(f"Found {len(misplaced)} potentially misplaced mindmaps:")
+                print()
+                for item in misplaced:
+                    print(f"  {item['title'][:50]}...")
+                    print(f"    File: {item['file']}")
+                    print(f"    Suggested: {item['suggested_folder'] or '(root)'} ({item['probability']:.1%})")
+                    print()
+            else:
+                print(f"No misplacements found (threshold: {args.threshold:.0%})")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  ## Summary
  - Add tools for organizing mindmaps by semantic similarity using Procrustes analysis
  - Add batch folder renaming with LLM-generated abbreviated names
  - Enhance `generate_mindmap.py` with configurable LLM context options

  ## New Tools

  ### `build_folder_projections.py`
  Computes per-folder Procrustes W matrices and centroids for semantic matching. W matrices capture each folder's "semantic projection style" via orthogonal transformation.

  ### `suggest_folder.py`
  Two-stage folder suggestion:
  1. Top-k centroid filtering (~50K ops, cheap)
  2. Procrustes fit scoring with softmax probabilities (precise)

  ### `batch_rename_folders.py`
  Batch rename folders using LLM-generated names:
  - Processes root-to-leaf (parent context informs child naming)
  - Generates abbreviated names (Corp_Intel, Econ, Tech, Govt)
  - Updates all `cloudmapref` links and index after renaming
  - Saves multi-length descriptions (short/medium/long) to JSON

  ## Changes to `generate_mindmap.py`
  - `--llm-folder-context`: Context level (titles/paths/full/jsonl)
  - `--llm-folder-descriptions`: Save folder descriptions to JSON
  - Parent folder context to avoid redundant naming
  - Default model changed to `gemini-3-flash-preview` (supports thinking mode)
  - Fix JSON parsing for gemini CLI session wrapper

  ## Test plan
  - [x] Tested `suggest_folder.py` on real data - correctly identified misplacements
  - [x] Tested `batch_rename_folders.py` - renamed 62 folders successfully
  - [x] Verified index paths updated correctly after batch rename
  - [x] Tested LLM context levels (titles, paths, jsonl) with descriptions

  🤖 Generated with [Claude Code](https://claude.com/claude-code)