### PR TITLE
feat(agent-loop): Add Ollama backends and configurable agent variants

### DIFF
--- a/tools/agent-loop/UNIFIED_AGENT_LOOP_PROPOSAL.md
+++ b/tools/agent-loop/UNIFIED_AGENT_LOOP_PROPOSAL.md
@@ -29,11 +29,20 @@ python3 agent_loop.py
 # Single prompt
 python3 agent_loop.py "list files in current directory"
 
+# Use named agent variants
+python3 agent_loop.py -a yolo "create hello.py"        # Fast, auto-tools
+python3 agent_loop.py -a claude-opus "complex task"    # Opus model
+python3 agent_loop.py -a ollama "local prompt"         # Local Ollama
+
 # Different backends
 python3 agent_loop.py -b claude-code "prompt"          # Claude Code CLI
-python3 agent_loop.py -b claude-code --model opus "prompt"
 python3 agent_loop.py -b gemini "prompt"               # Gemini CLI
-python3 agent_loop.py -b claude --api-key $KEY "prompt" # Claude API
+python3 agent_loop.py -b ollama-api --host 192.168.1.5 "prompt"  # Remote Ollama
+python3 agent_loop.py -b ollama-cli -m codellama "prompt"        # Ollama CLI
+
+# Configuration
+python3 agent_loop.py --list-agents                    # Show available agents
+python3 agent_loop.py --init-config agents.json        # Create config file
 
 # Options
 python3 agent_loop.py --help
@@ -396,6 +405,45 @@ loop_config([
 ]).
 ```
 
+## Configuration
+
+Agent variants can be defined in `agents.yaml` or `agents.json`:
+
+```json
+{
+  "default": "claude-sonnet",
+  "agents": {
+    "claude-sonnet": {
+      "backend": "claude-code",
+      "model": "sonnet"
+    },
+    "yolo": {
+      "backend": "claude-code",
+      "model": "haiku",
+      "auto_tools": true,
+      "system_prompt": "Be fast and take action."
+    },
+    "ollama-remote": {
+      "backend": "ollama-api",
+      "model": "codellama",
+      "host": "192.168.1.100",
+      "port": 11434
+    },
+    "coding-assistant": {
+      "backend": "claude-code",
+      "model": "sonnet",
+      "agent_md": "./agents/coding.md",
+      "skills": ["./skills/git.md"],
+      "tools": ["bash", "read", "write", "edit"]
+    }
+  }
+}
+```
+
+Config fields: `backend`, `model`, `host`, `port`, `api_key`, `command`,
+`system_prompt`, `agent_md`, `tools`, `auto_tools`, `context_mode`,
+`max_context_tokens`, `max_messages`, `skills`, `timeout`, `show_tokens`.
+
 ## File Structure
 
 ```
@@ -404,6 +452,7 @@ tools/agent-loop/
 ├── agent_loop_module.pl            # Prolog generator
 └── generated/
     ├── agent_loop.py               # Main loop
+    ├── config.py                   # Configuration system
     ├── context.py                  # Context manager
     ├── tools.py                    # Tool handler
     ├── backends/
@@ -412,7 +461,9 @@ tools/agent-loop/
     │   ├── coro.py                 # Coro CLI backend (--verbose)
     │   ├── claude_code.py          # Claude Code CLI (-p mode)
     │   ├── claude_api.py           # Claude API backend
-    │   └── gemini.py               # Gemini CLI backend
+    │   ├── gemini.py               # Gemini CLI backend
+    │   ├── ollama_api.py           # Ollama REST API backend
+    │   └── ollama_cli.py           # Ollama CLI backend
     └── stubs/                      # Prolog-generated stubs
         ├── README.md
         └── *.py

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -74,14 +74,26 @@ agent_backend(openai, [
     supports_streaming(true)
 ]).
 
