### PR TITLE
feat(agent-loop): Add OpenAI backend, session persistence, skills loading, and context

### DIFF
--- a/tools/agent-loop/UNIFIED_AGENT_LOOP_PROPOSAL.md
+++ b/tools/agent-loop/UNIFIED_AGENT_LOOP_PROPOSAL.md
@@ -455,12 +455,15 @@ tools/agent-loop/
     ├── config.py                   # Configuration system
     ├── context.py                  # Context manager
     ├── tools.py                    # Tool handler
+    ├── sessions.py                 # Session persistence
+    ├── skills.py                   # Skills/agent.md loader
     ├── backends/
     │   ├── __init__.py
     │   ├── base.py                 # Abstract backend
     │   ├── coro.py                 # Coro CLI backend (--verbose)
     │   ├── claude_code.py          # Claude Code CLI (-p mode)
     │   ├── claude_api.py           # Claude API backend
+    │   ├── openai_api.py           # OpenAI API backend
     │   ├── gemini.py               # Gemini CLI backend
     │   ├── ollama_api.py           # Ollama REST API backend
     │   └── ollama_cli.py           # Ollama CLI backend
@@ -610,14 +613,20 @@ User: Add 3 to that
 - [x] Generate Python code from specs
 - [x] Generate documentation
 
-### Phase 5: ncurses Display Mode (Future)
+### Phase 5: Additional Backends ✓
+- [x] OpenAI API backend (GPT-4, GPT-4o)
+- [x] Ollama backends (API and CLI)
+- [x] Gemini CLI backend
+
+### Phase 6: Advanced Features ✓
+- [x] Session persistence (save/load conversations)
+- [x] Skills and agent.md loading
+- [x] Multiple context formats (plain, markdown, json, xml)
+- [x] Runtime slash commands (/backend, /iterations, /save, /load, /format)
+- [ ] Context summarization (future)
+
+### Phase 7: ncurses Display Mode (Future)
 - [ ] Add ncurses/terminfo based display
 - [ ] Spinner that updates in place
 - [ ] Progress bar for streaming
 - [ ] Status line at bottom
-
-### Phase 6: Advanced Features (Future)
-- [ ] OpenAI and Ollama backends
-- [ ] Limited context display mode
-- [ ] Context summarization
-- [ ] Multiple context formats (plain, markdown, json, xml)

--- a/tools/agent-loop/generated/backends/__init__.py
+++ b/tools/agent-loop/generated/backends/__init__.py
@@ -18,3 +18,10 @@ try:
     __all__.append('ClaudeAPIBackend')
 except ImportError:
     pass
+
+# OpenAI API backend (optional - requires openai package)
+try:
+    from .openai_api import OpenAIBackend
+    __all__.append('OpenAIBackend')
+except ImportError:
+    pass

