### PR TITLE
feat(density-explorer): Add Blend tab for input↔output embedding space blending

### DIFF
--- a/docs/proposals/custom_distance_blending.md
+++ b/docs/proposals/custom_distance_blending.md
@@ -1,0 +1,217 @@
+# Proposal: Custom Multi-Space Distance Blending
+
+## Context
+
+The density explorer's Blend tab supports input↔output embedding space blending
+(modes: None, Visualization, Tree Distance, Both). A fifth mode, "Custom," was
+deferred because it involves blending across distance spaces with different
+dimensionalities and semantics.
+
+### Observation: Information-Preserving Models
+
+The Bivector Paired model is designed to preserve input embedding geometry (good
+hit@k with minimal training). Testing shows this produces nearly identical
+distance orderings in input vs output space — only 8/299 MST edges differ. The
+input↔output blend is therefore a near-identity operation for tree distances.
+
+This means the existing input↔output blend can be collapsed into a single
+"embedding distance" term in a larger weighted sum, rather than occupying two
+separate slots.
+
+## Design
+
+### Distance-Level Blending
+
+All available distance spaces can be reduced to N×N distance matrices regardless
+of their native dimensionality. Blending at the distance level sidesteps the
+dimensionality mismatch problem entirely:
+
+```
+d_custom = w_emb * d_emb(α) + w_weights * d_weights + w_learned * d_learned + w_wiki * d_wiki
+```
+
+Where:
+- `d_emb(α)` = blended input↔output embedding distance (using existing α slider)
+- `d_weights` = cosine distance in weight space (64D)
+- `d_learned` = Euclidean distance in learned organizational metric space (64D)
+- `d_wiki` = predicted distance from Wikipedia physics distance model
+
+Weights `w_*` are normalized to sum to 1.
+
+### Available Distance Spaces
+
+| Space | Dim | Distance | Semantics |
+|-------|-----|----------|-----------|
+| Embedding (input↔output blend) | 768D | Cosine | Semantic similarity |
+| Weight Space | 64D | Cosine | Transformation recipe similarity |
+| Learned Metric | 64D | Euclidean | Organizational proximity |
+| Wikipedia Physics | N/A (pairwise) | Predicted | Category hierarchy distance |
+
+### Why Linear Distance Blending Works
+
+Linear interpolation of distance matrices preserves the metric properties needed
+by tree algorithms:
+- **Non-negativity**: Sum of non-negative distances is non-negative
+- **Zero diagonal**: Sum of zero-diagonal matrices has zero diagonal
+- **Symmetry**: Sum of symmetric matrices is symmetric
+- Triangle inequality is not guaranteed but MST/tree algorithms don't require it
+
+### Collapsing Input↔Output Into One Term
+
+Since the Bivector model preserves input geometry, `d_emb(α)` for any α produces
+nearly the same distance matrix. Rather than wasting two weight slots on input
+and output separately:
+
+1. The existing α slider controls the internal input↔output mix
+2. The result gets one weight `w_emb` in the custom sum
+3. Users who want to explore the (small) input↔output difference can still use α
+4. The significant blending happens between `d_emb` and the other spaces
+
+## UI Design
+
+### Custom Mode Controls
+
+When "Custom" is selected in the Blend tab:
+
+```
+Embedding Distance     [====|====] 0.40    α: [==|=] 0.50
+Weight Space Distance  [==|======] 0.20
+Learned Metric         [===|=====] 0.30
+Wikipedia Physics      [=|=======] 0.10
+                                   ----
+                            Total: 1.00    [Normalize] [Apply]
+```
+
+- Each space gets a weight slider (0.0–1.0) and numeric input
+- "Normalize" button rescales weights to sum to 1.0
+- Embedding Distance includes a nested α sub-slider for input↔output mix
+- Spaces that require a model (Weights, Learned) are disabled when no model is
+  selected, similar to existing 2D Projection Mode behavior
+- Wikipedia Physics is disabled when that distance model isn't available
+
+### Scope: Tree Distance Only
+
+Custom blending applies to **tree distance computation only**, not 2D layout.
+Rationale:
+- 2D layout blending requires projecting each space to 2D independently, then
+  blending coordinates. With 4+ spaces this creates too many SVD projections
+  and the blended 2D result loses interpretability.
+- Tree distances are NxN matrices that blend cleanly with weighted sums.
+- The existing Visualization blend (input↔output) remains available for layout.
+
+### Presets
+
+Common configurations as one-click presets:
+- **Semantic Only**: w_emb=1.0, rest=0 (baseline)
+- **Hierarchical**: w_emb=0.3, w_weights=0.3, w_learned=0.4
+- **Wikipedia-Guided**: w_emb=0.5, w_wiki=0.5
+- **Equal Mix**: all weights equal
+
+## Implementation
+
+### Backend (`density_core.py`)
+
+Add `compute_custom_distance_matrix()`:
+```python
+def compute_custom_distance_matrix(
+    embeddings: np.ndarray,
+    input_embeddings: Optional[np.ndarray],
+    weights: Optional[np.ndarray],
+    metric_model=None,
+    blend_weights: dict,  # {embedding: 0.4, weights: 0.2, learned: 0.3, wiki: 0.1}
+    embedding_alpha: float = 0.5,  # input↔output mix within embedding term
+) -> np.ndarray:
+    """Compute weighted sum of distance matrices from multiple spaces."""
+    dist_matrices = {}
+
+    # Embedding distance (with optional input↔output blend)
+    if blend_weights.get('embedding', 0) > 0:
+        if embedding_alpha is not None and input_embeddings is not None:
+            dist_matrices['embedding'] = blend_distance_matrices(
+                input_embeddings, embeddings, embedding_alpha
+            )
+        else:
+            dist_matrices['embedding'] = cosine_distance_matrix(embeddings)
+
+    # Weight space distance
+    if blend_weights.get('weights', 0) > 0 and weights is not None:
+        dist_matrices['weights'] = cosine_distance_matrix(weights)
+
+    # Learned metric distance
+    if blend_weights.get('learned', 0) > 0 and weights is not None:
+        metric_emb = compute_metric_embeddings(
+            input_embeddings, embeddings, weights, metric_model
+        )
+        dist_matrices['learned'] = euclidean_distance_matrix(metric_emb)
+
+    # Wikipedia physics predicted distance
+    if blend_weights.get('wiki', 0) > 0:
+        dist_matrices['wiki'] = compute_wikipedia_physics_distances(
+            input_embeddings or embeddings
+        )
+
+    # Normalize scale: each distance matrix to [0, 1] range
+    for key in dist_matrices:
+        d = dist_matrices[key]
+        d_max = d.max()
+        if d_max > 0:
+            dist_matrices[key] = d / d_max
+
+    # Weighted sum
+    result = np.zeros_like(next(iter(dist_matrices.values())))
+    total_weight = 0
+    for key, d in dist_matrices.items():
+        w = blend_weights.get(key, 0)
+        result += w * d
+        total_weight += w
+
+    if total_weight > 0:
+        result /= total_weight
+
+    np.fill_diagonal(result, 0)
+    return result
+```
+
+### Scale Normalization
+
+Different distance spaces have different scales:
+- Cosine distance: [0, 2] but typically [0, 1] for normalized embeddings
+- Euclidean in learned metric: unbounded, depends on model
+- Wikipedia physics predicted: model-specific range
+
+Before blending, normalize each distance matrix to [0, 1] by dividing by its
+max value. This ensures each space contributes proportionally to its weight
+regardless of native scale.
+
+### Backend (`flask_api.py`)
+
+Accept `custom_blend_weights` dict and `custom_embedding_alpha` in the
+`/api/compute` request body. When present, compute the custom distance matrix
+and pass it as `dist_matrix_override` to the tree builder.
+
+### Frontend (`index.html`)
+
+- Add Custom mode UI with weight sliders, normalization button, and presets
+- Send `custom_blend_weights` and `custom_embedding_alpha` in API request
+- Disable unavailable spaces based on model/data availability
+
+## Open Questions
+
+1. **Scale normalization**: Dividing by max is simple but sensitive to outliers.
+   Alternatives: percentile-based, z-score, or rank-based normalization. Rank
+   normalization (`d_rank[i,j] = rank(d[i,j]) / N^2`) would make all spaces
+   strictly comparable but loses magnitude information.
+
+2. **Visualization blending**: Should Custom mode also support layout blending?
+   This would require MDS on the blended distance matrix (feasible but slower
+   than SVD on individual embedding spaces).
+
+3. **Dynamic availability**: Some distance spaces require specific models or data.
+   Should unavailable spaces be hidden entirely or shown as disabled with
+   explanation?
+
+4. **Persistence**: Should custom weight presets be saveable/loadable?
+
+5. **Interaction with Tree Distance Metric selector**: The existing selector
+   (Data tab) picks a single distance metric. Custom blend mode supersedes
+   this. Should the selector be disabled/hidden when Custom blend is active?

