### PR TITLE
feat(federated): Add automatic cluster count selection with configurable variance

### DIFF
--- a/docs/CLUSTER_COUNT_THEORY.md
+++ b/docs/CLUSTER_COUNT_THEORY.md
@@ -89,13 +89,18 @@ where r is the intrinsic dimensionality (dimensions for target variance).
 
 ### Calculation
 
-We find r such that the top r singular values capture 80% of variance:
+We find r such that the top r singular values capture the target variance (configurable, default 80%):
 
 ```python
 cumvar = cumsum(σ²) / sum(σ²)
-r = argmin(cumvar >= 0.80) + 1
+r = argmin(cumvar >= target_variance) + 1
 K = 2^r  # Binary discretization per dimension
 ```
+
+**Relationship between target variance and cluster count:**
+- Higher target variance (e.g., 95% vs 80%) → more dimensions needed → larger r → **more clusters**
+- Lower target variance (e.g., 50%) → fewer dimensions needed → smaller r → **fewer clusters**
+- This makes intuitive sense: capturing more variance requires finer-grained clustering
 
 ### References
 
@@ -154,8 +159,10 @@ Best for: Quick estimation when you don't need precise intrinsic dimensionality 
 | Method | Formula | Theoretical Grounding | Computational Cost |
 |--------|---------|----------------------|-------------------|
 | Effective rank | (Σσ)²/Σσ² | Spectral theory, information theory | O(K³) for SVD |
-| Covering (2^r) | 2^r where r = dim(80% var) | Metric geometry, manifold theory | O(K³) for SVD |
+| Covering (2^r) | 2^r where r = dim(target_var) | Metric geometry, manifold theory | O(K³) for SVD |
 | √N | √K | Heuristic, model selection | O(1) |
+
+Note: The covering method's target variance is configurable (default: 80%). Use `--target-variance` to adjust.
 
 ## Recommendation
 


### PR DESCRIPTION
  ## Summary
  - Add `--cluster-criterion` option to automatically determine optimal K based on embedding structure
  - Add `--target-variance` parameter to make covering method configurable (default 80%)
  - Fix undefined variable bug in analyze script (`r_80` → `r_target`)

  ## Cluster Count Methods

  | Method | Formula | Use Case |
  |--------|---------|----------|
  | `effective_rank` | (Σσ)²/Σσ² | Default - spectral participation ratio |
  | `covering` | 2^r where r captures target variance | Geometric coverage guarantees |
  | `sqrt_n` | √N | Quick estimation |

  ## Target Variance Behavior

  Higher target variance → more dimensions needed → more clusters:
  - 50% variance → K=2
  - 80% variance → K=256 (default)
  - 95% variance → K=1024

  ## Test Results

  Trees-only models show excellent routing (>97% top-1 weight):
  | Model | Current K | Effective Rank | Top-1 Weight |
  |-------|----------|----------------|--------------|
  | s243a | 275 | 59 | 97.2% ✓ |
  | s243a_groups | 48 | 16 | 97.8% ✓ |

  🤖 Generated with [Claude Code](https://claude.com/claude-code)