### PR TITLE
feat(density-explorer): Add entropy-based arrows to smmx export

### DIFF
--- a/docs/proposals/CURATION_QUALITY_METRICS.md
+++ b/docs/proposals/CURATION_QUALITY_METRICS.md
@@ -1,0 +1,191 @@
+# Proposal: Curation Quality Metrics for Projected Embeddings
+
+## Overview
+
+This proposal describes metrics for measuring curation quality and how curation improves tree structure when applied via blended embeddings. The goal is to establish reproducible quality measures that work across different curation sources (personal, crowd-sourced, expert taxonomies).
+
+## Current Metrics in the Codebase
+
+### 1. Ranking Metrics (`scripts/evaluate_pearltrees_projection.py`)
+
+**What they measure:** How well the projection model retrieves the correct target given a query.
+
+| Metric | Description | Current Use |
+|--------|-------------|-------------|
+| R@1 | Recall at 1 - correct target in top result | Projection accuracy |
+| R@5 | Recall at 5 - correct target in top 5 | Retrieval quality |
+| R@10 | Recall at 10 - correct target in top 10 | Broader retrieval |
+| MRR | Mean Reciprocal Rank - average of 1/rank | Overall ranking quality |
+
+**Current location:** `scripts/evaluate_pearltrees_projection.py:132-149`
+
+**Curation quality application:**
+- Higher R@K with fewer curated examples = better curation efficiency
+- Compare MRR across curation sources to evaluate organizational quality
+- Track MRR vs. curation size to find minimum viable curation
+
+### 2. Cluster Quality Metrics (`scripts/analyze_federated_clusters.py`)
+
+**What they measure:** How well-separated and meaningful the learned clusters are.
+
+| Metric | Description | Current Use |
+|--------|-------------|-------------|
+| Top-1 softmax weight | Average weight on highest-scoring cluster | Routing confidence |
+| Top-10 softmax weight | Cumulative weight on top 10 clusters | Cluster spread |
+| Centroid similarity (mean) | Average pairwise similarity of centroids | Cluster distinctness |
+| Centroid similarity (max) | Maximum pairwise similarity | Worst-case overlap |
+| Effective rank | Spectral participation ratio | Intrinsic dimensionality |
+| Over-segmentation flag | top-1 < 50% indicates too many clusters | Model health |
+
+**Current location:** `scripts/analyze_federated_clusters.py:68-120`
+
+**Curation quality application:**
+- Well-curated data should produce high top-1 weights (confident routing)
+- Lower centroid similarity = better-separated conceptual clusters
+- Effective rank indicates how many distinct "directions" the curation captures
+
+### 3. Hierarchy Quality Metrics (`scripts/mindmap/hierarchy_objective.py`)
+
+**What they measure:** How well a tree structure matches semantic and information-theoretic principles.
+
+| Metric | Description | Current Use |
+|--------|-------------|-------------|
+| D(T) | Semantic distance - parent-child coherence | Tree structure quality |
+| H(T) | Entropy gain - information flow between levels | Hierarchical organization |
+| J(T) | Combined objective (α·D + β·H) | Overall hierarchy quality |
+
+**Current location:** `scripts/mindmap/hierarchy_objective.py:254-284`
+
+**Curation quality application:**
+- D(T): Good curation should produce low semantic distance (related concepts grouped)
+- H(T): Good curation should show entropy increasing with depth (general→specific)
+- J(T): Combined score for comparing curation strategies
+
+---
+
+## Proposed: Curation Quality Metrics
+
+### 4. Curation Efficiency Ratio (NEW)
+
+**Definition:**
+```
+CER = ΔQuality / ΔCuration_Size
+```
+
+Where:
+- ΔQuality = improvement in J(T) or MRR from adding curation
+- ΔCuration_Size = number of curated nodes/relationships added
+
+**Purpose:** Measure how much quality improvement each curated item provides. High CER = efficient curation.
+
+### 5. Generalization Gap (NEW)
+
+**Definition:**
+```
+G = Quality(unseen_data) / Quality(seen_data)
+```
+
+**Purpose:** Measure how well the curation transfers to new data. G ≈ 1.0 means good generalization.
+
+**Application to blended embeddings:**
+- Compute J(T) on trees built from curated data
+- Compute J(T) on trees built from foreign data (same embedding space)
+- Ratio indicates transfer quality
+
+### 6. Blend Sensitivity Analysis (NEW)
+
+**Definition:**
+```
+S(b) = dJ(T)/db at blend level b
+```
+
+**Purpose:** Measure how tree quality changes with blend ratio.
+
+**Interpretation:**
+- S(b) > 0: More projection improves quality
+- S(b) < 0: Too much projection hurts quality
+- S(b) = 0: Optimal blend point
+
+---
+
+## Measuring Curation Impact on Tree Structure
+
+### Experimental Protocol
+
+1. **Baseline (blend=0):** Build tree using raw embeddings
+   - Compute J(T), D(T), H(T)
+   - This represents "no curation influence"
+
+2. **Projected (blend=1):** Build tree using fully projected embeddings
+   - Compute J(T), D(T), H(T)
+   - This represents "full curation influence"
+
+3. **Blended (blend=0.1 to 0.9):** Sweep blend values
+   - Find optimal blend that maximizes J(T)
+   - Plot quality curves
+
+4. **Generalization test:** Repeat on held-out data
+   - Verify improvement transfers to unseen concepts
+
+### Expected Outcomes
+
+| Scenario | D(T) | H(T) | J(T) | Interpretation |
+|----------|------|------|------|----------------|
+| Good curation | ↓ | ↑ | ↑ | Tighter clusters, better hierarchy |
+| Poor curation | ↔ | ↔ | ↔ | No improvement over baseline |
+| Overfitting | ↓ seen, ↑ unseen | - | ↓ on unseen | Memorized, didn't generalize |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Integrate Existing Metrics
+
+1. Add J(T) computation to density explorer recompute
+2. Display D(T), H(T), J(T) in UI after tree generation
+3. Log metrics with blend value for analysis
+
+### Phase 2: Curation Efficiency Analysis
+
+1. Create `scripts/analyze_curation_efficiency.py`
+2. Input: curation data, test data, embedding model
+3. Output: CER curve, optimal curation size recommendation
+
+### Phase 3: Blend Optimization
+
+1. Add auto-blend feature to density explorer
+2. Sweep blend values, find optimal via J(T)
+3. Display recommended blend with confidence
+
+### Phase 4: Comparative Analysis Tool
+
+1. Compare multiple curation sources on same test data
+2. Generate report: which curation style works best for which domains
+3. Support A/B testing of curation strategies
+
+---
+
+## Relation to Reproducibility
+
+While curations are personal/perspectival, quality metrics are objective:
+
+| Aspect | Reproducible? | Notes |
+|--------|---------------|-------|
+| Curation content | No | Personal choice |
+| Metric computation | Yes | Same algorithm, same results |
+| Quality comparison | Yes | Can compare any two curations |
+| Optimal blend | Yes | Determined by optimization |
+
+This allows statements like:
+- "Curation A achieves J(T)=0.85 with 500 nodes"
+- "Curation B needs 2000 nodes for same quality"
+- "Curation A generalizes better (G=0.95 vs G=0.78)"
+
+---
+
+## References
+
+- `scripts/evaluate_pearltrees_projection.py` - Ranking metrics
+- `scripts/analyze_federated_clusters.py` - Cluster analysis
+- `scripts/mindmap/hierarchy_objective.py` - Hierarchy objective J(T)
+- `docs/CLUSTER_COUNT_THEORY.md` - Theoretical basis for cluster selection

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -2174,6 +2174,13 @@ json.dumps(data)
                 xml += `x="${x}" y="${y}" palette="${palette}" colorinfo="${palette}" `;
                 xml += `text="${escapeXml(node.title)}">\n`;
 
