### PR TITLE
fix(ci): harden SWI-Prolog install (retry + fallback when PPA is down)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,38 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install SWI-Prolog
-        run: |
-          set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends software-properties-common
-
-          added=0
-          set +e
-          sudo apt-add-repository ppa:swi-prolog/stable -y
-          status=$?
-          set -e
-          if [ "$status" -eq 0 ]; then
-            added=1
-          else
-            echo "WARN: Could not add PPA; installing SWI-Prolog from Ubuntu repo." >&2
-          fi
-
-          set +e
-          sudo apt-get update -qq
-          update_status=$?
-          set -e
-          if [ "$update_status" -ne 0 ] && [ "$added" -eq 1 ]; then
-            echo "WARN: apt-get update failed after adding PPA; removing PPA and retrying..." >&2
-            set +e
-            sudo apt-add-repository --remove ppa:swi-prolog/stable -y
-            set -e
-            sudo apt-get update -qq
-          elif [ "$update_status" -ne 0 ]; then
-            echo "ERROR: apt-get update failed." >&2
-            exit "$update_status"
-          fi
-
-          sudo apt-get install -y swi-prolog
+        run: bash scripts/ci/install_swi_prolog.sh
 
       - name: Verify SWI-Prolog installation
         run: swipl --version
@@ -133,38 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install SWI-Prolog
-        run: |
-          set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends software-properties-common
-
-          added=0
-          set +e
-          sudo apt-add-repository ppa:swi-prolog/stable -y
-          status=$?
-          set -e
-          if [ "$status" -eq 0 ]; then
-            added=1
-          else
-            echo "WARN: Could not add PPA; installing SWI-Prolog from Ubuntu repo." >&2
-          fi
-
-          set +e
-          sudo apt-get update -qq
-          update_status=$?
-          set -e
-          if [ "$update_status" -ne 0 ] && [ "$added" -eq 1 ]; then
-            echo "WARN: apt-get update failed after adding PPA; removing PPA and retrying..." >&2
-            set +e
-            sudo apt-add-repository --remove ppa:swi-prolog/stable -y
-            set -e
-            sudo apt-get update -qq
-          elif [ "$update_status" -ne 0 ]; then
-            echo "ERROR: apt-get update failed." >&2
-            exit "$update_status"
-          fi
-
-          sudo apt-get install -y swi-prolog
+        run: bash scripts/ci/install_swi_prolog.sh
 
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4

--- a/scripts/ci/install_swi_prolog.sh
+++ b/scripts/ci/install_swi_prolog.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PPA="ppa:swi-prolog/stable"
+
+retry() {
+  local attempts="$1"
+  local delay_seconds="$2"
+  shift 2
+
+  local attempt=1
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+
+    local exit_code=$?
+    if [ "$attempt" -ge "$attempts" ]; then
+      return "$exit_code"
+    fi
+
+    echo "WARN: command failed (attempt ${attempt}/${attempts}, exit=${exit_code}): $*" >&2
+    sleep "$delay_seconds"
+    attempt=$((attempt + 1))
+    delay_seconds=$((delay_seconds * 2))
+  done
+}
+
+retry 3 5 sudo apt-get update -qq
+retry 3 5 sudo apt-get install -y --no-install-recommends software-properties-common
+
+added=0
+if retry 2 5 timeout 90 sudo apt-add-repository "$PPA" -y; then
+  added=1
+else
+  echo "WARN: Could not add ${PPA}; installing SWI-Prolog from Ubuntu repo." >&2
+fi
+
+if ! retry 3 5 sudo apt-get update -qq; then
+  if [ "$added" -eq 1 ]; then
+    echo "WARN: apt-get update failed after adding ${PPA}; removing PPA and retrying..." >&2
+    sudo apt-add-repository --remove "$PPA" -y || true
+    retry 3 5 sudo apt-get update -qq
+  else
+    echo "ERROR: apt-get update failed." >&2
+    exit 1
+  fi
+fi
+
+retry 3 5 sudo apt-get install -y --no-install-recommends swi-prolog
+


### PR DESCRIPTION
  - Adds scripts/ci/install_swi_prolog.sh with retries + timeout around apt-add-repository and apt-get, and a clean
    fallback to Ubuntu’s swi-prolog package when ppa:swi-prolog/stable is unavailable.
  - Updates .github/workflows/test.yml to use the shared installer script in both the test and
    csharp_query_runtime_smoke jobs (removes duplicated inline install logic).
  - Goal: stop CI from going red due to intermittent Launchpad/PPA 503s while still preferring the PPA when it’s
    healthy.