### PR TITLE
perf(csharp-query): use Materialize row estimates for hash-join build-side selection

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -2213,12 +2213,15 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     case MaterializeNode materialize:
+                    {
                         if (context.Materialized.TryGetValue(materialize.Id, out var cached))
                         {
                             upperBound = cached.Count;
                             return true;
                         }
-                        return false;
+
+                        return TryEstimateRowUpperBound(materialize.Plan, context, out upperBound);
+                    }
 
                     default:
                         return false;


### PR DESCRIPTION
  - Improves TryEstimateRowUpperBound so MaterializeNode can be estimated from its underlying plan when not yet cached
    (better hash-join build-side decisions).
  - Adds regression coverage: verify_hash_build_prefers_smaller_materialize_input_rowcount to ensure we pick
    KeyJoinHashBuildLeft when left side is smaller but wrapped in materialize{...}.
  - Local smoke: built + ran the generated query project successfully.