### PR TITLE
feat(agent-loop): Add path validation, command blocklist, and security profiles

### DIFF
--- a/docs/proposals/AGENT_LOOP_SECURITY.md
+++ b/docs/proposals/AGENT_LOOP_SECURITY.md
@@ -1,0 +1,377 @@
+# Agent Loop Security Hardening
+
+## Problem
+
+The agent loop's `tools.py` executes bash commands with `shell=True` and performs file operations with no path validation beyond `startswith('/')`. The confirmation prompt is the only defense, and it's bypassed by `--auto-tools` and `--approval-mode yolo`.
+
+Meanwhile, UnifyWeaver already has a rich declarative security layer (shell_sandbox.pl, rpyc_security.pl, firewall rules, shell command constraints) — but none of it is connected to the agent loop's Python execution.
+
+This proposal covers practical hardening that works in Termux without containers, VMs, or root.
+
+## Current State
+
+| Layer | Status | Notes |
+|-------|--------|-------|
+| Tool whitelisting | Working | `allowed_tools` list in ToolHandler |
+| Confirmation prompts | Working | `confirm_destructive` flag |
+| Approval modes | Working | default/auto_edit/yolo/plan |
+| Path validation | **Missing** | No `..` resolution, no symlink checks |
+| Command sanitization | **Missing** | Raw `shell=True` execution |
+| Sensitive path blocking | **Missing** | Can read/write `/etc/shadow`, `~/.ssh/*` |
+| Sandbox integration | **Missing** | Only gemini passes `-s` to its CLI |
+| Declarative rules | **Not connected** | Prolog specs exist but aren't enforced |
+
+## Proposal: Layered Security
+
+### Layer 1: Path Validation (tools.py)
+
+Normalize all file paths and block dangerous targets. No external dependencies.
+
+```python
+import os
+
+# Sensitive paths that should never be read or written by agent tools
+BLOCKED_PATHS = {
+    '/etc/shadow', '/etc/passwd', '/etc/sudoers',
+    '/root/.ssh', '/root/.gnupg',
+}
+BLOCKED_PREFIXES = (
+    '/proc/', '/sys/', '/dev/',
+)
+BLOCKED_HOME_PATTERNS = (
+    '.ssh/', '.gnupg/', '.aws/', '.config/gcloud/',
+    '.env', '.netrc', '.npmrc',
+)
+
+def validate_path(raw_path: str, working_dir: str) -> tuple[str, str | None]:
+    """Resolve and validate a file path.
+
+    Returns (resolved_path, error_message).
+    error_message is None if the path is safe.
+    """
+    # Resolve relative paths against working_dir
+    if raw_path.startswith('/'):
+        resolved = os.path.realpath(raw_path)
+    else:
+        resolved = os.path.realpath(os.path.join(working_dir, raw_path))
+
+    # Block system paths
+    if resolved in BLOCKED_PATHS:
+        return resolved, f"Blocked: {resolved} is a sensitive system file"
+    for prefix in BLOCKED_PREFIXES:
+        if resolved.startswith(prefix):
+            return resolved, f"Blocked: {prefix} is a system directory"
+
+    # Block sensitive home directory patterns
+    home = os.path.expanduser('~')
+    if resolved.startswith(home):
+        rel = resolved[len(home):].lstrip('/')
+        for pattern in BLOCKED_HOME_PATTERNS:
+            if rel.startswith(pattern) or rel == pattern.rstrip('/'):
+                return resolved, f"Blocked: ~/{pattern} contains credentials"
+
+    return resolved, None
+```
+
+Key points:
+- `os.path.realpath()` resolves `..` and symlinks, defeating path traversal
+- Blocklists cover system files, credential stores, and cloud provider configs
+- Returns the resolved path so the tool can log what it actually accessed
+
+### Layer 2: Command Proxy via PATH (bash tool)
+
+Instead of raw `shell=True`, wrap commands through a proxy script that enforces constraints. This works on Termux without containers.
+
+**Approach A: PATH-based proxy**
+
+Create wrapper scripts in a `~/.agent-loop/bin/` directory that shadow dangerous commands:
+
+```bash
+# ~/.agent-loop/bin/rm — proxy that blocks rm -rf /
+#!/data/data/com.termux/files/usr/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        /) echo "BLOCKED: rm on /" >&2; exit 1 ;;
+        /*) ;; # absolute paths are allowed
+    esac
+done
+exec /data/data/com.termux/files/usr/bin/rm "$@"
+```
+
+The agent loop prepends this directory to `PATH` when calling subprocess:
+
+```python
+def _execute_bash(self, args: dict) -> ToolResult:
+    proxy_dir = os.path.expanduser('~/.agent-loop/bin')
+    env = os.environ.copy()
+    if os.path.isdir(proxy_dir):
+        env['PATH'] = proxy_dir + ':' + env.get('PATH', '')
+
+    result = subprocess.run(
+        command, shell=True, env=env,
+        capture_output=True, text=True,
+        timeout=120, cwd=self.working_dir
+    )
+```
+
+**Approach B: Command blocklist in Python**
+
+Before executing, check the command against patterns:
+
+```python
+BLOCKED_COMMANDS = [
+    r'\brm\s+-[rf]*\s+/',          # rm -rf /
+    r'\bmkfs\b',                    # format filesystem
+    r'\bdd\s+.*of=/dev/',          # write to device
+    r'>\s*/dev/sd',                # redirect to device
+    r'\bcurl\b.*\|\s*bash',        # curl | bash
+    r'\bwget\b.*\|\s*bash',        # wget | bash
+    r'\bchmod\s+777\b',            # world-writable
+    r'\bchown\s+root\b',           # chown to root
+]
+
+def is_command_blocked(command: str) -> str | None:
+    """Return reason if command is blocked, None if allowed."""
+    for pattern in BLOCKED_COMMANDS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return f"Blocked: matches dangerous pattern '{pattern}'"
+    return None
+```
+
+**Recommendation:** Use both — blocklist catches obvious dangers before execution, PATH proxies catch things the blocklist misses.
+
+### Layer 3: PRoot Sandbox (optional, Termux-compatible)
+
+PRoot is available on Termux (`pkg install proot`) and provides filesystem isolation via ptrace — no root required. The agent loop can optionally run bash commands inside proot:
+
+```python
+def _execute_bash_sandboxed(self, args: dict) -> ToolResult:
+    command = args.get('command', '')
+
+    if self.sandbox_mode == 'proot':
+        # Create isolated rootfs with bind mounts for allowed paths
+        proot_cmd = [
+            'proot',
+            '-0',                              # fake root
+            '-w', self.working_dir,            # working directory
+            '-b', f'{self.working_dir}',       # bind working dir
+            '-b', '/data/data/com.termux/files/usr',  # bind Termux usr
+            '/bin/bash', '-c', command,
+        ]
+        result = subprocess.run(
+            proot_cmd, capture_output=True, text=True,
+            timeout=120
+        )
+    else:
+        result = subprocess.run(
+            command, shell=True, ...
+        )
+```
+
+This connects the existing `shell_sandbox.pl` proot definitions to actual execution.
+
+**Tradeoffs:**
+- Requires `proot` package (`pkg install proot`)
+- ~10-30% overhead from ptrace interception
+- Not all programs work under proot (some syscalls aren't emulated)
+- Good for file isolation, not for network isolation
+
+### Layer 4: Network Restrictions
+
+For API backends making outbound requests, add domain allowlisting:
+
+```python
+ALLOWED_DOMAINS = {
+    'openrouter.ai',
+    'api.anthropic.com',
+    'api.openai.com',
+    'generativelanguage.googleapis.com',
+}
+
+def validate_url(url: str) -> str | None:
+    """Return error if URL domain is not in allowlist."""
+    from urllib.parse import urlparse
+    host = urlparse(url).hostname
+    if host and host not in ALLOWED_DOMAINS:
+        return f"Blocked: {host} not in allowed domains"
+    return None
+```
+
+For bash commands, this is harder — use iptables/nftables rules or a transparent proxy. On Termux without root, the practical option is to use proot with a restricted resolv.conf.
+
+### Layer 5: Tool Call Logging and Audit Trail
+
+Log every tool invocation for post-hoc review:
+
+```python
+import json
+from datetime import datetime
+
+class ToolAuditLog:
+    def __init__(self, log_dir='~/.agent-loop/audit'):
+        self.log_dir = os.path.expanduser(log_dir)
+        os.makedirs(self.log_dir, exist_ok=True)
+        self.log_file = os.path.join(
+            self.log_dir,
+            f"audit_{datetime.now():%Y%m%d}.jsonl"
+        )
+
+    def log(self, tool_call, result, blocked_reason=None):
+        entry = {
+            'timestamp': datetime.now().isoformat(),
+            'tool': tool_call.name,
+            'args': tool_call.arguments,
+            'success': result.success if result else False,
+            'blocked': blocked_reason,
+        }
+        with open(self.log_file, 'a') as f:
+            f.write(json.dumps(entry) + '\n')
+```
+
+### Layer 6: Security Profiles and Customization
+
+Tie layers 1-5 together with named profiles in `uwsal.json`. Every layer is independently configurable, and blocklists can be extended or replaced.
+
+```json
+{
+  "security": {
+    "profile": "cautious",
+    "blocked_paths": [],
+    "blocked_path_prefixes": [],
+    "blocked_home_patterns": [],
+    "blocked_commands": [],
+    "allowed_paths": [],
+    "allowed_commands": [],
+    "profiles": {
+      "open": {
+        "path_validation": false,
+        "command_blocklist": false,
+        "sandbox": "none",
+        "confirm_tools": false
+      },
+      "cautious": {
+        "path_validation": true,
+        "command_blocklist": true,
+        "sandbox": "none",
+        "confirm_tools": true
+      },
+      "sandboxed": {
+        "path_validation": true,
+        "command_blocklist": true,
+        "sandbox": "proot",
+        "confirm_tools": false,
+        "allowed_paths": ["./"],
+        "blocked_network": true
+      },
+      "paranoid": {
+        "path_validation": true,
+        "command_blocklist": true,
+        "sandbox": "proot",
+        "confirm_tools": true,
+        "blocked_network": true,
+        "audit_log": true
+      }
+    }
+  }
+}
+```
+
+#### Customizing Blocklists
+
+The built-in blocklists are defaults. Users can extend or override them in `uwsal.json`:
+
+```json
+{
+  "security": {
+    "profile": "cautious",
+    "blocked_paths": ["/data/production/"],
+    "blocked_commands": ["\\bsystemctl\\b"],
+    "allowed_paths": ["/etc/hosts"],
+    "allowed_commands": ["rm -rf ./build"]
+  }
+}
+```
+
+- **`blocked_*`** entries are *added* to the built-in defaults
+- **`allowed_*`** entries create *exceptions* — an allowed entry overrides a blocked match
+- Resolution order: allowed list checked first, then blocked list, then built-in defaults
+
+This means you can run with the default `cautious` profile but whitelist specific paths your project needs:
+
+```json
+{
+  "security": {
+    "profile": "cautious",
+    "allowed_paths": ["/etc/nginx/conf.d/", "/var/log/myapp/"]
+  }
+}
+```
+
+Or add project-specific blocks without touching the defaults:
+
+```json
+{
+  "security": {
+    "blocked_paths": ["/data/production/db/"],
+    "blocked_commands": ["\\bdrop\\s+database\\b"]
+  }
+}
+```
+
+#### CLI Flags
+
+```
+--security-profile PROFILE   Set security profile (open/cautious/sandboxed/paranoid)
+--no-security                Alias for --security-profile open
+--security-blocked-path P    Add path to blocklist (repeatable)
+--security-allowed-path P    Add path to allowlist (repeatable)
+```
+
+The `--no-security` flag is the explicit "I know what I'm doing" escape hatch. It disables path validation, command blocklists, and confirmation prompts entirely. This is useful for trusted environments, automated pipelines, or when the overhead of validation interferes with a specific workflow.
+
+#### Profile + Override Interaction
+
+CLI flags override config file settings, which override profile defaults:
+
+```
+Built-in defaults  ←  profile settings  ←  uwsal.json overrides  ←  CLI flags
+```
+
+Example: `cautious` profile enables path validation, but `--no-security` disables everything regardless of what's in the config file.
+
+## Implementation Priority
+
+| Priority | Layer | Effort | Impact |
+|----------|-------|--------|--------|
+| **P0** | Path validation | Small | Blocks path traversal and credential theft |
+| **P0** | Command blocklist | Small | Blocks obvious destructive commands |
+| **P1** | Audit logging | Small | Enables post-hoc review |
+| **P1** | PATH-based proxies | Medium | Defense-in-depth for bash |
+| **P2** | Security profiles | Medium | Unified configuration |
+| **P2** | PRoot sandbox | Medium | Filesystem isolation |
+| **P3** | Network restrictions | Large | Requires proot or root access |
+| **P3** | Declarative rule bridge | Large | Connect Prolog specs to Python |
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `tools.py` | Add `validate_path()`, command blocklist, PATH proxy support, audit log |
+| `agent_loop.py` | Add `--security-profile` flag, pass to ToolHandler |
+| `config.py` | Parse `security` section from uwsal.json |
+
+## Termux-Specific Notes
+
+- **No root**: PRoot works without root (ptrace-based). Firejail, bubblewrap, nsjail need root or specific capabilities.
+- **No Docker/Podman**: Termux doesn't support container runtimes.
+- **No iptables**: Network isolation requires root. Only option is proot with restricted DNS or transparent proxy via Termux:API.
+- **PRoot availability**: `pkg install proot` — already common in Termux for running Linux distros.
+- **PATH tricks work**: Termux uses a standard PATH layout, so `~/.agent-loop/bin` prepending works naturally.
+
+## Relationship to Existing Prolog Security
+
+The existing declarative layer (shell_sandbox.pl, rpyc_security.pl, firewall rules) defines *what* should be allowed. This proposal implements *enforcement* in the Python execution layer. A future P3 task could auto-generate the Python blocklists and security profiles from the Prolog specs, closing the loop between declaration and enforcement.
+
+---
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/tools/agent-loop/generated/tools.py
+++ b/tools/agent-loop/generated/tools.py
@@ -1,8 +1,9 @@
 """Tool handler for executing agent tool calls."""
 
 import os
+import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from backends.base import ToolCall
 
@@ -15,6 +16,139 @@ class ToolResult:
     tool_name: str
 
 
+# ── Path validation ────────────────────────────────────────────────────────
+
+# Sensitive paths that should never be accessed by agent tools
+_BLOCKED_PATHS = {
+    '/etc/shadow', '/etc/gshadow', '/etc/sudoers',
+}
+_BLOCKED_PREFIXES = (
+    '/proc/', '/sys/', '/dev/',
+)
+_BLOCKED_HOME_PATTERNS = (
+    '.ssh/', '.gnupg/', '.aws/', '.config/gcloud/',
+    '.env', '.netrc', '.npmrc',
+)
+
+
+def validate_path(raw_path: str, working_dir: str,
+                  extra_blocked: list[str] | None = None,
+                  extra_allowed: list[str] | None = None) -> tuple[str, str | None]:
+    """Resolve and validate a file path.
+
+    Returns (resolved_path, error_message).
+    error_message is None if the path is safe.
+    """
+    # Resolve relative paths and symlinks
+    if raw_path.startswith('/'):
+        resolved = os.path.realpath(raw_path)
+    else:
+        resolved = os.path.realpath(os.path.join(working_dir, raw_path))
+
+    # Check both raw (as typed) and resolved (after symlinks) paths,
+    # because on Termux /etc -> /system/etc and ~ -> /data/data/.../home
+    raw_abs = os.path.abspath(os.path.join(working_dir, raw_path)) if not raw_path.startswith('/') else raw_path
+    check_paths = {resolved, raw_abs}
+
+    # Check allowlist first — explicit allows override blocks
+    if extra_allowed:
+        for pattern in extra_allowed:
+            expanded = os.path.realpath(os.path.expanduser(pattern))
+            for p in check_paths:
+                if p == expanded or p.startswith(expanded.rstrip('/') + '/'):
+                    return resolved, None
+
+    # Check user-provided extra blocks
+    if extra_blocked:
+        for pattern in extra_blocked:
+            expanded = os.path.realpath(os.path.expanduser(pattern))
+            for p in check_paths:
+                if p == expanded or p.startswith(expanded.rstrip('/') + '/'):
+                    return resolved, f"Blocked by config: {raw_path}"
+
+    # Built-in blocks — check both raw and resolved
+    for p in check_paths:
+        if p in _BLOCKED_PATHS:
+            return resolved, f"Blocked: {raw_path} is a sensitive system file"
+        for prefix in _BLOCKED_PREFIXES:
+            if p.startswith(prefix):
+                return resolved, f"Blocked: {raw_path} is in a system directory"
+
+    # Sensitive home directory patterns — check against resolved path
+    home = os.path.expanduser('~')
+    for p in check_paths:
+        if p.startswith(home + '/'):
+            rel = p[len(home) + 1:]
+            for pattern in _BLOCKED_HOME_PATTERNS:
+                if rel == pattern.rstrip('/') or rel.startswith(pattern):
+                    return resolved, f"Blocked: ~/{pattern} may contain credentials"
+
+    return resolved, None
+
+
+# ── Command blocklist ──────────────────────────────────────────────────────
+
+_BLOCKED_COMMAND_PATTERNS = [
+    (r'\brm\s+-[rf]*\s+/', "rm with absolute path and force/recursive flags"),
+    (r'\bmkfs\b', "filesystem format"),
+    (r'\bdd\s+.*of=/dev/', "write to block device"),
+    (r'>\s*/dev/sd', "redirect to block device"),
+    (r'\bcurl\b.*\|\s*(?:ba)?sh', "pipe remote script to shell"),
+    (r'\bwget\b.*\|\s*(?:ba)?sh', "pipe remote script to shell"),
+    (r'\bchmod\s+777\b', "world-writable permissions"),
+    (r':\(\)\s*\{\s*:\|:\s*&\s*\}\s*;', "fork bomb"),
+    (r'\b>\s*/etc/', "overwrite system config"),
+]
+
+
+def is_command_blocked(command: str,
+                       extra_blocked: list[str] | None = None,
+                       extra_allowed: list[str] | None = None) -> str | None:
+    """Return reason if command is blocked, None if allowed."""
+    # Check allowlist first
+    if extra_allowed:
+        for pattern in extra_allowed:
+            if re.search(pattern, command, re.IGNORECASE):
+                return None
+
+    # Check user-provided extra blocks
+    if extra_blocked:
+        for pattern in extra_blocked:
+            if re.search(pattern, command, re.IGNORECASE):
+                return f"Blocked by config: matches '{pattern}'"
+
+    # Built-in blocks
+    for pattern, description in _BLOCKED_COMMAND_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return f"Blocked: {description}"
+    return None
+
+
+# ── Security config ────────────────────────────────────────────────────────
+
+@dataclass
+class SecurityConfig:
+    """Security settings for tool execution."""
+    path_validation: bool = True
+    command_blocklist: bool = True
+    blocked_paths: list[str] = field(default_factory=list)
+    blocked_commands: list[str] = field(default_factory=list)
+    allowed_paths: list[str] = field(default_factory=list)
+    allowed_commands: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_profile(cls, profile: str) -> 'SecurityConfig':
+        """Create config from a named profile."""
+        if profile == 'open':
+            return cls(path_validation=False, command_blocklist=False)
+        elif profile == 'cautious':
+            return cls(path_validation=True, command_blocklist=True)
+        elif profile in ('sandboxed', 'paranoid'):
+            return cls(path_validation=True, command_blocklist=True)
+        # Default to cautious
+        return cls(path_validation=True, command_blocklist=True)
+
+
 class ToolHandler:
     """Handles execution of tool calls from agent responses."""
 
@@ -22,11 +156,13 @@ class ToolHandler:
         self,
         allowed_tools: list[str] | None = None,
         confirm_destructive: bool = True,
-        working_dir: str | None = None
+        working_dir: str | None = None,
+        security: SecurityConfig | None = None
     ):
         self.allowed_tools = allowed_tools or ['bash', 'read', 'write', 'edit']
         self.confirm_destructive = confirm_destructive
         self.working_dir = working_dir or os.getcwd()
