### PR TITLE
feat(density-explorer): Reproducible embeddings, layout dataset override, and MiniLM support

### DIFF
--- a/docs/proposals/reproducible_embedding_datasets.md
+++ b/docs/proposals/reproducible_embedding_datasets.md
@@ -1,0 +1,175 @@
+# Proposal: Reproducible Wikipedia Physics Embedding Datasets
+
+## Problem
+
+The current `wikipedia_physics_nomic.npz` (300 items, 768D) and `wikipedia_physics_articles.npz`
+(200 items, 768D) datasets have unknown provenance — we can't determine exactly what text was
+embedded or which model version was used. Their embeddings have only 0.67 average cosine similarity
+despite covering the same articles, making comparisons unreliable.
+
+## Proposed Solution
+
+Generate three documented embedding variants from the same 300 Wikipedia physics articles,
+each embedding a different "view" of the article:
+
+| Dataset | Embeds | Purpose |
+|---------|--------|---------|
+| `wikipedia_physics_nomic_titles.npz` | Article title only | Baseline, matches mindmap builder use case |
+| `wikipedia_physics_nomic_text.npz` | Article content (text_preview) | Richer semantic signal |
+| `wikipedia_physics_nomic_paths.npz` | Materialized Pearltrees path | Organizational/hierarchical signal |
+
+All three use the same model (`nomic-embed-text-v1.5`), same prefix (`search_document:`),
+and same normalization. A metadata field records the exact generation parameters.
+
+### Phase 1: Titles and Text (straightforward)
+
+Source data exists in `reports/wikipedia_physics_articles.jsonl` (300 articles with title
+and text_preview). Script:
+
+1. Load 300 titles and text_previews from JSONL
+2. Embed titles with `"search_document: {title}"` → `_titles.npz`
+3. Embed text with `"search_document: {text_preview}"` → `_text.npz`
+4. Save with metadata: model name, prefix, timestamp, source file hash
+
+### Phase 2: Materialized Paths (complex)
+
+Currently only 14 of 300 articles have direct path matches in the training data.
+Generating paths for the remaining 286 requires navigating Wikipedia's category hierarchy
+up to a known Pearltrees folder.
+
+#### Challenges
+
+**1. Multiple category paths per article**
+
+A Wikipedia article like "Bose-Einstein statistics" belongs to multiple categories:
+- Category:Quantum mechanics → Category:Physics → ...
+- Category:Statistical mechanics → Category:Physics → ...
+- Category:Particle statistics → ...
+
+Each category path may lead to a different Pearltrees folder, producing multiple
+valid materialized paths. The existing bridge uses effective distance with dimension
+n=5 to combine these, but for embedding we need a single text representation.
+
+**Options:**
+- (a) Embed the shortest/best path only
+- (b) Embed all paths concatenated (longer text, richer signal)
+- (c) Embed each path separately, average the embeddings
+- (d) Embed the path with lowest effective distance to the target folder
+
+**2. Non-unique Pearltrees matches**
+
+A Wikipedia category like "Physics" might match multiple Pearltrees folders:
+- `science > Math, Physical Sciences & Engineering > Physics`
+- `s243a > Subjects of learning > Physics` (if it exists)
+
+The current bridge handles this by returning all matches with distances, but for
+embedding we'd need to pick one or embed multiple.
+
+**Options:**
+- (a) Use only the "canonical" Pearltrees tree (e.g., `science` tree)
+- (b) Pick the match with shortest path
+- (c) Embed all matches, let the model learn which is relevant
+
+**3. Missing Pearltrees IDs in the path**
+
+The materialized path format has two parts:
+```
+/10388356/11110453/10647426        ← Pearltrees numeric IDs
+- science
+  - Math, Physical Sciences & Engineering
+    - Physics
+      - Atomic Physics            ← human-readable hierarchy
+```
+
+For articles matched via Wikipedia categories (not direct Pearltrees entries),
+we don't have Pearltrees IDs for the article-level node. We could:
+- (a) Omit the ID line entirely (only embed the hierarchy text)
+- (b) Use `?` or `*` as placeholder for unknown IDs
+- (c) Use the parent folder's ID path + `/?` for the leaf
+
+**4. Category database required**
+
+Walking the Wikipedia category hierarchy requires `categorylinks.db` (built by
+`scripts/fetch_wikipedia_categories.py` from a Wikipedia SQL dump). This is a
+large download (~700MB compressed) and may not be available on all machines.
+
+**Option:** Pre-compute the paths once and store them in a JSONL, so the embedding
+script only needs the pre-computed paths (not the category database).
+
+#### Recommended Approach for Phase 2
+
+1. **Pre-compute paths** using the existing `WikipediaCategoryBridge`:
+   - For each of the 300 articles, walk Wikipedia categories up to Pearltrees folders
+   - Store all matched paths in `data/wikipedia_physics_article_paths.jsonl`
+   - Include: article title, all matched paths, effective distances, via-categories
+
+2. **Select best path per article**:
+   - Use the path with lowest effective distance
+   - If no match found, use a generic path: `- science\n  - Math, Physical Sciences & Engineering\n    - Physics\n      - {title}`
+
+3. **Embed the hierarchy text only** (no Pearltrees IDs):
+   - The ID line is numeric and unlikely to carry semantic meaning for the embedding model
+   - The hierarchy text captures the organizational structure
+
+4. **Save with full provenance**:
+   - Which path was selected and why
+   - All alternative paths in metadata
+
+### Existing datasets (keep as reference)
+
+Rename for clarity:
+- `wikipedia_physics_nomic.npz` → keep as-is (referenced in Flask API code)
+- `wikipedia_physics_articles.npz` → keep as-is (referenced in Flask API code)
+- Both marked as "unknown provenance" in documentation
+
+### Phase 3: Embedding Blending (future)
+
+Different embedding views (titles, text, paths, projected) capture different
+aspects of the same articles. Rather than choosing one view, blending allows
+combining them with a tunable ratio:
+
+```
+blended = α * embedding_A + (1 - α) * embedding_B
+```
+
+Where `α ∈ [0, 1]` controls the mix. After blending, L2-normalize.
+
+**Use cases:**
+- **Layout blending**: Blend title embeddings (categorical structure) with text
+  embeddings (content similarity) for a 2D layout that balances taxonomy and
+  topic — e.g., 70% title + 30% text keeps the hierarchical hub structure
+  while pulling content-related articles slightly closer.
+- **Tree blending**: Blend projected embeddings (organizational distance) with
+  raw embeddings (semantic distance) for tree construction — smoothly
+  transition between purely organizational and purely semantic trees.
+
+**Challenges:**
+- Blending requires embeddings to be in the same space and dimension. Title
+  and text embeddings from the same model (nomic-embed-text-v1.5, 768D) can
+  be blended directly. Projected embeddings (64D from Bivector model) cannot
+  be blended with raw 768D embeddings without projection.
+- The blend ratio is an additional parameter for every operation (layout + tree),
+  increasing UI complexity. A single slider per purpose (layout blend, tree
+  blend) is manageable, but the interaction between dataset choice, model
+  choice, and blend ratio creates many combinations.
+- Blending in the embedding space is not the same as blending in the distance
+  space. For tree construction, blending distances
+  (`d_blend = α * d_A + (1-α) * d_B`) may be more principled than blending
+  embeddings and computing distances on the blend.
+
+**Recommended approach:** Start with a single blend slider for layout (title ↔ text),
+keeping tree distances unblended. This covers the most useful case (tuning the
+2D visualization between categorical and semantic layouts) without combinatorial
+complexity. Add tree blending later if needed.
+
+## Open Questions
+
+1. Should Phase 2 use all 2198 category entries or just the 300 article subset?
+2. For articles with no category path at all, should we use a fallback template
+   or exclude them from the paths dataset?
+3. Should the embedding script also generate a 200-item subset of each variant
+   (to match the mindmap builder's article set)?
+4. Is `nomic-embed-text-v1.5` the right model, or should we use v1 for consistency
+   with the `generate_nomic_embeddings.py` script?
+5. For blending, should the API accept a blend ratio parameter, or should the
+   client compute the blended embeddings and send them via `/api/compute/from-embeddings`?

--- a/scripts/generate_reproducible_embeddings.py
+++ b/scripts/generate_reproducible_embeddings.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Generate reproducible Wikipedia physics embedding datasets.
+
+Phase 1 of the reproducible embedding datasets proposal:
+- wikipedia_physics_nomic_titles.npz: Embed article titles only
+- wikipedia_physics_nomic_text.npz: Embed article text_preview content
+
+Both use nomic-embed-text-v1.5 with "search_document: " prefix.
+Source: reports/wikipedia_physics_articles.jsonl (300 articles)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+
+def compute_file_hash(path: Path) -> str:
+    """SHA-256 hash of source file for provenance tracking."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_articles(jsonl_path: Path):
+    """Load titles and text_previews from the JSONL source."""
+    titles = []
+    text_previews = []
+    with open(jsonl_path) as f:
+        for line in f:
+            entry = json.loads(line)
+            titles.append(entry["title"])
+            text_previews.append(entry["text_preview"])
+    return titles, text_previews
+
+
+def embed(model, texts: list[str], prefix: str = "search_document: ", batch_size: int = 8):
+    """Embed texts with the given prefix."""
+    prefixed = [f"{prefix}{t}" for t in texts]
+    embeddings = model.encode(prefixed, show_progress_bar=True, batch_size=batch_size)
+    # L2-normalize
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    norms[norms == 0] = 1
+    embeddings = embeddings / norms
+    return embeddings.astype(np.float32)
+
+
+def save_dataset(
+    path: Path,
+    embeddings: np.ndarray,
+    titles: list[str],
+    input_texts: list[str],
+    model_name: str,
+    prefix: str,
+    source_hash: str,
+    source_file: str,
+    embed_field: str,
+):
+    """Save embeddings with full provenance metadata."""
+    metadata = {
+        "model": model_name,
+        "prefix": prefix,
+        "embed_field": embed_field,
+        "source_file": source_file,
+        "source_hash": source_hash,
+        "num_items": len(titles),
+        "embedding_dim": int(embeddings.shape[1]),
+        "normalized": True,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "script": "scripts/generate_reproducible_embeddings.py",
+    }
+
+    np.savez_compressed(
+        path,
+        embeddings=embeddings,
+        titles=np.array(titles),
+        input_texts=np.array(input_texts),
+        metadata=np.array(json.dumps(metadata)),
+    )
+    size_kb = path.stat().st_size / 1024
+    print(f"  Saved: {path} ({size_kb:.0f} KB, {embeddings.shape})")
+    return metadata
+
+
+def main():
+    project_root = Path(__file__).parent.parent
+    jsonl_path = project_root / "reports" / "wikipedia_physics_articles.jsonl"
+    output_dir = project_root / "datasets"
+
+    if not jsonl_path.exists():
+        print(f"ERROR: Source file not found: {jsonl_path}")
+        return 1
+
+    print(f"Source: {jsonl_path}")
+    source_hash = compute_file_hash(jsonl_path)
+    print(f"SHA-256: {source_hash}")
+
+    titles, text_previews = load_articles(jsonl_path)
+    print(f"Loaded {len(titles)} articles")
+
+    # Load model
+    print("\nLoading nomic-embed-text-v1.5...")
+    try:
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer(
+            "nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True, device="cpu"
+        )
+        model_name = "nomic-embed-text-v1.5"
+    except Exception as e:
+        print(f"ERROR loading model: {e}")
+        return 1
+
+    prefix = "search_document: "
+
+    # --- Titles dataset ---
+    print(f"\n--- Embedding titles ({len(titles)} items) ---")
+    title_embeddings = embed(model, titles, prefix=prefix)
+    title_meta = save_dataset(
+        path=output_dir / "wikipedia_physics_nomic_titles.npz",
+        embeddings=title_embeddings,
+        titles=titles,
+        input_texts=titles,
+        model_name=model_name,
+        prefix=prefix,
+        source_hash=source_hash,
+        source_file="reports/wikipedia_physics_articles.jsonl",
+        embed_field="title",
+    )
+
+    # --- Text dataset ---
+    print(f"\n--- Embedding text_previews ({len(text_previews)} items) ---")
+    text_embeddings = embed(model, text_previews, prefix=prefix)
+    text_meta = save_dataset(
+        path=output_dir / "wikipedia_physics_nomic_text.npz",
+        embeddings=text_embeddings,
+        titles=titles,
+        input_texts=text_previews,
+        model_name=model_name,
+        prefix=prefix,
+        source_hash=source_hash,
+        source_file="reports/wikipedia_physics_articles.jsonl",
+        embed_field="text_preview",
+    )
+
+    # --- Summary ---
+    print("\n=== Summary ===")
+    print(f"Model: {model_name}")
+    print(f"Prefix: '{prefix}'")
+    print(f"Source: {jsonl_path.name} (SHA-256: {source_hash[:16]}...)")
+    print(f"Titles:  {title_embeddings.shape} → wikipedia_physics_nomic_titles.npz")
+    print(f"Text:    {text_embeddings.shape} → wikipedia_physics_nomic_text.npz")
+
+    # Quick sanity: cosine similarity between title and text embeddings
+    cos_sim = np.sum(title_embeddings * text_embeddings, axis=1)
+    print(f"\nTitle-vs-text cosine similarity: mean={cos_sim.mean():.3f}, min={cos_sim.min():.3f}, max={cos_sim.max():.3f}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tools/density_explorer/scripts/generate_physics_json.py
+++ b/tools/density_explorer/scripts/generate_physics_json.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Generate physics.json with embeddings for density explorer."""
+"""Generate physics.json with embeddings for density explorer.
+
+Uses the deduplicated wikipedia_physics_nomic.npz (300 unique articles)
+rather than wikipedia_physics.npz (2198 categories with duplicates).
+"""
 
 import sys
 from pathlib import Path
@@ -9,27 +13,32 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from shared.density_core import load_and_compute
 
+
 def main():
-    # Paths
-    embeddings_path = Path(__file__).parent.parent.parent.parent / "datasets" / "wikipedia_physics.npz"
+    # Paths - use the clean Nomic 300 dataset (0 duplicate titles)
+    embeddings_path = Path(__file__).parent.parent.parent.parent / "datasets" / "wikipedia_physics_nomic.npz"
     output_path = Path(__file__).parent.parent / "web" / "data" / "physics.json"
+
+    if not embeddings_path.exists():
+        print(f"ERROR: Dataset not found: {embeddings_path}")
+        print("The wikipedia_physics_nomic.npz dataset contains 300 unique Wikipedia")
+        print("physics articles with 768D Nomic embeddings.")
+        return 1
 
     print(f"Loading embeddings from: {embeddings_path}")
 
-    # Compute manifold with both tree types and embeddings
+    # Compute manifold
     data = load_and_compute(
         str(embeddings_path),
         top_k=200,  # Use first 200 articles
-        tree_types=['mst', 'j-guided'],
-        include_embeddings=True,
-        embedding_precision=4,  # 4 decimal places for reasonable file size
         grid_size=100,
+        include_tree=True,
+        tree_type='mst',
+        include_peaks=True,
         n_peaks=5
     )
 
     print(f"Computed manifold: {data.n_points} points")
-    print(f"Trees: {list(data.trees.keys()) if data.trees else 'none'}")
-    print(f"Embeddings included: {len(data.embeddings) if data.embeddings else 0} vectors")
 
     # Write JSON
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -41,5 +50,7 @@ def main():
     print(f"Written to: {output_path}")
     print(f"File size: {size_kb:.1f} KB")
 
+    return 0
+
 if __name__ == "__main__":
-    main()
+    exit(main())

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -525,6 +525,8 @@
                             <label for="flaskDataset">Data Subset</label>
                             <select id="flaskDataset" style="width:100%;">
                                 <option value="wikipedia_physics_nomic">Wikipedia Physics (Nomic, 300)</option>
+                                <option value="wikipedia_physics_nomic_titles">Wikipedia Physics (Titles v1.5, 300)</option>
+                                <option value="wikipedia_physics_nomic_text">Wikipedia Physics (Text v1.5, 300)</option>
                                 <option value="wikipedia_physics_articles">Wikipedia Physics (Articles, 200)</option>
                                 <option value="wikipedia_physics">Wikipedia Physics (Categories, 2198)</option>
                                 <option value="pearltrees_nomic_routing">Pearltrees Routing</option>
@@ -541,11 +543,21 @@
                         <div class="control-group">
                             <label for="flaskProjectionMode">2D Projection Mode</label>
                             <select id="flaskProjectionMode" style="width:100%;">
-                                <option value="embedding">Embedding Space (semantic similarity)</option>
+                                <option value="embedding" id="embeddingModeOption">Embedding Space (semantic similarity)</option>
                                 <option value="weights">Weight Space (transformation recipes)</option>
                                 <option value="learned">Learned Metric (organizational structure)</option>
                                 <option value="wikipedia_physics">Wikipedia Physics (trained hierarchy)</option>
                                 <option value="wikipedia_physics_mds">Wikipedia Physics (MDS - distance faithful)</option>
+                            </select>
+                        </div>
+                        <div class="control-group" id="layoutDatasetGroup" style="display:none;">
+                            <label for="flaskLayoutDataset">2D Layout Dataset <span style="font-size:0.75rem; color:#94a3b8;">(override for SVD layout)</span></label>
+                            <select id="flaskLayoutDataset" style="width:100%;">
+                                <option value="">(Same as Data Subset)</option>
+                                <option value="wikipedia_physics_nomic">Nomic 300 (unknown provenance)</option>
+                                <option value="wikipedia_physics_nomic_titles">Titles v1.5 (300)</option>
+                                <option value="wikipedia_physics_nomic_text">Text v1.5 (300)</option>
+                                <option value="wikipedia_physics_articles">Articles 200</option>
                             </select>
                         </div>
                         <div class="control-group">
@@ -847,25 +859,30 @@
             'data/physics.json': {
                 name: 'Physics (Wikipedia)',
                 embeddings: {
-                    'minilm': {
-                        label: 'MiniLM (384D) - Fast',
-                        url: null,  // null = included in main JSON
-                        dim: 384
-                    },
                     'nomic': {
-                        label: 'Nomic (768D) - Better clustering',
+                        label: 'Nomic (768D) - Unknown provenance',
+                        url: null,  // null = included in main JSON (physics.json has 768D Nomic)
+                        dim: 768
+                    },
+                    'nomic_titles': {
+                        label: 'Nomic v1.5 (768D) - Titles',
                         url: 'data/physics_nomic_embeddings.json',
                         dim: 768
+                    },
+                    'minilm': {
+                        label: 'MiniLM (384D) - Titles',
+                        url: 'data/physics_minilm_embeddings.json',
+                        dim: 384
                     }
                 },
-                defaultLayout: 'minilm',  // MiniLM better for 2D layout (hubs in dense regions)
-                defaultTree: 'nomic'      // Nomic better for semantic tree distances
+                defaultLayout: 'nomic',
+                defaultTree: 'nomic'
             }
         };
 
         // Track current embedding state - separate for layout and tree
         let currentDatasetUrl = 'data/physics.json';
