### PR TITLE
perf(csharp-query): treat selective scan probes as tiny

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -2319,9 +2319,7 @@ namespace UnifyWeaver.QueryRuntime
                                 var joinIndexCached = context.JoinIndices.ContainsKey((leftScanPredicate, leftSignature));
 
                                 const int TinyProbeUpperBound = 64;
-                                var probeIsTiny = keyCount > 1 &&
-                                                  TryEstimateRowUpperBound(join.Right, context, out var probeUpperBound) &&
-                                                  probeUpperBound <= TinyProbeUpperBound;
+                                var probeIsTiny = keyCount > 1 && estimatedRightProbe <= TinyProbeUpperBound;
 
                                 if (probeIsTiny &&
                                     !joinIndexCached &&
@@ -2499,9 +2497,7 @@ namespace UnifyWeaver.QueryRuntime
                                 var joinIndexCached = context.JoinIndices.ContainsKey((rightScanPredicate, rightSignature));
 
                                 const int TinyProbeUpperBound = 64;
-                                var probeIsTiny = keyCount > 1 &&
-                                                  TryEstimateRowUpperBound(join.Left, context, out var probeUpperBound) &&
-                                                  probeUpperBound <= TinyProbeUpperBound;
+                                var probeIsTiny = keyCount > 1 && estimatedLeftProbe <= TinyProbeUpperBound;
 
                                 if (probeIsTiny &&
                                     !joinIndexCached &&


### PR DESCRIPTION
  - Fixes scan-scan multi-key joins so the KeyJoinScanIndexPartial “tiny probe” decision uses the already-computed
    selective scan row estimates (estimatedLeftProbe / estimatedRightProbe) instead of TryEstimateRowUpperBound, which
    can overestimate multi-constant pattern scans.
  - This avoids building full multi-key join indexes when the probe side is actually tiny but only looks “large” via a
    coarse upper-bound.
  - Adds regression coverage in tests/core/test_csharp_query_target.pl
    (verify_both_scan_join_selective_probe_uses_partial_index) using a selective multi-constant pattern probe.