### PR TITLE
perf(csharp-query): add grouped transitive single-seed fast paths

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -239,6 +239,8 @@ test_csharp_query_target :-
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
+        verify_parameterized_grouped_transitive_closure_single_seed_strategy_runtime,
+        verify_parameterized_grouped_transitive_closure_by_target_single_seed_strategy_runtime,
         verify_parameterized_reachability_plan,
         verify_parameterized_reachability_by_target_plan,
         verify_parameterized_reachability_both_inputs_plan,
@@ -2773,6 +2775,30 @@ verify_parameterized_reachability_by_target_single_strategy_runtime :-
         ['alice,charlie',
          'bob,charlie',
          'STRATEGY_USED:TransitiveClosureSeededByTargetSingle=true'],
+        Params,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_single_seed_strategy_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a, red, cat1]],
+    harness_source_with_strategy_flag_no_reuse(ModuleClass, Params, 'GroupedTransitiveClosureSeededSingle', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,red,cat1',
+         'a,c,red,cat1',
+         'STRATEGY_USED:GroupedTransitiveClosureSeededSingle=true'],
+        Params,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_by_target_single_seed_strategy_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param_end/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[c, red, cat1]],
+    harness_source_with_strategy_flag_no_reuse(ModuleClass, Params, 'GroupedTransitiveClosureSeededByTargetSingle', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,c,red,cat1',
+         'b,c,red,cat1',
+         'STRATEGY_USED:GroupedTransitiveClosureSeededByTargetSingle=true'],
         Params,
         HarnessSource).
 


### PR DESCRIPTION
  Adds grouped transitive-closure runtime fast paths for single fully-bound seed execution, mirroring the existing
  ungrouped optimization.

  - Runtime:
      - Adds GroupedTransitiveClosureSeededSingle strategy path for source-seeded grouped closure.
      - Adds GroupedTransitiveClosureSeededByTargetSingle strategy path for target-seeded grouped closure.
      - Guards fast-path activation to fully-bound grouped seeds (no wildcard group components), preserving existing
        fallback behavior.
      - File: src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
  - Tests:
      - Adds runtime strategy coverage for grouped source-seeded single execution.
      - Adds runtime strategy coverage for grouped target-seeded single execution.
      - Wires both into the C# query target suite.
      - File: tests/core/test_csharp_query_target.pl
  - Validation:
      - dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release
        passed.
      - Focused smoke passed with -SkipCodegen -ProjectFilter "cq_test_label_c_*".