### PR TITLE
docs: Add design docs for hierarchical tree transformations

### DIFF
--- a/docs/proposals/hierarchical_transformations_implementation_plan.md
+++ b/docs/proposals/hierarchical_transformations_implementation_plan.md
@@ -1,0 +1,264 @@
+# Implementation Plan: Hierarchical Tree Transformations
+
+## Overview
+
+This document outlines the implementation plan for hierarchical tree transformation predicates in the Pearltrees UnifyWeaver example.
+
+## File Structure
+
+```
+src/unifyweaver/examples/pearltrees/
+├── sources.pl                    # Existing - data sources
+├── queries.pl                    # Existing - aggregate queries and filters
+├── hierarchy.pl                  # NEW - hierarchical transformations
+├── templates.pl                  # Existing - output formats
+├── test_queries.pl               # Existing - 36 tests
+├── test_hierarchy.pl             # NEW - hierarchy tests
+└── test_templates.pl             # Existing - 44 tests
+```
+
+## Implementation Phases
+
+### Phase 1: Navigation Predicates
+
+**Goal**: Build foundation for traversing tree hierarchies.
+
+**Predicates**:
+- `tree_parent/2` - Get immediate parent
+- `tree_ancestors/2` - Get path to root
+- `tree_depth/2` - Compute depth from root
+- `tree_path/2` - Get full path as list
+
+**Dependencies**: `sources.pl` (pearl_trees/5)
+
+**Tests**: ~8 tests
+- Root has no parent
+- Leaf depth calculation
+- Multi-level ancestor chains
+- Path includes self
+
+**Estimated effort**: Small - straightforward recursion
+
+---
+
+### Phase 2: Structural Queries
+
+**Goal**: Identify special nodes in the hierarchy.
+
+**Predicates**:
+- `root_tree/1` - Find root nodes
+- `leaf_trees/1` - Find nodes with no children
+- `orphan_trees/1` - Find disconnected nodes
+- `tree_descendants/2` - Get all nodes under a tree
+- `tree_siblings/2` - Get nodes at same level
+- `subtree_trees/2` - Enumerate subtree
+
+**Dependencies**: Phase 1 predicates
+
+**Tests**: ~10 tests
+- Single root identification
+- Multiple orphans detection
+- Empty descendants for leaves
+- Siblings exclude self
+
+**Estimated effort**: Small - builds on Phase 1
+
+---
+
+### Phase 3: Path Operations
+
+**Goal**: Manipulate path representations.
+
+**Predicates**:
+- `path_depth/2` - Count path elements
+- `truncate_path/3` - Limit path depth
+- `path_prefix/3` - Check path containment
+- `common_ancestor/3` - Find shared ancestor
+
+**Dependencies**: Phase 1 (tree_path/2)
+
+**Tests**: ~6 tests
+- Truncate long paths
+- Truncate already-short paths (no-op)
+- Common ancestor of siblings
+- Common ancestor of cousins
+
+**Estimated effort**: Small - list manipulation
+
+---
+
+### Phase 4: Basic Transformations
+
+**Goal**: Core tree restructuring operations.
+
+**Predicates**:
+- `flatten_tree/3` - Collapse depth levels
+- `prune_tree/3` - Remove branches by criteria
+- `trees_at_depth/2` - Select by depth
+- `trees_by_parent/2` - Group by parent
+
+**Dependencies**: Phases 1-3
+
+**Tests**: ~10 tests
+- Flatten deep tree to depth 2
+- Prune by max_depth
+- Prune by has_type
+- Group siblings correctly
+
+**Estimated effort**: Medium - combines previous predicates
+
+---
+
+### Phase 5: Advanced Transformations
+
+**Goal**: Complex operations for reorganization.
+
+**Predicates**:
+- `reroot_tree/3` - Change hierarchy root
+- `merge_trees/3` - Combine multiple trees
+- `group_by_ancestor/3` - Cluster by ancestor at depth
+
+**Dependencies**: Phases 1-4
+
+**Tests**: ~8 tests
+- Reroot preserves structure
+- Reroot handles outside nodes
+- Merge with dedup
+- Group by depth=1
+
+**Estimated effort**: Medium - complex logic
+
+---
+
+### Phase 6: Integration
+
+**Goal**: Connect with existing queries.pl and templates.pl.
+
+**Tasks**:
+- Export predicates from hierarchy.pl
+- Use in queries.pl filters
+- Add transformation examples to compile_examples.pl
+- Update README.md documentation
+
+**Dependencies**: Phases 1-5
+
+**Tests**: ~4 integration tests
+- Filter then transform
+- Transform then generate output
+
+**Estimated effort**: Small - wiring
+
+---
+
+## Mock Data Requirements
+
+Extend `test_queries.pl` mock data or create new in `test_hierarchy.pl`:
+
+```prolog
+%% Mock hierarchy for testing:
+%%
+%%   root_1
+%%   ├── science_2
+%%   │   ├── physics_3
+%%   │   │   └── quantum_6
+%%   │   └── chemistry_4
+%%   ├── arts_5
+%%   │   └── music_7
+%%   └── orphan_99 (disconnected - parent doesn't exist)
+%%
+%% Depths:
+%%   root_1: 0
+%%   science_2, arts_5: 1
+%%   physics_3, chemistry_4, music_7: 2
+%%   quantum_6: 3
+
+setup_hierarchy_mock_data :-
+    % Trees with cluster_id relationships
+    assertz(mock_pearl_trees(tree, 'root_1', 'Root', 'uri:root_1', root)),
+    assertz(mock_pearl_trees(tree, 'science_2', 'Science', 'uri:science_2', 'uri:root_1')),
+    assertz(mock_pearl_trees(tree, 'physics_3', 'Physics', 'uri:physics_3', 'uri:science_2')),
+    assertz(mock_pearl_trees(tree, 'chemistry_4', 'Chemistry', 'uri:chemistry_4', 'uri:science_2')),
+    assertz(mock_pearl_trees(tree, 'arts_5', 'Arts', 'uri:arts_5', 'uri:root_1')),
+    assertz(mock_pearl_trees(tree, 'quantum_6', 'Quantum', 'uri:quantum_6', 'uri:physics_3')),
+    assertz(mock_pearl_trees(tree, 'music_7', 'Music', 'uri:music_7', 'uri:arts_5')),
+    % Orphan - parent uri doesn't exist
+    assertz(mock_pearl_trees(tree, 'orphan_99', 'Lost', 'uri:orphan_99', 'uri:nonexistent')).
+```
+
+## Test Summary
+
+| Phase | Predicates | Tests |
+|-------|-----------|-------|
+| 1. Navigation | 4 | ~8 |
+| 2. Structural | 6 | ~10 |
+| 3. Path Ops | 4 | ~6 |
+| 4. Basic Transform | 4 | ~10 |
+| 5. Advanced Transform | 3 | ~8 |
+| 6. Integration | - | ~4 |
+| **Total** | **21** | **~46** |
+
+Combined with existing tests:
+- queries.pl: 36 tests
+- hierarchy.pl: 46 tests
+- templates.pl: 44 tests
+- browser_automation.pl: 22 tests
+- **Total: ~148 tests**
+
+## Dependencies Graph
+
+```
+Phase 1: Navigation
+    │
+    ├──► Phase 2: Structural Queries
+    │        │
+    │        └──► Phase 4: Basic Transforms
+    │                  │
+    │                  └──► Phase 5: Advanced Transforms
+    │                             │
+    └──► Phase 3: Path Operations ◄┘
+              │
+              └──► Phase 6: Integration
+```
+
+## Relationship to Python Implementation
+
+| Python Function | Prolog Predicate | Notes |
+|-----------------|------------------|-------|
+| `build_user_hierarchy()` | `tree_parent/2`, `tree_ancestors/2` | Prolog uses backtracking vs explicit dict |
+| `curated_to_folder_structure()` | `flatten_tree/3`, `truncate_path/3` | Depth flattening |
+| Orphan handling | `orphan_trees/1` | Same concept |
+| `cluster_trees_into_folder_groups()` | Not in scope | Requires embeddings |
+| `build_mst_with_fixed_root()` | `reroot_tree/3` (partial) | MST needs graph library |
+
+The Prolog predicates provide **rule-based** transformations that complement the **embedding-based** Python implementation.
+
+## Success Criteria
+
+1. **All tests pass**: 46+ tests for hierarchy.pl
+2. **Documentation complete**: README updated, examples added
+3. **Integration working**: Can combine with filters and templates
+4. **Clear examples**: Show common transformation patterns
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Cycle detection (tree with ancestor pointing to descendant) | Add explicit check in tree_ancestors |
+| Performance on large hierarchies | Document that Prolog is for specification, not production |
+| Complex reroot logic | Start with simple cases, add edge cases incrementally |
+
+## Next Steps After Design Approval
+
+1. Create `hierarchy.pl` with Phase 1 predicates
+2. Create `test_hierarchy.pl` with mock data
+3. Implement and test each phase incrementally
+4. Update documentation
+5. Create PR
+
+## Open Questions
+
+1. **Should we support cycles?** Trees can have aliases that create logical cycles. Current plan: detect and fail gracefully.
+
+2. **How to handle multiple roots?** Multi-account scenarios may have multiple disconnected hierarchies. Current plan: treat as separate hierarchies, enumerate with `root_tree/1`.
+
+3. **Should transformations be lazy or eager?** Current plan: eager (compute full result). Could add generator-style for large hierarchies.