--- a/tools/density_explorer/flask_api.py
+++ b/tools/density_explorer/flask_api.py
@@ -374,6 +374,10 @@ def compute_manifold():
         if projection_mode not in ('embedding', 'weights', 'learned', 'wikipedia_physics', 'wikipedia_physics_mds'):
             return jsonify({'error': f'Invalid projection_mode: {projection_mode}. Use "embedding", "weights", "learned", "wikipedia_physics", or "wikipedia_physics_mds"'}), 400
 
+        # Extract blend parameters
+        blend_layout_alpha = data.get('blend_layout_alpha')
+        blend_tree_alpha = data.get('blend_tree_alpha')
+
         # Check for projection model
         model = data.get('model')
         blend_weights = None
@@ -489,7 +493,9 @@ def compute_manifold():
                     input_embeddings=input_embeddings,
                     max_branching=data.get('max_branching'),
                     root_id=root_id,
-                    tree_embeddings=tree_embeddings_override
+                    tree_embeddings=tree_embeddings_override,
+                    blend_layout_alpha=blend_layout_alpha,
+                    blend_tree_alpha=blend_tree_alpha
                 )
 
                 return result.to_json(), 200, {'Content-Type': 'application/json'}
@@ -591,6 +597,10 @@ def compute_from_embeddings():
                 # Fall back to using output embeddings as input (less accurate but functional)
                 input_embeddings = embeddings
 
