### PR TITLE
feat(http-cli): Add root selector for browse/grep/find/cat/exec/shell

### DIFF
--- a/src/unifyweaver/sources/service_source.pl
+++ b/src/unifyweaver/sources/service_source.pl
@@ -371,6 +371,9 @@ service_template(http_cli, service(http_cli, [
     https([cert_env('SSL_CERT'), key_env('SSL_KEY')]),
     endpoints([
         endpoint(health, get, '/health', [public(true)]),
+        endpoint(auth_status, get, '/auth/status', [public(true)]),
+        endpoint(auth_login, post, '/auth/login', [public(true)]),
+        endpoint(auth_me, get, '/auth/me', [roles([user, admin, shell])]),
         endpoint(commands, get, '/commands', [roles([user, admin, shell])]),
         endpoint(exec, post, '/exec', [roles([admin, shell])]),
         endpoint(grep, post, '/grep', [roles([user, admin, shell])]),


### PR DESCRIPTION
## Summary

This PR adds a root directory selector to the HTTP CLI server, allowing users to switch between Sandbox, Project, and Home directories across all tools including the interactive shell.

- Add `getRootDir` helper to resolve sandbox/project/home roots to actual paths
- Update `resolveWorkingDir` to accept root parameter for all operations
- Update all API handlers (grep, find, cat, exec, browse) to respect root selection
- Add root selector dropdown in frontend UI with Sandbox/Project/Home options
- Update shell WebSocket to accept root query parameter on connection
- Shell now starts in selected root directory with correct prompt
- Fix shell prompt to show current root instead of hardcoded "sandbox"
- Add xterm.js integration for proper terminal emulation with escape sequences
- Add text mode toggle for easy copy/paste of shell output
- Add missing frontend methods (navigateUp, handleEntryClick, viewFile, searchHere)

## Test plan

- [ ] Start server with `./node_modules/.bin/ts-node server.ts --port 3001`
- [ ] Open http://localhost:3001 in browser
- [ ] Verify root selector dropdown shows Sandbox/Project/Home options
- [ ] Select "Project" root and verify Browse tab shows project files
- [ ] Run grep search and verify it searches in project root
- [ ] Run find and verify it finds files in project root
- [ ] Use cat to read a file from project root
- [ ] Use exec (Custom tab) to run `pwd` and verify it shows project path
- [ ] Connect to interactive shell and verify prompt shows "project:~$"
- [ ] Run `pwd` in shell and verify it shows project directory
- [ ] Switch to "Home" root and repeat tests
- [ ] Toggle text mode in shell and verify copy/paste works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