+        self.security = security or SecurityConfig()
 
         # Tool implementations
         self.tools = {
@@ -105,6 +241,20 @@ class ToolHandler:
                 tool_name='bash'
             )
 
+        # Command blocklist check
+        if self.security.command_blocklist:
+            reason = is_command_blocked(
+                command,
+                extra_blocked=self.security.blocked_commands,
+                extra_allowed=self.security.allowed_commands,
+            )
+            if reason:
+                return ToolResult(
+                    success=False,
+                    output=f"[Security] {reason}",
+                    tool_name='bash'
+                )
+
         try:
             result = subprocess.run(
                 command,
@@ -138,20 +288,32 @@ class ToolHandler:
                 tool_name='bash'
             )
 
+    def _validate_file_path(self, raw_path: str, tool_name: str) -> tuple[Path, ToolResult | None]:
+        """Validate and resolve a file path. Returns (resolved, error_or_None)."""
+        if not raw_path:
+            return Path(), ToolResult(False, "No path provided", tool_name)
+
+        if self.security.path_validation:
+            resolved, error = validate_path(
+                raw_path, self.working_dir,
+                extra_blocked=self.security.blocked_paths,
+                extra_allowed=self.security.allowed_paths,
+            )
+            if error:
+                return Path(resolved), ToolResult(False, f"[Security] {error}", tool_name)
+            return Path(resolved), None
+
+        # No validation — resolve path the simple way
+        if raw_path.startswith('/'):
+            return Path(raw_path), None
+        return Path(self.working_dir) / raw_path, None
+
     def _read_file(self, args: dict) -> ToolResult:
         """Read a file."""
         path = args.get('path', '')
