### PR TITLE
fix(agent-loop): Fix duplicate messages, sliding window, and add context limits

### DIFF
--- a/tools/agent-loop/generated/backends/base.py
+++ b/tools/agent-loop/generated/backends/base.py
@@ -26,8 +26,12 @@ class AgentBackend(ABC):
     """Abstract interface for agent backends."""
 
     @abstractmethod
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
-        """Send a message with context, get response."""
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
+        """Send a message with context, get response.
+
+        Optional kwargs:
+            on_status: Callback for status updates (e.g. tool call progress)
+        """
         raise NotImplementedError
 
     def parse_tool_calls(self, response: str) -> list[ToolCall]:

--- a/tools/agent-loop/generated/backends/claude_api.py
+++ b/tools/agent-loop/generated/backends/claude_api.py
@@ -43,7 +43,7 @@ class ClaudeAPIBackend(AgentBackend):
 
         self.client = anthropic.Anthropic(api_key=self.api_key)
 
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to Claude API and get response."""
         # Build messages array
         messages = []
@@ -56,11 +56,7 @@ class ClaudeAPIBackend(AgentBackend):
                     "content": msg['content']
                 })
 
-        # Add current message
-        messages.append({
-            "role": "user",
-            "content": message
-        })
+        # Note: current message is already in context (added by agent_loop)
 
         try:
             response = self.client.messages.create(
@@ -140,7 +136,7 @@ class ClaudeAPIBackend(AgentBackend):
                     "role": msg['role'],
                     "content": msg['content']
                 })
-        messages.append({"role": "user", "content": message})
+        # Note: current message is already in context (added by agent_loop)
 
         try:
             content_parts = []

--- a/tools/agent-loop/generated/backends/claude_code.py
+++ b/tools/agent-loop/generated/backends/claude_code.py
@@ -17,7 +17,7 @@ class ClaudeCodeBackend(AgentBackend):
             re.IGNORECASE
         )
 
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to Claude Code CLI and get response."""
         # Format the prompt with context
         prompt = self._format_prompt(message, context)

--- a/tools/agent-loop/generated/backends/coro.py
+++ b/tools/agent-loop/generated/backends/coro.py
@@ -17,7 +17,7 @@ class CoroBackend(AgentBackend):
             re.IGNORECASE
         )
 
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to coro CLI and get response."""
         # Format the prompt with context
         prompt = self._format_prompt(message, context)

--- a/tools/agent-loop/generated/backends/gemini.py
+++ b/tools/agent-loop/generated/backends/gemini.py
@@ -19,11 +19,10 @@ class GeminiBackend(AgentBackend):
         self.allowed_tools = allowed_tools or []
         self._on_status = None  # Callback for status updates
 
-    def send_message(self, message: str, context: list[dict],
-                     on_status=None) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to Gemini CLI with live streaming output."""
         prompt = self._format_prompt(message, context)
