### PR TITLE
feat(shell): Add xterm.js terminal with text mode fallback

### DIFF
--- a/examples/http-cli-server/README.md
+++ b/examples/http-cli-server/README.md
@@ -12,11 +12,14 @@ Prolog (`spec.pl`) and generate TypeScript code using UnifyWeaver's generators.
 ## Features
 
 - **PTY Shell**: Real pseudo-terminal via node-pty with full terminal emulation
+- **xterm.js Terminal**: Rich terminal UI with colors, cursor control, and proper keyboard handling
+- **Text Mode Fallback**: Plain HTML fallback when xterm.js is unavailable or blocked
 - **Syntax Highlighting**: Code viewing with highlight.js (20+ languages)
 - **Root Selector**: Switch between sandbox, project, and home directories
 - **Results Panel**: Download/copy buttons for grep, find, cat, exec output
 - **HTTPS Support**: Self-signed or custom certificates
 - **Role-based Auth**: JWT tokens with shell/admin/user roles
+- **Firewall Package Control**: Control which npm/CDN packages are allowed in generated code
 
 ## Files
 
@@ -110,9 +113,15 @@ Switch between three directory roots:
 ### Shell Features
 
 - Real PTY via node-pty (not character emulation)
+- **xterm.js** terminal emulation with catppuccin theme
+- Auto-detects xterm.js availability on page load
+- Falls back to text mode if xterm.js blocked or unavailable
 - ANSI escape code stripping for text display
-- Terminal resize support
-- Capture mode (mobile keyboard) and text mode
+- Terminal resize support (via FitAddon)
+- Three input modes:
+  - **Terminal**: xterm.js with full keyboard handling
+  - **Text Mode**: Simple input field for command entry
+  - **Capture Mode**: Hidden input for mobile keyboards (fallback)
 
 ### Syntax Highlighting
 
@@ -171,8 +180,30 @@ Benefits of the declarative approach:
 - Can target multiple languages (TypeScript, Python, Go)
 - Validates specification before generation
 
+## Firewall Package Control
+
+The firewall system (`src/unifyweaver/core/firewall.pl`) can control which
+packages are included in generated code:
+
+```prolog
+% Allow only specific npm packages
+:- assertz(firewall:firewall_default([
+    npm_packages([vue, xterm, '@xterm/addon-fit']),
+    cdn_packages(['*unpkg.com*', '*jsdelivr.net*', '*cdnjs*'])
+])).
+
+% Deny xterm.js (forces text mode fallback)
+:- assertz(firewall:firewall_default([
+    denied([xterm])
+])).
+```
+
+The generator checks `is_package_allowed/2` and uses fallback implementations
+when packages are blocked by firewall policy.
+
 ## Related
 
+- `../../src/unifyweaver/core/firewall.pl` - Package installation control
 - `../../src/unifyweaver/sources/service_source.pl` - Service source type
 - `../../src/unifyweaver/glue/http_server_generator.pl` - Server generator
 - `../../src/unifyweaver/glue/auth_generator.pl` - Auth generator

--- a/src/unifyweaver/ui/html_interface_generator.pl
+++ b/src/unifyweaver/ui/html_interface_generator.pl
@@ -86,6 +86,10 @@ generate_html_head(Title, Theme, Head) :-
   <!-- Highlight.js for syntax highlighting -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <!-- xterm.js for terminal emulation (optional - falls back to text mode) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
+  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.js"></script>
   <style>
 ~w
   </style>
@@ -319,6 +323,16 @@ generate_component_css(Colors, _Spacing, Borders, CSS) :-
     }
     .shell-input:focus { outline: none; }
     .prompt { color: ~w; font-family: monospace; }
