### PR TITLE
feat(agent-loop): Add export, cost tracking, search, streaming, and retry utilities

### DIFF
--- a/tools/agent-loop/UNIFIED_AGENT_LOOP_PROPOSAL.md
+++ b/tools/agent-loop/UNIFIED_AGENT_LOOP_PROPOSAL.md
@@ -457,13 +457,17 @@ tools/agent-loop/
     ├── tools.py                    # Tool handler
     ├── sessions.py                 # Session persistence
     ├── skills.py                   # Skills/agent.md loader
+    ├── export.py                   # Export to markdown/HTML/JSON
+    ├── costs.py                    # API cost tracking
+    ├── search.py                   # Session search
+    ├── retry.py                    # Retry logic with backoff
     ├── backends/
     │   ├── __init__.py
     │   ├── base.py                 # Abstract backend
     │   ├── coro.py                 # Coro CLI backend (--verbose)
     │   ├── claude_code.py          # Claude Code CLI (-p mode)
-    │   ├── claude_api.py           # Claude API backend
-    │   ├── openai_api.py           # OpenAI API backend
+    │   ├── claude_api.py           # Claude API backend (+ streaming)
+    │   ├── openai_api.py           # OpenAI API backend (+ streaming)
     │   ├── gemini.py               # Gemini CLI backend
     │   ├── ollama_api.py           # Ollama REST API backend
     │   └── ollama_cli.py           # Ollama CLI backend
@@ -625,7 +629,14 @@ User: Add 3 to that
 - [x] Runtime slash commands (/backend, /iterations, /save, /load, /format)
 - [ ] Context summarization (future)
 
-### Phase 7: ncurses Display Mode (Future)
+### Phase 7: Utilities ✓
+- [x] Export to markdown/HTML/JSON/text
+- [x] API cost tracking with pricing database
+- [x] Session search across conversations
+- [x] Streaming support for Claude/OpenAI APIs
+- [x] Retry logic with exponential backoff
+
+### Phase 8: ncurses Display Mode (Future)
 - [ ] Add ncurses/terminfo based display
 - [ ] Spinner that updates in place
 - [ ] Progress bar for streaming

