### PR TITLE
feat(examples): Add query-based filtering predicates for Pearltrees

### DIFF
--- a/docs/proposals/pearltrees_unifyweaver_native.md
+++ b/docs/proposals/pearltrees_unifyweaver_native.md
@@ -130,6 +130,12 @@ Generate mindmap tools in multiple languages:
 - Implement `incomplete_tree/2` for scanning
 - Add tests (15 plunit tests)
 
+### Phase 2b: Query-Based Filtering ✓ (Extension)
+- Composable filter predicates (`apply_filters/3`)
+- Domain, type, title, and count filters
+- Filter negation with `not/1`
+- Add tests (21 plunit tests)
+
 ### Phase 3: Template-Based Generation ✓
 - Create multi-format templates (SMMX, FreeMind, OPML, GraphML, VUE, Mermaid)
 - Generate mindmap files from Prolog
@@ -145,7 +151,7 @@ Generate mindmap tools in multiple languages:
 - External API config in `.local/tools/browser-automation/api_config.json`
 - Add tests (22 plunit tests)
 
-**Total: 81 plunit tests across 3 test files**
+**Total: 102 plunit tests across 3 test files**
 
 ## Mindmap Tool Flexibility Goals
 
@@ -203,16 +209,16 @@ All phases implemented in `src/unifyweaver/examples/pearltrees/`:
 | File | Description |
 |------|-------------|
 | `sources.pl` | SQLite/JSONL source definitions |
-| `queries.pl` | Aggregate queries (`tree_with_children/3`, etc.) |
+| `queries.pl` | Aggregate queries and composable filters |
 | `templates.pl` | Multi-format output (SMMX, FreeMind, OPML, GraphML, VUE, Mermaid) |
 | `compile_examples.pl` | Cross-target compilation demos |
 | `browser_automation.pl` | Abstract workflow predicates |
-| `test_*.pl` | 81 plunit tests (15 queries + 44 templates + 22 automation) |
+| `test_*.pl` | 102 plunit tests (36 queries/filters + 44 templates + 22 automation) |
 
 ## Future Work
 
 Potential extensions from flexibility goals:
-1. Query-based filtering predicates
+1. ~~Query-based filtering predicates~~ ✓ (PR #557)
 2. Hierarchical tree transformations
 3. Cross-account tree merging
 4. Incremental update tracking

--- a/src/unifyweaver/examples/pearltrees/queries.pl
+++ b/src/unifyweaver/examples/pearltrees/queries.pl
@@ -5,11 +5,42 @@
 %% grouping/aggregation code.
 
 :- module(pearltrees_queries, [
+    % Core queries
     tree_with_children/3,
     tree_child_count/2,
     incomplete_tree/2,
     trees_by_cluster/2,
-    pagepearl_urls/2
+    pagepearl_urls/2,
+
+    % Query-based filters
+    filter_trees/2,
+    filter_children/3,
+
+    % Domain filters
+    has_domain_links/2,
+    trees_with_domain/2,
+    has_wikipedia_links/1,
+
+    % Type filters
+    has_child_type/2,
+    trees_with_type/2,
+    children_of_type/3,
+
+    % Title/keyword filters
+    title_contains/2,
+    trees_matching/2,
+    children_matching/3,
+
+    % Count filters
+    trees_with_min_children/2,
+    trees_with_max_children/2,
+    trees_in_size_range/3,
+
+    % Combined filters
+    apply_filters/3,
+
+    % Statistics
+    tree_size_distribution/2
 ]).
 
 :- use_module(sources).
@@ -107,20 +138,6 @@ pagepearl_urls(TreeId, Urls) :-
     ).
 
 %% --------------------------------------------------------------------
-%% Example: Filter trees by URL domain
-%%
-%% Shows how predicates can compose for filtering.
-%% --------------------------------------------------------------------
-
-%% has_wikipedia_links(?TreeId) is nondet.
-%%   True if tree contains any Wikipedia links.
-has_wikipedia_links(TreeId) :-
-    pagepearl_urls(TreeId, Urls),
-    member(Url, Urls),
-    sub_atom(Url, _, _, _, 'wikipedia.org'),
-    !.  % Cut after first match
-
-%% --------------------------------------------------------------------
 %% Example: Statistics query
 %%
 %% Aggregate of aggregates - count trees by child count ranges.
@@ -136,3 +153,203 @@ tree_size_distribution(medium, Count) :-
     aggregate_all(count, (tree_child_count(_, C), C > 10, C =< 50), Count).
 tree_size_distribution(large, Count) :-
     aggregate_all(count, (tree_child_count(_, C), C > 50), Count).
