### PR TITLE
feat(pearltrees): Add alias handling and cycle detection

### DIFF
--- a/docs/proposals/hierarchical_transformations_implementation_plan.md
+++ b/docs/proposals/hierarchical_transformations_implementation_plan.md
@@ -269,22 +269,35 @@ Phase 1: Navigation
 7. ✅ Updated README with Phases 7-9 documentation
 8. ✅ All 100 tests passing (81 hierarchy + 19 semantic)
 
-## Open Questions
+## Completed: Alias Handling and Cycle Detection
 
-1. **Should we support cycles?** Trees can have aliases that create logical cycles. Current plan: detect and fail gracefully.
+9. ✅ Implemented cycle detection (`has_cycle/1`, `cycle_free_path/2`)
+10. ✅ Added `follow_aliases` option to traversal predicates
+11. ✅ Implemented alias resolution (`alias_target/2`, `alias_children/2`, `tree_aliases/2`)
+12. ✅ All traversal predicates now use cycle-safe implementations
+13. ✅ Added 24 new tests (105 hierarchy + 19 semantic = 124 total)
+
+## Resolved Questions
+
+1. **~~Should we support cycles?~~** ✅ RESOLVED: Yes, cycles are detected and handled gracefully. `has_cycle/1` detects cycles, and all traversal predicates use cycle-safe implementations that stop at repeated nodes.
 
 2. **How to handle multiple roots?** Multi-account scenarios may have multiple disconnected hierarchies. Current plan: treat as separate hierarchies, enumerate with `root_tree/1`.
 
 3. **Should transformations be lazy or eager?** Current plan: eager (compute full result). Could add generator-style for large hierarchies.
 
-## Important: AliasPearl Handling
+## Implemented: AliasPearl Handling
 
-When building structural hierarchies and embeddings, **AliasPearls must be followed** to bridge across accounts:
+AliasPearls are now fully supported for cross-account traversal:
 
 ```prolog
 %% AliasPearls link trees across accounts
 %% pearl_children(TreeId, alias, Title, Order, null, SeeAlsoUri)
 %%   SeeAlsoUri → target tree in another account
+
+%% New predicates:
+alias_target(SeeAlsoUri, TargetTreeId).     % Resolve alias to tree
+alias_children(TreeId, AliasTargets).       % Get all alias targets
+tree_aliases(TreeId, AliasInfo).            % Get detailed alias info
 
 %% Traversal predicates should support:
 tree_descendants(TreeId, Descendants) :-

--- a/src/unifyweaver/examples/pearltrees/README.md
+++ b/src/unifyweaver/examples/pearltrees/README.md
@@ -27,7 +27,7 @@ This example shows how UnifyWeaver can:
 | `test_queries.pl` | 36 plunit tests for queries and filters |
 | `test_templates.pl` | 44 plunit tests for templates (all formats) |
 | `test_browser_automation.pl` | 22 plunit tests for browser automation |
-| `test_hierarchy.pl` | 81 plunit tests for hierarchy predicates |
+| `test_hierarchy.pl` | 105 plunit tests for hierarchy predicates |
 | `test_semantic_hierarchy.pl` | 19 plunit tests for semantic predicates |
 
 ## Source Definitions
@@ -265,6 +265,51 @@ Example embedding format:
       - Quantum Mechanics
 ```
 
