### PR TITLE
feat(density-explorer): Add Blend tab with L^n multi-space distance blending

### DIFF
--- a/docs/proposals/custom_distance_blending.md
+++ b/docs/proposals/custom_distance_blending.md
@@ -3,9 +3,16 @@
 ## Context
 
 The density explorer's Blend tab supports input↔output embedding space blending
-(modes: None, Visualization, Tree Distance, Both). A fifth mode, "Custom," was
-deferred because it involves blending across distance spaces with different
-dimensionalities and semantics.
+(modes: None, Visualization, Tree Distance, Both). These controls handle
+blending between input and output embedding spaces via an α slider.
+
+Below these controls, a **Customization** section (separated by a horizontal
+line) combines the blended embedding distance with other distance spaces for
+tree construction. This is a second layer: Blend produces `d_emb(α)`, then
+Customization mixes `d_emb(α)` with other distance metrics.
+
+The Visualization blend (2D layout) remains independent and is not affected
+by the Customization section.
 
 ### Observation: Information-Preserving Models
 
@@ -15,117 +22,214 @@ distance orderings in input vs output space — only 8/299 MST edges differ. The
 input↔output blend is therefore a near-identity operation for tree distances.
 
 This means the existing input↔output blend can be collapsed into a single
-"embedding distance" term in a larger weighted sum, rather than occupying two
-separate slots.
+"embedding distance" term in the customization layer, rather than occupying two
+separate slots. The significant differences come from mixing embedding distances
+with other distance spaces (weights, learned metric, Wikipedia physics).
 
-## Design
+## Architecture: Inline Customization
 
-### Distance-Level Blending
-
-All available distance spaces can be reduced to N×N distance matrices regardless
-of their native dimensionality. Blending at the distance level sidesteps the
-dimensionality mismatch problem entirely:
-
-```
-d_custom = w_emb * d_emb(α) + w_weights * d_weights + w_learned * d_learned + w_wiki * d_wiki
-```
-
-Where:
-- `d_emb(α)` = blended input↔output embedding distance (using existing α slider)
-- `d_weights` = cosine distance in weight space (64D)
-- `d_learned` = Euclidean distance in learned organizational metric space (64D)
-- `d_wiki` = predicted distance from Wikipedia physics distance model
-
-Weights `w_*` are normalized to sum to 1.
-
-### Available Distance Spaces
-
-| Space | Dim | Distance | Semantics |
-|-------|-----|----------|-----------|
-| Embedding (input↔output blend) | 768D | Cosine | Semantic similarity |
-| Weight Space | 64D | Cosine | Transformation recipe similarity |
-| Learned Metric | 64D | Euclidean | Organizational proximity |
-| Wikipedia Physics | N/A (pairwise) | Predicted | Category hierarchy distance |
-
-### Why Linear Distance Blending Works
-
-Linear interpolation of distance matrices preserves the metric properties needed
-by tree algorithms:
-- **Non-negativity**: Sum of non-negative distances is non-negative
-- **Zero diagonal**: Sum of zero-diagonal matrices has zero diagonal
-- **Symmetry**: Sum of symmetric matrices is symmetric
-- Triangle inequality is not guaranteed but MST/tree algorithms don't require it
-
-### Collapsing Input↔Output Into One Term
-
-Since the Bivector model preserves input geometry, `d_emb(α)` for any α produces
-nearly the same distance matrix. Rather than wasting two weight slots on input
-and output separately:
-
-1. The existing α slider controls the internal input↔output mix
-2. The result gets one weight `w_emb` in the custom sum
-3. Users who want to explore the (small) input↔output difference can still use α
-4. The significant blending happens between `d_emb` and the other spaces
-
-## UI Design
-
-### Custom Mode Controls
-
-When "Custom" is selected in the Blend tab:
+Each blend slider has its own customization dropdown placed directly beneath it.
+The customization is contextually paired with the slider it modifies. The number
+of customization dropdowns depends on which blend mode is selected:
 
 ```
-Embedding Distance     [====|====] 0.40    α: [==|=] 0.50
-Weight Space Distance  [==|======] 0.20
-Learned Metric         [===|=====] 0.30
-Wikipedia Physics      [=|=======] 0.10
-                                   ----
-                            Total: 1.00    [Normalize] [Apply]
+Mode: Visualization                Mode: Tree Distance
+┌──────────────────────────┐      ┌──────────────────────────┐
+│ Viz α: [===|===] 0.50    │      │ Tree α: [===|===] 0.50   │
+│ Customize: [None      ▾] │      │ Customize: [None      ▾] │
+│ [L^n controls if active] │      │ [L^n controls if active] │
+└──────────────────────────┘      └──────────────────────────┘
+
+Mode: Both
+┌──────────────────────────┐
+│ Viz α: [===|===] 0.50    │
+│ Customize: [None      ▾] │
+│ [L^n controls if active] │
+├──────────────────────────┤  ← <hr>
+│ Tree α: [===|===] 0.50   │
+│ Customize: [None      ▾] │
+│ [L^n controls if active] │
+└──────────────────────────┘
 ```
 
-- Each space gets a weight slider (0.0–1.0) and numeric input
-- "Normalize" button rescales weights to sum to 1.0
-- Embedding Distance includes a nested α sub-slider for input↔output mix
-- Spaces that require a model (Weights, Learned) are disabled when no model is
-  selected, similar to existing 2D Projection Mode behavior
-- Wikipedia Physics is disabled when that distance model isn't available
+- Each slider produces `d_emb(α)` from its input↔output blend
+- Each customization dropdown independently combines `d_emb(α)` with other
+  distance spaces for its purpose (layout or tree)
+- When customization is "None", only `d_emb(α)` is used (current behavior)
+- In "Both" mode, the two customization dropdowns are independent — you can
+  have L^n for tree distances while visualization uses no customization
 
-### Scope: Tree Distance Only
+### Visualization Customization
 
