### PR TITLE
perf(csharp-query): optimize reachability transitive closure

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -7,7 +7,7 @@ Roadmap: `docs/targets/csharp-query-runtime-roadmap.md`
 ## Status (v0.1)
 - **Non-recursive clauses** – fact scans, joins, selections, projections, and unions translate to query nodes executed via LINQ.
 - **Arithmetic & comparisons** – `is/2`, inequality operators, and `dif/2` become arithmetic or selection nodes with runtime evaluation.
-- **Recursive predicates** – semi-naive fixpoint driver supports single-predicate recursion (e.g., reachability, factorial).
+- **Recursive predicates** – semi-naive fixpoint driver supports single-predicate recursion; canonical reachability patterns compile to `TransitiveClosureNode` for faster closure evaluation.
 - **Mutual recursion** – strongly connected predicate groups emit `mutual_fixpoint` plans composed of `cross_ref` nodes, enabling even/odd style dependencies.
 - **Negation (safe/stratified)** – `\+/1` compiles to `NegationNode` and supports stratified negation over derived predicates via program definition materialisation.
 - **Deduplication** – per-predicate `HashSet<object[]>` mirrors Bash distinct semantics.

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -1865,29 +1865,11 @@ verify_recursive_arithmetic_plan :-
 verify_recursive_plan :-
     csharp_query_target:build_query_plan(test_reachable/2, [target(csharp_query)], Plan),
     get_dict(is_recursive, Plan, true),
-    get_dict(root, Plan, fixpoint{type:fixpoint, head:_, base:Base, recursive:[RecursiveClause], width:2}),
-    Base = projection{
-        type:projection,
-        input:relation_scan{predicate:predicate{name:test_fact, arity:2}, type:relation_scan, width:_},
-        columns:[0, 1],
+    get_dict(root, Plan, transitive_closure{type:transitive_closure,
+        head:predicate{name:test_reachable, arity:2},
+        edge:predicate{name:test_fact, arity:2},
         width:2
-    },
-    RecursiveClause = projection{
-        type:projection,
-        input:JoinNode,
-        columns:[0, 3],
-        width:2
-    },
-    JoinNode = join{
-        type:join,
-        left:relation_scan{predicate:predicate{name:test_fact, arity:2}, type:relation_scan, width:_},
-        right:recursive_ref{predicate:predicate{name:test_reachable, arity:2}, role:delta, type:recursive_ref, width:_},
-        left_keys:[1],
-        right_keys:[0],
-        left_width:_,
-        right_width:_,
-        width:_
-    },
+    }),
     maybe_run_query_runtime(Plan, ['alice,bob', 'bob,charlie', 'alice,charlie']).
 
 verify_mutual_recursion_plan :-


### PR DESCRIPTION
  - Adds a dedicated TransitiveClosureNode runtime operator to compute transitive closure without allocating join rows
    per fixpoint iteration.
  - Updates the C# query plan compiler to recognize the standard reachable/2 over edge/2 pattern (including forward/
    backward join variants) and emit transitive_closure plans.
  - Adjusts C# query target tests to assert the optimized plan shape and confirms runtime smoke coverage for
    test_reachable/2.

  Push the branch and open the PR when you’re ready, then I’ll continue with the next perf slice (parameterized/demand-
  driven reachability or further join heuristics).