+                // Add arrow from parent to child (for non-root nodes)
+                if (!isRoot) {
+                    xml += `        <parent-relation guid="${generateGuid()}">\n`;
+                    xml += '          <style target-arrow="filledArrow"/>\n';
+                    xml += '        </parent-relation>\n';
+                }
+
                 // Add Wikipedia link
                 xml += `        <link urllink="${escapeXml(wikiUrl)}"/>\n`;
 

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -2174,10 +2174,10 @@ json.dumps(data)
                 xml += `x="${x}" y="${y}" palette="${palette}" colorinfo="${palette}" `;
                 xml += `text="${escapeXml(node.title)}">\n`;
 
-                // Add arrow from parent to child (for non-root nodes)
+                // Add arrow pointing toward parent/root (for non-root nodes)
                 if (!isRoot) {
                     xml += `        <parent-relation guid="${generateGuid()}">\n`;
-                    xml += '          <style target-arrow="filledArrow"/>\n';
+                    xml += '          <style source-arrow="filledArrow"/>\n';
                     xml += '        </parent-relation>\n';
                 }
 

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -892,6 +892,49 @@ def compute_density_grid(points_2d, bandwidth=None, grid_size=100, padding=0.1):
     return {'x_min': float(x_min), 'x_max': float(x_max), 'y_min': float(y_min), 'y_max': float(y_max),
             'grid_size': grid_size, 'values': Z.tolist(), 'bandwidth': float(bandwidth)}
 
