### PR TITLE
feat: HTTP CLI Server for AI Browser Agents

### DIFF
--- a/docs/HTTP_CLI_SERVER.md
+++ b/docs/HTTP_CLI_SERVER.md
@@ -1,0 +1,157 @@
+# HTTP CLI Server
+
+A sandboxed HTTP interface for shell search commands, designed for AI browser agents (like Comet/Perplexity) to explore codebases.
+
+## Overview
+
+The HTTP CLI Server exposes `grep`, `find`, `cat`, and other read-only commands via HTTP endpoints, with a Vue-based web interface. It includes a feedback channel for agent-to-agent communication.
+
+```bash
+# Start server
+SANDBOX_ROOT=/path/to/project npx ts-node src/unifyweaver/shell/http-server.ts
+
+# Access at http://localhost:3001
+```
+
+## Target Audiences
+
+### 1. AI Browser Agents (Primary)
+
+**Examples:** Comet (Perplexity), Claude with web access, automated research tools
+
+**Strengths:**
+- Clean JSON API for programmatic access
+- Structured feedback channel (`POST /feedback`) for observations
+- Sandboxed execution prevents accidental modifications
+- CORS enabled for browser-based agents
+
+**Weaknesses:**
+- Limited to read-only operations
+- No command chaining or pipelines
+- Cannot invoke build/test/compile workflows
+
+**Best for:** Code exploration, searching for patterns, reading files, leaving observations for human review.
+
+### 2. Shell-Literate Developers
+
+**Examples:** Developers comfortable with grep, find, CLI flags
+
+**Strengths:**
+- Familiar command syntax - write commands as you would in terminal
+- Options field accepts standard CLI flags (`-i`, `--include=*.ts`, `-type d`)
+- Quick access without opening a terminal
+- Safe sandbox prevents accidental `rm -rf` disasters
+
+**Weaknesses:**
+- Must know CLI flags (no GUI affordances)
+- "Custom" tab's JSON array for arguments is unintuitive
+- No tab completion or command history
+- Limited command set (grep/find/cat/ls/head/tail/wc only)
+
+**Best for:** Quick searches when you don't want to context-switch to terminal.
+
+### 3. General Users / Non-Technical
+
+**Strengths:**
+- Web-based UI is accessible
+- Tabbed interface separates operations clearly
+
+**Weaknesses:**
+- "Options (space-separated)" requires knowing CLI flags
+- No guided controls (checkboxes for "case insensitive", dropdowns for file types)
+- Error messages assume CLI familiarity
+- No help text explaining what each option does
+
+**Not recommended** for users unfamiliar with shell commands. A GUI with explicit controls would serve this audience better.
+
+## API Reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/` | GET | HTML/Vue interface |
+| `/health` | GET | Server status and config |
+| `/commands` | GET | List allowed commands |
+| `/grep` | POST | Search file contents |
+| `/find` | POST | Find files by pattern |
+| `/cat` | POST | Read file contents |
+| `/exec` | POST | Execute allowed command |
+| `/feedback` | POST | Submit feedback (for agents) |
+| `/feedback` | GET | Read feedback history |
+
+### Example: Grep
+
+```bash
+curl -X POST http://localhost:3001/grep \
+  -H "Content-Type: application/json" \
+  -d '{"pattern": "export.*function", "path": "src/", "options": ["-i"]}'
+```
+
+### Example: Feedback
+
+```bash
+curl -X POST http://localhost:3001/feedback \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Found authentication logic in src/auth/",
+    "type": "info",
+    "context": "grep for validateToken"
+  }'
+```
+
+## Design Decisions
+
+### Why Shell-Style Input?
+
+The tool targets users who already know shell commands. Rather than building GUI abstractions that hide the underlying operations, it exposes the actual command interface. This is:
+
+- **Transparent:** You see exactly what command runs
+- **Flexible:** Any valid flag works, not just predefined options
+- **Educational:** Users learn real CLI skills
+
+The tradeoff is accessibility - users must know flags like `-i` (case insensitive) or `-type d` (directories only).
+
+### Why Read-Only?
+
+The sandbox restricts operations to prevent:
+- Accidental file deletion
+- Writes outside the project
+- Execution of arbitrary code
+
+This is intentional for AI agent use cases where the agent should observe but not modify.
+
+### Why Feedback Channel?
+
+AI agents performing research need a way to record observations. The `/feedback` endpoint creates a structured log that:
+- Timestamps each entry
+- Categorizes by type (info, success, warning, error, suggestion)
+- Preserves context for human review
+- Enables agent-to-agent communication
+
+## Limitations
+
+1. **No command composition** - Cannot pipe `grep | xargs | sed`
+2. **No UnifyWeaver integration** - Cannot invoke `uvw compile` or `uvw test`
+3. **No persistent sessions** - Each request is stateless
+4. **No write operations** - By design, but limits utility for some workflows
+5. **GUI not beginner-friendly** - Requires CLI knowledge
+
+## Future Directions
+
+Potential improvements based on user feedback:
+
+- **Explicit controls** - Checkboxes for common options (case-insensitive, file types)
+- **List mode** - Dedicated `ls` operation with directories-only toggle
+- **UnifyWeaver commands** - Expose compile/test as first-class operations
+- **Command presets** - "Search TypeScript", "Find test files", etc.
+- **Better Custom tab** - Simple text input instead of JSON array
+
+## Files
+
+- `src/unifyweaver/shell/http-server.ts` - Server implementation
+- `src/unifyweaver/shell/command-proxy.ts` - Command validation
+- `comet-feedback.log` - Feedback entries (in sandbox root)
+
+## See Also
+
+- [SHELL_COMMAND_CONSTRAINTS.md](./SHELL_COMMAND_CONSTRAINTS.md) - Constraint system
+- [command-proxy.ts](../src/unifyweaver/shell/command-proxy.ts) - Allowed commands