-        self._on_status = on_status
+        self._on_status = kwargs.get('on_status')
 
         # Use stream-json for live progress
         cmd = [

--- a/tools/agent-loop/generated/backends/ollama_api.py
+++ b/tools/agent-loop/generated/backends/ollama_api.py
@@ -24,7 +24,7 @@ class OllamaAPIBackend(AgentBackend):
         self.timeout = timeout
         self.base_url = f"http://{host}:{port}"
 
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to Ollama API and get response."""
         # Build messages array
         messages = []

--- a/tools/agent-loop/generated/backends/ollama_cli.py
+++ b/tools/agent-loop/generated/backends/ollama_cli.py
@@ -17,7 +17,7 @@ class OllamaCLIBackend(AgentBackend):
         self.model = model
         self.timeout = timeout
 
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to Ollama CLI and get response."""
         # Format the prompt with context
         prompt = self._format_prompt(message, context)

--- a/tools/agent-loop/generated/backends/openai_api.py
+++ b/tools/agent-loop/generated/backends/openai_api.py
@@ -50,7 +50,7 @@ class OpenAIBackend(AgentBackend):
 
         self.client = openai.OpenAI(**client_kwargs)
 
-    def send_message(self, message: str, context: list[dict]) -> AgentResponse:
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to OpenAI API and get response."""
         # Build messages array
         messages = [
@@ -65,11 +65,7 @@ class OpenAIBackend(AgentBackend):
                     "content": msg['content']
                 })
 
-        # Add current message
-        messages.append({
-            "role": "user",
-            "content": message
-        })
+        # Note: current message is already in context (added by agent_loop)
 
         try:
             response = self.client.chat.completions.create(

--- a/tools/agent-loop/generated/context.py
+++ b/tools/agent-loop/generated/context.py
@@ -29,6 +29,16 @@ class Message:
     tokens: int = 0
 
 
+def _count_words(text: str) -> int:
+    """Count words in text."""
+    return len(text.split())
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from text (chars / 4 heuristic)."""
+    return max(1, len(text) // 4)
+
+
 class ContextManager:
     """Manages conversation history and context window."""
 
@@ -36,34 +46,61 @@ class ContextManager:
         self,
         max_tokens: int = 100000,
         max_messages: int = 50,
+        max_chars: int = 0,      # 0 = unlimited
+        max_words: int = 0,      # 0 = unlimited
         behavior: ContextBehavior = ContextBehavior.CONTINUE,
         format: ContextFormat = ContextFormat.PLAIN
     ):
         self.messages: list[Message] = []
         self.max_tokens = max_tokens
         self.max_messages = max_messages
+        self.max_chars = max_chars
+        self.max_words = max_words
         self.behavior = behavior
         self.format = format
         self._token_count = 0
+        self._char_count = 0
+        self._word_count = 0
 
     def add_message(self, role: str, content: str, tokens: int = 0) -> None:
         """Add a message to the context."""
+        # Estimate tokens if not provided
+        if tokens == 0:
+            tokens = _estimate_tokens(content)
+
         msg = Message(role=role, content=content, tokens=tokens)
         self.messages.append(msg)
         self._token_count += tokens
+        self._char_count += len(content)
+        self._word_count += _count_words(content)
         self._trim_if_needed()
 
     def _trim_if_needed(self) -> None:
-        """Remove old messages if context is too large."""
+        """Remove old messages if any context limit is exceeded."""
         # Trim by message count
         while len(self.messages) > self.max_messages:
-            removed = self.messages.pop(0)
-            self._token_count -= removed.tokens
+            self._remove_oldest()
 
         # Trim by token count (keep at least 2 messages)
         while self._token_count > self.max_tokens and len(self.messages) > 2:
-            removed = self.messages.pop(0)
-            self._token_count -= removed.tokens
+            self._remove_oldest()
+
+        # Trim by character count
+        if self.max_chars > 0:
+            while self._char_count > self.max_chars and len(self.messages) > 2:
+                self._remove_oldest()
+
+        # Trim by word count
+        if self.max_words > 0:
+            while self._word_count > self.max_words and len(self.messages) > 2:
+                self._remove_oldest()
+
+    def _remove_oldest(self) -> None:
+        """Remove the oldest message and update counters."""
+        removed = self.messages.pop(0)
+        self._token_count -= removed.tokens
+        self._char_count -= len(removed.content)
+        self._word_count -= _count_words(removed.content)
 
     def get_context(self) -> list[dict]:
         """Get context formatted for the backend."""
@@ -72,8 +109,8 @@ class ContextManager:
 
         messages = self.messages
         if self.behavior == ContextBehavior.SLIDING:
-            # Keep only recent messages
-            messages = self.messages[-10:]
+            # Keep only recent messages (use configured max_messages)
+            messages = self.messages[-self.max_messages:]
 
         return [
             {"role": msg.role, "content": msg.content}
@@ -130,11 +167,23 @@ class ContextManager:
         """Clear all messages from context."""
         self.messages.clear()
         self._token_count = 0
+        self._char_count = 0
+        self._word_count = 0
 
     @property
     def token_count(self) -> int:
-        """Current total token count."""
+        """Current total token count (estimated if not provided)."""
         return self._token_count
+
+    @property
+    def char_count(self) -> int:
+        """Current total character count."""
+        return self._char_count
+
+    @property
+    def word_count(self) -> int:
+        """Current total word count."""
+        return self._word_count
 
     @property
     def message_count(self) -> int:


### PR DESCRIPTION
## Summary

- **Fix duplicate messages in API backends**: `agent_loop.py` adds the user message to context before calling `send_message()`, but `claude_api.py` and `openai_api.py` were appending it again, causing every message to appear twice in the API request
- **Fix sliding window hardcoded -10**: `context.py` used `self.messages[-10:]` instead of `self.messages[-self.max_messages:]`, ignoring the configured `max_messages` setting
- **Fix fragile on_status pattern**: Replaced `try/except TypeError` wrapper with `**kwargs` on all backend `send_message()` signatures, preventing real TypeErrors from being silently swallowed
- **Add context limits**: New `max_chars`, `max_words` parameters on `ContextManager` with automatic trimming, plus token estimation (chars/4 heuristic) when actual token counts aren't available

## Changes

| File | Change |
|------|--------|
| `context.py` | Fix sliding window, add `max_chars`/`max_words`/token estimation, extract `_remove_oldest()` helper |
| `backends/base.py` | Add `**kwargs` to abstract `send_message` signature |
| `backends/claude_api.py` | Remove duplicate message append, add `**kwargs` |
| `backends/openai_api.py` | Remove duplicate message append, add `**kwargs` |
| `backends/coro.py` | Add `**kwargs` to `send_message` |
| `backends/claude_code.py` | Add `**kwargs` to `send_message` |
| `backends/gemini.py` | Add `**kwargs` to `send_message` |
| `backends/ollama_api.py` | Add `**kwargs` to `send_message` |
| `backends/ollama_cli.py` | Add `**kwargs` to `send_message` |
| `agent_loop.py` | Remove try/except TypeError, add `--max-chars`/`--max-words`/`--max-tokens` CLI args, show char/word counts in status |

## New CLI args

```
--max-chars N    Max characters in context (0 = unlimited)
--max-words N    Max words in context (0 = unlimited)
--max-tokens N   Max tokens in context (default: 100000, uses estimation)
```

## Test plan

- [x] `python3 agent_loop.py -b coro --fancy "What is 2+2?"` — works, returns correct answer
- [x] `python3 agent_loop.py -b gemini --fancy "What is 3+3?"` — works with spinner
- [x] `python3 agent_loop.py -b coro --context-mode sliding "What is 5+5?"` — sliding window uses configured max_messages
- [x] `python3 agent_loop.py -b coro --max-chars 5000 "Hello"` — context trimming by character count works
- [x] Unit test: ContextManager trims by chars, words, and tokens correctly

Bugs identified by Kimi K2 thinking model code review via coro backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)"
```