--- a/tools/agent-loop/generated/costs.py
+++ b/tools/agent-loop/generated/costs.py
@@ -1,0 +1,164 @@
+"""Cost tracking for API usage."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+import json
+from pathlib import Path
+
+
+# Pricing per 1M tokens (as of early 2025, approximate)
+# Users should update these as prices change
+DEFAULT_PRICING = {
+    # Claude models
+    "claude-opus-4-20250514": {"input": 15.0, "output": 75.0},
+    "claude-sonnet-4-20250514": {"input": 3.0, "output": 15.0},
+    "claude-haiku-3-5-20241022": {"input": 0.80, "output": 4.0},
+    # Aliases
+    "opus": {"input": 15.0, "output": 75.0},
+    "sonnet": {"input": 3.0, "output": 15.0},
+    "haiku": {"input": 0.80, "output": 4.0},
+    # OpenAI models
+    "gpt-4o": {"input": 2.50, "output": 10.0},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4-turbo": {"input": 10.0, "output": 30.0},
+    "gpt-4": {"input": 30.0, "output": 60.0},
+    "gpt-3.5-turbo": {"input": 0.50, "output": 1.50},
+    # Gemini (free tier has limits, these are paid tier)
+    "gemini-2.5-flash": {"input": 0.075, "output": 0.30},
+    "gemini-2.5-pro": {"input": 1.25, "output": 5.0},
+    # Local models (free)
+    "llama3": {"input": 0.0, "output": 0.0},
+    "codellama": {"input": 0.0, "output": 0.0},
+    "mistral": {"input": 0.0, "output": 0.0},
+}
+
+
+@dataclass
+class UsageRecord:
+    """Record of a single API call."""
+    timestamp: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    input_cost: float
+    output_cost: float
+    total_cost: float
+
+
+@dataclass
+class CostTracker:
+    """Track API costs for a session."""
+
+    pricing: dict = field(default_factory=lambda: DEFAULT_PRICING.copy())
+    records: list[UsageRecord] = field(default_factory=list)
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost: float = 0.0
+
+    def record_usage(self, model: str, input_tokens: int, output_tokens: int) -> UsageRecord:
+        """Record token usage and calculate cost."""
+        # Get pricing for model
+        pricing = self.pricing.get(model, {"input": 0.0, "output": 0.0})
+
+        # Calculate costs (pricing is per 1M tokens)
+        input_cost = (input_tokens / 1_000_000) * pricing["input"]
+        output_cost = (output_tokens / 1_000_000) * pricing["output"]
+        total_cost = input_cost + output_cost
+
+        # Create record
+        record = UsageRecord(
+            timestamp=datetime.now().isoformat(),
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            input_cost=input_cost,
+            output_cost=output_cost,
+            total_cost=total_cost
+        )
+
+        # Update totals
+        self.records.append(record)
+        self.total_input_tokens += input_tokens
+        self.total_output_tokens += output_tokens
+        self.total_cost += total_cost
+
+        return record
+
+    def get_summary(self) -> dict:
+        """Get a summary of costs."""
+        return {
+            "total_requests": len(self.records),
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "total_tokens": self.total_input_tokens + self.total_output_tokens,
+            "total_cost_usd": round(self.total_cost, 6),
+            "cost_formatted": f"${self.total_cost:.4f}"
+        }
+
+    def format_status(self) -> str:
+        """Format cost status for display."""
+        summary = self.get_summary()
+        return (
+            f"Tokens: {summary['total_input_tokens']:,} in / "
+            f"{summary['total_output_tokens']:,} out | "
+            f"Cost: {summary['cost_formatted']}"
+        )
+
+    def reset(self) -> None:
+        """Reset all tracking."""
+        self.records.clear()
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        self.total_cost = 0.0
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            "summary": self.get_summary(),
+            "records": [
+                {
+                    "timestamp": r.timestamp,
+                    "model": r.model,
+                    "input_tokens": r.input_tokens,
+                    "output_tokens": r.output_tokens,
+                    "input_cost": r.input_cost,
+                    "output_cost": r.output_cost,
+                    "total_cost": r.total_cost
+                }
+                for r in self.records
+            ]
+        }
+
+    def save(self, path: str | Path) -> None:
+        """Save cost data to JSON file."""
+        path = Path(path)
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+    @classmethod
+    def load(cls, path: str | Path) -> "CostTracker":
+        """Load cost data from JSON file."""
+        path = Path(path)
+        data = json.loads(path.read_text())
+
+        tracker = cls()
+        for r in data.get("records", []):
+            record = UsageRecord(
+                timestamp=r["timestamp"],
+                model=r["model"],
+                input_tokens=r["input_tokens"],
+                output_tokens=r["output_tokens"],
+                input_cost=r["input_cost"],
+                output_cost=r["output_cost"],
+                total_cost=r["total_cost"]
+            )
+            tracker.records.append(record)
+            tracker.total_input_tokens += record.input_tokens
+            tracker.total_output_tokens += record.output_tokens
+            tracker.total_cost += record.total_cost
+
+        return tracker
+
+    def set_pricing(self, model: str, input_price: float, output_price: float) -> None:
+        """Set custom pricing for a model (per 1M tokens)."""
+        self.pricing[model] = {"input": input_price, "output": output_price}

--- a/tools/agent-loop/generated/export.py
+++ b/tools/agent-loop/generated/export.py
@@ -1,0 +1,202 @@
+"""Export conversations to various formats."""
+
+from pathlib import Path
+from datetime import datetime
+from context import ContextManager
+
+
+class ConversationExporter:
+    """Export conversation history to different formats."""
+
+    def __init__(self, context: ContextManager):
+        self.context = context
+
+    def to_markdown(self, title: str = "Conversation") -> str:
+        """Export conversation to Markdown format."""
+        lines = [
+            f"# {title}",
+            "",
+            f"*Exported: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*",
+            f"*Messages: {self.context.message_count} | Tokens: {self.context.token_count}*",
+            "",
+            "---",
+            ""
+        ]
+
+        for msg in self.context.messages:
+            role = "**You:**" if msg.role == "user" else "**Assistant:**"
+            lines.append(role)
+            lines.append("")
+            lines.append(msg.content)
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def to_html(self, title: str = "Conversation") -> str:
+        """Export conversation to HTML format."""
+        messages_html = []
+
+        for msg in self.context.messages:
+            role_class = "user" if msg.role == "user" else "assistant"
+            role_label = "You" if msg.role == "user" else "Assistant"
+            # Escape HTML and preserve newlines
+            content = self._escape_html(msg.content).replace("\n", "<br>")
+            messages_html.append(f'''
+        <div class="message {role_class}">
+            <div class="role">{role_label}</div>
+            <div class="content">{content}</div>
+        </div>''')
+
+        return f'''<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{self._escape_html(title)}</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }}
+        h1 {{
+            color: #333;
+            border-bottom: 2px solid #ddd;
+            padding-bottom: 10px;
+        }}
+        .meta {{
+            color: #666;
+            font-size: 0.9em;
+            margin-bottom: 20px;
+        }}
+        .message {{
+            margin: 15px 0;
+            padding: 15px;
+            border-radius: 8px;
+        }}
+        .message.user {{
+            background: #e3f2fd;
+            margin-left: 20px;
+        }}
+        .message.assistant {{
+            background: #fff;
+            border: 1px solid #ddd;
+            margin-right: 20px;
+        }}
+        .role {{
+            font-weight: bold;
+            margin-bottom: 8px;
+            color: #555;
+        }}
+        .content {{
+            line-height: 1.6;
+            white-space: pre-wrap;
+        }}
+        code {{
+            background: #f0f0f0;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Consolas', 'Monaco', monospace;
+        }}
+        pre {{
+            background: #2d2d2d;
+            color: #f8f8f2;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+        }}
+    </style>
+</head>
+<body>
+    <h1>{self._escape_html(title)}</h1>
+    <div class="meta">
+        Exported: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} |
+        Messages: {self.context.message_count} |
+        Tokens: {self.context.token_count}
+    </div>
+    {"".join(messages_html)}
+</body>
+</html>'''
+
+    def to_json(self) -> str:
+        """Export conversation to JSON format."""
+        import json
+        data = {
+            "exported": datetime.now().isoformat(),
+            "message_count": self.context.message_count,
+            "token_count": self.context.token_count,
+            "messages": [
+                {
+                    "role": msg.role,
+                    "content": msg.content,
+                    "tokens": msg.tokens
+                }
+                for msg in self.context.messages
+            ]
+        }
+        return json.dumps(data, indent=2)
+
+    def to_text(self) -> str:
+        """Export conversation to plain text format."""
+        lines = [
+            f"Conversation Export",
+            f"Exported: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Messages: {self.context.message_count} | Tokens: {self.context.token_count}",
+            "",
+            "=" * 60,
+            ""
+        ]
+
+        for msg in self.context.messages:
+            role = "You:" if msg.role == "user" else "Assistant:"
+            lines.append(role)
+            lines.append(msg.content)
+            lines.append("")
+            lines.append("-" * 40)
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def save(self, path: str | Path, format: str = "auto", title: str = "Conversation") -> None:
+        """Save conversation to file.
+
+        Args:
+            path: Output file path
+            format: Export format ('markdown', 'html', 'json', 'text', 'auto')
+            title: Title for the export
+        """
+        path = Path(path)
+
+        # Auto-detect format from extension
+        if format == "auto":
+            ext = path.suffix.lower()
+            format_map = {
+                ".md": "markdown",
+                ".html": "html",
+                ".htm": "html",
+                ".json": "json",
+                ".txt": "text"
+            }
+            format = format_map.get(ext, "markdown")
+
+        # Generate content
+        if format == "markdown":
+            content = self.to_markdown(title)
+        elif format == "html":
+            content = self.to_html(title)
+        elif format == "json":
+            content = self.to_json()
+        else:
+            content = self.to_text()
+
+        path.write_text(content)
+
+    def _escape_html(self, text: str) -> str:
+        """Escape HTML special characters."""
+        return (text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace('"', "&quot;"))

--- a/tools/agent-loop/generated/retry.py
+++ b/tools/agent-loop/generated/retry.py
@@ -1,0 +1,166 @@
+"""Retry logic for transient failures."""
+
+import time
+import random
+from typing import Callable, TypeVar, Any
+from functools import wraps
+
+T = TypeVar("T")
+
+
+class RetryError(Exception):
+    """Raised when all retry attempts fail."""
+
+    def __init__(self, message: str, last_error: Exception, attempts: int):
+        super().__init__(message)
+        self.last_error = last_error
+        self.attempts = attempts
+
+
+def retry(
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    exponential_base: float = 2.0,
+    jitter: bool = True,
+    retryable_exceptions: tuple = (Exception,),
+    on_retry: Callable[[Exception, int, float], None] | None = None
+) -> Callable:
+    """Decorator for retrying functions with exponential backoff.
+
+    Args:
+        max_attempts: Maximum number of attempts (including first try)
+        base_delay: Initial delay between retries in seconds
+        max_delay: Maximum delay between retries
+        exponential_base: Base for exponential backoff
+        jitter: Add random jitter to delays
+        retryable_exceptions: Tuple of exception types to retry on
+        on_retry: Callback called before each retry (exception, attempt, delay)
+
+    Example:
+        @retry(max_attempts=3, base_delay=1.0)
+        def call_api():
+            return requests.get(url)
+    """
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> T:
+            last_exception = None
+
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except retryable_exceptions as e:
+                    last_exception = e
+
+                    if attempt == max_attempts:
+                        raise RetryError(
+                            f"Failed after {max_attempts} attempts: {e}",
+                            last_error=e,
+                            attempts=max_attempts
+                        )
+
+                    # Calculate delay with exponential backoff
+                    delay = min(
+                        base_delay * (exponential_base ** (attempt - 1)),
+                        max_delay
+                    )
+
+                    # Add jitter
+                    if jitter:
+                        delay = delay * (0.5 + random.random())
+
+                    # Call retry callback
+                    if on_retry:
+                        on_retry(e, attempt, delay)
+
+                    time.sleep(delay)
+
+            # Should never reach here, but just in case
+            raise RetryError(
+                f"Failed after {max_attempts} attempts",
+                last_error=last_exception,
+                attempts=max_attempts
+            )
+
+        return wrapper
+    return decorator
+
+
+def retry_call(
+    func: Callable[..., T],
+    args: tuple = (),
+    kwargs: dict | None = None,
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    exponential_base: float = 2.0,
+    jitter: bool = True,
+    retryable_exceptions: tuple = (Exception,),
+    on_retry: Callable[[Exception, int, float], None] | None = None
+) -> T:
+    """Call a function with retry logic.
+
+    Args:
+        func: Function to call
+        args: Positional arguments for the function
+        kwargs: Keyword arguments for the function
+        max_attempts: Maximum number of attempts
+        base_delay: Initial delay between retries
+        max_delay: Maximum delay between retries
+        exponential_base: Base for exponential backoff
+        jitter: Add random jitter to delays
+        retryable_exceptions: Tuple of exception types to retry on
+        on_retry: Callback called before each retry
+
+    Example:
+        result = retry_call(
+            requests.get,
+            args=(url,),
+            kwargs={"timeout": 10},
+            max_attempts=3
+        )
+    """
+    kwargs = kwargs or {}
+
+    @retry(
+        max_attempts=max_attempts,
+        base_delay=base_delay,
+        max_delay=max_delay,
+        exponential_base=exponential_base,
+        jitter=jitter,
+        retryable_exceptions=retryable_exceptions,
+        on_retry=on_retry
+    )
+    def wrapped():
+        return func(*args, **kwargs)
+
+    return wrapped()
+
+
+# Common retryable exception patterns for API calls
+API_RETRYABLE_ERRORS = (
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
+# For use with requests library
+def is_retryable_status(status_code: int) -> bool:
+    """Check if an HTTP status code is retryable."""
+    return status_code in (
+        408,  # Request Timeout
+        429,  # Too Many Requests
+        500,  # Internal Server Error
+        502,  # Bad Gateway
+        503,  # Service Unavailable
+        504,  # Gateway Timeout
+    )
+
+
+class RetryableAPIError(Exception):
+    """Exception for retryable API errors."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code