--- a/tools/agent-loop/generated/backends/openai_api.py
+++ b/tools/agent-loop/generated/backends/openai_api.py
@@ -1,0 +1,151 @@
+"""OpenAI API backend using the OpenAI SDK."""
+
+import os
+from .base import AgentBackend, AgentResponse, ToolCall
+
+# Try to import openai, but don't fail if not installed
+try:
+    import openai
+    HAS_OPENAI = True
+except ImportError:
+    HAS_OPENAI = False
+
+
+class OpenAIBackend(AgentBackend):
+    """OpenAI API backend (GPT-4, GPT-3.5, etc.)."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "gpt-4o",
+        max_tokens: int = 4096,
+        system_prompt: str | None = None,
+        base_url: str | None = None
+    ):
+        if not HAS_OPENAI:
+            raise ImportError(
+                "openai package not installed. "
+                "Install with: pip install openai"
+            )
+
+        # Get API key from parameter or environment
+        self.api_key = api_key or os.environ.get('OPENAI_API_KEY')
+        if not self.api_key:
+            raise ValueError(
+                "API key required. Set OPENAI_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+        self.model = model
+        self.max_tokens = max_tokens
+        self.system_prompt = system_prompt or (
+            "You are a helpful AI assistant. Be concise and direct."
+        )
+        self.base_url = base_url  # For OpenAI-compatible APIs
+
+        # Initialize client
+        client_kwargs = {"api_key": self.api_key}
+        if self.base_url:
+            client_kwargs["base_url"] = self.base_url
+
+        self.client = openai.OpenAI(**client_kwargs)
+
+    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+        """Send message to OpenAI API and get response."""
+        # Build messages array
+        messages = [
+            {"role": "system", "content": self.system_prompt}
+        ]
+
+        # Add context messages
+        for msg in context:
+            if msg.get('role') in ('user', 'assistant'):
+                messages.append({
+                    "role": msg['role'],
+                    "content": msg['content']
+                })
+
+        # Add current message
+        messages.append({
+            "role": "user",
+            "content": message
+        })
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                max_tokens=self.max_tokens,
+                messages=messages
+            )
+
+            # Extract content
+            content = ""
+            if response.choices and len(response.choices) > 0:
+                choice = response.choices[0]
+                if choice.message and choice.message.content:
+                    content = choice.message.content
+
+            # Extract token usage
+            tokens = {}
+            if response.usage:
+                tokens = {
+                    'input': response.usage.prompt_tokens,
+                    'output': response.usage.completion_tokens,
+                    'total': response.usage.total_tokens
+                }
+
+            # Extract tool calls
+            tool_calls = self._extract_tool_calls(response)
+
+            return AgentResponse(
+                content=content,
+                tool_calls=tool_calls,
+                tokens=tokens,
+                raw=response
+            )
+
+        except openai.APIError as e:
+            return AgentResponse(
+                content=f"[API Error: {e}]",
+                tokens={}
+            )
+        except Exception as e:
+            return AgentResponse(
+                content=f"[Error: {e}]",
+                tokens={}
+            )
+
+    def _extract_tool_calls(self, response) -> list[ToolCall]:
+        """Extract tool calls from response."""
+        tool_calls = []
+
+        if not response.choices or len(response.choices) == 0:
+            return tool_calls
+
+        choice = response.choices[0]
+        if not choice.message or not choice.message.tool_calls:
+            return tool_calls
+
+        for tc in choice.message.tool_calls:
+            if tc.type == "function":
+                import json
+                try:
+                    arguments = json.loads(tc.function.arguments)
+                except json.JSONDecodeError:
+                    arguments = {"raw": tc.function.arguments}
+
+                tool_calls.append(ToolCall(
+                    name=tc.function.name,
+                    arguments=arguments,
+                    id=tc.id
+                ))
+
+        return tool_calls
+
+    def supports_streaming(self) -> bool:
+        """OpenAI API supports streaming."""
+        return True
+
+    @property
+    def name(self) -> str:
+        return f"OpenAI ({self.model})"

--- a/tools/agent-loop/generated/config.py
+++ b/tools/agent-loop/generated/config.py
@@ -217,6 +217,19 @@ def get_default_config() -> Config:
         model='llama3'
     )
 
+    # OpenAI
+    config.agents['openai'] = AgentConfig(
+        name='openai',
+        backend='openai',
+        model='gpt-4o'
+    )
+
+    config.agents['gpt-4o-mini'] = AgentConfig(
+        name='gpt-4o-mini',
+        backend='openai',
+        model='gpt-4o-mini'
+    )
+
     return config
 
 
@@ -265,6 +278,16 @@ def save_example_config(path: str | Path):
                 "backend": "claude",
                 "model": "claude-sonnet-4-20250514",
                 "api_key": "$ANTHROPIC_API_KEY"
+            },
+            "openai": {
+                "backend": "openai",
+                "model": "gpt-4o",
+                "api_key": "$OPENAI_API_KEY"
+            },
+            "openai-mini": {
+                "backend": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "$OPENAI_API_KEY"
             },
             "coding-assistant": {
                 "backend": "claude-code",

--- a/tools/agent-loop/generated/sessions.py
+++ b/tools/agent-loop/generated/sessions.py
@@ -1,0 +1,169 @@
+"""Session persistence for saving and loading conversations."""
+
+import json
+from pathlib import Path
+from datetime import datetime
+from dataclasses import dataclass, asdict
+from typing import Any
+
+from context import ContextManager, Message, ContextBehavior, ContextFormat
+
+
+@dataclass
+class SessionMetadata:
+    """Metadata about a saved session."""
+    id: str
+    name: str
+    created: str
+    modified: str
+    backend: str
+    message_count: int
+    token_count: int
+
+
+class SessionManager:
+    """Manages saving and loading conversation sessions."""
+
+    def __init__(self, sessions_dir: str | Path | None = None):
+        if sessions_dir is None:
+            # Default to ~/.agent-loop/sessions
+            sessions_dir = Path.home() / ".agent-loop" / "sessions"
+        self.sessions_dir = Path(sessions_dir)
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    def save_session(
+        self,
+        context: ContextManager,
+        session_id: str | None = None,
+        name: str | None = None,
+        backend_name: str = "unknown",
+        extra: dict | None = None
+    ) -> str:
+        """Save a conversation session to disk.
+
+        Returns the session ID.
+        """
+        # Generate session ID if not provided
+        if session_id is None:
+            session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        # Generate name if not provided
+        if name is None:
+            name = f"Session {session_id}"
+
+        now = datetime.now().isoformat()
+
+        session_data = {
+            "metadata": {
+                "id": session_id,
+                "name": name,
+                "created": now,
+                "modified": now,
+                "backend": backend_name,
+                "message_count": context.message_count,
+                "token_count": context.token_count,
+            },
+            "settings": {
+                "max_tokens": context.max_tokens,
+                "max_messages": context.max_messages,
+                "behavior": context.behavior.value,
+                "format": context.format.value,
+            },
+            "messages": [
+                {
+                    "role": msg.role,
+                    "content": msg.content,
+                    "tokens": msg.tokens
+                }
+                for msg in context.messages
+            ],
+            "extra": extra or {}
+        }
+
+        # Save to file
+        session_path = self.sessions_dir / f"{session_id}.json"
+        session_path.write_text(json.dumps(session_data, indent=2))
+
+        return session_id
+
+    def load_session(self, session_id: str) -> tuple[ContextManager, dict]:
+        """Load a conversation session from disk.
+
+        Returns (context_manager, metadata_dict).
+        """
+        session_path = self.sessions_dir / f"{session_id}.json"
+
+        if not session_path.exists():
+            raise FileNotFoundError(f"Session not found: {session_id}")
+
+        data = json.loads(session_path.read_text())
+
+        # Restore settings
+        settings = data.get("settings", {})
+        behavior = ContextBehavior(settings.get("behavior", "continue"))
+        format_ = ContextFormat(settings.get("format", "plain"))
+
+        context = ContextManager(
+            max_tokens=settings.get("max_tokens", 100000),
+            max_messages=settings.get("max_messages", 50),
+            behavior=behavior,
+            format=format_
+        )
+
+        # Restore messages
+        for msg_data in data.get("messages", []):
+            context.add_message(
+                role=msg_data["role"],
+                content=msg_data["content"],
+                tokens=msg_data.get("tokens", 0)
+            )
+
+        return context, data.get("metadata", {}), data.get("extra", {})
+
+    def list_sessions(self) -> list[SessionMetadata]:
+        """List all saved sessions."""
+        sessions = []
+
+        for path in sorted(self.sessions_dir.glob("*.json"), reverse=True):
+            try:
+                data = json.loads(path.read_text())
+                meta = data.get("metadata", {})
+                sessions.append(SessionMetadata(
+                    id=meta.get("id", path.stem),
+                    name=meta.get("name", "Unnamed"),
+                    created=meta.get("created", ""),
+                    modified=meta.get("modified", ""),
+                    backend=meta.get("backend", "unknown"),
+                    message_count=meta.get("message_count", 0),
+                    token_count=meta.get("token_count", 0)
+                ))
+            except (json.JSONDecodeError, KeyError):
+                # Skip invalid session files
+                continue
+
+        return sessions
+
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a saved session."""
+        session_path = self.sessions_dir / f"{session_id}.json"
+        if session_path.exists():
+            session_path.unlink()
+            return True
+        return False
+
+    def session_exists(self, session_id: str) -> bool:
+        """Check if a session exists."""
+        session_path = self.sessions_dir / f"{session_id}.json"
+        return session_path.exists()
+
+    def update_session_name(self, session_id: str, new_name: str) -> bool:
+        """Update the name of a saved session."""
+        session_path = self.sessions_dir / f"{session_id}.json"
+        if not session_path.exists():
+            return False
+
+        data = json.loads(session_path.read_text())
+        data["metadata"]["name"] = new_name
+        data["metadata"]["modified"] = datetime.now().isoformat()
+        session_path.write_text(json.dumps(data, indent=2))
+        return True

