### PR TITLE
perf(csharp-query): canonicalize seeded transitive-closure cache keys

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -109,6 +109,8 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
 - Prepared-style cache reuse (useful for repeated parameterized calls):
   - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));`
   - `executor.ClearCaches();` (if underlying facts change)
+  - Note: cache reuse assumes deterministic/pure evaluation (no side effects). If order or effects matter, disable caches and compile with `ordered` / `unordered(false)`.
+  - Seeded transitive-closure caches treat the seed list as a set (deduped + order-insensitive) so repeated calls with the same seeds in a different order hit the same cache entry.
 
 ## Configuration
 - New preference atom: `target(csharp_query)`.


### PR DESCRIPTION
  - Makes TransitiveClosureSeeded / TransitiveClosureSeededByTarget cache keys order-insensitive by sorting the deduped
    seed rows before keying.
  - Improves cache hit rate when callers pass the same seed set in different orders (no semantic changes to results).
  - Adds regression coverage in tests/core/test_csharp_query_target.pl for both seeded modes.

  Local verification:

  - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/uw_tc_cachekey_smoke_small
    -SkipCodegen -ProjectFilter "cq_test_reachab_*" (PASS)