### PR TITLE
feat(examples): Add abstract browser automation workflow

### DIFF
--- a/src/unifyweaver/examples/pearltrees/README.md
+++ b/src/unifyweaver/examples/pearltrees/README.md
@@ -20,8 +20,10 @@ This example shows how UnifyWeaver can:
 | `queries.pl` | Aggregate queries for tree/pearl data |
 | `templates.pl` | SMMX XML generation from tree data |
 | `compile_examples.pl` | Cross-target code generation examples |
+| `browser_automation.pl` | Abstract browser automation workflow |
 | `test_queries.pl` | 15 plunit tests for queries |
 | `test_templates.pl` | 16 plunit tests for templates |
+| `test_browser_automation.pl` | 22 plunit tests for browser automation |
 
 ## Source Definitions
 
@@ -93,6 +95,38 @@ swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_queries.pl
 
 # Run template tests (16 tests)
 swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_templates.pl
+
+# Run browser automation tests (22 tests)
+swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_browser_automation.pl
+```
+
+## Browser Automation Workflow
+
+Abstract workflow for browser-based data fetching:
+
+```prolog
+% Workflow steps are abstract - concrete API details in external config
+workflow_step(fetch_tree, 1, step(navigate, tree_page, [])).
+workflow_step(fetch_tree, 2, step(wait, page_load, [seconds(3)])).
+workflow_step(fetch_tree, 3, step(fetch, tree_api, [])).
+workflow_step(fetch_tree, 4, step(parse, tree_response, [])).
+```
+
+API endpoints and URLs come from `.local/tools/browser-automation/api_config.json`:
+
+```json
+{
+  "endpoints": {
+    "tree_api": {
+      "url_template": "https://www.pearltrees.com/s/.../getTreeAndPearls?treeId={tree_id}"
+    }
+  },
+  "urls": {
+    "tree_page": {
+      "template": "https://www.pearltrees.com/{account}/{slug}/id{tree_id}"
+    }
+  }
+}
 ```
 
 ## Cross-Target Examples
@@ -114,7 +148,7 @@ See generated code examples for Python, C#, and Go:
 | `build_children_index.py` | `pearl_children/6` source + SQLite target |
 | `generate_mindmap.py` | `tree_with_children/3` + template |
 | `scan_incomplete_mindmaps.py` | `incomplete_tree/2` query |
-| `batch_repair.py` | Timing DSL (future) + API source |
+| `batch_repair.py` | `browser_automation.pl` workflow + `api_config.json` |
 
 The existing Python tools remain the production implementation. These UnifyWeaver examples show how similar functionality could be generated for multiple targets from a single declarative specification.
 

--- a/src/unifyweaver/examples/pearltrees/browser_automation.pl
+++ b/src/unifyweaver/examples/pearltrees/browser_automation.pl
@@ -1,0 +1,325 @@
+%% pearltrees/browser_automation.pl - Abstract browser automation workflow
+%%
+%% Defines abstract predicates for browser-based data fetching.
+%% Concrete API endpoints and commands come from external JSON config.
+%%
+%% This separation allows:
+%% - UnifyWeaver to define the workflow logic
+%% - Config file to specify API details (URLs, selectors, etc.)
+%% - Different targets to implement the actual browser commands
+
+:- module(pearltrees_browser_automation, [
+    % Workflow steps (abstract)
+    workflow_step/3,
+    execute_workflow/3,
+
+    % Config loading
+    load_api_config/2,
+    api_endpoint/3,
+    api_param/4,
+
+    % Abstract browser operations
+    browser_navigate/2,
+    browser_wait/2,
+    browser_fetch_api/3,
+    browser_evaluate/3,
+
+    % Data extraction
+    parse_tree_response/3,
+    extract_pearls/2,
+
+    % Utilities (exported for testing)
+    expand_template/3,
+    get_context/3,
+    put_context/4,
+    resolve_wait/3
+]).
+
+%% --------------------------------------------------------------------
+%% Workflow Definition (Abstract)
+%%
+%% Workflows are sequences of steps. Each step has:
+%% - Name (atom)
+%% - Type (navigate, wait, fetch, parse)
+%% - Parameters (from config or computed)
+%% --------------------------------------------------------------------
+
+%% workflow_step(+WorkflowName, +StepIndex, -Step) is nondet.
+%%   Define workflow steps. Steps execute in order by index.
+
+% Fetch tree workflow
+workflow_step(fetch_tree, 1, step(navigate, tree_page, [])).
+workflow_step(fetch_tree, 2, step(wait, page_load, [seconds(3)])).
+workflow_step(fetch_tree, 3, step(fetch, tree_api, [])).
+workflow_step(fetch_tree, 4, step(parse, tree_response, [])).
+
+% Batch fetch workflow (multiple trees)
+workflow_step(batch_fetch, 1, step(navigate, tree_page, [])).
+workflow_step(batch_fetch, 2, step(wait, page_load, [seconds(3)])).
+workflow_step(batch_fetch, 3, step(fetch, tree_api, [])).
+workflow_step(batch_fetch, 4, step(parse, tree_response, [])).
+workflow_step(batch_fetch, 5, step(delay, human_like, [])).
+
+%% execute_workflow(+WorkflowName, +Config, +Context) is det.
+%%   Execute all steps in a workflow with given config and context.
+%%   Context contains runtime values like tree_id, account, etc.
+execute_workflow(WorkflowName, Config, Context) :-
+    findall(Idx-Step, workflow_step(WorkflowName, Idx, Step), Steps),
+    keysort(Steps, Sorted),
+    execute_steps(Sorted, Config, Context).
+
+execute_steps([], _, _).
+execute_steps([_Idx-Step|Rest], Config, Context) :-
+    execute_step(Step, Config, Context, NewContext),
+    execute_steps(Rest, Config, NewContext).
+
+%% execute_step(+Step, +Config, +Context, -NewContext) is det.
+%%   Execute a single workflow step.
+execute_step(step(navigate, Target, _Params), Config, Context, Context) :-
+    resolve_url(Target, Config, Context, Url),
+    browser_navigate(Url, Context).
+
+execute_step(step(wait, Type, Params), _Config, Context, Context) :-
+    resolve_wait(Type, Params, Duration),
+    browser_wait(Duration, Context).
+
+execute_step(step(fetch, Endpoint, _Params), Config, Context, NewContext) :-
+    resolve_endpoint(Endpoint, Config, Context, Url),
+    browser_fetch_api(Url, Context, Response),
+    put_context(response, Response, Context, NewContext).
+
+execute_step(step(parse, Parser, _Params), _Config, Context, NewContext) :-
+    get_context(response, Context, Response),
+    parse_response(Parser, Response, Data),
+    put_context(parsed_data, Data, Context, NewContext).
+
+execute_step(step(delay, Type, _Params), Config, Context, Context) :-
+    resolve_delay(Type, Config, Duration),
+    browser_wait(Duration, Context).
+
+%% --------------------------------------------------------------------
+%% Config Loading
+%%
+%% API config is loaded from external JSON file.
+%% Config structure:
+%% {
+%%   "endpoints": {
+%%     "tree_api": {"url_template": "...", "method": "GET"},
+%%     ...
+%%   },
+%%   "urls": {
+%%     "tree_page": {"template": "https://.../{account}/{slug}/id{tree_id}"}
+%%   },
+%%   "timing": {
+%%     "page_load_wait": 3,
+%%     "human_like_delay": {"distribution": "gamma", "mean": 144, "shape": 2}
+%%   }
+%% }
+%% --------------------------------------------------------------------
+
+:- dynamic api_config_cache/2.
+
+%% load_api_config(+FilePath, -Config) is det.
+%%   Load API configuration from JSON file.
+load_api_config(FilePath, Config) :-
+    (   api_config_cache(FilePath, Cached)
+    ->  Config = Cached
+    ;   read_json_file(FilePath, Config),
+        assertz(api_config_cache(FilePath, Config))
+    ).
+
+%% api_endpoint(+Config, +Name, -Endpoint) is semidet.
+%%   Get endpoint definition from config.
+api_endpoint(Config, Name, Endpoint) :-
+    get_dict(endpoints, Config, Endpoints),
+    get_dict(Name, Endpoints, Endpoint).
+
+%% api_param(+Config, +Section, +Key, -Value) is semidet.
+%%   Get a parameter from config section.
+api_param(Config, Section, Key, Value) :-
+    get_dict(Section, Config, SectionDict),
+    get_dict(Key, SectionDict, Value).
+
+%% --------------------------------------------------------------------
+%% URL Resolution
+%%
+%% Resolve URL templates using context variables.
+%% Template: "https://example.com/{account}/{slug}/id{tree_id}"
+%% Context: _{account: "user", slug: "science", tree_id: "12345"}
+%% Result: "https://example.com/user/science/id12345"
+%% --------------------------------------------------------------------
+
+resolve_url(Target, Config, Context, Url) :-
+    api_param(Config, urls, Target, UrlDef),
+    get_dict(template, UrlDef, Template),
+    expand_template(Template, Context, Url).
+
+resolve_endpoint(Endpoint, Config, Context, Url) :-
+    api_endpoint(Config, Endpoint, EndpointDef),
+    get_dict(url_template, EndpointDef, Template),
+    expand_template(Template, Context, Url).
+
+%% expand_template(+Template, +Context, -Expanded) is det.
+%%   Replace {var} placeholders with context values.
+expand_template(Template, Context, Expanded) :-
+    atom_string(Template, TemplateStr),
+    expand_vars(TemplateStr, Context, ExpandedStr),
+    atom_string(Expanded, ExpandedStr).
+
+expand_vars(Str, Context, Result) :-
+    (   sub_string(Str, Before, _, After, "{"),
+        sub_string(Str, _, _, AfterClose, "}"),
+        AfterClose < After
+    ->  % Found a variable
+        sub_string(Str, 0, Before, _, Prefix),
+        VarStart is Before + 1,
+        sub_string(Str, VarStart, _, _, Rest),
+        sub_string(Rest, VarLen, _, _, "}"),
+        sub_string(Rest, 0, VarLen, _, VarName),
+        atom_string(VarAtom, VarName),
+        (   get_dict(VarAtom, Context, Value)
+        ->  true
+        ;   Value = ""
+        ),
+        format(string(ValueStr), "~w", [Value]),
+        SuffixStart is VarStart + VarLen + 1,
+        sub_string(Str, SuffixStart, _, 0, Suffix),
+        string_concat(Prefix, ValueStr, Temp),
+        string_concat(Temp, Suffix, NewStr),
+        expand_vars(NewStr, Context, Result)
+    ;   Result = Str
+    ).
+
+%% --------------------------------------------------------------------
+%% Timing Resolution
+%% --------------------------------------------------------------------
+
+resolve_wait(page_load, Params, Duration) :-
+    (   member(seconds(S), Params)
+    ->  Duration = S
+    ;   Duration = 3
+    ).
+
+resolve_wait(custom, Params, Duration) :-
+    member(seconds(Duration), Params).
+
+resolve_delay(human_like, Config, Duration) :-
+    (   api_param(Config, timing, human_like_delay, DelayDef)
+    ->  generate_delay(DelayDef, Duration)
+    ;   Duration = 144  % Default mean
+    ).
+
+%% generate_delay(+DelayDef, -Duration) is det.
+%%   Generate delay based on distribution config.
+generate_delay(DelayDef, Duration) :-
+    get_dict(distribution, DelayDef, Distribution),
+    (   Distribution == "gamma"
+    ->  get_dict(mean, DelayDef, Mean),
+        get_dict(shape, DelayDef, Shape),
+        % Placeholder - actual implementation depends on target
+        Duration = Mean  % Would use gamma distribution
+    ;   get_dict(mean, DelayDef, Duration)
+    ).
+
+%% --------------------------------------------------------------------
+%% Context Helpers
+%% --------------------------------------------------------------------
+
+get_context(Key, Context, Value) :-
+    get_dict(Key, Context, Value).
+
+put_context(Key, Value, Context, NewContext) :-
+    put_dict(Key, Context, Value, NewContext).
+
+%% --------------------------------------------------------------------
+%% Abstract Browser Operations (to be implemented per target)
+%% --------------------------------------------------------------------
+
+%% browser_navigate(+Url, +Context) is det.
+%%   Navigate browser to URL. Implementation depends on target.
+browser_navigate(Url, _Context) :-
+    format('BROWSER_NAVIGATE: ~w~n', [Url]).
+
+%% browser_wait(+Duration, +Context) is det.
+%%   Wait for specified duration in seconds.
+browser_wait(Duration, _Context) :-
+    format('BROWSER_WAIT: ~w seconds~n', [Duration]).
+
+%% browser_fetch_api(+Url, +Context, -Response) is det.
+%%   Fetch data from API endpoint via browser.
+browser_fetch_api(Url, _Context, Response) :-
+    format('BROWSER_FETCH: ~w~n', [Url]),
+    Response = _{status: 200, data: null}.  % Placeholder
+
+%% browser_evaluate(+Script, +Context, -Result) is det.
+%%   Evaluate JavaScript in browser context.
+browser_evaluate(Script, _Context, Result) :-
+    format('BROWSER_EVALUATE: ~w~n', [Script]),
+    Result = null.  % Placeholder
+
+%% --------------------------------------------------------------------
+%% Response Parsing
+%% --------------------------------------------------------------------
+
+parse_response(tree_response, Response, Data) :-
+    get_dict(data, Response, RawData),
+    parse_tree_response(RawData, Data).
+
+%% parse_tree_response(+RawData, -TreeInfo, -Pearls) is det.
+%%   Parse API response into tree info and pearl list.
+parse_tree_response(null, _{}, []) :- !.
+parse_tree_response(RawData, TreeInfo, Pearls) :-
+    (   is_dict(RawData)
+    ->  extract_tree_info(RawData, TreeInfo),
+        extract_pearls(RawData, Pearls)
+    ;   TreeInfo = _{},
+        Pearls = []
+    ).
+
+extract_tree_info(Data, TreeInfo) :-
+    (   get_dict(tree, Data, Tree)
+    ->  TreeInfo = Tree
+    ;   TreeInfo = _{}
+    ).
+
+%% extract_pearls(+Data, -Pearls) is det.
+%%   Extract pearl list from API response.
+extract_pearls(Data, Pearls) :-
+    (   get_dict(pearls, Data, PearlList),
+        is_list(PearlList)
+    ->  maplist(normalize_pearl, PearlList, Pearls)
+    ;   Pearls = []
+    ).
+
+normalize_pearl(Raw, Pearl) :-
+    (   is_dict(Raw)
+    ->  dict_get_default(id, Raw, 0, Id),
+        dict_get_default(contentType, Raw, 0, Type),
+        dict_get_default(title, Raw, "", Title),
+        Pearl = pearl(Id, Type, Title)
+    ;   Pearl = pearl(0, 0, "")
+    ).
+
+%% dict_get_default(+Key, +Dict, +Default, -Value) is det.
+%%   Get value from dict, or return default if key missing.
+dict_get_default(Key, Dict, Default, Value) :-
+    (   get_dict(Key, Dict, V)
+    ->  Value = V
+    ;   Value = Default
+    ).
+
+%% --------------------------------------------------------------------
+%% Utility: Read JSON file
+%% --------------------------------------------------------------------
+
+read_json_file(FilePath, Data) :-
+    (   exists_file(FilePath)
+    ->  setup_call_cleanup(
+            open(FilePath, read, Stream),
+            json_read_dict(Stream, Data),
+            close(Stream)
+        )
+    ;   Data = _{}
+    ).
+
+:- use_module(library(http/json)).

--- a/src/unifyweaver/examples/pearltrees/test_browser_automation.pl
+++ b/src/unifyweaver/examples/pearltrees/test_browser_automation.pl
@@ -1,0 +1,167 @@
+%% pearltrees/test_browser_automation.pl - Tests for abstract browser automation
+%%
+%% Run with: swipl -g "run_tests" -t halt test_browser_automation.pl
+
+:- module(test_browser_automation, []).
+
+:- use_module(library(plunit)).
+:- use_module(browser_automation).
+
+%% --------------------------------------------------------------------
+%% Tests for URL template expansion
+%% --------------------------------------------------------------------
+
+:- begin_tests(expand_template).
+
+test(simple_variable) :-
+    Context = _{tree_id: "12345"},
+    expand_template("id{tree_id}", Context, Result),
+    Result == 'id12345'.
+
+test(multiple_variables) :-
+    Context = _{account: "user1", slug: "science", tree_id: "12345"},
+    expand_template("https://example.com/{account}/{slug}/id{tree_id}", Context, Result),
+    Result == 'https://example.com/user1/science/id12345'.
+
+test(missing_variable_empty) :-
+    Context = _{account: "user1"},
+    expand_template("{account}/{missing}", Context, Result),
+    Result == 'user1/'.
+
+test(no_variables) :-
+    Context = _{},
+    expand_template("https://example.com/static", Context, Result),
+    Result == 'https://example.com/static'.
+
+test(numeric_value) :-
+    Context = _{tree_id: 12345},
+    expand_template("id{tree_id}", Context, Result),
+    Result == 'id12345'.
+
+:- end_tests(expand_template).
+
+%% --------------------------------------------------------------------
+%% Tests for workflow steps
+%% --------------------------------------------------------------------
+
+:- begin_tests(workflow_steps).
+
+test(fetch_tree_has_four_steps) :-
+    findall(Idx, workflow_step(fetch_tree, Idx, _), Indices),
+    length(Indices, 4).
+
+test(fetch_tree_starts_with_navigate) :-
+    workflow_step(fetch_tree, 1, Step),
+    Step = step(navigate, tree_page, []).
+
+test(fetch_tree_ends_with_parse) :-
+    workflow_step(fetch_tree, 4, Step),
+    Step = step(parse, tree_response, []).
+
+test(batch_fetch_has_delay_step) :-
+    workflow_step(batch_fetch, 5, Step),
+    Step = step(delay, human_like, []).
+
+:- end_tests(workflow_steps).
+
+%% --------------------------------------------------------------------
+%% Tests for context helpers
+%% --------------------------------------------------------------------
+
+:- begin_tests(context).
+
+test(put_and_get) :-
+    Context = _{},
+    put_context(foo, bar, Context, Context1),
+    get_context(foo, Context1, Value),
+    Value == bar.
+
+test(overwrite_value) :-
+    Context = _{foo: old},
+    put_context(foo, new, Context, Context1),
+    get_context(foo, Context1, Value),
+    Value == new.
+
+test(preserve_other_keys) :-
+    Context = _{foo: 1, bar: 2},
+    put_context(baz, 3, Context, Context1),
+    get_context(foo, Context1, V1),
+    get_context(bar, Context1, V2),
+    get_context(baz, Context1, V3),
+    V1 == 1, V2 == 2, V3 == 3.
+
+:- end_tests(context).
+
+%% --------------------------------------------------------------------
+%% Tests for pearl extraction
+%% --------------------------------------------------------------------
+
+:- begin_tests(extract_pearls).
+
+test(empty_data) :-
+    extract_pearls(_{}, Pearls),
+    Pearls == [].
+
+test(missing_pearls_key) :-
+    extract_pearls(_{tree: _{id: 123}}, Pearls),
+    Pearls == [].
+
+test(extracts_pearl_list) :-
+    Data = _{pearls: [
+        _{id: 1, contentType: 1, title: "Link 1"},
+        _{id: 2, contentType: 2, title: "Subtree"}
+    ]},
+    extract_pearls(Data, Pearls),
+    length(Pearls, 2).
+
+test(normalizes_pearl_structure) :-
+    Data = _{pearls: [_{id: 42, contentType: 1, title: "Test"}]},
+    extract_pearls(Data, [Pearl]),
+    Pearl = pearl(42, 1, "Test").
+
+:- end_tests(extract_pearls).
+
+%% --------------------------------------------------------------------
+%% Tests for timing resolution
+%% --------------------------------------------------------------------
+
+:- begin_tests(timing).
+
+test(page_load_default) :-
+    resolve_wait(page_load, [], Duration),
+    Duration == 3.
+
+test(page_load_custom) :-
+    resolve_wait(page_load, [seconds(5)], Duration),
+    Duration == 5.
+
+test(custom_wait) :-
+    resolve_wait(custom, [seconds(10)], Duration),
+    Duration == 10.
+
+:- end_tests(timing).
+
+%% --------------------------------------------------------------------
+%% Tests for config access
+%% --------------------------------------------------------------------
+
+:- begin_tests(config_access).
+
+test(api_endpoint_lookup) :-
+    Config = _{endpoints: _{
+        tree_api: _{url_template: "https://example.com/api?id={tree_id}"}
+    }},
+    api_endpoint(Config, tree_api, Endpoint),
+    get_dict(url_template, Endpoint, Url),
+    Url == "https://example.com/api?id={tree_id}".
+
+test(api_param_lookup) :-
+    Config = _{timing: _{page_load_wait: 3}},
+    api_param(Config, timing, page_load_wait, Value),
+    Value == 3.
+
+test(missing_endpoint_fails, [fail]) :-
+    Config = _{endpoints: _{}},
+    api_endpoint(Config, nonexistent, _).
+
+:- end_tests(config_access).


### PR DESCRIPTION
## Summary

Extends the Pearltrees UnifyWeaver examples with abstract browser automation workflow predicates. Separates workflow logic (tracked) from concrete API details (untracked config file).

- Add abstract workflow predicates: navigate, wait, fetch, parse steps
- URL template expansion with context variables
- API config schema in `.local/tools/browser-automation/api_config.json`
- 22 new plunit tests for browser automation

## Files Changed

```
src/unifyweaver/examples/pearltrees/
├── browser_automation.pl       # NEW: Abstract workflow (320+ lines)
├── test_browser_automation.pl  # NEW: 22 tests
└── README.md                   # Updated with browser automation docs
```

## Design: Separation of Concerns

**Tracked (workflow logic):**
```prolog
workflow_step(fetch_tree, 1, step(navigate, tree_page, [])).
workflow_step(fetch_tree, 2, step(wait, page_load, [seconds(3)])).
workflow_step(fetch_tree, 3, step(fetch, tree_api, [])).
workflow_step(fetch_tree, 4, step(parse, tree_response, [])).
```

**Untracked (API details in config):**
```json
{
  "endpoints": {
    "tree_api": {"url_template": "https://.../getTreeAndPearls?treeId={tree_id}"}
  },
  "urls": {
    "tree_page": {"template": "https://.../{account}/{slug}/id{tree_id}"}
  }
}
```

## Key Features

| Feature | Description |
|---------|-------------|
| `workflow_step/3` | Define abstract workflow steps |
| `execute_workflow/3` | Orchestrate step execution |
| `expand_template/3` | URL template variable substitution |
| `resolve_wait/3` | Timing resolution from config |
| `extract_pearls/2` | Parse API response into pearl terms |

## Test Coverage

| Test Suite | Tests |
|------------|-------|
| `test_queries.pl` | 15 |
| `test_templates.pl` | 16 |
| `test_browser_automation.pl` | 22 |
| **Total** | **53** |

## Test Plan

- [x] All 53 tests pass
- [x] README updated with browser automation section
- [ ] Review workflow abstraction design

## Related

- Builds on PR #554 (Pearltrees UnifyWeaver-Native Processing)
- Config file location: `.local/tools/browser-automation/api_config.json`