--- a/docs/proposals/hierarchical_transformations_philosophy.md
+++ b/docs/proposals/hierarchical_transformations_philosophy.md
@@ -1,0 +1,208 @@
+# Philosophy: UnifyWeaver-Native Hierarchical Transformations
+
+## Why UnifyWeaver-Native?
+
+The existing Python `--curated-folders` implementation in `generate_mindmap.py` solves the real problem of organizing large hierarchical bookmark collections. It works. So why create a UnifyWeaver-native version?
+
+### 1. Declarative Expression
+
+The Python implementation mixes **what** with **how**:
+
+```python
+# Python: Imperative - describes HOW to flatten
+def curated_to_folder_structure(tree_to_group, group_hierarchy, max_depth):
+    result = {}
+    for tree_url, group_id in tree_to_group.items():
+        path = compute_path(group_id, group_hierarchy)
+        if len(path.parts) > max_depth:
+            path = Path(*path.parts[:max_depth])  # Truncate
+        result[tree_url] = path
+    return result
+```
+
+UnifyWeaver expresses **what** we want:
+
+```prolog
+% Prolog: Declarative - describes WHAT flattening means
+flattened_path(TreeId, Path, MaxDepth) :-
+    tree_path(TreeId, FullPath),
+    truncate_path(FullPath, MaxDepth, Path).
+```
+
+The declarative form:
+- Is easier to reason about
+- Can be compiled to multiple targets
+- Separates transformation logic from execution
+
+### 2. Composability
+
+Python functions are composed by calling each other. Prolog predicates compose through unification:
+
+```prolog
+% Combine transformations naturally
+transformed_tree(TreeId, FinalPath) :-
+    tree_with_children(TreeId, _, Children),
+    filter_children(Children, pagepearl, FilteredChildren),
+    flatten_to_depth(TreeId, 3, FlatPath),
+    semantic_group(TreeId, GroupId),
+    group_path(GroupId, FlatPath, FinalPath).
+```
+
+Each predicate is independently testable and reusable.
+
+### 3. Multi-Target Generation
+
+The same transformation logic can generate:
+- **Python**: For integration with existing tools
+- **SQL**: For database-level transformations
+- **Go**: For CLI tools
+- **Direct execution**: In SWI-Prolog for prototyping
+
+### 4. Educational Value
+
+These examples demonstrate UnifyWeaver's capabilities for:
+- Tree traversal and recursion
+- Aggregation over hierarchies
+- Constraint-based transformations
+- Path manipulation
+
+## Design Principles
+
+### Principle 1: Preserve User Intent
+
+The user's hierarchy represents their mental model. Transformations should:
+- **Preserve the root** - Start from where the user starts
+- **Maintain relationships** - Parent links follow actual hierarchy, not folder structure
+- **Handle orphans explicitly** - Don't silently drop disconnected nodes
+
+### Principle 2: Separation of Concerns
+
+| Concern | Responsibility |
+|---------|---------------|
+| **Structure** | How trees relate to each other (parent/child) |
+| **Organization** | How trees are grouped into folders |
+| **Presentation** | How folders are named and paths are computed |
+| **Clustering** | Semantic similarity (embeddings, centroids) |
+
+Each concern should be addressable independently.
+
+### Principle 3: Composable Primitives
+
+Build complex transformations from simple primitives:
+
+| Primitive | Purpose |
+|-----------|---------|
+| `tree_depth/2` | Compute depth from root |
+| `tree_path/2` | Compute path from root |
+| `tree_ancestors/2` | List ancestors to root |
+| `tree_descendants/2` | List all descendants |
+| `subtree/2` | Extract subtree rooted at node |
+| `flatten_to_depth/3` | Truncate paths at depth |
+| `reroot_at/3` | Change root, adjust paths |
+
+### Principle 4: Explicit Over Implicit
+
+Make transformations explicit:
+
+```prolog
+% BAD: Implicit flattening
+generate_paths(Trees, Paths) :-
+    ... % Hidden depth limit?
+
+% GOOD: Explicit transformation
+generate_paths(Trees, Paths, Options) :-
+    option(max_depth(MaxDepth), Options, infinite),
+    maplist(flatten_to_depth(MaxDepth), Trees, Paths).
+```
+
+### Principle 5: Testability
+
+Every predicate should be testable with mock data:
+
+```prolog
+test(flatten_deep_tree) :-
+    % Setup: 5-level tree
+    mock_tree(deep, TreeId),
+    tree_depth(TreeId, 5),
+    % Transform
+    flatten_to_depth(TreeId, 3, Path),
+    % Verify
+    path_depth(Path, 3).
+```
+
+## Relationship to Python Implementation
+
+The UnifyWeaver-native approach **complements** the Python implementation:
+
+| Python Implementation | UnifyWeaver Native |
+|-----------------------|-------------------|
+| Production tool | Educational examples |
+| Embedding-based clustering | Rule-based transformations |
+| LLM folder naming | Template-based naming |
+| Performance optimized | Clarity optimized |
+
+### What We're NOT Doing
+
+- **Not replacing** `generate_mindmap.py`
+- **Not reimplementing** embedding computation
+- **Not duplicating** LLM integration
+
+### What We ARE Doing
+
+- **Expressing** hierarchical transformations declaratively
+- **Demonstrating** UnifyWeaver's tree manipulation capabilities
+- **Creating** reusable transformation primitives
+- **Enabling** multi-target code generation for tree operations
+
+## Transformation Categories
+
+### 1. Structural Transformations
+
+Change the shape of the tree:
+- **Flatten**: Reduce depth
+- **Prune**: Remove branches by criteria
+- **Graft**: Attach subtrees elsewhere
+- **Split**: Divide large trees
+
+### 2. Path Transformations
+
+Change how paths are computed:
+- **Reroot**: Change the starting point
+- **Abbreviate**: Shorten path components
+- **Namespace**: Add prefixes for multi-account
+
+### 3. Grouping Transformations
+
+Change how trees are organized:
+- **Cluster by parent**: Preserve hierarchy
+- **Cluster by type**: Group similar content
+- **Cluster by depth**: Organize by level
+
+### 4. Filter Transformations
+
+Select subsets:
+- **By depth**: Trees at specific levels
+- **By content**: Trees with specific children
+- **By connectivity**: Connected vs orphan trees
+
+## Success Criteria
+
+1. **Clarity**: Someone reading the Prolog can understand what transformation occurs
+2. **Testability**: All predicates have unit tests with mock data
+3. **Composability**: Primitives can be combined for complex transformations
+4. **Target Generation**: At least Python target generates working code
+5. **Documentation**: Examples show common transformation patterns
+
+## Non-Goals
+
+- Performance parity with Python (Prolog is for specification, not production)
+- Full embedding/ML integration (use Python for that)
+- Replacing existing tools (complement, not replace)
+- Supporting all edge cases (focus on common patterns)
+
+## Next Steps
+
+1. **Specification**: Define predicate signatures and behaviors
+2. **Implementation**: Write Prolog predicates with tests
+3. **Examples**: Show common transformation patterns
+4. **Integration**: Connect to existing Pearltrees example