+def compute_fisher_entropy(embeddings, k=10):
+    """
+    Compute Fisher-based entropy for each node using local density.
+    Higher density = more general concept = lower entropy
+    Lower density = more specific concept = higher entropy
+    """
+    n = len(embeddings)
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    emb_norm = embeddings / (norms + 1e-8)
+
+    # Compute pairwise distances
+    diff = emb_norm[:, np.newaxis, :] - emb_norm[np.newaxis, :, :]
+    dist_matrix = np.sqrt((diff ** 2).sum(axis=2))
+
+    # k-NN density: inverse of average distance to k nearest neighbors
+    k_actual = min(k, n - 1)
+    knn_dists = np.sort(dist_matrix, axis=1)[:, 1:k_actual+1]  # Exclude self
+    avg_knn_dist = knn_dists.mean(axis=1)
+    density = 1.0 / (avg_knn_dist + 1e-8)
+
+    # Fisher entropy: log(1/density) = -log(density)
+    # Normalize to 0-1 range for easier use
+    entropy = -np.log(density + 1e-8)
+    entropy = (entropy - entropy.min()) / (entropy.max() - entropy.min() + 1e-8)
+
+    return entropy
+
+# Storage for external entropy data (optional)
+_external_entropy = None
+
+def set_external_entropy(entropy_dict):
+    """Set externally computed entropy/probability data."""
+    global _external_entropy
+    _external_entropy = entropy_dict
+    print(f"Loaded external entropy for {len(entropy_dict)} nodes")
+
+def get_node_entropy(node_id, fisher_entropy):
+    """Get entropy for a node, preferring external data if available."""
+    global _external_entropy
+    if _external_entropy is not None and node_id in _external_entropy:
+        return float(_external_entropy[node_id])
+    return float(fisher_entropy[node_id])
+
 def build_mst_tree(embeddings, points_2d, titles=None):
     norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
     emb_norm = embeddings / (norms + 1e-8)
@@ -915,12 +958,18 @@ def build_mst_tree(embeddings, points_2d, titles=None):
                 visited.add(neighbor)
                 parent[neighbor], depth[neighbor] = node, depth[node] + 1
                 queue.append(neighbor)
+
+    # Compute Fisher entropy for each node
+    fisher_entropy = compute_fisher_entropy(embeddings)
+
     nodes, edges = [], []
     for i in range(len(embeddings)):
         p_id = parent.get(i)
+        node_ent = get_node_entropy(i, fisher_entropy)
         nodes.append({'id': i, 'title': titles[i] if titles else f"Node {i}",
                       'parent_id': int(p_id) if p_id is not None else None,
-                      'depth': int(depth.get(i, 0)), 'x': float(points_2d[i, 0]), 'y': float(points_2d[i, 1])})
+                      'depth': int(depth.get(i, 0)), 'x': float(points_2d[i, 0]), 'y': float(points_2d[i, 1]),
+                      'entropy': node_ent})
         if p_id is not None:
             edges.append({'source_id': int(p_id), 'target_id': i, 'weight': float(cos_dist[i, p_id])})
     return {'nodes': nodes, 'edges': edges, 'root_id': root, 'tree_type': 'mst'}