--- a/docs/HTTP_CLI_SERVER.md
+++ b/docs/HTTP_CLI_SERVER.md
@@ -4,7 +4,9 @@ A sandboxed HTTP interface for shell search commands, designed for AI browser ag
 
 ## Overview
 
-The HTTP CLI Server exposes `grep`, `find`, `cat`, and other read-only commands via HTTP endpoints, with a Vue-based web interface. It includes a feedback channel for agent-to-agent communication.
+The HTTP CLI Server exposes `grep`, `find`, `cat`, and other read-only commands via HTTP endpoints, with a Vue-based web interface. It includes a file browser, working directory support, glob expansion, and a feedback channel for agent-to-agent communication.
+
+**Status:** Prototype - functional but needs security hardening before production use.
 
 ```bash
 # Start server
@@ -44,9 +46,8 @@ SANDBOX_ROOT=/path/to/project npx ts-node src/unifyweaver/shell/http-server.ts
 
 **Weaknesses:**
 - Must know CLI flags (no GUI affordances)
-- "Custom" tab's JSON array for arguments is unintuitive
 - No tab completion or command history
-- Limited command set (grep/find/cat/ls/head/tail/wc only)
+- Limited command set (cd/pwd/grep/find/cat/ls/head/tail/wc)
 
 **Best for:** Quick searches when you don't want to context-switch to terminal.
 
@@ -71,12 +72,21 @@ SANDBOX_ROOT=/path/to/project npx ts-node src/unifyweaver/shell/http-server.ts
 | `/` | GET | HTML/Vue interface |
 | `/health` | GET | Server status and config |
 | `/commands` | GET | List allowed commands |
+| `/browse` | POST | Browse directory contents |
 | `/grep` | POST | Search file contents |
 | `/find` | POST | Find files by pattern |
 | `/cat` | POST | Read file contents |
 | `/exec` | POST | Execute allowed command |
 | `/feedback` | POST | Submit feedback (for agents) |
 | `/feedback` | GET | Read feedback history |
+
+### Example: Browse
+
+```bash
+curl -X POST http://localhost:3001/browse \
+  -H "Content-Type: application/json" \
+  -d '{"path": "src/"}'
+```
 
 ### Example: Grep
 
@@ -135,15 +145,36 @@ AI agents performing research need a way to record observations. The `/feedback`
 4. **No write operations** - By design, but limits utility for some workflows
 5. **GUI not beginner-friendly** - Requires CLI knowledge
 
+## Security Considerations
+
+**Current state:** This is a prototype for local development use only.
+
+**Not production-ready due to:**
+- No authentication - anyone with network access can use the server
+- HTTP only - no TLS/HTTPS encryption
+- CORS allows all origins (`*`)
+- No rate limiting
+- No audit logging beyond basic request logs
+
+**Before exposing to networks:**
+1. Add authentication (API keys, OAuth, or basic auth)
+2. Enable HTTPS with valid certificates
+3. Restrict CORS to specific origins
+4. Add rate limiting to prevent abuse
+5. Implement proper audit logging
+6. Consider IP allowlisting
+
+**Safe for:** Local development on trusted networks, behind VPN, or with proper reverse proxy (nginx/caddy with auth).
+
 ## Future Directions
 
 Potential improvements based on user feedback:
 
+- **Authentication** - API keys or OAuth for secure access
+- **HTTPS support** - TLS encryption for network use
 - **Explicit controls** - Checkboxes for common options (case-insensitive, file types)
-- **List mode** - Dedicated `ls` operation with directories-only toggle
 - **UnifyWeaver commands** - Expose compile/test as first-class operations
 - **Command presets** - "Search TypeScript", "Find test files", etc.
-- **Better Custom tab** - Simple text input instead of JSON array
 
 ## Files
 

--- a/docs/SHELL_COMMAND_CONSTRAINTS.md
+++ b/docs/SHELL_COMMAND_CONSTRAINTS.md
@@ -326,6 +326,7 @@ src/unifyweaver/shell/
 ├── index.ts                    # Module exports
 ├── command-proxy.ts            # Original per-command validators
 ├── proxy-cli.ts                # CLI wrapper
+├── http-server.ts              # HTTP server for web/AI browser access
 ├── constraints.ts              # Constraint vocabulary & analyzer
 ├── constraint-loader.ts        # JSON loading
 ├── constraint-store.ts         # Storage abstraction layer
@@ -336,6 +337,61 @@ src/unifyweaver/shell/
 ├── store-and-edit-demo.ts      # Storage & edit demo
 └── llm-provider-demo.ts        # LLM provider demo
 ```