-Custom blending applies to **tree distance computation only**, not 2D layout.
-Rationale:
-- 2D layout blending requires projecting each space to 2D independently, then
-  blending coordinates. With 4+ spaces this creates too many SVD projections
-  and the blended 2D result loses interpretability.
-- Tree distances are NxN matrices that blend cleanly with weighted sums.
-- The existing Visualization blend (input↔output) remains available for layout.
+When a custom distance matrix is computed for visualization, 2D coordinates
+are obtained via **MDS** (multidimensional scaling) on the blended distance
+matrix, since SVD on a single embedding space no longer applies when mixing
+multiple spaces. This uses the existing `classical_mds_2d()` function.
 
-### Presets
+### Tree Customization
 
-Common configurations as one-click presets:
-- **Semantic Only**: w_emb=1.0, rest=0 (baseline)
-- **Hierarchical**: w_emb=0.3, w_weights=0.3, w_learned=0.4
-- **Wikipedia-Guided**: w_emb=0.5, w_wiki=0.5
-- **Equal Mix**: all weights equal
+L^n power mean of distance matrices, passed as `dist_matrix_override` to the
+tree builder. This is the primary use case.
 
-## Implementation
+## Available Distance Spaces
+
+| Space | Dim | Distance | Semantics | Requires |
+|-------|-----|----------|-----------|----------|
+| Embedding `d_emb(α)` | 768D | Cosine | Semantic similarity | Always available |
+| Weight Space `d_w` | 64D | Cosine | Transformation recipe similarity | Model |
+| Learned Metric `d_l` | 64D | Euclidean | Organizational proximity | Model |
+| Wikipedia Physics `d_wiki` | N/A | Predicted | Category hierarchy distance | Wiki model |
+
+All spaces are reduced to N×N distance matrices and normalized to [0,1] before
+combination, sidestepping the dimensionality mismatch.
+
+## Customization Methods
+
+### Method 1: None (default)
+
+No customization. Tree uses `d_emb(α)` from the blend controls (or raw
+embedding distance if blend is also None). This is the current behavior.
+
+### Method 2: L^n (Generalized Power Mean)
+
+```
+d_custom = (w₁·d₁ⁿ + w₂·d₂ⁿ + ... + wₖ·dₖⁿ)^(1/n)
+```
+
+Where `dᵢ` are normalized distance matrices and `wᵢ` are weights summing to 1.
+
+The exponent `n` controls the blending behavior:
+
+| n | Name | Behavior |
+|---|------|----------|
+| -1 | Harmonic | Strongly favors spaces where points are close |
+| 0 | Geometric | Geometric mean (balanced, multiplicative) |
+| 0.5 | Lenient | Being close in ANY space helps |
+| **1** | **Linear** | **Weighted average (default)** |
+| 2 | Euclidean | Points must be close in ALL spaces |
+| ∞ | Max | Dominated by largest distance |
+
+#### UI Controls
+
+```
+Method: [L^n          ▾]
+
+  n: [1.0  ]   Presets: [Linear] [Euclidean] [Harmonic]
+
+  Space                    Weight    Effective
+  ─────────────────────────────────────────────
+  Embedding (blended)      [3    ]   = 0.43
+  Weight Space             [2    ]   = 0.29      (disabled if no model)
+  Learned Metric           [2    ]   = 0.29      (disabled if no model)
+  Wikipedia Physics        [0    ]   = 0.00      (disabled if no wiki model)
+                           ─────
+                    Total: 7       [Normalize]
+
+  [Apply Customization]
+```
+
+- **Weight text boxes**: Users enter relative weights (any positive number).
+  Effective (normalized) weights shown beside each input.
+- **Normalize button**: Rescales raw weights to sum to 1.0 in-place.
+- **n text box**: Defaults to 1.0. Named preset buttons set common values.
+- **Disabled spaces**: Grayed out when prerequisites aren't met, with tooltip
+  explaining why (e.g., "Requires a Transformation Model").
+
+#### Special Cases for n
+
+- **n=0** (geometric mean): Use `exp(w₁·log(d₁) + w₂·log(d₂) + ...)` to avoid
+  numerical issues. Requires all distances > 0; replace zeros with ε=1e-10.
+- **n→±∞**: Not implemented directly. Cap at reasonable range (e.g., [-10, 10]).
+
+#### Presets
+
+Quick-set buttons for common configurations:
+
+| Preset | n | Weights | Use case |
+|--------|---|---------|----------|
+| Semantic Only | 1 | emb=1, rest=0 | Baseline |
+| Hierarchical | 1 | emb=0.3, w=0.3, l=0.4 | Organizational tree |
+| Wikipedia-Guided | 1 | emb=0.5, wiki=0.5 | Category-informed |
+| Equal Mix | 1 | all equal | Exploratory |
+| Strict Consensus | 2 | all equal | Must be close in all spaces |
+
+### Method 3: Formulaic (future)
+
+A formula editor where each distance matrix is a named variable:
+
+```
+Variables: E = d_emb(α), W = d_weights, L = d_learned, P = d_wiki
+
+Formula: [sqrt(0.5 * E^2 + 0.3 * W^2 + 0.2 * L^2)          ]
+```
+
+This subsumes L^n (the formula `(w1*E^n + w2*W^n)^(1/n)` is just one case)
+and enables arbitrary combinations:
+- `min(E, W)` — take the closer distance in either space
+- `E * (1 - 0.3 * W)` — semantic distance discounted by weight similarity
+- `E + 0.5 * max(L - 0.3, 0)` — semantic with learned penalty for distant items
+
+#### Implementation Considerations
+
+- **Expression parser**: Use a safe math expression evaluator (e.g., math.js in
+  the browser, or `numexpr`/`ast.literal_eval` in Python). Must NOT use `eval()`.
+- **Matrix operations**: Variables are N×N matrices. The parser must support
+  element-wise operations, not matrix multiplication.
+- **Validation**: Check that the formula produces a valid distance matrix
+  (symmetric, non-negative, zero diagonal) and warn if violated.
+- **Error handling**: Show parse errors inline, don't submit invalid formulas.
+- **Presets as formulas**: The L^n presets can also be shown as their formula
+  equivalents for learning.
+
+**Status: Deferred.** Implement L^n first; Formulaic is a later enhancement.
+
+## Scale Normalization
+
+Before combining, each distance matrix is normalized to [0, 1]:
+
+```python
+d_normalized = d / d.max()
+```
+
+This ensures each space contributes proportionally to its weight regardless of
+native scale. Alternatives considered:
+
+| Method | Pros | Cons |
+|--------|------|------|
+| **Max normalization** | Simple, preserves ordering | Sensitive to outliers |
+| Percentile (95th) | Robust to outliers | Clips extreme distances |
+| Z-score | Statistical normalization | Can produce negatives |
+| Rank normalization | Perfectly comparable | Loses magnitude info |
+
+**Recommendation:** Start with max normalization. If outlier sensitivity is a
+problem in practice, switch to 95th percentile.
+
+## Implementation Plan
 
 ### Backend (`density_core.py`)
 
 Add `compute_custom_distance_matrix()`:
+
 ```python
 def compute_custom_distance_matrix(
     embeddings: np.ndarray,
     input_embeddings: Optional[np.ndarray],
     weights: Optional[np.ndarray],
     metric_model=None,
-    blend_weights: dict,  # {embedding: 0.4, weights: 0.2, learned: 0.3, wiki: 0.1}
-    embedding_alpha: float = 0.5,  # input↔output mix within embedding term
+    space_weights: dict,       # {embedding: 3, weights: 2, learned: 2, wiki: 0}
+    embedding_alpha: float,    # from existing blend slider
+    power_n: float = 1.0,     # L^n exponent
 ) -> np.ndarray:
-    """Compute weighted sum of distance matrices from multiple spaces."""
+    """
+    Compute L^n power mean of distance matrices from multiple spaces.
+
+    Normalizes each distance matrix to [0,1], raises to power n,
+    computes weighted sum, then takes the (1/n)-th root.
+    """
     dist_matrices = {}
 
-    # Embedding distance (with optional input↔output blend)
-    if blend_weights.get('embedding', 0) > 0:
+    # 1. Compute each distance matrix
+    if space_weights.get('embedding', 0) > 0:
         if embedding_alpha is not None and input_embeddings is not None:
             dist_matrices['embedding'] = blend_distance_matrices(
                 input_embeddings, embeddings, embedding_alpha
@@ -133,85 +237,139 @@ def compute_custom_distance_matrix(
         else:
             dist_matrices['embedding'] = cosine_distance_matrix(embeddings)
 
-    # Weight space distance
-    if blend_weights.get('weights', 0) > 0 and weights is not None:
+    if space_weights.get('weights', 0) > 0 and weights is not None:
         dist_matrices['weights'] = cosine_distance_matrix(weights)
 
-    # Learned metric distance
-    if blend_weights.get('learned', 0) > 0 and weights is not None:
+    if space_weights.get('learned', 0) > 0 and weights is not None:
         metric_emb = compute_metric_embeddings(
             input_embeddings, embeddings, weights, metric_model
         )
         dist_matrices['learned'] = euclidean_distance_matrix(metric_emb)
 
-    # Wikipedia physics predicted distance
-    if blend_weights.get('wiki', 0) > 0:
+    if space_weights.get('wiki', 0) > 0:
         dist_matrices['wiki'] = compute_wikipedia_physics_distances(
             input_embeddings or embeddings
         )
 
-    # Normalize scale: each distance matrix to [0, 1] range
+    # 2. Normalize each to [0, 1]
     for key in dist_matrices:
         d = dist_matrices[key]
         d_max = d.max()
         if d_max > 0:
             dist_matrices[key] = d / d_max
 
-    # Weighted sum
-    result = np.zeros_like(next(iter(dist_matrices.values())))
-    total_weight = 0
-    for key, d in dist_matrices.items():
-        w = blend_weights.get(key, 0)
-        result += w * d
-        total_weight += w
+    # 3. Normalize weights to sum to 1
+    active_weights = {k: space_weights[k] for k in dist_matrices}
+    total = sum(active_weights.values())
+    if total > 0:
+        active_weights = {k: v/total for k, v in active_weights.items()}
 
-    if total_weight > 0:
-        result /= total_weight
+    # 4. Compute L^n power mean
+    n = power_n
+    if abs(n) < 1e-10:
+        # Geometric mean: exp(Σ wᵢ·log(dᵢ))
+        log_sum = np.zeros_like(next(iter(dist_matrices.values())))
+        for key, d in dist_matrices.items():
+            w = active_weights[key]
+            log_sum += w * np.log(d + 1e-10)
+        result = np.exp(log_sum)
+    else:
+        # General case: (Σ wᵢ·dᵢⁿ)^(1/n)
+        powered_sum = np.zeros_like(next(iter(dist_matrices.values())))
+        for key, d in dist_matrices.items():
+            w = active_weights[key]
+            powered_sum += w * np.power(d + 1e-10, n)
+        result = np.power(powered_sum, 1.0 / n)
 
     np.fill_diagonal(result, 0)
     return result
 ```
 
-### Scale Normalization
-
-Different distance spaces have different scales:
-- Cosine distance: [0, 2] but typically [0, 1] for normalized embeddings
-- Euclidean in learned metric: unbounded, depends on model
-- Wikipedia physics predicted: model-specific range
-
-Before blending, normalize each distance matrix to [0, 1] by dividing by its
-max value. This ensures each space contributes proportionally to its weight
-regardless of native scale.
-
 ### Backend (`flask_api.py`)
 
