### PR TITLE
feat(targets): Add multi-framework compilation for Vue, Flutter, SwiftUI

### DIFF
--- a/src/unifyweaver/targets/flutter_target.pl
+++ b/src/unifyweaver/targets/flutter_target.pl
@@ -1,0 +1,875 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% flutter_target.pl - Flutter/Dart Code Generation Target
+%
+% Generates Flutter widgets and Dart code from UI patterns. Supports:
+%   - Navigation (Navigator 2.0, GoRouter)
+%   - State management (Provider, Riverpod, setState)
+%   - Data fetching (FutureBuilder, http package)
+%   - Persistence (shared_preferences, Hive)
+%
+% Flutter uses a widget-based architecture where everything is a widget.
+% State management patterns differ from React hooks - Flutter uses
+% StatefulWidget, Provider, or Riverpod for reactive state.
+%
+% Usage:
+%   ?- compile_navigation_pattern(tab, Screens, [], flutter, [], Code).
+%   ?- compile_state_pattern(global, Shape, [], flutter, [], Code).
+
+:- module(flutter_target, [
+    % Target capabilities
+    target_capabilities/1,
+    flutter_capabilities/1,
+
+    % Pattern compilation
+    compile_navigation_pattern/6,
+    compile_state_pattern/6,
+    compile_data_pattern/5,
+    compile_persistence_pattern/5,
+
+    % Testing
+    test_flutter_target/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% TARGET CAPABILITIES
+% ============================================================================
+
+%% flutter_capabilities(-Capabilities)
+%
+%  Lists what Flutter target can do.
+%
+flutter_capabilities([
+    % Direct capabilities
+    supports(material_design),
+    supports(cupertino_design),
+    supports(custom_widgets),
+    supports(animations),
+    supports(gestures),
+    supports(platform_channels),
+
+    % Libraries
+    library('flutter/material.dart'),
+    library('go_router'),
+    library('flutter_riverpod'),
+    library('shared_preferences'),
+    library('hive'),
+    library('dio'),
+
+    % Limitations
+    limitation(no_hot_reload_for_native),
+    limitation(large_app_size)
+]).
+
+target_capabilities(Caps) :- flutter_capabilities(Caps).
+
+% ============================================================================
+% HELPER PREDICATES
+% ============================================================================
+
+option_value(Options, Key, Value, Default) :-
+    Opt =.. [Key, Value],
+    (   member(Opt, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+capitalize_first(Str, Cap) :-
+    (   atom(Str) -> atom_string(Str, S) ; S = Str ),
+    string_chars(S, [H|T]),
+    upcase_atom(H, HU),
+    atom_chars(HU, [HUC]),
+    string_chars(Cap, [HUC|T]).
+
+to_pascal_case(Name, Pascal) :-
+    atom_string(Name, Str),
+    split_string(Str, "_", "", Parts),
+    maplist(capitalize_first, Parts, CapParts),
+    atomics_to_string(CapParts, Pascal).
+
+% ============================================================================
+% PATTERN COMPILATION - Navigation
+% ============================================================================
+%
+% Flutter uses Navigator 2.0 or GoRouter for declarative routing.
+% Unlike web frameworks, Flutter navigation is imperative by default.
+
+%% compile_navigation_pattern(+Type, +Screens, +Config, +Target, +Options, -Code)
+compile_navigation_pattern(stack, Screens, _Config, flutter, Options, Code) :-
+    option_value(Options, component_name, Name, 'AppRouter'),
+    generate_flutter_go_router(Screens, stack, Name, Code).
+compile_navigation_pattern(tab, Screens, _Config, flutter, Options, Code) :-
+    option_value(Options, component_name, Name, 'TabScaffold'),
+    generate_flutter_tab_scaffold(Screens, Name, Code).
+compile_navigation_pattern(drawer, Screens, _Config, flutter, Options, Code) :-
+    option_value(Options, component_name, Name, 'DrawerScaffold'),
+    generate_flutter_drawer_scaffold(Screens, Name, Code).
+
+generate_flutter_go_router(Screens, _Type, Name, Code) :-
+    generate_flutter_route_definitions(Screens, RouteDefs),
+    generate_flutter_route_imports(Screens, Imports),
+    format(string(Code),
+"// ~w - GoRouter Configuration
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+~w
+
+final ~w = GoRouter(
+  initialLocation: '/',
+  routes: [
+~w
+  ],
+);
+
+// Usage: MaterialApp.router(routerConfig: ~w)
+", [Name, Imports, Name, RouteDefs, Name]).
+
+generate_flutter_route_definitions(Screens, Defs) :-
+    findall(RouteDef, (
+        member(screen(ScreenName, Component, _Opts), Screens),
+        atom_string(ScreenName, NameStr),
+        to_pascal_case(Component, WidgetName),
+        format(string(RouteDef),
+"    GoRoute(
+      path: '/~w',
+      name: '~w',
+      builder: (context, state) => const ~w(),
+    )", [NameStr, NameStr, WidgetName])
+    ), RouteDefList),
+    atomic_list_concat(RouteDefList, ',\n', Defs).
+
+generate_flutter_route_imports(Screens, Imports) :-
+    findall(ImportLine, (
+        member(screen(_, Component, _), Screens),
+        atom_string(Component, CompStr),
+        string_lower(CompStr, LowerComp),
+        format(string(ImportLine), "import 'screens/~w.dart';", [LowerComp])
+    ), ImportLines),
+    atomic_list_concat(ImportLines, '\n', Imports).
+
+generate_flutter_tab_scaffold(Screens, Name, Code) :-
+    generate_flutter_tab_items(Screens, TabItems),
+    generate_flutter_tab_views(Screens, TabViews),
+    format(string(Code),
+"// ~w - Bottom Navigation Tab Scaffold
+import 'package:flutter/material.dart';
+
+class ~w extends StatefulWidget {
+  const ~w({super.key});
+
+  @override
+  State<~w> createState() => _~wState();
+}
+
+class _~wState extends State<~w> {
+  int _currentIndex = 0;
+
+  final List<Widget> _screens = [
+~w
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _screens,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) => setState(() => _currentIndex = index),
+        type: BottomNavigationBarType.fixed,
+        items: const [
+~w
+        ],
+      ),
+    );
+  }
+}
+", [Name, Name, Name, Name, Name, Name, Name, TabViews, TabItems]).
+
+generate_flutter_tab_items(Screens, Items) :-
+    findall(TabItem, (
+        member(screen(ScreenName, _, Opts), Screens),
+        (   member(title(Title), Opts) -> true ; atom_string(ScreenName, Title) ),
+        (   member(icon(Icon), Opts) -> true ; Icon = 'Icons.circle' ),
+        format(string(TabItem),
+"          BottomNavigationBarItem(
+            icon: Icon(~w),
+            label: '~w',
+          )", [Icon, Title])
+    ), TabItemList),
+    atomic_list_concat(TabItemList, ',\n', Items).
+
+generate_flutter_tab_views(Screens, Views) :-
+    findall(View, (
+        member(screen(_, Component, _), Screens),
+        to_pascal_case(Component, WidgetName),
+        format(string(View), "    const ~w(),", [WidgetName])
+    ), ViewList),
+    atomic_list_concat(ViewList, '\n', Views).
+
+generate_flutter_drawer_scaffold(Screens, Name, Code) :-
+    generate_flutter_drawer_items(Screens, DrawerItems),
+    format(string(Code),
+"// ~w - Drawer Navigation Scaffold
+import 'package:flutter/material.dart';
+
+class ~w extends StatefulWidget {
+  const ~w({super.key});
+
+  @override
+  State<~w> createState() => _~wState();
+}
+
+class _~wState extends State<~w> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('App'),
+      ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(
+                color: Colors.blue,
+              ),
+              child: Text(
+                'Navigation',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                ),
+              ),
+            ),
+~w
+          ],
+        ),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    // Return the selected screen based on _selectedIndex
+    switch (_selectedIndex) {
+      default:
+        return const Center(child: Text('Select a screen'));
+    }
+  }
+}
+", [Name, Name, Name, Name, Name, Name, Name, DrawerItems]).
+
+generate_flutter_drawer_items(Screens, Items) :-
+    findall(DrawerItem, (
+        nth0(Index, Screens, screen(ScreenName, _, Opts)),
+        (   member(title(Title), Opts) -> true ; atom_string(ScreenName, Title) ),
+        (   member(icon(Icon), Opts) -> true ; Icon = 'Icons.circle' ),
+        format(string(DrawerItem),
+"            ListTile(
+              leading: Icon(~w),
+              title: Text('~w'),
+              selected: _selectedIndex == ~w,
+              onTap: () {
+                setState(() => _selectedIndex = ~w);
+                Navigator.pop(context);
+              },
+            )", [Icon, Title, Index, Index])
+    ), DrawerItemList),
+    atomic_list_concat(DrawerItemList, ',\n', Items).
+
+% ============================================================================
+% PATTERN COMPILATION - State
+% ============================================================================
+%
+% Flutter state management options:
+% - Local: StatefulWidget with setState
+% - Global: Riverpod (StateNotifier, StateNotifierProvider)
+% - Derived: Computed values via Provider
+
+%% compile_state_pattern(+Type, +Shape, +Config, +Target, +Options, -Code)
+compile_state_pattern(local, Shape, _Config, flutter, _Options, Code) :-
+    generate_flutter_stateful_widget(Shape, Code).
+compile_state_pattern(global, Shape, _Config, flutter, _Options, Code) :-
+    generate_flutter_riverpod_provider(Shape, Code).
+compile_state_pattern(derived, Shape, _Config, flutter, _Options, Code) :-
+    generate_flutter_computed_provider(Shape, Code).
+
+generate_flutter_stateful_widget(Shape, Code) :-
+    findall(FieldDef, (
+        member(field(Name, Initial), Shape),
+        format(string(FieldDef), "  var _~w = ~w;", [Name, Initial])
+    ), FieldDefs),
+    atomic_list_concat(FieldDefs, '\n', FieldsCode),
+    findall(SetterDef, (
+        member(field(Name, _), Shape),
+        capitalize_first(Name, CapName),
+        format(string(SetterDef),
+"  void set~w(dynamic value) {
+    setState(() => _~w = value);
+  }", [CapName, Name])
+    ), SetterDefs),
+    atomic_list_concat(SetterDefs, '\n\n', SettersCode),
+    format(string(Code),
+"// Flutter StatefulWidget - Local State
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatefulWidget {
+  const MyWidget({super.key});
+
+  @override
+  State<MyWidget> createState() => _MyWidgetState();
+}
+
+class _MyWidgetState extends State<MyWidget> {
+  // State fields
+~w
+
+  // Setters with setState
+~w
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      // Use state fields here
+    );
+  }
+}
+", [FieldsCode, SettersCode]).
+
+generate_flutter_riverpod_provider(Shape, Code) :-
+    member(store(StoreName), Shape),
+    member(slices(Slices), Shape),
+    to_pascal_case(StoreName, StoreClass),
+    generate_riverpod_state_class(Slices, StoreClass, StateClass),
+    generate_riverpod_notifier(Slices, StoreClass, NotifierCode),
+    format(string(Code),
+"// Riverpod State Management - ~w
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+~w
+
+~w
+
+final ~wProvider = StateNotifierProvider<~wNotifier, ~wState>((ref) {
+  return ~wNotifier();
+});
+
+// Usage:
+// final state = ref.watch(~wProvider);
+// ref.read(~wProvider.notifier).toggleTheme();
+", [StoreName, StateClass, NotifierCode, StoreName, StoreClass, StoreClass, StoreClass, StoreName, StoreName]).
+
+generate_riverpod_state_class(Slices, StoreClass, Code) :-
+    findall(FieldDef, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, FType), Fields),
+        dart_type(FType, DartType),
+        format(string(FieldDef), "  final ~w ~w;", [DartType, FName])
+    ), FieldDefs),
+    atomic_list_concat(FieldDefs, '\n', FieldsStr),
+    findall(ParamDef, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, _), Fields),
+        format(string(ParamDef), "    required this.~w,", [FName])
+    ), ParamDefs),
+    atomic_list_concat(ParamDefs, '\n', ParamsStr),
+    findall(CopyParam, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, _), Fields),
+        format(string(CopyParam), "    ~w? ~w,", [FName, FName])
+    ), CopyParams),
+    atomic_list_concat(CopyParams, '\n', CopyParamsStr),
+    findall(CopyField, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, _), Fields),
+        format(string(CopyField), "      ~w: ~w ?? this.~w,", [FName, FName, FName])
+    ), CopyFields),
+    atomic_list_concat(CopyFields, '\n', CopyFieldsStr),
+    format(string(Code),
+"class ~wState {
+~w
+
+  const ~wState({
+~w
+  });
+
+  ~wState copyWith({
+~w
+  }) {
+    return ~wState(
+~w
+    );
+  }
+}", [StoreClass, FieldsStr, StoreClass, ParamsStr, StoreClass, CopyParamsStr, StoreClass, CopyFieldsStr]).
+
+dart_type("'light' | 'dark'", "String").
+dart_type("boolean", "bool").
+dart_type("string | null", "String?").
+dart_type("number", "int").
+dart_type(_, "dynamic").
+
+generate_riverpod_notifier(Slices, StoreClass, Code) :-
+    findall(ActionDef, (
+        member(slice(_, _, Actions), Slices),
+        member(action(AName, _), Actions),
+        generate_riverpod_action(AName, ActionDef)
+    ), ActionDefs),
+    (   ActionDefs = []
+    ->  ActionsStr = "  // Add actions here"
+    ;   atomic_list_concat(ActionDefs, '\n\n', ActionsStr)
+    ),
+    findall(InitField, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, FType), Fields),
+        dart_default_value(FType, Default),
+        format(string(InitField), "      ~w: ~w,", [FName, Default])
+    ), InitFields),
+    atomic_list_concat(InitFields, '\n', InitStr),
+    format(string(Code),
+"class ~wNotifier extends StateNotifier<~wState> {
+  ~wNotifier() : super(const ~wState(
+~w
+  ));
+
+~w
+}", [StoreClass, StoreClass, StoreClass, StoreClass, InitStr, ActionsStr]).
+
+dart_default_value("'light' | 'dark'", "'light'").
+dart_default_value("boolean", "false").
+dart_default_value("string | null", "null").
+dart_default_value("number", "0").
+dart_default_value(_, "null").
+
+generate_riverpod_action(toggleTheme, Code) :-
+    format(string(Code),
+"  void toggleTheme() {
+    state = state.copyWith(
+      theme: state.theme == 'light' ? 'dark' : 'light',
+    );
+  }", []).
+generate_riverpod_action(toggleSidebar, Code) :-
+    format(string(Code),
+"  void toggleSidebar() {
+    state = state.copyWith(
+      sidebarOpen: !state.sidebarOpen,
+    );
+  }", []).
+generate_riverpod_action(Name, Code) :-
+    \+ member(Name, [toggleTheme, toggleSidebar]),
+    format(string(Code),
+"  void ~w(dynamic value) {
+    // TODO: Implement ~w action
+  }", [Name, Name]).
+
+generate_flutter_computed_provider(Shape, Code) :-
+    member(deps(Deps), Shape),
+    member(derive(Derivation), Shape),
+    atomic_list_concat(Deps, ', ', DepsStr),
+    format(string(Code),
+"// Riverpod Computed Provider
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+// Assumes providers for: ~w
+final derivedProvider = Provider<dynamic>((ref) {
+  // Watch dependencies
+  // final dep1 = ref.watch(dep1Provider);
+  // final dep2 = ref.watch(dep2Provider);
+
+  // Compute derived value
+  return ~w;
+});
+", [DepsStr, Derivation]).
+
+% ============================================================================
+% PATTERN COMPILATION - Data Fetching
+% ============================================================================
+%
+% Flutter uses FutureBuilder/StreamBuilder with http or Dio for data fetching.
+% Riverpod provides FutureProvider and AsyncNotifierProvider for async state.
+
+%% compile_data_pattern(+Type, +Config, +Target, +Options, -Code)
+compile_data_pattern(query, Config, flutter, _Options, Code) :-
+    generate_flutter_future_provider(Config, Code).
+compile_data_pattern(mutation, Config, flutter, _Options, Code) :-
+    generate_flutter_mutation_notifier(Config, Code).
+compile_data_pattern(infinite, Config, flutter, _Options, Code) :-
+    generate_flutter_paginated_provider(Config, Code).
+
+generate_flutter_future_provider(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    to_pascal_case(Name, ProviderName),
+    format(string(Code),
+"// Flutter FutureProvider - ~w
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class ~wData {
+  // TODO: Define response type
+  final Map<String, dynamic> data;
+
+  ~wData(this.data);
+
+  factory ~wData.fromJson(Map<String, dynamic> json) {
+    return ~wData(json);
+  }
+}
+
+final ~wProvider = FutureProvider.autoDispose<~wData>((ref) async {
+  final response = await http.get(Uri.parse('~w'));
+
+  if (response.statusCode != 200) {
+    throw Exception('Failed to load data');
+  }
+
+  return ~wData.fromJson(jsonDecode(response.body));
+});
+
+// Usage in widget:
+// final asyncValue = ref.watch(~wProvider);
+// asyncValue.when(
+//   data: (data) => Text(data.toString()),
+//   loading: () => CircularProgressIndicator(),
+//   error: (e, st) => Text('Error: \\$e'),
+// );
+", [Name, ProviderName, ProviderName, ProviderName, ProviderName, Name, ProviderName, Endpoint, ProviderName, Name]).
+
+generate_flutter_mutation_notifier(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(method(Method), Config) -> true ; Method = 'POST' ),
+    to_pascal_case(Name, NotifierName),
+    format(string(Code),
+"// Flutter Mutation Notifier - ~w
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+enum MutationStatus { idle, loading, success, error }
+
+class ~wState {
+  final MutationStatus status;
+  final dynamic data;
+  final String? error;
+
+  const ~wState({
+    this.status = MutationStatus.idle,
+    this.data,
+    this.error,
+  });
+
+  ~wState copyWith({
+    MutationStatus? status,
+    dynamic data,
+    String? error,
+  }) {
+    return ~wState(
+      status: status ?? this.status,
+      data: data ?? this.data,
+      error: error ?? this.error,
+    );
+  }
+}
+
+class ~wNotifier extends StateNotifier<~wState> {
+  ~wNotifier() : super(const ~wState());
+
+  Future<void> mutate(Map<String, dynamic> variables) async {
+    state = state.copyWith(status: MutationStatus.loading);
+
+    try {
+      final response = await http.~w(
+        Uri.parse('~w'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(variables),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Mutation failed');
+      }
+
+      state = state.copyWith(
+        status: MutationStatus.success,
+        data: jsonDecode(response.body),
+      );
+    } catch (e) {
+      state = state.copyWith(
+        status: MutationStatus.error,
+        error: e.toString(),
+      );
+    }
+  }
+
+  void reset() {
+    state = const ~wState();
+  }
+}
+
+final ~wProvider = StateNotifierProvider<~wNotifier, ~wState>((ref) {
+  return ~wNotifier();
+});
+
+// Usage:
+// ref.read(~wProvider.notifier).mutate({'key': 'value'});
+", [Name, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, Method, Endpoint, NotifierName, Name, NotifierName, NotifierName, NotifierName, Name]).
+
+generate_flutter_paginated_provider(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(page_param(PageParam), Config) -> true ; PageParam = 'page' ),
+    to_pascal_case(Name, NotifierName),
+    format(string(Code),
+"// Flutter Paginated Provider - ~w
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class ~wState {
+  final List<dynamic> items;
+  final int currentPage;
+  final bool hasMore;
+  final bool isLoading;
+  final String? error;
+
+  const ~wState({
+    this.items = const [],
+    this.currentPage = 1,
+    this.hasMore = true,
+    this.isLoading = false,
+    this.error,
+  });
+
+  ~wState copyWith({
+    List<dynamic>? items,
+    int? currentPage,
+    bool? hasMore,
+    bool? isLoading,
+    String? error,
+  }) {
+    return ~wState(
+      items: items ?? this.items,
+      currentPage: currentPage ?? this.currentPage,
+      hasMore: hasMore ?? this.hasMore,
+      isLoading: isLoading ?? this.isLoading,
+      error: error ?? this.error,
+    );
+  }
+}
+
+class ~wNotifier extends StateNotifier<~wState> {
+  ~wNotifier() : super(const ~wState());
+
+  Future<void> loadMore() async {
+    if (state.isLoading || !state.hasMore) return;
+
+    state = state.copyWith(isLoading: true);
+
+    try {
+      final response = await http.get(
+        Uri.parse('~w?~w=${state.currentPage}'),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Failed to load page');
+      }
+
+      final data = jsonDecode(response.body);
+      final newItems = data['data'] as List<dynamic>;
+      final hasMore = data['hasMore'] as bool? ?? false;
+
+      state = state.copyWith(
+        items: [...state.items, ...newItems],
+        currentPage: state.currentPage + 1,
+        hasMore: hasMore,
+        isLoading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  void refresh() {
+    state = const ~wState();
+    loadMore();
+  }
+}
+
+final ~wProvider = StateNotifierProvider<~wNotifier, ~wState>((ref) {
+  return ~wNotifier();
+});
+
+// Usage with ListView:
+// NotificationListener<ScrollNotification>(
+//   onNotification: (notification) {
+//     if (notification.metrics.pixels >= notification.metrics.maxScrollExtent - 200) {
+//       ref.read(~wProvider.notifier).loadMore();
+//     }
+//     return false;
+//   },
+//   child: ListView.builder(...),
+// )
+", [Name, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, NotifierName, Endpoint, PageParam, NotifierName, Name, NotifierName, NotifierName, NotifierName, Name]).
+
+% ============================================================================
+% PATTERN COMPILATION - Persistence
+% ============================================================================
+%
+% Flutter uses shared_preferences for simple key-value storage,
+% or Hive for more complex local storage needs.
+
+%% compile_persistence_pattern(+Type, +Config, +Target, +Options, -Code)
+compile_persistence_pattern(local, Config, flutter, _Options, Code) :-
+    generate_flutter_shared_prefs(Config, Code).
+compile_persistence_pattern(secure, Config, flutter, _Options, Code) :-
+    generate_flutter_secure_storage(Config, Code).
+
+generate_flutter_shared_prefs(Config, Code) :-
+    member(key(Key), Config),
+    to_pascal_case(Key, ClassName),
+    format(string(Code),
+"// Flutter SharedPreferences - ~w
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+
+class ~wStorage {
+  static const String _key = '~w';
+
+  static Future<Map<String, dynamic>?> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_key);
+    if (stored == null) return null;
+    return jsonDecode(stored) as Map<String, dynamic>;
+  }
+
+  static Future<void> save(Map<String, dynamic> data) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode(data));
+  }
+
+  static Future<void> remove() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}
+
+// Riverpod provider for reactive storage
+final ~wProvider = FutureProvider<Map<String, dynamic>?>((ref) async {
+  return ~wStorage.load();
+});
+
+// Usage:
+// final data = await ~wStorage.load();
+// await ~wStorage.save({'theme': 'dark'});
+", [Key, ClassName, Key, Key, ClassName, ClassName, ClassName]).
+
+generate_flutter_secure_storage(Config, Code) :-
+    member(key(Key), Config),
+    to_pascal_case(Key, ClassName),
+    format(string(Code),
+"// Flutter Secure Storage - ~w
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'dart:convert';
+
+class ~wSecureStorage {
+  static const String _key = '~w';
+  static const _storage = FlutterSecureStorage();
+
+  static Future<Map<String, dynamic>?> load() async {
+    final stored = await _storage.read(key: _key);
+    if (stored == null) return null;
+    return jsonDecode(stored) as Map<String, dynamic>;
+  }
+
+  static Future<void> save(Map<String, dynamic> data) async {
+    await _storage.write(key: _key, value: jsonEncode(data));
+  }
+
+  static Future<void> remove() async {
+    await _storage.delete(key: _key);
+  }
+}
+
+// Riverpod provider for reactive secure storage
+final ~wSecureProvider = FutureProvider<Map<String, dynamic>?>((ref) async {
+  return ~wSecureStorage.load();
+});
+
+// Usage:
+// final data = await ~wSecureStorage.load();
+// await ~wSecureStorage.save({'token': 'secret'});
+", [Key, ClassName, Key, Key, ClassName, ClassName, ClassName]).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_flutter_target :-
+    format('~n=== Flutter Target Tests ===~n~n'),
+
+    % Test 1: Navigation pattern
+    format('Test 1: Tab navigation generation...~n'),
+    (   compile_navigation_pattern(tab,
+            [screen(home, 'HomeScreen', [title('Home')]),
+             screen(profile, 'ProfileScreen', [title('Profile')])],
+            [], flutter, [], Code1),
+        sub_string(Code1, _, _, _, "BottomNavigationBar"),
+        sub_string(Code1, _, _, _, "StatefulWidget")
+    ->  format('  PASS: Tab scaffold generated~n')
+    ;   format('  FAIL: Tab navigation incorrect~n')
+    ),
+
+    % Test 2: State pattern
+    format('~nTest 2: Riverpod state generation...~n'),
+    (   compile_state_pattern(global,
+            [store(appStore), slices([slice(ui, [field(theme, "'light' | 'dark'")], [action(toggleTheme, _)])])],
+            [], flutter, [], Code2),
+        sub_string(Code2, _, _, _, "StateNotifier"),
+        sub_string(Code2, _, _, _, "StateNotifierProvider")
+    ->  format('  PASS: Riverpod provider generated~n')
+    ;   format('  FAIL: State pattern incorrect~n')
+    ),
+
+    % Test 3: Data pattern
+    format('~nTest 3: FutureProvider generation...~n'),
+    (   compile_data_pattern(query,
+            [name(fetchUsers), endpoint('/api/users')],
+            flutter, [], Code3),
+        sub_string(Code3, _, _, _, "FutureProvider"),
+        sub_string(Code3, _, _, _, "http.get")
+    ->  format('  PASS: FutureProvider generated~n')
+    ;   format('  FAIL: Data pattern incorrect~n')
+    ),
+
+    % Test 4: Persistence pattern
+    format('~nTest 4: SharedPreferences generation...~n'),
+    (   compile_persistence_pattern(local,
+            [key(userPrefs)],
+            flutter, [], Code4),
+        sub_string(Code4, _, _, _, "SharedPreferences"),
+        sub_string(Code4, _, _, _, "jsonEncode")
+    ->  format('  PASS: SharedPreferences generated~n')
+    ;   format('  FAIL: Persistence pattern incorrect~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('Flutter target module loaded~n', [])
+), now).

--- a/src/unifyweaver/targets/swiftui_target.pl
+++ b/src/unifyweaver/targets/swiftui_target.pl
@@ -1,0 +1,872 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% swiftui_target.pl - SwiftUI Code Generation Target
+%
+% Generates SwiftUI views and Swift code from UI patterns. Supports:
+%   - Navigation (NavigationStack, TabView)
+%   - State management (@State, @StateObject, @EnvironmentObject)
+%   - Data fetching (async/await, URLSession)
+%   - Persistence (@AppStorage, UserDefaults)
+%
+% SwiftUI uses a declarative approach with property wrappers for state.
+% The View protocol defines the body property that returns the UI.
+%
+% Usage:
+%   ?- compile_navigation_pattern(tab, Screens, [], swiftui, [], Code).
+%   ?- compile_state_pattern(global, Shape, [], swiftui, [], Code).
+
+:- module(swiftui_target, [
+    % Target capabilities
+    target_capabilities/1,
+    swiftui_capabilities/1,
+
+    % Pattern compilation
+    compile_navigation_pattern/6,
+    compile_state_pattern/6,
+    compile_data_pattern/5,
+    compile_persistence_pattern/5,
+
+    % Testing
+    test_swiftui_target/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% TARGET CAPABILITIES
+% ============================================================================
+
+%% swiftui_capabilities(-Capabilities)
+%
+%  Lists what SwiftUI target can do.
+%
+swiftui_capabilities([
+    % Direct capabilities
+    supports(declarative_ui),
+    supports(property_wrappers),
+    supports(combine_framework),
+    supports(async_await),
+    supports(previews),
+    supports(accessibility),
+
+    % Libraries/Frameworks
+    library('SwiftUI'),
+    library('Combine'),
+    library('Foundation'),
+
+    % Limitations
+    limitation(ios_14_minimum),
+    limitation(no_uikit_direct),
+    limitation(limited_customization)
+]).
+
+target_capabilities(Caps) :- swiftui_capabilities(Caps).
+
+% ============================================================================
+% HELPER PREDICATES
+% ============================================================================
+
+option_value(Options, Key, Value, Default) :-
+    Opt =.. [Key, Value],
+    (   member(Opt, Options)
+    ->  true
+    ;   Value = Default
+    ).
+
+capitalize_first(Str, Cap) :-
+    (   atom(Str) -> atom_string(Str, S) ; S = Str ),
+    string_chars(S, [H|T]),
+    upcase_atom(H, HU),
+    atom_chars(HU, [HUC]),
+    string_chars(Cap, [HUC|T]).
+
+to_pascal_case(Name, Pascal) :-
+    atom_string(Name, Str),
+    split_string(Str, "_", "", Parts),
+    maplist(capitalize_first, Parts, CapParts),
+    atomics_to_string(CapParts, Pascal).
+
+% ============================================================================
+% PATTERN COMPILATION - Navigation
+% ============================================================================
+%
+% SwiftUI uses NavigationStack (iOS 16+) or NavigationView for navigation,
+% and TabView for tab-based navigation.
+
+%% compile_navigation_pattern(+Type, +Screens, +Config, +Target, +Options, -Code)
+compile_navigation_pattern(stack, Screens, _Config, swiftui, Options, Code) :-
+    option_value(Options, component_name, Name, 'AppNavigation'),
+    generate_swiftui_navigation_stack(Screens, Name, Code).
+compile_navigation_pattern(tab, Screens, _Config, swiftui, Options, Code) :-
+    option_value(Options, component_name, Name, 'MainTabView'),
+    generate_swiftui_tab_view(Screens, Name, Code).
+compile_navigation_pattern(drawer, Screens, _Config, swiftui, Options, Code) :-
+    option_value(Options, component_name, Name, 'SidebarNavigation'),
+    generate_swiftui_sidebar(Screens, Name, Code).
+
+generate_swiftui_navigation_stack(Screens, Name, Code) :-
+    generate_swiftui_navigation_links(Screens, NavLinks),
+    generate_swiftui_navigation_destinations(Screens, Destinations),
+    format(string(Code),
+"// ~w - SwiftUI Navigation Stack
+import SwiftUI
+
+enum AppRoute: Hashable {
+~w
+}
+
+struct ~w: View {
+    var body: some View {
+        NavigationStack {
+            List {
+~w
+            }
+            .navigationTitle(\"Navigation\")
+            .navigationDestination(for: AppRoute.self) { route in
+                switch route {
+~w
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ~w()
+}
+", [Name, Destinations, Name, NavLinks, Destinations, Name]).
+
+generate_swiftui_navigation_links(Screens, Links) :-
+    findall(Link, (
+        member(screen(ScreenName, _, Opts), Screens),
+        (   member(title(Title), Opts) -> true ; atom_string(ScreenName, Title) ),
+        atom_string(ScreenName, NameStr),
+        format(string(Link),
+"                NavigationLink(value: AppRoute.~w) {
+                    Text(\"~w\")
+                }", [NameStr, Title])
+    ), LinkList),
+    atomic_list_concat(LinkList, '\n', Links).
+
+generate_swiftui_navigation_destinations(Screens, Destinations) :-
+    findall(Switch, (
+        member(screen(ScreenName, Component, _), Screens),
+        atom_string(ScreenName, NameStr),
+        to_pascal_case(Component, ViewName),
+        format(string(Switch),
+"                case .~w:
+                    ~w()", [NameStr, ViewName])
+    ), SwitchList),
+    atomic_list_concat(SwitchList, '\n', Destinations).
+
+generate_swiftui_tab_view(Screens, Name, Code) :-
+    generate_swiftui_tab_items(Screens, TabItems),
+    format(string(Code),
+"// ~w - SwiftUI Tab View
+import SwiftUI
+
+struct ~w: View {
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+~w
+        }
+    }
+}
+
+#Preview {
+    ~w()
+}
+", [Name, Name, TabItems, Name]).
+
+generate_swiftui_tab_items(Screens, Items) :-
+    findall(TabItem, (
+        nth0(Index, Screens, screen(ScreenName, Component, Opts)),
+        (   member(title(Title), Opts) -> true ; atom_string(ScreenName, Title) ),
+        (   member(icon(Icon), Opts) -> true ; Icon = 'circle' ),
+        to_pascal_case(Component, ViewName),
+        format(string(TabItem),
+"            ~w()
+                .tabItem {
+                    Label(\"~w\", systemImage: \"~w\")
+                }
+                .tag(~w)", [ViewName, Title, Icon, Index])
+    ), TabItemList),
+    atomic_list_concat(TabItemList, '\n', Items).
+
+generate_swiftui_sidebar(Screens, Name, Code) :-
+    Screens = [screen(FirstScreen, _, _)|_],
+    atom_string(FirstScreen, FirstItem),
+    generate_swiftui_sidebar_items(Screens, SidebarItems),
+    generate_swiftui_sidebar_detail(Screens, DetailView),
+    generate_swiftui_icon_cases(Screens, IconCases),
+    format(string(Code),
+"// ~w - SwiftUI Sidebar Navigation
+import SwiftUI
+
+enum SidebarItem: String, CaseIterable, Identifiable {
+~w
+
+    var id: String { rawValue }
+}
+
+struct ~w: View {
+    @State private var selectedItem: SidebarItem? = .~w
+
+    var body: some View {
+        NavigationSplitView {
+            List(SidebarItem.allCases, selection: $selectedItem) { item in
+                NavigationLink(value: item) {
+                    Label(item.rawValue.capitalized, systemImage: iconFor(item))
+                }
+            }
+            .navigationTitle(\"Menu\")
+        } detail: {
+            if let item = selectedItem {
+~w
+            } else {
+                Text(\"Select an item\")
+            }
+        }
+    }
+
+    private func iconFor(_ item: SidebarItem) -> String {
+        switch item {
+~w
+        }
+    }
+}
+
+#Preview {
+    ~w()
+}
+", [Name, SidebarItems, Name, FirstItem, DetailView, IconCases, Name]).
+
+generate_swiftui_sidebar_items(Screens, Items) :-
+    findall(Item, (
+        member(screen(ScreenName, _, _), Screens),
+        atom_string(ScreenName, NameStr),
+        format(string(Item), "    case ~w", [NameStr])
+    ), ItemList),
+    atomic_list_concat(ItemList, '\n', Items).
+
+generate_swiftui_sidebar_detail(Screens, DetailView) :-
+    findall(Case, (
+        member(screen(ScreenName, Component, _), Screens),
+        atom_string(ScreenName, NameStr),
+        to_pascal_case(Component, ViewName),
+        format(string(Case),
+"                switch item {
+                case .~w:
+                    ~w()
+                }", [NameStr, ViewName])
+    ), _CaseList),
+    % Simplified for now - just switch on item
+    format(string(DetailView),
+"                switch item {
+                default:
+                    Text(item.rawValue.capitalized)
+                }", []).
+
+generate_swiftui_icon_cases(Screens, Cases) :-
+    findall(Case, (
+        member(screen(ScreenName, _, Opts), Screens),
+        atom_string(ScreenName, NameStr),
+        (   member(icon(Icon), Opts) -> true ; Icon = 'circle' ),
+        format(string(Case), "        case .~w: return \"~w\"", [NameStr, Icon])
+    ), CaseList),
+    atomic_list_concat(CaseList, '\n', Cases).
+
+% ============================================================================
+% PATTERN COMPILATION - State
+% ============================================================================
+%
+% SwiftUI state management uses property wrappers:
+% - @State for local view state
+% - @StateObject for owning ObservableObject instances
+% - @ObservedObject for passed-in ObservableObject references
+% - @EnvironmentObject for dependency injection
+
+%% compile_state_pattern(+Type, +Shape, +Config, +Target, +Options, -Code)
+compile_state_pattern(local, Shape, _Config, swiftui, _Options, Code) :-
+    generate_swiftui_local_state(Shape, Code).
+compile_state_pattern(global, Shape, _Config, swiftui, _Options, Code) :-
+    generate_swiftui_observable_object(Shape, Code).
+compile_state_pattern(derived, Shape, _Config, swiftui, _Options, Code) :-
+    generate_swiftui_computed_property(Shape, Code).
+
+generate_swiftui_local_state(Shape, Code) :-
+    findall(StateDef, (
+        member(field(Name, Initial), Shape),
+        swift_type_and_default(Initial, SwiftType, Default),
+        format(string(StateDef), "    @State private var ~w: ~w = ~w", [Name, SwiftType, Default])
+    ), StateDefs),
+    atomic_list_concat(StateDefs, '\n', StatesCode),
+    format(string(Code),
+"// SwiftUI Local State
+import SwiftUI
+
+struct MyView: View {
+    // State properties
+~w
+
+    var body: some View {
+        VStack {
+            // Use state properties here
+        }
+    }
+}
+", [StatesCode]).
+
+swift_type_and_default("'light' | 'dark'", "String", "\"light\"").
+swift_type_and_default("boolean", "Bool", "false").
+swift_type_and_default("string | null", "String?", "nil").
+swift_type_and_default("number", "Int", "0").
+swift_type_and_default(Val, "String", Quoted) :-
+    atom(Val),
+    format(string(Quoted), "\"~w\"", [Val]).
+swift_type_and_default(_, "Any", "nil").
+
+generate_swiftui_observable_object(Shape, Code) :-
+    member(store(StoreName), Shape),
+    member(slices(Slices), Shape),
+    to_pascal_case(StoreName, ClassName),
+    generate_swift_published_properties(Slices, Properties),
+    generate_swift_methods(Slices, Methods),
+    format(string(Code),
+"// SwiftUI ObservableObject - ~w
+import SwiftUI
+import Combine
+
+@MainActor
+class ~w: ObservableObject {
+    // Published properties
+~w
+
+    // Singleton instance (optional)
+    static let shared = ~w()
+
+    private init() {}
+
+    // Methods
+~w
+}
+
+// Usage in View:
+// @StateObject private var store = ~w.shared
+// or
+// @EnvironmentObject var store: ~w
+
+// In App:
+// ContentView()
+//     .environmentObject(~w.shared)
+", [StoreName, ClassName, Properties, ClassName, Methods, ClassName, ClassName, ClassName]).
+
+generate_swift_published_properties(Slices, Properties) :-
+    findall(PropDef, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, FType), Fields),
+        swift_type_and_default(FType, SwiftType, Default),
+        format(string(PropDef), "    @Published var ~w: ~w = ~w", [FName, SwiftType, Default])
+    ), PropDefs),
+    atomic_list_concat(PropDefs, '\n', Properties).
+
+generate_swift_methods(Slices, Methods) :-
+    findall(MethodDef, (
+        member(slice(_, _, Actions), Slices),
+        member(action(AName, _), Actions),
+        generate_swift_method(AName, MethodDef)
+    ), MethodDefs),
+    (   MethodDefs = []
+    ->  Methods = "    // Add methods here"
+    ;   atomic_list_concat(MethodDefs, '\n\n', Methods)
+    ).
+
+generate_swift_method(toggleTheme, Code) :-
+    format(string(Code),
+"    func toggleTheme() {
+        theme = theme == \"light\" ? \"dark\" : \"light\"
+    }", []).
+generate_swift_method(toggleSidebar, Code) :-
+    format(string(Code),
+"    func toggleSidebar() {
+        sidebarOpen.toggle()
+    }", []).
+generate_swift_method(Name, Code) :-
+    \+ member(Name, [toggleTheme, toggleSidebar]),
+    format(string(Code),
+"    func ~w(_ value: Any) {
+        // TODO: Implement ~w
+    }", [Name, Name]).
+
+generate_swiftui_computed_property(Shape, Code) :-
+    member(deps(Deps), Shape),
+    member(derive(Derivation), Shape),
+    atomic_list_concat(Deps, ', ', DepsStr),
+    format(string(Code),
+"// SwiftUI Computed Property
+import SwiftUI
+
+// In a View or ObservableObject:
+// Assumes properties exist for: ~w
+
+var derivedValue: some View {
+    // Computed based on dependencies
+    // return ~w
+}
+
+// Or as a computed property in ObservableObject:
+// var derivedValue: SomeType {
+//     // Combine dependencies
+// }
+", [DepsStr, Derivation]).
+
+% ============================================================================
+% PATTERN COMPILATION - Data Fetching
+% ============================================================================
+%
+% SwiftUI uses async/await with URLSession for data fetching.
+% State is managed with @State for loading/error states.
+
+%% compile_data_pattern(+Type, +Config, +Target, +Options, -Code)
+compile_data_pattern(query, Config, swiftui, _Options, Code) :-
+    generate_swiftui_async_fetch(Config, Code).
+compile_data_pattern(mutation, Config, swiftui, _Options, Code) :-
+    generate_swiftui_mutation(Config, Code).
+compile_data_pattern(infinite, Config, swiftui, _Options, Code) :-
+    generate_swiftui_paginated_fetch(Config, Code).
+
+generate_swiftui_async_fetch(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    to_pascal_case(Name, ClassName),
+    format(string(Code),
+"// SwiftUI Async Data Fetch - ~w
+import SwiftUI
+
+// Response model
+struct ~wResponse: Codable {
+    // TODO: Define response properties
+    let data: [String: AnyCodable]?
+}
+
+// View Model
+@MainActor
+class ~wViewModel: ObservableObject {
+    @Published var data: ~wResponse?
+    @Published var isLoading = false
+    @Published var error: Error?
+
+    func fetch() async {
+        isLoading = true
+        error = nil
+
+        do {
+            guard let url = URL(string: \"~w\") else {
+                throw URLError(.badURL)
+            }
+
+            let (data, response) = try await URLSession.shared.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                throw URLError(.badServerResponse)
+            }
+
+            self.data = try JSONDecoder().decode(~wResponse.self, from: data)
+        } catch {
+            self.error = error
+        }
+
+        isLoading = false
+    }
+}
+
+// Usage in View:
+struct ~wView: View {
+    @StateObject private var viewModel = ~wViewModel()
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let error = viewModel.error {
+                Text(\"Error: \\(error.localizedDescription)\")
+            } else if let data = viewModel.data {
+                Text(\"Data loaded\")
+            } else {
+                Text(\"No data\")
+            }
+        }
+        .task {
+            await viewModel.fetch()
+        }
+    }
+}
+", [Name, ClassName, ClassName, ClassName, Endpoint, ClassName, ClassName, ClassName]).
+
+generate_swiftui_mutation(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(method(Method), Config) -> true ; Method = 'POST' ),
+    to_pascal_case(Name, ClassName),
+    string_upper(Method, MethodUpper),
+    format(string(Code),
+"// SwiftUI Mutation - ~w
+import SwiftUI
+
+// Request/Response models
+struct ~wRequest: Codable {
+    // TODO: Define request properties
+}
+
+struct ~wResponse: Codable {
+    // TODO: Define response properties
+    let success: Bool
+}
+
+// View Model
+@MainActor
+class ~wViewModel: ObservableObject {
+    @Published var isLoading = false
+    @Published var result: ~wResponse?
+    @Published var error: Error?
+
+    func mutate(_ input: ~wRequest) async {
+        isLoading = true
+        error = nil
+
+        do {
+            guard let url = URL(string: \"~w\") else {
+                throw URLError(.badURL)
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = \"~w\"
+            request.setValue(\"application/json\", forHTTPHeaderField: \"Content-Type\")
+            request.httpBody = try JSONEncoder().encode(input)
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                throw URLError(.badServerResponse)
+            }
+
+            self.result = try JSONDecoder().decode(~wResponse.self, from: data)
+        } catch {
+            self.error = error
+        }
+
+        isLoading = false
+    }
+
+    func reset() {
+        result = nil
+        error = nil
+    }
+}
+
+// Usage:
+// @StateObject private var viewModel = ~wViewModel()
+// Button(\"Submit\") {
+//     Task { await viewModel.mutate(input) }
+// }
+", [Name, ClassName, ClassName, ClassName, ClassName, ClassName, Endpoint, MethodUpper, ClassName, ClassName]).
+
+generate_swiftui_paginated_fetch(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(page_param(PageParam), Config) -> true ; PageParam = 'page' ),
+    to_pascal_case(Name, ClassName),
+    format(string(Code),
+"// SwiftUI Paginated Fetch - ~w
+import SwiftUI
+
+// Page response model
+struct ~wPage: Codable {
+    let data: [~wItem]
+    let hasMore: Bool
+    let nextPage: Int?
+}
+
+struct ~wItem: Codable, Identifiable {
+    let id: String
+    // TODO: Add item properties
+}
+
+// View Model
+@MainActor
+class ~wViewModel: ObservableObject {
+    @Published var items: [~wItem] = []
+    @Published var isLoading = false
+    @Published var hasMore = true
+    @Published var error: Error?
+
+    private var currentPage = 1
+
+    func loadMore() async {
+        guard !isLoading, hasMore else { return }
+
+        isLoading = true
+        error = nil
+
+        do {
+            guard let url = URL(string: \"~w?~w=\\(currentPage)\") else {
+                throw URLError(.badURL)
+            }
+
+            let (data, response) = try await URLSession.shared.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                throw URLError(.badServerResponse)
+            }
+
+            let page = try JSONDecoder().decode(~wPage.self, from: data)
+
+            items.append(contentsOf: page.data)
+            hasMore = page.hasMore
+            currentPage += 1
+        } catch {
+            self.error = error
+        }
+
+        isLoading = false
+    }
+
+    func refresh() async {
+        items = []
+        currentPage = 1
+        hasMore = true
+        await loadMore()
+    }
+}
+
+// Usage with List:
+struct ~wListView: View {
+    @StateObject private var viewModel = ~wViewModel()
+
+    var body: some View {
+        List {
+            ForEach(viewModel.items) { item in
+                Text(item.id)
+            }
+
+            if viewModel.hasMore {
+                ProgressView()
+                    .onAppear {
+                        Task { await viewModel.loadMore() }
+                    }
+            }
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+        .task {
+            await viewModel.loadMore()
+        }
+    }
+}
+", [Name, ClassName, ClassName, ClassName, ClassName, ClassName, Endpoint, PageParam, ClassName, ClassName, ClassName]).
+
+% ============================================================================
+% PATTERN COMPILATION - Persistence
+% ============================================================================
+%
+% SwiftUI uses @AppStorage for simple UserDefaults binding,
+% or custom persistence for complex data.
+
+%% compile_persistence_pattern(+Type, +Config, +Target, +Options, -Code)
+compile_persistence_pattern(local, Config, swiftui, _Options, Code) :-
+    generate_swiftui_app_storage(Config, Code).
+compile_persistence_pattern(secure, Config, swiftui, _Options, Code) :-
+    generate_swiftui_keychain(Config, Code).
+
+generate_swiftui_app_storage(Config, Code) :-
+    member(key(Key), Config),
+    to_pascal_case(Key, ClassName),
+    format(string(Code),
+"// SwiftUI AppStorage - ~w
+import SwiftUI
+
+// For simple values, use @AppStorage directly in views:
+struct SettingsView: View {
+    @AppStorage(\"~w\") private var storedValue: String = \"\"
+
+    var body: some View {
+        TextField(\"Value\", text: $storedValue)
+    }
+}
+
+// For complex objects, use a manager:
+@MainActor
+class ~wStorage: ObservableObject {
+    private let key = \"~w\"
+
+    @Published var data: [String: Any]? {
+        didSet {
+            save()
+        }
+    }
+
+    init() {
+        load()
+    }
+
+    private func load() {
+        if let stored = UserDefaults.standard.dictionary(forKey: key) {
+            data = stored
+        }
+    }
+
+    private func save() {
+        if let data = data {
+            UserDefaults.standard.set(data, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    func remove() {
+        data = nil
+    }
+}
+
+// Usage:
+// @StateObject private var storage = ~wStorage()
+", [Key, Key, ClassName, Key, ClassName]).
+
+generate_swiftui_keychain(Config, Code) :-
+    member(key(Key), Config),
+    to_pascal_case(Key, ClassName),
+    format(string(Code),
+"// SwiftUI Keychain Storage - ~w
+import SwiftUI
+import Security
+
+@MainActor
+class ~wSecureStorage: ObservableObject {
+    private let key = \"~w\"
+
+    @Published var data: Data?
+
+    init() {
+        load()
+    }
+
+    private func load() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status == errSecSuccess {
+            data = result as? Data
+        }
+    }
+
+    func save(_ value: Data) {
+        // Delete existing
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        // Add new
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: value
+        ]
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status == errSecSuccess {
+            data = value
+        }
+    }
+
+    func remove() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(query as CFDictionary)
+        data = nil
+    }
+}
+
+// Usage:
+// @StateObject private var secureStorage = ~wSecureStorage()
+// secureStorage.save(\"secret\".data(using: .utf8)!)
+", [Key, ClassName, Key, ClassName]).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_swiftui_target :-
+    format('~n=== SwiftUI Target Tests ===~n~n'),
+
+    % Test 1: Navigation pattern
+    format('Test 1: Tab navigation generation...~n'),
+    (   compile_navigation_pattern(tab,
+            [screen(home, 'HomeView', [title('Home'), icon('house')]),
+             screen(profile, 'ProfileView', [title('Profile'), icon('person')])],
+            [], swiftui, [], Code1),
+        sub_string(Code1, _, _, _, "TabView"),
+        sub_string(Code1, _, _, _, "@State")
+    ->  format('  PASS: TabView generated~n')
+    ;   format('  FAIL: Tab navigation incorrect~n')
+    ),
+
+    % Test 2: State pattern
+    format('~nTest 2: ObservableObject generation...~n'),
+    (   compile_state_pattern(global,
+            [store(appStore), slices([slice(ui, [field(theme, "'light' | 'dark'")], [action(toggleTheme, _)])])],
+            [], swiftui, [], Code2),
+        sub_string(Code2, _, _, _, "ObservableObject"),
+        sub_string(Code2, _, _, _, "@Published")
+    ->  format('  PASS: ObservableObject generated~n')
+    ;   format('  FAIL: State pattern incorrect~n')
+    ),
+
+    % Test 3: Data pattern
+    format('~nTest 3: Async fetch generation...~n'),
+    (   compile_data_pattern(query,
+            [name(fetchUsers), endpoint('/api/users')],
+            swiftui, [], Code3),
+        sub_string(Code3, _, _, _, "URLSession"),
+        sub_string(Code3, _, _, _, "async")
+    ->  format('  PASS: Async fetch generated~n')
+    ;   format('  FAIL: Data pattern incorrect~n')
+    ),
+
+    % Test 4: Persistence pattern
+    format('~nTest 4: AppStorage generation...~n'),
+    (   compile_persistence_pattern(local,
+            [key(userPrefs)],
+            swiftui, [], Code4),
+        sub_string(Code4, _, _, _, "@AppStorage"),
+        sub_string(Code4, _, _, _, "UserDefaults")
+    ->  format('  PASS: AppStorage generated~n')
+    ;   format('  FAIL: Persistence pattern incorrect~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('SwiftUI target module loaded~n', [])
+), now).

--- a/src/unifyweaver/targets/target_interface.pl
+++ b/src/unifyweaver/targets/target_interface.pl
@@ -1,0 +1,214 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% target_interface.pl - Common Interface for All Code Generation Targets
+%
+% Defines the contract that each target (React Native, Vue, Flutter, SwiftUI)
+% must implement to compile UI patterns. This enables framework-agnostic
+% pattern definitions that compile to multiple targets.
+%
+% Each target must implement:
+%   1. compile_navigation_pattern/6 - Stack, Tab, Drawer navigation
+%   2. compile_state_pattern/6      - Local, Global, Derived state
+%   3. compile_data_pattern/5       - Query, Mutation, Infinite
+%   4. compile_persistence_pattern/5 - Local, Secure storage
+%   5. target_capabilities/2        - What the target supports
+%
+% Pattern types are defined in ui_patterns.pl and are target-agnostic.
+
+:- module(target_interface, [
+    % Target registration
+    register_target/2,              % +TargetName, +Module
+    registered_target/2,            % ?TargetName, ?Module
+
+    % Capability checking
+    target_supports/2,              % +Target, +Capability
+    target_library/2,               % +Target, +Library
+    target_limitation/2,            % +Target, +Limitation
+
+    % Framework mappings - common concepts across frameworks
+    state_hook_equivalent/2,        % +Target, -Equivalent
+    query_hook_equivalent/2,        % +Target, -Equivalent
+    navigation_equivalent/2,        % +Target, -Equivalent
+    persistence_equivalent/2,       % +Target, -Equivalent
+
+    % Testing
+    test_target_interface/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% DYNAMIC STORAGE
+% ============================================================================
+
+:- dynamic registered_target_/2.    % registered_target_(Name, Module)
+
+% ============================================================================
+% TARGET REGISTRATION
+% ============================================================================
+
+%% register_target(+TargetName, +Module)
+%
+%  Register a target module for compilation.
+%
+register_target(Name, Module) :-
+    atom(Name),
+    atom(Module),
+    (   registered_target_(Name, _)
+    ->  retract(registered_target_(Name, _))
+    ;   true
+    ),
+    assertz(registered_target_(Name, Module)).
+
+%% registered_target(?Name, ?Module)
+%
+%  Query registered targets.
+%
+registered_target(Name, Module) :-
+    registered_target_(Name, Module).
+
+% ============================================================================
+% FRAMEWORK EQUIVALENCE MAPPINGS
+% ============================================================================
+%
+% These mappings document how common UI patterns translate across frameworks.
+% Each target implements these differently, but the concepts are equivalent.
+
+%% state_hook_equivalent(+Target, -Equivalent)
+%
+%  What each framework uses for local component state.
+%
+state_hook_equivalent(react_native, 'useState').
+state_hook_equivalent(vue, 'ref/reactive').
+state_hook_equivalent(flutter, 'StatefulWidget/setState').
+state_hook_equivalent(swiftui, '@State').
+
+%% query_hook_equivalent(+Target, -Equivalent)
+%
+%  What each framework uses for data fetching with caching.
+%
+query_hook_equivalent(react_native, '@tanstack/react-query').
+query_hook_equivalent(vue, '@tanstack/vue-query').
+query_hook_equivalent(flutter, 'FutureBuilder/riverpod').
+query_hook_equivalent(swiftui, 'async/await + @State').
+
+%% navigation_equivalent(+Target, -Equivalent)
+%
+%  What each framework uses for navigation.
+%
+navigation_equivalent(react_native, '@react-navigation').
+navigation_equivalent(vue, 'vue-router').
+navigation_equivalent(flutter, 'Navigator/GoRouter').
+navigation_equivalent(swiftui, 'NavigationStack').
+
+%% persistence_equivalent(+Target, -Equivalent)
+%
+%  What each framework uses for local persistence.
+%
+persistence_equivalent(react_native, '@react-native-async-storage').
+persistence_equivalent(vue, 'localStorage/pinia-persist').
+persistence_equivalent(flutter, 'shared_preferences/hive').
+persistence_equivalent(swiftui, 'UserDefaults/@AppStorage').
+
+% ============================================================================
+% CAPABILITY CHECKING
+% ============================================================================
+
+%% target_supports(+Target, +Capability)
+%
+%  Check if a target supports a capability.
+%
+target_supports(Target, Capability) :-
+    registered_target(Target, Module),
+    Goal =.. [target_capabilities, Caps],
+    call(Module:Goal),
+    member(supports(Capability), Caps).
+
+%% target_library(+Target, +Library)
+%
+%  Get libraries used by a target.
+%
+target_library(Target, Library) :-
+    registered_target(Target, Module),
+    Goal =.. [target_capabilities, Caps],
+    call(Module:Goal),
+    member(library(Library), Caps).
+
+%% target_limitation(+Target, +Limitation)
+%
+%  Get limitations of a target.
+%
+target_limitation(Target, Limitation) :-
+    registered_target(Target, Module),
+    Goal =.. [target_capabilities, Caps],
+    call(Module:Goal),
+    member(limitation(Limitation), Caps).
+
+% ============================================================================
+% REQUIRED PREDICATES DOCUMENTATION
+% ============================================================================
+%
+% Each target module MUST export these predicates:
+%
+% target_capabilities(-Capabilities)
+%   Returns list of: supports(X), library(X), limitation(X), glue_required(X)
+%
+% compile_navigation_pattern(+Type, +Screens, +Config, +Target, +Options, -Code)
+%   Type: stack | tab | drawer
+%   Screens: [screen(Name, Component, Opts), ...]
+%   Generates: Navigation component/widget for the target framework
+%
+% compile_state_pattern(+Type, +Shape, +Config, +Target, +Options, -Code)
+%   Type: local | global | derived
+%   Shape: Pattern-specific state shape
+%   Generates: State management code for the target framework
+%
+% compile_data_pattern(+Type, +Config, +Target, +Options, -Code)
+%   Type: query | mutation | infinite
+%   Config: [name(N), endpoint(E), ...]
+%   Generates: Data fetching hooks/widgets for the target framework
+%
+% compile_persistence_pattern(+Type, +Config, +Target, +Options, -Code)
+%   Type: local | secure
+%   Config: [key(K), schema(S), ...]
+%   Generates: Persistence hooks/widgets for the target framework
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_target_interface :-
+    format('~n=== Target Interface Tests ===~n~n'),
+
+    % Test 1: Framework equivalence mappings
+    format('Test 1: Framework equivalence mappings...~n'),
+    (   state_hook_equivalent(react_native, RNState),
+        state_hook_equivalent(vue, VueState),
+        state_hook_equivalent(flutter, FlutterState),
+        state_hook_equivalent(swiftui, SwiftState),
+        RNState \= VueState,
+        FlutterState \= SwiftState
+    ->  format('  PASS: All frameworks have state equivalents~n')
+    ;   format('  FAIL: Missing state equivalents~n')
+    ),
+
+    % Test 2: Query equivalence mappings
+    format('~nTest 2: Query equivalence mappings...~n'),
+    (   query_hook_equivalent(react_native, _),
+        query_hook_equivalent(vue, _),
+        query_hook_equivalent(flutter, _),
+        query_hook_equivalent(swiftui, _)
+    ->  format('  PASS: All frameworks have query equivalents~n')
+    ;   format('  FAIL: Missing query equivalents~n')
+    ),
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('Target interface module loaded~n', [])
+), now).

--- a/src/unifyweaver/targets/test_multi_target.pl
+++ b/src/unifyweaver/targets/test_multi_target.pl
@@ -1,0 +1,317 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% test_multi_target.pl - Multi-Framework Compilation Tests
+%
+% Tests that the same UI patterns compile correctly to all supported targets:
+%   - React Native
+%   - Vue
+%   - Flutter
+%   - SwiftUI
+%
+% Run with: swipl -g "run_tests" -t halt test_multi_target.pl
+
+:- module(test_multi_target, []).
+
+:- use_module(library(plunit)).
+
+% Load all targets (use except to avoid import conflicts)
+:- use_module('../patterns/ui_patterns').
+:- use_module('vue_target', []).
+:- use_module('flutter_target', []).
+:- use_module('swiftui_target', []).
+
+% ============================================================================
+% Test Data - Shared Patterns
+% ============================================================================
+
+test_screens([
+    screen(home, 'HomeScreen', [title('Home')]),
+    screen(search, 'SearchScreen', [title('Search')]),
+    screen(profile, 'ProfileScreen', [title('Profile')])
+]).
+
+test_global_state([
+    store(appStore),
+    slices([
+        slice(ui, [
+            field(theme, "'light' | 'dark'"),
+            field(sidebarOpen, "boolean")
+        ], [
+            action(toggleTheme, _),
+            action(toggleSidebar, _)
+        ])
+    ])
+]).
+
+test_query_config([
+    name(fetchUsers),
+    endpoint('/api/users'),
+    stale_time(60000)
+]).
+
+test_mutation_config([
+    name(createUser),
+    endpoint('/api/users'),
+    method('POST')
+]).
+
+test_persistence_config([
+    key(userPrefs),
+    schema('{ theme: string }')
+]).
+
+% ============================================================================
+% Tests: Navigation Patterns
+% ============================================================================
+
+:- begin_tests(navigation_multi_target).
+
+test(react_native_tab_nav) :-
+    test_screens(Screens),
+    ui_patterns:compile_navigation_pattern(tab, Screens, [], react_native, [], Code),
+    sub_string(Code, _, _, _, "createBottomTabNavigator"),
+    sub_string(Code, _, _, _, "Tab.Screen").
+
+test(vue_tab_nav) :-
+    test_screens(Screens),
+    vue_target:compile_navigation_pattern(tab, Screens, [], vue, [], Code),
+    sub_string(Code, _, _, _, "router-link"),
+    sub_string(Code, _, _, _, "tab-bar").
+
+test(flutter_tab_nav) :-
+    test_screens(Screens),
+    flutter_target:compile_navigation_pattern(tab, Screens, [], flutter, [], Code),
+    sub_string(Code, _, _, _, "BottomNavigationBar"),
+    sub_string(Code, _, _, _, "StatefulWidget").
+
+test(swiftui_tab_nav) :-
+    test_screens(Screens),
+    swiftui_target:compile_navigation_pattern(tab, Screens, [], swiftui, [], Code),
+    sub_string(Code, _, _, _, "TabView"),
+    sub_string(Code, _, _, _, "tabItem").
+
+test(react_native_stack_nav) :-
+    test_screens(Screens),
+    ui_patterns:compile_navigation_pattern(stack, Screens, [], react_native, [], Code),
+    sub_string(Code, _, _, _, "createStackNavigator"),
+    sub_string(Code, _, _, _, "Stack.Navigator").
+
+test(vue_stack_nav) :-
+    test_screens(Screens),
+    vue_target:compile_navigation_pattern(stack, Screens, [], vue, [], Code),
+    sub_string(Code, _, _, _, "createRouter"),
+    sub_string(Code, _, _, _, "RouteRecordRaw").
+
+test(flutter_stack_nav) :-
+    test_screens(Screens),
+    flutter_target:compile_navigation_pattern(stack, Screens, [], flutter, [], Code),
+    sub_string(Code, _, _, _, "GoRouter"),
+    sub_string(Code, _, _, _, "GoRoute").
+
+test(swiftui_stack_nav) :-
+    test_screens(Screens),
+    swiftui_target:compile_navigation_pattern(stack, Screens, [], swiftui, [], Code),
+    sub_string(Code, _, _, _, "NavigationStack"),
+    sub_string(Code, _, _, _, "navigationDestination").
+
+:- end_tests(navigation_multi_target).
+
+% ============================================================================
+% Tests: State Patterns
+% ============================================================================
+
+:- begin_tests(state_multi_target).
+
+test(react_native_global_state) :-
+    test_global_state(Shape),
+    ui_patterns:compile_state_pattern(global, Shape, [], react_native, [], Code),
+    sub_string(Code, _, _, _, "zustand"),
+    sub_string(Code, _, _, _, "create").
+
+test(vue_global_state) :-
+    test_global_state(Shape),
+    vue_target:compile_state_pattern(global, Shape, [], vue, [], Code),
+    sub_string(Code, _, _, _, "defineStore"),
+    sub_string(Code, _, _, _, "pinia").
+
+test(flutter_global_state) :-
+    test_global_state(Shape),
+    flutter_target:compile_state_pattern(global, Shape, [], flutter, [], Code),
+    sub_string(Code, _, _, _, "StateNotifier"),
+    sub_string(Code, _, _, _, "StateNotifierProvider").
+
+test(swiftui_global_state) :-
+    test_global_state(Shape),
+    swiftui_target:compile_state_pattern(global, Shape, [], swiftui, [], Code),
+    sub_string(Code, _, _, _, "ObservableObject"),
+    sub_string(Code, _, _, _, "@Published").
+
+test(react_native_local_state) :-
+    ui_patterns:compile_state_pattern(local, [field(count, 0)], [], react_native, [], Code),
+    sub_string(Code, _, _, _, "useState").
+
+test(vue_local_state) :-
+    vue_target:compile_state_pattern(local, [field(count, 0)], [], vue, [], Code),
+    sub_string(Code, _, _, _, "ref").
+
+test(flutter_local_state) :-
+    flutter_target:compile_state_pattern(local, [field(count, 0)], [], flutter, [], Code),
+    sub_string(Code, _, _, _, "StatefulWidget"),
+    sub_string(Code, _, _, _, "setState").
+
+test(swiftui_local_state) :-
+    swiftui_target:compile_state_pattern(local, [field(count, 0)], [], swiftui, [], Code),
+    sub_string(Code, _, _, _, "@State").
+
+:- end_tests(state_multi_target).
+
+% ============================================================================
+% Tests: Data Patterns
+% ============================================================================
+
+:- begin_tests(data_multi_target).
+
+test(react_native_query) :-
+    test_query_config(Config),
+    ui_patterns:compile_data_pattern(query, Config, react_native, [], Code),
+    sub_string(Code, _, _, _, "useQuery"),
+    sub_string(Code, _, _, _, "@tanstack/react-query").
+
+test(vue_query) :-
+    test_query_config(Config),
+    vue_target:compile_data_pattern(query, Config, vue, [], Code),
+    sub_string(Code, _, _, _, "useQuery"),
+    sub_string(Code, _, _, _, "@tanstack/vue-query").
+
+test(flutter_query) :-
+    test_query_config(Config),
+    flutter_target:compile_data_pattern(query, Config, flutter, [], Code),
+    sub_string(Code, _, _, _, "FutureProvider"),
+    sub_string(Code, _, _, _, "http.get").
+
+test(swiftui_query) :-
+    test_query_config(Config),
+    swiftui_target:compile_data_pattern(query, Config, swiftui, [], Code),
+    sub_string(Code, _, _, _, "URLSession"),
+    sub_string(Code, _, _, _, "async").
+
+test(react_native_mutation) :-
+    test_mutation_config(Config),
+    ui_patterns:compile_data_pattern(mutation, Config, react_native, [], Code),
+    sub_string(Code, _, _, _, "useMutation").
+
+test(vue_mutation) :-
+    test_mutation_config(Config),
+    vue_target:compile_data_pattern(mutation, Config, vue, [], Code),
+    sub_string(Code, _, _, _, "useMutation").
+
+test(flutter_mutation) :-
+    test_mutation_config(Config),
+    flutter_target:compile_data_pattern(mutation, Config, flutter, [], Code),
+    sub_string(Code, _, _, _, "mutate"),
+    sub_string(Code, _, _, _, "StateNotifier").
+
+test(swiftui_mutation) :-
+    test_mutation_config(Config),
+    swiftui_target:compile_data_pattern(mutation, Config, swiftui, [], Code),
+    sub_string(Code, _, _, _, "httpMethod"),
+    sub_string(Code, _, _, _, "POST").
+
+:- end_tests(data_multi_target).
+
+% ============================================================================
+% Tests: Persistence Patterns
+% ============================================================================
+
+:- begin_tests(persistence_multi_target).
+
+test(react_native_persistence) :-
+    test_persistence_config(Config),
+    ui_patterns:compile_persistence_pattern(local, Config, react_native, [], Code),
+    sub_string(Code, _, _, _, "AsyncStorage").
+
+test(vue_persistence) :-
+    test_persistence_config(Config),
+    vue_target:compile_persistence_pattern(local, Config, vue, [], Code),
+    sub_string(Code, _, _, _, "localStorage").
+
+test(flutter_persistence) :-
+    test_persistence_config(Config),
+    flutter_target:compile_persistence_pattern(local, Config, flutter, [], Code),
+    sub_string(Code, _, _, _, "SharedPreferences").
+
+test(swiftui_persistence) :-
+    test_persistence_config(Config),
+    swiftui_target:compile_persistence_pattern(local, Config, swiftui, [], Code),
+    sub_string(Code, _, _, _, "UserDefaults").
+
+:- end_tests(persistence_multi_target).
+
+% ============================================================================
+% Tests: Target Capabilities
+% ============================================================================
+
+:- begin_tests(target_capabilities).
+
+test(vue_has_capabilities) :-
+    vue_target:target_capabilities(Caps),
+    member(supports(ui_components), Caps).
+
+test(flutter_has_capabilities) :-
+    flutter_target:target_capabilities(Caps),
+    member(supports(material_design), Caps).
+
+test(swiftui_has_capabilities) :-
+    swiftui_target:target_capabilities(Caps),
+    member(supports(declarative_ui), Caps).
+
+:- end_tests(target_capabilities).
+
+% ============================================================================
+% Tests: Cross-Framework Consistency
+% ============================================================================
+
+:- begin_tests(cross_framework_consistency).
+
+% Verify all targets generate non-empty code for the same pattern
+test(all_targets_generate_tab_nav) :-
+    test_screens(Screens),
+    ui_patterns:compile_navigation_pattern(tab, Screens, [], react_native, [], RN),
+    vue_target:compile_navigation_pattern(tab, Screens, [], vue, [], Vue),
+    flutter_target:compile_navigation_pattern(tab, Screens, [], flutter, [], Flutter),
+    swiftui_target:compile_navigation_pattern(tab, Screens, [], swiftui, [], SwiftUI),
+    RN \= "",
+    Vue \= "",
+    Flutter \= "",
+    SwiftUI \= "".
+
+test(all_targets_generate_global_state) :-
+    test_global_state(Shape),
+    ui_patterns:compile_state_pattern(global, Shape, [], react_native, [], RN),
+    vue_target:compile_state_pattern(global, Shape, [], vue, [], Vue),
+    flutter_target:compile_state_pattern(global, Shape, [], flutter, [], Flutter),
+    swiftui_target:compile_state_pattern(global, Shape, [], swiftui, [], SwiftUI),
+    RN \= "",
+    Vue \= "",
+    Flutter \= "",
+    SwiftUI \= "".
+
+test(all_targets_generate_query) :-
+    test_query_config(Config),
+    ui_patterns:compile_data_pattern(query, Config, react_native, [], RN),
+    vue_target:compile_data_pattern(query, Config, vue, [], Vue),
+    flutter_target:compile_data_pattern(query, Config, flutter, [], Flutter),
+    swiftui_target:compile_data_pattern(query, Config, swiftui, [], SwiftUI),
+    RN \= "",
+    Vue \= "",
+    Flutter \= "",
+    SwiftUI \= "".
+
+:- end_tests(cross_framework_consistency).
+
+% ============================================================================
+% Run tests when loaded directly
+% ============================================================================
+
+:- initialization(run_tests, main).

--- a/src/unifyweaver/targets/vue_target.pl
+++ b/src/unifyweaver/targets/vue_target.pl
@@ -26,7 +26,14 @@
     test_vue_target/0,
     % Target capabilities
     vue_capabilities/1,
-    requires_glue/2
+    target_capabilities/1,          % Alias for consistency
+    requires_glue/2,
+
+    % Pattern compilation (for ui_patterns integration)
+    compile_navigation_pattern/6,
+    compile_state_pattern/6,
+    compile_data_pattern/5,
+    compile_persistence_pattern/5
 ]).
 
 :- use_module(library(lists)).
@@ -98,7 +105,7 @@ compile_predicate_to_vue(Module:Pred/Arity, Options, VueCode) :-
 %
 %  Generate a Vue SFC from component specification.
 %
-compile_component_to_vue(Name, Props, Template, VueCode) :-
+compile_component_to_vue(_Name, Props, Template, VueCode) :-
     generate_props_interface(Props, PropsInterface),
     generate_props_defaults(Props, PropsDefaults),
     format(string(VueCode),
@@ -216,7 +223,7 @@ compile_glue_component(Module:Pred/Arity, Reason, Options, VueCode) :-
     atom_string(Module, ModStr),
     option_value(Options, component_name, Name, PredStr),
     option_value(Options, api_endpoint, Endpoint, "/api/prolog"),
-    capitalize_first(Name, ComponentName),
+    capitalize_first(Name, _ComponentName),
 
     % Generate endpoint path from predicate
     format(string(EndpointPath), "~w/~w/~w", [Endpoint, ModStr, PredStr]),
@@ -372,6 +379,593 @@ generate_arg_types(Arity, Types) :-
         format(string(ArgLine), "arg~w?: any;", [N])
     ), Lines),
     atomic_list_concat(Lines, '\n  ', Types).
+
+% Alias for target_capabilities
+target_capabilities(Caps) :- vue_capabilities(Caps).
+
+% ============================================================================
+% PATTERN COMPILATION - Navigation
+% ============================================================================
+%
+% Vue uses vue-router for navigation. Unlike mobile frameworks, Vue apps
+% typically use URL-based routing rather than screen stacks.
+
+%% compile_navigation_pattern(+Type, +Screens, +Config, +Target, +Options, -Code)
+compile_navigation_pattern(stack, Screens, _Config, vue, Options, Code) :-
+    option_value(Options, component_name, Name, 'AppRouter'),
+    generate_vue_router(Screens, stack, Name, Code).
+compile_navigation_pattern(tab, Screens, _Config, vue, Options, Code) :-
+    option_value(Options, component_name, Name, 'TabRouter'),
+    generate_vue_tab_navigation(Screens, Name, Code).
+compile_navigation_pattern(drawer, Screens, _Config, vue, Options, Code) :-
+    option_value(Options, component_name, Name, 'DrawerLayout'),
+    generate_vue_drawer_navigation(Screens, Name, Code).
+
+generate_vue_router(Screens, _Type, Name, Code) :-
+    generate_vue_route_definitions(Screens, RouteDefs),
+    generate_vue_route_imports(Screens, Imports),
+    format(string(Code),
+"// ~w - Vue Router Configuration
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
+~w
+
+const routes: RouteRecordRaw[] = [
+~w
+];
+
+export const ~w = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+export default ~w;
+", [Name, Imports, RouteDefs, Name, Name]).
+
+generate_vue_route_definitions(Screens, Defs) :-
+    findall(RouteDef, (
+        member(screen(ScreenName, Component, Opts), Screens),
+        (   member(title(Title), Opts) -> true ; Title = ScreenName ),
+        atom_string(ScreenName, NameStr),
+        format(string(RouteDef),
+"  {
+    path: '/~w',
+    name: '~w',
+    component: ~w,
+    meta: { title: '~w' },
+  }", [NameStr, NameStr, Component, Title])
+    ), RouteDefList),
+    atomic_list_concat(RouteDefList, ',\n', Defs).
+
+generate_vue_route_imports(Screens, Imports) :-
+    findall(ImportLine, (
+        member(screen(_, Component, _), Screens),
+        format(string(ImportLine), "import ~w from '@/views/~w.vue';", [Component, Component])
+    ), ImportLines),
+    atomic_list_concat(ImportLines, '\n', Imports).
+
+generate_vue_tab_navigation(Screens, Name, Code) :-
+    generate_vue_tab_items(Screens, TabItems),
+    format(string(Code),
+"<template>
+  <div class=\"~w\">
+    <nav class=\"tab-bar\">
+~w
+    </nav>
+    <main class=\"tab-content\">
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<script setup lang=\"ts\">
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+</script>
+
+<style scoped>
+.~w {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.tab-bar a {
+  flex: 1;
+  padding: 1rem;
+  text-align: center;
+  text-decoration: none;
+  color: #4a5568;
+  border-bottom: 2px solid transparent;
+}
+
+.tab-bar a.router-link-active {
+  color: #3182ce;
+  border-bottom-color: #3182ce;
+}
+
+.tab-content {
+  flex: 1;
+  overflow: auto;
+}
+</style>
+", [Name, TabItems, Name]).
+
+generate_vue_tab_items(Screens, Items) :-
+    findall(TabItem, (
+        member(screen(ScreenName, _, Opts), Screens),
+        (   member(title(Title), Opts) -> true ; atom_string(ScreenName, Title) ),
+        atom_string(ScreenName, NameStr),
+        format(string(TabItem),
+"      <router-link to=\"/~w\">~w</router-link>", [NameStr, Title])
+    ), TabItemList),
+    atomic_list_concat(TabItemList, '\n', Items).
+
+generate_vue_drawer_navigation(Screens, Name, Code) :-
+    generate_vue_drawer_items(Screens, DrawerItems),
+    format(string(Code),
+"<template>
+  <div class=\"~w\">
+    <aside class=\"drawer\" :class=\"{ open: isOpen }\">
+      <nav class=\"drawer-nav\">
+~w
+      </nav>
+    </aside>
+    <div class=\"drawer-overlay\" v-if=\"isOpen\" @click=\"isOpen = false\" />
+    <main class=\"drawer-content\">
+      <button class=\"drawer-toggle\" @click=\"isOpen = !isOpen\">
+        <span class=\"hamburger\"></span>
+      </button>
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<script setup lang=\"ts\">
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+const isOpen = ref(false);
+</script>
+
+<style scoped>
+.~w {
+  display: flex;
+  height: 100vh;
+}
+
+.drawer {
+  position: fixed;
+  left: -280px;
+  width: 280px;
+  height: 100vh;
+  background: #fff;
+  box-shadow: 2px 0 8px rgba(0,0,0,0.1);
+  transition: left 0.3s ease;
+  z-index: 100;
+}
+
+.drawer.open {
+  left: 0;
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.3);
+  z-index: 99;
+}
+
+.drawer-nav a {
+  display: block;
+  padding: 1rem 1.5rem;
+  color: #4a5568;
+  text-decoration: none;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.drawer-nav a.router-link-active {
+  background: #ebf8ff;
+  color: #3182ce;
+}
+
+.drawer-content {
+  flex: 1;
+  overflow: auto;
+}
+
+.drawer-toggle {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 50;
+  padding: 0.5rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+</style>
+", [Name, DrawerItems, Name]).
+
+generate_vue_drawer_items(Screens, Items) :-
+    findall(DrawerItem, (
+        member(screen(ScreenName, _, Opts), Screens),
+        (   member(title(Title), Opts) -> true ; atom_string(ScreenName, Title) ),
+        atom_string(ScreenName, NameStr),
+        format(string(DrawerItem),
+"        <router-link to=\"/~w\" @click=\"isOpen = false\">~w</router-link>", [NameStr, Title])
+    ), DrawerItemList),
+    atomic_list_concat(DrawerItemList, '\n', Items).
+
+% ============================================================================
+% PATTERN COMPILATION - State
+% ============================================================================
+%
+% Vue uses the Composition API (ref, reactive) for local state and
+% Pinia for global state management.
+
+%% compile_state_pattern(+Type, +Shape, +Config, +Target, +Options, -Code)
+compile_state_pattern(local, Shape, _Config, vue, _Options, Code) :-
+    generate_vue_local_state(Shape, Code).
+compile_state_pattern(global, Shape, _Config, vue, _Options, Code) :-
+    generate_vue_pinia_store(Shape, Code).
+compile_state_pattern(derived, Shape, _Config, vue, _Options, Code) :-
+    generate_vue_computed_state(Shape, Code).
+
+generate_vue_local_state(Shape, Code) :-
+    findall(RefDef, (
+        member(field(Name, Initial), Shape),
+        format(string(RefDef), "const ~w = ref(~w);", [Name, Initial])
+    ), RefDefs),
+    atomic_list_concat(RefDefs, '\n', RefsCode),
+    format(string(Code),
+"// Vue Composition API - Local State
+import { ref } from 'vue';
+
+// Usage in <script setup>:
+~w
+", [RefsCode]).
+
+generate_vue_pinia_store(Shape, Code) :-
+    member(store(StoreName), Shape),
+    member(slices(Slices), Shape),
+    generate_pinia_state(Slices, StateDefs),
+    generate_pinia_getters(Slices, GetterDefs),
+    generate_pinia_actions(Slices, ActionDefs),
+    format(string(Code),
+"// Pinia Store - ~w
+import { defineStore } from 'pinia';
+
+export const use~wStore = defineStore('~w', {
+  state: () => ({
+~w
+  }),
+
+  getters: {
+~w
+  },
+
+  actions: {
+~w
+  },
+});
+", [StoreName, StoreName, StoreName, StateDefs, GetterDefs, ActionDefs]).
+
+generate_pinia_state(Slices, StateDefs) :-
+    findall(StateDef, (
+        member(slice(_, Fields, _), Slices),
+        member(field(FName, FType), Fields),
+        pinia_default_value(FType, Default),
+        format(string(StateDef), "    ~w: ~w,", [FName, Default])
+    ), StateDefList),
+    atomic_list_concat(StateDefList, '\n', StateDefs).
+
+pinia_default_value("'light' | 'dark'", "'light'").
+pinia_default_value("boolean", "false").
+pinia_default_value("string | null", "null").
+pinia_default_value("number", "0").
+pinia_default_value(_, "null").
+
+generate_pinia_getters(_Slices, Getters) :-
+    Getters = "    // Add computed getters here".
+
+generate_pinia_actions(Slices, ActionDefs) :-
+    findall(ActionDef, (
+        member(slice(_, _, Actions), Slices),
+        member(action(AName, _ABody), Actions),
+        generate_pinia_action(AName, ActionDef)
+    ), ActionDefList),
+    (   ActionDefList = []
+    ->  ActionDefs = "    // Add actions here"
+    ;   atomic_list_concat(ActionDefList, '\n', ActionDefs)
+    ).
+
+generate_pinia_action(toggleTheme, Code) :-
+    format(string(Code),
+"    toggleTheme() {
+      this.theme = this.theme === 'light' ? 'dark' : 'light';
+    },", []).
+generate_pinia_action(toggleSidebar, Code) :-
+    format(string(Code),
+"    toggleSidebar() {
+      this.sidebarOpen = !this.sidebarOpen;
+    },", []).
+generate_pinia_action(Name, Code) :-
+    \+ member(Name, [toggleTheme, toggleSidebar]),
+    format(string(Code),
+"    ~w(value: unknown) {
+      // TODO: Implement ~w action
+    },", [Name, Name]).
+
+generate_vue_computed_state(Shape, Code) :-
+    member(deps(Deps), Shape),
+    member(derive(Derivation), Shape),
+    atomic_list_concat(Deps, ', ', DepsStr),
+    format(string(Code),
+"// Vue Composition API - Computed State
+import { computed } from 'vue';
+
+// Usage in <script setup>:
+// Assumes ~w are defined as refs
+const derivedValue = computed(() => {
+  return ~w;
+});
+", [DepsStr, Derivation]).
+
+% ============================================================================
+% PATTERN COMPILATION - Data Fetching
+% ============================================================================
+%
+% Vue uses @tanstack/vue-query for data fetching, similar to React Query.
+
+%% compile_data_pattern(+Type, +Config, +Target, +Options, -Code)
+compile_data_pattern(query, Config, vue, _Options, Code) :-
+    generate_vue_query_composable(Config, Code).
+compile_data_pattern(mutation, Config, vue, _Options, Code) :-
+    generate_vue_mutation_composable(Config, Code).
+compile_data_pattern(infinite, Config, vue, _Options, Code) :-
+    generate_vue_infinite_query(Config, Code).
+
+generate_vue_query_composable(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(stale_time(StaleTime), Config) -> true ; StaleTime = 300000 ),
+    capitalize_first(Name, HookName),
+    format(string(Code),
+"// Vue Query Composable - ~w
+import { useQuery } from '@tanstack/vue-query';
+import type { Ref } from 'vue';
+
+interface ~wData {
+  // TODO: Define response type
+  [key: string]: unknown;
+}
+
+interface ~wVariables {
+  // TODO: Define variables type
+  [key: string]: unknown;
+}
+
+export function use~w(variables?: Ref<~wVariables> | ~wVariables) {
+  return useQuery({
+    queryKey: ['~w', variables],
+    queryFn: async () => {
+      const response = await fetch('~w', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) throw new Error('Network response was not ok');
+      return response.json() as Promise<~wData>;
+    },
+    staleTime: ~w,
+  });
+}
+", [Name, Name, Name, HookName, Name, Name, Name, Endpoint, Name, StaleTime]).
+
+generate_vue_mutation_composable(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(method(Method), Config) -> true ; Method = 'POST' ),
+    capitalize_first(Name, HookName),
+    format(string(Code),
+"// Vue Mutation Composable - ~w
+import { useMutation, useQueryClient } from '@tanstack/vue-query';
+
+interface ~wVariables {
+  // TODO: Define input type
+  [key: string]: unknown;
+}
+
+interface ~wResponse {
+  // TODO: Define response type
+  [key: string]: unknown;
+}
+
+export function use~w() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (variables: ~wVariables) => {
+      const response = await fetch('~w', {
+        method: '~w',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(variables),
+      });
+      if (!response.ok) throw new Error('Network response was not ok');
+      return response.json() as Promise<~wResponse>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['~w'] });
+    },
+  });
+}
+", [Name, Name, Name, HookName, Name, Endpoint, Method, Name, Name]).
+
+generate_vue_infinite_query(Config, Code) :-
+    member(name(Name), Config),
+    member(endpoint(Endpoint), Config),
+    (   member(page_param(PageParam), Config) -> true ; PageParam = 'page' ),
+    capitalize_first(Name, HookName),
+    format(string(Code),
+"// Vue Infinite Query Composable - ~w
+import { useInfiniteQuery } from '@tanstack/vue-query';
+
+interface ~wPage {
+  data: unknown[];
+  nextPage?: number;
+  hasMore: boolean;
+}
+
+export function use~w() {
+  return useInfiniteQuery({
+    queryKey: ['~w'],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await fetch(`~w?~w=${pageParam}`);
+      if (!response.ok) throw new Error('Network response was not ok');
+      return response.json() as Promise<~wPage>;
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.hasMore ? lastPage.nextPage : undefined,
+  });
+}
+", [Name, Name, HookName, Name, Endpoint, PageParam, Name]).
+
+% ============================================================================
+% PATTERN COMPILATION - Persistence
+% ============================================================================
+%
+% Vue uses localStorage/sessionStorage or plugins like pinia-plugin-persistedstate.
+
+%% compile_persistence_pattern(+Type, +Config, +Target, +Options, -Code)
+compile_persistence_pattern(local, Config, vue, _Options, Code) :-
+    generate_vue_storage_composable(Config, Code).
+compile_persistence_pattern(secure, Config, vue, _Options, Code) :-
+    % For Vue web, "secure" storage uses the same localStorage but with encryption note
+    generate_vue_secure_storage_composable(Config, Code).
+
+generate_vue_storage_composable(Config, Code) :-
+    member(key(Key), Config),
+    (   member(schema(Schema), Config) -> true ; Schema = 'unknown' ),
+    capitalize_first(Key, HookName),
+    format(string(Code),
+"// Vue Storage Composable - ~w
+import { ref, watch, onMounted } from 'vue';
+
+const STORAGE_KEY = '~w';
+
+type ~wData = ~w;
+
+export function use~w() {
+  const data = ref<~wData | null>(null);
+  const loading = ref(true);
+  const error = ref<Error | null>(null);
+
+  const load = () => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        data.value = JSON.parse(stored);
+      }
+    } catch (e) {
+      error.value = e as Error;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const save = (value: ~wData) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      data.value = value;
+    } catch (e) {
+      error.value = e as Error;
+      throw e;
+    }
+  };
+
+  const remove = () => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+      data.value = null;
+    } catch (e) {
+      error.value = e as Error;
+      throw e;
+    }
+  };
+
+  onMounted(load);
+
+  return { data, loading, error, save, remove };
+}
+", [Key, Key, Key, Schema, HookName, Key, Key]).
+
+generate_vue_secure_storage_composable(Config, Code) :-
+    member(key(Key), Config),
+    (   member(schema(Schema), Config) -> true ; Schema = 'unknown' ),
+    capitalize_first(Key, HookName),
+    format(string(Code),
+"// Vue Secure Storage Composable - ~w
+// Note: For true secure storage in web apps, consider using
+// encrypted localStorage or a secure backend API.
+import { ref, onMounted } from 'vue';
+
+const STORAGE_KEY = '~w';
+
+type ~wData = ~w;
+
+export function use~w() {
+  const data = ref<~wData | null>(null);
+  const loading = ref(true);
+  const error = ref<Error | null>(null);
+
+  const load = () => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        // TODO: Add decryption here for secure storage
+        data.value = JSON.parse(stored);
+      }
+    } catch (e) {
+      error.value = e as Error;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const save = (value: ~wData) => {
+    try {
+      // TODO: Add encryption here for secure storage
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      data.value = value;
+    } catch (e) {
+      error.value = e as Error;
+      throw e;
+    }
+  };
+
+  const remove = () => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+      data.value = null;
+    } catch (e) {
+      error.value = e as Error;
+      throw e;
+    }
+  };
+
+  onMounted(load);
+
+  return { data, loading, error, save, remove };
+}
+", [Key, Key, Key, Schema, HookName, Key]).
 
 % ============================================================================
 % TESTING


### PR DESCRIPTION
## Summary

- Add pattern compilation support for Vue 3, Flutter, and SwiftUI frameworks
- Same UI patterns now compile to 4 different platforms from a single definition
- Include target interface documentation and 34 cross-framework tests

## Framework Support

| Pattern Type | React Native | Vue 3 | Flutter | SwiftUI |
|--------------|--------------|-------|---------|---------|
| **Navigation** | React Navigation | Vue Router | GoRouter | NavigationStack |
| **State (local)** | useState | ref/reactive | StatefulWidget | @State |
| **State (global)** | Zustand | Pinia | Riverpod | ObservableObject |
| **Data Query** | React Query | Vue Query | FutureProvider | async/await |
| **Data Mutation** | useMutation | useMutation | StateNotifier | URLSession |
| **Persistence** | AsyncStorage | localStorage | SharedPreferences | @AppStorage |

## New Files

| File | Lines | Description |
|------|-------|-------------|
| `targets/target_interface.pl` | 214 | Documents the target contract |
| `targets/flutter_target.pl` | 875 | Flutter/Dart code generation |
| `targets/swiftui_target.pl` | 872 | SwiftUI/Swift code generation |
| `targets/test_multi_target.pl` | 317 | Cross-framework tests |

## Modified Files

| File | Changes | Description |
|------|---------|-------------|
| `targets/vue_target.pl` | +597 | Added pattern compilation predicates |
| `patterns/README.md` | Updated | Multi-framework documentation |

## Usage Example

```prolog
%% Define pattern once
?- navigation_pattern(tab, [
       screen(home, 'HomeScreen', [title('Home')]),
       screen(profile, 'ProfileScreen', [title('Profile')])
   ], Pattern),
   define_pattern(app_nav, Pattern, []).

%% Compile to all targets
?- compile_pattern(app_nav, react_native, [], RNCode).
?- vue_target:compile_navigation_pattern(tab, Screens, [], vue, [], VueCode).
?- flutter_target:compile_navigation_pattern(tab, Screens, [], flutter, [], FlutterCode).
?- swiftui_target:compile_navigation_pattern(tab, Screens, [], swiftui, [], SwiftCode).
```

## Test Plan

- [x] All 34 multi-target tests pass
- [x] Navigation patterns compile to all 4 targets
- [x] State patterns compile to all 4 targets
- [x] Data patterns compile to all 4 targets
- [x] Persistence patterns compile to all 4 targets
- [x] Cross-framework consistency verified

```bash
# Run multi-target tests
swipl -g "run_tests" -t halt src/unifyweaver/targets/test_multi_target.pl
```

## Design Notes

- Each target implements the same interface defined in `target_interface.pl`
- Patterns are framework-agnostic; targets handle framework-specific idioms
- Target capabilities are documented for feature detection
- Framework equivalence mappings help translate concepts across platforms

---
Generated with [Claude Code](https://claude.ai/code)
