### PR TITLE
feat(ui): Add file upload and download with Android 14+ support

### DIFF
--- a/examples/http-cli-server/README.md
+++ b/examples/http-cli-server/README.md
@@ -17,6 +17,8 @@ Prolog (`spec.pl`) and generate TypeScript code using UnifyWeaver's generators.
 - **Syntax Highlighting**: Code viewing with highlight.js (20+ languages)
 - **Root Selector**: Switch between sandbox, project, and home directories
 - **Results Panel**: Download/copy buttons for grep, find, cat, exec output
+- **File Upload**: Upload files with File System Access API support for Android 14+
+- **File Download**: Download files from the server with proper MIME types
 - **HTTPS Support**: Self-signed or custom certificates
 - **Role-based Auth**: JWT tokens with shell/admin/user roles
 - **Firewall Package Control**: Control which npm/CDN packages are allowed in generated code
@@ -95,7 +97,8 @@ The generated server includes a complete Vue.js single-page application:
 
 | Tab | Description | Required Role |
 |-----|-------------|---------------|
-| Browse | File browser with navigation | user |
+| Browse | File browser with navigation and download | user |
+| Upload | Upload files to server | admin, shell |
 | Grep | Regex search in files | user |
 | Find | Find files by pattern | user |
 | Cat | View file with syntax highlighting | user |
@@ -123,6 +126,21 @@ Switch between three directory roots:
   - **Text Mode**: Simple input field for command entry
   - **Capture Mode**: Hidden input for mobile keyboards (fallback)
 
+### Upload Features
+
+- **File System Access API**: Uses `showOpenFilePicker()` on Chrome for better file browser
+- **Android 14+ Support**: Works around Android 14's media-centric file picker limitations
+- **Immediate Upload**: Files upload automatically after selection (no separate button)
+- **Standard Fallback**: Falls back to `<input type="file">` on Firefox and older browsers
+- **Size Limits**: 50MB per upload request
+- **Path Validation**: Prevents directory traversal attacks
+
+### Download Features
+
+- **Browse Integration**: Download button appears when a file is selected
+- **MIME Type Detection**: Proper Content-Type headers for common file types
+- **Size Limits**: 100MB maximum download size
+
 ### Syntax Highlighting
 
 File viewing uses highlight.js with support for:
@@ -149,6 +167,8 @@ The `spec.pl` file defines:
   - `POST /cat` - Read file contents
   - `POST /exec` - Execute commands (admin/shell only)
   - `POST /feedback` - Submit feedback
+  - `POST /upload` - Upload files (admin/shell only, multipart/form-data)
+  - `GET /download` - Download files (authenticated)
 
 ### Authentication Specification
 

--- a/examples/http-cli-server/spec.pl
+++ b/examples/http-cli-server/spec.pl
@@ -48,7 +48,9 @@ http_cli_service(Spec) :-
             endpoint(find, post, '/find', [roles([user, admin, shell])]),
             endpoint(cat, post, '/cat', [roles([user, admin, shell])]),
             endpoint(exec, post, '/exec', [roles([admin, shell])]),
-            endpoint(feedback, post, '/feedback', [roles([user, admin, shell])])
+            endpoint(feedback, post, '/feedback', [roles([user, admin, shell])]),
+            endpoint(upload, post, '/upload', [roles([admin, shell])]),
+            endpoint(download, get, '/download', [roles([user, admin, shell])])
         ]),
 
         % WebSocket shell