-        let layoutEmbeddingType = 'minilm';
+        let layoutEmbeddingType = 'nomic';
         let treeEmbeddingType = 'nomic';
         let layoutEmbeddings = null;  // Embeddings for 2D projection
         let treeEmbeddings = null;    // Embeddings for tree distance calculations
@@ -1484,6 +1501,28 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
                 loadFlaskBtn.addEventListener('click', loadFromFlaskApi);
             }
 
+            // Show/hide layout dataset override based on model + projection mode
+            function updateLayoutDatasetVisibility() {
+                const model = document.getElementById('flaskModel')?.value;
+                const projMode = document.getElementById('flaskProjectionMode')?.value;
+                const group = document.getElementById('layoutDatasetGroup');
+                const embOption = document.getElementById('embeddingModeOption');
+                const hasModel = model && model !== 'None' && model !== '';
+                if (group) {
+                    // Show when a projection model is selected AND projection mode is embedding
+                    group.style.display = (hasModel && projMode === 'embedding') ? 'block' : 'none';
+                }
+                // Clarify what "Embedding Space" means based on whether a model is active
+                if (embOption) {
+                    embOption.textContent = hasModel
+                        ? 'Projected Embedding Space (model output for layout)'
+                        : 'Embedding Space (semantic similarity)';
+                }
+            }
+            document.getElementById('flaskModel')?.addEventListener('change', updateLayoutDatasetVisibility);
+            document.getElementById('flaskProjectionMode')?.addEventListener('change', updateLayoutDatasetVisibility);
+            updateLayoutDatasetVisibility();
+
             // Projection mode
             projectionModeSelect.addEventListener('change', handleProjectionModeChange);
             clearAxisBtn.addEventListener('click', clearAxisSelection);