-        if not path:
-            return ToolResult(
-                success=False,
-                output="No path provided",
-                tool_name='read'
-            )
-
-        # Resolve path relative to working directory
-        file_path = Path(self.working_dir) / path
-        if path.startswith('/'):
-            file_path = Path(path)
+        file_path, error = self._validate_file_path(path, 'read')
+        if error:
+            return error
 
         try:
             content = file_path.read_text()
@@ -178,17 +340,9 @@ class ToolHandler:
         path = args.get('path', '')
         content = args.get('content', '')
 
-        if not path:
-            return ToolResult(
-                success=False,
-                output="No path provided",
-                tool_name='write'
-            )
-
-        # Resolve path
-        file_path = Path(self.working_dir) / path
-        if path.startswith('/'):
-            file_path = Path(path)
+        file_path, error = self._validate_file_path(path, 'write')
+        if error:
+            return error
 
         try:
             # Create parent directories if needed
@@ -212,12 +366,9 @@ class ToolHandler:
         old_string = args.get('old_string', '')
         new_string = args.get('new_string', '')
 
-        if not path:
-            return ToolResult(
-                success=False,
-                output="No path provided",
-                tool_name='edit'
-            )
+        file_path, error = self._validate_file_path(path, 'edit')
+        if error:
+            return error
 
         if not old_string:
             return ToolResult(
@@ -225,11 +376,6 @@ class ToolHandler:
                 output="No old_string provided",
                 tool_name='edit'
             )