+### Alias Handling (Cross-Account Traversal)
+
+AliasPearls link trees across accounts. When `follow_aliases(true)` is set, traversal predicates follow these links:
+
+| Predicate | Description |
+|-----------|-------------|
+| `alias_target/2` | Resolve alias URI to target tree ID |
+| `alias_children/2` | Get all alias targets from a tree |
+| `tree_aliases/2` | Get detailed alias info (title, order, target) |
+
+Example: Follow aliases when getting descendants:
+```prolog
+?- tree_descendants('arts_5', Descendants, [follow_aliases(true)]).
+% Includes both direct children AND trees linked via aliases
+```
+
+Alias handling is essential for:
+- **Semantic embeddings**: Hierarchical context spans accounts
+- **Curated folders**: Complete hierarchy includes cross-account links
+- **User's mental model**: Users organize across accounts via aliases
+
+### Cycle Detection
+
+Cycles can occur when tree relationships form loops (A -> B -> A). All traversal predicates detect cycles to prevent infinite loops:
+
+| Predicate | Description |
+|-----------|-------------|
+| `has_cycle/1` | True if tree has a cycle in its ancestry |
+| `cycle_free_path/2` | Get path stopping at cycle point |
+
+Example:
+```prolog
+?- has_cycle('suspicious_tree').
+true.  % Cycle detected - traversal would loop
+
+?- cycle_free_path('suspicious_tree', Path).
+Path = ['tree_a', 'tree_b'].  % Stops before repeating
+```
+
+Cycle detection is automatic in:
+- `tree_ancestors/2,3`
+- `tree_descendants/2,3`
+- `tree_path/2,3`
+- `subtree_tree/2,3`
+
 See `docs/proposals/hierarchical_transformations_specification.md` for the full specification.
 
 ## Semantic Hierarchy (Phases 7-9)
@@ -338,7 +383,7 @@ swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_templates.
 # Run browser automation tests (22 tests)
 swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_browser_automation.pl
 
-# Run hierarchy tests (81 tests)
+# Run hierarchy tests (105 tests)
 swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_hierarchy.pl
 
 # Run semantic hierarchy tests (19 tests)


### PR DESCRIPTION
## Summary

- Add cross-account traversal via AliasPearls with `follow_aliases` option
- Add cycle detection to prevent infinite loops in tree traversal
- All traversal predicates now use cycle-safe implementations
- 24 new tests bringing total to 124 tests (105 hierarchy + 19 semantic)

## Changes

### Alias Handling (Cross-Account Traversal)

AliasPearls link trees across accounts. New predicates:

| Predicate | Description |
|-----------|-------------|
| `alias_target/2` | Resolve alias URI to target tree ID |
| `alias_children/2` | Get all alias targets from a tree |
| `tree_aliases/2` | Get detailed alias info (title, order, target) |

Usage:
```prolog
?- tree_descendants('my_tree', Descendants, [follow_aliases(true)]).
% Includes both direct children AND trees linked via aliases
```

### Cycle Detection

Cycles can occur when tree relationships form loops (A -> B -> A):

| Predicate | Description |
|-----------|-------------|
| `has_cycle/1` | True if tree has a cycle in its ancestry |
| `cycle_free_path/2` | Get path stopping at cycle point |

Cycle detection is now automatic in:
- `tree_ancestors/2,3`
- `tree_descendants/2,3`
- `tree_path/2,3`
- `subtree_tree/2,3`

### Internal Helpers

- `tree_ancestors_safe/5` - Cycle-safe ancestor traversal
- `tree_descendant_safe/4` - Cycle-safe descendant enumeration
- `tree_parent_extended/3` - Parent lookup with alias support

## Test Plan

- [x] All 105 hierarchy tests pass (24 new tests added)
- [x] All 19 semantic hierarchy tests pass
- [x] No regressions in existing functionality

```bash
# Run hierarchy tests (105 tests)
swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_hierarchy.pl

# Run semantic tests (19 tests)
swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_semantic_hierarchy.pl
```

### New Test Suites

| Suite | Tests | Description |
|-------|-------|-------------|
| `alias_target` | 5 | Alias URI resolution |
| `alias_children` | 3 | Alias target collection |
| `tree_aliases` | 2 | Detailed alias info |
| `has_cycle` | 5 | Cycle detection |
| `cycle_free_path` | 3 | Path with cycle handling |
| `cycle_safe_ancestors` | 3 | Ancestor traversal with cycles |
| `follow_aliases` | 3 | Descendant traversal via aliases |

## Documentation

- Updated `README.md` with new predicate tables and examples
- Updated `hierarchical_transformations_implementation_plan.md` with completion status
- Resolved open question about cycle handling

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