--- a/src/unifyweaver/glue/http_server_generator.pl
+++ b/src/unifyweaver/glue/http_server_generator.pl
@@ -909,6 +909,11 @@ async function handleRequest(
   const user = token ? verifyToken(token) : null;
 
   try {
+    // Handle upload separately - don\'t parse body as JSON (it\'s multipart)
+    if (method === \'POST\' && pathname === \'/upload\') {
+      return handle_upload(req, res, {}, user);
+    }
+
     const body = await parseBody(req);
 
     // Route to handlers

--- a/src/unifyweaver/ui/http_cli_ui.pl
+++ b/src/unifyweaver/ui/http_cli_ui.pl
@@ -348,26 +348,29 @@ upload_panel_spec(
                 placeholder("e.g., uploads/ or leave empty")
             ]),
 
-            % File drop zone / selector
+            % File selection options
             container(panel, [
-                id(upload_dropzone),
                 class(upload_dropzone),
-                on_click(trigger_file_input),
-                style("border: 2px dashed #0f3460; padding: 40px; text-align: center; cursor: pointer; border-radius: 8px; transition: border-color 0.2s;")
+                style("border: 2px dashed #0f3460; padding: 20px; text-align: center; border-radius: 8px;")
             ], [
-                layout(stack, [spacing(10), align(center)], [
-                    component(text, [content("📁 Click to select files"), style("font-size: 18px;")]),
-                    component(text, [content("or drag and drop"), style(muted)]),
-                    component(text, [content("Max 50MB per file"), style(muted), size(12)])
+                layout(stack, [spacing(15), align(center)], [
+                    component(text, [content("📁 Select files to upload"), style("font-size: 18px;")]),
+                    component(text, [content("Max 50MB per file"), style(muted), size(12)]),
+                    % File System Access API button (better picker on Android 14+)
+                    component(button, [
+                        label("📂 Open File Picker"),
+                        on_click(open_file_picker),
+                        style("margin-top: 10px;")
+                    ]),
+                    component(text, [content("Or use standard input:"), style(muted), size(12)]),
+                    component(file_input, [
+                        id(upload_file_input),
+                        multiple(true),
+                        accept("*/*,application/pdf,text/plain"),
+                        on_change(handle_file_select),
+                        style("padding: 10px;")
+                    ])
                 ])
-            ]),
-
-            % Hidden file input
-            component(file_input, [
-                id(upload_file_input),
-                multiple(true),
-                on_change(handle_file_select),
-                style("display: none;")
             ]),
 
             % Selected files list

--- a/src/unifyweaver/ui/vue_generator.pl
+++ b/src/unifyweaver/ui/vue_generator.pl
@@ -404,6 +404,23 @@ generate_container(collapse, Options, Content, Indent, GenOpts, Code) :-
            [IndentStr, NextIndentStr, Expanded, Expanded, Header,
             NextIndentStr, Expanded, ContentCode, NextIndentStr, IndentStr]).
 
+% Label container - for file input association
+generate_container(label, Options, Content, Indent, GenOpts, Code) :-
+    get_option(for, Options, For, ''),
+    get_option(class, Options, Class, ''),
+    get_option(style, Options, Style, ''),
+
+    indent_string(Indent, IndentStr),
+    NextIndent is Indent + 1,
+    generate_node(Content, NextIndent, GenOpts, ContentCode),
+
+    (For \= '' -> format(atom(ForAttr), ' for="~w"', [For]) ; ForAttr = ''),
+    (Class \= '' -> format(atom(ClassAttr), ' class="~w"', [Class]) ; ClassAttr = ''),
+    (Style \= '' -> format(atom(StyleAttr), ' style="~w"', [Style]) ; StyleAttr = ''),
+
+    format(atom(Code), '~w<label~w~w~w>~n~w~w</label>~n',
+           [IndentStr, ForAttr, ClassAttr, StyleAttr, ContentCode, IndentStr]).
+
 % Default container fallback
 generate_container(Type, _Options, Content, Indent, GenOpts, Code) :-
     NextIndent is Indent + 1,
@@ -608,6 +625,28 @@ generate_component(textarea, Options, Indent, _GenOpts, Code) :-
         format(atom(Code), '~w<textarea v-model="~w" placeholder="~w" rows="~w" style="width: 100%; padding: 10px;"></textarea>~n',
                [IndentStr, CamelBind, Placeholder, Rows])
     ).
+
+% File input component - uses label wrapper for mobile compatibility
+generate_component(file_input, Options, Indent, _GenOpts, Code) :-
+    get_option(id, Options, Id, 'file_input'),
+    get_option(multiple, Options, Multiple, false),
+    get_option(on_change, Options, OnChange, ''),
+    get_option(accept, Options, Accept, ''),
+    get_option(style, Options, Style, ''),
+
+    indent_string(Indent, IndentStr),
+
+    % Build attributes
+    (Multiple == true -> MultipleAttr = ' multiple' ; MultipleAttr = ''),
+    (Accept \= '' -> format(atom(AcceptAttr), ' accept="~w"', [Accept]) ; AcceptAttr = ''),
+    (OnChange \= '' ->
+        onclick_to_vue(OnChange, VueChange),
+        format(atom(ChangeAttr), ' @change="~w"', [VueChange])
+    ; ChangeAttr = ''),
+    (Style \= '' -> format(atom(StyleAttr), ' style="~w"', [Style]) ; StyleAttr = ''),
+
+    format(atom(Code), '~w<input type="file" id="~w"~w~w~w~w>~n',
+           [IndentStr, Id, MultipleAttr, AcceptAttr, ChangeAttr, StyleAttr]).
 
 % Checkbox component
 generate_component(checkbox, Options, Indent, _GenOpts, Code) :-

--- a/src/unifyweaver/ui/vue_generator.pl
+++ b/src/unifyweaver/ui/vue_generator.pl
@@ -520,6 +520,14 @@ disabled_to_vue(not(X), VueCond) :- !,
     format(atom(VueCond), '!~w', [VueX]).
 disabled_to_vue(eq(A, B), VueCond) :- !, condition_to_vue(eq(A, B), VueCond).
 disabled_to_vue(not_eq(A, B), VueCond) :- !, condition_to_vue(not_eq(A, B), VueCond).
+disabled_to_vue(or(A, B), VueCond) :- !,
+    disabled_to_vue(A, VA),
+    disabled_to_vue(B, VB),
+    format(atom(VueCond), '~w || ~w', [VA, VB]).
+disabled_to_vue(and(A, B), VueCond) :- !,
+    disabled_to_vue(A, VA),
+    disabled_to_vue(B, VB),
+    format(atom(VueCond), '~w && ~w', [VA, VB]).
 disabled_to_vue(X, X) :- atom(X), !.
 disabled_to_vue(X, Result) :- term_to_atom(X, Result).
 


### PR DESCRIPTION
## Summary

- Add file upload/download capability to the HTTP CLI server GUI
- Implement File System Access API for better file picker on Android 14+
- Files upload to the working directory by default

## Changes

### Upload (`POST /upload`)
- Multipart form-data handler with custom parser (no external deps)
- 50MB size limit with path validation to prevent traversal attacks
- File System Access API (`showOpenFilePicker`) for Chrome/Android 14+
- Immediate upload after file selection for reliable mobile support
- Falls back to standard `<input type="file">` on Firefox

### Download (`GET /download`)
- Stream files with proper Content-Disposition headers
- MIME type detection for common file types
- 100MB size limit
- Download button in browse panel for selected files

### Generator Enhancements
- `file_input` component in vue_generator
- `label` container type for mobile-friendly file inputs
- `or()`/`and()` support in `disabled_to_vue`
- Route `/upload` before body parsing to preserve multipart stream

## Test plan

- [ ] Open File Picker button opens native file browser on Android Chrome
- [ ] Selected files upload immediately to working directory
- [ ] Standard file input works on Firefox
- [ ] Download button downloads selected file from browse panel
- [ ] Regeneration produces identical output

---

Generated with [Claude Code](https://claude.com/claude-code)
