### PR TITLE
perf(csharp-query): partial index for recursive multi-key joins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,19 +23,31 @@ jobs:
           sudo apt-get install -y --no-install-recommends software-properties-common
 
           added=0
-          for attempt in 1 2 3 4 5; do
-            if sudo apt-add-repository ppa:swi-prolog/stable -y; then
-              added=1
-              break
-            fi
-            echo "WARN: Launchpad unavailable; retrying apt-add-repository ($attempt/5)..." >&2
-            sleep $((attempt * 15))
-          done
-          if [ "$added" -eq 0 ]; then
+          set +e
+          sudo apt-add-repository ppa:swi-prolog/stable -y
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            added=1
+          else
             echo "WARN: Could not add PPA; installing SWI-Prolog from Ubuntu repo." >&2
           fi
 
+          set +e
           sudo apt-get update -qq
+          update_status=$?
+          set -e
+          if [ "$update_status" -ne 0 ] && [ "$added" -eq 1 ]; then
+            echo "WARN: apt-get update failed after adding PPA; removing PPA and retrying..." >&2
+            set +e
+            sudo apt-add-repository --remove ppa:swi-prolog/stable -y
+            set -e
+            sudo apt-get update -qq
+          elif [ "$update_status" -ne 0 ]; then
+            echo "ERROR: apt-get update failed." >&2
+            exit "$update_status"
+          fi
+
           sudo apt-get install -y swi-prolog
 
       - name: Verify SWI-Prolog installation
@@ -127,19 +139,31 @@ jobs:
           sudo apt-get install -y --no-install-recommends software-properties-common
 
           added=0
-          for attempt in 1 2 3 4 5; do
-            if sudo apt-add-repository ppa:swi-prolog/stable -y; then
-              added=1
-              break
-            fi
-            echo "WARN: Launchpad unavailable; retrying apt-add-repository ($attempt/5)..." >&2
-            sleep $((attempt * 15))
-          done
-          if [ "$added" -eq 0 ]; then
+          set +e
+          sudo apt-add-repository ppa:swi-prolog/stable -y
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            added=1
+          else
             echo "WARN: Could not add PPA; installing SWI-Prolog from Ubuntu repo." >&2
           fi
 
+          set +e
           sudo apt-get update -qq
+          update_status=$?
+          set -e
+          if [ "$update_status" -ne 0 ] && [ "$added" -eq 1 ]; then
+            echo "WARN: apt-get update failed after adding PPA; removing PPA and retrying..." >&2
+            set +e
+            sudo apt-add-repository --remove ppa:swi-prolog/stable -y
+            set -e
+            sudo apt-get update -qq
+          elif [ "$update_status" -ne 0 ]; then
+            echo "ERROR: apt-get update failed." >&2
+            exit "$update_status"
+          fi
+
           sudo apt-get install -y swi-prolog
 
       - name: Install .NET SDK

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -23,6 +23,8 @@
 :- dynamic user:test_factorial_input/1.
 :- dynamic user:test_fib_param/2.
 :- dynamic user:test_recursive_label_path/3.
+:- dynamic user:test_sparse_input_fact/3.
+:- dynamic user:test_sparse_input_filtered/3.
 :- dynamic user:test_post_agg_param/2.
 :- dynamic user:test_customer/1.
 :- dynamic user:test_customer_alice_or_bob/1.
@@ -184,6 +186,7 @@ test_csharp_query_target :-
         verify_parameterized_recursive_single_key_join_keeps_scan_index,
         verify_recursive_selection_scan_uses_scan_index,
         verify_recursive_multi_key_recursive_join_uses_partial_index,
+        verify_parameterized_sparse_input_positions_runtime,
         verify_parameterized_fib_plan,
         verify_parameterized_fib_delta_first_join_order,
         verify_parameterized_fib_runtime,
@@ -455,12 +458,19 @@ setup_test_data :-
         test_fib_param(N2, F2),
         F is F1 + F2
     )),
