### PR TITLE
Add OpenRouter backend, stream-json, and fix context management

### DIFF
--- a/tools/agent-loop/generated/backends/__init__.py
+++ b/tools/agent-loop/generated/backends/__init__.py
@@ -5,11 +5,12 @@ from .claude_code import ClaudeCodeBackend
 from .gemini import GeminiBackend
 from .ollama_api import OllamaAPIBackend
 from .ollama_cli import OllamaCLIBackend
+from .openrouter_api import OpenRouterBackend
 
 __all__ = [
     'AgentBackend', 'AgentResponse', 'ToolCall',
     'CoroBackend', 'ClaudeCodeBackend', 'GeminiBackend',
-    'OllamaAPIBackend', 'OllamaCLIBackend'
+    'OllamaAPIBackend', 'OllamaCLIBackend', 'OpenRouterBackend'
 ]
 
 # Claude API backend (optional - requires anthropic package)

--- a/tools/agent-loop/generated/backends/coro.py
+++ b/tools/agent-loop/generated/backends/coro.py
@@ -1,31 +1,110 @@
 """Coro-code CLI backend using single-task mode."""
 
+import json as _json
+import os
 import subprocess
 import re
+import tempfile
 from .base import AgentBackend, AgentResponse, ToolCall
 
 
 class CoroBackend(AgentBackend):
     """Coro-code CLI backend using single-task mode."""
 
-    def __init__(self, command: str = "claude", verbose: bool = True):
+    def __init__(self, command: str = "coro", verbose: bool = True,
+                 debug: bool = True, max_steps: int = 5,
+                 config: str | None = None, no_fallback: bool = False,
+                 max_context_tokens: int = 0):
         self.command = command
         self.verbose = verbose
+        self.debug = debug
+        self.max_steps = max_steps
+        self.config = config or self._find_config(no_fallback=no_fallback)
+        self.max_context_tokens = max_context_tokens  # 0 = use coro's default
+        self._temp_config = None  # temp config file with max_token override
+        self.model = self._read_model_from_config()
+
+        # If max_context_tokens is set, create a temp config with max_token
+        if self.max_context_tokens > 0:
+            self._temp_config = self._create_limited_config()
         # Patterns for parsing coro output
         self.token_pattern = re.compile(
             r'(?:Input|Output|Total):\s*([\d,]+)\s*tokens?',
             re.IGNORECASE
         )
+        # Coro debug format: "Tokens: 3639 input + 80 output = 3719 total"
+        self._coro_token_pattern = re.compile(
+            r'Tokens:\s*(\d+)\s*input\s*\+\s*(\d+)\s*output\s*=\s*(\d+)\s*total'
+        )
+        # Duration: "Duration: 2.26s"
+        self._duration_pattern = re.compile(r'Duration:\s*([\d.]+)s')
+        # Pattern for ANSI escape codes (colors, cursor movement, etc.)
+        self._ansi_pattern = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')
+
+    def _find_config(self, no_fallback: bool = False) -> str | None:
+        """Find coro config, checking CWD then home directory."""
+        # Check current directory first
+        if os.path.isfile('coro.json'):
+            return None  # coro will find it itself
+        if no_fallback:
+            return None
+        # Check home directory as fallback
+        home_config = os.path.expanduser('~/coro.json')
+        if os.path.isfile(home_config):
+            return home_config
+        return None
+
+    def _read_coro_config(self) -> dict:
+        """Read the full coro config from the best available path."""
+        for path in filter(None, [
+            self.config,
+            'coro.json' if os.path.isfile('coro.json') else None,
+            os.path.expanduser('~/coro.json'),
+        ]):
+            try:
+                with open(path) as f:
+                    return _json.load(f)
+            except Exception:
+                continue
+        return {}
+
+    def _read_model_from_config(self) -> str:
+        """Read model name from coro config file."""
+        return self._read_coro_config().get('model', 'unknown')
+
+    def _create_limited_config(self) -> str | None:
+        """Create a temp coro.json with max_token set to limit context."""
+        base = self._read_coro_config()
+        if not base:
+            return None
+        base['max_token'] = self.max_context_tokens
+        try:
+            tf = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.json', prefix='coro_',
+                delete=False
+            )
+            _json.dump(base, tf, indent=2)
+            tf.close()
+            return tf.name
+        except Exception:
+            return None
 
     def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to coro CLI and get response."""
-        # Format the prompt with context
         prompt = self._format_prompt(message, context)
 
         # Build command
         cmd = [self.command]
-        if self.verbose:
+        # Use temp config (with max_token) if available, else original
+        config_path = self._temp_config or self.config
+        if config_path:
+            cmd.extend(['-c', config_path])
+        if self.debug:
+            cmd.append('--debug')
+        elif self.verbose:
             cmd.append('--verbose')
+        if self.max_steps > 0:
+            cmd.extend(['--max-steps', str(self.max_steps)])
         cmd.append(prompt)
 
         # Run coro in single-task mode
@@ -68,6 +147,10 @@ class CoroBackend(AgentBackend):
             raw=output
         )
 
+    def _strip_ansi(self, text: str) -> str:
+        """Remove ANSI escape codes from text."""
+        return self._ansi_pattern.sub('', text)
+
     def _format_prompt(self, message: str, context: list[dict]) -> str:
         """Format message with conversation context."""
         if not context:
@@ -97,11 +180,28 @@ Current request: {message}"""
         blank_count = 0
 
         for line in lines:
+            plain = self._strip_ansi(line)
             # Skip token report lines
-            if self.token_pattern.search(line):
+            if self.token_pattern.search(plain):
+                continue
+            if self._coro_token_pattern.search(plain):
+                continue
+            if self._duration_pattern.search(plain):
+                continue
+            # Skip verbose/debug log lines (timestamps like 2026-...)
+            if re.match(r'^\s*\d{4}-\d{2}-\d{2}T', plain):
+                continue
+            stripped = plain.strip()
+            # Skip residual cursor control fragments after ANSI stripping
+            if stripped and all(c in '[0123456789ABCDJKHfm;' for c in stripped):
+                continue
+            if stripped in ['Previous conversation:', 'Current request:'] or \
+               stripped.startswith('Current request: ') or \
+               stripped.startswith('User: ') or \
+               stripped.startswith('Assistant: '):
                 continue
             # Skip common noise patterns
-            if line.strip() in ['', '...', '─' * 10]:
+            if stripped in ['', '...', '─' * 10]:
                 blank_count += 1
                 if blank_count <= 1:
                     cleaned.append(line)
@@ -112,6 +212,8 @@ Current request: {message}"""
 
         # Remove leading/trailing blank lines
         result = '\n'.join(cleaned).strip()
+        # Strip any remaining ANSI codes
+        result = self._strip_ansi(result)
 
         # Remove common assistant prefixes from claude output
         for prefix in ['A:', 'Assistant:', 'Claude:']:
@@ -123,10 +225,24 @@ Current request: {message}"""
 
     def _parse_tokens(self, output: str) -> dict[str, int]:
         """Extract token counts from output."""
+        plain = self._strip_ansi(output)
         tokens = {}
-        for match in self.token_pattern.finditer(output):
-            # Get the type (Input/Output/Total) from context
-            line = output[max(0, match.start()-20):match.end()]
+
+        # Try coro debug format first: "Tokens: N input + N output = N total"
+        match = self._coro_token_pattern.search(plain)
+        if match:
+            tokens['input'] = int(match.group(1))
+            tokens['output'] = int(match.group(2))
+            tokens['total'] = int(match.group(3))
+            # Also extract duration if available
+            dur = self._duration_pattern.search(plain)
+            if dur:
+                tokens['duration'] = float(dur.group(1))
+            return tokens
+
+        # Fall back to generic pattern
+        for match in self.token_pattern.finditer(plain):
+            line = plain[max(0, match.start()-20):match.end()]
             count = int(match.group(1).replace(',', ''))
 
             if 'input' in line.lower():