--- a/tools/agent-loop/generated/skills.py
+++ b/tools/agent-loop/generated/skills.py
@@ -1,0 +1,196 @@
+"""Skills and agent.md loader for customizing agent behavior."""
+
+from pathlib import Path
+from typing import Any
+
+
+class SkillsLoader:
+    """Loads and combines skills and agent.md files into system prompts."""
+
+    def __init__(self, base_dir: str | Path | None = None):
+        self.base_dir = Path(base_dir) if base_dir else Path.cwd()
+
+    def load_agent_md(self, path: str | Path) -> str:
+        """Load an agent.md file.
+
+        The agent.md file defines the agent's persona, capabilities,
+        and default instructions.
+        """
+        full_path = self._resolve_path(path)
+
+        if not full_path.exists():
+            raise FileNotFoundError(f"Agent file not found: {full_path}")
+
+        return full_path.read_text()
+
+    def load_skill(self, path: str | Path) -> str:
+        """Load a single skill file.
+
+        Skill files contain specific instructions for a capability
+        (e.g., git operations, testing, code review).
+        """
+        full_path = self._resolve_path(path)
+
+        if not full_path.exists():
+            raise FileNotFoundError(f"Skill file not found: {full_path}")
+
+        return full_path.read_text()
+
+    def load_skills(self, paths: list[str | Path]) -> list[str]:
+        """Load multiple skill files."""
+        skills = []
+        for path in paths:
+            try:
+                skills.append(self.load_skill(path))
+            except FileNotFoundError as e:
+                print(f"[Warning: {e}]")
+        return skills
+
+    def build_system_prompt(
+        self,
+        base_prompt: str | None = None,
+        agent_md: str | Path | None = None,
+        skills: list[str | Path] | None = None
+    ) -> str:
+        """Build a complete system prompt from components.
+
+        Order:
+        1. agent.md (defines persona and core instructions)
+        2. Skills (specialized capabilities)
+        3. Base prompt (additional instructions/overrides)
+        """
+        parts = []
+
+        # Load agent.md if provided
+        if agent_md:
+            try:
+                content = self.load_agent_md(agent_md)
+                parts.append(content)
+            except FileNotFoundError as e:
+                print(f"[Warning: {e}]")
+
+        # Load skills
+        if skills:
+            skill_contents = self.load_skills(skills)
+            if skill_contents:
+                parts.append("\n## Skills\n")
+                for skill in skill_contents:
+                    parts.append(skill)
+                    parts.append("")  # Blank line separator
+
+        # Add base prompt
+        if base_prompt:
+            if parts:
+                parts.append("\n## Additional Instructions\n")
+            parts.append(base_prompt)
+
+        return "\n".join(parts) if parts else ""
+
+    def _resolve_path(self, path: str | Path) -> Path:
+        """Resolve a path relative to base_dir if not absolute."""
+        path = Path(path)
+        if path.is_absolute():
+            return path
+        return self.base_dir / path
+
+
+def create_example_agent_md(path: str | Path):
+    """Create an example agent.md file."""
+    content = """# Coding Assistant
+
+You are a skilled software engineer with expertise in multiple programming languages.
+
+## Principles
+
+- Write clean, readable, maintainable code
+- Follow established conventions and patterns
+- Test your changes when possible
+- Explain your reasoning
+
+## Communication Style
+
+- Be concise and direct
+- Use code examples when helpful
+- Ask clarifying questions when requirements are unclear
+
+## Tools
+
+You have access to:
+- `bash`: Execute shell commands
+- `read`: Read file contents
+- `write`: Create or overwrite files
+- `edit`: Make targeted edits to files
+
+## Process
+
+1. Understand the request
+2. Explore relevant code if needed
+3. Plan the approach
+4. Implement changes
+5. Verify the changes work
+"""
+    Path(path).write_text(content)
+
+
+def create_example_skill(path: str | Path, skill_type: str = "git"):
+    """Create an example skill file."""
+    skills = {
+        "git": """## Git Skill
+
+You are proficient with Git version control.
+
+### Commit Guidelines
+- Write clear, descriptive commit messages
+- Use conventional commit format: type(scope): description
+- Keep commits focused and atomic
+
+### Common Operations
+- Always check `git status` before committing
+- Review diffs before staging changes
+- Pull before pushing to avoid conflicts
+
+### Branch Naming
+- feature/description for new features
+- fix/description for bug fixes
+- docs/description for documentation
+""",
+        "testing": """## Testing Skill
+
+You write thorough tests for code changes.
+
+### Test Types
+- Unit tests for individual functions
+- Integration tests for component interactions
+- End-to-end tests for user workflows
+
+### Best Practices
+- Test both happy path and edge cases
+- Use descriptive test names
+- Keep tests independent and isolated
+- Mock external dependencies
+
+### Commands
+- Run tests with appropriate test runner
+- Check test coverage when available
+""",
+        "code-review": """## Code Review Skill
+
+You perform thorough code reviews.
+
+### Review Checklist
+- [ ] Code is readable and well-structured
+- [ ] No obvious bugs or logic errors
+- [ ] Error handling is appropriate
+- [ ] No security vulnerabilities
+- [ ] Tests cover the changes
+- [ ] Documentation is updated
+
+### Feedback Style
+- Be constructive and specific
+- Explain the "why" behind suggestions
+- Distinguish between required changes and suggestions
+"""
+    }
+
+    content = skills.get(skill_type, skills["git"])
+    Path(path).write_text(content)