-Accept `custom_blend_weights` dict and `custom_embedding_alpha` in the
-`/api/compute` request body. When present, compute the custom distance matrix
-and pass it as `dist_matrix_override` to the tree builder.
+Accept in `/api/compute` request body:
+```json
+{
+  "custom_space_weights": {"embedding": 3, "weights": 2, "learned": 2, "wiki": 0},
+  "custom_power_n": 1.0
+}
+```
+
+When present, compute the custom distance matrix and pass as
+`dist_matrix_override` to the tree builder. The existing `blend_tree_alpha`
+feeds into the embedding distance term.
 
 ### Frontend (`index.html`)
 
-- Add Custom mode UI with weight sliders, normalization button, and presets
-- Send `custom_blend_weights` and `custom_embedding_alpha` in API request
-- Disable unavailable spaces based on model/data availability
+Each blend slider group (Visualization, Tree) gets a customization dropdown
+placed directly beneath its slider + text input:
+
+```html
+<!-- Visualization group -->
+<div id="blendVizGroup">
+  <label>Layout Blend: 0.50</label>
+  <input type="range" ...>
+  <select id="vizCustomize">  <!-- NEW -->
+    <option value="none">Customize: None</option>
+    <option value="ln">Customize: L^n</option>
+    <option value="formula" disabled>Customize: Formulaic (coming soon)</option>
+  </select>
+  <div id="vizCustomizeControls" style="display:none">
+    <!-- n input, weight text boxes, normalize button -->
+  </div>
+</div>
+
+<!-- Horizontal rule (only in Both mode) -->
+<hr id="blendSeparator">
+
+<!-- Tree group -->
+<div id="blendTreeGroup">
+  <label>Tree Blend: 0.50</label>
+  <input type="range" ...>
+  <select id="treeCustomize">  <!-- NEW -->
+    ...same options...
+  </select>
+  <div id="treeCustomizeControls" style="display:none">
+    <!-- n input, weight text boxes, normalize button -->
+  </div>
+</div>
+```
+
+The existing "Apply Blend" button triggers the full computation including
+any active customization. No separate button needed — customization params
+are sent alongside blend params in the same API request.
+
+## Interaction with Existing Controls
+
+- **Tree Distance Metric selector** (Data tab): When tree customization is
+  active (not None), it supersedes the Tree Distance Metric selector. The
+  selector could show "(overridden by Customization)" or be visually dimmed.
+- **Blend α sliders**: Still control the input↔output mix within the embedding
+  distance term. Active even when customization is enabled — the blended
+  embedding distance feeds into the customization as one of the distance spaces.
+- **Each customization is independent**: Viz customization and tree
+  customization can use different methods, different weights, and different n
+  values. The only shared element is the blend mode selector that determines
+  which slider groups are visible.
 
 ## Open Questions
 
-1. **Scale normalization**: Dividing by max is simple but sensitive to outliers.
-   Alternatives: percentile-based, z-score, or rank-based normalization. Rank
-   normalization (`d_rank[i,j] = rank(d[i,j]) / N^2`) would make all spaces
-   strictly comparable but loses magnitude information.
+1. **Scale normalization**: Start with max normalization or use percentile?
 
-2. **Visualization blending**: Should Custom mode also support layout blending?
-   This would require MDS on the blended distance matrix (feasible but slower
-   than SVD on individual embedding spaces).
+2. **Dynamic availability**: Show unavailable spaces as disabled (with tooltip)
+   or hide entirely?
 
-3. **Dynamic availability**: Some distance spaces require specific models or data.
-   Should unavailable spaces be hidden entirely or shown as disabled with
-   explanation?
+3. **Persistence**: Should custom weight configurations be saveable/loadable?
 
-4. **Persistence**: Should custom weight presets be saveable/loadable?
+4. **Formulaic safety**: Which expression parser to use? math.js (browser) is
+   well-tested but adds a dependency. A minimal custom parser for basic
+   arithmetic + element-wise functions might suffice.
 
-5. **Interaction with Tree Distance Metric selector**: The existing selector
-   (Data tab) picks a single distance metric. Custom blend mode supersedes
-   this. Should the selector be disabled/hidden when Custom blend is active?
+5. **MDS performance**: Visualization customization uses MDS on the custom
+   distance matrix. For 200-300 points this is fast, but for larger datasets
+   it may be slower than SVD. Should there be a point count threshold that
+   disables viz customization?
+
+6. **Shared customization**: Should "Both" mode offer a "Link customization"
+   toggle that applies the same method/weights to both viz and tree, reducing
+   the number of controls for the common case?

--- a/tools/density_explorer/flask_api.py
+++ b/tools/density_explorer/flask_api.py
@@ -378,6 +378,12 @@ def compute_manifold():
         blend_layout_alpha = data.get('blend_layout_alpha')
         blend_tree_alpha = data.get('blend_tree_alpha')
 
+        # Extract L^n customization parameters
+        custom_viz_space_weights = data.get('custom_viz_space_weights')
+        custom_viz_power_n = float(data.get('custom_viz_power_n', 1.0))
+        custom_tree_space_weights = data.get('custom_tree_space_weights')
+        custom_tree_power_n = float(data.get('custom_tree_power_n', 1.0))
+
         # Check for projection model
         model = data.get('model')
         blend_weights = None
@@ -495,7 +501,11 @@ def compute_manifold():
                     root_id=root_id,
                     tree_embeddings=tree_embeddings_override,
                     blend_layout_alpha=blend_layout_alpha,
-                    blend_tree_alpha=blend_tree_alpha
+                    blend_tree_alpha=blend_tree_alpha,
+                    custom_viz_space_weights=custom_viz_space_weights,
+                    custom_viz_power_n=custom_viz_power_n,
+                    custom_tree_space_weights=custom_tree_space_weights,
+                    custom_tree_power_n=custom_tree_power_n,
                 )
 
                 return result.to_json(), 200, {'Content-Type': 'application/json'}