-    assertz(user:mode(test_recursive_label_path(+, -, +))),
     assertz(user:test_recursive_label_path(a, b, red)),
     assertz(user:test_recursive_label_path(b, c, red)),
     assertz(user:(test_recursive_label_path(X, Z, L) :-
         test_recursive_label_path(X, Y, L),
         test_recursive_label_path(Y, Z, L)
+    )),
+    assertz(user:mode(test_sparse_input_filtered(+, -, +))),
+    assertz(user:test_sparse_input_fact(a, 1, red)),
+    assertz(user:test_sparse_input_fact(a, 2, red)),
+    assertz(user:test_sparse_input_fact(a, 3, blue)),
+    assertz(user:(test_sparse_input_filtered(X, Y, L) :-
+        test_sparse_input_fact(X, Y, L),
+        Y > 1
     )),
     assertz(user:mode(test_post_agg_param(+, -))),
     assertz(user:test_post_agg_param(0, 0)),
@@ -626,7 +636,9 @@ cleanup_test_data :-
     retractall(user:test_fib_param(_, _)),
     retractall(user:mode(test_fib_param(_,_))),
     retractall(user:test_recursive_label_path(_, _, _)),
-    retractall(user:mode(test_recursive_label_path(_, _, _))),
+    retractall(user:test_sparse_input_fact(_, _, _)),
+    retractall(user:test_sparse_input_filtered(_, _, _)),
+    retractall(user:mode(test_sparse_input_filtered(_, _, _))),
     retractall(user:test_post_agg_param(_, _)),
     retractall(user:mode(test_post_agg_param(_,_))),
     retractall(user:test_banned(_)),
@@ -1488,13 +1500,22 @@ verify_recursive_multi_key_recursive_join_uses_partial_index :-
     sub_term(recursive_ref{type:recursive_ref, predicate:predicate{name:test_recursive_label_path, arity:3}, role:_, width:_}, Left),
     sub_term(recursive_ref{type:recursive_ref, predicate:predicate{name:test_recursive_label_path, arity:3}, role:_, width:_}, Right),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
-    harness_source_with_strategy_flag(ModuleClass, [[a, red]], 'KeyJoinRecursiveIndexPartial', HarnessSource),
+    harness_source_with_strategy_flag(ModuleClass, [], 'KeyJoinRecursiveIndexPartial', HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
         ['a,b,red',
+         'b,c,red',
          'a,c,red',
          'STRATEGY_USED:KeyJoinRecursiveIndexPartial=true'],
-        [[a, red]],
+        [],
         HarnessSource).
+
+verify_parameterized_sparse_input_positions_runtime :-
+    csharp_query_target:build_query_plan(test_sparse_input_filtered/3, [target(csharp_query)], Plan),
+    get_dict(metadata, Plan, Meta),
+    get_dict(modes, Meta, [input, output, input]),
+    get_dict(root, Plan, Root),
+    sub_term(selection{type:selection, input:_, predicate:_, width:_}, Root),
+    maybe_run_query_runtime(Plan, ['a,2,red'], [[a, red]]).
 
 verify_parameterized_fib_plan :-
     csharp_query_target:build_query_plan(test_fib_param/2, [target(csharp_query)], Plan),


### PR DESCRIPTION
  - Adds KeyJoinRecursiveIndexPartial for tiny-probe multi-key recursive joins (pivot RecursiveFactIndex + filter
    remaining keys) to avoid building full RecursiveJoinIndex.
  - Fixes parameter filtering/bound scans when input positions are non-contiguous and parameters are passed as compact
    tuples.
  - Adds regression coverage in tests/core/test_csharp_query_target.pl (recursive partial-index strategy + sparse input
    positions runtime).
  - CI hardening: tolerates Launchpad/PPA outages during SWI-Prolog install (fallback to Ubuntu repo; remove PPA if apt-
    get update fails after adding it).