--- a/tools/agent-loop/generated/backends/openrouter_api.py
+++ b/tools/agent-loop/generated/backends/openrouter_api.py
@@ -1,0 +1,283 @@
+"""OpenRouter API backend using urllib (no pip dependencies)."""
+
+import json
+import os
+import sys
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+from .base import AgentBackend, AgentResponse, ToolCall
+
+
+# Default tool schemas for function calling (OpenAI format)
+DEFAULT_TOOL_SCHEMAS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Execute a bash command and return its output.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "The bash command to execute"
+                    }
+                },
+                "required": ["command"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read",
+            "description": "Read the contents of a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Absolute or relative file path to read"
+                    }
+                },
+                "required": ["path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write",
+            "description": "Write content to a file (creates or overwrites).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path to write to"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Content to write to the file"
+                    }
+                },
+                "required": ["path", "content"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "edit",
+            "description": "Edit a file by replacing a unique string with a new string.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path to edit"
+                    },
+                    "old_string": {
+                        "type": "string",
+                        "description": "The exact string to find (must be unique in the file)"
+                    },
+                    "new_string": {
+                        "type": "string",
+                        "description": "The replacement string"
+                    }
+                },
+                "required": ["path", "old_string", "new_string"]
+            }
+        }
+    },
+]
+
+
+class OpenRouterBackend(AgentBackend):
+    """OpenRouter API backend (OpenAI-compatible, no pip deps)."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str = "https://openrouter.ai/api/v1",
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        system_prompt: str | None = None,
+        tools: list[dict] | None = None,
+    ):
+        # Auto-detect from coro.json if not provided
+        coro_config = self._read_coro_config()
+        self.api_key = (api_key
+                        or os.environ.get('OPENROUTER_API_KEY')
+                        or coro_config.get('api_key'))
+        self.model = model or coro_config.get('model', 'moonshotai/kimi-k2.5')
+        self.base_url = base_url or coro_config.get('base_url',
+                                                     'https://openrouter.ai/api/v1')
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.system_prompt = system_prompt or (
+            "You are a helpful AI coding assistant. "
+            "Answer questions directly and concisely. "
+            "When asked to perform tasks, use the available tools."
+        )
+        self.tool_schemas = tools  # None = no tools, [] = explicit empty
+
+        if not self.api_key:
+            raise ValueError(
+                "OpenRouter API key required. Set OPENROUTER_API_KEY "
+                "or provide --api-key, or have ~/coro.json with api_key."
+            )
+
+    @staticmethod
+    def _read_coro_config() -> dict:
+        """Read api_key/model/base_url from coro.json as fallback."""
+        for path in ['coro.json', os.path.expanduser('~/coro.json')]:
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+                return {
+                    'api_key': data.get('api_key'),
+                    'model': data.get('model'),
+                    'base_url': data.get('base_url'),
+                }
+            except (FileNotFoundError, json.JSONDecodeError):
+                continue
+        return {}
+
+    def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
+        """Send message to OpenRouter API."""
+        on_status = kwargs.get('on_status')
+
+        # Build messages array
+        messages = [{"role": "system", "content": self.system_prompt}]
+
+        for msg in context:
+            role = msg.get('role')
+            if role in ('user', 'assistant'):
+                messages.append({"role": role, "content": msg['content']})
+
+        # Add current message (only if not already the last context message)
+        if not context or context[-1].get('content') != message:
+            messages.append({"role": "user", "content": message})
+
+        # Build request body
+        body = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+        }
+
+        if self.tool_schemas:
+            body["tools"] = self.tool_schemas
+            body["tool_choice"] = "auto"
+
+        # Make API request
+        url = f"{self.base_url.rstrip('/')}/chat/completions"
+        req_data = json.dumps(body).encode('utf-8')
+
+        req = Request(
+            url,
+            data=req_data,
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {self.api_key}',
+                'HTTP-Referer': 'https://github.com/s243a/UnifyWeaver',
+                'X-Title': 'UnifyWeaver Agent Loop',
+            },
+            method='POST'
+        )
+
+        if on_status:
+            on_status("Waiting for response...")
+
+        try:
+            with urlopen(req, timeout=300) as resp:
+                data = json.loads(resp.read().decode('utf-8'))
+        except HTTPError as e:
+            error_body = e.read().decode('utf-8', errors='replace')
+            try:
+                err_data = json.loads(error_body)
+                err_msg = err_data.get('error', {}).get('message', error_body[:200])
+            except json.JSONDecodeError:
+                err_msg = error_body[:200]
+            return AgentResponse(
+                content=f"[API Error {e.code}: {err_msg}]",
+                tokens={}
+            )
+        except URLError as e:
+            return AgentResponse(
+                content=f"[Network Error: {e.reason}]",
+                tokens={}
+            )
+        except Exception as e:
+            return AgentResponse(
+                content=f"[Error: {e}]",
+                tokens={}
+            )
+
+        # Parse response
+        content = ""
+        tool_calls = []
+        tokens = {}
+
+        if data.get('choices'):
+            choice = data['choices'][0]
+            msg = choice.get('message', {})
+
+            # Text content
+            content = msg.get('content') or ''
+
+            # Tool calls
+            for tc in msg.get('tool_calls', []):
+                if tc.get('type') == 'function':
+                    func = tc.get('function', {})
+                    try:
+                        arguments = json.loads(func.get('arguments', '{}'))
+                    except json.JSONDecodeError:
+                        arguments = {"raw": func.get('arguments', '')}
+                    tool_calls.append(ToolCall(
+                        name=func.get('name', ''),
+                        arguments=arguments,
+                        id=tc.get('id', '')
+                    ))
+                    if on_status:
+                        desc = self._describe_tool_call(
+                            func.get('name', '?'), arguments)
+                        on_status(f"[{len(tool_calls)}] {desc}")
+
+        # Token usage
+        usage = data.get('usage', {})
+        if usage:
+            tokens = {
+                'input': usage.get('prompt_tokens', 0),
+                'output': usage.get('completion_tokens', 0),
+                'total': usage.get('total_tokens', 0),
+            }
+
+        return AgentResponse(
+            content=content,
+            tool_calls=tool_calls,
+            tokens=tokens,
+            raw=data
+        )
+
+    def _describe_tool_call(self, tool_name: str, params: dict) -> str:
+        """Create a short description of a tool call."""
+        if tool_name == 'read':
+            return f"reading {os.path.basename(params.get('path', '?'))}"
+        elif tool_name == 'write':
+            return f"writing {os.path.basename(params.get('path', '?'))}"
+        elif tool_name == 'edit':
+            return f"editing {os.path.basename(params.get('path', '?'))}"
+        elif tool_name == 'bash':
+            cmd = params.get('command', '?')
+            if len(cmd) > 72:
+                cmd = cmd[:69] + '...'
+            return f"$ {cmd}"
+        return tool_name
+
+    @property
+    def name(self) -> str:
+        return f"OpenRouter ({self.model})"

--- a/tools/agent-loop/generated/costs.py
+++ b/tools/agent-loop/generated/costs.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 import json
+import os
+import sys
+import time
 from pathlib import Path
+from urllib.request import urlopen, Request
+from urllib.error import URLError
 
 
 # Pricing per 1M tokens (as of early 2025, approximate)
@@ -162,3 +167,89 @@ class CostTracker:
     def set_pricing(self, model: str, input_price: float, output_price: float) -> None:
         """Set custom pricing for a model (per 1M tokens)."""
         self.pricing[model] = {"input": input_price, "output": output_price}
+
+    def ensure_pricing(self, model: str) -> bool:
+        """Ensure pricing exists for a model. Fetch from OpenRouter if needed.
+
+        Returns True if pricing is available (even if zero).
+        """
+        if model in self.pricing:
+            return True
+        # Try OpenRouter lookup
+        pricing = fetch_openrouter_pricing(model)
+        if pricing:
+            self.pricing[model] = pricing
+            return True
+        return False
+
+
+# --- OpenRouter pricing ---
+
+_OPENROUTER_CACHE_DIR = Path(os.environ.get(
+    'AGENT_LOOP_CACHE', os.path.expanduser('~/.agent-loop/cache')
+))
+_OPENROUTER_CACHE_FILE = _OPENROUTER_CACHE_DIR / 'openrouter_pricing.json'
+_OPENROUTER_CACHE_TTL = 86400  # 1 day
+
+
+def _load_openrouter_cache() -> dict | None:
+    """Load cached OpenRouter pricing if fresh enough."""
+    try:
+        if not _OPENROUTER_CACHE_FILE.exists():
+            return None
+        age = time.time() - _OPENROUTER_CACHE_FILE.stat().st_mtime
+        if age > _OPENROUTER_CACHE_TTL:
+            return None
+        return json.loads(_OPENROUTER_CACHE_FILE.read_text())
+    except Exception:
+        return None
+
+
+def _save_openrouter_cache(pricing: dict) -> None:
+    """Save OpenRouter pricing to cache."""
+    try:
+        _OPENROUTER_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        _OPENROUTER_CACHE_FILE.write_text(json.dumps(pricing))
+    except Exception:
+        pass
+
+
+def fetch_openrouter_pricing(model_id: str) -> dict | None:
+    """Fetch pricing for a model from OpenRouter's API.
+
+    Returns dict with 'input' and 'output' keys (per 1M tokens),
+    or None if not found.
+    """
+    # Check cache first
+    cache = _load_openrouter_cache()
+    if cache and model_id in cache:
+        return cache[model_id]
+
+    # Fetch from API
+    try:
+        req = Request(
+            'https://openrouter.ai/api/v1/models',
+            headers={'Content-Type': 'application/json'}
+        )
+        with urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+    except (URLError, json.JSONDecodeError, OSError) as e:
+        print(f"  [OpenRouter pricing fetch failed: {e}]", file=sys.stderr)
+        return None
+
+    # Parse all models into cache format: {model_id: {input: X, output: Y}}
+    pricing_cache = {}
+    for m in data.get('data', []):
+        mid = m.get('id', '')
+        p = m.get('pricing', {})
+        prompt_per_token = float(p.get('prompt', '0') or '0')
+        completion_per_token = float(p.get('completion', '0') or '0')
+        # Convert per-token to per-1M-tokens
+        pricing_cache[mid] = {
+            'input': round(prompt_per_token * 1_000_000, 4),
+            'output': round(completion_per_token * 1_000_000, 4),
+        }
+
+    _save_openrouter_cache(pricing_cache)
+
+    return pricing_cache.get(model_id)


### PR DESCRIPTION
## Summary

- **New OpenRouter API backend** (`-b openrouter`) — calls OpenRouter directly using `urllib` (no pip deps), with full context control and tool calling support
- **Fix critical context management bug** — empty `ContextManager` was falsy due to `__len__`, causing `context or ContextManager()` to silently replace all configured contexts with defaults, breaking `--max-chars`/`--max-words`/`--max-tokens` for every backend
- **Claude-code stream-json** — rewrite backend to use `--output-format stream-json` for live tool call progress in `--fancy` mode
- **Coro backend improvements** — fix wrong default command, add debug mode, ANSI stripping, token parsing, config discovery, and `max_token` passthrough
- **OpenRouter pricing auto-fetch** — query `/api/v1/models` endpoint, cache locally for 1 day, show real costs instead of `$0.0000`

## OpenRouter Backend

New API backend that reads credentials from `~/coro.json` (or `OPENROUTER_API_KEY` env var), giving full context management control that the coro CLI backend cannot provide (coro manages its own 20K+ token context internally).

```bash
# Basic usage (auto-reads model + key from ~/coro.json)
python3 agent_loop.py -b openrouter "What is 2+2?"

# With specific model
python3 agent_loop.py -b openrouter -m moonshotai/kimi-k2.5 "prompt"

# Context limits actually work
python3 agent_loop.py -b openrouter --max-chars 50
```

Supports OpenAI-compatible function calling with tool schemas for `bash`, `read`, `write`, and `edit`.

## Context Management Bug Fix

The root cause of `--max-chars` not working for any backend:

```python
# Before (broken): ContextManager.__len__ returns 0 when empty,
# making bool() return False, replacing our configured context
self.context = context or ContextManager()

# After (fixed): explicit None check
self.context = context if context is not None else ContextManager()
```

Additional context fixes:
- Trim minimum reduced from 2 to 1 message so aggressive limits (e.g. `--max-chars 50`) can actually evict messages
- `get_context()` now enforces char/word limits at retrieval time by building newest-to-oldest

## Coro Backend Fixes

- Fix default command from `"claude"` to `"coro"` (was silently calling claude-code in interactive mode)
- Remove broken `coro → claude` fallback (different CLI argument formats)
- Add `--debug` mode with coro-specific token parsing (`Tokens: N input + N output = N total`)
- Add `--max-steps 5` default to prevent runaway iterations
- Add ANSI escape code stripping (`\x1b\[[0-9;]*[A-Za-z]`)
- Add config discovery: CWD `coro.json` → `~/coro.json` fallback
- Add `max_token` passthrough: `--max-tokens` creates a temp coro.json to limit coro's internal context

## Stream-JSON & Display

- Claude-code backend rewritten from `subprocess.run` to `subprocess.Popen` with NDJSON event parsing
- Spinner shows tool calls as permanent lines (committed via `update()` with threading lock)
- Elapsed time display after 2 seconds: `(5s)`, `(10s)`, etc.
- Terminal width truncation prevents line wrapping
- File paths use `os.path.basename()` for readability

## Cost Tracking

- `fetch_openrouter_pricing()` queries `https://openrouter.ai/api/v1/models` for per-token pricing
- Cached to `~/.agent-loop/cache/openrouter_pricing.json` (1-day TTL)
- `ensure_pricing()` auto-fetches on first use for unknown models
- Converts per-token to per-1M-tokens format matching existing cost tracker

## Test plan

- [x] OpenRouter basic query (`-b openrouter "What is 2+2?"`)
- [x] OpenRouter context trimming (`--max-chars 50` forgets secret code)
- [x] Coro context trimming (`--max-chars 50` forgets secret code)
- [x] Cost tracking shows real prices (e.g. `$0.0009` not `$0.0000`)
- [x] Claude-code stream-json shows live tool calls in `--fancy` mode
- [x] Spinner shows tool descriptions as permanent lines
- [ ] OpenRouter tool calling (`--auto-tools "List files"`)
- [ ] Coro `--max-tokens` limits internal context size

---

Generated with [Claude Code](https://claude.com/claude-code)