-
-        # Resolve path
-        file_path = Path(self.working_dir) / path
-        if path.startswith('/'):
-            file_path = Path(path)
 
         try:
             content = file_path.read_text()


### PR DESCRIPTION
## Summary

- **Path validation** — `realpath()` resolves symlinks and `..` traversal; blocklists for system files (`/etc/shadow`, `/proc/`), credential dirs (`~/.ssh/`, `~/.aws/`, `~/.gnupg/`), and secrets files (`~/.env`, `~/.netrc`)
- **Command blocklist** — regex patterns block dangerous commands (`rm -rf /`, `curl|bash`, `dd` to devices, fork bombs, `chmod 777`, overwriting `/etc/`)
- **Security profiles** — `--security-profile open/cautious/sandboxed/paranoid` and `--no-security` escape hatch; default is `cautious`
- **Customizable blocklists** — `uwsal.json` supports `blocked_paths`, `allowed_paths`, `blocked_commands`, `allowed_commands` with allow overriding block
- **Dual-path checking** — validates both raw and resolved paths, important on Termux where `/etc` symlinks to `/system/etc`
- **Updated documentation** — agent-loop README updated with security, uwsal.json config, and recent test status

## Test plan

- [x] Default (cautious) — normal prompts work without interference
- [x] `--no-security` — disables all checks
- [x] `--auto-tools "Read /etc/shadow"` — blocked by path validation, model informed
- [x] Command blocklist catches `rm -rf /`, `curl|bash`, `chmod 777`
- [x] Normal commands (`ls`, `git status`) pass through
- [x] Allowlist overrides blocklist (tested in unit tests)
- [x] Termux symlink handling (`/etc/shadow` → `/system/etc/shadow` both caught)

---

Generated with [Claude Code](https://claude.com/claude-code)
