### PR TITLE
feat(agent-loop): Unified config with uwsal.json and API key resolution

### DIFF
--- a/docs/proposals/UNIFIED_CONFIG.md
+++ b/docs/proposals/UNIFIED_CONFIG.md
@@ -1,0 +1,67 @@
+# Unified config with uwsal.json and API key resolution
+
+## Summary
+
+- **uwsal.json** (Unify Weaver, Simple Agent Loop) is the primary config file, checked before coro.json
+- **API key resolution** follows a 5-level priority chain: CLI arg > env var > config file > coro.json fallback > standard file locations
+- **`--no-fallback`** extended to skip coro.json for both command resolution and config discovery (uwsal.json is always checked)
+
+## API key resolution priority
+
+```
+1. --api-key CLI argument
+2. Backend-specific env var (OPENROUTER_API_KEY, ANTHROPIC_API_KEY, etc.)
+3. uwsal.json (keys.<backend> or top-level api_key)
+4. coro.json fallback (skipped with --no-fallback)
+5. Standard file locations (~/.anthropic/api_key, etc.)
+```
+
+## uwsal.json format
+
+```json
+{
+  "api_key": "sk-or-...",
+  "model": "moonshotai/kimi-k2.5",
+  "base_url": "https://openrouter.ai/api/v1",
+  "keys": {
+    "openrouter": "sk-or-...",
+    "anthropic": "sk-ant-...",
+    "openai": "sk-..."
+  }
+}
+```
+
+- Top-level `api_key` / `model` / `base_url` — default for any backend
+- `keys` object — per-provider keys, looked up by backend type
+- Both are optional; backends use what they find
+
+## Config file search order
+
+```
+1. CWD/uwsal.json
+2. ~/uwsal.json
+3. CWD/coro.json     (skipped with --no-fallback)
+4. ~/coro.json       (skipped with --no-fallback)
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `config.py` | Added `read_config_cascade()` and `resolve_api_key()` |
+| `agent_loop.py` | Backend factory uses shared config; extended `--no-fallback` |
+| `openrouter_api.py` | Removed `_read_coro_config()`; simplified constructor |
+| `coro.py` | `_find_config()` and `_read_coro_config()` check uwsal.json first |
+
+## Test plan
+
+- [x] Default — reads API key from coro.json fallback
+- [x] `--api-key` — CLI key takes precedence (401 with fake key confirms it was used)
+- [x] `--no-fallback` without uwsal.json — correctly fails with config error
+- [x] `--no-fallback` with ~/uwsal.json — works, reads from uwsal.json
+- [ ] Per-provider keys via `keys` object in uwsal.json
+- [ ] Env var precedence over config file
+
+---
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/tools/agent-loop/generated/backends/openrouter_api.py
+++ b/tools/agent-loop/generated/backends/openrouter_api.py
@@ -106,14 +106,9 @@ class OpenRouterBackend(AgentBackend):
         system_prompt: str | None = None,
         tools: list[dict] | None = None,
     ):
-        # Auto-detect from coro.json if not provided
-        coro_config = self._read_coro_config()
-        self.api_key = (api_key
-                        or os.environ.get('OPENROUTER_API_KEY')
-                        or coro_config.get('api_key'))
-        self.model = model or coro_config.get('model', 'moonshotai/kimi-k2.5')
-        self.base_url = base_url or coro_config.get('base_url',
-                                                     'https://openrouter.ai/api/v1')
+        self.api_key = api_key
+        self.model = model or 'moonshotai/kimi-k2.5'
+        self.base_url = base_url or 'https://openrouter.ai/api/v1'
         self.max_tokens = max_tokens
         self.temperature = temperature
         self.system_prompt = system_prompt or (
@@ -125,25 +120,9 @@ class OpenRouterBackend(AgentBackend):
 
         if not self.api_key:
             raise ValueError(
-                "OpenRouter API key required. Set OPENROUTER_API_KEY "
-                "or provide --api-key, or have ~/coro.json with api_key."
+                "OpenRouter API key required. Set OPENROUTER_API_KEY, "
+                "provide --api-key, or add api_key to uwsal.json / coro.json."
             )
-
-    @staticmethod
-    def _read_coro_config() -> dict:
-        """Read api_key/model/base_url from coro.json as fallback."""
-        for path in ['coro.json', os.path.expanduser('~/coro.json')]:
-            try:
-                with open(path) as f:
-                    data = json.load(f)
-                return {
-                    'api_key': data.get('api_key'),
-                    'model': data.get('model'),
-                    'base_url': data.get('base_url'),
-                }
-            except (FileNotFoundError, json.JSONDecodeError):
-                continue
-        return {}
 
     def send_message(self, message: str, context: list[dict], **kwargs) -> AgentResponse:
         """Send message to OpenRouter API."""


### PR DESCRIPTION
## Summary

- **Introduces `uwsal.json`** (Unify Weaver, Simple Agent Loop) as the primary config file, with `coro.json` as a fallback
- **Unified API key resolution** with 5-level priority chain: `--api-key` > env var > `uwsal.json` > `coro.json` > standard file locations (`~/.anthropic/api_key`, etc.)
- **Extends `--no-fallback`** to skip `coro.json` for both command and config discovery (uwsal.json is always checked)
- **Simplifies OpenRouter backend** — removes internal `_read_coro_config()`, constructor takes pre-resolved values from the shared config system

## Test plan

- [x] Default — reads API key from coro.json fallback, works as before
- [x] `--api-key "sk-or-test"` — CLI key takes precedence (401 confirms fake key was used)
- [x] `--no-fallback` without uwsal.json — correctly fails with config error
- [x] `--no-fallback` with `~/uwsal.json` — works, reads from uwsal.json

---

Generated with [Claude Code](https://claude.com/claude-code)
