### PR TITLE
feat(density-explorer): Add convexity-blended projection mode

### DIFF
--- a/tools/density_explorer/flask_api.py
+++ b/tools/density_explorer/flask_api.py
@@ -371,8 +371,8 @@ def compute_manifold():
 
         # Extract projection mode
         projection_mode = data.get('projection_mode', 'embedding')
-        if projection_mode not in ('embedding', 'weights', 'learned', 'wikipedia_physics', 'wikipedia_physics_mds'):
-            return jsonify({'error': f'Invalid projection_mode: {projection_mode}. Use "embedding", "weights", "learned", "wikipedia_physics", or "wikipedia_physics_mds"'}), 400
+        if projection_mode not in ('embedding', 'weights', 'learned', 'wikipedia_physics', 'wikipedia_physics_mds', 'convexity_blend'):
+            return jsonify({'error': f'Invalid projection_mode: {projection_mode}. Use "embedding", "weights", "learned", "wikipedia_physics", "wikipedia_physics_mds", or "convexity_blend"'}), 400
 
         # Extract blend parameters
         blend_layout_alpha = data.get('blend_layout_alpha')
@@ -383,6 +383,11 @@ def compute_manifold():
         custom_viz_power_n = float(data.get('custom_viz_power_n', 1.0))
         custom_tree_space_weights = data.get('custom_tree_space_weights')
         custom_tree_power_n = float(data.get('custom_tree_power_n', 1.0))
+
+        # Extract convexity blend parameters
+        convexity_alpha = float(data.get('convexity_alpha', 0.5))
+        convexity_metric = data.get('convexity_metric', 'determinant')
+        convexity_subspace_k = int(data.get('convexity_subspace_k', 20))
 
         # Check for projection model
         model = data.get('model')
@@ -506,6 +511,9 @@ def compute_manifold():
                     custom_viz_power_n=custom_viz_power_n,
                     custom_tree_space_weights=custom_tree_space_weights,
                     custom_tree_power_n=custom_tree_power_n,
+                    convexity_alpha=convexity_alpha,
+                    convexity_metric=convexity_metric,
+                    convexity_subspace_k=convexity_subspace_k,
                 )
 
                 return result.to_json(), 200, {'Content-Type': 'application/json'}
@@ -547,6 +555,9 @@ def compute_manifold():
             custom_viz_power_n=custom_viz_power_n,
             custom_tree_space_weights=custom_tree_space_weights,
             custom_tree_power_n=custom_tree_power_n,
+            convexity_alpha=convexity_alpha,
+            convexity_metric=convexity_metric,
+            convexity_subspace_k=convexity_subspace_k,
         )
 
         # Return as JSON
@@ -623,6 +634,11 @@ def compute_from_embeddings():
         custom_tree_space_weights = data.get('custom_tree_space_weights')
         custom_tree_power_n = float(data.get('custom_tree_power_n', 1.0))
 
+        # Convexity blend parameters
+        convexity_alpha = float(data.get('convexity_alpha', 0.5))
+        convexity_metric = data.get('convexity_metric', 'determinant')
+        convexity_subspace_k = int(data.get('convexity_subspace_k', 20))
+
         result = compute_density_manifold(
             embeddings=embeddings,
             titles=titles,
@@ -637,6 +653,7 @@ def compute_from_embeddings():
             weights=weights,
             input_embeddings=input_embeddings,
             max_branching=data.get('max_branching'),
+            root_id=data.get('root_id'),
             tree_embeddings=tree_embeddings,
             blend_layout_alpha=blend_layout_alpha,
             blend_tree_alpha=blend_tree_alpha,
@@ -644,6 +661,9 @@ def compute_from_embeddings():
             custom_viz_power_n=custom_viz_power_n,
             custom_tree_space_weights=custom_tree_space_weights,
             custom_tree_power_n=custom_tree_power_n,
+            convexity_alpha=convexity_alpha,
+            convexity_metric=convexity_metric,
+            convexity_subspace_k=convexity_subspace_k,
         )
 
         return result.to_json(), 200, {'Content-Type': 'application/json'}