### PR DESCRIPTION
## Summary

Major enhancement to the agent loop with four new capabilities:

1. **OpenAI API Backend** - Support for GPT-4, GPT-4o, and compatible APIs
2. **Session Persistence** - Save, load, and list conversation sessions
3. **Skills/Agent.md Loading** - Customize agent behavior with markdown files
4. **Context Formats** - Multiple formats for context serialization

## New Files

| File | Description |
|------|-------------|
| `backends/openai_api.py` | OpenAI API backend (GPT-4, GPT-4o-mini) |
| `sessions.py` | Session save/load/list management |
| `skills.py` | Skills and agent.md file loader |

## New Features

### OpenAI Backend

```bash
# Use OpenAI GPT-4o
python agent_loop.py --agent openai "explain this code"

# Use GPT-4o-mini for faster responses
python agent_loop.py --backend openai --model gpt-4o-mini "quick question"
```

Config example:
```json
{
  "openai": {
    "backend": "openai",
    "model": "gpt-4o",
    "api_key": "$OPENAI_API_KEY"
  }
}
```

### Session Persistence

```bash
# List saved sessions
python agent_loop.py --list-sessions

# Load a saved session
python agent_loop.py --session 20260201_143022
```

Runtime commands:
```
/save my-project        # Save with name
/load 20260201_143022   # Load by ID
/sessions               # List sessions
```