--- a/docs/proposals/hierarchical_transformations_specification.md
+++ b/docs/proposals/hierarchical_transformations_specification.md
@@ -1,0 +1,556 @@
+# Specification: Hierarchical Tree Transformations
+
+## Overview
+
+This document specifies the Prolog predicates for hierarchical tree transformations in the Pearltrees UnifyWeaver example. These predicates build on the existing `queries.pl` foundation.
+
+## Module Structure
+
+```prolog
+:- module(pearltrees_hierarchy, [
+    % Navigation predicates
+    tree_parent/2,
+    tree_ancestors/2,
+    tree_descendants/2,
+    tree_siblings/2,
+    tree_depth/2,
+    tree_path/2,
+
+    % Structural queries
+    root_tree/1,
+    leaf_trees/1,
+    orphan_trees/1,
+    subtree_trees/2,
+
+    % Transformation predicates
+    flatten_tree/3,
+    prune_tree/3,
+    reroot_tree/3,
+    merge_trees/3,
+
+    % Path operations
+    path_depth/2,
+    truncate_path/3,
+    path_prefix/3,
+    common_ancestor/3,
+
+    % Grouping predicates
+    trees_at_depth/2,
+    trees_by_parent/2,
+    group_by_ancestor/3
+]).
+```
+
+## Data Model
+
+### Tree Relationships
+
+Trees are related through `cluster_id` (parent reference):
+
+```prolog
+%% pearl_trees(Type, TreeId, Title, Uri, ClusterId)
+%%   ClusterId is the parent tree's URI, or root marker for top-level trees.
+
+%% Example hierarchy:
+%%   Root (cluster_id = 'root')
+%%     ├── Science (cluster_id = Root.uri)
+%%     │   ├── Physics (cluster_id = Science.uri)
+%%     │   └── Chemistry (cluster_id = Science.uri)
+%%     └── Arts (cluster_id = Root.uri)
+%%         └── Music (cluster_id = Arts.uri)
+```
+
+### Path Representation
+
+Paths are lists from root to node:
+
+```prolog
+%% path(['Root', 'Science', 'Physics'])
+%% path([RootId, ScienceId, PhysicsId])  % TreeId version
+```
+
+## Predicate Specifications
+
+### Navigation Predicates
+
+#### tree_parent/2
+
+```prolog
+%% tree_parent(?TreeId, ?ParentId) is nondet.
+%%   True if ParentId is the immediate parent of TreeId.
+%%
+%%   Implementation notes:
+%%   - Derives parent from cluster_id relationship
+%%   - Fails for root trees (no parent)
+%%
+%% Example:
+%%   ?- tree_parent('physics_123', Parent).
+%%   Parent = 'science_456'.
+
+tree_parent(TreeId, ParentId) :-
+    pearl_trees(tree, TreeId, _, _, ClusterId),
+    ClusterId \= root,
+    cluster_to_tree_id(ClusterId, ParentId).
+```
+
+#### tree_ancestors/2
+
+```prolog
+%% tree_ancestors(?TreeId, ?Ancestors) is det.
+%%   Ancestors is the list of tree IDs from TreeId to root (exclusive).
+%%   Returns [] for root trees.
+%%
+%% Example:
+%%   ?- tree_ancestors('physics_123', Ancestors).
+%%   Ancestors = ['science_456', 'root_789'].
+
+tree_ancestors(TreeId, Ancestors) :-
+    tree_ancestors_(TreeId, [], Ancestors).
+
+tree_ancestors_(TreeId, Acc, Ancestors) :-
+    (   tree_parent(TreeId, ParentId)
+    ->  tree_ancestors_(ParentId, [ParentId|Acc], Ancestors)
+    ;   reverse(Acc, Ancestors)
+    ).
+```
+
+#### tree_descendants/2
+
+```prolog
+%% tree_descendants(?TreeId, ?Descendants) is det.
+%%   Descendants is the list of all tree IDs under TreeId (recursive).
+%%
+%% Example:
+%%   ?- tree_descendants('science_456', Descendants).
+%%   Descendants = ['physics_123', 'chemistry_124', 'quantum_125'].
+
+tree_descendants(TreeId, Descendants) :-
+    findall(ChildId, tree_parent(ChildId, TreeId), DirectChildren),
+    maplist(tree_descendants, DirectChildren, NestedDescendants),
+    append([DirectChildren|NestedDescendants], Descendants).
+```
+
+#### tree_siblings/2
+
+```prolog
+%% tree_siblings(?TreeId, ?Siblings) is det.
+%%   Siblings is the list of trees sharing the same parent (excluding TreeId).
+%%
+%% Example:
+%%   ?- tree_siblings('physics_123', Siblings).
+%%   Siblings = ['chemistry_124'].
+
+tree_siblings(TreeId, Siblings) :-
+    tree_parent(TreeId, ParentId),
+    findall(SibId,
+            (tree_parent(SibId, ParentId), SibId \= TreeId),
+            Siblings).
+```
+
+#### tree_depth/2
+
+```prolog
+%% tree_depth(?TreeId, ?Depth) is det.
+%%   Depth is the number of edges from root to TreeId.
+%%   Root has depth 0.
+%%
+%% Example:
+%%   ?- tree_depth('physics_123', Depth).
+%%   Depth = 2.
+
+tree_depth(TreeId, Depth) :-
+    tree_ancestors(TreeId, Ancestors),
+    length(Ancestors, Depth).
+```
+
+#### tree_path/2
+
+```prolog
+%% tree_path(?TreeId, ?Path) is det.
+%%   Path is the list of TreeIds from root to TreeId (inclusive).
+%%
+%% Example:
+%%   ?- tree_path('physics_123', Path).
+%%   Path = ['root_789', 'science_456', 'physics_123'].
+
+tree_path(TreeId, Path) :-
+    tree_ancestors(TreeId, Ancestors),
+    append(Ancestors, [TreeId], Path).
+```
+
+### Structural Queries
+
+#### root_tree/1
+
+```prolog
+%% root_tree(?TreeId) is nondet.
+%%   True if TreeId has no parent (is a root).
+%%
+%% Example:
+%%   ?- root_tree(RootId).
+%%   RootId = 'root_789'.
+
+root_tree(TreeId) :-
+    pearl_trees(tree, TreeId, _, _, ClusterId),
+    (ClusterId = root ; ClusterId = '').
+```
+
+#### leaf_trees/1
+
+```prolog
+%% leaf_trees(?TreeId) is nondet.
+%%   True if TreeId has no child trees.
+%%
+%% Example:
+%%   ?- leaf_trees(LeafId).
+%%   LeafId = 'physics_123' ;
+%%   LeafId = 'chemistry_124'.
+
+leaf_trees(TreeId) :-
+    pearl_trees(tree, TreeId, _, _, _),
+    \+ tree_parent(_, TreeId).
+```
+
+#### orphan_trees/1
+
+```prolog
+%% orphan_trees(?TreeId) is nondet.
+%%   True if TreeId's parent doesn't exist in the dataset.
+%%   These are trees disconnected from the main hierarchy.
+%%
+%% Example:
+%%   ?- orphan_trees(OrphanId).
+%%   OrphanId = 'lost_999'.
+
+orphan_trees(TreeId) :-
+    pearl_trees(tree, TreeId, _, _, ClusterId),
+    ClusterId \= root,
+    ClusterId \= '',
+    \+ cluster_to_tree_id(ClusterId, _).
+```
+
+#### subtree_trees/2
+
+```prolog
+%% subtree_trees(?RootId, ?TreeId) is nondet.
+%%   True if TreeId is RootId or a descendant of RootId.
+%%
+%% Example:
+%%   ?- subtree_trees('science_456', TreeId).
+%%   TreeId = 'science_456' ;
+%%   TreeId = 'physics_123' ;
+%%   TreeId = 'chemistry_124'.
+
+subtree_trees(RootId, RootId) :-
+    pearl_trees(tree, RootId, _, _, _).
+subtree_trees(RootId, TreeId) :-
+    tree_descendants(RootId, Descendants),
+    member(TreeId, Descendants).
+```
+
+### Transformation Predicates
+
+#### flatten_tree/3
+
+```prolog
+%% flatten_tree(?TreeId, +MaxDepth, ?FlatChildren) is det.
+%%   Collect all descendants up to MaxDepth into a flat list.
+%%   Children beyond MaxDepth are "promoted" to MaxDepth level.
+%%
+%% Example:
+%%   ?- flatten_tree('root_789', 1, FlatChildren).
+%%   % Returns Science, Arts, Physics, Chemistry, Music all at depth 1
+%%   FlatChildren = [tree_info('science_456', 'Science', 1), ...].
+
+flatten_tree(TreeId, MaxDepth, FlatChildren) :-
+    findall(
+        tree_info(DescId, Title, min(Depth, MaxDepth)),
+        (   subtree_trees(TreeId, DescId),
+            DescId \= TreeId,
+            pearl_trees(tree, DescId, Title, _, _),
+            tree_depth_relative(TreeId, DescId, Depth)
+        ),
+        FlatChildren
+    ).
+
+%% tree_depth_relative(+AncestorId, +DescendantId, -RelativeDepth)
+%%   Depth of Descendant relative to Ancestor.
+tree_depth_relative(AncestorId, DescendantId, RelativeDepth) :-
+    tree_depth(AncestorId, AncestorDepth),
+    tree_depth(DescendantId, DescendantDepth),
+    RelativeDepth is DescendantDepth - AncestorDepth.
+```
+
+#### prune_tree/3
+
+```prolog
+%% prune_tree(?TreeId, +Filter, ?PrunedDescendants) is det.
+%%   Return descendants that match Filter, excluding pruned branches.
+%%   If a node fails Filter, its entire subtree is excluded.
+%%
+%% Filter terms:
+%%   - max_depth(N): Exclude nodes deeper than N
+%%   - has_type(Type): Include only nodes with children of Type
+%%   - title_match(Pattern): Include only matching titles
+%%
+%% Example:
+%%   ?- prune_tree('root_789', max_depth(2), Pruned).
+%%   Pruned = ['science_456', 'physics_123', 'arts_457'].
+
+prune_tree(TreeId, Filter, PrunedDescendants) :-
+    findall(
+        DescId,
+        (   subtree_trees(TreeId, DescId),
+            DescId \= TreeId,
+            passes_prune_filter(DescId, TreeId, Filter)
+        ),
+        PrunedDescendants
+    ).
+
+passes_prune_filter(TreeId, RootId, max_depth(N)) :-
+    tree_depth_relative(RootId, TreeId, Depth),
+    Depth =< N.
+passes_prune_filter(TreeId, _, has_type(Type)) :-
+    has_child_type(TreeId, Type).
+passes_prune_filter(TreeId, _, title_match(Pattern)) :-
+    pearl_trees(tree, TreeId, Title, _, _),
+    title_matches(Title, Pattern).
+```
+
+#### reroot_tree/3
+
+```prolog
+%% reroot_tree(+OldRoot, +NewRoot, -Mapping) is det.
+%%   Compute new paths as if NewRoot were the root.
+%%   Mapping is a list of reroot_info(TreeId, OldPath, NewPath) terms.
+%%
+%%   Trees not descended from NewRoot get paths prefixed with '..'.
+%%
+%% Example:
+%%   ?- reroot_tree('root_789', 'science_456', Mapping).
+%%   Mapping = [
+%%     reroot_info('physics_123', [...], ['science_456', 'physics_123']),
+%%     reroot_info('arts_457', [...], ['..', 'arts_457'])
+%%   ].
+
+reroot_tree(OldRoot, NewRoot, Mapping) :-
+    findall(
+        reroot_info(TreeId, OldPath, NewPath),
+        (   subtree_trees(OldRoot, TreeId),
+            tree_path(TreeId, OldPath),
+            compute_rerooted_path(TreeId, NewRoot, NewPath)
+        ),
+        Mapping
+    ).
+
+compute_rerooted_path(TreeId, NewRoot, NewPath) :-
+    (   subtree_trees(NewRoot, TreeId)
+    ->  % TreeId is under NewRoot: compute relative path
+        tree_path(TreeId, FullPath),
+        tree_path(NewRoot, NewRootPath),
+        length(NewRootPath, PrefixLen),
+        length(FullPath, FullLen),
+        DropLen is PrefixLen - 1,
+        (DropLen > 0 -> length(Prefix, DropLen), append(Prefix, NewPath, FullPath) ; NewPath = FullPath)
+    ;   % TreeId is outside NewRoot: prefix with '..'
+        tree_path(TreeId, FullPath),
+        NewPath = ['..', TreeId]
+    ).
+```
+
+#### merge_trees/3
+
+```prolog
+%% merge_trees(+TreeIds, +MergeOptions, -MergedChildren) is det.
+%%   Merge children from multiple trees into a single list.
+%%   Handles duplicates based on MergeOptions.
+%%
+%% MergeOptions:
+%%   - dedup(url): Remove duplicates by URL
+%%   - dedup(title): Remove duplicates by title
+%%   - keep_all: Keep all children
+%%   - sort_by(order): Sort by original order
+%%   - sort_by(title): Sort alphabetically
+%%
+%% Example:
+%%   ?- merge_trees(['physics_123', 'chemistry_124'], [dedup(url)], Merged).
+
+merge_trees(TreeIds, MergeOptions, MergedChildren) :-
+    findall(
+        Child,
+        (   member(TreeId, TreeIds),
+            tree_with_children(TreeId, _, Children),
+            member(Child, Children)
+        ),
+        AllChildren
+    ),
+    apply_merge_options(AllChildren, MergeOptions, MergedChildren).
+
+apply_merge_options(Children, Options, Result) :-
+    (   member(dedup(url), Options)
+    ->  dedup_by_url(Children, Deduped)
+    ;   member(dedup(title), Options)
+    ->  dedup_by_title(Children, Deduped)
+    ;   Deduped = Children
+    ),
+    (   member(sort_by(title), Options)
+    ->  sort_by_title(Deduped, Result)
+    ;   Result = Deduped
+    ).
+```
+
+### Path Operations
+
+#### path_depth/2
+
+```prolog
+%% path_depth(+Path, -Depth) is det.
+%%   Depth is the number of elements in Path minus 1.
+%%
+%% Example:
+%%   ?- path_depth(['root', 'science', 'physics'], Depth).
+%%   Depth = 2.
+
+path_depth(Path, Depth) :-
+    length(Path, Len),
+    Depth is Len - 1.
+```
+
+#### truncate_path/3
+
+```prolog
+%% truncate_path(+Path, +MaxDepth, -TruncatedPath) is det.
+%%   Truncate Path to at most MaxDepth+1 elements (root + MaxDepth levels).
+%%
+%% Example:
+%%   ?- truncate_path(['root', 'a', 'b', 'c', 'd'], 2, Truncated).
+%%   Truncated = ['root', 'a', 'b'].
+
+truncate_path(Path, MaxDepth, TruncatedPath) :-
+    MaxLen is MaxDepth + 1,
+    length(Path, Len),
+    (   Len =< MaxLen
+    ->  TruncatedPath = Path
+    ;   length(TruncatedPath, MaxLen),
+        append(TruncatedPath, _, Path)
+    ).
+```
+
+#### common_ancestor/3
+
+```prolog
+%% common_ancestor(+TreeId1, +TreeId2, -AncestorId) is det.
+%%   Find the nearest common ancestor of two trees.
+%%
+%% Example:
+%%   ?- common_ancestor('physics_123', 'chemistry_124', Ancestor).
+%%   Ancestor = 'science_456'.
+
+common_ancestor(TreeId1, TreeId2, AncestorId) :-
+    tree_path(TreeId1, Path1),
+    tree_path(TreeId2, Path2),
+    common_prefix(Path1, Path2, CommonPath),
+    last(CommonPath, AncestorId).
+
+common_prefix([H|T1], [H|T2], [H|Common]) :-
+    !,
+    common_prefix(T1, T2, Common).
+common_prefix(_, _, []).
+```
+
+### Grouping Predicates
+
+#### trees_at_depth/2
+
+```prolog
+%% trees_at_depth(+Depth, -TreeIds) is det.
+%%   Find all trees at exactly Depth levels from root.
+%%
+%% Example:
+%%   ?- trees_at_depth(2, Trees).
+%%   Trees = ['physics_123', 'chemistry_124', 'music_125'].
+
+trees_at_depth(Depth, TreeIds) :-
+    findall(TreeId,
+            (pearl_trees(tree, TreeId, _, _, _), tree_depth(TreeId, Depth)),
+            TreeIds).
+```
+
+#### trees_by_parent/2
+
+```prolog
+%% trees_by_parent(?ParentId, ?Children) is nondet.
+%%   Group trees by their parent.
+%%
+%% Example:
+%%   ?- trees_by_parent('science_456', Children).
+%%   Children = ['physics_123', 'chemistry_124'].
+
+trees_by_parent(ParentId, Children) :-
+    pearl_trees(tree, ParentId, _, ParentUri, _),
+    findall(ChildId,
+            (pearl_trees(tree, ChildId, _, _, ClusterId),
+             ClusterId = ParentUri),
+            Children),
+    Children \= [].
+```
+
+#### group_by_ancestor/3
+
+```prolog
+%% group_by_ancestor(+Depth, -Groups) is det.
+%%   Group all trees by their ancestor at Depth.
+%%   Groups is a list of group(AncestorId, TreeIds) terms.
+%%
+%% Example:
+%%   ?- group_by_ancestor(1, Groups).
+%%   Groups = [group('science_456', ['physics_123', 'chemistry_124']),
+%%             group('arts_457', ['music_125'])].
+
+group_by_ancestor(Depth, Groups) :-
+    trees_at_depth(Depth, Ancestors),
+    findall(
+        group(AncestorId, Descendants),
+        (   member(AncestorId, Ancestors),
+            findall(DescId, subtree_trees(AncestorId, DescId), AllDesc),
+            exclude(=(AncestorId), AllDesc, Descendants)
+        ),
+        Groups
+    ).
+```
+
+## Helper Predicates
+
+```prolog
+%% cluster_to_tree_id(+ClusterId, -TreeId) is semidet.
+%%   Convert a cluster URI to its tree ID.
+cluster_to_tree_id(ClusterId, TreeId) :-
+    pearl_trees(tree, TreeId, _, ClusterId, _).
+
+%% title_matches/2 - from queries.pl
+%% has_child_type/2 - from queries.pl
+%% tree_with_children/3 - from queries.pl
+```
+
+## Integration with Existing Predicates
+
+These predicates build on `queries.pl`:
+
+| queries.pl | hierarchy.pl |
+|------------|--------------|
+| `tree_with_children/3` | Used by `merge_trees/3` |
+| `tree_child_count/2` | Used for leaf detection |
+| `has_child_type/2` | Used in `prune_tree/3` filters |
+| `title_matches/2` | Used in `prune_tree/3` filters |
+| `apply_filters/3` | Can compose with hierarchy predicates |
+
+## Test Requirements
+
+Each predicate requires tests with mock data covering:
+
+1. **Base cases**: Empty trees, single nodes
+2. **Recursion**: Multi-level hierarchies
+3. **Edge cases**: Orphans, cycles (if applicable), maximum depth
+4. **Composition**: Combining with filter predicates
+
+Target: 30+ tests for hierarchy predicates.