--- a/tools/density_explorer/shared/data_format.py
+++ b/tools/density_explorer/shared/data_format.py
@@ -78,7 +78,8 @@ class ProjectionInfo:
     """SVD projection metadata."""
     variance_explained: List[float]  # [pc1_var, pc2_var]
     singular_values: List[float]
-    mode: str = "embedding"  # "embedding" or "weights"
+    mode: str = "embedding"  # "embedding", "weights", "convexity_blend", etc.
+    extra: Optional[Dict[str, Any]] = None  # Additional info (e.g. convexity scores)
 
 
 @dataclass
@@ -123,7 +124,12 @@ class DensityManifoldData:
                 tree_type=data['tree']['tree_type']
             ) if data.get('tree') else None,
             peaks=[DensityPeak(**p) for p in data['peaks']] if data.get('peaks') else None,
-            projection=ProjectionInfo(**data['projection']),
+            projection=ProjectionInfo(
+                variance_explained=data['projection']['variance_explained'],
+                singular_values=data['projection']['singular_values'],
+                mode=data['projection'].get('mode', 'embedding'),
+                extra=data['projection'].get('extra'),
+            ),
             n_points=data['n_points']
         )
 
@@ -191,7 +197,8 @@ JSON_SCHEMA = {
             "properties": {
                 "variance_explained": {"type": "array", "items": {"type": "number"}},
                 "singular_values": {"type": "array", "items": {"type": "number"}},
-                "mode": {"type": "string", "enum": ["embedding", "weights"]}
+                "mode": {"type": "string"},
+                "extra": {"type": ["object", "null"]}
             }
         },
         "n_points": {"type": "integer"}

--- a/tools/density_explorer/web/index.html
+++ b/tools/density_explorer/web/index.html
@@ -549,7 +549,36 @@
                                 <option value="learned">Learned Metric (organizational structure)</option>
                                 <option value="wikipedia_physics">Wikipedia Physics (trained hierarchy)</option>
                                 <option value="wikipedia_physics_mds">Wikipedia Physics (MDS - distance faithful)</option>
+                                <option value="convexity_blend">Convexity Blend (hierarchy visibility)</option>
                             </select>
+                        </div>
+                        <div class="control-group" id="convexityControlsGroup" style="display:none;">
+                            <div style="padding: 8px; background: rgba(15, 52, 96, 0.3); border: 1px solid #0f3460; border-radius: 4px;">
+                                <label>Variance <span style="font-size:0.75rem; color:#94a3b8;">|</span> Convexity:
+                                    <span class="value" id="convexityAlphaValue">0.50</span>
+                                </label>
+                                <div style="display: flex; gap: 8px; align-items: center;">
+                                    <span style="font-size: 0.75rem; color: #94a3b8; white-space: nowrap;">Variance</span>
+                                    <input type="range" id="convexityAlpha" min="0" max="1" value="0.5" step="0.05" style="flex: 1;">
+                                    <span style="font-size: 0.75rem; color: #94a3b8; white-space: nowrap;">Convexity</span>
+                                </div>
+                                <div style="margin-top: 8px;">
+                                    <label for="convexityMetric" style="font-size: 0.8rem;">Convexity Metric</label>
+                                    <select id="convexityMetric" style="width:100%; padding: 4px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; font-size: 0.8rem;">
+                                        <option value="determinant">Determinant (both axes convex)</option>
+                                        <option value="min_eigenvalue">Min Eigenvalue (weakest axis)</option>
+                                        <option value="trace">Trace / Laplacian (total curvature)</option>
+                                        <option value="geometric_mean">Geometric Mean (balanced)</option>
+                                    </select>
+                                </div>
+                                <div style="margin-top: 8px;">
+                                    <label for="convexitySubspaceK" style="font-size: 0.8rem;">Subspace Dim (k)</label>
+                                    <input type="number" id="convexitySubspaceK" value="20" min="3" max="100"
+                                           style="width: 80px; padding: 4px 8px; background: #1a1a2e; border: 1px solid #0f3460; color: #eee; border-radius: 4px; font-size: 0.85rem;">
+                                </div>
+                                <div id="convexityInfoDisplay" style="font-size: 0.75rem; color: #94a3b8; margin-top: 8px;">
+                                </div>
+                            </div>
                         </div>
                         <div class="control-group" id="layoutDatasetGroup" style="display:none;">
                             <label for="flaskLayoutDataset">2D Layout Dataset <span style="font-size:0.75rem; color:#94a3b8;">(override for SVD layout)</span></label>
