### PR TITLE
feat(agent-loop): Add iteration limits and slash commands for runtime control

### DIFF
--- a/tools/agent-loop/generated/config.py
+++ b/tools/agent-loop/generated/config.py
@@ -43,6 +43,9 @@ class AgentConfig:
     # Skills (paths to skill files)
     skills: list[str] = field(default_factory=list)
 
+    # Loop control
+    max_iterations: int = 0  # 0 = unlimited, N = pause after N tool iterations
+
     # Additional options
     timeout: int = 300
     show_tokens: bool = True
@@ -94,6 +97,7 @@ def _load_agent_config(name: str, data: dict) -> AgentConfig:
         max_context_tokens=data.get('max_context_tokens', 100000),
         max_messages=data.get('max_messages', 50),
         skills=data.get('skills', []),
+        max_iterations=data.get('max_iterations', 0),
         timeout=data.get('timeout', 300),
         show_tokens=data.get('show_tokens', True),
         extra=data.get('extra', {})


### PR DESCRIPTION
## Summary

Adds control over agent loop iterations and runtime configuration:

1. **Iteration Limits**
   - Pause after N tool iterations to let user review progress
   - Configurable via CLI, config file, or slash command
   - User can continue, or provide new input to redirect

2. **Slash Commands**
   - `/iterations [N]` - View or set max iterations
   - `/backend [name]` - View or switch agent/backend
   - Commands work with or without `/` prefix

## Changes

| File | Changes |
|------|---------|
| `agent_loop.py` | Add iteration tracking, slash command handlers, CLI arg |
| `config.py` | Add `max_iterations` field to AgentConfig |

## New CLI Option

```
--max-iterations, -i N    Max tool iterations before pausing (0 = unlimited)
```

## New Config Option

```json
{
  "agents": {
    "careful": {
      "backend": "claude-code",
      "model": "sonnet",
      "max_iterations": 3
    }
  }
}
```

## Slash Commands

| Command | Description |
|---------|-------------|
| `/iterations` | Show current max iterations setting |
| `/iterations N` | Set max iterations (0 = unlimited) |
| `/backend` | Show current backend and list available agents |
| `/backend name` | Switch to a different agent/backend |

## Usage Examples

```bash
# Start with 5 iteration limit
python agent_loop.py -i 5 "refactor this module"

# Unlimited iterations (default)
python agent_loop.py "fix all the bugs"
```

During session:
```
You: /iterations 3
[Max iterations set to: 3]

You: do a complex refactoring task
[Calling backend...]
  ... tool output ...
[Iteration 1: continuing with tool results...]
  ... tool output ...
[Iteration 2: continuing with tool results...]
  ... tool output ...
[Iteration 3: continuing with tool results...]

[Paused after 3 iteration(s)]
[Press Enter to continue, or type a message]
You:

You: /backend yolo
[Switched to backend: claude-code (haiku)]
```

## Test Plan

- [ ] Verify `--max-iterations 3` pauses after 3 tool loops
- [ ] Verify `/iterations` shows current setting
- [ ] Verify `/iterations 5` updates the limit
- [ ] Verify `/backend` lists available agents
- [ ] Verify `/backend yolo` switches backend
- [ ] Verify pressing Enter continues the loop
- [ ] Verify typing new input redirects the conversation
- [ ] Verify `max_iterations: 0` means unlimited