+
+## HTTP CLI Server
+
+The HTTP server exposes shell search commands via HTTP endpoints, enabling AI browsers (like Comet/Perplexity) to search your project.
+
+### Starting the Server
+
+```bash
+# Start on default port (3001)
+npx ts-node src/unifyweaver/shell/http-server.ts
+
+# Start on custom port
+npx ts-node src/unifyweaver/shell/http-server.ts --port 8080
+
+# With custom sandbox root
+SANDBOX_ROOT=/path/to/project npx ts-node src/unifyweaver/shell/http-server.ts
+```
+
+### Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/` | GET | HTML/Vue interface |
+| `/health` | GET | Health check |
+| `/commands` | GET | List available commands |
+| `/grep` | POST | Search file contents |
+| `/find` | POST | Find files by pattern |
+| `/cat` | POST | Read file contents |
+| `/exec` | POST | Execute allowed command |
+
+### Example Usage
+
+```bash
+# Search for pattern
+curl -X POST http://localhost:3001/grep \
+  -H "Content-Type: application/json" \
+  -d '{"pattern": "export.*function", "path": "src/"}'
+
+# Find TypeScript files
+curl -X POST http://localhost:3001/find \
+  -H "Content-Type: application/json" \
+  -d '{"pattern": "*.ts", "path": "."}'
+
+# Read a file
+curl -X POST http://localhost:3001/cat \
+  -H "Content-Type: application/json" \
+  -d '{"path": "src/index.ts"}'
+```
+
+### Security
+
+- Only search commands allowed: `grep`, `find`, `cat`, `head`, `tail`, `ls`, `wc`
+- All operations restricted to sandbox directory
+- Uses `command-proxy.ts` validation for security checks
+- CORS enabled for browser access
 
 ## Running the Demos
 
@@ -351,6 +407,9 @@ npx ts-node src/unifyweaver/shell/llm-provider-demo.ts
 
 # LLM provider demo with live tests
 npx ts-node src/unifyweaver/shell/llm-provider-demo.ts --test
