### PR TITLE
perf(csharp-query): use distinct-key tie-break for unfiltered recursive multi-key joins

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -40,6 +40,7 @@
 :- dynamic user:test_recursive_label_path_cat_selective/4.
 :- dynamic user:test_recursive_label_path_cat_asym/4.
 :- dynamic user:test_recursive_label_path_cat_tie/4.
+:- dynamic user:test_recursive_label_path_distinct_unfiltered/4.
 :- dynamic user:test_sparse_input_fact/3.
 :- dynamic user:test_sparse_input_filtered/3.
 :- dynamic user:test_post_agg_param/2.
@@ -242,6 +243,7 @@ test_csharp_query_target :-
         verify_recursive_multi_key_recursive_selection_join_selective_probe_uses_partial_index,
         verify_recursive_multi_key_recursive_selection_join_prefers_filtered_build_side,
         verify_recursive_multi_key_recursive_selection_join_prefers_distinct_tie_break,
+        verify_recursive_multi_key_recursive_join_prefers_unfiltered_distinct_tie_break,
         verify_recursive_multi_key_recursive_selection_join_tiny_probe_prefers_hash_build,
         verify_parameterized_sparse_input_positions_runtime,
         verify_parameterized_fib_plan,
@@ -736,6 +738,20 @@ setup_test_data :-
         test_recursive_label_path_cat_tie(Y, Z, L, cat2),
         test_catmix(Cat)
     )),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(r1, a, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(r1, b, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(r1, c, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(r2, d, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(r2, e, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(a, x, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(b, y, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(c, z, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(d, u, red, cat1)),
+    assertz(user:test_recursive_label_path_distinct_unfiltered(e, v, red, cat1)),
+    assertz(user:(test_recursive_label_path_distinct_unfiltered(X, Z, L, Cat) :-
+        test_recursive_label_path_distinct_unfiltered(X, Y, L, Cat),
+        test_recursive_label_path_distinct_unfiltered(Y, Z, L, Cat)
+    )),
     assertz(user:mode(test_sparse_input_filtered(+, -, +))),
     assertz(user:test_sparse_input_fact(a, 1, red)),
     assertz(user:test_sparse_input_fact(a, 2, red)),
@@ -987,6 +1003,7 @@ cleanup_test_data :-
     retractall(user:test_sparse_input_fact(_, _, _)),
     retractall(user:test_recursive_label_path_cat_asym(_, _, _, _)),
     retractall(user:test_recursive_label_path_cat_tie(_, _, _, _)),
+    retractall(user:test_recursive_label_path_distinct_unfiltered(_, _, _, _)),
     retractall(user:test_sparse_input_filtered(_, _, _)),
     retractall(user:mode(test_sparse_input_filtered(_, _, _))),
     retractall(user:test_post_agg_param(_, _)),
@@ -2389,6 +2406,24 @@ verify_recursive_multi_key_recursive_join_uses_partial_index :-
          'b,c,red',
          'a,c,red',
          'STRATEGY_USED:KeyJoinRecursiveIndexPartial=true'],
+        [],
+        HarnessSource).
+
+verify_recursive_multi_key_recursive_join_prefers_unfiltered_distinct_tie_break :-
+    csharp_query_target:build_query_plan(test_recursive_label_path_distinct_unfiltered/4, [target(csharp_query)], Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    sub_term(fixpoint{type:fixpoint, head:predicate{name:test_recursive_label_path_distinct_unfiltered, arity:4}, base:_, recursive:_, width:_}, Root),
+    sub_term(join{type:join, left:Left, right:Right, left_keys:LeftKeys, right_keys:RightKeys, left_width:_, right_width:_, width:_}, Root),
+    length(LeftKeys, KeyCount),
+    KeyCount > 1,
+    length(RightKeys, KeyCount),
+    sub_term(recursive_ref{type:recursive_ref, predicate:predicate{name:test_recursive_label_path_distinct_unfiltered, arity:4}, role:_, width:_}, Left),
+    sub_term(recursive_ref{type:recursive_ref, predicate:predicate{name:test_recursive_label_path_distinct_unfiltered, arity:4}, role:_, width:_}, Right),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    harness_source_with_strategy_flag_quiet(ModuleClass, [], 'KeyJoinRecursiveBuildDistinct', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['STRATEGY_USED:KeyJoinRecursiveBuildDistinct=true'],
         [],
         HarnessSource).
 


### PR DESCRIPTION
## Summary

  - extends recursive multi-key join build-side selection to handle unfiltered recursive-vs-recursive ties using sampled
    key distinctness
      1. filtered-rowcount decision (when filters exist)
      2. distinct-key tie-break
  - adds strategy traces for observability:
      - `KeyJoinRecursiveBuildDistinct`
      - `KeyJoinRecursiveBuildDistinctLeft`
      - `KeyJoinRecursiveBuildDistinctRight`
  - adds focused runtime coverage with a new unfiltered recursive test dataset and assertion

  ## Why

  Previously, unfiltered recursive ties fell straight to delta/rowcount fallback, which can choose a weaker hash-build
  side in multi-key joins. Using sampled join-key distinctness improves tie resolution while preserving existing
  behavior when a clear filtered-rowcount winner exists.

  ## Files Changed

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`
      - generalized recursive build-side selectivity flow
      - added unfiltered distinct-key tie-break path and trace markers
  - `tests/core/test_csharp_query_target.pl`
      - added `test_recursive_label_path_distinct_unfiltered/4` setup/cleanup
      - added `verify_recursive_multi_key_recursive_join_prefers_unfiltered_distinct_tie_break`

  ## Validation

  - targeted runtime test for new strategy path: passed
  - full codegen suite: `SKIP_CSHARP_EXECUTION=1 ... test_csharp_query_target` passed (`141/141`)
  - runtime core build passed:
      - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release --no-
        restore`