### PR TITLE
feat: Add mindmap filtering and organization tools

### DIFF
--- a/scripts/filter_incomplete_trees.py
+++ b/scripts/filter_incomplete_trees.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+Filter incomplete mindmaps using semantic embeddings.
+
+Supports two filtering methods:
+1. Lexical: Embed a query string directly (finds similar titles/paths)
+2. Structural: Use an existing tree's output embedding (finds similar hierarchy positions)
+
+Usage:
+    # Lexical filtering - find trees with "science" in path/title
+    python3 scripts/filter_incomplete_trees.py \
+        --query "science" \
+        --top-k 10 --format tree
+
+    # Structural filtering - find trees near the "science" tree in hierarchy
+    python3 scripts/filter_incomplete_trees.py \
+        --tree-query "science" \
+        --top-k 10 --format tree
+
+    # Both methods combined (blend)
+    python3 scripts/filter_incomplete_trees.py \
+        --query "science" \
+        --tree-query "science" \
+        --alpha 0.5 \
+        --top-k 10 --format tree
+"""
+
+import argparse
+import json
+import numpy as np
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple
+from dataclasses import dataclass
+
+
+@dataclass
+class FilteredTree:
+    tree_id: str
+    title: str
+    uri: str
+    path_text: str
+    similarity: float
+    lexical_score: float = 0.0
+    structural_score: float = 0.0
+
+
+def cosine_sim(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-8))
+
+
+def load_incomplete_trees(scan_path: Path, jsonl_path: Path) -> List[Dict]:
+    """Load incomplete trees with their hierarchical paths."""
+    # Load path lookup
+    path_lookup = {}
+    with open(jsonl_path) as f:
+        for line in f:
+            record = json.loads(line.strip())
+            tree_id = record.get('tree_id', '')
+            if tree_id:
+                path_lookup[str(tree_id)] = record.get('target_text', '')
+
+    # Load incomplete trees
+    with open(scan_path) as f:
+        incomplete = json.load(f)['maps']
+
+    # Merge path data
+    result = []
+    for m in incomplete:
+        tid = m['tree_id']
+        path_text = path_lookup.get(tid, '')
+        if path_text:
+            lines = path_text.split('\n')
+            path_lines = [l for l in lines if not l.startswith('/')]
+            hierarchical_text = '\n'.join(path_lines)
+        else:
+            hierarchical_text = m['title']
+
+        result.append({
+            'tree_id': tid,
+            'title': m['title'],
+            'uri': m['uri'],
+            'path_text': hierarchical_text
+        })
+
+    return result
+
+
+def embed_trees(trees: List[Dict], cache_path: Optional[Path] = None) -> np.ndarray:
+    """Embed tree paths, with optional caching."""
+    if cache_path and cache_path.exists():
+        print(f"Loading cached embeddings from {cache_path}")
+        data = np.load(cache_path, allow_pickle=True)
+        return data['embeddings']
+
+    from sentence_transformers import SentenceTransformer
+    print("Loading Nomic model...")
+    nomic = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
+
+    texts = [t['path_text'] for t in trees]
+    print(f"Embedding {len(texts)} paths...")
+
+    batch_size = 100
+    all_embeddings = []
+    for i in range(0, len(texts), batch_size):
+        batch = texts[i:i+batch_size]
+        embs = nomic.encode(batch, show_progress_bar=False)
+        all_embeddings.extend(embs)
+        if (i // batch_size) % 10 == 0:
+            print(f"  {min(i+batch_size, len(texts))}/{len(texts)}")
+
+    embeddings = np.array(all_embeddings)
+
+    if cache_path:
+        print(f"Caching embeddings to {cache_path}")
+        np.savez_compressed(cache_path,
+            embeddings=embeddings,
+            tree_ids=np.array([t['tree_id'] for t in trees]),
+            uris=np.array([t['uri'] for t in trees]),
+            titles=np.array([t['title'] for t in trees])
+        )
+
+    return embeddings
+
+
+def find_tree_embedding(tree_query: str, emb_path: Path) -> Optional[np.ndarray]:
+    """Find output embedding for a tree by title."""
+    if not emb_path.exists():
+        print(f"Warning: {emb_path} not found")
+        return None
+
+    data = np.load(emb_path, allow_pickle=True)
+    titles = data['titles']
+    output_nomic = data['output_nomic']
+
+    # Find matching tree
+    query_lower = tree_query.lower()
+    for i, title in enumerate(titles):
+        if query_lower in str(title).lower():
+            print(f"Found tree: '{title}' (idx={i})")
+            return output_nomic[i]
+
+    print(f"Warning: No tree matching '{tree_query}' found")
+    return None
+
+
+def filter_trees(
+    trees: List[Dict],
+    embeddings: np.ndarray,
+    query: Optional[str] = None,
+    tree_query_emb: Optional[np.ndarray] = None,
+    alpha: float = 0.5,
+    top_k: int = 10
+) -> List[FilteredTree]:
+    """Filter trees by semantic similarity.
+
+    Args:
+        trees: List of tree dicts
+        embeddings: Tree path embeddings
+        query: Lexical query string
+        tree_query_emb: Structural query (existing tree's output embedding)
+        alpha: Blend weight (0=lexical only, 1=structural only)
+        top_k: Number of results
+
+    Returns:
+        List of FilteredTree results
+    """
+    from sentence_transformers import SentenceTransformer
+
+    lexical_scores = np.zeros(len(trees))
+    structural_scores = np.zeros(len(trees))
+
+    # Lexical scoring
+    if query:
+        nomic = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
+        query_emb = nomic.encode([query])[0]
+        for i in range(len(embeddings)):
+            lexical_scores[i] = cosine_sim(query_emb, embeddings[i])
+
+    # Structural scoring
+    if tree_query_emb is not None:
+        for i in range(len(embeddings)):
+            structural_scores[i] = cosine_sim(tree_query_emb, embeddings[i])
+
+    # Blend scores
+    if query and tree_query_emb is not None:
+        final_scores = (1 - alpha) * lexical_scores + alpha * structural_scores
+    elif query:
+        final_scores = lexical_scores
+    elif tree_query_emb is not None:
+        final_scores = structural_scores
+    else:
+        raise ValueError("Must provide either query or tree_query_emb")
+
+    # Get top-k
+    top_indices = np.argsort(final_scores)[::-1][:top_k]
+
+    results = []
+    for idx in top_indices:
+        results.append(FilteredTree(
+            tree_id=trees[idx]['tree_id'],
+            title=trees[idx]['title'],
+            uri=trees[idx]['uri'],
+            path_text=trees[idx]['path_text'],
+            similarity=final_scores[idx],
+            lexical_score=lexical_scores[idx],
+            structural_score=structural_scores[idx]
+        ))
+
+    return results
+
+
+def build_merged_tree(results: List[FilteredTree]) -> str:
+    """Build merged tree view from filtered results."""
+
+    class TreeNode:
+        def __init__(self, name):
+            self.name = name
+            self.children = {}
+            self.results = []
+            self.count = 0
+
+    def parse_path(path_text):
+        lines = path_text.split('\n')
+        path = []
+        for line in lines:
+            stripped = line.lstrip('- ').strip()
+            if stripped:
+                path.append(stripped)
+        return path
+
+    root = TreeNode('ROOT')
+
+    for r in results:
+        path = parse_path(r.path_text) if r.path_text else [r.title]
+        current = root
+        for part in path:
+            if part not in current.children:
+                current.children[part] = TreeNode(part)
+            current = current.children[part]
+        current.results.append(r)
+
+    def compute_counts(node):
+        node.count = len(node.results)
+        for child in node.children.values():
+            node.count += compute_counts(child)
+        return node.count
+
+    compute_counts(root)
+
+    def format_tree(node, prefix=''):
+        lines = []
+        items = sorted(node.children.items(), key=lambda x: (-x[1].count, x[0]))
+
+        for i, (name, child) in enumerate(items):
+            is_last = i == len(items) - 1
+            connector = '└── ' if is_last else '├── '
+            count_str = f' ({child.count})' if child.count > 0 else ''
+            lines.append(f'{prefix}{connector}{name}{count_str}')
+
+            new_prefix = prefix + ('    ' if is_last else '│   ')
+
+            for r in child.results:
+                score_info = f'[{r.similarity:.3f}]'
+                if r.lexical_score and r.structural_score:
+                    score_info = f'[L:{r.lexical_score:.3f} S:{r.structural_score:.3f} = {r.similarity:.3f}]'
+                lines.append(f'{new_prefix}★ {score_info} {r.uri}')
+
+            child_output = format_tree(child, new_prefix)
+            if child_output:
+                lines.append(child_output)
+
+        return '\n'.join(filter(None, lines))
+
+    return format_tree(root)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Filter incomplete trees using semantic embeddings',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('--scan', type=Path,
+                       default=Path('.local/data/scans/incomplete_mindmaps.json'),
+                       help='Path to incomplete mindmaps JSON')
+    parser.add_argument('--data', type=Path,
+                       default=Path('reports/pearltrees_targets_full_multi_account.jsonl'),
+                       help='Path to JSONL with paths')
+    parser.add_argument('--embeddings-cache', type=Path,
+                       default=Path('.local/data/scans/incomplete_embeddings.npz'),
+                       help='Cache path for embeddings')
+    parser.add_argument('--output-embeddings', type=Path,
+                       default=Path('models/dual_embeddings_full.npz'),
+                       help='Path to pre-built output embeddings (for structural query)')
+
+    parser.add_argument('--query', type=str, default=None,
+                       help='Lexical query string')
+    parser.add_argument('--tree-query', type=str, default=None,
+                       help='Structural query - find tree by title and use its output embedding')
+    parser.add_argument('--alpha', type=float, default=0.5,
+                       help='Blend weight: 0=lexical, 1=structural (default: 0.5)')
+    parser.add_argument('--top-k', type=int, default=10,
+                       help='Number of results')
+
+    parser.add_argument('--format', choices=['tree', 'list', 'urls', 'json'],
+                       default='tree', help='Output format')
+    parser.add_argument('--output', '-o', type=Path, default=None,
+                       help='Output file')
+
+    args = parser.parse_args()
+
+    if not args.query and not args.tree_query:
+        parser.error("Must provide --query and/or --tree-query")
+
+    # Load data
+    print("Loading incomplete trees...")
+    trees = load_incomplete_trees(args.scan, args.data)
+    print(f"Loaded {len(trees)} incomplete trees")
+
+    # Get/create embeddings
+    embeddings = embed_trees(trees, args.embeddings_cache)
+
+    # Get structural query embedding if requested
+    tree_query_emb = None
+    if args.tree_query:
+        tree_query_emb = find_tree_embedding(args.tree_query, args.output_embeddings)
+
+    # Filter
+    print(f"\nFiltering with:")
+    if args.query:
+        print(f"  Lexical query: '{args.query}'")
+    if args.tree_query:
+        print(f"  Structural query: '{args.tree_query}'")
+    if args.query and tree_query_emb is not None:
+        print(f"  Alpha: {args.alpha} (0=lexical, 1=structural)")
+
+    results = filter_trees(
+        trees, embeddings,
+        query=args.query,
+        tree_query_emb=tree_query_emb,
+        alpha=args.alpha,
+        top_k=args.top_k
+    )
+
+    # Format output
+    if args.format == 'tree':
+        output = f"=== Top {args.top_k} results ===\n\n"
+        output += build_merged_tree(results)
+    elif args.format == 'list':
+        lines = []
+        for i, r in enumerate(results, 1):
+            lines.append(f"{i}. [{r.similarity:.4f}] {r.title}")
+            lines.append(f"   {r.uri}")
+        output = '\n'.join(lines)
+    elif args.format == 'urls':
+        output = '\n'.join(r.uri for r in results)
+    elif args.format == 'json':
+        output = json.dumps([{
+            'tree_id': r.tree_id,
+            'title': r.title,
+            'uri': r.uri,
+            'similarity': r.similarity,
+            'lexical_score': r.lexical_score,
+            'structural_score': r.structural_score
+        } for r in results], indent=2)
+
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(output)
+        print(f"\nWritten to {args.output}")
+    else:
+        print(f"\n{output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/organize_incomplete_trees.py
+++ b/scripts/organize_incomplete_trees.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Organize incomplete mindmaps into a hierarchical view.
+
+Merges the incomplete tree URIs into a tree structure based on their
+Pearltrees hierarchy paths, showing counts at each level.
+
+This helps identify which topics have the most incomplete trees,
+allowing you to prioritize API fetches by interest area.
+
+Usage:
+    python3 scripts/organize_incomplete_trees.py \
+        --scan .local/data/scans/incomplete_mindmaps.json \
+        --data reports/pearltrees_targets_full_multi_account.jsonl
+
+    # Output as text tree:
+    python3 scripts/organize_incomplete_trees.py --scan ... --format tree
+
+    # Output as JSON for further processing:
+    python3 scripts/organize_incomplete_trees.py --scan ... --format json
+
+    # Save URLs grouped by top-level category:
+    python3 scripts/organize_incomplete_trees.py --scan ... --format grouped
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TreeNode:
+    """A node in the merged tree."""
+    name: str
+    children: Dict[str, 'TreeNode'] = field(default_factory=dict)
+    incomplete_trees: List[dict] = field(default_factory=list)
+    count: int = 0  # Total incomplete trees in this subtree
+
+
+def load_path_lookup(data_path: Path) -> Dict[str, dict]:
+    """Load tree_id -> full record mapping from JSONL."""
+    lookup = {}
+    with open(data_path) as f:
+        for line in f:
+            record = json.loads(line.strip())
+            tree_id = record.get('tree_id', '')
+            if tree_id:
+                lookup[str(tree_id)] = record
+    return lookup
+
+
+def parse_path(target_text: str) -> List[str]:
+    """Parse target_text into path components."""
+    lines = target_text.split('\n')
+    # Skip the ID line (starts with /)
+    path_lines = [l for l in lines if not l.startswith('/')]
+
+    path = []
+    for line in path_lines:
+        stripped = line.lstrip('- ').strip()
+        if stripped:
+            path.append(stripped)
+    return path
+
+
+def build_merged_tree(incomplete_trees: List[dict], path_lookup: Dict[str, dict]) -> TreeNode:
+    """Build a merged tree from incomplete trees."""
+    root = TreeNode('ROOT')
+
+    for m in incomplete_trees:
+        tree_id = m['tree_id']
+        record = path_lookup.get(tree_id, {})
+        target_text = record.get('target_text', '')
+
+        if not target_text:
+            # No path found, put under "Unknown"
+            path = ['Unknown', m['title']]
+        else:
+            path = parse_path(target_text)
+
+        # Navigate/create path
+        current = root
+        for part in path:
+            if part not in current.children:
+                current.children[part] = TreeNode(part)
+            current = current.children[part]
+
+        # Add the incomplete tree at the leaf
+        current.incomplete_trees.append(m)
+
+    # Compute counts
+    def compute_counts(node: TreeNode) -> int:
+        node.count = len(node.incomplete_trees)
+        for child in node.children.values():
+            node.count += compute_counts(child)
+        return node.count
+
+    compute_counts(root)
+    return root
+
+
+def format_tree(node: TreeNode, prefix: str = '', show_urls: bool = False, min_count: int = 1) -> str:
+    """Format tree as string with box-drawing characters."""
+    lines = []
+
+    # Sort children by count (descending) then name
+    items = sorted(node.children.items(), key=lambda x: (-x[1].count, x[0]))
+    visible_items = [x for x in items if x[1].count >= min_count]
+
+    for i, (name, child) in enumerate(visible_items):
+        is_last = i == len(visible_items) - 1
+        connector = '\u2514\u2500\u2500 ' if is_last else '\u251c\u2500\u2500 '
+
+        # Show count
+        count_str = f' ({child.count})' if child.count > 0 else ''
+
+        lines.append(f'{prefix}{connector}{name}{count_str}')
+
+        new_prefix = prefix + ('    ' if is_last else '\u2502   ')
+
+        # Show URLs at this node (these are the incomplete trees filed here)
+        if show_urls and child.incomplete_trees:
+            for tree in child.incomplete_trees[:3]:  # Limit to 3 per folder
+                lines.append(f'{new_prefix}\u2192 {tree["uri"]}')
+            if len(child.incomplete_trees) > 3:
+                lines.append(f'{new_prefix}... and {len(child.incomplete_trees) - 3} more')
+
+        child_output = format_tree(child, new_prefix, show_urls, min_count)
+        if child_output:
+            lines.append(child_output)
+
+    return '\n'.join(filter(None, lines))
+
+
+def get_grouped_urls(node: TreeNode, depth: int = 1) -> Dict[str, List[str]]:
+    """Get URLs grouped by category at specified depth."""
+    groups = defaultdict(list)
+
+    def collect(n: TreeNode, path: List[str], target_depth: int):
+        if len(path) == target_depth:
+            # Collect all URLs in this subtree
+            def get_all_urls(node: TreeNode) -> List[str]:
+                urls = [t['uri'] for t in node.incomplete_trees]
+                for child in node.children.values():
+                    urls.extend(get_all_urls(child))
+                return urls
+
+            category = ' > '.join(path) if path else 'Root'
+            groups[category].extend(get_all_urls(n))
+        else:
+            for name, child in n.children.items():
+                collect(child, path + [name], target_depth)
+
+    collect(node, [], depth)
+    return dict(groups)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Organize incomplete mindmaps into hierarchical view',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument('--scan', type=Path, required=True,
+                       help='Path to incomplete_mindmaps.json')
+    parser.add_argument('--data', type=Path,
+                       default=Path('reports/pearltrees_targets_full_multi_account.jsonl'),
+                       help='Path to JSONL with path data')
+    parser.add_argument('--format', choices=['tree', 'json', 'grouped', 'summary'],
+                       default='tree', help='Output format')
+    parser.add_argument('--min-count', type=int, default=1,
+                       help='Minimum count to show in tree (default: 1)')
+    parser.add_argument('--show-urls', action='store_true',
+                       help='Show sample URLs in tree output')
+    parser.add_argument('--group-depth', type=int, default=2,
+                       help='Depth for grouped output (default: 2)')
+    parser.add_argument('--output', '-o', type=Path,
+                       help='Output file (default: stdout)')
+
+    args = parser.parse_args()
+
+    # Load data
+    print(f"Loading incomplete trees from {args.scan}...", file=__import__('sys').stderr)
+    with open(args.scan) as f:
+        scan_data = json.load(f)
+    incomplete = scan_data['maps']
+    print(f"Loaded {len(incomplete)} incomplete trees", file=__import__('sys').stderr)
+
+    print(f"Loading path data from {args.data}...", file=__import__('sys').stderr)
+    path_lookup = load_path_lookup(args.data)
+    print(f"Loaded {len(path_lookup)} path entries", file=__import__('sys').stderr)
+
+    # Build tree
+    tree = build_merged_tree(incomplete, path_lookup)
+
+    # Output
+    if args.format == 'tree':
+        output = format_tree(tree, min_count=args.min_count, show_urls=args.show_urls)
+    elif args.format == 'json':
+        def tree_to_dict(node: TreeNode) -> dict:
+            return {
+                'name': node.name,
+                'count': node.count,
+                'trees': [{'uri': t['uri'], 'title': t['title']} for t in node.incomplete_trees],
+                'children': {k: tree_to_dict(v) for k, v in sorted(node.children.items())}
+            }
+        output = json.dumps(tree_to_dict(tree), indent=2)
+    elif args.format == 'grouped':
+        groups = get_grouped_urls(tree, args.group_depth)
+        output = json.dumps(groups, indent=2)
+    elif args.format == 'summary':
+        # Show top-level categories with counts
+        lines = ["Top-level categories by incomplete tree count:", ""]
+        for name, child in sorted(tree.children.items(), key=lambda x: -x[1].count):
+            lines.append(f"  {child.count:4d}  {name}")
+        output = '\n'.join(lines)
+
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(output)
+        print(f"Written to {args.output}", file=__import__('sys').stderr)
+    else:
+        print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/scan_incomplete_mindmaps.py
+++ b/scripts/scan_incomplete_mindmaps.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Scan mindmaps for incomplete/missing data.
+
+Identifies mindmaps with only 1 node (root only), which typically indicates
+the tree data wasn't properly fetched or the RDF export was incomplete.
+
+Usage:
+    python3 scripts/scan_incomplete_mindmaps.py output/mindmaps_curated/
+    python3 scripts/scan_incomplete_mindmaps.py output/mindmaps_curated/ --account s243a
+    python3 scripts/scan_incomplete_mindmaps.py output/mindmaps_curated/ --output incomplete.json
+    python3 scripts/scan_incomplete_mindmaps.py output/mindmaps_curated/ --threshold 3
+"""
+
+import argparse
+import json
+import zipfile
+import re
+from pathlib import Path
+from collections import defaultdict
+from typing import List, Dict, Optional
+
+
+def count_topics(smmx_path: Path) -> tuple:
+    """Count topics in a mindmap and extract metadata.
+
+    Returns:
+        (topic_count, title, tree_id, uri) or (None, None, None, None) on error
+    """
+    try:
+        with zipfile.ZipFile(smmx_path, 'r') as zf:
+            xml_content = zf.read('document/mindmap.xml').decode('utf-8')
+            topic_count = xml_content.count('<topic ')
+
+            # Extract title
+            title_match = re.search(r'<title text="([^"]*)"', xml_content)
+            title = title_match.group(1) if title_match else "Unknown"
+
+            # Extract tree ID from filename
+            # Supports: id{number}, Title_id{number}, Title_{number}
+            stem = smmx_path.stem
+            tree_id = None
+
+            # Try id{number} prefix
+            if stem.startswith('id') and stem[2:].isdigit():
+                tree_id = stem[2:]
+            else:
+                # Try Title_id{number} or Title_{number} suffix
+                id_match = re.search(r'_id(\d+)$', stem)
+                if id_match:
+                    tree_id = id_match.group(1)
+                else:
+                    # Try just trailing digits (at least 6)
+                    id_match = re.search(r'_(\d{6,})$', stem)
+                    if id_match:
+                        tree_id = id_match.group(1)
+
+            # If still no tree_id, extract from urllink inside the mindmap
+            if not tree_id:
+                url_id_match = re.search(r'urllink="https://www\.pearltrees\.com/[^"]+/id(\d+)"', xml_content)
+                if url_id_match:
+                    tree_id = url_id_match.group(1)
+                else:
+                    # Last resort: fallback to stem
+                    tree_id = stem
+
+            # Extract actual URI from root topic's urllink
+            uri_match = re.search(r'urllink="(https://www\.pearltrees\.com/[^"]+/id' + tree_id + r')"', xml_content)
+            if uri_match:
+                uri = uri_match.group(1)
+            else:
+                # Fallback: try to find any pearltrees URL with this tree_id
+                uri_match = re.search(r'urllink="(https://www\.pearltrees\.com/[^"]*id' + tree_id + r'[^"]*)"', xml_content)
+                uri = uri_match.group(1) if uri_match else None
+
+            return topic_count, title, tree_id, uri
+    except Exception as e:
+        return None, None, None, None
+
+
+def detect_account(path: Path, base_dir: Path) -> str:
+    """Detect account from path structure."""
+    try:
+        rel_path = str(path.relative_to(base_dir))
+    except ValueError:
+        rel_path = str(path)
+
+    # Check path patterns for known accounts
+    if 's243a_groups' in rel_path or 's243a-groups' in rel_path:
+        return 's243a_groups'
+    elif 's243a' in rel_path:
+        return 's243a'
+    elif rel_path.startswith('Gods_of_Earth'):
+        return 's243a'
+    elif rel_path.startswith('Chomsky'):
+        return 's243a'
+    else:
+        # Check base_dir name for account hints
+        base_name = base_dir.name.lower()
+        if 's243a_groups' in base_name or 's243a-groups' in base_name:
+            return 's243a_groups'
+        elif 'curated' in base_name or 's243a' in base_name:
+            # mindmaps_curated is s243a's export
+            return 's243a'
+        return 'other'
+
+
+def get_pearltrees_uri(tree_id: str, account: str) -> str:
+    """Generate Pearltrees URI for a tree."""
+    if account == 's243a_groups':
+        return f"https://www.pearltrees.com/s243a-groups/id{tree_id}"
+    elif account == 's243a':
+        return f"https://www.pearltrees.com/s243a/id{tree_id}"
+    else:
+        # For unknown accounts, use generic format (user can look it up)
+        return f"https://www.pearltrees.com/*/id{tree_id}"
+
+
+def scan_mindmaps(
+    base_dir: Path,
+    threshold: int = 1,
+    account_filter: Optional[str] = None,
+    exclude_private: bool = False
+) -> List[Dict]:
+    """Scan mindmaps and find incomplete ones.
+
+    Args:
+        base_dir: Directory containing .smmx files
+        threshold: Maximum topic count to consider incomplete (default: 1)
+        account_filter: Only include maps from this account
+        exclude_private: Exclude maps with "*private*" title
+
+    Returns:
+        List of dicts with path, title, tree_id, account, topic_count
+    """
+    smmx_files = list(base_dir.rglob("*.smmx"))
+    incomplete = []
+
+    for smmx_path in smmx_files:
+        topic_count, title, tree_id, uri = count_topics(smmx_path)
+
+        if topic_count is None:
+            continue
+
+        if topic_count > threshold:
+            continue
+
+        if exclude_private and title == "*private*":
+            continue
+
+        account = detect_account(smmx_path, base_dir)
+
+        if account_filter and account != account_filter:
+            continue
+
+        try:
+            rel_path = str(smmx_path.relative_to(base_dir))
+        except ValueError:
+            rel_path = str(smmx_path)
+
+        # Use extracted URI from mindmap, fall back to constructed URI
+        if not uri:
+            uri = get_pearltrees_uri(tree_id, account)
+
+        incomplete.append({
+            'path': rel_path,
+            'title': title,
+            'tree_id': tree_id,
+            'account': account,
+            'topic_count': topic_count,
+            'uri': uri
+        })
+
+    return incomplete
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Scan for incomplete mindmaps')
+    parser.add_argument('directory', type=Path, help='Directory to scan')
+    parser.add_argument('--threshold', type=int, default=1,
+                        help='Max topic count to consider incomplete (default: 1)')
+    parser.add_argument('--account', type=str, default=None,
+                        help='Filter by account (e.g., s243a, s243a_groups)')
+    parser.add_argument('--exclude-private', action='store_true',
+                        help='Exclude maps with "*private*" title')
+    parser.add_argument('--output', '-o', type=Path, default=None,
+                        help='Output JSON file for results')
+    parser.add_argument('--format', choices=['summary', 'list', 'json', 'urls'],
+                        default='summary', help='Output format')
+    args = parser.parse_args()
+
+    if not args.directory.exists():
+        print(f"Error: Directory not found: {args.directory}")
+        return 1
+
+    print(f"Scanning {args.directory}...")
+    incomplete = scan_mindmaps(
+        args.directory,
+        threshold=args.threshold,
+        account_filter=args.account,
+        exclude_private=args.exclude_private
+    )
+
+    # Sort by account, then title
+    incomplete.sort(key=lambda x: (x['account'], x['title']))
+
+    if args.format == 'json' or args.output:
+        output_data = {
+            'count': len(incomplete),
+            'threshold': args.threshold,
+            'account_filter': args.account,
+            'maps': incomplete
+        }
+
+        if args.output:
+            with open(args.output, 'w') as f:
+                json.dump(output_data, f, indent=2)
+            print(f"Written {len(incomplete)} entries to {args.output}")
+        else:
+            print(json.dumps(output_data, indent=2))
+
+    elif args.format == 'urls':
+        # Output Pearltrees URLs for easy fetching
+        for m in incomplete:
+            print(m['uri'])
+
+    elif args.format == 'list':
+        for m in incomplete:
+            print(f"{m['tree_id']}\t{m['title']}\t{m['account']}\t{m['path']}")
+
+    else:  # summary
+        print(f"\nFound {len(incomplete)} incomplete mindmaps (threshold: {args.threshold})\n")
+
+        # Group by account
+        by_account = defaultdict(list)
+        for m in incomplete:
+            by_account[m['account']].append(m)
+
+        print("By account:")
+        for acc, maps in sorted(by_account.items(), key=lambda x: -len(x[1])):
+            print(f"  {acc}: {len(maps)}")
+
+        # Show sample
+        print(f"\nSample (first 20):")
+        print("-" * 80)
+        for m in incomplete[:20]:
+            title_display = m['title'][:40] if len(m['title']) > 40 else m['title']
+            print(f"  {m['tree_id']:>10} | {title_display:<40} | {m['account']}")
+
+        if len(incomplete) > 20:
+            print(f"  ... and {len(incomplete) - 20} more")
+
+        print(f"\nUse --format=urls to get Pearltrees URLs for repair")
+        print(f"Use --output=file.json to save full results")
+
+
+if __name__ == '__main__':
+    exit(main() or 0)


### PR DESCRIPTION
  ## Summary

  Add three scripts for analyzing and prioritizing incomplete mindmaps:

  - **scan_incomplete_mindmaps.py** - Scan .smmx files to identify single-node mindmaps that need completion
  - **organize_incomplete_trees.py** - Generate hierarchical views showing which topics have incomplete trees
  - **filter_incomplete_trees.py** - Semantic filtering with lexical and structural queries using embeddings

  ## Features

  ### Scanning
  ```bash
  python3 scripts/scan_incomplete_mindmaps.py output/mindmaps_curated/ \
    --output .local/data/scans/incomplete_mindmaps.json

  Hierarchical Organization

  python3 scripts/organize_incomplete_trees.py \
    --scan .local/data/scans/incomplete_mindmaps.json \
    --data reports/pearltrees_targets_repaired.jsonl \
    --format tree

  Semantic Filtering

  # Lexical query
  python3 scripts/filter_incomplete_trees.py --query "science" --top-k 100

  # Structural query (find trees near a specific tree in hierarchy)
  python3 scripts/filter_incomplete_trees.py --tree-query "physics" --top-k 100

  # Blended
  python3 scripts/filter_incomplete_trees.py --query "physics" --tree-query "science" --alpha 0.5

  Use Case

  These tools support the mindmap repair workflow by:
  1. Identifying which mindmaps are incomplete (single root node only)
  2. Organizing them by Pearltrees hierarchy to see topic distribution
  3. Filtering/prioritizing by semantic similarity to focus on specific areas

  🤖 Generated with https://claude.com/claude-code