-agent_backend(ollama, [
+agent_backend(ollama_api, [
     type(api),
     endpoint("http://localhost:11434/api/chat"),
     model("llama3"),
-    description("Ollama local API backend"),
+    description("Ollama REST API backend for local models"),
+    default_host("localhost"),
+    default_port(11434),
     context_format(messages_array),
     auth_required(false),
     supports_streaming(true)
+]).
+
+agent_backend(ollama_cli, [
+    type(cli),
+    command("ollama"),
+    args(["run"]),
+    description("Ollama CLI backend using 'ollama run' command"),
+    default_model("llama3"),
+    context_format(conversation_history),
+    supports_streaming(false)
 ]).
 
 %% =============================================================================

--- a/tools/agent-loop/generated/backends/__init__.py
+++ b/tools/agent-loop/generated/backends/__init__.py
@@ -3,10 +3,13 @@ from .base import AgentBackend, AgentResponse, ToolCall
 from .coro import CoroBackend
 from .claude_code import ClaudeCodeBackend
 from .gemini import GeminiBackend
+from .ollama_api import OllamaAPIBackend
+from .ollama_cli import OllamaCLIBackend
 
 __all__ = [
     'AgentBackend', 'AgentResponse', 'ToolCall',
-    'CoroBackend', 'ClaudeCodeBackend', 'GeminiBackend'
+    'CoroBackend', 'ClaudeCodeBackend', 'GeminiBackend',
+    'OllamaAPIBackend', 'OllamaCLIBackend'
 ]
 
 # Claude API backend (optional - requires anthropic package)

--- a/tools/agent-loop/generated/backends/ollama_api.py
+++ b/tools/agent-loop/generated/backends/ollama_api.py
@@ -1,0 +1,122 @@
+"""Ollama API backend for local LLM inference."""
+
+import json
+import urllib.request
+import urllib.error
+from .base import AgentBackend, AgentResponse, ToolCall
+
+
+class OllamaAPIBackend(AgentBackend):
+    """Ollama REST API backend for local models."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 11434,
+        model: str = "llama3",
+        system_prompt: str | None = None,
+        timeout: int = 300
+    ):
+        self.host = host
+        self.port = port
+        self.model = model
+        self.system_prompt = system_prompt or "You are a helpful assistant."
+        self.timeout = timeout
+        self.base_url = f"http://{host}:{port}"
+
+    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+        """Send message to Ollama API and get response."""
+        # Build messages array
+        messages = []
+
+        # Add system prompt
+        if self.system_prompt:
+            messages.append({
+                "role": "system",
+                "content": self.system_prompt
+            })
+
+        # Add context messages
+        for msg in context:
+            if msg.get('role') in ('user', 'assistant'):
+                messages.append({
+                    "role": msg['role'],
+                    "content": msg['content']
+                })
+
+        # Add current message
+        messages.append({
+            "role": "user",
+            "content": message
+        })
+
+        # Build request
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False
+        }
+
+        try:
+            url = f"{self.base_url}/api/chat"
+            data = json.dumps(payload).encode('utf-8')
+            req = urllib.request.Request(
+                url,
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST"
+            )
+
+            with urllib.request.urlopen(req, timeout=self.timeout) as response:
+                result = json.loads(response.read().decode('utf-8'))
+
+            # Extract content
+            content = result.get("message", {}).get("content", "")
+
+            # Extract token counts if available
+            tokens = {}
+            if "eval_count" in result:
+                tokens["output"] = result["eval_count"]
+            if "prompt_eval_count" in result:
+                tokens["input"] = result["prompt_eval_count"]
+
+            return AgentResponse(
+                content=content,
+                tool_calls=[],
+                tokens=tokens,
+                raw=result
+            )
+
+        except urllib.error.URLError as e:
+            return AgentResponse(
+                content=f"[Error: Cannot connect to Ollama at {self.base_url}. Is Ollama running? Error: {e}]",
+                tokens={}
+            )
+        except json.JSONDecodeError as e:
+            return AgentResponse(
+                content=f"[Error: Invalid JSON response from Ollama: {e}]",
+                tokens={}
+            )
+        except Exception as e:
+            return AgentResponse(
+                content=f"[Error: {e}]",
+                tokens={}
+            )
+
+    def list_models(self) -> list[str]:
+        """List available models on the Ollama server."""
+        try:
+            url = f"{self.base_url}/api/tags"
+            req = urllib.request.Request(url, method="GET")
+
+            with urllib.request.urlopen(req, timeout=10) as response:
+                result = json.loads(response.read().decode('utf-8'))
+
+            return [m["name"] for m in result.get("models", [])]
+
+        except Exception:
+            return []
+
+    @property
+    def name(self) -> str:
+        return f"Ollama API ({self.model}@{self.host}:{self.port})"

--- a/tools/agent-loop/generated/backends/ollama_cli.py
+++ b/tools/agent-loop/generated/backends/ollama_cli.py
@@ -1,0 +1,120 @@
+"""Ollama CLI backend using the ollama run command."""
+
+import subprocess
+from .base import AgentBackend, AgentResponse, ToolCall
+
+
+class OllamaCLIBackend(AgentBackend):
+    """Ollama CLI backend using 'ollama run' command."""
+
+    def __init__(
+        self,
+        command: str = "ollama",
+        model: str = "llama3",
+        timeout: int = 300
+    ):
+        self.command = command
+        self.model = model
+        self.timeout = timeout
+
+    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+        """Send message to Ollama CLI and get response."""
+        # Format the prompt with context
+        prompt = self._format_prompt(message, context)
+
+        # Build command: ollama run <model> "<prompt>"
+        # Note: ollama run reads from stdin if no prompt given
+        cmd = [self.command, "run", self.model]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout
+            )
+
+            output = result.stdout
+            if result.returncode != 0 and result.stderr:
+                output = f"[Error: {result.stderr.strip()}]"
+
+        except subprocess.TimeoutExpired:
+            return AgentResponse(
+                content=f"[Error: Command timed out after {self.timeout} seconds]",
+                tokens={}
+            )
+        except FileNotFoundError:
+            return AgentResponse(
+                content=f"[Error: Command '{self.command}' not found. Install Ollama from https://ollama.ai]",
+                tokens={}
+            )
+        except Exception as e:
+            return AgentResponse(
+                content=f"[Error: {e}]",
+                tokens={}
+            )
+
+        # Clean the output
+        content = self._clean_output(output)
+
+        return AgentResponse(
+            content=content,
+            tool_calls=[],
+            tokens={},  # CLI doesn't report tokens
+            raw=output
+        )
+
+    def _format_prompt(self, message: str, context: list[dict]) -> str:
+        """Format message with conversation context."""
+        if not context:
+            return message
+
+        # Format last few messages as context
+        history_lines = []
+        for msg in context[-6:]:  # Last 6 messages (3 exchanges)
+            role = "User" if msg.get('role') == 'user' else "Assistant"
+            content = msg.get('content', '')
+            # Truncate very long messages in context
+            if len(content) > 500:
+                content = content[:500] + "..."
+            history_lines.append(f"{role}: {content}")
+
+        history = "\n".join(history_lines)
+
+        return f"""Previous conversation:
+{history}
+
+Current request: {message}"""
+
+    def _clean_output(self, output: str) -> str:
+        """Clean up output."""
+        result = output.strip()
+
+        # Remove common prefixes
+        for prefix in ['A:', 'Assistant:']:
+            if result.startswith(prefix):
+                result = result[len(prefix):].strip()
+                break
+
+        return result
+
+    def list_models(self) -> list[str]:
+        """List available models using 'ollama list'."""
+        try:
+            result = subprocess.run(
+                [self.command, "list"],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            if result.returncode == 0:
+                lines = result.stdout.strip().split('\n')[1:]  # Skip header
+                return [line.split()[0] for line in lines if line.strip()]
+        except Exception:
+            pass
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"Ollama CLI ({self.model})"

--- a/tools/agent-loop/generated/config.py
+++ b/tools/agent-loop/generated/config.py
@@ -1,0 +1,283 @@
+"""Configuration system for agent loop variants."""
+
+import os
+import json
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import Any
+
+# Try to import yaml, fall back to JSON only
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+
+@dataclass
+class AgentConfig:
+    """Configuration for an agent variant."""
+    name: str
+    backend: str  # coro, claude-code, gemini, claude, ollama-api, ollama-cli
+    model: str | None = None
+
+    # Connection settings
+    host: str | None = None  # For network backends (ollama-api)
+    port: int | None = None
+    api_key: str | None = None  # Or env var name like $ANTHROPIC_API_KEY
+    command: str | None = None  # For CLI backends
+
+    # Prompt settings
+    system_prompt: str | None = None
+    agent_md: str | None = None  # Path to agent.md file
+
+    # Tool settings
+    tools: list[str] = field(default_factory=lambda: ['bash', 'read', 'write', 'edit'])
+    auto_tools: bool = False  # Skip confirmation
+
+    # Context settings
+    context_mode: str = "continue"  # continue, fresh, sliding
+    max_context_tokens: int = 100000
+    max_messages: int = 50
+
+    # Skills (paths to skill files)
+    skills: list[str] = field(default_factory=list)
+
+    # Additional options
+    timeout: int = 300
+    show_tokens: bool = True
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class Config:
+    """Root configuration with multiple agent variants."""
+    default: str = "default"
+    agents: dict[str, AgentConfig] = field(default_factory=dict)
+
+    # Global settings
+    config_dir: str = ""
+    skills_dir: str = ""
+
+
+def _resolve_env_var(value: str) -> str:
+    """Resolve environment variable references like $VAR or ${VAR}."""
+    if not isinstance(value, str):
+        return value
+    if value.startswith('$'):
+        var_name = value[1:]
+        if var_name.startswith('{') and var_name.endswith('}'):
+            var_name = var_name[1:-1]
+        return os.environ.get(var_name, value)
+    return value
+
+
+def _load_agent_config(name: str, data: dict) -> AgentConfig:
+    """Load an agent config from a dictionary."""
+    # Resolve env vars in sensitive fields
+    if 'api_key' in data:
+        data['api_key'] = _resolve_env_var(data['api_key'])
+
+    return AgentConfig(
+        name=name,
+        backend=data.get('backend', 'coro'),
+        model=data.get('model'),
+        host=data.get('host'),
+        port=data.get('port'),
+        api_key=data.get('api_key'),
+        command=data.get('command'),
+        system_prompt=data.get('system_prompt'),
+        agent_md=data.get('agent_md'),
+        tools=data.get('tools', ['bash', 'read', 'write', 'edit']),
+        auto_tools=data.get('auto_tools', False),
+        context_mode=data.get('context_mode', 'continue'),
+        max_context_tokens=data.get('max_context_tokens', 100000),
+        max_messages=data.get('max_messages', 50),
+        skills=data.get('skills', []),
+        timeout=data.get('timeout', 300),
+        show_tokens=data.get('show_tokens', True),
+        extra=data.get('extra', {})
+    )
+
+
+def load_config(path: str | Path) -> Config:
+    """Load configuration from a YAML or JSON file."""
+    path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    content = path.read_text()
+
+    # Parse based on extension
+    if path.suffix in ('.yaml', '.yml'):
+        if not HAS_YAML:
+            raise ImportError("PyYAML not installed. Use JSON config or: pip install pyyaml")
+        data = yaml.safe_load(content)
+    else:
+        data = json.loads(content)
+
+    # Build config
+    config = Config(
+        default=data.get('default', 'default'),
+        config_dir=str(path.parent),
+        skills_dir=data.get('skills_dir', '')
+    )
+
+    # Load agent configs
+    for name, agent_data in data.get('agents', {}).items():
+        config.agents[name] = _load_agent_config(name, agent_data)
+
+    # Create default if not present
+    if 'default' not in config.agents:
+        config.agents['default'] = AgentConfig(name='default', backend='coro')
+
+    return config
+
+
+def load_config_from_dir(dir_path: str | Path = None) -> Config | None:
+    """Load config from standard locations in a directory."""
+    if dir_path is None:
+        dir_path = Path.cwd()
+    else:
+        dir_path = Path(dir_path)
+
+    # Check standard config file names
+    for name in ['agents.yaml', 'agents.yml', 'agents.json',
+                 '.agents.yaml', '.agents.yml', '.agents.json']:
+        config_path = dir_path / name
+        if config_path.exists():
+            return load_config(config_path)
+
+    return None
+
+
+def get_default_config() -> Config:
+    """Get a default configuration with common presets."""
+    config = Config()
+
+    # Default coro backend
+    config.agents['default'] = AgentConfig(
+        name='default',
+        backend='coro',
+        command='claude'
+    )
+
+    # Claude Code with different models
+    config.agents['claude-sonnet'] = AgentConfig(
+        name='claude-sonnet',
+        backend='claude-code',
+        model='sonnet'
+    )
+
+    config.agents['claude-opus'] = AgentConfig(
+        name='claude-opus',
+        backend='claude-code',
+        model='opus'
+    )
+
+    config.agents['claude-haiku'] = AgentConfig(
+        name='claude-haiku',
+        backend='claude-code',
+        model='haiku'
+    )
+
+    # Yolo mode - auto tools with haiku for speed
+    config.agents['yolo'] = AgentConfig(
+        name='yolo',
+        backend='claude-code',
+        model='haiku',
+        auto_tools=True,
+        system_prompt="Be concise and take action. Execute tools without asking."
+    )
+
+    # Gemini
+    config.agents['gemini'] = AgentConfig(
+        name='gemini',
+        backend='gemini',
+        model='gemini-2.5-flash'
+    )
+
+    # Local Ollama
+    config.agents['ollama'] = AgentConfig(
+        name='ollama',
+        backend='ollama-api',
+        model='llama3',
+        host='localhost',
+        port=11434
+    )
+
+    config.agents['ollama-cli'] = AgentConfig(
+        name='ollama-cli',
+        backend='ollama-cli',
+        model='llama3'
+    )
+
+    return config
+
+
+def save_example_config(path: str | Path):
+    """Save an example configuration file."""
+    path = Path(path)
+
+    example = {
+        "default": "claude-sonnet",
+        "skills_dir": "./skills",
+        "agents": {
+            "claude-sonnet": {
+                "backend": "claude-code",
+                "model": "sonnet",
+                "tools": ["bash", "read", "write", "edit"],
+                "context_mode": "continue"
+            },
+            "claude-opus": {
+                "backend": "claude-code",
+                "model": "opus",
+                "system_prompt": "You are a senior software engineer. Be thorough."
+            },
+            "yolo": {
+                "backend": "claude-code",
+                "model": "haiku",
+                "auto_tools": True,
+                "system_prompt": "Be fast and take action without asking."
+            },
+            "gemini": {
+                "backend": "gemini",
+                "model": "gemini-2.5-flash"
+            },
+            "ollama-local": {
+                "backend": "ollama-api",
+                "model": "llama3",
+                "host": "localhost",
+                "port": 11434
+            },
+            "ollama-remote": {
+                "backend": "ollama-api",
+                "model": "codellama",
+                "host": "192.168.1.100",
+                "port": 11434
+            },
+            "claude-api": {
+                "backend": "claude",
+                "model": "claude-sonnet-4-20250514",
+                "api_key": "$ANTHROPIC_API_KEY"
+            },
+            "coding-assistant": {
+                "backend": "claude-code",
+                "model": "sonnet",
+                "agent_md": "./agents/coding.md",
+                "skills": ["./skills/git.md", "./skills/testing.md"],
+                "tools": ["bash", "read", "write", "edit"],
+                "system_prompt": "You are a coding assistant focused on clean, tested code."
+            }
+        }
+    }
+
+    if path.suffix in ('.yaml', '.yml'):
+        if not HAS_YAML:
+            raise ImportError("PyYAML not installed for YAML output")
+        content = yaml.dump(example, default_flow_style=False, sort_keys=False)
+    else:
+        content = json.dumps(example, indent=2)
+
+    path.write_text(content)


### PR DESCRIPTION
## Summary

Extends the UnifyWeaver Agent Loop with:

1. **Ollama Backend Support**
   - `OllamaAPIBackend`: REST API backend for local/remote Ollama instances
   - `OllamaCLIBackend`: CLI backend using `ollama run` command
   - Configurable host/port for network deployments

2. **Configuration System**
   - Named agent variants in `agents.yaml` or `agents.json`
   - Built-in presets: yolo, claude-opus, gemini, ollama, etc.
   - Environment variable resolution for API keys (`$ANTHROPIC_API_KEY`)

3. **Agent Customization**
   - System prompts and agent.md files
   - Skills loading from files
   - Tool availability control
   - Context modes: continue, fresh, sliding
   - Auto-tool execution (yolo mode)

## New Files

| File | Description |
|------|-------------|
| `backends/ollama_api.py` | Ollama REST API backend |
| `backends/ollama_cli.py` | Ollama CLI backend |
| `config.py` | Configuration system with AgentConfig dataclass |

## CLI Changes

New arguments:
- `--agent/-a`: Select agent variant from config
- `--config/-C`: Specify config file path
- `--list-agents`: List available agent variants
- `--init-config`: Generate example config file
- `--host`, `--port`: Override network settings
- `--system-prompt`: Override system prompt

## Example Config

```json
{
  "default": "claude-sonnet",
  "agents": {
    "yolo": {
      "backend": "claude-code",
      "model": "haiku",
      "auto_tools": true,
      "system_prompt": "Be fast and take action without asking."
    },
    "ollama-remote": {
      "backend": "ollama-api",
      "model": "codellama",
      "host": "192.168.1.100",
      "port": 11434
    }
  }
}
```

## Usage Examples

```bash
# Use yolo preset (haiku, auto-tools)
python agent_loop.py --agent yolo "fix the bug"

# Use remote Ollama
python agent_loop.py --agent ollama-remote "explain this code"

# Override on command line
python agent_loop.py --backend ollama-api --host 10.0.0.5 --model codellama

# List available agents
python agent_loop.py --list-agents

# Generate example config
python agent_loop.py --init-config agents.yaml
```

## Test Plan

- [ ] Verify `--list-agents` shows all configured agents
- [ ] Verify `--agent yolo` enables auto-tools mode
- [ ] Test Ollama API backend with local instance
- [ ] Test Ollama CLI backend with `ollama run`
- [ ] Verify config file auto-discovery (agents.yaml in cwd)
- [ ] Verify CLI args override config values
- [ ] Test `--init-config` generates valid example config