--- a/tools/agent-loop/generated/search.py
+++ b/tools/agent-loop/generated/search.py
@@ -1,0 +1,205 @@
+"""Search across conversation sessions."""
+
+import json
+import re
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Iterator
+
+
+@dataclass
+class SearchResult:
+    """A single search result."""
+    session_id: str
+    session_name: str
+    message_index: int
+    role: str
+    content: str
+    match_start: int
+    match_end: int
+    context_before: str
+    context_after: str
+
+    def format(self, max_width: int = 80) -> str:
+        """Format result for display."""
+        # Highlight the match
+        before = self.content[:self.match_start]
+        match = self.content[self.match_start:self.match_end]
+        after = self.content[self.match_end:]
+
+        # Truncate if too long
+        if len(before) > 30:
+            before = "..." + before[-27:]
+        if len(after) > 30:
+            after = after[:27] + "..."
+
+        snippet = f"{before}**{match}**{after}"
+
+        return f"[{self.session_id}] {self.role}: {snippet}"
+
+
+class SessionSearcher:
+    """Search through saved conversation sessions."""
+
+    def __init__(self, sessions_dir: str | Path):
+        self.sessions_dir = Path(sessions_dir)
+
+    def search(
+        self,
+        query: str,
+        case_sensitive: bool = False,
+        regex: bool = False,
+        role_filter: str | None = None,
+        limit: int = 50
+    ) -> list[SearchResult]:
+        """Search for a query across all sessions.
+
+        Args:
+            query: Search query (string or regex pattern)
+            case_sensitive: Whether search is case-sensitive
+            regex: Treat query as regex pattern
+            role_filter: Filter by role ('user' or 'assistant')
+            limit: Maximum number of results
+
+        Returns:
+            List of SearchResult objects
+        """
+        results = []
+
+        # Compile pattern
+        flags = 0 if case_sensitive else re.IGNORECASE
+        if regex:
+            pattern = re.compile(query, flags)
+        else:
+            pattern = re.compile(re.escape(query), flags)
+
+        # Search each session
+        for session_path in self.sessions_dir.glob("*.json"):
+            try:
+                session_results = self._search_session(
+                    session_path, pattern, role_filter
+                )
+                results.extend(session_results)
+
+                if len(results) >= limit:
+                    break
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+        return results[:limit]
+
+    def _search_session(
+        self,
+        session_path: Path,
+        pattern: re.Pattern,
+        role_filter: str | None
+    ) -> list[SearchResult]:
+        """Search within a single session file."""
+        results = []
+
+        data = json.loads(session_path.read_text())
+        session_id = data.get("metadata", {}).get("id", session_path.stem)
+        session_name = data.get("metadata", {}).get("name", "Unnamed")
+
+        for i, msg in enumerate(data.get("messages", [])):
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+
+            # Apply role filter
+            if role_filter and role != role_filter:
+                continue
+
+            # Find all matches in this message
+            for match in pattern.finditer(content):
+                # Extract context
+                start = max(0, match.start() - 50)
+                end = min(len(content), match.end() + 50)
+
+                results.append(SearchResult(
+                    session_id=session_id,
+                    session_name=session_name,
+                    message_index=i,
+                    role=role,
+                    content=content,
+                    match_start=match.start(),
+                    match_end=match.end(),
+                    context_before=content[start:match.start()],
+                    context_after=content[match.end():end]
+                ))
+
+        return results
+
+    def search_in_session(
+        self,
+        session_id: str,
+        query: str,
+        case_sensitive: bool = False
+    ) -> list[SearchResult]:
+        """Search within a specific session."""
+        session_path = self.sessions_dir / f"{session_id}.json"
+        if not session_path.exists():
+            return []
+
+        flags = 0 if case_sensitive else re.IGNORECASE
+        pattern = re.compile(re.escape(query), flags)
+
+        return self._search_session(session_path, pattern, None)
+
+    def list_sessions_containing(
+        self,
+        query: str,
+        case_sensitive: bool = False
+    ) -> list[dict]:
+        """List sessions that contain a query (without full results)."""
+        flags = 0 if case_sensitive else re.IGNORECASE
+        pattern = re.compile(re.escape(query), flags)
+
+        sessions = []
+
+        for session_path in self.sessions_dir.glob("*.json"):
+            try:
+                data = json.loads(session_path.read_text())
+                messages = data.get("messages", [])
+
+                # Check if any message matches
+                match_count = 0
+                for msg in messages:
+                    content = msg.get("content", "")
+                    match_count += len(pattern.findall(content))
+
+                if match_count > 0:
+                    metadata = data.get("metadata", {})
+                    sessions.append({
+                        "id": metadata.get("id", session_path.stem),
+                        "name": metadata.get("name", "Unnamed"),
+                        "match_count": match_count,
+                        "message_count": len(messages)
+                    })
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+        # Sort by match count
+        sessions.sort(key=lambda x: x["match_count"], reverse=True)
+        return sessions
+
+    def get_session_stats(self) -> dict:
+        """Get statistics about all sessions."""
+        total_sessions = 0
+        total_messages = 0
+        total_tokens = 0
+
+        for session_path in self.sessions_dir.glob("*.json"):
+            try:
+                data = json.loads(session_path.read_text())
+                total_sessions += 1
+                messages = data.get("messages", [])
+                total_messages += len(messages)
+                total_tokens += sum(m.get("tokens", 0) for m in messages)
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+        return {
+            "total_sessions": total_sessions,
+            "total_messages": total_messages,
+            "total_tokens": total_tokens
+        }