+        # Blend parameters
+        blend_layout_alpha = data.get('blend_layout_alpha')
+        blend_tree_alpha = data.get('blend_tree_alpha')
+
         result = compute_density_manifold(
             embeddings=embeddings,
             titles=titles,
@@ -605,7 +615,9 @@ def compute_from_embeddings():
             weights=weights,
             input_embeddings=input_embeddings,
             max_branching=data.get('max_branching'),
-            tree_embeddings=tree_embeddings
+            tree_embeddings=tree_embeddings,
+            blend_layout_alpha=blend_layout_alpha,
+            blend_tree_alpha=blend_tree_alpha
         )
 
         return result.to_json(), 200, {'Content-Type': 'application/json'}

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -403,6 +403,7 @@
                 <div class="tab-buttons">
                     <button class="tab-btn active" data-tab="view">View</button>
                     <button class="tab-btn" data-tab="data">Data</button>
+                    <button class="tab-btn" data-tab="blend">Blend</button>
                     <button class="tab-btn" data-tab="compute">Compute</button>
                 </div>
 
@@ -533,7 +534,7 @@
                             </select>
                         </div>
                         <div class="control-group">
-                            <label for="flaskModel">Projection Model</label>
+                            <label for="flaskModel">Transformation Model</label>
                             <select id="flaskModel" style="width:100%;">
                                 <option value="">None (raw embeddings)</option>
                                 <option value="bivector_paired" selected>Bivector Paired</option>
@@ -685,7 +686,7 @@
                     <button id="loadMLBackendBtn" class="secondary">Load ML Backend</button>
                     <button id="testEmbedBtn" class="secondary" disabled style="margin-top: 5px;">Test Embedding</button>
 
-                    <h2>Projection Model</h2>
+                    <h2>Transformation Model</h2>
                     <div class="control-group">
                         <label for="projectionModelSource">Source</label>
                         <select id="projectionModelSource">