@@ -844,6 +873,10 @@
                 <div class="info-item" id="infoBlendItem" style="display: none;">
                     <span class="label">Blend</span>
                     <span class="value" id="infoBlend">-</span>
+                </div>
+                <div class="info-item" id="infoConvexityItem" style="display: none;">
+                    <span class="label">Convexity</span>
+                    <span class="value" id="infoConvexity">-</span>
                 </div>
             </div>
             <div class="status" id="status">
@@ -1675,10 +1708,24 @@ set_real_embeddings(_js_embeddings.to_py(), list(_js_titles))
                         projModeSelect.value = 'embedding';
                     }
                 }
+                // Show/hide convexity controls
+                const convexityGroup = document.getElementById('convexityControlsGroup');
+                if (convexityGroup) {
+                    convexityGroup.style.display = (projMode === 'convexity_blend') ? 'block' : 'none';
+                }
             }
             document.getElementById('flaskModel')?.addEventListener('change', updateLayoutDatasetVisibility);
             document.getElementById('flaskProjectionMode')?.addEventListener('change', updateLayoutDatasetVisibility);
             updateLayoutDatasetVisibility();
+
+            // Convexity alpha slider sync
+            const convexAlpha = document.getElementById('convexityAlpha');
+            if (convexAlpha) {
+                convexAlpha.addEventListener('input', () => {
+                    document.getElementById('convexityAlphaValue').textContent =
+                        parseFloat(convexAlpha.value).toFixed(2);
+                });
+            }
 
             // Blend controls
             if (blendModeSelect) {
@@ -3084,6 +3131,17 @@ json.dumps(data)
                         requestBody.max_branching = maxBranching;
                     }
 