### PR DESCRIPTION
## Summary

Adds five utility features to improve the agent loop's usability and reliability:

1. **Conversation Export** - Save conversations to multiple formats
2. **Cost Tracking** - Monitor API usage and estimated costs
3. **Session Search** - Find content across saved sessions
4. **Streaming Support** - Real-time output for API backends
5. **Retry Logic** - Handle transient failures gracefully

## New Files

| File | Lines | Description |
|------|-------|-------------|
| `export.py` | 170 | Export to markdown, HTML, JSON, text |
| `costs.py` | 160 | Cost tracking with pricing database |
| `search.py` | 175 | Search across saved sessions |
| `retry.py` | 165 | Retry with exponential backoff |

## Features

### 1. Conversation Export

```bash
# From CLI (format auto-detected from extension)
/export conversation.md
/export chat.html
/export data.json
```

Formats:
- **Markdown**: Headers, formatting, metadata
- **HTML**: Styled, responsive, self-contained
- **JSON**: Structured data with timestamps
- **Text**: Plain text with separators

### 2. Cost Tracking

```
/cost

Cost Summary:
  Requests: 5
  Input tokens: 12,450
  Output tokens: 3,280
  Total tokens: 15,730
  Estimated cost: $0.0523
```

Pricing database includes:
- Claude (Opus, Sonnet, Haiku)
- OpenAI (GPT-4o, GPT-4o-mini, GPT-4, GPT-3.5)
- Gemini (Flash, Pro)
- Local models (Ollama - free)