@@ -530,7 +540,13 @@ def compute_manifold():
             n_peaks=n_peaks,
             projection_mode=projection_mode,  # Pass actual mode (embedding or wikipedia_physics)
             max_branching=data.get('max_branching'),
-            root_id=root_id
+            root_id=root_id,
+            blend_layout_alpha=blend_layout_alpha,
+            blend_tree_alpha=blend_tree_alpha,
+            custom_viz_space_weights=custom_viz_space_weights,
+            custom_viz_power_n=custom_viz_power_n,
+            custom_tree_space_weights=custom_tree_space_weights,
+            custom_tree_power_n=custom_tree_power_n,
         )
 
         # Return as JSON
@@ -601,6 +617,12 @@ def compute_from_embeddings():
         blend_layout_alpha = data.get('blend_layout_alpha')
         blend_tree_alpha = data.get('blend_tree_alpha')
 
+        # L^n customization parameters
+        custom_viz_space_weights = data.get('custom_viz_space_weights')
+        custom_viz_power_n = float(data.get('custom_viz_power_n', 1.0))
+        custom_tree_space_weights = data.get('custom_tree_space_weights')
+        custom_tree_power_n = float(data.get('custom_tree_power_n', 1.0))
+
         result = compute_density_manifold(
             embeddings=embeddings,
             titles=titles,
@@ -617,7 +639,11 @@ def compute_from_embeddings():
             max_branching=data.get('max_branching'),
             tree_embeddings=tree_embeddings,
             blend_layout_alpha=blend_layout_alpha,
-            blend_tree_alpha=blend_tree_alpha
+            blend_tree_alpha=blend_tree_alpha,
+            custom_viz_space_weights=custom_viz_space_weights,
+            custom_viz_power_n=custom_viz_power_n,
+            custom_tree_space_weights=custom_tree_space_weights,
+            custom_tree_power_n=custom_tree_power_n,
         )
 
         return result.to_json(), 200, {'Content-Type': 'application/json'}

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -731,7 +731,6 @@
                                 <option value="visualization">Visualization (2D layout)</option>
                                 <option value="tree">Tree Distance</option>
                                 <option value="both">Both (independent)</option>
-                                <option value="custom" disabled title="Multi-space weighted blending — coming soon">Custom (coming soon)</option>
                             </select>
                         </div>
 
@@ -744,6 +743,33 @@
                             </div>
                             <input type="number" id="blendLayoutAlphaInput" min="0" max="1" step="0.01" value="0.5"
                                    style="width: 80px; padding: 4px 8px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; margin-top: 4px; font-size: 0.85rem;">
+                            <div style="margin-top: 8px;">
+                                <label for="vizCustomizeMethod" style="font-size: 0.8rem;">Customize Distance</label>
+                                <select id="vizCustomizeMethod" style="width:100%; padding: 6px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; font-size: 0.8rem;">
+                                    <option value="none">None</option>
+                                    <option value="ln">L^n Power Mean</option>
+                                    <option value="formula" disabled>Formulaic (coming soon)</option>
+                                </select>
+                            </div>
+                            <div id="vizCustomizeControls" style="display: none; margin-top: 8px; padding: 8px; background: rgba(15, 52, 96, 0.3); border: 1px solid #0f3460; border-radius: 4px;">
+                                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+                                    <label style="font-size: 0.75rem; white-space: nowrap;">n:</label>
+                                    <input type="number" id="vizPowerN" value="1.0" step="0.5" min="-10" max="10"
+                                           style="width: 60px; padding: 4px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; font-size: 0.8rem;">
+                                    <button type="button" class="secondary" id="vizPresetLinear" style="width:auto; padding: 3px 8px; margin: 0; font-size: 0.7rem;">Linear</button>
+                                    <button type="button" class="secondary" id="vizPresetEuclidean" style="width:auto; padding: 3px 8px; margin: 0; font-size: 0.7rem;">Euclid</button>
+                                    <button type="button" class="secondary" id="vizPresetHarmonic" style="width:auto; padding: 3px 8px; margin: 0; font-size: 0.7rem;">Harmonic</button>
+                                </div>
+                                <div style="font-size: 0.75rem; color: #94a3b8; margin-bottom: 4px;">
+                                    <div style="display: grid; grid-template-columns: 1fr 50px 60px; gap: 4px; align-items: center;">
+                                        <span style="font-weight: bold;">Space</span>
+                                        <span style="font-weight: bold;">Weight</span>
+                                        <span style="font-weight: bold;">Eff.</span>
+                                    </div>
+                                    <div id="vizSpaceWeightsContainer"></div>
+                                </div>
+                                <button type="button" class="secondary" id="vizNormalizeBtn" style="font-size: 0.75rem; padding: 4px 8px;">Normalize</button>
+                            </div>
                         </div>
 
                         <div id="blendTreeGroup" class="control-group" style="display: none;">
@@ -755,6 +781,33 @@
                             </div>
                             <input type="number" id="blendTreeAlphaInput" min="0" max="1" step="0.01" value="0.5"
                                    style="width: 80px; padding: 4px 8px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; margin-top: 4px; font-size: 0.85rem;">
