### PR TITLE
feat(patterns): Add pattern composition and i18n support

### DIFF
--- a/src/unifyweaver/i18n/i18n.pl
+++ b/src/unifyweaver/i18n/i18n.pl
@@ -1,0 +1,628 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% i18n.pl - Internationalization and Localization Module
+%
+% Provides translation key management, interpolation, and pluralization
+% for generating localized UI code across all target frameworks.
+%
+% Key features:
+%   - Translation key definition: t('key')
+%   - Variable interpolation: {{name}} syntax
+%   - Pluralization: zero/one/other forms
+%   - Multi-locale support
+%   - Target-specific code generation
+%
+% Usage:
+%   ?- define_translations(en, ['greeting' - "Hello, {{name}}!"]).
+%   ?- resolve_translation('greeting', en, [name('World')], Text).
+%   ?- extract_translation_keys(Spec, Keys).
+
+:- module(i18n, [
+    % Translation definition
+    define_translations/2,      % +Locale, +Translations
+    add_translation/3,          % +Locale, +Key, +Value
+    get_translation/3,          % +Locale, +Key, -Value
+    clear_translations/0,       % Clear all translations
+    clear_translations/1,       % +Locale - Clear locale translations
+
+    % Translation keys (term constructors)
+    t/2,                        % +Key, -Term
+    t/3,                        % +Key, +Vars, -Term
+    t_plural/3,                 % +Key, +Count, -Term
+
+    % Resolution
+    resolve_translation/4,      % +Key, +Locale, +Vars, -Text
+    resolve_plural/4,           % +Key, +Count, +Locale, -Text
+
+    % Spec transformation
+    localize_spec/3,            % +Spec, +Locale, -LocalizedSpec
+    extract_translation_keys/2, % +Spec, -Keys
+
+    % Code generation
+    generate_i18n_setup/3,      % +Target, +Locales, -Code
+    generate_translation_file/3, % +Target, +Locale, -Content
+    generate_translation_json/2, % +Locale, -JSON
+
+    % Validation
+    find_missing_translations/3, % +Spec, +Locale, -MissingKeys
+    validate_translations/2,     % +Locale, -Errors
+    list_locales/1,             % -Locales
+
+    % Testing
+    test_i18n/0
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% DYNAMIC STORAGE
+% ============================================================================
+
+:- dynamic stored_translation/3.  % stored_translation(Locale, Key, Value)
+:- dynamic default_locale/1.      % default_locale(Locale)
+
+% Default locale
+:- initialization((
+    (   default_locale(_)
+    ->  true
+    ;   assertz(default_locale(en))
+    )
+), now).
+
+% ============================================================================
+% TRANSLATION DEFINITION
+% ============================================================================
+
+%% define_translations(+Locale, +Translations)
+%
+%  Define multiple translations for a locale.
+%
+%  Translations: [Key - Value, ...]
+%
+define_translations(Locale, Translations) :-
+    atom(Locale),
+    is_list(Translations),
+    forall(member(Key - Value, Translations),
+           add_translation(Locale, Key, Value)).
+
+%% add_translation(+Locale, +Key, +Value)
+%
+%  Add a single translation.
+%
+add_translation(Locale, Key, Value) :-
+    atom(Locale),
+    (atom(Key) ; string(Key)),
+    (atom(Value) ; string(Value)),
+    % Convert key to atom if string
+    (string(Key) -> atom_string(KeyAtom, Key) ; KeyAtom = Key),
+    % Convert value to string for consistency
+    (atom(Value) -> atom_string(ValueStr, Value) ; ValueStr = Value),
+    retractall(stored_translation(Locale, KeyAtom, _)),
+    assertz(stored_translation(Locale, KeyAtom, ValueStr)).
+
+%% get_translation(+Locale, +Key, -Value)
+%
+%  Get a translation value.
+%
+get_translation(Locale, Key, Value) :-
+    (string(Key) -> atom_string(KeyAtom, Key) ; KeyAtom = Key),
+    stored_translation(Locale, KeyAtom, Value).
+
+%% clear_translations/0
+%
+%  Clear all translations.
+%
+clear_translations :-
+    retractall(stored_translation(_, _, _)).
+
+%% clear_translations(+Locale)
+%
+%  Clear translations for a specific locale.
+%
+clear_translations(Locale) :-
+    retractall(stored_translation(Locale, _, _)).
+
+%% list_locales(-Locales)
+%
+%  Get list of all defined locales.
+%
+list_locales(Locales) :-
+    findall(L, stored_translation(L, _, _), AllLocales),
+    sort(AllLocales, Locales).
+
+% ============================================================================
+% TRANSLATION KEY CONSTRUCTORS
+% ============================================================================
+
+%% t(+Key, -Term)
+%
+%  Create a translation key term.
+%
+t(Key, t(Key)).
+
+%% t(+Key, +Vars, -Term)
+%
+%  Create a translation key term with variables.
+%
+t(Key, Vars, t(Key, Vars)).
+
+%% t_plural(+Key, +Count, -Term)
+%
+%  Create a plural translation key term.
+%
+t_plural(Key, Count, t_plural(Key, Count)).
+
+% ============================================================================
+% TRANSLATION RESOLUTION
+% ============================================================================
+
+%% resolve_translation(+Key, +Locale, +Vars, -Text)
+%
+%  Resolve a translation key to text with variable interpolation.
+%
+resolve_translation(Key, Locale, Vars, Text) :-
+    (string(Key) -> atom_string(KeyAtom, Key) ; KeyAtom = Key),
+    (   get_translation(Locale, KeyAtom, Template)
+    ->  interpolate_vars(Template, Vars, Text)
+    ;   % Fallback to default locale
+        default_locale(DefaultLocale),
+        DefaultLocale \= Locale,
+        get_translation(DefaultLocale, KeyAtom, Template)
+    ->  interpolate_vars(Template, Vars, Text)
+    ;   % Return key as fallback
+        atom_string(KeyAtom, Text)
+    ).
+
+%% interpolate_vars(+Template, +Vars, -Result)
+%
+%  Replace {{var}} placeholders with values.
+%
+interpolate_vars(Template, [], Template) :- !.
+interpolate_vars(Template, Vars, Result) :-
+    string(Template),
+    foldl(replace_var, Vars, Template, Result).
+
+replace_var(VarSpec, In, Out) :-
+    VarSpec =.. [Name, Value],
+    atom_string(Name, NameStr),
+    format(string(Placeholder), "{{~w}}", [NameStr]),
+    (   atom(Value)
+    ->  atom_string(Value, ValueStr)
+    ;   number(Value)
+    ->  number_string(Value, ValueStr)
+    ;   ValueStr = Value
+    ),
+    replace_all_occurrences(In, Placeholder, ValueStr, Out).
+
+replace_all_occurrences(In, Search, Replace, Out) :-
+    (   sub_string(In, Before, Len, After, Search),
+        string_length(Search, Len)
+    ->  sub_string(In, 0, Before, _, Prefix),
+        AfterStart is Before + Len,
+        sub_string(In, AfterStart, After, 0, Suffix),
+        string_concat(Prefix, Replace, Temp),
+        replace_all_occurrences(Suffix, Search, Replace, RestOut),
+        string_concat(Temp, RestOut, Out)
+    ;   Out = In
+    ).
+
+%% resolve_plural(+Key, +Count, +Locale, -Text)
+%
+%  Resolve a plural translation.
+%
+%  Looks for keys: key.zero, key.one, key.other
+%
+resolve_plural(Key, Count, Locale, Text) :-
+    (string(Key) -> atom_string(KeyAtom, Key) ; KeyAtom = Key),
+    plural_form(Count, Form),
+    atom_concat(KeyAtom, '.', KeyPrefix),
+    atom_concat(KeyPrefix, Form, PluralKey),
+    (   get_translation(Locale, PluralKey, Template)
+    ->  interpolate_vars(Template, [count(Count)], Text)
+    ;   % Fallback to .other
+        atom_concat(KeyPrefix, other, OtherKey),
+        get_translation(Locale, OtherKey, OtherTemplate)
+    ->  interpolate_vars(OtherTemplate, [count(Count)], Text)
+    ;   % Fallback to base key
+        get_translation(Locale, KeyAtom, BaseTemplate)
+    ->  interpolate_vars(BaseTemplate, [count(Count)], Text)
+    ;   format(string(Text), "~w (~d)", [KeyAtom, Count])
+    ).
+
+plural_form(0, zero).
+plural_form(1, one).
+plural_form(N, other) :- N \= 0, N \= 1.
+
+% ============================================================================
+% SPEC TRANSFORMATION
+% ============================================================================
+
+%% extract_translation_keys(+Spec, -Keys)
+%
+%  Extract all t() keys from a specification.
+%
+extract_translation_keys(Spec, Keys) :-
+    extract_keys_acc(Spec, [], KeyList),
+    sort(KeyList, Keys).
+
+extract_keys_acc(t(Key), Acc, [Key|Acc]) :- !.
+extract_keys_acc(t(Key, _), Acc, [Key|Acc]) :- !.
+extract_keys_acc(t_plural(Key, _), Acc, [Key|Acc]) :- !.
+
+extract_keys_acc(Spec, Acc, Result) :-
+    compound(Spec),
+    Spec =.. [_|Args],
+    foldl(extract_keys_from_arg, Args, Acc, Result),
+    !.
+
+extract_keys_acc(_, Acc, Acc).
+
+extract_keys_from_arg(Arg, Acc, Result) :-
+    is_list(Arg),
+    !,
+    foldl(extract_keys_acc, Arg, Acc, Result).
+
+extract_keys_from_arg(Arg, Acc, Result) :-
+    extract_keys_acc(Arg, Acc, Result).
+
+%% localize_spec(+Spec, +Locale, -LocalizedSpec)
+%
+%  Replace t() terms with resolved translations.
+%
+localize_spec(t(Key), Locale, Text) :-
+    !,
+    resolve_translation(Key, Locale, [], Text).
+
+localize_spec(t(Key, Vars), Locale, Text) :-
+    !,
+    resolve_translation(Key, Locale, Vars, Text).
+
+localize_spec(t_plural(Key, Count), Locale, Text) :-
+    !,
+    resolve_plural(Key, Count, Locale, Text).
+
+localize_spec(Spec, Locale, Localized) :-
+    compound(Spec),
+    Spec =.. [Functor|Args],
+    maplist(localize_spec_wrapper(Locale), Args, LocalizedArgs),
+    Localized =.. [Functor|LocalizedArgs],
+    !.
+
+localize_spec(Spec, _, Spec).
+
+localize_spec_wrapper(Locale, Arg, Result) :-
+    is_list(Arg),
+    !,
+    maplist(localize_spec_wrapper(Locale), Arg, Result).
+
+localize_spec_wrapper(Locale, Arg, Result) :-
+    localize_spec(Arg, Locale, Result).
+
+% ============================================================================
+% CODE GENERATION
+% ============================================================================
+
+%% generate_i18n_setup(+Target, +Locales, -Code)
+%
+%  Generate i18n setup code for a target framework.
+%
+generate_i18n_setup(react_native, Locales, Code) :-
+    generate_react_i18n_setup(Locales, Code).
+
+generate_i18n_setup(vue, Locales, Code) :-
+    generate_vue_i18n_setup(Locales, Code).
+
+generate_i18n_setup(flutter, Locales, Code) :-
+    generate_flutter_i18n_setup(Locales, Code).
+
+generate_i18n_setup(swiftui, Locales, Code) :-
+    generate_swiftui_i18n_setup(Locales, Code).
+
+%% generate_react_i18n_setup(+Locales, -Code)
+generate_react_i18n_setup(Locales, Code) :-
+    maplist(locale_import_line, Locales, ImportLines),
+    atomic_list_concat(ImportLines, '\n', ImportsStr),
+    maplist(locale_resource_entry, Locales, ResourceEntries),
+    atomic_list_concat(ResourceEntries, ',\n    ', ResourcesStr),
+    format(string(Code),
+"import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+~w
+
+i18n.use(initReactI18next).init({
+  resources: {
+    ~w
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false
+  }
+});
+
+export default i18n;", [ImportsStr, ResourcesStr]).
+
+locale_import_line(Locale, Line) :-
+    format(string(Line), "import ~w from './locales/~w.json';", [Locale, Locale]).
+
+locale_resource_entry(Locale, Entry) :-
+    format(string(Entry), "~w: { translation: ~w }", [Locale, Locale]).
+
+%% generate_vue_i18n_setup(+Locales, -Code)
+generate_vue_i18n_setup(Locales, Code) :-
+    maplist(locale_import_line, Locales, ImportLines),
+    atomic_list_concat(ImportLines, '\n', ImportsStr),
+    maplist(vue_message_entry, Locales, MessageEntries),
+    atomic_list_concat(MessageEntries, ', ', MessagesStr),
+    format(string(Code),
+"import { createI18n } from 'vue-i18n';
+
+~w
+
+export const i18n = createI18n({
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { ~w }
+});", [ImportsStr, MessagesStr]).
+
+vue_message_entry(Locale, Entry) :-
+    format(string(Entry), "~w", [Locale]).
+
+%% generate_flutter_i18n_setup(+Locales, -Code)
+generate_flutter_i18n_setup(Locales, Code) :-
+    maplist(flutter_locale_entry, Locales, LocaleEntries),
+    atomic_list_concat(LocaleEntries, ',\n    ', LocalesStr),
+    format(string(Code),
+"import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+class AppLocalizations {
+  final Locale locale;
+
+  AppLocalizations(this.locale);
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static const List<Locale> supportedLocales = [
+    ~w
+  ];
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'es'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}", [LocalesStr]).
+
+flutter_locale_entry(Locale, Entry) :-
+    format(string(Entry), "Locale('~w')", [Locale]).
+
+%% generate_swiftui_i18n_setup(+Locales, -Code)
+generate_swiftui_i18n_setup(_Locales, Code) :-
+    Code = "import SwiftUI
+
+// SwiftUI uses native localization with Localizable.strings files
+// Translation keys are used with LocalizedStringKey(\"key\")
+
+extension Text {
+    init(localized key: String) {
+        self.init(LocalizedStringKey(key))
+    }
+}".
+
+%% generate_translation_file(+Target, +Locale, -Content)
+%
+%  Generate a translation file for a specific target and locale.
+%
+generate_translation_file(react_native, Locale, Content) :-
+    generate_translation_json(Locale, Content).
+
+generate_translation_file(vue, Locale, Content) :-
+    generate_translation_json(Locale, Content).
+
+generate_translation_file(flutter, Locale, Content) :-
+    generate_flutter_arb(Locale, Content).
+
+generate_translation_file(swiftui, Locale, Content) :-
+    generate_strings_file(Locale, Content).
+
+%% generate_translation_json(+Locale, -JSON)
+%
+%  Generate JSON translation file content.
+%
+generate_translation_json(Locale, JSON) :-
+    findall(Entry, (
+        stored_translation(Locale, Key, Value),
+        format(string(Entry), "  \"~w\": \"~w\"", [Key, Value])
+    ), Entries),
+    atomic_list_concat(Entries, ',\n', EntriesStr),
+    format(string(JSON), "{\n~w\n}", [EntriesStr]).
+
+%% generate_flutter_arb(+Locale, -ARB)
+generate_flutter_arb(Locale, ARB) :-
+    findall(Entry, (
+        stored_translation(Locale, Key, Value),
+        arb_key(Key, ArbKey),
+        format(string(Entry), "  \"~w\": \"~w\"", [ArbKey, Value])
+    ), Entries),
+    atomic_list_concat(Entries, ',\n', EntriesStr),
+    format(string(ARB), "{\n  \"@@locale\": \"~w\",\n~w\n}", [Locale, EntriesStr]).
+
+arb_key(Key, ArbKey) :-
+    atom_string(Key, KeyStr),
+    replace_all_occurrences(KeyStr, ".", "_", ArbKeyStr),
+    atom_string(ArbKey, ArbKeyStr).
+
+%% generate_strings_file(+Locale, -Content)
+generate_strings_file(Locale, Content) :-
+    findall(Entry, (
+        stored_translation(Locale, Key, Value),
+        format(string(Entry), "\"~w\" = \"~w\";", [Key, Value])
+    ), Entries),
+    atomic_list_concat(Entries, '\n', Content).
+
+% ============================================================================
+% VALIDATION
+% ============================================================================
+
+%% find_missing_translations(+Spec, +Locale, -MissingKeys)
+%
+%  Find translation keys used in spec but not defined for locale.
+%
+find_missing_translations(Spec, Locale, MissingKeys) :-
+    extract_translation_keys(Spec, UsedKeys),
+    findall(Key, (
+        member(Key, UsedKeys),
+        \+ get_translation(Locale, Key, _)
+    ), MissingKeys).
+
+%% validate_translations(+Locale, -Errors)
+%
+%  Validate translations for a locale.
+%
+validate_translations(Locale, Errors) :-
+    findall(Error, validate_translation_error(Locale, Error), Errors).
+
+validate_translation_error(Locale, error(empty_value, Key)) :-
+    stored_translation(Locale, Key, Value),
+    string_length(Value, 0).
+
+validate_translation_error(Locale, error(unbalanced_braces, Key)) :-
+    stored_translation(Locale, Key, Value),
+    \+ balanced_interpolation(Value).
+
+balanced_interpolation(Value) :-
+    string(Value),
+    findall(_, sub_string(Value, _, _, _, "{{"), Opens),
+    findall(_, sub_string(Value, _, _, _, "}}"), Closes),
+    length(Opens, N),
+    length(Closes, N).
+
+% ============================================================================
+% TESTING
+% ============================================================================
+
+test_i18n :-
+    format('~n=== i18n Tests ===~n~n'),
+
+    % Setup
+    clear_translations,
+
+    % Test 1: Define translations
+    format('Test 1: Define translations...~n'),
+    define_translations(en, [
+        'greeting' - "Hello!",
+        'welcome' - "Welcome, {{name}}!",
+        'items.zero' - "No items",
+        'items.one' - "1 item",
+        'items.other' - "{{count}} items"
+    ]),
+    (   get_translation(en, 'greeting', "Hello!")
+    ->  format('  PASS: Translations defined~n')
+    ;   format('  FAIL: Translations not defined~n')
+    ),
+
+    % Test 2: Simple resolution
+    format('~nTest 2: Simple resolution...~n'),
+    (   resolve_translation('greeting', en, [], Text1),
+        Text1 = "Hello!"
+    ->  format('  PASS: Resolved to: ~w~n', [Text1])
+    ;   format('  FAIL: Resolution broken~n')
+    ),
+
+    % Test 3: Interpolation
+    format('~nTest 3: Interpolation...~n'),
+    (   resolve_translation('welcome', en, [name('World')], Text2),
+        Text2 = "Welcome, World!"
+    ->  format('  PASS: Interpolated: ~w~n', [Text2])
+    ;   format('  FAIL: Interpolation broken~n')
+    ),
+
+    % Test 4: Pluralization - zero
+    format('~nTest 4: Pluralization (zero)...~n'),
+    (   resolve_plural('items', 0, en, Text3),
+        Text3 = "No items"
+    ->  format('  PASS: Plural zero: ~w~n', [Text3])
+    ;   format('  FAIL: Plural zero broken~n')
+    ),
+
+    % Test 5: Pluralization - one
+    format('~nTest 5: Pluralization (one)...~n'),
+    (   resolve_plural('items', 1, en, Text4),
+        Text4 = "1 item"
+    ->  format('  PASS: Plural one: ~w~n', [Text4])
+    ;   format('  FAIL: Plural one broken~n')
+    ),
+
+    % Test 6: Pluralization - other
+    format('~nTest 6: Pluralization (other)...~n'),
+    (   resolve_plural('items', 5, en, Text5),
+        Text5 = "5 items"
+    ->  format('  PASS: Plural other: ~w~n', [Text5])
+    ;   format('  FAIL: Plural other broken~n')
+    ),
+
+    % Test 7: Key extraction
+    format('~nTest 7: Key extraction...~n'),
+    TestSpec = nav([title(t('nav.home')), icon(t('nav.icon'))]),
+    (   extract_translation_keys(TestSpec, Keys),
+        member('nav.home', Keys),
+        member('nav.icon', Keys)
+    ->  format('  PASS: Extracted keys: ~w~n', [Keys])
+    ;   format('  FAIL: Key extraction broken~n')
+    ),
+
+    % Test 8: JSON generation
+    format('~nTest 8: JSON generation...~n'),
+    (   generate_translation_json(en, JSON),
+        sub_string(JSON, _, _, _, "greeting"),
+        sub_string(JSON, _, _, _, "Hello!")
+    ->  format('  PASS: JSON generated~n')
+    ;   format('  FAIL: JSON generation broken~n')
+    ),
+
+    % Test 9: Missing translation detection
+    format('~nTest 9: Missing translation detection...~n'),
+    MissingSpec = screen([title(t('undefined.key'))]),
+    (   find_missing_translations(MissingSpec, en, Missing),
+        member('undefined.key', Missing)
+    ->  format('  PASS: Found missing keys: ~w~n', [Missing])
+    ;   format('  FAIL: Missing detection broken~n')
+    ),
+
+    % Test 10: i18n setup generation
+    format('~nTest 10: i18n setup generation...~n'),
+    (   generate_i18n_setup(react_native, [en, es], SetupCode),
+        sub_string(SetupCode, _, _, _, "i18next"),
+        sub_string(SetupCode, _, _, _, "initReactI18next")
+    ->  format('  PASS: Setup code generated~n')
+    ;   format('  FAIL: Setup generation broken~n')
+    ),
+
+    % Cleanup
+    clear_translations,
+
+    format('~n=== Tests Complete ===~n').
+
+% ============================================================================
+% INITIALIZATION
+% ============================================================================
+
+:- initialization((
+    format('i18n module loaded~n', [])
+), now).

--- a/src/unifyweaver/i18n/test_i18n.pl
+++ b/src/unifyweaver/i18n/test_i18n.pl
@@ -1,0 +1,346 @@
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (s243a)
+%
+% test_i18n.pl - plunit tests for i18n module
+%
+% Tests translation definition, interpolation, pluralization,
+% and code generation for all target frameworks.
+%
+% Run with: swipl -g "run_tests" -t halt test_i18n.pl
+
+:- module(test_i18n, []).
+
+:- use_module(library(plunit)).
+:- use_module('i18n').
+
+% ============================================================================
+% Setup/Cleanup
+% ============================================================================
+
+setup_test_translations :-
+    i18n:clear_translations,
+    i18n:define_translations(en, [
+        'greeting' - "Hello!",
+        'welcome' - "Welcome, {{name}}!",
+        'farewell' - "Goodbye, {{name}}. See you {{when}}!",
+        'items.zero' - "No items",
+        'items.one' - "1 item",
+        'items.other' - "{{count}} items",
+        'nav.home' - "Home",
+        'nav.cart' - "Cart",
+        'auth.login' - "Login",
+        'auth.error.required' - "This field is required"
+    ]),
+    i18n:define_translations(es, [
+        'greeting' - "Hola!",
+        'welcome' - "Bienvenido, {{name}}!",
+        'items.zero' - "Sin articulos",
+        'items.one' - "1 articulo",
+        'items.other' - "{{count}} articulos",
+        'nav.home' - "Inicio",
+        'nav.cart' - "Carrito"
+    ]).
+
+cleanup_test_translations :-
+    i18n:clear_translations.
+
+% ============================================================================
+% Tests: Translation Definition
+% ============================================================================
+
+:- begin_tests(translation_definition, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(define_simple_translation) :-
+    i18n:get_translation(en, 'greeting', Value),
+    Value = "Hello!".
+
+test(define_multiple_translations) :-
+    i18n:get_translation(en, 'greeting', _),
+    i18n:get_translation(en, 'welcome', _),
+    i18n:get_translation(en, 'nav.home', _).
+
+test(define_multiple_locales) :-
+    i18n:get_translation(en, 'greeting', "Hello!"),
+    i18n:get_translation(es, 'greeting', "Hola!").
+
+test(list_locales) :-
+    i18n:list_locales(Locales),
+    member(en, Locales),
+    member(es, Locales).
+
+test(overwrite_translation) :-
+    i18n:add_translation(en, 'test.overwrite', "Original"),
+    i18n:add_translation(en, 'test.overwrite', "Updated"),
+    i18n:get_translation(en, 'test.overwrite', "Updated").
+
+:- end_tests(translation_definition).
+
+% ============================================================================
+% Tests: Translation Resolution
+% ============================================================================
+
+:- begin_tests(translation_resolution, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(resolve_simple) :-
+    i18n:resolve_translation('greeting', en, [], Text),
+    Text = "Hello!".
+
+test(resolve_different_locale) :-
+    i18n:resolve_translation('greeting', es, [], Text),
+    Text = "Hola!".
+
+test(resolve_missing_returns_key) :-
+    i18n:resolve_translation('nonexistent.key', en, [], Text),
+    Text = "nonexistent.key".
+
+test(resolve_dotted_key) :-
+    i18n:resolve_translation('nav.home', en, [], Text),
+    Text = "Home".
+
+:- end_tests(translation_resolution).
+
+% ============================================================================
+% Tests: Interpolation
+% ============================================================================
+
+:- begin_tests(interpolation, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(interpolate_single_var) :-
+    i18n:resolve_translation('welcome', en, [name('World')], Text),
+    Text = "Welcome, World!".
+
+test(interpolate_multiple_vars) :-
+    i18n:resolve_translation('farewell', en, [name('John'), when('tomorrow')], Text),
+    Text = "Goodbye, John. See you tomorrow!".
+
+test(interpolate_number) :-
+    i18n:add_translation(en, 'test.number', "Count: {{n}}"),
+    i18n:resolve_translation('test.number', en, [n(42)], Text),
+    Text = "Count: 42".
+
+test(interpolate_missing_var_unchanged) :-
+    i18n:resolve_translation('welcome', en, [], Text),
+    sub_string(Text, _, _, _, "{{name}}").
+
+:- end_tests(interpolation).
+
+% ============================================================================
+% Tests: Pluralization
+% ============================================================================
+
+:- begin_tests(pluralization, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(plural_zero) :-
+    i18n:resolve_plural('items', 0, en, Text),
+    Text = "No items".
+
+test(plural_one) :-
+    i18n:resolve_plural('items', 1, en, Text),
+    Text = "1 item".
+
+test(plural_other_small) :-
+    i18n:resolve_plural('items', 5, en, Text),
+    Text = "5 items".
+
+test(plural_other_large) :-
+    i18n:resolve_plural('items', 100, en, Text),
+    Text = "100 items".
+
+test(plural_spanish) :-
+    i18n:resolve_plural('items', 5, es, Text),
+    Text = "5 articulos".
+
+test(plural_fallback_to_other) :-
+    i18n:add_translation(en, 'only.other', "{{count}} things"),
+    i18n:resolve_plural('only', 7, en, Text),
+    Text = "7 things".
+
+:- end_tests(pluralization).
+
+% ============================================================================
+% Tests: Key Extraction
+% ============================================================================
+
+:- begin_tests(key_extraction, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(extract_single_key) :-
+    Spec = title(t('nav.home')),
+    i18n:extract_translation_keys(Spec, Keys),
+    Keys = ['nav.home'].
+
+test(extract_multiple_keys) :-
+    Spec = nav([t('nav.home'), t('nav.cart')]),
+    i18n:extract_translation_keys(Spec, Keys),
+    length(Keys, 2),
+    member('nav.home', Keys),
+    member('nav.cart', Keys).
+
+test(extract_nested_keys) :-
+    Spec = screen([
+        header(t('greeting')),
+        body([text(t('welcome'))])
+    ]),
+    i18n:extract_translation_keys(Spec, Keys),
+    member('greeting', Keys),
+    member('welcome', Keys).
+
+test(extract_no_duplicates) :-
+    Spec = tabs([t('nav.home'), t('nav.home'), t('nav.cart')]),
+    i18n:extract_translation_keys(Spec, Keys),
+    length(Keys, 2).
+
+test(extract_empty_spec) :-
+    Spec = simple(value),
+    i18n:extract_translation_keys(Spec, Keys),
+    Keys = [].
+
+:- end_tests(key_extraction).
+
+% ============================================================================
+% Tests: Spec Localization
+% ============================================================================
+
+:- begin_tests(spec_localization, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(localize_simple_spec) :-
+    Spec = title(t('greeting')),
+    i18n:localize_spec(Spec, en, Localized),
+    Localized = title("Hello!").
+
+test(localize_nested_spec) :-
+    Spec = nav([screen(home, t('nav.home')), screen(cart, t('nav.cart'))]),
+    i18n:localize_spec(Spec, en, Localized),
+    Localized = nav([screen(home, "Home"), screen(cart, "Cart")]).
+
+test(localize_different_locale) :-
+    Spec = title(t('nav.home')),
+    i18n:localize_spec(Spec, es, Localized),
+    Localized = title("Inicio").
+
+test(localize_with_interpolation) :-
+    Spec = message(t('welcome', [name('User')])),
+    i18n:localize_spec(Spec, en, Localized),
+    Localized = message("Welcome, User!").
+
+:- end_tests(spec_localization).
+
+% ============================================================================
+% Tests: Missing Translation Detection
+% ============================================================================
+
+:- begin_tests(missing_detection, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(find_missing_single) :-
+    Spec = title(t('undefined.key')),
+    i18n:find_missing_translations(Spec, en, Missing),
+    Missing = ['undefined.key'].
+
+test(find_missing_multiple) :-
+    Spec = screen([t('undefined1'), t('undefined2')]),
+    i18n:find_missing_translations(Spec, en, Missing),
+    length(Missing, 2).
+
+test(find_missing_partial) :-
+    Spec = screen([t('nav.home'), t('undefined')]),
+    i18n:find_missing_translations(Spec, en, Missing),
+    Missing = ['undefined'].
+
+test(find_missing_none) :-
+    Spec = screen([t('nav.home'), t('nav.cart')]),
+    i18n:find_missing_translations(Spec, en, Missing),
+    Missing = [].
+
+test(find_missing_different_locale) :-
+    Spec = title(t('auth.login')),
+    i18n:find_missing_translations(Spec, es, Missing),
+    Missing = ['auth.login'].
+
+:- end_tests(missing_detection).
+
+% ============================================================================
+% Tests: JSON Generation
+% ============================================================================
+
+:- begin_tests(json_generation, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(json_has_braces) :-
+    i18n:generate_translation_json(en, JSON),
+    sub_string(JSON, 0, _, _, "{"),
+    sub_string(JSON, _, _, 0, "}").
+
+test(json_has_keys) :-
+    i18n:generate_translation_json(en, JSON),
+    sub_string(JSON, _, _, _, "\"greeting\""),
+    sub_string(JSON, _, _, _, "\"nav.home\"").
+
+test(json_has_values) :-
+    i18n:generate_translation_json(en, JSON),
+    sub_string(JSON, _, _, _, "Hello!"),
+    sub_string(JSON, _, _, _, "Home").
+
+test(json_different_locale) :-
+    i18n:generate_translation_json(es, JSON),
+    sub_string(JSON, _, _, _, "Hola!"),
+    sub_string(JSON, _, _, _, "Inicio").
+
+:- end_tests(json_generation).
+
+% ============================================================================
+% Tests: i18n Setup Generation
+% ============================================================================
+
+:- begin_tests(setup_generation, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(react_native_setup) :-
+    i18n:generate_i18n_setup(react_native, [en, es], Code),
+    sub_string(Code, _, _, _, "i18next"),
+    sub_string(Code, _, _, _, "initReactI18next"),
+    sub_string(Code, _, _, _, "en.json"),
+    sub_string(Code, _, _, _, "es.json").
+
+test(vue_setup) :-
+    i18n:generate_i18n_setup(vue, [en, es], Code),
+    sub_string(Code, _, _, _, "vue-i18n"),
+    sub_string(Code, _, _, _, "createI18n").
+
+test(flutter_setup) :-
+    i18n:generate_i18n_setup(flutter, [en, es], Code),
+    sub_string(Code, _, _, _, "AppLocalizations"),
+    sub_string(Code, _, _, _, "LocalizationsDelegate").
+
+test(swiftui_setup) :-
+    i18n:generate_i18n_setup(swiftui, [en, es], Code),
+    sub_string(Code, _, _, _, "SwiftUI"),
+    sub_string(Code, _, _, _, "LocalizedStringKey").
+
+:- end_tests(setup_generation).
+
+% ============================================================================
+% Tests: Validation
+% ============================================================================
+
+:- begin_tests(validation, [setup(setup_test_translations), cleanup(cleanup_test_translations)]).
+
+test(validate_empty_value) :-
+    i18n:add_translation(en, 'test.empty', ""),
+    i18n:validate_translations(en, Errors),
+    member(error(empty_value, 'test.empty'), Errors).
+
+test(validate_unbalanced_braces) :-
+    i18n:add_translation(en, 'test.unbalanced', "Hello {{name"),
+    i18n:validate_translations(en, Errors),
+    member(error(unbalanced_braces, 'test.unbalanced'), Errors).
+
+test(validate_good_translations) :-
+    i18n:clear_translations,
+    i18n:add_translation(en, 'test.good', "Valid translation"),
+    i18n:validate_translations(en, Errors),
+    Errors = [].
+
+:- end_tests(validation).
+
+% ============================================================================
+% Run tests when loaded directly
+% ============================================================================
+
+:- initialization(run_tests, main).

--- a/src/unifyweaver/patterns/pattern_composition.pl
+++ b/src/unifyweaver/patterns/pattern_composition.pl
@@ -3,21 +3,47 @@
 %
 % pattern_composition.pl - Advanced Pattern Composition Tools
 %
-% Provides dependency resolution, conflict detection, and validation
-% for composing multiple UI patterns across frameworks.
+% Provides hierarchical composition, reference resolution, slots,
+% templates, and validation for composing UI patterns.
 %
 % Key features:
+%   - Pattern references: ref(other_pattern)
+%   - Slots: Named placeholders that can be filled
+%   - Templates: Parameterized pattern generators
 %   - Dependency resolution with topological sorting
 %   - Conflict detection (name clashes, incompatible requirements)
 %   - Target compatibility validation
-%   - Composition graph analysis
 %
 % Usage:
+%   ?- resolve_refs_in_spec(Spec, context{}, Resolved).
+%   ?- fill_slots(layout, [fill(header, ref(app_header))], Filled).
+%   ?- instantiate_template(crud, [entity(product)], Spec).
 %   ?- compose_with_deps([app_nav, app_store], react_native, [], Result).
-%   ?- detect_conflicts([pattern1, pattern2], Conflicts).
-%   ?- validate_composition([patterns], target, Errors).
 
 :- module(pattern_composition, [
+    % Pattern references
+    is_pattern_ref/1,               % +Term
+    resolve_ref/3,                  % +Ref, +Context, -ResolvedSpec
+    resolve_refs_in_spec/3,         % +Spec, +Context, -ResolvedSpec
+
+    % Slots
+    define_slotted_pattern/4,       % +Name, +Spec, +Slots, +Options
+    fill_slots/3,                   % +PatternName, +Fills, -FilledSpec
+    fill_slots_in_spec/3,           % +Spec, +Fills, -FilledSpec
+    validate_slot_fills/3,          % +PatternName, +Fills, -Errors
+    get_pattern_slots/2,            % +PatternName, -Slots
+
+    % Templates
+    define_template/3,              % +TemplateName, +Params, +SpecTemplate
+    instantiate_template/3,         % +TemplateName, +ParamValues, -PatternSpec
+    template_exists/1,              % +TemplateName
+    get_template_params/2,          % +TemplateName, -Params
+
+    % Hierarchical composition
+    compose_hierarchical/3,         % +RootPattern, +Options, -ComposedSpec
+    get_pattern_tree/2,             % +PatternName, -Tree
+    get_pattern_refs/2,             % +PatternName, -Refs
+
     % Dependency resolution
     compose_with_deps/4,            % +Patterns, +Target, +Options, -Result
     resolve_dependencies/2,         % +Patterns, -AllPatterns
@@ -30,6 +56,7 @@
     % Validation
     validate_composition/3,         % +Patterns, +Target, -Errors
     validate_for_target/3,          % +Patterns, +Target, -Errors
+    check_circular_refs/2,          % +PatternName, -HasCircular
 
     % Analysis
     composition_graph/2,            % +Patterns, -Graph
@@ -42,6 +69,344 @@
 
 :- use_module(library(lists)).
 :- use_module('ui_patterns').
+
+% ============================================================================
+% DYNAMIC STORAGE
+% ============================================================================
+
+:- dynamic stored_template/3.   % stored_template(Name, Params, SpecTemplate)
+:- dynamic slot_definition/3.   % slot_definition(PatternName, SlotName, Default)
+
+% ============================================================================
+% PATTERN REFERENCES
+% ============================================================================
+
+%% is_pattern_ref(+Term)
+%
+%  Check if a term is a pattern reference.
+%
+is_pattern_ref(ref(Name)) :-
+    atom(Name).
+
+%% resolve_ref(+Ref, +Context, -ResolvedSpec)
+%
+%  Resolve a pattern reference to its specification.
+%
+%  Context can contain:
+%    - visited: list of already visited patterns (cycle detection)
+%    - fills: slot fills to apply
+%
+resolve_ref(ref(Name), Context, ResolvedSpec) :-
+    atom(Name),
+    % Check for circular reference
+    (   is_dict(Context), get_dict(visited, Context, Visited)
+    ->  \+ member(Name, Visited),
+        NewVisited = [Name|Visited]
+    ;   NewVisited = [Name]
+    ),
+    % Get the pattern
+    catch(ui_patterns:stored_pattern(Name, Spec, _), _, fail),
+    % Recursively resolve refs in the spec
+    (   is_dict(Context)
+    ->  put_dict(visited, Context, NewVisited, NewContext)
+    ;   NewContext = context{visited: NewVisited}
+    ),
+    resolve_refs_in_spec(Spec, NewContext, ResolvedSpec).
+
+resolve_ref(Ref, _, Ref) :-
+    \+ is_pattern_ref(Ref).
+
+%% resolve_refs_in_spec(+Spec, +Context, -ResolvedSpec)
+%
+%  Recursively resolve all pattern references in a specification.
+%
+resolve_refs_in_spec(ref(Name), Context, Resolved) :-
+    !,
+    resolve_ref(ref(Name), Context, Resolved).
+
+resolve_refs_in_spec(Spec, Context, Resolved) :-
+    compound(Spec),
+    Spec =.. [Functor|Args],
+    maplist(resolve_refs_in_arg(Context), Args, ResolvedArgs),
+    Resolved =.. [Functor|ResolvedArgs],
+    !.
+
+resolve_refs_in_spec(Spec, _, Spec).
+
+resolve_refs_in_arg(Context, Arg, Resolved) :-
+    is_list(Arg),
+    !,
+    maplist(resolve_refs_in_spec_wrapper(Context), Arg, Resolved).
+
+resolve_refs_in_arg(Context, Arg, Resolved) :-
+    resolve_refs_in_spec(Arg, Context, Resolved).
+
+resolve_refs_in_spec_wrapper(Context, Spec, Resolved) :-
+    resolve_refs_in_spec(Spec, Context, Resolved).
+
+%% get_pattern_refs(+PatternName, -Refs)
+%
+%  Get all pattern references in a pattern.
+%
+get_pattern_refs(PatternName, Refs) :-
+    catch(ui_patterns:stored_pattern(PatternName, Spec, _), _, fail),
+    collect_refs(Spec, RefList),
+    sort(RefList, Refs).
+
+collect_refs(ref(Name), [Name]) :-
+    !.
+
+collect_refs(Spec, Refs) :-
+    compound(Spec),
+    Spec =.. [_|Args],
+    maplist(collect_refs_from_arg, Args, RefLists),
+    append(RefLists, Refs),
+    !.
+
+collect_refs(_, []).
+
+collect_refs_from_arg(Arg, Refs) :-
+    is_list(Arg),
+    !,
+    maplist(collect_refs, Arg, RefLists),
+    append(RefLists, Refs).
+
+collect_refs_from_arg(Arg, Refs) :-
+    collect_refs(Arg, Refs).
+
+% ============================================================================
+% SLOTS
+% ============================================================================
+
+%% define_slotted_pattern(+Name, +Spec, +Slots, +Options)
+%
+%  Define a pattern with named slots.
+%
+%  Slots: [slot_name, ...] or [slot(name, default), ...]
+%
+define_slotted_pattern(Name, Spec, Slots, Options) :-
+    atom(Name),
+    is_list(Slots),
+    % Register slots
+    forall(member(S, Slots), register_slot(Name, S)),
+    % Define the pattern with slots option
+    SlotsOpt = slots(Slots),
+    (   member(slots(_), Options)
+    ->  NewOptions = Options
+    ;   NewOptions = [SlotsOpt|Options]
+    ),
+    catch(ui_patterns:define_pattern(Name, Spec, NewOptions), _, true).
+
+register_slot(PatternName, slot(SlotName, Default)) :-
+    !,
+    retractall(slot_definition(PatternName, SlotName, _)),
+    assertz(slot_definition(PatternName, SlotName, Default)).
+
+register_slot(PatternName, SlotName) :-
+    atom(SlotName),
+    retractall(slot_definition(PatternName, SlotName, _)),
+    assertz(slot_definition(PatternName, SlotName, none)).
+
+%% get_pattern_slots(+PatternName, -Slots)
+%
+%  Get the slot names for a pattern.
+%
+get_pattern_slots(PatternName, Slots) :-
+    findall(SlotName, slot_definition(PatternName, SlotName, _), Slots).
+
+%% fill_slots(+PatternName, +Fills, -FilledSpec)
+%
+%  Fill slots in a pattern with provided values.
+%
+%  Fills: [fill(slot_name, value), ...]
+%
+fill_slots(PatternName, Fills, FilledSpec) :-
+    catch(ui_patterns:stored_pattern(PatternName, Spec, _), _, fail),
+    fill_slots_in_spec(Spec, Fills, FilledSpec).
+
+%% fill_slots_in_spec(+Spec, +Fills, -FilledSpec)
+%
+%  Fill slot references in a spec with values from Fills.
+%
+fill_slots_in_spec(slot(Name), Fills, Filled) :-
+    !,
+    (   member(fill(Name, Value), Fills)
+    ->  Filled = Value
+    ;   Filled = slot(Name)  % Keep unfilled slot
+    ).
+
+fill_slots_in_spec(Spec, Fills, Filled) :-
+    compound(Spec),
+    Spec =.. [Functor|Args],
+    maplist(fill_slots_in_arg(Fills), Args, FilledArgs),
+    Filled =.. [Functor|FilledArgs],
+    !.
+
+fill_slots_in_spec(Spec, _, Spec).
+
+fill_slots_in_arg(Fills, Arg, Filled) :-
+    is_list(Arg),
+    !,
+    maplist(fill_slots_in_spec_wrapper(Fills), Arg, Filled).
+
+fill_slots_in_arg(Fills, Arg, Filled) :-
+    fill_slots_in_spec(Arg, Fills, Filled).
+
+fill_slots_in_spec_wrapper(Fills, Spec, Filled) :-
+    fill_slots_in_spec(Spec, Fills, Filled).
+
+%% validate_slot_fills(+PatternName, +Fills, -Errors)
+%
+%  Validate that all required slots are filled.
+%
+validate_slot_fills(PatternName, Fills, Errors) :-
+    get_pattern_slots(PatternName, Slots),
+    findall(Error, (
+        member(SlotName, Slots),
+        slot_definition(PatternName, SlotName, none),  % Required (no default)
+        \+ member(fill(SlotName, _), Fills),
+        format(atom(Error), "Missing required slot: ~w", [SlotName])
+    ), Errors).
+
+% ============================================================================
+% TEMPLATES
+% ============================================================================
+
+%% define_template(+TemplateName, +Params, +SpecTemplate)
+%
+%  Define a parameterized pattern template.
+%
+%  Params: [param_name, ...] - parameter names
+%  SpecTemplate: Pattern spec with ~w placeholders or param(name) references
+%
+define_template(Name, Params, SpecTemplate) :-
+    atom(Name),
+    is_list(Params),
+    retractall(stored_template(Name, _, _)),
+    assertz(stored_template(Name, Params, SpecTemplate)).
+
+%% template_exists(+TemplateName)
+%
+%  Check if a template exists.
+%
+template_exists(Name) :-
+    stored_template(Name, _, _).
+
+%% get_template_params(+TemplateName, -Params)
+%
+%  Get parameter names for a template.
+%
+get_template_params(Name, Params) :-
+    stored_template(Name, Params, _).
+
+%% instantiate_template(+TemplateName, +ParamValues, -PatternSpec)
+%
+%  Create a pattern spec by instantiating a template with parameter values.
+%
+%  ParamValues: [param_name(value), ...]
+%
+instantiate_template(Name, ParamValues, PatternSpec) :-
+    stored_template(Name, Params, SpecTemplate),
+    substitute_params(SpecTemplate, Params, ParamValues, PatternSpec).
+
+substitute_params(param(ParamName), _Params, ParamValues, Value) :-
+    !,
+    member(ParamOpt, ParamValues),
+    ParamOpt =.. [ParamName, Value].
+
+substitute_params(Spec, Params, ParamValues, Result) :-
+    atom(Spec),
+    atom_string(Spec, SpecStr),
+    (   sub_string(SpecStr, _, _, _, "~w")
+    ->  % Has format placeholder - substitute first param
+        Params = [FirstParam|_],
+        member(ParamOpt, ParamValues),
+        ParamOpt =.. [FirstParam, Value],
+        format(atom(Result), Spec, [Value])
+    ;   Result = Spec
+    ),
+    !.
+
+substitute_params(Spec, Params, ParamValues, Result) :-
+    compound(Spec),
+    Spec =.. [Functor|Args],
+    maplist(substitute_params_wrapper(Params, ParamValues), Args, SubstArgs),
+    Result =.. [Functor|SubstArgs],
+    !.
+
+substitute_params(Spec, _, _, Spec).
+
+substitute_params_wrapper(Params, ParamValues, Arg, Result) :-
+    is_list(Arg),
+    !,
+    maplist(substitute_params_in_list(Params, ParamValues), Arg, Result).
+
+substitute_params_wrapper(Params, ParamValues, Arg, Result) :-
+    substitute_params(Arg, Params, ParamValues, Result).
+
+substitute_params_in_list(Params, ParamValues, Item, Result) :-
+    substitute_params(Item, Params, ParamValues, Result).
+
+% ============================================================================
+% HIERARCHICAL COMPOSITION
+% ============================================================================
+
+%% get_pattern_tree(+PatternName, -Tree)
+%
+%  Get the dependency tree for a pattern.
+%
+%  Tree: tree(Name, Spec, Children)
+%
+get_pattern_tree(PatternName, Tree) :-
+    get_pattern_tree_acc(PatternName, [], Tree).
+
+get_pattern_tree_acc(PatternName, Visited, tree(PatternName, Spec, Children)) :-
+    \+ member(PatternName, Visited),
+    catch(ui_patterns:stored_pattern(PatternName, Spec, _), _, fail),
+    get_pattern_refs(PatternName, Refs),
+    NewVisited = [PatternName|Visited],
+    findall(Child, (
+        member(Ref, Refs),
+        get_pattern_tree_acc(Ref, NewVisited, Child)
+    ), Children).
+
+get_pattern_tree_acc(PatternName, Visited, tree(PatternName, circular, [])) :-
+    member(PatternName, Visited).
+
+%% compose_hierarchical(+RootPattern, +Options, -ComposedSpec)
+%
+%  Compose a pattern with all its references resolved.
+%
+compose_hierarchical(RootPattern, Options, ComposedSpec) :-
+    catch(ui_patterns:stored_pattern(RootPattern, Spec, _), _, fail),
+    (   member(fills(Fills), Options)
+    ->  fill_slots_in_spec(Spec, Fills, FilledSpec)
+    ;   FilledSpec = Spec
+    ),
+    resolve_refs_in_spec(FilledSpec, context{visited: []}, ComposedSpec).
+
+%% check_circular_refs(+PatternName, -HasCircular)
+%
+%  Check if a pattern has circular references.
+%
+check_circular_refs(PatternName, HasCircular) :-
+    check_circular_acc(PatternName, [], HasCircular).
+
+check_circular_acc(PatternName, Visited, true) :-
+    member(PatternName, Visited),
+    !.
+
+check_circular_acc(PatternName, Visited, HasCircular) :-
+    get_pattern_refs(PatternName, Refs),
+    NewVisited = [PatternName|Visited],
+    (   Refs = []
+    ->  HasCircular = false
+    ;   (   member(Ref, Refs),
+            check_circular_acc(Ref, NewVisited, true)
+        ->  HasCircular = true
+        ;   HasCircular = false
+        )
+    ).
 
 % ============================================================================
 % DEPENDENCY RESOLUTION
@@ -418,8 +783,52 @@ test_pattern_composition :-
     % Setup test patterns
     setup_test_patterns,
 
-    % Test 1: Dependency resolution
-    format('Test 1: Dependency resolution...~n'),
+    % Test 1: Pattern reference detection
+    format('Test 1: Pattern reference detection...~n'),
+    (   is_pattern_ref(ref(test_nav)),
+        \+ is_pattern_ref(not_a_ref),
+        \+ is_pattern_ref(ref)
+    ->  format('  PASS: Reference detection works~n')
+    ;   format('  FAIL: Reference detection broken~n')
+    ),
+
+    % Test 2: Template definition
+    format('~nTest 2: Template definition...~n'),
+    define_template(test_crud, [entity],
+        navigation(stack, [screen(list, '~wList', [])], [])),
+    (   template_exists(test_crud),
+        get_template_params(test_crud, [entity])
+    ->  format('  PASS: Template defined~n')
+    ;   format('  FAIL: Template not defined~n')
+    ),
+
+    % Test 3: Template instantiation
+    format('~nTest 3: Template instantiation...~n'),
+    (   instantiate_template(test_crud, [entity(product)], InstSpec),
+        InstSpec = navigation(stack, [screen(list, productList, [])], [])
+    ->  format('  PASS: Template instantiated~n')
+    ;   format('  FAIL: Template instantiation failed~n')
+    ),
+
+    % Test 4: Slot filling
+    format('~nTest 4: Slot filling...~n'),
+    TestSlotSpec = layout([slot(header), slot(content)]),
+    (   fill_slots_in_spec(TestSlotSpec, [fill(header, text('Header'))], FilledSlot),
+        FilledSlot = layout([text('Header'), slot(content)])
+    ->  format('  PASS: Slots filled~n')
+    ;   format('  FAIL: Slot filling broken~n')
+    ),
+
+    % Test 5: Pattern ref resolution
+    format('~nTest 5: Pattern ref resolution...~n'),
+    (   get_pattern_refs(test_with_ref, TestRefs),
+        member(test_nav, TestRefs)
+    ->  format('  PASS: Found refs: ~w~n', [TestRefs])
+    ;   format('  FAIL: Ref extraction broken~n')
+    ),
+
+    % Test 6: Dependency resolution
+    format('~nTest 6: Dependency resolution...~n'),
     (   resolve_dependencies([test_screen_with_deps], Resolved),
         member(test_base_store, Resolved),
         member(test_screen_with_deps, Resolved)
@@ -427,8 +836,8 @@ test_pattern_composition :-
     ;   format('  FAIL: Dependency resolution failed~n')
     ),
 
-    % Test 2: Dependency ordering
-    format('~nTest 2: Dependency ordering...~n'),
+    % Test 7: Dependency ordering
+    format('~nTest 7: Dependency ordering...~n'),
     (   dependency_order([test_screen_with_deps, test_base_store], Ordered),
         nth0(I1, Ordered, test_base_store),
         nth0(I2, Ordered, test_screen_with_deps),
@@ -437,40 +846,40 @@ test_pattern_composition :-
     ;   format('  FAIL: Ordering incorrect~n')
     ),
 
-    % Test 3: Conflict detection - name clash
-    format('~nTest 3: Conflict detection (name clash)...~n'),
+    % Test 8: Conflict detection - name clash
+    format('~nTest 8: Conflict detection (name clash)...~n'),
     (   detect_conflicts([test_store1, test_store2], Conflicts1),
         member(conflict(name_clash, _, _, _), Conflicts1)
     ->  format('  PASS: Name clash detected~n')
     ;   format('  FAIL: Name clash not detected~n')
     ),
 
-    % Test 4: No conflicts for compatible patterns
-    format('~nTest 4: Compatible patterns...~n'),
+    % Test 9: No conflicts for compatible patterns
+    format('~nTest 9: Compatible patterns...~n'),
     (   detect_conflicts([test_nav, test_query], Conflicts2),
         Conflicts2 = []
     ->  format('  PASS: No false conflicts~n')
     ;   format('  FAIL: False conflicts detected~n')
     ),
 
-    % Test 5: Target validation
-    format('~nTest 5: Target validation...~n'),
+    % Test 10: Target validation
+    format('~nTest 10: Target validation...~n'),
     (   validate_for_target([test_nav], react_native, Errors1),
         Errors1 = []
     ->  format('  PASS: Valid for target~n')
     ;   format('  FAIL: Validation incorrect~n')
     ),
 
-    % Test 6: Composition summary
-    format('~nTest 6: Composition summary...~n'),
+    % Test 11: Composition summary
+    format('~nTest 11: Composition summary...~n'),
     (   composition_summary([test_nav, test_query, test_store1], Summary),
         Summary = summary(pattern_count(3), _, _, _)
     ->  format('  PASS: Summary generated~n')
     ;   format('  FAIL: Summary incorrect~n')
     ),
 
-    % Test 7: Full composition with deps
-    format('~nTest 7: Full composition with deps...~n'),
+    % Test 12: Full composition with deps
+    format('~nTest 12: Full composition with deps...~n'),
     (   compose_with_deps([test_screen_with_deps], react_native, [], Result),
         Result = composition(patterns(Ps), _, _, _),
         length(Ps, L),
@@ -509,7 +918,12 @@ setup_test_patterns :-
         []),
     ui_patterns:define_pattern(test_screen_with_deps,
         navigation(stack, [screen(main, 'Main', [])], []),
-        [depends_on([test_base_store])]).
+        [depends_on([test_base_store])]),
+
+    % Pattern with reference
+    ui_patterns:define_pattern(test_with_ref,
+        composed([ref(test_nav), ref(test_query)], []),
+        []).
 
 cleanup_test_patterns :-
     retractall(ui_patterns:stored_pattern(test_nav, _, _)),
@@ -517,7 +931,9 @@ cleanup_test_patterns :-
     retractall(ui_patterns:stored_pattern(test_store1, _, _)),
     retractall(ui_patterns:stored_pattern(test_store2, _, _)),
     retractall(ui_patterns:stored_pattern(test_base_store, _, _)),
-    retractall(ui_patterns:stored_pattern(test_screen_with_deps, _, _)).
+    retractall(ui_patterns:stored_pattern(test_screen_with_deps, _, _)),
+    retractall(ui_patterns:stored_pattern(test_with_ref, _, _)),
+    retractall(stored_template(test_crud, _, _)).
 
 % ============================================================================
 % INITIALIZATION


### PR DESCRIPTION
## Summary

- Add pattern composition features: refs, slots, and templates
- Add i18n module for internationalization and localization
- Enable multi-locale code generation across all targets

## Changes

### Pattern Composition (pattern_composition.pl)

**New Features:**

| Feature | Description | Example |
|---------|-------------|---------|
| Pattern refs | Reference other patterns | `ref(other_pattern)` |
| Slots | Named placeholders | `slot(header)` + `fill(header, content)` |
| Templates | Parameterized patterns | `instantiate_template(crud, [entity(product)], Spec)` |
| Composition | Resolve all refs | `compose_hierarchical(root, [], Composed)` |

**Example:**
```prolog
% Define template
define_template(crud_screens, [entity],
    navigation(stack, [
        screen(list, '~wListScreen', []),
        screen(detail, '~wDetailScreen', [])
    ], []))

% Instantiate
instantiate_template(crud_screens, [entity(product)], Spec)
% Result: navigation(stack, [screen(list, productListScreen, []), ...])

% Fill slots
fill_slots_in_spec(
    layout([slot(header), slot(content)]),
    [fill(header, text('Hello'))],
    Filled)
% Result: layout([text('Hello'), slot(content)])
```

### i18n Module (i18n/i18n.pl)

**Features:**

| Feature | Usage |
|---------|-------|
| Translation keys | `t('nav.home')` |
| Interpolation | `"Hello, {{name}}!"` + `[name('World')]` |
| Pluralization | `'items.zero'`, `'items.one'`, `'items.other'` |
| Key extraction | `extract_translation_keys(Spec, Keys)` |
| Missing detection | `find_missing_translations(Spec, locale, Missing)` |
| Code generation | `generate_i18n_setup(react_native, [en, es], Code)` |

**Example:**
```prolog
% Define translations
define_translations(en, [
    'nav.home' - "Home",
    'welcome' - "Welcome, {{name}}!",
    'items.zero' - "No items",
    'items.one' - "1 item",
    'items.other' - "{{count}} items"
])

% Resolve
resolve_translation('welcome', en, [name('User')], Text)
% Text = "Welcome, User!"

% Pluralization
resolve_plural('items', 5, en, Text)
% Text = "5 items"
```

### Target-Specific i18n Code

**React Native:**
```typescript
import i18n from 'i18next';
import { initReactI18next } from 'react-i18next';
// Generated setup and locale files
```

**Vue:**
```typescript
import { createI18n } from 'vue-i18n';
// Generated setup and locale files
```

**Flutter:**
```dart
class AppLocalizations { ... }
// Generated ARB files
```

**SwiftUI:**
```swift
Text(LocalizedStringKey("nav.home"))
// Generated Localizable.strings files
```

## Tests

- **Pattern composition:** 30 existing + 12 inline tests (all passing)
- **i18n module:** 44 new plunit tests (all passing)

## Test Plan

- [x] Run pattern composition tests
- [x] Run i18n tests
- [x] Run ui_patterns tests (38 passed)
- [x] Run ui_patterns_extended tests (50 passed)
- [x] Run e-commerce tests (43 passed)

Generated with [Claude Code](https://claude.com/claude-code)