### PR DESCRIPTION
## Summary

- Add three design documents for UnifyWeaver-native hierarchical tree transformations
- Define 21 predicates for tree traversal, restructuring, and path manipulation
- Plan 6 implementation phases with ~46 tests

## Documents Created

| Document | Purpose |
|----------|---------|
| `hierarchical_transformations_philosophy.md` | Design principles, goals, relationship to Python curated folders |
| `hierarchical_transformations_specification.md` | Predicate signatures, behaviors, and examples |
| `hierarchical_transformations_implementation_plan.md` | Phases, dependencies, testing approach |

## Key Capabilities

**Navigation**:
- `tree_parent/2`, `tree_ancestors/2`, `tree_depth/2`, `tree_path/2`

**Structural Queries**:
- `root_tree/1`, `leaf_trees/1`, `orphan_trees/1`, `subtree_trees/2`

**Transformations**:
- `flatten_tree/3` - Collapse depth levels
- `prune_tree/3` - Remove branches by criteria
- `reroot_tree/3` - Change hierarchy root
- `merge_trees/3` - Combine multiple trees

**Grouping**:
- `trees_at_depth/2`, `trees_by_parent/2`, `group_by_ancestor/3`

## Relationship to Curated Folders

These predicates provide **rule-based** transformations that complement the **embedding-based** Python `--curated-folders` implementation:

| Python Function | Prolog Predicate |
|-----------------|------------------|
| `build_user_hierarchy()` | `tree_parent/2`, `tree_ancestors/2` |
| `curated_to_folder_structure()` | `flatten_tree/3`, `truncate_path/3` |
| Orphan handling | `orphan_trees/1` |

## Test plan

- [x] Documents follow existing proposal format
- [x] Predicates build on existing queries.pl foundation
- [x] Implementation plan includes ~46 tests across 6 phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