Sessions stored in `~/.agent-loop/sessions/` as JSON.

### Skills and Agent.md

Configure custom agent personas and skills:

```json
{
  "coding-assistant": {
    "backend": "claude-code",
    "model": "sonnet",
    "agent_md": "./agents/coding.md",
    "skills": [
      "./skills/git.md",
      "./skills/testing.md"
    ]
  }
}
```

The loader combines agent.md + skills + system_prompt into the final prompt.

### Context Formats

```bash
# Set format from CLI
python agent_loop.py --context-format markdown

# Change at runtime
/format json
```

Available formats:
- `plain` - Simple text with role prefixes
- `markdown` - Markdown formatted messages
- `json` - JSON array of message objects
- `xml` - XML structure with message elements

## New CLI Options

| Option | Description |
|--------|-------------|
| `--session/-s ID` | Load a saved session |
| `--list-sessions` | List all saved sessions |
| `--sessions-dir PATH` | Custom sessions directory |
| `--context-format TYPE` | Set context format |

## New Slash Commands

| Command | Description |
|---------|-------------|
| `/save [name]` | Save current session |
| `/load <id>` | Load a saved session |
| `/sessions` | List saved sessions |
| `/format [type]` | Show or set context format |

## Test Plan

- [ ] Verify OpenAI backend with OPENAI_API_KEY set
- [ ] Verify `/save` creates session file in ~/.agent-loop/sessions/
- [ ] Verify `/load` restores conversation context
- [ ] Verify `/sessions` lists saved sessions
- [ ] Verify `--list-sessions` works from CLI
- [ ] Verify skills loading combines files correctly
- [ ] Verify `/format json` changes output format
- [ ] Verify `--context-format markdown` works from CLI
