### PR TITLE
perf(csharp-query): peek scan-index probes for partial joins

### DIFF
--- a/scripts/testing/run_csharp_query_runtime_smoke.ps1
+++ b/scripts/testing/run_csharp_query_runtime_smoke.ps1
@@ -18,7 +18,7 @@ param(
     [string]$OutputDir = "tmp/csharp_query_smoke",
 
     [Parameter(Mandatory = $false)]
-    [string]$ProjectFilter = "csharp_query_*",
+    [string]$ProjectFilter = "*",
 
     [Parameter(Mandatory = $false)]
     [switch]$KeepArtifacts,
@@ -165,7 +165,9 @@ $env:NUGET_PACKAGES = $nugetPackages
 $env:NUGET_HTTP_CACHE_PATH = $nugetHttpCache
 
 if (-not $SkipCodegen) {
-    $generatedDirs = Get-ChildItem -Path $outputPath -Directory -Filter "csharp_query_*" -ErrorAction SilentlyContinue
+    $generatedDirs = Get-ChildItem -Path $outputPath -Directory -ErrorAction SilentlyContinue | Where-Object {
+        Test-Path (Join-Path $_.FullName "expected_rows.txt")
+    }
     if ($generatedDirs) {
         $generatedDirs | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -269,7 +271,9 @@ foreach ($project in $projects) {
 }
 
 if (-not $KeepArtifacts) {
-    Get-ChildItem -Path $outputPath -Directory -Filter "csharp_query_*" | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    Get-ChildItem -Path $outputPath -Directory -ErrorAction SilentlyContinue | Where-Object {
+        Test-Path (Join-Path $_.FullName "expected_rows.txt")
+    } | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 if ($failures -gt 0) {


### PR DESCRIPTION
  - Improves KeyJoinScanIndexPartial selection for multi-key scan-index joins by peeking the probe enumeration (up to 65
    rows) instead of relying on TryEstimateRowUpperBound, so selective SelectionNode probes (e.g. over ParamSeedNode)
    still get the partial-index strategy.
  - Applies the same “peek then fall back” logic for both left-scan and right-scan scan-index join paths in src/
    unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs.
  - Adds regression verify_param_seed_filtered_probe_uses_scan_index_partial in tests/core/test_csharp_query_target.pl.
  - Makes scripts/testing/run_csharp_query_runtime_smoke.ps1 discover/clean generated projects by expected_rows.txt
    (works for both cq_* and csharp_query_* outputs; default ProjectFilter is now *).