@@ -1943,7 +1982,22 @@ set_dual_embeddings(_js_layout_emb.to_py(), _js_tree_emb.to_py(), list(_js_title
                 );
 
                 if (needsApiProjection) {
-                    // Use Flask API to apply the model/projection mode consistently
+                    // Flask API mode with a model: sync the layout embedding choice
+                    // to the 2D Layout Dataset selector and reload via API.
+                    // The Bivector model projects embeddings for tree distances,
+                    // but the 2D SVD layout can use raw embeddings from any dataset.
+                    const layoutDatasetSelect = document.getElementById('flaskLayoutDataset');
+                    if (layoutDatasetSelect) {
+                        // Map embedding type to a layout dataset
+                        const embeddingToDataset = {
+                            'minilm': '',  // MiniLM = same as data subset (original raw embeddings)
+                            'nomic': '',   // Nomic = same as data subset
+                        };
+                        const mapped = embeddingToDataset[selected];
+                        if (mapped !== undefined) {
+                            layoutDatasetSelect.value = mapped;
+                        }
+                    }
                     console.log('Using Flask API for projection (model or special mode selected)');
                     await loadFromFlaskApi();
                     return;
@@ -2437,8 +2491,6 @@ json.dumps(data)
             if (embeddingsFlaskNote) {
                 embeddingsFlaskNote.style.display = isFlaskApi ? 'block' : 'none';
             }
-            // Keep embedding selectors enabled - they affect Pyodide recompute
-            // Flask API uses its own Projection Mode / Tree Metric settings
 
             if (value === 'custom') {
                 customUrlGroup.style.display = 'block';
@@ -2478,6 +2530,7 @@ json.dumps(data)
             const dataset = document.getElementById('flaskDataset').value;
             const model = document.getElementById('flaskModel').value;
             const projectionMode = document.getElementById('flaskProjectionMode').value;
+            const layoutDataset = document.getElementById('flaskLayoutDataset')?.value || '';
             const treeMetric = document.getElementById('flaskTreeMetric').value;
             const treeType = document.getElementById('flaskTreeType').value;
             const topK = parseInt(document.getElementById('flaskTopK').value) || 200;
@@ -2582,6 +2635,11 @@ json.dumps(data)
 
                     if (model) {
                         requestBody.model = model;
+                    }
+
+                    // Layout dataset override: use different embeddings for 2D SVD layout
+                    if (layoutDataset && model && projectionMode === 'embedding') {
+                        requestBody.layout_dataset = layoutDataset;
                     }
 
                     response = await fetch(`${apiUrl}/api/compute`, {


### PR DESCRIPTION
  Summary

  - Reproducible embedding datasets (Phase 1): Add generate_reproducible_embeddings.py to create title and text embedding
  datasets from the 300 Wikipedia physics articles using nomic-embed-text-v1.5 with full provenance (model, prefix, source hash,
   timestamps)
  - Layout dataset override: Flask API now accepts a layout_dataset parameter so 2D SVD layout can use different raw embeddings
  than tree distance computation — enables comparing how the same tree looks in different embedding spaces
  - MiniLM restored as layout option: Three embedding choices for layout projection: Nomic (768D, unknown provenance), Nomic
  v1.5 (768D, titles), and MiniLM (384D, titles)
  - Deduplicated physics.json source: generate_physics_json.py now uses wikipedia_physics_nomic.npz (300 unique articles)
  instead of wikipedia_physics.npz (2198 categories with duplicates), fixing the 23 duplicate "Physics" entries in search
  - UI clarity: Dynamic label for "Embedding Space" projection mode distinguishes raw vs projected when a Bivector model is
  active

  Test plan

  - Open density explorer, select Flask API mode
  - Verify new dataset options appear: "Titles v1.5" and "Text v1.5"
  - Switch Layout embedding between Nomic, Nomic v1.5 Titles, and MiniLM — SVD variance should change
  - With a Bivector model selected, verify the "2D Layout Dataset" override appears
  - Search for "Physics" — should return exactly one result (no duplicates)
  - Run python scripts/generate_reproducible_embeddings.py to regenerate title/text datasets

  🤖 Generated with https://claude.com/claude-code