### PR TITLE
feat: Mindmap repair tooling and MST folder grouping proposal

### DIFF
--- a/docs/proposals/mst_circle_folder_grouping.md
+++ b/docs/proposals/mst_circle_folder_grouping.md
@@ -1,0 +1,280 @@
+# Proposal: MST Circle-Based Folder Grouping
+
+## Problem Statement
+
+When organizing large collections of mindmaps into folders, we want:
+1. Semantically coherent folders (related items together)
+2. Controlled folder sizes (4-8 items per folder ideally)
+3. Hierarchical structure that reflects natural topic relationships
+
+Current approaches (K-means clustering) partition based on embedding centroids, which may not respect the natural semantic topology.
+
+## Proposed Algorithm: MST Circle Partitioning
+
+### Core Concepts
+
+1. **MST (Minimum Spanning Tree)**: Built from all items using embedding distances as edge weights. Represents minimal semantic connections between items.
+
+2. **Cuts**: Edges removed from the MST to partition it into disconnected regions.
+
+3. **Circles**: The connected regions that remain after all cuts are made. Each circle becomes a folder.
+
+4. **Boundary Nodes**: Nodes adjacent to cut edges - the "interface" of each circle.
+
+### Distance Metrics
+
+- **Within a circle**: Distance between two nodes = sum of MST edge weights along the path connecting them (using original MST structure before cuts).
+
+- **Between circles**: Must traverse through branches, accumulating edge weights.
+
+- **Direct transitions**: Within a circle, you can transition directly between any nodes on the cuts (boundary nodes), but distance is still calculated via MST path.
+
+### Optimization Objective
+
+**Minimize the sum of pairwise distances between boundary nodes of each circle.**
+
+For a circle with boundary nodes {A, B, C, D}:
+```
+Circle cost = d(A,B) + d(A,C) + d(A,D) + d(B,C) + d(B,D) + d(C,D)
+```
+
+Where d(X,Y) = sum of MST edge weights along path from X to Y.
+
+**Total cost = sum of all circle costs**
+
+### Constraints
+
+- Target folder size: N nodes per circle (or range [min_size, max_size])
+- Branching factor: 4-8 boundary nodes per circle (manageable pairwise combinations)
+- **Max depth**: Maximum folder hierarchy depth - forces larger groups to fit all items within depth limit. This prevents over-fragmentation and encourages meaningful groupings. **Scales logarithmically with collection size**: `max_depth ≈ log_F(N)` where F = target folder size. User specifies "I want ~20 items per folder" and depth constraint follows: `log(N) / log(F)`. For N=10000, F=20 → ~3 levels.
+
+### Emergent Properties
+
+This metric naturally favors:
+1. **Tight clusters**: Small distances between boundary nodes
+2. **Lower branching**: Fewer boundary nodes = fewer pairwise combinations
+
+With branching of 4-8:
+- 4 boundary nodes → C(4,2) = 6 pairs
+- 6 boundary nodes → C(6,2) = 15 pairs
+- 8 boundary nodes → C(8,2) = 28 pairs
+
+### Algorithm Sketch
+
+1. **Build MST** from all items (embedding cosine distance as edge weight)
+
+2. **Initialize**: Each node is its own circle
+
+3. **Bottom-up merge**:
+   - Consider merging adjacent circles
+   - Compute new circle cost (pairwise boundary distances)
+   - Merge if cost is below threshold AND size constraint satisfied
+   - Continue until no more beneficial merges
+
+4. **Result**: Each circle becomes a folder
+
+### Alternative: Top-Down Approach
+
+1. Start with full MST as one circle
+2. Find cut that minimizes total cost of resulting circles
+3. Recursively split circles that exceed max_size
+4. Stop when all circles are within size constraints
+
+### Folder Hierarchy
+
+The cuts naturally define a hierarchy:
+- Circles at the same "level" of cuts become sibling folders
+- Parent-child relationships follow the MST branch structure
+- Folder depth emerges from the number of cuts traversed
+
+### Comparison to Current Approach (K-means)
+
+| Aspect | K-means | MST Circles |
+|--------|---------|-------------|
+| Basis | Embedding centroids | Tree topology |
+| Respects natural structure | Partially | Yes |
+| Size control | Via K | Via merge/split constraints |
+| Folder naming | Representative title | Boundary node representative |
+| Hierarchy | Imposed | Emergent from MST |
+
+## Implementation Notes
+
+- Pre-compute all pairwise MST path distances (or compute on demand)
+- Use Union-Find for efficient circle merging
+- Cache boundary node sets for each circle
+- Consider parallel computation for large collections
+
+## Computational Complexity
+
+The optimization problem is:
+- **Minimize**: Sum of pairwise boundary distances across all circles
+- **Subject to**: Folder size constraints, max depth
+
+General graph partitioning is NP-hard, but since we operate on a **tree** (MST), efficient solutions may exist:
+- Dynamic programming on trees often yields polynomial solutions
+- Greedy heuristics may work well in practice
+- Local search can refine initial solutions
+
+### Greedy Local Search Strategy
+
+1. **Identify** large cuts (high cost due to quadratic pairwise growth)
+2. **Find** semantically close neighboring cuts
+3. **Move** a boundary node from large cut → smaller nearby cut
+4. **Accept** if total cost decreases (n² → (n-1)² on large cut offsets small increase on destination)
+5. **Repeat** until no improving moves
+
+### Randomized Variant (Stochastic Hill Climbing)
+
+1. **Randomly pick a node**
+2. **Flip coin** (50/50): use hop-based or semantic-distance neighborhood
+3. **Select top-k sibling branches** from chosen criteria
+4. **Evaluate moves** among this sample
+5. **Accept** improving moves
+6. **Repeat** until convergence or iteration limit
+
+This adds stochasticity to escape local optima and reduce computation via sampling.
+
+### Initialization Strategies
+
+**Option A: Start with no cuts, add cuts**
+- Begin with one circle containing all nodes
+- Gradually add cuts to split
+- Cuts near roots/leaves only useful at start of optimization
+
+**Option B: Start with all cuts, merge**
+- Every node starts as its own circle
+- Merge circles together
+- Problem: initially violates depth constraints
+
+**Option C: Incremental growth (recommended - try first)**
+- Start with one seed node
+- Add neighboring nodes from MST one at a time
+- At each step: decide same circle or new cut?
+- Optimize locally as you grow
+- Never violates constraints - builds organically
+- Assumes 2D tree (branches don't cross) for well-defined contiguous regions
+
+All three options are valid; recommend starting with Option C as it avoids constraint violations and builds the solution organically. **Grow from the root** of the tree for natural top-down traversal.
+
+### Dynamic Level Constraint
+
+As nodes are added, adjust the depth constraint dynamically:
+- Start loose (few elements, plenty of depth room)
+- Get stricter as you approach total elements
+- Prevents "running out of depth" at the end
+- Example: `allowed_depth = max_depth × (1 - elements_added/total) + min_depth`
+
+### Two Algorithm Versions
+
+| Aspect | MST Version | Curated Hierarchy Version |
+|--------|-------------|---------------------------|
+| Tree source | Built from embeddings | Pearltrees actual hierarchy |
+| Constraint | Soft (emergent from similarity) | Hard (fixed structure) |
+| Flexibility | Can reorganize freely | Must respect existing parent-child |
+| Use case | Fresh organization | Enhance existing curation |
+
+Same cut optimization problem applied to different underlying trees. The curated version respects human curation; the MST version is purely algorithmic.
+
+**MST advantage**: More flexible for items without a clear hierarchical home:
+- Orphans with no parent
+- Items from other accounts
+- New items that don't fit existing categories
+- Cross-cutting topics spanning multiple branches
+
+**Hybrid approach** (future work): Use MST on projected embeddings that encode both semantic content and hierarchical position. Implement MST and curated versions separately first.
+
+This naturally balances cut sizes while respecting semantic proximity. The quadratic penalty on large cuts drives items toward smaller, nearby cuts.
+
+**Loop detection required**: Use tabu list (forbid reversing recent moves), track visited states, or only accept strictly improving moves to prevent oscillation.
+
+**Efficiency optimizations**:
+- Start at leaves (bottom-up) - smaller subproblems first
+- Only consider local neighborhoods - define by:
+  - **Hop count**: 2, 4, or 8 branch traversals (powers of 2)
+  - **Semantic distance**: threshold on accumulated MST edge weights
+  - Or both: "within 4 hops AND distance < threshold"
+  - **Alternating**: Switch between hop-based and distance-based rounds to escape local optima
+- Don't compare distant branches - prune to nearby candidates
+- This reduces from O(n²) candidate moves to O(n × branching_factor)
+
+Further analysis needed to determine if exact polynomial solution exists.
+
+## Open Questions
+
+1. Optimal merge/split strategy (greedy vs. dynamic programming)?
+2. How to handle very dense vs. very sparse regions?
+3. Should circle cost be normalized by size?
+4. How to name folders based on circle content?
+5. Is there a polynomial-time exact algorithm for tree partitioning with these constraints?
+
+## Implementation Order
+
+Implement the four versions in this order:
+
+1. **MST Version** - Pure algorithmic approach using embeddings
+2. **Curated Hierarchy Version** - Respects existing Pearltrees parent-child relationships
+3. **Hybrid Version** - Combines MST flexibility with curated structure (MST on projected embeddings)
+4. **Tangent Deviation Version** - Hybrid with manifold-based deviation penalty
+
+### Version 4: Tangent Deviation Hybrid
+
+This version uses differential geometry to measure deviation from curated structure:
+
+**Cost function**: `Total_Cost = MST_circle_cost + λ × tangent_deviation_penalty`
+
+**Tangent deviation at each node**:
+```python
+def tangent_deviation(node, embeddings, mst_neighbors, curated_neighbors):
+    node_vec = embeddings[node]
+
+    # MST-induced tangent (avg direction to MST neighbors)
+    t_mst = mean([embeddings[n] - node_vec for n in mst_neighbors])
+
+    # Curated-induced tangent (avg direction to curated neighbors)
+    t_curated = mean([embeddings[n] - node_vec for n in curated_neighbors])
+
+    # Deviation = 1 - cosine_similarity
+    return 1 - cos_sim(t_mst, t_curated)
+
+# Total penalty = sum over all nodes
+tangent_deviation_penalty = sum(tangent_deviation(n, ...) for n in nodes)
+```
+
+**Intuition**: The graph Laplacian is the discrete Laplace-Beltrami operator. Graph connectivity induces a manifold approximation. If MST and curated graphs induce the same local differential structure (tangent directions), they are equivalent. Deviation = difference in induced geometry.
+
+**Properties**:
+- Cheap to compute (dot products)
+- Intuitive: "do the two graphs point you in the same direction at each point?"
+- Grounded in differential geometry
+- λ controls strength of curated "attraction force"
+
+### Alternative Hybrid Approaches (Future Work)
+
+The hybrid approach described above (MST on projected embeddings) is one option. Other hybrid approaches to explore:
+
+- **Secondary Attraction Force**: Add a term that pulls nodes toward their curated positions, balancing MST-derived semantic grouping with curated placement. The "force" is the gradient of a cost penalty term: `Total_Cost = MST_circle_cost + λ × curated_deviation_penalty`. Candidates for `curated_deviation_penalty`:
+  - **Graph Laplacian deviation**: The graph Laplacian is the discrete analog of the Laplace-Beltrami operator on manifolds. Key principle: **graph proximity should reflect manifold locality** - connected nodes should have similar differential properties (tangent spaces, curvature, gradient behavior).
+
+    **Concrete test**: Use MST connectivity to define "nearby" and compute induced differential properties. Do the same with curated hierarchy. If the derivatives match, structures are equivalent. If not, MST has deviated from the curated-induced manifold. The curated structure encodes human knowledge about semantic relationships; deviation means losing that structure.
+
+    **Practical measure**: Cosine similarity between tangent vectors. At each node, estimate tangent from directions to neighbors. Compare MST-induced tangent vs curated-induced tangent: `cos(θ) = t_mst · t_curated`. If cos ≈ 1, structures agree locally. Cheap to compute (dot products), intuitive (do the graphs point you in the same direction?).
+
+    Refinement needed: want invariance to "harmless" rearrangements (sibling reordering). Candidates: spectral distance, resistance distance, heat kernel trace
+  - Distance from curated parent in embedding space
+  - Hierarchy depth deviation
+  - Penalty for separating curated siblings
+- **Weighted Edges**: Use curated hierarchy to weight MST edges (shorter distance = same curated parent)
+- **Constrained Cuts**: Only allow cuts that don't split curated parent-child pairs
+
+These can be explored after the core MST and Curated versions are working.
+
+## Next Steps
+
+1. Implement MST version prototype on existing mindmap collection
+2. Compare folder coherence vs. K-means
+3. Implement Curated hierarchy version
+4. Implement Hybrid version (projected embeddings)
+5. Implement Tangent Deviation version
+6. Tune size constraints and λ parameter
+7. Evaluate folder naming strategies
+8. Compare all four versions on test collection

--- a/docs/workflows/mindmap_repair.md
+++ b/docs/workflows/mindmap_repair.md
@@ -1,0 +1,208 @@
+# Mindmap Repair Workflow
+
+This document describes the process for identifying and repairing incomplete mindmaps (trees with only a root node and no children).
+
+## Overview
+
+Pearltrees RDF exports may contain trees where children weren't properly fetched. This workflow:
+1. Scans for incomplete mindmaps
+2. Groups children by parent tree from RDF
+3. Repairs mindmaps by loading children from the index
+4. Prioritizes remaining repairs using semantic filtering
+
+## Files and Tools
+
+| File | Description |
+|------|-------------|
+| `scripts/scan_incomplete_mindmaps.py` | Scan for mindmaps with ≤N nodes |
+| `scripts/build_children_index.py` | Build parent→children SQLite index from RDF |
+| `scripts/repair_incomplete_mindmaps.py` | Batch repair using children index |
+| `scripts/organize_incomplete_trees.py` | Organize remaining trees hierarchically |
+
+## Step 1: Scan for Incomplete Mindmaps
+
+```bash
+python3 scripts/scan_incomplete_mindmaps.py output/mindmaps_curated/ \
+  --threshold 1 \
+  --output .local/data/scans/incomplete_mindmaps.json
+```
+
+Options:
+- `--threshold N` - Max topic count to consider incomplete (default: 1)
+- `--format urls` - Output Pearltrees URLs for fetching
+- `--format tree` - Show hierarchical summary
+- `--exclude-private` - Skip private trees
+
+## Step 2: Build Children Index from RDF
+
+```bash
+python3 scripts/build_children_index.py \
+  --rdf data/rdf/pearltrees_export.rdf \
+  --output .local/data/children_index.db
+```
+
+This parses the RDF and groups children by `pt:parentTree`, storing:
+- `parent_tree_id` - Tree ID
+- `pearl_type` - PagePearl, RefPearl, AliasPearl, SectionPearl, etc.
+- `title`, `pos_order`, `external_url`, `see_also_uri`
+
+## Step 3: Repair Incomplete Mindmaps
+
+```bash
+# Dry run first
+python3 scripts/repair_incomplete_mindmaps.py \
+  --scan .local/data/scans/incomplete_mindmaps.json \
+  --children-index .local/data/children_index.db \
+  --output-dir output/mindmaps_curated \
+  --dry-run
+
+# Then actual repair
+python3 scripts/repair_incomplete_mindmaps.py \
+  --scan .local/data/scans/incomplete_mindmaps.json \
+  --children-index .local/data/children_index.db \
+  --output-dir output/mindmaps_curated
+```
+
+## Step 4: Organize Remaining Incomplete Trees
+
+After repair, some trees may still be empty (no children in RDF). Organize them hierarchically for review:
+
+```bash
+python3 scripts/organize_incomplete_trees.py \
+  --scan .local/data/scans/incomplete_mindmaps.json \
+  --data reports/pearltrees_targets_full_multi_account.jsonl \
+  --format tree --show-urls \
+  --output .local/data/scans/incomplete_tree_full.txt
+```
+
+## Step 5: Semantic Filtering for Priority Fetching
+
+Filter incomplete trees by semantic similarity to a topic:
+
+```python
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+# Load or create embeddings from hierarchical paths
+nomic = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
+
+# Embed each tree's hierarchical path (from JSONL target_text)
+embeddings = nomic.encode(path_texts)
+
+# Query by topic
+query_emb = nomic.encode(["science"])[0]
+
+# Or use existing output embedding from a related tree
+# This captures structural relationships, not just lexical
+science_tree_emb = output_nomic[science_tree_idx]
+
+# Compute cosine similarities
+similarities = [cosine_sim(query_emb, emb) for emb in embeddings]
+```
+
+### Two Filtering Approaches
+
+1. **Lexical query** (e.g., embed "science"):
+   - Finds trees with similar words in title/path
+   - Good for topic-based filtering
+
+2. **Structural query** (use existing tree's output embedding):
+   - Finds trees in similar hierarchical positions
+   - Captures organizational relationships
+
+### Generate Filtered Tree View
+
+```bash
+python3 scripts/organize_incomplete_trees.py \
+  --scan .local/data/scans/incomplete_mindmaps.json \
+  --filter-embeddings .local/data/scans/incomplete_embeddings.npz \
+  --query "science" \
+  --top-k 10 \
+  --format tree --show-urls
+```
+
+## Repair Statistics Example
+
+After running the full workflow:
+
+| Status | Count |
+|--------|-------|
+| Original incomplete | 3,720 |
+| Repaired from RDF | 1,074 |
+| Remaining (no children in RDF) | 2,646 |
+
+The remaining 2,646 trees need API fetching to repair.
+
+## API Fetching (Future Work)
+
+For trees without children in RDF, use Playwright to fetch from Pearltrees:
+
+```bash
+# Get prioritized URLs
+python3 scripts/organize_incomplete_trees.py \
+  --scan .local/data/scans/incomplete_mindmaps.json \
+  --format urls \
+  --filter-query "science" \
+  --top-k 50 > urls_to_fetch.txt
+
+# Fetch with rate limiting (example)
+# scripts/fetch_pearltrees_batch.py --urls urls_to_fetch.txt --delay 5
+```
+
+## Semantic Filtering Methods
+
+The `filter_incomplete_trees.py` script supports multiple filtering approaches:
+
+### 1. Lexical Filtering
+Embed the query text directly. Good for finding trees with similar words:
+
+```bash
+python3 scripts/filter_incomplete_trees.py --query "science" --top-k 10
+```
+
+### 2. Structural Filtering
+Use an existing tree's output embedding. Finds trees in similar hierarchy positions:
+
+```bash
+python3 scripts/filter_incomplete_trees.py --tree-query "science" --top-k 10
+```
+
+### 3. Blended Filtering
+Combine both methods with alpha weighting:
+
+```bash
+python3 scripts/filter_incomplete_trees.py \
+  --query "science" \
+  --tree-query "science" \
+  --alpha 0.5 \
+  --top-k 10 --format tree
+```
+
+Output shows both scores: `[L:0.775 S:0.662 = 0.718]`
+
+## Integration with Bookmark Filing Assistant
+
+This mindmap repair workflow complements the bookmark filing assistant:
+
+1. **Repair Phase**: Fix incomplete mindmaps to improve folder coverage
+2. **Filing Phase**: Use repaired hierarchy for better bookmark filing suggestions
+3. **Feedback Loop**: Missing trees identified during filing can trigger repair
+
+### Future Integration Points
+
+- `scripts/bookmark_filing_assistant.py` can use repair status to deprioritize incomplete folders
+- Dual-objective scoring can leverage both input (semantic) and output (structural) embeddings
+- Users without API access can still benefit from RDF-based repairs
+
+### Embedding Reuse
+
+The embeddings created for filtering (`incomplete_embeddings.npz`) can be:
+- Cached for fast repeated queries
+- Used for clustering to identify related incomplete trees
+- Merged with the main federated model for unified search
+
+## Related Documentation
+
+- `docs/proposals/pearltrees_unifyweaver_native.md` - Future UnifyWeaver-native approach using aggregates
+- `docs/ai-skills/bookmark-filing-agent.md` - Semantic search for bookmark filing
+- `scripts/filter_incomplete_trees.py` - Semantic filtering tool

--- a/scripts/build_children_index.py
+++ b/scripts/build_children_index.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Build a parent→children index from Pearltrees RDF.
+
+Groups all pearls (PagePearl, RefPearl, AliasPearl, SectionPearl, RootPearl)
+by their parentTree and stores in SQLite or JSON for fast lookup.
+
+Usage:
+    python3 scripts/build_children_index.py context/PT/pearltrees_export_s243a_2026-01-02.rdf
+    python3 scripts/build_children_index.py context/PT/*.rdf --output .local/data/children_index.db
+    python3 scripts/build_children_index.py context/PT/*.rdf --format json --output .local/data/children_index.json
+"""
+
+import argparse
+import json
+import sqlite3
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from collections import defaultdict
+from typing import Dict, List, Optional
+from dataclasses import dataclass, asdict
+
+NAMESPACES = {
+    'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+    'pt': 'http://www.pearltrees.com/rdf/0.1/#',
+    'dcterms': 'http://purl.org/dc/elements/1.1/',
+}
+
+
+@dataclass
+class ChildPearl:
+    """Represents a pearl that is a child of a tree."""
+    uri: str
+    pearl_type: str  # PagePearl, RefPearl, AliasPearl, SectionPearl, RootPearl
+    title: str
+    pos_order: int
+    external_url: Optional[str] = None  # For PagePearl
+    see_also_uri: Optional[str] = None  # For RefPearl/AliasPearl - target tree
+
+
+def extract_tree_id(uri: str) -> Optional[str]:
+    """Extract tree ID from URI like https://www.pearltrees.com/s243a/foo/id12345"""
+    match = re.search(r'id(\d+)', uri)
+    return match.group(1) if match else None
+
+
+def parse_rdf_children(rdf_file: Path) -> Dict[str, List[ChildPearl]]:
+    """
+    Parse RDF file and group children by parent tree.
+
+    Returns:
+        Dict mapping parent_tree_uri -> list of ChildPearl
+    """
+    children_by_parent: Dict[str, List[ChildPearl]] = defaultdict(list)
+
+    try:
+        tree = ET.parse(rdf_file)
+        root = tree.getroot()
+    except ET.ParseError as e:
+        print(f"Error parsing {rdf_file}: {e}")
+        return children_by_parent
+
+    pearl_types = ['PagePearl', 'RefPearl', 'AliasPearl', 'SectionPearl', 'RootPearl']
+
+    for pearl_type in pearl_types:
+        for elem in root.findall(f".//{{{NAMESPACES['pt']}}}{pearl_type}"):
+            uri = elem.get(f"{{{NAMESPACES['rdf']}}}about")
+            if not uri:
+                continue
+
+            # Get parent tree
+            parent_elem = elem.find(f"{{{NAMESPACES['pt']}}}parentTree")
+            if parent_elem is None:
+                continue
+            parent_uri = parent_elem.get(f"{{{NAMESPACES['rdf']}}}resource")
+            if not parent_uri:
+                continue
+
+            # Get title
+            title_elem = elem.find(f"{{{NAMESPACES['dcterms']}}}title")
+            title = title_elem.text if title_elem is not None and title_elem.text else ""
+
+            # Get position
+            pos_elem = elem.find(f"{{{NAMESPACES['pt']}}}posOrder")
+            pos_order = int(pos_elem.text) if pos_elem is not None and pos_elem.text else 0
+
+            # Get external URL for PagePearl
+            external_url = None
+            if pearl_type == 'PagePearl':
+                id_elem = elem.find(f"{{{NAMESPACES['dcterms']}}}identifier")
+                external_url = id_elem.text if id_elem is not None and id_elem.text else None
+
+            # Get seeAlso for RefPearl/AliasPearl
+            see_also_uri = None
+            if pearl_type in ('RefPearl', 'AliasPearl'):
+                see_also = elem.find(f"{{{NAMESPACES['rdfs']}}}seeAlso")
+                if see_also is not None:
+                    see_also_uri = see_also.get(f"{{{NAMESPACES['rdf']}}}resource")
+
+            child = ChildPearl(
+                uri=uri,
+                pearl_type=pearl_type,
+                title=title,
+                pos_order=pos_order,
+                external_url=external_url,
+                see_also_uri=see_also_uri
+            )
+
+            children_by_parent[parent_uri].append(child)
+
+    # Sort children by pos_order
+    for parent_uri in children_by_parent:
+        children_by_parent[parent_uri].sort(key=lambda c: c.pos_order)
+
+    return children_by_parent
+
+
+def save_to_sqlite(children_by_parent: Dict[str, List[ChildPearl]], db_path: Path):
+    """Save children index to SQLite database."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Create tables
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS children (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            parent_tree_uri TEXT NOT NULL,
+            parent_tree_id TEXT,
+            uri TEXT NOT NULL,
+            pearl_type TEXT NOT NULL,
+            title TEXT,
+            pos_order INTEGER,
+            external_url TEXT,
+            see_also_uri TEXT,
+            UNIQUE(parent_tree_uri, uri)
+        )
+    ''')
+
+    cursor.execute('CREATE INDEX IF NOT EXISTS idx_parent_tree_uri ON children(parent_tree_uri)')
+    cursor.execute('CREATE INDEX IF NOT EXISTS idx_parent_tree_id ON children(parent_tree_id)')
+
+    # Insert data
+    for parent_uri, children in children_by_parent.items():
+        parent_id = extract_tree_id(parent_uri)
+        for child in children:
+            cursor.execute('''
+                INSERT OR REPLACE INTO children
+                (parent_tree_uri, parent_tree_id, uri, pearl_type, title, pos_order, external_url, see_also_uri)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                parent_uri,
+                parent_id,
+                child.uri,
+                child.pearl_type,
+                child.title,
+                child.pos_order,
+                child.external_url,
+                child.see_also_uri
+            ))
+
+    conn.commit()
+
+    # Stats
+    cursor.execute('SELECT COUNT(DISTINCT parent_tree_uri) FROM children')
+    parent_count = cursor.fetchone()[0]
+    cursor.execute('SELECT COUNT(*) FROM children')
+    child_count = cursor.fetchone()[0]
+
+    conn.close()
+
+    print(f"Saved {child_count} children across {parent_count} parent trees to {db_path}")
+
+
+def save_to_json(children_by_parent: Dict[str, List[ChildPearl]], json_path: Path):
+    """Save children index to JSON file."""
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convert to serializable format
+    data = {}
+    for parent_uri, children in children_by_parent.items():
+        parent_id = extract_tree_id(parent_uri)
+        data[parent_uri] = {
+            'parent_id': parent_id,
+            'children': [asdict(c) for c in children]
+        }
+
+    with open(json_path, 'w') as f:
+        json.dump(data, f, indent=2)
+
+    print(f"Saved {len(data)} parent trees to {json_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Build parent→children index from RDF')
+    parser.add_argument('rdf_files', type=Path, nargs='+', help='RDF files to parse')
+    parser.add_argument('--output', '-o', type=Path,
+                        default=Path('.local/data/children_index.db'),
+                        help='Output file path')
+    parser.add_argument('--format', choices=['sqlite', 'json'], default='sqlite',
+                        help='Output format (default: sqlite)')
+
+    args = parser.parse_args()
+
+    # Collect children from all RDF files
+    all_children: Dict[str, List[ChildPearl]] = defaultdict(list)
+
+    for rdf_file in args.rdf_files:
+        if not rdf_file.exists():
+            print(f"Warning: {rdf_file} not found, skipping")
+            continue
+
+        print(f"Parsing {rdf_file}...")
+        children = parse_rdf_children(rdf_file)
+
+        for parent_uri, child_list in children.items():
+            all_children[parent_uri].extend(child_list)
+
+    # Remove duplicates and re-sort
+    for parent_uri in all_children:
+        seen = set()
+        unique = []
+        for child in all_children[parent_uri]:
+            if child.uri not in seen:
+                seen.add(child.uri)
+                unique.append(child)
+        unique.sort(key=lambda c: c.pos_order)
+        all_children[parent_uri] = unique
+
+    # Save
+    if args.format == 'sqlite':
+        save_to_sqlite(all_children, args.output)
+    else:
+        save_to_json(all_children, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/find_mindmap.py
+++ b/scripts/find_mindmap.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Find mindmap files by tree ID or pattern.
+
+Supports multiple filename formats:
+  - id{number}.smmx
+  - Title_id{number}.smmx
+  - Title_{number}.smmx
+
+Usage:
+    # Find by tree ID
+    python3 scripts/find_mindmap.py 75009241
+    python3 scripts/find_mindmap.py 75009241 14165883 10088091
+
+    # Find by title pattern (case-insensitive)
+    python3 scripts/find_mindmap.py --title "psychology"
+    python3 scripts/find_mindmap.py --title "science" --title "math"
+
+    # Find by glob pattern
+    python3 scripts/find_mindmap.py --glob "*Psychology*.smmx"
+
+    # Use index for fast lookup
+    python3 scripts/find_mindmap.py --index .local/data/scans/mindmap_index.json 75009241
+
+    # List all IDs in directory
+    python3 scripts/find_mindmap.py --list-ids
+
+    # Search in specific directory
+    python3 scripts/find_mindmap.py -d output/mindmaps_curated 75009241
+"""
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple
+
+
+def extract_tree_id(filename: str) -> Optional[str]:
+    """Extract tree ID from filename.
+
+    Supports:
+      - id{number}.smmx
+      - Title_id{number}.smmx
+      - Title_{number}.smmx (6+ digits)
+    """
+    stem = Path(filename).stem
+
+    # id{number} prefix
+    if stem.startswith('id') and stem[2:].isdigit():
+        return stem[2:]
+
+    # Title_id{number} suffix
+    match = re.search(r'_id(\d+)$', stem)
+    if match:
+        return match.group(1)
+
+    # Title_{number} suffix (6+ digits)
+    match = re.search(r'_(\d{6,})$', stem)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def find_by_id(tree_id: str, search_dir: Path) -> List[Path]:
+    """Find mindmap files matching a tree ID."""
+    results = []
+
+    # Try exact patterns first (faster)
+    patterns = [
+        f"id{tree_id}.smmx",
+        f"*_id{tree_id}.smmx",
+        f"*_{tree_id}.smmx",
+    ]
+
+    for pattern in patterns:
+        results.extend(search_dir.rglob(pattern))
+
+    return list(set(results))  # Dedupe
+
+
+def find_by_title(title_pattern: str, search_dir: Path) -> List[Path]:
+    """Find mindmap files with title matching pattern (case-insensitive)."""
+    results = []
+    pattern_lower = title_pattern.lower()
+
+    for smmx in search_dir.rglob("*.smmx"):
+        if pattern_lower in smmx.stem.lower():
+            results.append(smmx)
+
+    return results
+
+
+def find_by_glob(glob_pattern: str, search_dir: Path) -> List[Path]:
+    """Find mindmap files matching glob pattern."""
+    return list(search_dir.rglob(glob_pattern))
+
+
+def find_in_index(tree_id: str, index: Dict[str, str]) -> Optional[str]:
+    """Look up tree ID in index."""
+    return index.get(tree_id)
+
+
+def list_all_ids(search_dir: Path) -> List[Tuple[str, Path]]:
+    """List all tree IDs found in directory."""
+    results = []
+
+    for smmx in search_dir.rglob("*.smmx"):
+        tree_id = extract_tree_id(smmx.name)
+        if tree_id:
+            results.append((tree_id, smmx))
+
+    return sorted(results, key=lambda x: x[0])
+
+
+def load_index(index_path: Path) -> Dict[str, str]:
+    """Load mindmap index file."""
+    if index_path.exists():
+        with open(index_path) as f:
+            return json.load(f)
+    return {}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Find mindmap files by ID or pattern',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument('tree_ids', nargs='*', help='Tree IDs to find')
+    parser.add_argument('-d', '--directory', type=Path,
+                        default=Path('output/mindmaps_curated'),
+                        help='Directory to search (default: output/mindmaps_curated)')
+    parser.add_argument('--title', action='append', dest='titles',
+                        help='Find by title pattern (case-insensitive, can repeat)')
+    parser.add_argument('--glob', action='append', dest='globs',
+                        help='Find by glob pattern (can repeat)')
+    parser.add_argument('--index', type=Path, default=None,
+                        help='Use index file for fast lookup')
+    parser.add_argument('--list-ids', action='store_true',
+                        help='List all tree IDs in directory')
+    parser.add_argument('--format', choices=['path', 'name', 'id', 'full'],
+                        default='path', help='Output format')
+    parser.add_argument('--exists', action='store_true',
+                        help='Only show files that exist (for index lookups)')
+
+    args = parser.parse_args()
+
+    # Load index if specified
+    index = {}
+    if args.index:
+        index = load_index(args.index)
+        if index:
+            print(f"Loaded index: {len(index)} entries", file=__import__('sys').stderr)
+
+    results = []
+
+    # List all IDs mode
+    if args.list_ids:
+        id_list = list_all_ids(args.directory)
+        print(f"Found {len(id_list)} mindmaps with IDs:\n")
+        for tree_id, path in id_list:
+            if args.format == 'id':
+                print(tree_id)
+            elif args.format == 'name':
+                print(f"{tree_id}\t{path.name}")
+            elif args.format == 'full':
+                print(f"{tree_id}\t{path.name}\t{path}")
+            else:
+                print(f"{tree_id}\t{path}")
+        return
+
+    # Find by tree IDs
+    for tree_id in args.tree_ids:
+        # Try index first
+        if index and tree_id in index:
+            path_str = index[tree_id]
+            path = Path(path_str)
+            if not args.exists or path.exists():
+                results.append(('index', tree_id, path))
+            continue
+
+        # Fall back to filesystem search
+        found = find_by_id(tree_id, args.directory)
+        for path in found:
+            results.append(('fs', tree_id, path))
+
+        if not found:
+            results.append(('notfound', tree_id, None))
+
+    # Find by title patterns
+    if args.titles:
+        for title in args.titles:
+            found = find_by_title(title, args.directory)
+            for path in found:
+                tree_id = extract_tree_id(path.name) or '?'
+                results.append(('title', tree_id, path))
+
+    # Find by glob patterns
+    if args.globs:
+        for glob in args.globs:
+            found = find_by_glob(glob, args.directory)
+            for path in found:
+                tree_id = extract_tree_id(path.name) or '?'
+                results.append(('glob', tree_id, path))
+
+    # Output results
+    if not results:
+        if not args.tree_ids and not args.titles and not args.globs:
+            parser.print_help()
+        return
+
+    for source, tree_id, path in results:
+        if path is None:
+            print(f"NOT FOUND: {tree_id}")
+        elif args.format == 'path':
+            print(path)
+        elif args.format == 'name':
+            print(path.name)
+        elif args.format == 'id':
+            print(tree_id)
+        elif args.format == 'full':
+            print(f"{tree_id}\t{path.name}\t{path}\t[{source}]")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_mindmap.py
+++ b/scripts/generate_mindmap.py
@@ -3272,6 +3272,9 @@ def generate_recursive(cluster_url: str, data_path: Path, output_dir: Path,
                 parent_title = url_to_title.get(parent_url)
 
     # Generate this cluster's map
+    # Filter out LLM-specific kwargs that generate_single_map doesn't accept
+    single_map_kwargs = {k: v for k, v in kwargs.items()
+                         if k not in ('llm_context_level', 'llm_descriptions_path')}
     child_urls = generate_single_map(
         cluster_url=cluster_url,
         data_path=data_path,
@@ -3288,7 +3291,7 @@ def generate_recursive(cluster_url: str, data_path: Path, output_dir: Path,
         parent_title=parent_title,
         flat_hierarchy=curated_folders,  # Preserve true hierarchy in curated mode
         children_index=children_index,
-        **kwargs
+        **single_map_kwargs
     )
 
     total_generated = 1

--- a/scripts/repair_incomplete_mindmaps.py
+++ b/scripts/repair_incomplete_mindmaps.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Repair incomplete mindmaps by loading children from the SQLite index.
+
+Reads the scan results and regenerates mindmaps that have missing children.
+
+Usage:
+    python3 scripts/repair_incomplete_mindmaps.py \
+        --scan .local/data/scans/incomplete_mindmaps.json \
+        --children-index .local/data/children_index.db \
+        --output-dir output/mindmaps_curated \
+        --data reports/pearltrees_targets_combined_2026-01-02_trees.jsonl
+
+    # Dry run to see what would be repaired:
+    python3 scripts/repair_incomplete_mindmaps.py --scan ... --dry-run
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+import zipfile
+from pathlib import Path
+from typing import Dict, List, Optional
+from dataclasses import dataclass
+from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.dom import minidom
+import uuid
+import hashlib
+
+
+@dataclass
+class ChildPearl:
+    """A pearl child of a tree."""
+    uri: str
+    pearl_type: str
+    title: str
+    pos_order: int
+    external_url: str = ""
+    see_also_uri: str = ""
+
+
+def load_children_from_index(db_path: Path, tree_id: str) -> List[ChildPearl]:
+    """Load children for a tree from the SQLite index."""
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute('''
+        SELECT pearl_type, title, pos_order, external_url, see_also_uri, uri
+        FROM children
+        WHERE parent_tree_id = ?
+        ORDER BY pos_order
+    ''', (str(tree_id),))
+
+    children = []
+    for row in cursor.fetchall():
+        pearl_type, title, pos_order, external_url, see_also_uri, uri = row
+        # Skip RootPearl
+        if pearl_type == 'RootPearl':
+            continue
+        children.append(ChildPearl(
+            uri=uri or '',
+            pearl_type=pearl_type,
+            title=title or '',
+            pos_order=pos_order or 0,
+            external_url=external_url or '',
+            see_also_uri=see_also_uri or ''
+        ))
+
+    conn.close()
+    return children
+
+
+def generate_guid() -> str:
+    """Generate a unique GUID for a topic."""
+    return hashlib.md5(uuid.uuid4().bytes).hexdigest()[:22]
+
+
+def extract_domain(url: str) -> str:
+    """Extract domain from URL for display."""
+    if not url:
+        return ""
+    try:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        domain = parsed.netloc
+        # Strip common prefixes
+        for prefix in ('www.', 'en.', 'docs.', 'm.'):
+            if domain.startswith(prefix):
+                domain = domain[len(prefix):]
+                break
+        return domain
+    except Exception:
+        return ""
+
+
+def generate_mindmap_xml(tree_id: str, title: str, uri: str,
+                         children: List[ChildPearl], expanded_mode: bool = True) -> str:
+    """Generate SimpleMind XML for a tree with children."""
+
+    # Root element
+    root = Element('simplemind-mindmaps')
+    root.set('generator', 'UnifyWeaver')
+    root.set('gen-version', '1.0.0')
+    root.set('doc-version', '3')
+
+    mindmap = SubElement(root, 'mindmap')
+
+    # Meta
+    meta = SubElement(mindmap, 'meta')
+    guid_elem = SubElement(meta, 'guid')
+    guid_elem.set('guid', hashlib.md5(tree_id.encode()).hexdigest().upper()[:32])
+    title_elem = SubElement(meta, 'title')
+    title_elem.set('text', title)
+    style = SubElement(meta, 'style')
+    style.set('key', 'system.soft-palette')
+    numbering = SubElement(meta, 'auto-numbering')
+    numbering.set('style', 'disabled')
+    scroll = SubElement(meta, 'scrollstate')
+    scroll.set('zoom', '40')
+    scroll.set('x', '0')
+    scroll.set('y', '0')
+    central = SubElement(meta, 'main-centraltheme')
+    central.set('id', '0')
+
+    # Topics
+    topics = SubElement(mindmap, 'topics')
+
+    # Root topic
+    root_topic = SubElement(topics, 'topic')
+    root_topic.set('id', '0')
+    root_topic.set('parent', '-1')
+    root_topic.set('guid', generate_guid())
+    root_topic.set('x', '0.00')
+    root_topic.set('y', '0.00')
+    root_topic.set('palette', '1')
+    root_topic.set('colorinfo', '1')
+    # Wrap title for display
+    display_title = title.replace(' ', '\\N') if len(title) > 15 else title
+    root_topic.set('text', display_title)
+
+    layout = SubElement(root_topic, 'layout')
+    layout.set('mode', 'radial')
+    layout.set('direction', 'auto')
+    layout.set('flow', 'default')
+
+    style = SubElement(root_topic, 'style')
+    font = SubElement(style, 'font')
+    font.set('scale', '1.50')
+
+    link = SubElement(root_topic, 'link')
+    link.set('urllink', uri)
+
+    # Child topics
+    next_id = 1
+    child_node_id = 1000
+    palette_idx = 2
+
+    for child in children:
+        topic = SubElement(topics, 'topic')
+        topic.set('id', str(next_id))
+        topic.set('parent', '0')
+        topic.set('guid', generate_guid())
+        topic.set('x', '0.00')
+        topic.set('y', '0.00')
+        topic.set('palette', str((palette_idx % 8) + 1))
+        topic.set('colorinfo', str((palette_idx % 8) + 1))
+
+        # Wrap title
+        child_title = child.title.replace(' ', '\\N') if len(child.title) > 12 else child.title
+        topic.set('text', child_title)
+
+        style = SubElement(topic, 'style')
+        # PagePearl and Section get no border
+        if child.pearl_type in ('PagePearl', 'SectionPearl'):
+            style.set('borderstyle', 'sbsNone')
+
+        # Link to Pearltrees URI
+        link = SubElement(topic, 'link')
+        link.set('urllink', child.uri)
+
+        # For PagePearl in expanded mode, add domain child node
+        if expanded_mode and child.pearl_type == 'PagePearl' and child.external_url:
+            domain = extract_domain(child.external_url)
+            if domain:
+                child_topic = SubElement(topics, 'topic')
+                child_topic.set('id', str(child_node_id))
+                child_topic.set('parent', str(next_id))
+                child_topic.set('guid', generate_guid())
+                child_topic.set('x', '30.00')
+                child_topic.set('y', '20.00')
+                child_topic.set('text', domain)
+
+                child_style = SubElement(child_topic, 'style')
+                child_style.set('borderstyle', 'sbsNone')
+
+                child_link = SubElement(child_topic, 'link')
+                child_link.set('urllink', child.external_url)
+
+                child_node_id += 1
+
+        next_id += 1
+        palette_idx += 1
+
+    # Relations (empty)
+    SubElement(mindmap, 'relations')
+
+    # Convert to string with pretty printing
+    rough_string = tostring(root, encoding='unicode')
+    reparsed = minidom.parseString(rough_string)
+    pretty = reparsed.toprettyxml(indent="  ")
+
+    # Clean up extra blank lines and fix declaration
+    lines = [l for l in pretty.split('\n') if l.strip()]
+    lines[0] = '<?xml version="1.0" encoding="UTF-8"?>'
+    lines.insert(1, '<!DOCTYPE simplemind-mindmaps>')
+
+    return '\n'.join(lines)
+
+
+def write_smmx(xml_content: str, output_path: Path):
+    """Write XML to .smmx file (zip format)."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr('document/mindmap.xml', xml_content)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Repair incomplete mindmaps')
+    parser.add_argument('--scan', type=Path, required=True,
+                        help='Path to scan results JSON')
+    parser.add_argument('--children-index', type=Path, required=True,
+                        help='Path to children index SQLite database')
+    parser.add_argument('--output-dir', type=Path, required=True,
+                        help='Base output directory for mindmaps')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would be repaired without writing files')
+    parser.add_argument('--limit', type=int, default=None,
+                        help='Limit number of repairs (for testing)')
+    parser.add_argument('--expanded', action='store_true', default=True,
+                        help='Use expanded mode for PagePearls (default: True)')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Verbose output')
+
+    args = parser.parse_args()
+
+    # Load scan results
+    with open(args.scan) as f:
+        scan_data = json.load(f)
+
+    maps = scan_data.get('maps', [])
+    print(f"Loaded {len(maps)} incomplete mindmaps from scan")
+
+    if args.limit:
+        maps = maps[:args.limit]
+        print(f"Limited to {args.limit} maps for testing")
+
+    # Stats
+    repaired = 0
+    skipped_no_children = 0
+    skipped_private = 0
+    errors = 0
+
+    for i, m in enumerate(maps):
+        tree_id = m.get('tree_id', '')
+        title = m.get('title', 'Unknown')
+        uri = m.get('uri', '')
+        rel_path = m.get('path', '')
+
+        # Skip private trees (optional)
+        if title == '*private*':
+            skipped_private += 1
+            continue
+
+        # Load children from index
+        children = load_children_from_index(args.children_index, tree_id)
+
+        if not children:
+            skipped_no_children += 1
+            if args.verbose:
+                print(f"  [{i+1}/{len(maps)}] {tree_id}: No children in index, skipping")
+            continue
+
+        output_path = args.output_dir / rel_path
+
+        if args.dry_run:
+            print(f"  [{i+1}/{len(maps)}] Would repair: {tree_id} ({title[:30]}) - {len(children)} children -> {rel_path}")
+            repaired += 1
+            continue
+
+        try:
+            # Generate and write mindmap
+            xml = generate_mindmap_xml(tree_id, title, uri, children,
+                                       expanded_mode=args.expanded)
+            write_smmx(xml, output_path)
+            repaired += 1
+
+            if args.verbose or (repaired % 100 == 0):
+                print(f"  [{i+1}/{len(maps)}] Repaired: {tree_id} ({title[:30]}) - {len(children)} children")
+        except Exception as e:
+            errors += 1
+            print(f"  [{i+1}/{len(maps)}] Error repairing {tree_id}: {e}")
+
+    # Summary
+    print(f"\n{'DRY RUN - ' if args.dry_run else ''}Repair Summary:")
+    print(f"  Repaired: {repaired}")
+    print(f"  Skipped (no children in index): {skipped_no_children}")
+    print(f"  Skipped (private): {skipped_private}")
+    print(f"  Errors: {errors}")
+    print(f"  Total processed: {repaired + skipped_no_children + skipped_private + errors}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
  ## Summary

  - Add tooling for identifying and repairing incomplete mindmaps
  - Add MST circle-based folder grouping algorithm proposal
  - Fix bug in recursive mindmap generation

  ## Changes

  ### Mindmap Repair Tooling
  - `scripts/build_children_index.py` - Parse RDF to create parent→children SQLite index
  - `scripts/repair_incomplete_mindmaps.py` - Batch repair mindmaps using children index
  - `scripts/find_mindmap.py` - Search for mindmaps by ID or title
  - `scripts/scan_incomplete_mindmaps.py` - Enhanced scanning for incomplete trees
  - `docs/workflows/mindmap_repair.md` - Complete workflow documentation

  ### MST Folder Grouping Proposal
  - `docs/proposals/mst_circle_folder_grouping.md` - Algorithm design for semantic folder organization
  - Four implementation versions: MST, Curated, Hybrid, Tangent Deviation
  - Tangent Deviation version uses differential geometry (cosine similarity of manifold tangents) to measure deviation from curated structure

  ### Bug Fix
  - Fix TypeError when `llm_context_level` passed to `generate_single_map()`

  ## Test plan

  - [ ] Run `build_children_index.py` on RDF files
  - [ ] Run `repair_incomplete_mindmaps.py --dry-run` to verify detection
  - [ ] Generate mindmaps with `--curated-folders` option
  - [ ] Review MST proposal for algorithmic correctness

  🤖 Generated with [Claude Code](https://claude.com/claude-code)