+
+# HTTP CLI server
+npx ts-node src/unifyweaver/shell/http-server.ts
 ```
 
 ## Integration with Command Proxy

--- a/examples/prototypes/README.md
+++ b/examples/prototypes/README.md
@@ -1,0 +1,26 @@
+# Prototypes
+
+Experimental tools and proof-of-concept implementations.
+
+## HTTP CLI Server
+
+A sandboxed HTTP interface for shell search commands, designed for AI browser agents.
+
+**Location:** `src/unifyweaver/shell/http-server.ts`
+
+**Features:**
+- File browser with working directory support
+- Shell commands: cd, pwd, grep, find, cat, head, tail, ls, wc
+- Glob expansion for patterns like `*.ts`, `*/`
+- Feedback channel for agent communication
+- Vue 3 web interface
+
+**Usage:**
+```bash
+SANDBOX_ROOT=/path/to/project npx ts-node src/unifyweaver/shell/http-server.ts
+# Access at http://localhost:3001
+```
+
+**Documentation:** See [docs/HTTP_CLI_SERVER.md](../../docs/HTTP_CLI_SERVER.md)
+
+**Status:** Prototype - works but needs security hardening (authentication, HTTPS) before production use.

--- a/src/unifyweaver/shell/http-server.ts
+++ b/src/unifyweaver/shell/http-server.ts
@@ -1,0 +1,706 @@
+#!/usr/bin/env ts-node
+/**
+ * HTTP CLI Server
+ *
+ * Exposes shell search commands (grep, find, cat, rg) via HTTP endpoints
+ * for use with AI browsers like Comet (Perplexity).
+ *
+ * Uses command-proxy.ts for validation and execution.
+ *
+ * Usage:
+ *   ts-node http-server.ts
+ *   ts-node http-server.ts --port 3001
+ *
+ * Endpoints:
+ *   GET  /health              - Health check
+ *   GET  /commands            - List available commands
+ *   POST /exec                - Execute a command
+ *   POST /grep                - Search file contents
+ *   POST /find                - Find files by pattern
+ *   POST /cat                 - Read file contents
+ *   GET  /                    - Serve HTML interface
+ *
+ * @module unifyweaver/shell/http-server
+ */
+
+import * as http from 'http';
+import * as url from 'url';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+  execute,
+  validateCommand,
+  listCommands,
+  Risk,
+  SANDBOX_ROOT
+} from './command-proxy';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const DEFAULT_PORT = 3001;
+const MAX_BODY_SIZE = 1024 * 1024; // 1MB
+const ALLOWED_ORIGINS = ['*']; // Configure for production
+
+// Commands specifically allowed for search operations
+const SEARCH_COMMANDS = ['grep', 'find', 'cat', 'head', 'tail', 'ls', 'wc'];
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SearchRequest {
+  pattern?: string;
+  path?: string;
+  options?: string[];
+  command?: string;
+  args?: string[];
+}
+
+interface APIResponse {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+  warning?: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function parseBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    let size = 0;
+
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_SIZE) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      body += chunk.toString();
+    });
+
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function sendJSON(res: http.ServerResponse, data: APIResponse, status = 200): void {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS[0],
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(JSON.stringify(data, null, 2));
+}
+
+function sendHTML(res: http.ServerResponse, html: string): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS[0]
+  });
+  res.end(html);
+}
+
+function sendError(res: http.ServerResponse, message: string, status = 400): void {
+  sendJSON(res, { success: false, error: message }, status);
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+async function handleHealth(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  sendJSON(res, {
+    success: true,
+    data: {
+      status: 'ok',
+      sandboxRoot: SANDBOX_ROOT,
+      commands: SEARCH_COMMANDS,
+      timestamp: new Date().toISOString()
+    }
+  });
+}
+
+async function handleCommands(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const commands = listCommands().filter(c =>
+    SEARCH_COMMANDS.includes(c.name) || c.risk === Risk.SAFE
+  );
+
+  sendJSON(res, {
+    success: true,
+    data: {
+      commands,
+      searchCommands: SEARCH_COMMANDS
+    }
+  });
+}
+
+async function handleExec(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  try {
+    const body = await parseBody(req);
+    const { command, args = [] } = JSON.parse(body) as SearchRequest;
+
+    if (!command) {
+      return sendError(res, 'Missing command');
+    }
+
+    // Only allow search commands
+    if (!SEARCH_COMMANDS.includes(command)) {
+      return sendError(res, `Command not allowed. Allowed: ${SEARCH_COMMANDS.join(', ')}`, 403);
+    }
+
+    // Validate first
+    const validation = validateCommand(command, args, { role: 'user' });
+    if (!validation.ok) {
+      return sendError(res, validation.reason || 'Validation failed', 403);
+    }
+
+    // Execute
+    const cmdString = [command, ...args].join(' ');
+    const result = await execute(cmdString, { role: 'user', cwd: SANDBOX_ROOT });
+
+    if (!result.success) {
+      return sendJSON(res, {
+        success: false,
+        error: result.error,
+        warning: result.warning
+      }, 400);
+    }
+
+    sendJSON(res, {
+      success: true,
+      data: {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        code: result.code
+      },
+      warning: result.warning
+    });
+  } catch (err) {
+    sendError(res, (err as Error).message, 500);
+  }
+}
+
+async function handleGrep(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  try {
+    const body = await parseBody(req);
+    const { pattern, path: searchPath = '.', options = [] } = JSON.parse(body) as SearchRequest;
+
+    if (!pattern) {
+      return sendError(res, 'Missing pattern');
+    }
+
+    // Build grep command
+    const args = [
+      '-r',           // Recursive
+      '-n',           // Line numbers
+      '--color=never', // No color codes in output
+      ...options,
+      pattern,
+      searchPath
+    ];
+
+    const cmdString = ['grep', ...args].join(' ');
+    const result = await execute(cmdString, { role: 'user', cwd: SANDBOX_ROOT });
+
+    sendJSON(res, {
+      success: true,
+      data: {
+        matches: result.stdout?.split('\n').filter(Boolean) || [],
+        count: result.stdout?.split('\n').filter(Boolean).length || 0,
+        stderr: result.stderr
+      },
+      warning: result.warning
+    });
+  } catch (err) {
+    sendError(res, (err as Error).message, 500);
+  }
+}
+
+async function handleFind(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  try {
+    const body = await parseBody(req);
+    const { pattern, path: searchPath = '.', options = [] } = JSON.parse(body) as SearchRequest;
+
+    // Build find command
+    const args = [searchPath];
+
+    if (pattern) {
+      args.push('-name', pattern);
+    }
+
+    args.push(...options);
+
+    const cmdString = ['find', ...args].join(' ');
+    const result = await execute(cmdString, { role: 'user', cwd: SANDBOX_ROOT });
+
+    sendJSON(res, {
+      success: true,
+      data: {
+        files: result.stdout?.split('\n').filter(Boolean) || [],
+        count: result.stdout?.split('\n').filter(Boolean).length || 0,
+        stderr: result.stderr
+      },
+      warning: result.warning
+    });
+  } catch (err) {
+    sendError(res, (err as Error).message, 500);
+  }
+}
+
+async function handleCat(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  try {
+    const body = await parseBody(req);
+    const { path: filePath, options = [] } = JSON.parse(body) as SearchRequest;
+
+    if (!filePath) {
+      return sendError(res, 'Missing path');
+    }
+
+    const args = [...options, filePath];
+    const cmdString = ['cat', ...args].join(' ');
+    const result = await execute(cmdString, { role: 'user', cwd: SANDBOX_ROOT });
+
+    if (!result.success) {
+      return sendJSON(res, {
+        success: false,
+        error: result.error
+      }, 400);
+    }
+
+    sendJSON(res, {
+      success: true,
+      data: {
+        content: result.stdout,
+        lines: result.stdout?.split('\n').length || 0
+      },
+      warning: result.warning
+    });
+  } catch (err) {
+    sendError(res, (err as Error).message, 500);
+  }
+}
+
+// ============================================================================
+// HTML Interface
+// ============================================================================
+
+function getHTMLInterface(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UnifyWeaver CLI Search</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+      background: #1a1a2e;
+      color: #eee;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    .container { max-width: 1200px; margin: 0 auto; }
+    h1 { color: #e94560; margin-bottom: 20px; }
+    .tabs {
+      display: flex;
+      gap: 5px;
+      margin-bottom: 20px;
+    }
+    .tab {
+      padding: 10px 20px;
+      background: #16213e;
+      border: none;
+      color: #94a3b8;
+      cursor: pointer;
+      border-radius: 5px 5px 0 0;
+    }
+    .tab.active { background: #0f3460; color: #e94560; }
+    .panel {
+      background: #16213e;
+      padding: 20px;
+      border-radius: 0 5px 5px 5px;
+    }
+    .form-group { margin-bottom: 15px; }
+    label { display: block; margin-bottom: 5px; color: #94a3b8; }
+    input, textarea {
+      width: 100%;
+      padding: 10px;
+      background: #0f3460;
+      border: 1px solid #1a1a2e;
+      color: #eee;
+      border-radius: 5px;
+      font-family: monospace;
+    }
+    input:focus, textarea:focus {
+      outline: none;
+      border-color: #e94560;
+    }
+    button {
+      padding: 10px 20px;
+      background: #e94560;
+      border: none;
+      color: #fff;
+      cursor: pointer;
+      border-radius: 5px;
+      font-weight: bold;
+    }
+    button:hover { background: #ff6b6b; }
+    button:disabled { background: #444; cursor: not-allowed; }
+    .results {
+      margin-top: 20px;
+      background: #0f3460;
+      padding: 15px;
+      border-radius: 5px;
+      max-height: 500px;
+      overflow: auto;
+    }
+    .results pre {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .error { color: #ff6b6b; }
+    .success { color: #4ade80; }
+    .warning { color: #fbbf24; }
+    .count { color: #94a3b8; font-size: 14px; margin-bottom: 10px; }
+    .help {
+      background: #0f3460;
+      padding: 15px;
+      border-radius: 5px;
+      margin-top: 20px;
+      font-size: 14px;
+    }
+    .help h3 { color: #e94560; margin-bottom: 10px; }
+    .help code {
+      background: #1a1a2e;
+      padding: 2px 6px;
+      border-radius: 3px;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" class="container">
+    <h1>🔍 UnifyWeaver CLI Search</h1>
+
+    <div class="tabs">
+      <button class="tab" :class="{ active: tab === 'grep' }" @click="tab = 'grep'">Grep</button>
+      <button class="tab" :class="{ active: tab === 'find' }" @click="tab = 'find'">Find</button>
+      <button class="tab" :class="{ active: tab === 'cat' }" @click="tab = 'cat'">Cat</button>
+      <button class="tab" :class="{ active: tab === 'exec' }" @click="tab = 'exec'">Custom</button>
+    </div>
+
+    <!-- Grep Panel -->
+    <div class="panel" v-if="tab === 'grep'">
+      <div class="form-group">
+        <label>Search Pattern (regex)</label>
+        <input v-model="grep.pattern" placeholder="e.g., function.*export" @keyup.enter="doGrep">
+      </div>
+      <div class="form-group">
+        <label>Path (relative to sandbox)</label>
+        <input v-model="grep.path" placeholder="e.g., src/ or .">
+      </div>
+      <div class="form-group">
+        <label>Options (space-separated)</label>
+        <input v-model="grep.options" placeholder="e.g., -i --include=*.ts">
+      </div>
+      <button @click="doGrep" :disabled="loading">{{ loading ? 'Searching...' : 'Search' }}</button>
+    </div>
+
+    <!-- Find Panel -->
+    <div class="panel" v-if="tab === 'find'">
+      <div class="form-group">
+        <label>File Pattern</label>
+        <input v-model="find.pattern" placeholder="e.g., *.ts or index.*" @keyup.enter="doFind">
+      </div>
+      <div class="form-group">
+        <label>Search Path</label>
+        <input v-model="find.path" placeholder="e.g., src/ or .">
+      </div>
+      <div class="form-group">
+        <label>Options (space-separated)</label>
+        <input v-model="find.options" placeholder="e.g., -type f -maxdepth 3">
+      </div>
+      <button @click="doFind" :disabled="loading">{{ loading ? 'Finding...' : 'Find Files' }}</button>
+    </div>
+
+    <!-- Cat Panel -->
+    <div class="panel" v-if="tab === 'cat'">
+      <div class="form-group">
+        <label>File Path</label>
+        <input v-model="cat.path" placeholder="e.g., src/index.ts" @keyup.enter="doCat">
+      </div>
+      <button @click="doCat" :disabled="loading">{{ loading ? 'Reading...' : 'Read File' }}</button>
+    </div>
+
+    <!-- Custom Exec Panel -->
+    <div class="panel" v-if="tab === 'exec'">
+      <div class="form-group">
+        <label>Command</label>
+        <input v-model="exec.command" placeholder="e.g., ls, grep, find, cat, head, tail, wc" @keyup.enter="doExec">
+      </div>
+      <div class="form-group">
+        <label>Arguments (JSON array)</label>
+        <input v-model="exec.args" placeholder='e.g., ["-la", "src/"]'>
+      </div>
+      <button @click="doExec" :disabled="loading">{{ loading ? 'Running...' : 'Execute' }}</button>
+      <p class="count" style="margin-top: 10px;">Allowed: grep, find, cat, head, tail, ls, wc</p>
+    </div>
+
+    <!-- Results -->
+    <div class="results" v-if="result">
+      <p v-if="result.warning" class="warning">⚠️ {{ result.warning }}</p>
+      <p v-if="result.error" class="error">❌ {{ result.error }}</p>
+      <p v-if="result.data?.count !== undefined" class="count">Found {{ result.data.count }} results</p>
+      <pre v-if="result.data?.stdout">{{ result.data.stdout }}</pre>
+      <pre v-if="result.data?.content">{{ result.data.content }}</pre>
+      <pre v-if="result.data?.matches">{{ result.data.matches.join('\\n') }}</pre>
+      <pre v-if="result.data?.files">{{ result.data.files.join('\\n') }}</pre>
+    </div>
+
+    <!-- Help -->
+    <div class="help">
+      <h3>Quick Help</h3>
+      <p><strong>Grep:</strong> Search file contents with regex. Use <code>-i</code> for case-insensitive, <code>--include=*.ts</code> for file filters.</p>
+      <p><strong>Find:</strong> Find files by name pattern. Use <code>-type f</code> for files only, <code>-maxdepth N</code> to limit depth.</p>
+      <p><strong>Cat:</strong> Read entire file contents.</p>
+      <p><strong>Sandbox:</strong> All operations are restricted to the sandbox directory.</p>
+    </div>
+  </div>
+
+  <script>
+    const { createApp, ref, reactive } = Vue;
+
+    createApp({
+      setup() {
+        const tab = ref('grep');
+        const loading = ref(false);
+        const result = ref(null);
+
+        const grep = reactive({ pattern: '', path: '.', options: '' });
+        const find = reactive({ pattern: '', path: '.', options: '' });
+        const cat = reactive({ path: '' });
+        const exec = reactive({ command: '', args: '[]' });
+
+        async function doGrep() {
+          loading.value = true;
+          result.value = null;
+          try {
+            const res = await fetch('/grep', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                pattern: grep.pattern,
+                path: grep.path,
+                options: grep.options.split(/\\s+/).filter(Boolean)
+              })
+            });
+            result.value = await res.json();
+          } catch (err) {
+            result.value = { error: err.message };
+          }
+          loading.value = false;
+        }
+
+        async function doFind() {
+          loading.value = true;
+          result.value = null;
+          try {
+            const res = await fetch('/find', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                pattern: find.pattern,
+                path: find.path,
+                options: find.options.split(/\\s+/).filter(Boolean)
+              })
+            });
+            result.value = await res.json();
+          } catch (err) {
+            result.value = { error: err.message };
+          }
+          loading.value = false;
+        }
+
+        async function doCat() {
+          loading.value = true;
+          result.value = null;
+          try {
+            const res = await fetch('/cat', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ path: cat.path })
+            });
+            result.value = await res.json();
+          } catch (err) {
+            result.value = { error: err.message };
+          }
+          loading.value = false;
+        }
+
+        async function doExec() {
+          loading.value = true;
+          result.value = null;
+          try {
+            const res = await fetch('/exec', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                command: exec.command,
+                args: JSON.parse(exec.args || '[]')
+              })
+            });
+            result.value = await res.json();
+          } catch (err) {
+            result.value = { error: err.message };
+          }
+          loading.value = false;
+        }
+
+        return { tab, loading, result, grep, find, cat, exec, doGrep, doFind, doCat, doExec };
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>`;
+}
+
+// ============================================================================
+// Router
+// ============================================================================
+
+async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const parsedUrl = url.parse(req.url || '/', true);
+  const pathname = parsedUrl.pathname || '/';
+  const method = req.method || 'GET';
+
+  // Handle CORS preflight
+  if (method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': ALLOWED_ORIGINS[0],
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+    return;
+  }
+
+  // Log request
+  console.log(`[${new Date().toISOString()}] ${method} ${pathname}`);
+
+  try {
+    // Route requests
+    if (pathname === '/' && method === 'GET') {
+      sendHTML(res, getHTMLInterface());
+    } else if (pathname === '/health' && method === 'GET') {
+      await handleHealth(req, res);
+    } else if (pathname === '/commands' && method === 'GET') {
+      await handleCommands(req, res);
+    } else if (pathname === '/exec' && method === 'POST') {
+      await handleExec(req, res);
+    } else if (pathname === '/grep' && method === 'POST') {
+      await handleGrep(req, res);
+    } else if (pathname === '/find' && method === 'POST') {
+      await handleFind(req, res);
+    } else if (pathname === '/cat' && method === 'POST') {
+      await handleCat(req, res);
+    } else {
+      sendError(res, 'Not found', 404);
+    }
+  } catch (err) {
+    console.error('Request error:', err);
+    sendError(res, 'Internal server error', 500);
+  }
+}
+
+// ============================================================================
+// Server
+// ============================================================================
+
+function startServer(port: number): void {
+  const server = http.createServer(handleRequest);
+
+  server.listen(port, () => {
+    console.log(`
+╔════════════════════════════════════════════════════════════╗
+║           UnifyWeaver HTTP CLI Server                      ║
+╠════════════════════════════════════════════════════════════╣
+║  Server running at: http://localhost:${port.toString().padEnd(24)}║
+║  Sandbox root:      ${SANDBOX_ROOT.slice(0, 35).padEnd(36)}║
+║                                                            ║
+║  Endpoints:                                                ║
+║    GET  /           - HTML interface                       ║
+║    GET  /health     - Health check                         ║
+║    GET  /commands   - List commands                        ║
+║    POST /grep       - Search contents                      ║
+║    POST /find       - Find files                           ║
+║    POST /cat        - Read file                            ║
+║    POST /exec       - Execute command                      ║
+╚════════════════════════════════════════════════════════════╝
+`);
+  });
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`Port ${port} is already in use`);
+    } else {
+      console.error('Server error:', err);
+    }
+    process.exit(1);
+  });
+}
+
+// ============================================================================
+// CLI Entry
+// ============================================================================
+
+function main(): void {
+  const args = process.argv.slice(2);
+  let port = DEFAULT_PORT;
+
+  // Parse --port argument
+  const portIdx = args.indexOf('--port');
+  if (portIdx !== -1 && args[portIdx + 1]) {
+    port = parseInt(args[portIdx + 1], 10);
+    if (isNaN(port)) {
+      console.error('Invalid port number');
+      process.exit(1);
+    }
+  }
+
+  // Help
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`
+UnifyWeaver HTTP CLI Server
+
+Usage:
+  ts-node http-server.ts [options]
+
+Options:
+  --port <number>   Port to listen on (default: ${DEFAULT_PORT})
+  --help, -h        Show this help
+
+Environment:
+  SANDBOX_ROOT      Root directory for sandbox operations
+
+Examples:
+  ts-node http-server.ts
+  ts-node http-server.ts --port 8080
+  SANDBOX_ROOT=/tmp/sandbox ts-node http-server.ts
+`);
+    process.exit(0);
+  }
+
+  startServer(port);
+}
+
+main();