### 3. Session Search

```bash
# From CLI
python agent_loop.py --search "database migration"

# At runtime
/search refactoring
```

Features:
- Case-insensitive by default
- Regex support
- Role filtering (user/assistant)
- Context snippets in results

### 4. Streaming Support

```bash
# Enable from CLI
python agent_loop.py --stream

# Toggle at runtime
/stream
```

Supported backends:
- Claude API (via `send_message_streaming`)
- OpenAI API (via `send_message_streaming`)

### 5. Retry Logic

Available for use in backends:

```python
from retry import retry, retry_call

@retry(max_attempts=3, base_delay=1.0)
def call_api():
    return requests.get(url)

# Or functional style
result = retry_call(requests.get, args=(url,), max_attempts=3)
```

Features:
- Exponential backoff
- Configurable jitter
- Callback on retry
- Custom retryable exceptions

## New CLI Options

| Option | Description |
|--------|-------------|
| `--stream` | Enable streaming output |
| `--no-cost-tracking` | Disable cost tracking |
| `--search QUERY` | Search sessions and exit |

## New Slash Commands

| Command | Description |
|---------|-------------|
| `/export <path>` | Export conversation to file |
| `/cost` | Show API cost summary |
| `/search <query>` | Search saved sessions |
| `/stream` | Toggle streaming mode |

## Test Plan

- [ ] Verify `/export conversation.md` creates valid markdown
- [ ] Verify `/export chat.html` creates styled HTML
- [ ] Verify `/cost` shows accurate token counts
- [ ] Verify cost estimates match pricing
- [ ] Verify `/search` finds content across sessions
- [ ] Verify `--search` works from CLI
- [ ] Verify `--stream` shows real-time output
- [ ] Verify `/stream` toggles streaming
- [ ] Verify retry logic handles transient failures