+                            <div style="margin-top: 8px;">
+                                <label for="treeCustomizeMethod" style="font-size: 0.8rem;">Customize Distance</label>
+                                <select id="treeCustomizeMethod" style="width:100%; padding: 6px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; font-size: 0.8rem;">
+                                    <option value="none">None</option>
+                                    <option value="ln">L^n Power Mean</option>
+                                    <option value="formula" disabled>Formulaic (coming soon)</option>
+                                </select>
+                            </div>
+                            <div id="treeCustomizeControls" style="display: none; margin-top: 8px; padding: 8px; background: rgba(15, 52, 96, 0.3); border: 1px solid #0f3460; border-radius: 4px;">
+                                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+                                    <label style="font-size: 0.75rem; white-space: nowrap;">n:</label>
+                                    <input type="number" id="treePowerN" value="1.0" step="0.5" min="-10" max="10"
+                                           style="width: 60px; padding: 4px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; font-size: 0.8rem;">
+                                    <button type="button" class="secondary" id="treePresetLinear" style="width:auto; padding: 3px 8px; margin: 0; font-size: 0.7rem;">Linear</button>
+                                    <button type="button" class="secondary" id="treePresetEuclidean" style="width:auto; padding: 3px 8px; margin: 0; font-size: 0.7rem;">Euclid</button>
+                                    <button type="button" class="secondary" id="treePresetHarmonic" style="width:auto; padding: 3px 8px; margin: 0; font-size: 0.7rem;">Harmonic</button>
+                                </div>
+                                <div style="font-size: 0.75rem; color: #94a3b8; margin-bottom: 4px;">
+                                    <div style="display: grid; grid-template-columns: 1fr 50px 60px; gap: 4px; align-items: center;">
+                                        <span style="font-weight: bold;">Space</span>
+                                        <span style="font-weight: bold;">Weight</span>
+                                        <span style="font-weight: bold;">Eff.</span>
+                                    </div>
+                                    <div id="treeSpaceWeightsContainer"></div>
+                                </div>
+                                <button type="button" class="secondary" id="treeNormalizeBtn" style="font-size: 0.75rem; padding: 4px 8px;">Normalize</button>
+                            </div>
                         </div>
 
                         <div id="blendStatusText" style="font-size: 0.8rem; color: #94a3b8; margin-top: 10px;">Blending disabled.</div>
@@ -917,11 +970,29 @@
         const blendTreeGroup = document.getElementById('blendTreeGroup');
         const blendStatusText = document.getElementById('blendStatusText');
         const applyBlendBtn = document.getElementById('applyBlendBtn');
+        // Customization elements
+        const vizCustomizeMethod = document.getElementById('vizCustomizeMethod');
+        const vizCustomizeControls = document.getElementById('vizCustomizeControls');
+        const vizPowerN = document.getElementById('vizPowerN');
+        const vizSpaceWeightsContainer = document.getElementById('vizSpaceWeightsContainer');
+        const vizNormalizeBtn = document.getElementById('vizNormalizeBtn');
+        const treeCustomizeMethod = document.getElementById('treeCustomizeMethod');
+        const treeCustomizeControls = document.getElementById('treeCustomizeControls');
+        const treePowerN = document.getElementById('treePowerN');
+        const treeSpaceWeightsContainer = document.getElementById('treeSpaceWeightsContainer');
+        const treeNormalizeBtn = document.getElementById('treeNormalizeBtn');
 
         // Blend state
         let blendMode = 'none';
         let blendLayoutAlpha = 0.5;
         let blendTreeAlpha = 0.5;
+        // Customization state
+        let vizCustomize = 'none';
+        let treeCustomize = 'none';
+        let vizSpaceWeights = { embedding: 1, weights: 0, learned: 0, wiki: 0 };
+        let treeSpaceWeights = { embedding: 1, weights: 0, learned: 0, wiki: 0 };
+        let vizPowerNValue = 1.0;
+        let treePowerNValue = 1.0;
 
         // Legacy reference for compatibility
         const embeddingSelect = layoutEmbeddingSelect;
@@ -1632,6 +1703,38 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
             document.getElementById('flaskModel')?.addEventListener('change', updateBlendAvailability);
             updateBlendAvailability();
 
+            // Customization event listeners
+            if (vizCustomizeMethod) {
+                vizCustomizeMethod.addEventListener('change', () => handleCustomizeMethodChange('viz'));
+            }
+            if (treeCustomizeMethod) {
+                treeCustomizeMethod.addEventListener('change', () => handleCustomizeMethodChange('tree'));
+            }
+            if (vizPowerN) {
+                vizPowerN.addEventListener('change', () => { vizPowerNValue = parseFloat(vizPowerN.value) || 1.0; });
+            }
+            if (treePowerN) {
+                treePowerN.addEventListener('change', () => { treePowerNValue = parseFloat(treePowerN.value) || 1.0; });
+            }
+            if (vizNormalizeBtn) {
+                vizNormalizeBtn.addEventListener('click', () => normalizeWeights('viz'));
+            }
+            if (treeNormalizeBtn) {
+                treeNormalizeBtn.addEventListener('click', () => normalizeWeights('tree'));
+            }
+            // Preset buttons
+            document.getElementById('vizPresetLinear')?.addEventListener('click', () => setPresetN('viz', 1.0));
+            document.getElementById('vizPresetEuclidean')?.addEventListener('click', () => setPresetN('viz', 2.0));
+            document.getElementById('vizPresetHarmonic')?.addEventListener('click', () => setPresetN('viz', -1.0));
+            document.getElementById('treePresetLinear')?.addEventListener('click', () => setPresetN('tree', 1.0));
+            document.getElementById('treePresetEuclidean')?.addEventListener('click', () => setPresetN('tree', 2.0));
+            document.getElementById('treePresetHarmonic')?.addEventListener('click', () => setPresetN('tree', -1.0));
+            // Refresh customization UI when model changes
+            document.getElementById('flaskModel')?.addEventListener('change', () => {
+                if (vizCustomize === 'ln') buildSpaceWeightsUI('viz', vizSpaceWeightsContainer, vizSpaceWeights);
+                if (treeCustomize === 'ln') buildSpaceWeightsUI('tree', treeSpaceWeightsContainer, treeSpaceWeights);
+            });
+
             // Projection mode
             projectionModeSelect.addEventListener('change', handleProjectionModeChange);
             clearAxisBtn.addEventListener('click', clearAxisSelection);