+
+%% ====================================================================
+%% Query-Based Filtering Predicates
+%% ====================================================================
+%%
+%% Composable filters for selecting trees and children based on
+%% various criteria. These can be compiled to WHERE clauses in SQL,
+%% LINQ predicates in C#, or filter() calls in Python/Go.
+
+%% --------------------------------------------------------------------
+%% Generic Filter Framework
+%% --------------------------------------------------------------------
+
+%% filter_trees(+Filter, -TreeId) is nondet.
+%%   Apply a filter to find matching trees.
+%%   Filter is a term describing the filter criteria.
+filter_trees(domain(Domain), TreeId) :-
+    has_domain_links(TreeId, Domain).
+filter_trees(type(Type), TreeId) :-
+    has_child_type(TreeId, Type).
+filter_trees(title_match(Pattern), TreeId) :-
+    title_contains(TreeId, Pattern).
+filter_trees(min_children(N), TreeId) :-
+    trees_with_min_children(N, TreeId).
+filter_trees(max_children(N), TreeId) :-
+    trees_with_max_children(N, TreeId).
+filter_trees(incomplete, TreeId) :-
+    incomplete_tree(TreeId, _).
+filter_trees(cluster(ClusterId), TreeId) :-
+    pearl_trees(tree, TreeId, _, _, ClusterId).
+
+%% filter_children(+TreeId, +Filter, -Child) is nondet.
+%%   Apply a filter to find matching children within a tree.
+filter_children(TreeId, type(Type), child(Type, Title, Url, Order)) :-
+    pearl_children(TreeId, Type, Title, Order, Url, _).
+filter_children(TreeId, title_match(Pattern), child(Type, Title, Url, Order)) :-
+    pearl_children(TreeId, Type, Title, Order, Url, _),
+    title_matches(Title, Pattern).
+filter_children(TreeId, has_url, child(Type, Title, Url, Order)) :-
+    pearl_children(TreeId, Type, Title, Order, Url, _),
+    Url \= null,
+    Url \= ''.
+filter_children(TreeId, domain(Domain), child(Type, Title, Url, Order)) :-
+    pearl_children(TreeId, Type, Title, Order, Url, _),
+    Url \= null,
+    sub_atom(Url, _, _, _, Domain).
+
+%% --------------------------------------------------------------------
+%% Domain Filters
+%% --------------------------------------------------------------------
+
+%% has_domain_links(+TreeId, +Domain) is semidet.
+%%   True if tree contains links to the specified domain.
+has_domain_links(TreeId, Domain) :-
+    pearl_trees(tree, TreeId, _, _, _),
+    pearl_children(TreeId, pagepearl, _, _, Url, _),
+    Url \= null,
+    sub_atom(Url, _, _, _, Domain),
+    !.  % Cut after first match
+
+%% trees_with_domain(+Domain, -TreeId) is nondet.
+%%   Find all trees containing links to a domain.
+trees_with_domain(Domain, TreeId) :-
+    pearl_trees(tree, TreeId, _, _, _),
+    has_domain_links(TreeId, Domain).
+
+%% has_wikipedia_links(+TreeId) is semidet.
+%%   True if tree contains any Wikipedia links.
+%%   (Kept for backward compatibility)
+has_wikipedia_links(TreeId) :-
+    has_domain_links(TreeId, 'wikipedia.org').
+
+%% --------------------------------------------------------------------
+%% Type Filters
+%% --------------------------------------------------------------------
+
+%% has_child_type(+TreeId, +Type) is semidet.
+%%   True if tree has at least one child of the given type.
+has_child_type(TreeId, Type) :-
+    pearl_trees(tree, TreeId, _, _, _),
+    pearl_children(TreeId, Type, _, _, _, _),
+    !.  % Cut after first match
+
+%% trees_with_type(+Type, -TreeId) is nondet.
+%%   Find all trees containing children of a specific type.
+trees_with_type(Type, TreeId) :-
+    pearl_trees(tree, TreeId, _, _, _),
+    has_child_type(TreeId, Type).
+
+%% children_of_type(+TreeId, +Type, -Children) is det.
+%%   Get all children of a specific type from a tree.
+children_of_type(TreeId, Type, Children) :-
+    aggregate_all(
+        bag(child(Type, Title, Url, Order)),
+        pearl_children(TreeId, Type, Title, Order, Url, _),
+        Children
+    ).
+
+%% --------------------------------------------------------------------
+%% Title/Keyword Filters
+%% --------------------------------------------------------------------
+
+%% title_contains(+TreeId, +Pattern) is semidet.
+%%   True if tree title or any child title contains pattern.
+title_contains(TreeId, Pattern) :-
+    pearl_trees(tree, TreeId, Title, _, _),
+    (   title_matches(Title, Pattern)
+    ->  true
+    ;   pearl_children(TreeId, _, ChildTitle, _, _, _),
+        title_matches(ChildTitle, Pattern)
+    ),
+    !.
+
+%% title_matches(+Title, +Pattern) is semidet.
+%%   Case-insensitive substring match.
+title_matches(Title, Pattern) :-
+    downcase_atom(Title, LowerTitle),
+    downcase_atom(Pattern, LowerPattern),
+    sub_atom(LowerTitle, _, _, _, LowerPattern).
+
+%% trees_matching(+Pattern, -TreeId) is nondet.
+%%   Find trees with titles matching a pattern.
+trees_matching(Pattern, TreeId) :-
+    pearl_trees(tree, TreeId, Title, _, _),
+    title_matches(Title, Pattern).
+
+%% children_matching(+TreeId, +Pattern, -Children) is det.
+%%   Get children with titles matching a pattern.
+children_matching(TreeId, Pattern, Children) :-
+    aggregate_all(
+        bag(child(Type, Title, Url, Order)),
+        (   pearl_children(TreeId, Type, Title, Order, Url, _),
+            title_matches(Title, Pattern)
+        ),
+        Children
+    ).
+
+%% --------------------------------------------------------------------
+%% Count Filters
+%% --------------------------------------------------------------------
+
+%% trees_with_min_children(+MinCount, -TreeId) is nondet.
+%%   Find trees with at least N children.
+trees_with_min_children(MinCount, TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count >= MinCount.
+
+%% trees_with_max_children(+MaxCount, -TreeId) is nondet.
+%%   Find trees with at most N children.
+trees_with_max_children(MaxCount, TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count =< MaxCount.
+
+%% trees_in_size_range(+Min, +Max, -TreeId) is nondet.
+%%   Find trees with children count in range [Min, Max].
+trees_in_size_range(Min, Max, TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count >= Min,
+    Count =< Max.
+
+%% --------------------------------------------------------------------
+%% Combined Filters
+%% --------------------------------------------------------------------
+
+%% apply_filters(+Filters, -TreeId, -TreeInfo) is nondet.
+%%   Apply multiple filters and return matching trees with info.
+%%   Filters is a list of filter terms.
+%%   TreeInfo = tree_info(TreeId, Title, ChildCount).
+apply_filters(Filters, TreeId, tree_info(TreeId, Title, ChildCount)) :-
+    pearl_trees(tree, TreeId, Title, _, _),
+    tree_child_count(TreeId, ChildCount),
+    all_filters_match(Filters, TreeId).
+
+all_filters_match([], _).
+all_filters_match([Filter|Rest], TreeId) :-
+    filter_matches(Filter, TreeId),
+    all_filters_match(Rest, TreeId).
+
+filter_matches(domain(Domain), TreeId) :-
+    has_domain_links(TreeId, Domain).
+filter_matches(type(Type), TreeId) :-
+    has_child_type(TreeId, Type).
+filter_matches(title_match(Pattern), TreeId) :-
+    title_contains(TreeId, Pattern).
+filter_matches(min_children(N), TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count >= N.
+filter_matches(max_children(N), TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count =< N.
+filter_matches(incomplete, TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count =< 1.
+filter_matches(complete, TreeId) :-
+    tree_child_count(TreeId, Count),
+    Count > 1.
+filter_matches(cluster(ClusterId), TreeId) :-
+    pearl_trees(tree, TreeId, _, _, ClusterId).
+filter_matches(not(Filter), TreeId) :-
+    \+ filter_matches(Filter, TreeId).


### PR DESCRIPTION
## Summary

- Add composable filter predicates for selecting trees and children based on domain, type, title, and count criteria
- Implement generic filter framework with `apply_filters/3` supporting filter negation via `not/1`
- Add 21 new tests for filtering predicates (total: 36 query tests, 102 overall)
- Update documentation and mark Future Work item 1 as complete

## Filter Types

| Filter | Predicate | Description |
|--------|-----------|-------------|
| Domain | `has_domain_links/2` | Trees with links to a domain |
| Type | `has_child_type/2` | Trees containing specific child types |
| Title | `title_contains/2` | Title/content keyword search |
| Count | `trees_with_min_children/2` | Trees with minimum child count |
| Combined | `apply_filters/3` | Multiple filters at once |

## Example Usage

```prolog
%% Find trees with GitHub links and at least 2 children
?- apply_filters([domain('github.com'), min_children(2)], TreeId, Info).
Info = tree_info('12347', 'Tech Links', 2).

%% Find incomplete trees (negation)
?- apply_filters([not(min_children(2))], TreeId, Info).
Info = tree_info('12346', 'Empty Tree', 1).
```

## Test plan

- [x] All 36 query tests pass (`swipl -g "run_tests" -t halt test_queries.pl`)
- [x] Documentation updated in README.md
- [x] Proposal updated with Phase 2b and Future Work item 1 marked complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
