### PR TITLE
Perf: keep scan-index joins in fixpoints (even without cache reuse)

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -2223,7 +2223,7 @@ namespace UnifyWeaver.QueryRuntime
 
                         var otherNode = leftIsScan ? join.Right : join.Left;
 
-                        if (!scanIndexCached && _cacheContext is null && !IsRecursiveProbe(otherNode))
+                        if (context.FixpointDepth == 0 && !scanIndexCached && _cacheContext is null && !IsRecursiveProbe(otherNode))
                         {
                             const int TinyProbeUpperBound = 64;
                             if (joinKeyCount == 1 &&


### PR DESCRIPTION
  - Prevents the “tiny probe” heuristic from disabling scan-index joins during fixpoint execution when
    QueryExecutorOptions.ReuseCaches=false, avoiding repeated full scans across iterations.
  - Adds a manual-plan smoke test that runs a FixpointNode containing a scan-vs-tiny-projection join and asserts
    STRATEGY_USED:KeyJoinScanIndex=true with ReuseCaches:false.
  - Files: src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs, tests/core/test_csharp_query_target.pl.