@@ -1800,14 +1903,17 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
         function updateBlendStatus() {
             if (!blendStatusText) return;
 
+            const vizSuffix = vizCustomize === 'ln' ? ' + L^n' : '';
+            const treeSuffix = treeCustomize === 'ln' ? ' + L^n' : '';
+
             if (blendMode === 'none') {
                 blendStatusText.textContent = 'Blending disabled.';
             } else if (blendMode === 'visualization') {
-                blendStatusText.textContent = `Layout: ${(blendLayoutAlpha * 100).toFixed(0)}% input / ${((1 - blendLayoutAlpha) * 100).toFixed(0)}% output`;
+                blendStatusText.textContent = `Layout: ${(blendLayoutAlpha * 100).toFixed(0)}% input / ${((1 - blendLayoutAlpha) * 100).toFixed(0)}% output${vizSuffix}`;
             } else if (blendMode === 'tree') {
-                blendStatusText.textContent = `Tree: ${(blendTreeAlpha * 100).toFixed(0)}% input / ${((1 - blendTreeAlpha) * 100).toFixed(0)}% output`;
+                blendStatusText.textContent = `Tree: ${(blendTreeAlpha * 100).toFixed(0)}% input / ${((1 - blendTreeAlpha) * 100).toFixed(0)}% output${treeSuffix}`;
             } else if (blendMode === 'both') {
-                blendStatusText.textContent = `Layout: ${(blendLayoutAlpha * 100).toFixed(0)}%in/${((1 - blendLayoutAlpha) * 100).toFixed(0)}%out | Tree: ${(blendTreeAlpha * 100).toFixed(0)}%in/${((1 - blendTreeAlpha) * 100).toFixed(0)}%out`;
+                blendStatusText.textContent = `Layout: ${(blendLayoutAlpha * 100).toFixed(0)}%in/${((1 - blendLayoutAlpha) * 100).toFixed(0)}%out${vizSuffix} | Tree: ${(blendTreeAlpha * 100).toFixed(0)}%in/${((1 - blendTreeAlpha) * 100).toFixed(0)}%out${treeSuffix}`;
             }
         }
 
