### PR TITLE
perf(csharp-query): enable partial scan-index in fixpoints

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -1410,13 +1410,13 @@ verify_parameterized_recursive_multi_key_join_strategy_partial_index :-
         sub_term(recursive_ref{type:recursive_ref, predicate:predicate{name:test_group_reach_param, arity:3}, role:_, width:_}, Right)
     ),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
-    harness_source_with_strategy_flag(ModuleClass, [[alice, laptop]], 'KeyJoinScanIndex', HarnessSource),
+    harness_source_with_strategy_flag(ModuleClass, [[alice, laptop]], 'KeyJoinScanIndexPartial', HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
         ['alice,laptop,0',
          'alice,laptop,1',
          'alice,laptop,2',
          'alice,laptop,3',
-         'STRATEGY_USED:KeyJoinScanIndex=true'],
+         'STRATEGY_USED:KeyJoinScanIndexPartial=true'],
         [[alice, laptop]],
         HarnessSource).
 


### PR DESCRIPTION
  - Enables KeyJoinScanIndexPartial inside fixpoint execution by teaching IsRecursiveProbe about FixpointNode,
    MutualFixpointNode, and DefineMutualFixpointNode in src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs.
  - Keeps behavior the same; this only changes join strategy selection (avoids building full join-indexes when the probe
    is tiny in recursive contexts).
  - Updates tests/core/test_csharp_query_target.pl so
    verify_parameterized_recursive_multi_key_join_strategy_partial_index expects KeyJoinScanIndexPartial.