### PR TITLE
perf(csharp-query): rowcount-first join ordering

### DIFF
--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1953,11 +1953,11 @@ candidate_key(cand(Index, Term, Role, Vars, Arity), VarCounts, BoundVars, Key) :
     candidate_score_key(Index, Term, Role, Vars, Arity, VarCounts, BoundVars, Key).
 
 % Prefer candidates that share already-bound variables. Next, keep the join graph
-% connected when possible. When tied, prefer literals with more constant
-% arguments (PatternScan-selective). When facts are available at compile time,
-% prefer more selective patterns (fewer matching fact rows). Finally, prefer
-% smaller arity, then original order.
-candidate_score_key(Index, Term, Role, Vars, Arity, VarCounts, BoundVars, [Shared, Connected, ConstArgs, NegEstimate, NegArity, NegIndex]) :-
+% connected when possible. Then prefer more selective candidates based on the
+% estimated row count (exact when facts are available at compile time, heuristic
+% otherwise). When tied, prefer literals with more constant arguments
+% (PatternScan-selective). Finally, prefer smaller arity, then original order.
+candidate_score_key(Index, Term, Role, Vars, Arity, VarCounts, BoundVars, [Shared, Connected, NegEstimate, ConstArgs, NegArity, NegIndex]) :-
     shared_bound_count(Vars, BoundVars, Shared),
     connectivity_score(Vars, VarCounts, Connected),
     constant_arg_count_in_term(Term, ConstArgs),


### PR DESCRIPTION
  - Updates join reordering in src/unifyweaver/targets/csharp_target.pl to prefer lower estimated rowcount (exact for
    compile-time facts, heuristic otherwise) before constant-arg count, improving selectivity-driven join plans across
    different predicates.
  - Adds a regression test verify_join_ordering_rowcount_over_constargs_plan in tests/core/test_csharp_query_target.pl
    to ensure a smaller relation can be chosen ahead of a larger relation even when the larger one has more constants.
  - Local run: SKIP_CSHARP_EXECUTION=1 tests/core/test_csharp_query_target.pl passed.