### PR TITLE
perf(csharp-query): fast reachability for mode(+,+)

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1031,6 +1031,7 @@ transitive_closure_supported_modes(Modes) :-
     (   Positions == []
     ;   Positions == [0]
     ;   Positions == [1]
+    ;   Positions == [0, 1]
     ).
 
 transitive_closure_base_clause(HeadSpec, Head-Body, EdgeSpec) :-


### PR DESCRIPTION
  - Runtime: add TransitiveClosureNode fast-path for InputPositions=[0,1] (grouped BFS; chooses forward/backward
    expansion by seed count) in src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs.
  - Compiler: allow transitive_closure emission for mode(+,+) in src/unifyweaver/targets/csharp_target.pl.
  - Tests: add test_reachable_param_both/2 + verify_parameterized_reachability_both_inputs_plan in tests/core/
    test_csharp_query_target.pl.