+                    if (rootId != null) {
+                        requestBody.root_id = rootId;
+                    }
+
+                    // Convexity blend parameters
+                    if (projectionMode === 'convexity_blend') {
+                        requestBody.convexity_alpha = parseFloat(document.getElementById('convexityAlpha')?.value || 0.5);
+                        requestBody.convexity_metric = document.getElementById('convexityMetric')?.value || 'determinant';
+                        requestBody.convexity_subspace_k = parseInt(document.getElementById('convexitySubspaceK')?.value || 20);
+                    }
+
                     setStatus('Sending dual embeddings to Flask API...', 'loading');
                     console.log('Calling /api/compute/from-embeddings');
                     response = await fetch(`${apiUrl}/api/compute/from-embeddings`, {
@@ -3127,6 +3185,13 @@ json.dumps(data)
                     // Blend parameters
                     const blendParams = getBlendParams();
                     Object.assign(requestBody, blendParams);
+
+                    // Convexity blend parameters
+                    if (projectionMode === 'convexity_blend') {
+                        requestBody.convexity_alpha = parseFloat(document.getElementById('convexityAlpha')?.value || 0.5);
+                        requestBody.convexity_metric = document.getElementById('convexityMetric')?.value || 'determinant';
+                        requestBody.convexity_subspace_k = parseInt(document.getElementById('convexitySubspaceK')?.value || 20);
+                    }
 
                     response = await fetch(`${apiUrl}/api/compute`, {
                         method: 'POST',
@@ -3995,8 +4060,39 @@ json.dumps(data)
                 document.getElementById('infoVar1').textContent = 'Custom';
                 document.getElementById('infoVar2').textContent = 'Axis';
             } else {
+                const isConvexity = currentData.projection.mode === 'convexity_blend';
+                const prefix = isConvexity ? 'Conv' : 'SVD';
+                document.getElementById('infoVar1').parentElement.querySelector('.label').textContent = `${prefix} Var 1`;
+                document.getElementById('infoVar2').parentElement.querySelector('.label').textContent = `${prefix} Var 2`;
                 document.getElementById('infoVar1').textContent = currentData.projection.variance_explained[0].toFixed(1) + '%';
                 document.getElementById('infoVar2').textContent = currentData.projection.variance_explained[1].toFixed(1) + '%';
+            }
+
+            // Convexity info
+            const convItem = document.getElementById('infoConvexityItem');
+            if (convItem) {
+                if (currentData.projection.mode === 'convexity_blend' && currentData.projection.extra) {
+                    convItem.style.display = '';
+                    const extra = currentData.projection.extra;
+                    document.getElementById('infoConvexity').textContent =
+                        extra.convexity_score?.toExponential(2) || '-';
+
+                    // Populate sidebar detail panel
+                    const convInfoDisplay = document.getElementById('convexityInfoDisplay');
+                    if (convInfoDisplay) {
+                        convInfoDisplay.innerHTML = `
+                            <div>Variance captured: ${extra.variance_score?.toFixed(1) || '-'}%</div>
+                            <div>Convexity score: ${extra.convexity_score?.toExponential(3) || '-'}</div>
+                            <div>SVD variance: ${extra.svd_variance?.toFixed(1) || '-'}%</div>
+                            <div>SVD convexity: ${extra.svd_convexity?.toExponential(3) || '-'}</div>
+                            <div>Directions: [${extra.direction_indices?.join(', ') || '-'}]</div>
+                        `;
+                    }
+                } else {
+                    convItem.style.display = 'none';
+                    const convInfoDisplay = document.getElementById('convexityInfoDisplay');
+                    if (convInfoDisplay) convInfoDisplay.innerHTML = '';
+                }
             }
         }
 


### PR DESCRIPTION
  ## Summary

  - Add new "Convexity Blend" projection mode that finds a 2D viewing plane balancing variance capture (SVD) with KDE contour
  curvature at the root node
  - Implement greedy direction selection in a top-k SVD subspace using the KDE Hessian matrix
  - Add frontend controls (alpha slider, metric selector, subspace dimension) and info display showing variance vs convexity
  tradeoff

  ## How it works

  Standard SVD projection maximizes spread (variance) but ignores hierarchy structure. The convexity blend works in a top-k SVD
  subspace (default k=20), computes the KDE Hessian at the root point, then scores each canonical direction by blending
  normalized variance with curvature magnitude. A slider (alpha) controls the balance: 0 = pure SVD, 1 = pure convexity.

  A notable emergent behavior: increasing convexity weight naturally centers the root node in the visualization, because the
  algorithm optimizes for maximal branch curvature radiating from that point. For a physics dataset, "Physics" literally becomes
   the visual center — matching human intuition about topic centrality.

  ## Changes

  - `shared/data_format.py` — Add `extra` field to `ProjectionInfo` for mode-specific metadata
  - `shared/density_core.py` — Add `kde_gradient_hessian()`, `convexity_project_2d()`, wire into `compute_density_manifold()`
  - `flask_api.py` — Add validation, param extraction, passthrough at all 3 call sites
  - `web/index.html` — Dropdown option, convexity controls panel, request params, info bar display

  ## Test plan

  - [x] Unit tests: Hessian symmetry, alpha=0 gives SVD directions [0,1], alpha=1 gives different directions
  - [x] API tests: curl with alpha=0.0/0.5/1.0 returns correct direction indices and scores
  - [x] Browser: controls appear/hide on mode switch, full API round-trip, info bar displays correctly
  - [x] Performance: <100ms overhead for 300 points

  🤖 Generated with [Claude Code](https://claude.com/claude-code)