@@ -1818,12 +1924,14 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
 
             if (blendMode !== 'none') {
                 blendItem.style.display = '';
+                const vizSuffix = vizCustomize === 'ln' ? '+L^n' : '';
+                const treeSuffix = treeCustomize === 'ln' ? '+L^n' : '';
                 if (blendMode === 'visualization') {
-                    blendInfo.textContent = `Viz: ${(blendLayoutAlpha * 100).toFixed(0)}%in`;
+                    blendInfo.textContent = `Viz: ${(blendLayoutAlpha * 100).toFixed(0)}%in${vizSuffix}`;
                 } else if (blendMode === 'tree') {
-                    blendInfo.textContent = `Tree: ${(blendTreeAlpha * 100).toFixed(0)}%in`;
+                    blendInfo.textContent = `Tree: ${(blendTreeAlpha * 100).toFixed(0)}%in${treeSuffix}`;
                 } else if (blendMode === 'both') {
-                    blendInfo.textContent = `V:${(blendLayoutAlpha * 100).toFixed(0)}% T:${(blendTreeAlpha * 100).toFixed(0)}%`;
+                    blendInfo.textContent = `V:${(blendLayoutAlpha * 100).toFixed(0)}%${vizSuffix} T:${(blendTreeAlpha * 100).toFixed(0)}%${treeSuffix}`;
                 }
             } else {
                 blendItem.style.display = 'none';
@@ -1836,15 +1944,170 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
             const params = {};
             if (blendMode === 'visualization' || blendMode === 'both') {
                 params.blend_layout_alpha = blendLayoutAlpha;
+                if (vizCustomize === 'ln') {
+                    params.custom_viz_space_weights = { ...vizSpaceWeights };
+                    params.custom_viz_power_n = vizPowerNValue;
+                }
             }
             if (blendMode === 'tree' || blendMode === 'both') {
                 params.blend_tree_alpha = blendTreeAlpha;
+                if (treeCustomize === 'ln') {
+                    params.custom_tree_space_weights = { ...treeSpaceWeights };
+                    params.custom_tree_power_n = treePowerNValue;
+                }
             }
             return params;
         }
 
         async function applyBlend() {
             await loadFromFlaskApi();
+        }
+
+        // ============================================================
+        // Customization Functions (L^n Power Mean)
+        // ============================================================
+
+        const SPACE_DEFINITIONS = [
+            { key: 'embedding', label: 'Embedding (blended)', requiresModel: false, requiresWiki: false },
+            { key: 'weights', label: 'Weight Space', requiresModel: true, requiresWiki: false },
+            { key: 'learned', label: 'Learned Metric', requiresModel: true, requiresWiki: false },
+            { key: 'wiki', label: 'Wikipedia Physics', requiresModel: false, requiresWiki: true },
+        ];
+
+        function hasTransformationModel() {
+            const model = document.getElementById('flaskModel')?.value;
+            return model && model !== 'None' && model !== '';
+        }
+
+        function hasWikiModel() {
+            const dataset = document.getElementById('flaskDataset')?.value || '';
+            return dataset.includes('physics');
+        }
+
+        function isSpaceAvailable(spaceDef) {
+            if (spaceDef.requiresModel && !hasTransformationModel()) return false;
+            if (spaceDef.requiresWiki && !hasWikiModel()) return false;
+            return true;
+        }
+
+        function buildSpaceWeightsUI(prefix, container, currentWeights) {
+            container.innerHTML = '';
+            SPACE_DEFINITIONS.forEach(spaceDef => {
+                const available = isSpaceAvailable(spaceDef);
+                const weight = currentWeights[spaceDef.key] || 0;
+
+                const row = document.createElement('div');
+                row.style.cssText = 'display: grid; grid-template-columns: 1fr 50px 60px; gap: 4px; align-items: center; margin-top: 3px;';
+
+                const label = document.createElement('span');
+                label.textContent = spaceDef.label;
+                label.style.cssText = available ? '' : 'opacity: 0.4;';
+                if (!available) {
+                    label.title = spaceDef.requiresModel ? 'Requires Transformation Model' : 'Requires Wikipedia Physics dataset';
+                }
+
+                const input = document.createElement('input');
+                input.type = 'number';
+                input.min = '0';
+                input.step = '1';
+                input.value = weight;
+                input.disabled = !available;
+                input.dataset.spaceKey = spaceDef.key;
+                input.dataset.prefix = prefix;
+                input.style.cssText = 'width: 50px; padding: 2px 4px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 3px; font-size: 0.75rem;';
+                input.addEventListener('change', () => handleSpaceWeightChange(prefix, spaceDef.key, input));
+                input.addEventListener('input', () => handleSpaceWeightChange(prefix, spaceDef.key, input));
+
+                const effective = document.createElement('span');
+                effective.id = `${prefix}EffWeight_${spaceDef.key}`;
+                effective.style.cssText = 'font-size: 0.7rem; color: #e94560;';
+
+                row.appendChild(label);
+                row.appendChild(input);
+                row.appendChild(effective);
+                container.appendChild(row);
+            });
+            updateEffectiveWeights(prefix);
+        }
+
+        function handleSpaceWeightChange(prefix, key, input) {
+            const val = Math.max(0, parseFloat(input.value) || 0);
+            input.value = val;
+            if (prefix === 'viz') {
+                vizSpaceWeights[key] = val;
+            } else {
+                treeSpaceWeights[key] = val;
+            }
+            updateEffectiveWeights(prefix);
+        }
+
+        function updateEffectiveWeights(prefix) {
+            const weights = prefix === 'viz' ? vizSpaceWeights : treeSpaceWeights;
+            let total = 0;
+            SPACE_DEFINITIONS.forEach(sd => {
+                if (isSpaceAvailable(sd)) {
+                    total += (weights[sd.key] || 0);
+                }
+            });
+            SPACE_DEFINITIONS.forEach(sd => {
+                const el = document.getElementById(`${prefix}EffWeight_${sd.key}`);
+                if (el) {
+                    const w = weights[sd.key] || 0;
+                    const eff = total > 0 ? (w / total) : 0;
+                    el.textContent = `= ${eff.toFixed(2)}`;
+                }
+            });
+        }
+
+        function normalizeWeights(prefix) {
+            const weights = prefix === 'viz' ? vizSpaceWeights : treeSpaceWeights;
+            let total = 0;
+            SPACE_DEFINITIONS.forEach(sd => {
+                if (isSpaceAvailable(sd)) {
+                    total += (weights[sd.key] || 0);
+                }
+            });
+            if (total > 0) {
+                SPACE_DEFINITIONS.forEach(sd => {
+                    if (isSpaceAvailable(sd)) {
+                        weights[sd.key] = parseFloat((weights[sd.key] / total).toFixed(3));
+                    }
+                });
+            }
+            const container = prefix === 'viz' ? vizSpaceWeightsContainer : treeSpaceWeightsContainer;
+            buildSpaceWeightsUI(prefix, container, weights);
+        }
+
+        function handleCustomizeMethodChange(prefix) {
+            const select = prefix === 'viz' ? vizCustomizeMethod : treeCustomizeMethod;
+            const controls = prefix === 'viz' ? vizCustomizeControls : treeCustomizeControls;
+            const method = select.value;
+
+            if (prefix === 'viz') {
+                vizCustomize = method;
+            } else {
+                treeCustomize = method;
+            }
+
+            controls.style.display = method === 'ln' ? 'block' : 'none';
+
+            if (method === 'ln') {
+                const container = prefix === 'viz' ? vizSpaceWeightsContainer : treeSpaceWeightsContainer;
+                const weights = prefix === 'viz' ? vizSpaceWeights : treeSpaceWeights;
+                buildSpaceWeightsUI(prefix, container, weights);
+            }
+
+            updateBlendStatus();
+        }
+
+        function setPresetN(prefix, value) {
+            const input = prefix === 'viz' ? vizPowerN : treePowerN;
+            input.value = value;
+            if (prefix === 'viz') {
+                vizPowerNValue = value;
+            } else {
+                treePowerNValue = value;
+            }
         }
 
         // Projection Model Functions


### PR DESCRIPTION
  ## Summary

  - **Blend tab** for input↔output embedding space blending with four modes (None, Visualization, Tree Distance, Both) and
  independent alpha sliders
  - **L^n customization** beneath each blend slider — combines embedding, weight space, learned metric, and Wikipedia physics
  distances using generalized power mean
  - **Inline UI** with power n presets (Linear/Euclidean/Harmonic), per-space weight text boxes, effective weight display, and
  normalize button
  - **Backend** helpers: `cosine_distance_matrix()`, `euclidean_distance_matrix()`, `compute_custom_distance_matrix()` with
  scale normalization and geometric mean special case

  ## Key finding

  The Bivector Paired model preserves input geometry so well that input↔output tree blending barely changes the MST (8/299
  edges differ). The significant tree differences come from mixing *across* distance spaces. With equal-weight Euclidean
  blending (n=2), the consensus MST produces high-confidence long branches like Physics → List of physicists → David Lee and
  Physics → Nuclear Physics → Nuclear — hierarchical paths validated by all four distance perspectives simultaneously.

  ## Test plan

  - [x] Regression: embedding-only custom matches non-customized (299/299 edges)
  - [x] Weight-only custom produces different tree (226/299 edges differ)
  - [x] Different n values (1 vs 2) produce different trees (57 edges differ)
  - [x] Browser: weights, effective weights, presets, normalize all functional
  - [x] Both mode: two independent customization dropdowns
  - [x] No model: weight/learned spaces correctly disabled
  - [x] Info bar and status text show "+ L^n" when active

  🤖 Generated with [Claude Code](https://claude.com/claude-code)