@@ -713,6 +714,54 @@
                     </div>
                     <button id="testProjectionBtn" class="secondary" disabled>Test Projection</button>
                 </div>
+
+                <!-- BLEND TAB -->
+                <div class="tab-panel" id="tab-blend">
+                    <h2>Embedding Blend</h2>
+
+                    <div id="blendModelWarning" style="padding: 10px; background: rgba(243, 156, 18, 0.15); border: 1px solid #f39c12; border-radius: 4px; margin-bottom: 15px; font-size: 0.85rem; color: #f39c12;">
+                        Select a Transformation Model in the Data tab to enable blending between input and output embedding spaces.
+                    </div>
+
+                    <div id="blendControls" style="display: none;">
+                        <div class="control-group">
+                            <label for="blendMode">Blend Mode</label>
+                            <select id="blendMode" style="width:100%;">
+                                <option value="none">None</option>
+                                <option value="visualization">Visualization (2D layout)</option>
+                                <option value="tree">Tree Distance</option>
+                                <option value="both">Both (independent)</option>
+                                <option value="custom" disabled title="Multi-space weighted blending — coming soon">Custom (coming soon)</option>
+                            </select>
+                        </div>
+
+                        <div id="blendVisualizationGroup" class="control-group" style="display: none;">
+                            <label>Layout Blend: <span class="value" id="blendLayoutAlphaValue">0.50</span></label>
+                            <div style="display: flex; gap: 8px; align-items: center;">
+                                <span style="font-size: 0.75rem; color: #94a3b8; white-space: nowrap;">Output</span>
+                                <input type="range" id="blendLayoutAlpha" min="0" max="1" value="0.5" step="0.01" style="flex: 1;">
+                                <span style="font-size: 0.75rem; color: #94a3b8; white-space: nowrap;">Input</span>
+                            </div>
+                            <input type="number" id="blendLayoutAlphaInput" min="0" max="1" step="0.01" value="0.5"
+                                   style="width: 80px; padding: 4px 8px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; margin-top: 4px; font-size: 0.85rem;">
+                        </div>
+
+                        <div id="blendTreeGroup" class="control-group" style="display: none;">
+                            <label>Tree Blend: <span class="value" id="blendTreeAlphaValue">0.50</span></label>
+                            <div style="display: flex; gap: 8px; align-items: center;">
+                                <span style="font-size: 0.75rem; color: #94a3b8; white-space: nowrap;">Output</span>
+                                <input type="range" id="blendTreeAlpha" min="0" max="1" value="0.5" step="0.01" style="flex: 1;">
+                                <span style="font-size: 0.75rem; color: #94a3b8; white-space: nowrap;">Input</span>
+                            </div>
+                            <input type="number" id="blendTreeAlphaInput" min="0" max="1" step="0.01" value="0.5"
+                                   style="width: 80px; padding: 4px 8px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; margin-top: 4px; font-size: 0.85rem;">
+                        </div>
+
+                        <div id="blendStatusText" style="font-size: 0.8rem; color: #94a3b8; margin-top: 10px;">Blending disabled.</div>
+
+                        <button id="applyBlendBtn" class="primary" style="margin-top: 10px;">Apply Blend</button>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -738,6 +787,10 @@
                 <div class="info-item">
                     <span class="label">SVD Var 2</span>
                     <span class="value" id="infoVar2">-</span>
+                </div>
+                <div class="info-item" id="infoBlendItem" style="display: none;">
+                    <span class="label">Blend</span>
+                    <span class="value" id="infoBlend">-</span>
                 </div>
             </div>
             <div class="status" id="status">
@@ -849,6 +902,26 @@
         const layoutEmbeddingLabel = document.getElementById('layoutEmbeddingLabel');
         const treeEmbeddingLabel = document.getElementById('treeEmbeddingLabel');
         const embeddingLoadingStatus = document.getElementById('embeddingLoadingStatus');
