### PR TITLE
perf(csharp-query): seed transitive closure by target (mode(-,+))

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1030,6 +1030,7 @@ transitive_closure_supported_modes(Modes) :-
     input_positions(Modes, Positions),
     (   Positions == []
     ;   Positions == [0]
+    ;   Positions == [1]
     ).
 
 transitive_closure_base_clause(HeadSpec, Head-Body, EdgeSpec) :-


### PR DESCRIPTION
  - Runtime: add TransitiveClosureNode fast-path for InputPositions=[1] (reverse-seeded closure via index on edge column
    1) in src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs.
  - Compiler: allow canonical reachability to compile to transitive_closure for mode(-,+) (skips need-closure/param-
    seed) in src/unifyweaver/targets/csharp_target.pl.
  - Tests: add test_reachable_param_end/2 + verify_parameterized_reachability_by_target_plan in tests/core/
    test_csharp_query_target.pl.