### PR TITLE
fix(wasm-graph): Improve mobile UX and fix addEdge function

### DIFF
--- a/examples/wasm-graph/README.md
+++ b/examples/wasm-graph/README.md
@@ -67,6 +67,14 @@ The generated app includes:
 - Load/clear sample data
 - Responsive Cytoscape.js visualization
 
+### Mobile Support
+
+On mobile devices (< 768px width):
+- Layout is 150% of screen width for better usability
+- Swipe horizontally to navigate between sidebar and graph
+- One finger on graph: pan the graph
+- Two fingers on graph: scroll the page (navigate to sidebar)
+
 ## Architecture
 
 ```

--- a/examples/wasm-graph/index.html
+++ b/examples/wasm-graph/index.html
@@ -105,6 +105,13 @@
     .info-panel p { font-size: 0.85rem; color: #aaa; }
     .layout-buttons { display: flex; gap: 0.5rem; flex-wrap: wrap; }
     .layout-buttons button { flex: 1; min-width: 80px; }
+
+    /* Mobile: wider than screen to allow horizontal scroll */
+    @media (max-width: 768px) {
+      body { min-width: 150vw; overflow-x: auto; }
+      main { grid-template-columns: 280px 1fr; min-width: 150vw; }
+      #graph { min-width: 100vw; }
+    }
   </style>
 </head>
 <body>
@@ -225,7 +232,7 @@
         const node = evt.target;
         document.getElementById('selectedInfo').style.display = 'block';
         document.getElementById('selectedNodeInfo').textContent =
-          `ID: $${node.id()}, Label: $${node.data('label')}`;
+          `ID: ${node.id()}, Label: ${node.data('label')}`;
       });
 
       cy.on('tap', function(evt) {
@@ -235,6 +242,27 @@
       });
 
       updateEdgeList();
+
+      // Two-finger touch scrolls page (to navigate back to sidebar)
+      const graphEl = document.getElementById('graph');
+      let twoFingerStart = null;
+      graphEl.addEventListener('touchstart', (e) => {
+        if (e.touches.length === 2) {
+          twoFingerStart = { x: e.touches[0].clientX, scrollX: window.scrollX };
+          cy.userPanningEnabled(false);
+        }
+      }, { passive: true });
+      graphEl.addEventListener('touchmove', (e) => {
+        if (e.touches.length === 2 && twoFingerStart) {
+          const dx = twoFingerStart.x - e.touches[0].clientX;
+          window.scrollTo(twoFingerStart.scrollX + dx, 0);
+        }
+      }, { passive: true });
+      graphEl.addEventListener('touchend', () => {
+        twoFingerStart = null;
+        cy.userPanningEnabled(true);
+      }, { passive: true });
+
       document.getElementById('status').textContent = 'Ready';
       document.getElementById('status').className = 'status ready';
     }
@@ -249,16 +277,16 @@
       if (!from || !to) return;
 
       // Add nodes if they don't exist
-      if (!cy.$(`#$${from}`).length) {
+      if (!cy.$(`#${from}`).length) {
         cy.add({ data: { id: from, label: from } });
       }
-      if (!cy.$(`#$${to}`).length) {
+      if (!cy.$(`#${to}`).length) {
         cy.add({ data: { id: to, label: to } });
       }
 
       // Add edge
-      const edgeId = `e_$${from}_$${to}`;
-      if (!cy.$(`#$${edgeId}`).length) {
+      const edgeId = `e_${from}_${to}`;
+      if (!cy.$(`#${edgeId}`).length) {
         cy.add({ data: { id: edgeId, source: from, target: to } });
       }
 
@@ -287,7 +315,7 @@
     };
 
     window.removeEdge = function(edgeId) {
-      cy.$(`#$${edgeId}`).remove();
+      cy.$(`#${edgeId}`).remove();
       // Remove orphan nodes
       cy.nodes().forEach(node => {
         if (node.degree() === 0) node.remove();
@@ -300,8 +328,8 @@
       document.getElementById('edgeCount').textContent = edges.length;
       document.getElementById('edges').innerHTML = edges.map(e =>
         `<div class="item">
-          <span class="relation"><span class="name">$${e.source().id()}</span> → <span class="name">$${e.target().id()}</span></span>
-          <button class="danger" onclick="removeEdge('$${e.id()}')">×</button>
+          <span class="relation"><span class="name">${e.source().id()}</span> → <span class="name">${e.target().id()}</span></span>
+          <button class="danger" onclick="removeEdge('${e.id()}')">×</button>
         </div>`
       ).join('');
     }


### PR DESCRIPTION
## Summary

Improves mobile usability for the wasm-graph example and fixes a bug where adding edges only created one node.

## Changes

| File | Description |
|------|-------------|
| `examples/wasm-graph/graph_module.pl` | Add mobile CSS, two-finger scroll, fix template literals |
| `examples/wasm-graph/index.html` | Regenerated with fixes |
| `examples/wasm-graph/README.md` | Add Mobile Support documentation |

## Mobile Improvements

### Wider Layout
- On screens < 768px, layout is now 150% of screen width
- Users can swipe horizontally to navigate between sidebar and graph
- Provides more space for both controls and graph visualization

### Two-Finger Navigation
- **One finger** on graph: pans the graph (unchanged)
- **Two fingers** on graph: scrolls the page horizontally
- Allows users to navigate back to sidebar when viewing the graph

## Bug Fix

### addEdge Template Literals
- **Before:** `$${from}` produced literal `$${from}` in JavaScript
- **After:** `${from}` produces correct template literal interpolation
- Both nodes now correctly created when adding a new edge

## Test Plan

- [x] Mobile: Swipe left/right to navigate between sidebar and graph
- [x] Mobile: One finger pans the graph
- [x] Mobile: Two fingers scroll the page
- [x] Add edge: Enter two names → both nodes and edge created
- [x] Layout buttons work correctly
- [x] Remove edge works correctly
- [x] Load Sample Data restores family tree
