### PR TITLE
ix(targets): Add module-qualified predicate support to Go/C# targets

### DIFF
--- a/src/unifyweaver/examples/pearltrees/README.md
+++ b/src/unifyweaver/examples/pearltrees/README.md
@@ -29,7 +29,7 @@ This example shows how UnifyWeaver can:
 | `test_browser_automation.pl` | 22 plunit tests for browser automation |
 | `test_hierarchy.pl` | 105 plunit tests for hierarchy predicates |
 | `test_semantic_hierarchy.pl` | 19 plunit tests for semantic predicates |
-| `test_codegen.pl` | 21 plunit tests for code generation |
+| `test_codegen.pl` | 25 plunit tests for code generation |
 
 ## Source Definitions
 
@@ -391,14 +391,16 @@ Predicates can be compiled to Python with full JSONL pipeline support:
 
 ### Go and C# Targets
 
-Go and C# compilation infrastructure is available, though module-qualified predicates require additional setup:
+Go and C# targets fully support module-qualified predicates:
 
 ```prolog
 ?- use_module('src/unifyweaver/targets/go_target'),
-   compile_predicate_to_go(my_pred/2, [], Code).
+   compile_predicate_to_go(pearltrees_queries:tree_child_count/2, [json_input(true)], Code).
+% Generates Go code with JSON input processing
 
 ?- use_module('src/unifyweaver/targets/csharp_target'),
-   compile_predicate_to_csharp(my_pred/2, [], Code).
+   compile_predicate_to_csharp(pearltrees_queries:tree_child_count/2, [mode(generator)], Code).
+% Generates C# code with fixpoint solver
 ```
 
 ### Template Generation

--- a/src/unifyweaver/examples/pearltrees/test_codegen.pl
+++ b/src/unifyweaver/examples/pearltrees/test_codegen.pl
@@ -77,8 +77,7 @@ test(python_has_jsonl_support) :-
 %% Tests: Go Target
 %% ============================================================================
 %%
-%% Note: Go target currently doesn't handle module-qualified predicates well.
-%% These tests verify the infrastructure is present rather than full compilation.
+%% Go target now supports module-qualified predicates.
 
 :- begin_tests(go_target).
 
@@ -90,14 +89,23 @@ test(go_target_has_exports) :-
     current_predicate(go_target:compile_predicate_to_go/3),
     current_predicate(go_target:init_go_target/0).
 
+test(go_compile_module_qualified_predicate, [nondet]) :-
+    % Test that module-qualified predicates can be compiled
+    compile_predicate_to_go(pearltrees_queries:tree_child_count/2, [json_input(true)], Code),
+    code_min_length(Code, 100),
+    code_has_structure(Code, ['package main', 'func']).
+
+test(go_compile_hierarchy_predicate, [nondet]) :-
+    compile_predicate_to_go(pearltrees_hierarchy:tree_depth/2, [json_input(true)], Code),
+    code_min_length(Code, 100).
+
 :- end_tests(go_target).
 
 %% ============================================================================
 %% Tests: C# Target
 %% ============================================================================
 %%
-%% Note: C# target currently doesn't handle module-qualified predicates well.
-%% These tests verify the infrastructure is present.
+%% C# target now supports module-qualified predicates.
 
 :- begin_tests(csharp_target).
 
@@ -106,6 +114,17 @@ test(csharp_target_module_loads) :-
 
 test(csharp_target_has_exports) :-
     current_predicate(csharp_target:compile_predicate_to_csharp/3).
+
+test(csharp_compile_module_qualified_predicate) :-
+    % Test that module-qualified predicates can be compiled in generator mode
+    compile_predicate_to_csharp(pearltrees_queries:tree_child_count/2, [mode(generator)], Code),
+    code_min_length(Code, 100),
+    code_has_structure(Code, ['class', 'void']).
+
+test(csharp_compile_hierarchy_predicate) :-
+    % Test compiling another module-qualified predicate
+    compile_predicate_to_csharp(pearltrees_queries:incomplete_tree/2, [mode(generator)], Code),
+    code_min_length(Code, 100).
 
 :- end_tests(csharp_target).
 


### PR DESCRIPTION
## Summary

- Fix Go and C# targets to properly compile module-qualified predicates (e.g., `pearltrees_queries:tree_child_count/2`)
- Add module context tracking via `set_compilation_module/1` and `get_compilation_module/1` helpers
- Replace all `clause(Head, Body)` and `user:clause(Head, Body)` calls with module-aware `module_clause/2`
- Update codegen tests to verify module-qualified compilation works (25 tests now, was 21)
- Update README documentation to reflect full module-qualified support

## Test plan

- [x] Run `swipl -g "run_tests" -t halt src/unifyweaver/examples/pearltrees/test_codegen.pl` - all 25 tests pass
- [x] Verify Go target compiles `pearltrees_queries:tree_child_count/2` and `pearltrees_hierarchy:tree_depth/2`
- [x] Verify C# target compiles `pearltrees_queries:tree_child_count/2` and `pearltrees_queries:incomplete_tree/2`
- [x] Confirm README documentation is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
