### PR TITLE
feat(mindmap): Add curated hierarchy tree source for folder grouping

### DIFF
--- a/scripts/mindmap/README.md
+++ b/scripts/mindmap/README.md
@@ -373,6 +373,10 @@ python3 scripts/mindmap/mst_folder_grouping.py \
 python3 scripts/mindmap/mst_folder_grouping.py \
   --trees-only --target-size 10 --max-depth 8 \
   --internal-cost arithmetic --verbose
+
+# Use curated hierarchy (respects Pearltrees parent-child structure)
+python3 scripts/mindmap/mst_folder_grouping.py \
+  --subset physics --tree-source curated --target-size 8 --max-depth 3 --verbose
 ```
 
 **Options Summary:**
@@ -385,8 +389,18 @@ python3 scripts/mindmap/mst_folder_grouping.py \
 | `--subdivision-method` | `multilevel`, `bisection` | `multilevel` | How to split oversized folders |
 | `--size-cost` | `gm_maximize`, `quadratic`, `geometric` | `gm_maximize` | Size cost (gm_maximize is scale-invariant) |
 | `--internal-cost` | `none`, `arithmetic`, `geometric` | `none` | Cost function for internal edges |
+| `--tree-source` | `mst`, `curated` | `mst` | Tree source for partitioning |
 | `--stats`, `-s` | flag | off | Print statistics tables (markdown format) |
 | `--verbose`, `-v` | flag | off | Print detailed progress |
+
+**Tree Source Modes:**
+
+| Mode | Description | Compute Cost | Best For |
+|------|-------------|--------------|----------|
+| `mst` | Build MST from embeddings | O(N²) or O(N*k) | Fresh organization, items without clear hierarchy |
+| `curated` | Use Pearltrees parent-child hierarchy | O(N) | Respecting existing curation, enhancing structure |
+
+The `curated` mode skips MST computation entirely, using the actual Pearltrees hierarchy paths from the JSONL `target_text` field. Edge weights are still computed from embedding distances for subdivision decisions.
 
 **Subdivision Methods:**
 


### PR DESCRIPTION
  ## Summary
  - Add `--tree-source curated` option to use Pearltrees parent-child hierarchy instead of computing MST
  - Skips O(N²) MST computation - uses O(N) hierarchy parsing from JSONL paths
  - Same subdivision algorithm works on both tree types

  ## How It Works

  The curated mode parses `target_text` paths from JSONL (e.g., `/id1/id2/.../idn`) to extract parent-child relationships, then applies the same folder partitioning algorithm. Edge weights are still computed from embedding distances for subdivision decisions.

  Orphan nodes (no parent in subset) are connected to their nearest neighbor by embedding similarity.

  ## Comparison (physics subset, 261 trees)

  | Metric | MST | Curated |
  |--------|-----|---------|
  | Folders | 43 | 72 |
  | Avg folder size | 6.1 | 3.4 |
  | Max folder size | 16 | 8 |
  | Respects hierarchy | No | Yes |

  Results are data-dependent - curated works best when the existing hierarchy is well-organized.

  ## Usage

  ```bash
  # Use curated hierarchy (respects Pearltrees structure)
  python3 scripts/mindmap/mst_folder_grouping.py \
    --subset physics --tree-source curated --target-size 8 --max-depth 3

  # Compare with MST (default)
  python3 scripts/mindmap/mst_folder_grouping.py \
    --subset physics --tree-source mst --target-size 8 --max-depth 3

  Test plan

  - Test on physics subset with curated source
  - Compare results with MST source
  - Verify orphan node handling
  - Test on full trees dataset with curated source

  🤖 Generated with https://claude.ai/code