+
+        // Blend tab elements
+        const blendModeSelect = document.getElementById('blendMode');
+        const blendModelWarning = document.getElementById('blendModelWarning');
+        const blendControls = document.getElementById('blendControls');
+        const blendLayoutAlphaSlider = document.getElementById('blendLayoutAlpha');
+        const blendLayoutAlphaValue = document.getElementById('blendLayoutAlphaValue');
+        const blendLayoutAlphaInput = document.getElementById('blendLayoutAlphaInput');
+        const blendTreeAlphaSlider = document.getElementById('blendTreeAlpha');
+        const blendTreeAlphaValue = document.getElementById('blendTreeAlphaValue');
+        const blendTreeAlphaInput = document.getElementById('blendTreeAlphaInput');
+        const blendVisualizationGroup = document.getElementById('blendVisualizationGroup');
+        const blendTreeGroup = document.getElementById('blendTreeGroup');
+        const blendStatusText = document.getElementById('blendStatusText');
+        const applyBlendBtn = document.getElementById('applyBlendBtn');
+
+        // Blend state
+        let blendMode = 'none';
+        let blendLayoutAlpha = 0.5;
+        let blendTreeAlpha = 0.5;
 
         // Legacy reference for compatibility
         const embeddingSelect = layoutEmbeddingSelect;
@@ -1505,6 +1578,7 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
             function updateLayoutDatasetVisibility() {
                 const model = document.getElementById('flaskModel')?.value;
                 const projMode = document.getElementById('flaskProjectionMode')?.value;
+                const projModeSelect = document.getElementById('flaskProjectionMode');
                 const group = document.getElementById('layoutDatasetGroup');
                 const embOption = document.getElementById('embeddingModeOption');
                 const hasModel = model && model !== 'None' && model !== '';
@@ -1518,10 +1592,45 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
                         ? 'Projected Embedding Space (model output for layout)'
                         : 'Embedding Space (semantic similarity)';
                 }
+                // Disable model-dependent projection modes when no model is selected
+                if (projModeSelect) {
+                    for (const opt of projModeSelect.options) {
+                        if (opt.value === 'weights' || opt.value === 'learned') {
+                            opt.disabled = !hasModel;
+                        }
+                    }
+                    // If current selection requires a model but none is selected, reset to embedding
+                    if (!hasModel && (projMode === 'weights' || projMode === 'learned')) {
+                        projModeSelect.value = 'embedding';
+                    }
+                }
             }
             document.getElementById('flaskModel')?.addEventListener('change', updateLayoutDatasetVisibility);
             document.getElementById('flaskProjectionMode')?.addEventListener('change', updateLayoutDatasetVisibility);
             updateLayoutDatasetVisibility();
+
+            // Blend controls
+            if (blendModeSelect) {
+                blendModeSelect.addEventListener('change', handleBlendModeChange);
+            }
+            if (blendLayoutAlphaSlider) {
+                blendLayoutAlphaSlider.addEventListener('input', () => syncBlendSlider('layout'));
+            }
+            if (blendLayoutAlphaInput) {
+                blendLayoutAlphaInput.addEventListener('change', () => syncBlendInput('layout'));
+            }
+            if (blendTreeAlphaSlider) {
+                blendTreeAlphaSlider.addEventListener('input', () => syncBlendSlider('tree'));
+            }
+            if (blendTreeAlphaInput) {
+                blendTreeAlphaInput.addEventListener('change', () => syncBlendInput('tree'));
+            }
+            if (applyBlendBtn) {
+                applyBlendBtn.addEventListener('click', applyBlend);
+            }
+            // Update blend availability when model changes
+            document.getElementById('flaskModel')?.addEventListener('change', updateBlendAvailability);
+            updateBlendAvailability();
 
             // Projection mode
             projectionModeSelect.addEventListener('change', handleProjectionModeChange);
@@ -1629,6 +1738,115 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
         }
 
         // ============================================================