@@ -945,12 +994,21 @@ def build_j_guided_tree(embeddings, points_2d, titles=None, k_neighbors=10):
             if d < min_dist: min_dist, best_parent = d, placed_node
         parent[idx], depth[idx] = best_parent, depth[best_parent] + 1
         placed.add(idx)
+
+    # Compute Fisher entropy from density (already computed above)
+    # entropy = -log(density), normalized to 0-1
+    log_density = np.log(density + 1e-8)
+    fisher_entropy = -log_density
+    fisher_entropy = (fisher_entropy - fisher_entropy.min()) / (fisher_entropy.max() - fisher_entropy.min() + 1e-8)
+
     nodes, edges = [], []
     for i in range(n):
         p_id = parent.get(i)
+        node_ent = get_node_entropy(i, fisher_entropy)
         nodes.append({'id': i, 'title': titles[i] if titles else f"Node {i}",
                       'parent_id': int(p_id) if p_id is not None else None,
-                      'depth': int(depth.get(i, 0)), 'x': float(points_2d[i, 0]), 'y': float(points_2d[i, 1])})
+                      'depth': int(depth.get(i, 0)), 'x': float(points_2d[i, 0]), 'y': float(points_2d[i, 1]),
+                      'entropy': node_ent})
         if p_id is not None:
             edges.append({'source_id': int(p_id), 'target_id': i, 'weight': float(dist_matrix[i, p_id])})
     return {'nodes': nodes, 'edges': edges, 'root_id': root, 'tree_type': 'j-guided'}
@@ -2174,10 +2232,20 @@ json.dumps(data)
                 xml += `x="${x}" y="${y}" palette="${palette}" colorinfo="${palette}" `;
                 xml += `text="${escapeXml(node.title)}">\n`;
 
-                // Add arrow pointing toward parent/root (for non-root nodes)
-                if (!isRoot) {
+                // Add arrow based on entropy: flows from general (low entropy) to specific (high entropy)
+                if (!isRoot && parentId !== -1) {
+                    const parentNode = nodeMap[parentId];
+                    const childEntropy = node.entropy || 0;
+                    const parentEntropy = parentNode?.entropy || 0;
+
                     xml += `        <parent-relation guid="${generateGuid()}">\n`;
-                    xml += '          <style source-arrow="filledArrow"/>\n';
+                    if (parentEntropy < childEntropy) {
+                        // Parent is more general → arrow points to child (target-arrow)
+                        xml += '          <style target-arrow="filledArrow"/>\n';
+                    } else {
+                        // Child is more general → arrow points to parent (source-arrow)
+                        xml += '          <style source-arrow="filledArrow"/>\n';
+                    }
                     xml += '        </parent-relation>\n';
                 }
 


### PR DESCRIPTION
  ## Summary
  - Add directional arrows to ".smmx" export showing concept flow
  - Compute Fisher entropy from local density to determine general vs specific concepts
  - Arrows flow from general (low entropy) → specific (high entropy)

  ## Changes

  ### Arrow Export
  - Non-root nodes get `<parent-relation>` with arrow styling
  - Arrow direction based on entropy comparison between connected nodes

  ### Fisher Entropy
  - Compute per-node entropy from k-NN density in embedding space
  - High density = general concept (low entropy)
  - Low density = specific concept (high entropy)
  - Support for optional external entropy data loading

  ### Documentation
  - Add `docs/proposals/CURATION_QUALITY_METRICS.md` covering:
    - Existing metrics (R@K, MRR, J(T), D(T), H(T))
    - Proposed new metrics (Curation Efficiency Ratio, Generalization Gap)
    - Blend sensitivity analysis methodology

  ## Test Plan
  - [x] Export mindmap with arrows, verify direction in SimpleMind
  - [x] Verify Fisher entropy correlates with concept generality
  - [ ] Test with external probability data (optional feature)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)