+    /* xterm.js terminal container */
+    .xterm-container {
+      background: #1e1e2e;
+      padding: 10px;
+      border-radius: 5px;
+      min-height: 300px;
+    }
+    .xterm-container .xterm {
+      padding: 5px;
+    }
     /* Code viewer with syntax highlighting */
     .code-viewer {
       position: relative;
@@ -781,25 +795,129 @@ const app = createApp({
     // Strip ANSI escape codes for text display
     const stripAnsi = (str) => str.replace(/\\x1b\\[[0-9;]*[a-zA-Z]|\\x1b\\][^\\x07]*\\x07|\\x1b\\[\\?[0-9;]*[a-zA-Z]/g, "").replace(/\\r\\n/g, "\\n").replace(/\\r/g, "");
 
+    // xterm.js terminal instance (null if not available)
+    let terminal = null;
+    let fitAddon = null;
+    const xtermAvailable = ref(typeof window.Terminal !== "undefined");
+
+    const initXterm = () => {
+      if (!xtermAvailable.value) return false;
+      try {
+        const container = document.getElementById("xterm_container");
+        if (!container) return false;
+
+        terminal = new window.Terminal({
+          cursorBlink: true,
+          fontSize: 14,
+          fontFamily: "Menlo, Monaco, \\"Courier New\\", monospace",
+          theme: {
+            background: "#1e1e2e",
+            foreground: "#cdd6f4",
+            cursor: "#f5e0dc",
+            cursorAccent: "#1e1e2e",
+            selectionBackground: "#585b70",
+            black: "#45475a",
+            red: "#f38ba8",
+            green: "#a6e3a1",
+            yellow: "#f9e2af",
+            blue: "#89b4fa",
+            magenta: "#f5c2e7",
+            cyan: "#94e2d5",
+            white: "#bac2de"
+          }
+        });
+
+        // Load fit addon if available
+        if (window.FitAddon) {
+          fitAddon = new window.FitAddon.FitAddon();
+          terminal.loadAddon(fitAddon);
+        }
+
+        terminal.open(container);
+        if (fitAddon) fitAddon.fit();
+
+        // Handle input from terminal
+        terminal.onData((data) => {
+          if (shell.ws && shell.connected) {
+            shell.ws.send(JSON.stringify({ type: "input", data }));
+          }
+        });
+
+        // Handle resize
+        window.addEventListener("resize", handleTerminalResize);
+
+        return true;
+      } catch (e) {
+        console.warn("xterm.js initialization failed:", e);
+        xtermAvailable.value = false;
+        return false;
+      }
+    };
+
+    const handleTerminalResize = () => {
+      if (fitAddon && terminal) {
+        fitAddon.fit();
+        if (shell.ws && shell.connected) {
+          shell.ws.send(JSON.stringify({
+            type: "resize",
+            cols: terminal.cols,
+            rows: terminal.rows
+          }));
+        }
+      }
+    };
+
     const connectShell = () => {
       const protocol = location.protocol === "https:" ? "wss:" : "ws:";
-      const wsUrl = `${protocol}//${location.host}/shell?token=${token.value}&root=${browseRoot.value}`;
+      const cols = terminal ? terminal.cols : 80;
+      const rows = terminal ? terminal.rows : 24;
+      const wsUrl = `${protocol}//${location.host}/shell?token=${token.value}&root=${browseRoot.value}&cols=${cols}&rows=${rows}`;
       shell.ws = new WebSocket(wsUrl);
-      shell.ws.onopen = () => { shell.connected = true; shell.output = `Connected to shell (${browseRoot.value} root).\\n`; };
+
+      shell.ws.onopen = () => {
+        shell.connected = true;
+        if (terminal) {
+          terminal.writeln("\\x1b[1;34m╔══════════════════════════════════════╗");
+          terminal.writeln("║     Connected to PTY Shell           ║");
+          terminal.writeln("╚══════════════════════════════════════╝\\x1b[0m");
+        } else {
+          shell.output = `Connected to shell (${browseRoot.value} root).\\n`;
+        }
+      };
+
       shell.ws.onmessage = (e) => {
         try {
           const msg = JSON.parse(e.data);
           if (msg.type === "output" || msg.type === "error") {
-            shell.output += stripAnsi(msg.data);
+            if (terminal && !shellTextMode.value) {
+              terminal.write(msg.data);
+            } else {
+              shell.output += stripAnsi(msg.data);
+            }
           } else if (msg.type === "prompt") {
-            shell.output += `${browseRoot.value}:~$ `;
+            if (!terminal || shellTextMode.value) {
+              shell.output += `${browseRoot.value}:~$ `;
+            }
           }
         } catch {
-          shell.output += stripAnsi(e.data);
+          if (terminal && !shellTextMode.value) {
+            terminal.write(e.data);
+          } else {
+            shell.output += stripAnsi(e.data);
+          }
         }
         scrollShell();
       };
-      shell.ws.onclose = () => { shell.connected = false; shell.output += "\\nDisconnected.\\n"; };
+
+      shell.ws.onclose = () => {
+        shell.connected = false;
+        if (terminal && !shellTextMode.value) {
+          terminal.writeln("\\r\\n\\x1b[31mDisconnected.\\x1b[0m");
+        } else {
+          shell.output += "\\nDisconnected.\\n";
+        }
+      };
+
       shell.ws.onerror = () => { shell.connected = false; };
     };
 
@@ -810,20 +928,33 @@ const app = createApp({
       }
     };
 
-    const clearShell = () => { shell.output = ""; };
+    const clearShell = () => {
+      shell.output = "";
+      if (terminal) terminal.clear();
+    };
 
     const disconnectShell = () => {
       if (shell.ws) {
         shell.ws.close();
         shell.ws = null;
       }
+      if (terminal) {
+        window.removeEventListener("resize", handleTerminalResize);
+        terminal.dispose();
+        terminal = null;
+        fitAddon = null;
+      }
     };
 
     const toggleShellMode = () => {
       shellTextMode.value = !shellTextMode.value;
       if (!shellTextMode.value) {
-        // Switching to capture mode - focus the hidden input
-        setTimeout(() => focusCaptureInput(), 100);
+        // Switching to terminal/capture mode
+        if (xtermAvailable.value && !terminal) {
+          setTimeout(() => initXterm(), 100);
+        } else {
+          setTimeout(() => focusCaptureInput(), 100);
+        }
       }
     };
 
@@ -969,21 +1100,28 @@ const app = createApp({
     });
 
     watch(tab, (newTab) => {
-      if (newTab === "shell" && !shell.connected && user.value?.roles?.includes("shell")) {
-        connectShell();
+      if (newTab === "shell" && user.value?.roles?.includes("shell")) {
+        // Initialize xterm if available and in terminal mode
+        if (xtermAvailable.value && !shellTextMode.value && !terminal) {
+          setTimeout(() => initXterm(), 100);
+        }
+        // Connect if not already connected
+        if (!shell.connected) {
+          setTimeout(() => connectShell(), xtermAvailable.value ? 200 : 0);
+        }
       }
     });
 
     return {
       authRequired, user, loginEmail, loginPassword, loginError, loading, token,
       tab, workingDir, browseRoot, results, resultCount, detectedLanguage, resultHeader,
-      browse, grep, find, cat, exec, feedback, shell, shellTextMode,
+      browse, grep, find, cat, exec, feedback, shell, shellTextMode, xtermAvailable,
       doLogin, doLogout, loadBrowse, navigateTo, navigateUp, selectFile,
       handleEntryClick, viewFile, searchHere, onRootChange, resetWorkingDir,
       doGrep, doFind, doCat, doExec, doFeedback,
       connectShell, disconnectShell, sendShellCommand, clearShell,
       toggleShellMode, focusCaptureInput, handleCaptureInput, handleCaptureKeydown,
-      formatSize, clearResults, copyResults, downloadFile
+      initXterm, formatSize, clearResults, copyResults, downloadFile
     };
   }
 });


### PR DESCRIPTION
## Summary

Add xterm.js terminal emulation to the generated HTTP CLI server with automatic fallback to text mode when xterm.js is unavailable or blocked by firewall policy.

## Features

### 1. xterm.js Terminal Support
- Rich terminal UI via xterm.js CDN (v5.3.0)
- Catppuccin color theme matching the prototype
- FitAddon for automatic terminal resize
- Proper keyboard handling (backspace, tab, ctrl+c, etc.)
- Auto-detects xterm.js availability on page load

### 2. Text Mode Fallback
- Plain HTML terminal preserved as fallback
- Activates when:
  - User toggles "Text Mode" button
  - xterm.js fails to load (CDN blocked, offline)
  - Firewall policy denies xterm package
- Capture mode for mobile keyboard input

### 3. Firewall Package Control
- New `npm_packages([...])` policy for npm whitelisting
- New `cdn_packages([...])` policy for CDN URL patterns
- `is_package_allowed/2` for silent conditional checks
- Generators can check firewall and use fallbacks

## Files Changed

| File | Description |
|------|-------------|
| `src/unifyweaver/core/firewall.pl` | Package validation predicates and implications |
| `src/unifyweaver/ui/html_interface_generator.pl` | xterm.js CDN links and Vue terminal code |
| `src/unifyweaver/ui/http_cli_ui.pl` | Shell panel spec with xterm container |
| `examples/http-cli-server/generated/server.ts` | Regenerated output |
| `examples/http-cli-server/README.md` | Documentation updates |

## Firewall Usage Example

```prolog
% Allow xterm.js (default)
:- assertz(firewall:firewall_default([
    npm_packages([vue, xterm, '@xterm/addon-fit']),
    cdn_packages(['*jsdelivr.net*', '*unpkg.com*'])
])).

% Deny xterm.js (forces text mode fallback)
:- assertz(firewall:firewall_default([
    denied([xterm])
])).
```

## Test Plan

- [ ] Start server: `cd examples/http-cli-server/generated && npx ts-node server.ts --cert server.cert --key server.key`
- [ ] Access https://localhost:3001
- [ ] Shell tab shows "(xterm)" indicator when xterm.js loaded
- [ ] Terminal mode: proper colors, backspace, tab completion work
- [ ] Toggle to "Text Mode": falls back to simple input
- [ ] Block xterm CDN in browser devtools: auto-falls back to text mode
- [ ] Regenerate: `./examples/http-cli-server/generate.sh` produces identical output

## Screenshots

Terminal mode with xterm.js:
- Catppuccin theme colors
- Proper cursor and selection
- Full keyboard support

Text mode fallback:
- Simple pre/input UI
- Native text selection
- Works on all browsers

---
Generated with [Claude Code](https://claude.ai/code)