+        // ============================================================
+        // Blend Functions
+        // ============================================================
+
+        function updateBlendAvailability() {
+            const model = document.getElementById('flaskModel')?.value;
+            const hasModel = model && model !== 'None' && model !== '';
+
+            if (blendModelWarning) {
+                blendModelWarning.style.display = hasModel ? 'none' : 'block';
+            }
+            if (blendControls) {
+                blendControls.style.display = hasModel ? 'block' : 'none';
+            }
+        }
+
+        function handleBlendModeChange() {
+            blendMode = blendModeSelect.value;
+
+            const showViz = (blendMode === 'visualization' || blendMode === 'both');
+            const showTree = (blendMode === 'tree' || blendMode === 'both');
+
+            blendVisualizationGroup.style.display = showViz ? 'block' : 'none';
+            blendTreeGroup.style.display = showTree ? 'block' : 'none';
+
+            updateBlendStatus();
+            updateBlendInfoBar();
+        }
+
+        function syncBlendSlider(type) {
+            if (type === 'layout') {
+                blendLayoutAlpha = parseFloat(blendLayoutAlphaSlider.value);
+                blendLayoutAlphaValue.textContent = blendLayoutAlpha.toFixed(2);
+                blendLayoutAlphaInput.value = blendLayoutAlpha.toFixed(2);
+            } else {
+                blendTreeAlpha = parseFloat(blendTreeAlphaSlider.value);
+                blendTreeAlphaValue.textContent = blendTreeAlpha.toFixed(2);
+                blendTreeAlphaInput.value = blendTreeAlpha.toFixed(2);
+            }
+            updateBlendStatus();
+            updateBlendInfoBar();
+        }
+
+        function syncBlendInput(type) {
+            if (type === 'layout') {
+                blendLayoutAlpha = Math.max(0, Math.min(1, parseFloat(blendLayoutAlphaInput.value) || 0));
+                blendLayoutAlphaSlider.value = blendLayoutAlpha;
+                blendLayoutAlphaValue.textContent = blendLayoutAlpha.toFixed(2);
+                blendLayoutAlphaInput.value = blendLayoutAlpha.toFixed(2);
+            } else {
+                blendTreeAlpha = Math.max(0, Math.min(1, parseFloat(blendTreeAlphaInput.value) || 0));
+                blendTreeAlphaSlider.value = blendTreeAlpha;
+                blendTreeAlphaValue.textContent = blendTreeAlpha.toFixed(2);
+                blendTreeAlphaInput.value = blendTreeAlpha.toFixed(2);
+            }
+            updateBlendStatus();
+            updateBlendInfoBar();
+        }
+
+        function updateBlendStatus() {
+            if (!blendStatusText) return;
+
+            if (blendMode === 'none') {
+                blendStatusText.textContent = 'Blending disabled.';
+            } else if (blendMode === 'visualization') {
+                blendStatusText.textContent = `Layout: ${(blendLayoutAlpha * 100).toFixed(0)}% input / ${((1 - blendLayoutAlpha) * 100).toFixed(0)}% output`;
+            } else if (blendMode === 'tree') {
+                blendStatusText.textContent = `Tree: ${(blendTreeAlpha * 100).toFixed(0)}% input / ${((1 - blendTreeAlpha) * 100).toFixed(0)}% output`;
+            } else if (blendMode === 'both') {
+                blendStatusText.textContent = `Layout: ${(blendLayoutAlpha * 100).toFixed(0)}%in/${((1 - blendLayoutAlpha) * 100).toFixed(0)}%out | Tree: ${(blendTreeAlpha * 100).toFixed(0)}%in/${((1 - blendTreeAlpha) * 100).toFixed(0)}%out`;
+            }
+        }
+
+        function updateBlendInfoBar() {
+            const blendItem = document.getElementById('infoBlendItem');
+            const blendInfo = document.getElementById('infoBlend');
+            if (!blendItem || !blendInfo) return;
+
+            if (blendMode !== 'none') {
+                blendItem.style.display = '';
+                if (blendMode === 'visualization') {
+                    blendInfo.textContent = `Viz: ${(blendLayoutAlpha * 100).toFixed(0)}%in`;
+                } else if (blendMode === 'tree') {
+                    blendInfo.textContent = `Tree: ${(blendTreeAlpha * 100).toFixed(0)}%in`;
+                } else if (blendMode === 'both') {
+                    blendInfo.textContent = `V:${(blendLayoutAlpha * 100).toFixed(0)}% T:${(blendTreeAlpha * 100).toFixed(0)}%`;
+                }
+            } else {
+                blendItem.style.display = 'none';
+            }
+        }
+
+        function getBlendParams() {
+            if (blendMode === 'none') return {};
+
+            const params = {};
+            if (blendMode === 'visualization' || blendMode === 'both') {
+                params.blend_layout_alpha = blendLayoutAlpha;
+            }
+            if (blendMode === 'tree' || blendMode === 'both') {
+                params.blend_tree_alpha = blendTreeAlpha;
+            }
+            return params;
+        }
+
+        async function applyBlend() {
+            await loadFromFlaskApi();
+        }
+
         // Projection Model Functions
         // ============================================================
         function handleProjectionSourceChange() {
@@ -2592,7 +2810,8 @@ json.dumps(data)
                         include_peaks: true,
                         tree_type: treeType,
                         tree_distance_metric: treeMetric,
-                        projection_mode: projectionMode
+                        projection_mode: projectionMode,
+                        ...getBlendParams()
                     };
 
                     if (bandwidth !== null && !isNaN(bandwidth) && bandwidth > 0) {
@@ -2641,6 +2860,10 @@ json.dumps(data)
                     if (layoutDataset && model && projectionMode === 'embedding') {
                         requestBody.layout_dataset = layoutDataset;
                     }
+
+                    // Blend parameters
+                    const blendParams = getBlendParams();
+                    Object.assign(requestBody, blendParams);
 
                     response = await fetch(`${apiUrl}/api/compute`, {
                         method: 'POST',
@@ -2696,7 +2919,16 @@ json.dumps(data)
                 const treeLabel = treeLabels[treeMetric] || treeMetric;
                 statusEl.textContent = `Loaded ${currentData.n_points} pts (${modeLabel}, ${treeLabel})`;
                 statusEl.style.color = '#27ae60';
-                setStatus(`Loaded from API: ${currentData.n_points} points, ${modeLabel} space, ${treeLabel} tree`);
+                let blendSuffix = '';
+                if (blendMode !== 'none') {
+                    const bp = getBlendParams();
+                    const parts = [];
+                    if (bp.blend_layout_alpha != null) parts.push(`viz=${bp.blend_layout_alpha.toFixed(2)}`);
+                    if (bp.blend_tree_alpha != null) parts.push(`tree=${bp.blend_tree_alpha.toFixed(2)}`);
+                    blendSuffix = `, blend: ${parts.join(', ')}`;
+                }
+                setStatus(`Loaded from API: ${currentData.n_points} points, ${modeLabel} space, ${treeLabel} tree${blendSuffix}`);
+                updateBlendInfoBar();
 
             } catch (error) {
                 statusEl.textContent = `Error: ${error.message}`;


### PR DESCRIPTION
  Summary

  - Add Blend tab with four modes: None, Visualization (2D layout blend), Tree Distance (distance matrix blend), Both
  (independent sliders), and Custom (disabled, proposal only)
  - Backend: blend_projections_2d() and blend_distance_matrices() in density_core.py, dist_matrix_override param in all three
  tree builders (MST, J-Guided, Density Greedy)
  - Rename "Projection Model" to "Transformation Model" for clarity; disable Weight Space / Learned Metric projection modes when
   no model is selected
  - Update Phase 3 blending docs with implementation findings: Bivector Paired model preserves input geometry so closely that
  tree blending changes only 8/299 MST edges — confirming the tension between retrieval-preserving models and hierarchical
  reshaping
  - Add Custom multi-space distance blending proposal (docs/proposals/custom_distance_blending.md) — weighted sum of distance
  matrices across embedding, weight, learned metric, and Wikipedia physics spaces

  Test plan

  - Select Flask API + Bivector Paired model
  - Blend tab: select Visualization, slide α from 0→1, Apply — layout shifts smoothly between output and input SVD
  - Blend tab: select Tree Distance, Apply — tree type shows "mst-blended" in info bar
  - Blend tab: select Both — two independent sliders appear
  - Blend tab: select None, Apply — reverts to standard behavior (tree type "mst")
  - Remove Transformation Model → Blend tab shows warning, controls hidden
  - Custom option is grayed out with "(coming soon)"
  - Weight Space / Learned Metric disabled in 2D Projection Mode when no model selected

  🤖 Generated with https://claude.com/claude-code