### PR TITLE
perf(csharp-query): memoize multi-seed transitive closure execution

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -7845,6 +7845,36 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("TransitiveClosureSeeded", traceKey, hit: false, built: true);
 
+                const int MaxMemoizedSeedCount = 32;
+                var canMemoizeSeeds =
+                    _cacheContext is not null &&
+                    seeds.Count > 1 &&
+                    seeds.Count <= MaxMemoizedSeedCount;
+
+                if (canMemoizeSeeds)
+                {
+                    trace?.RecordStrategy(closure, "TransitiveClosureSeededMemoizedMulti");
+                    var memoizedRows = new List<object[]>();
+
+                    foreach (var seed in seeds)
+                    {
+                        var seedParams = new List<object[]>(1) { new object[] { seed! } };
+                        foreach (var row in ExecuteSeededTransitiveClosure(closure, seedParams, context))
+                        {
+                            memoizedRows.Add(row);
+                        }
+                    }
+
+                    if (!context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var memoizedStoreBySeed))
+                    {
+                        memoizedStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                        context.TransitiveClosureSeededResults.Add(cacheKey, memoizedStoreBySeed);
+                    }
+
+                    memoizedStoreBySeed[new RowWrapper(seedsKey)] = memoizedRows;
+                    return memoizedRows;
+                }
+
                 if (seeds.Count == 1)
                 {
                     trace?.RecordStrategy(closure, "TransitiveClosureSeededSingle");
@@ -8058,6 +8088,36 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 trace?.RecordCacheLookup("TransitiveClosureSeededByTarget", traceKey, hit: false, built: true);
+
+                const int MaxMemoizedTargetSeedCount = 32;
+                var canMemoizeSeeds =
+                    _cacheContext is not null &&
+                    seeds.Count > 1 &&
+                    seeds.Count <= MaxMemoizedTargetSeedCount;
+
+                if (canMemoizeSeeds)
+                {
+                    trace?.RecordStrategy(closure, "TransitiveClosureSeededByTargetMemoizedMulti");
+                    var memoizedRows = new List<object[]>();
+
+                    foreach (var seed in seeds)
+                    {
+                        var seedParams = new List<object[]>(1) { new object[] { seed! } };
+                        foreach (var row in ExecuteSeededTransitiveClosureByTarget(closure, seedParams, context))
+                        {
+                            memoizedRows.Add(row);
+                        }
+                    }
+
+                    if (!context.TransitiveClosureSeededByTargetResults.TryGetValue(cacheKey, out var memoizedStoreBySeed))
+                    {
+                        memoizedStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                        context.TransitiveClosureSeededByTargetResults.Add(cacheKey, memoizedStoreBySeed);
+                    }
+
+                    memoizedStoreBySeed[new RowWrapper(seedsKey)] = memoizedRows;
+                    return memoizedRows;
+                }
 
                 if (seeds.Count == 1)
                 {

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -252,6 +252,8 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_cache_reuse_runtime,
         verify_parameterized_reachability_seed_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime,
+        verify_parameterized_reachability_seed_cache_overlap_reuse_runtime,
+        verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime,
         verify_transitive_closure_cache_reuse_runtime,
         verify_grouped_transitive_closure_cache_reuse_runtime,
         verify_mutual_recursion_plan,
@@ -2874,6 +2876,32 @@ verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime 
     maybe_run_query_runtime_with_harness(Plan,
         ['alice,bob',
          'alice,charlie',
+         'bob,charlie',
+         'CACHE_HIT:TransitiveClosureSeededByTarget=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_seed_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[alice], [bob]],
+    ExecParams = [[alice], [charlie]],
+    harness_source_with_cache_flag_warm_exec(ModuleClass, WarmParams, ExecParams, 'TransitiveClosureSeeded', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['alice,bob',
+         'alice,charlie',
+         'CACHE_HIT:TransitiveClosureSeeded=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param_end/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[charlie], [bob]],
+    ExecParams = [[charlie], [alice]],
+    harness_source_with_cache_flag_warm_exec(ModuleClass, WarmParams, ExecParams, 'TransitiveClosureSeededByTarget', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['alice,charlie',
          'bob,charlie',
          'CACHE_HIT:TransitiveClosureSeededByTarget=true'],
         ExecParams,


### PR DESCRIPTION
  - Adds a minimal transitive-closure fast path that reuses cached single-seed closures for multi-seed parameterized
    reachability.
  - Implements cache-aware memoized multi-seed execution for:
      - source-seeded closure (TransitiveClosureSeededMemoizedMulti)
      - target-seeded closure (TransitiveClosureSeededByTargetMemoizedMulti)
  - Preserves existing semantics by unioning per-seed results and caching the combined seed-set result.
  - Extends tests/core/test_csharp_query_target.pl with overlap-reuse coverage for both source and target seeded modes:
      - verifies cache reuse when warm and exec seed sets partially overlap.
  - Validation:
      - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
        csharp_query_smoke_transitive_opt -ProjectFilter "cq_test_reachab*" passed.