--- a/src/unifyweaver/shell/index.ts
+++ b/src/unifyweaver/shell/index.ts
@@ -157,3 +157,8 @@ export {
   // DSL builder
   EC
 } from './edit-review';
+
+// HTTP CLI Server
+// Run directly: ts-node http-server.ts [--port 3001]
+// Provides HTTP endpoints for grep, find, cat operations
+// See http-server.ts for standalone server


### PR DESCRIPTION
## Summary

Adds a sandboxed HTTP server that exposes shell search commands via a Vue-based web interface, designed for AI browser agents (like Comet/Perplexity) to explore codebases.

- HTTP server with Vue 3 UI at `http://localhost:3001`
- File browser with working directory support
- Shell commands: `cd`, `pwd`, `grep`, `find`, `cat`, `head`, `tail`, `ls`, `wc`
- Glob expansion for patterns like `*.ts` and `*/`
- Feedback channel for agent-to-agent communication
- Sandboxed to project directory for safety

## Features

### File Browser
- Navigate directories with clickable folder/file list
- "Set as Working Dir" to change context for all commands
- "Up" button for parent directory navigation

### Working Directory
- Persistent working directory state across all commands
- `cd` command support in Custom tab
- Visual indicator showing current working directory

### Glob Expansion
- Shell-style globs work in Custom tab: `ls -d */`, `ls *.md`
- Patterns expanded safely within sandbox

### Feedback Channel
- `POST /feedback` for agents to record observations
- `GET /feedback` to retrieve feedback history
- Timestamped JSON log with type categorization

## API Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/` | GET | Vue web interface |
| `/health` | GET | Server status |
| `/browse` | POST | Directory listing |
| `/grep` | POST | Search file contents |
| `/find` | POST | Find files by pattern |
| `/cat` | POST | Read file contents |
| `/exec` | POST | Execute allowed command |
| `/feedback` | GET/POST | Feedback channel |

## Usage

```bash
SANDBOX_ROOT=/path/to/project npx ts-node src/unifyweaver/shell/http-server.ts
```

## Security Note

This is a prototype for local development use. Before exposing to networks, add authentication, HTTPS, and rate limiting. See `docs/HTTP_CLI_SERVER.md` for details.

## Test Plan

- [ ] Start server and access web UI at localhost:3001
- [ ] Test Browse tab navigation and "Set as Working Dir"
- [ ] Test `cd` and `pwd` in Custom tab
- [ ] Test glob patterns: `ls -d */`, `ls *.ts`
- [ ] Test grep/find/cat with working directory set
- [ ] Test feedback submission and retrieval

---
Generated with [Claude Code](https://claude.ai/code)
