### PR TITLE
perf(csharp-query): memoize grouped multi-seed transitive closure

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -269,6 +269,8 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime,
+        verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime,
+        verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_cache_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_reuse_runtime,
         verify_parameterized_reachability_pairs_cache_reuse_runtime,
@@ -3055,6 +3057,34 @@ verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insens
          'b,c,red,cat1',
          'a,e,blue,cat1',
          'd,e,blue,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, red, cat1], [a, blue, cat1]],
+    ExecParams = [[a, red, cat1], [b, red, cat1]],
+    harness_source_with_cache_flag_warm_exec(ModuleClass, WarmParams, ExecParams, 'GroupedTransitiveClosureSeeded', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,red,cat1',
+         'a,c,red,cat1',
+         'b,c,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeeded=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param_end/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[c, red, cat1], [e, blue, cat1]],
+    ExecParams = [[c, red, cat1], [b, red, cat1]],
+    harness_source_with_cache_flag_warm_exec(ModuleClass, WarmParams, ExecParams, 'GroupedTransitiveClosureSeededByTarget', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,red,cat1',
+         'a,c,red,cat1',
+         'b,c,red,cat1',
          'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=true'],
         ExecParams,
         HarnessSource).


### PR DESCRIPTION
  - Extends transitive-closure memoization to grouped seeded execution paths for both source-seeded and target-seeded
    queries.
  - Adds cache-aware multi-seed fast paths in src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs:
      - GroupedTransitiveClosureSeededMemoizedMulti
      - GroupedTransitiveClosureSeededByTargetMemoizedMulti
  - Reuses cached single-seed grouped closures for overlapping multi-seed requests, then stores the combined seed-set
    result.
  - Adds BuildGroupedSeedTuple helper to build per-seed grouped parameter tuples safely and consistently.
  - Adds overlap-cache regression coverage in tests/core/test_csharp_query_target.pl for:
      - source-seeded grouped reachability overlap reuse
      - target-seeded grouped reachability overlap reuse
  - Validation run passed:
      - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
        csharp_query_smoke_grouped_transitive_opt -ProjectFilter "cq_test_label_c*"