### PR TITLE
perf(csharp-query): cache single-pair transitive closure probes

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -70,6 +70,7 @@ The current implementation emits static C# builders that assemble the plan via n
 - The query runtime’s default output order is unspecified (hash-set semantics). For deterministic ordering, use `order_by/...` (and `distinct(strategy(ordered))` when relevant) before `limit/offset`.
 - Cache/index reuse (e.g. `new QueryExecutorOptions(ReuseCaches: true)`) assumes deterministic/pure relations. Disable caches (or clear them via `executor.ClearCaches()`) if underlying facts/providers can change or have side effects.
 - Seeded transitive-closure caches treat the seed list as a set (deduped + order-insensitive), so calls with the same seeds in different orders share a cache entry.
+- Single concrete transitive pair probes (`source,target` both bound) now cache exact probe results (`TransitiveClosurePairsSingleProbe` and `GroupedTransitiveClosurePairsSingleProbe`) to avoid repeating one-off BFS checks across repeated calls.
 
 ## Current Limitations
 - Tail-recursive optimisation and memoised aggregates still fall back to iterative evaluation without specialised nodes.

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -285,6 +285,8 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_reuse_runtime,
         verify_parameterized_reachability_single_seed_strategy_runtime,
         verify_parameterized_reachability_by_target_single_strategy_runtime,
+        verify_parameterized_reachability_pairs_single_probe_cache_reuse_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime,
@@ -3439,6 +3441,28 @@ verify_parameterized_reachability_by_target_single_strategy_runtime :-
         ['alice,charlie',
          'bob,charlie',
          'STRATEGY_USED:TransitiveClosureSeededByTargetSingle=true'],
+        Params,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_single_probe_cache_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param_both/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[alice, charlie]],
+    harness_source_with_cache_flag(ModuleClass, Params, 'TransitiveClosurePairsSingleProbe', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['alice,charlie',
+         'CACHE_HIT:TransitiveClosurePairsSingleProbe=true'],
+        Params,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param_both/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a, c, red, cat1]],
+    harness_source_with_cache_flag(ModuleClass, Params, 'GroupedTransitiveClosurePairsSingleProbe', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,c,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosurePairsSingleProbe=true'],
         Params,
         HarnessSource).
 


### PR DESCRIPTION
  ## Summary
  Adds a minimal transitive-closure runtime fast-path for repeated single concrete pair probes by caching exact
  `(source,target)` reachability results.

  This targets the high-frequency case where the same pair probe is executed repeatedly (with `ReuseCaches: true`) and
  avoids re-running one-off BFS searches.

  ## Changes

  ### Runtime
    - Added exact-pair cache for non-grouped pair probes:
      - cache key: `(EdgeRelation, Predicate) + [source,target]`
      - cache key: `(EdgeRelation, Predicate, Groups) + [group...,source,target]`
      - cache name in trace: `GroupedTransitiveClosurePairsSingleProbe`
    - Preserved existing forward/backward single-probe strategy choice; cache wraps that path.
    - Added cache containers to `EvaluationContext`.
    - Wired cache clear/invalidation into `ClearCaches()` and predicate re-registration invalidation.

  ### Tests
  - `tests/core/test_csharp_query_target.pl`
    - Added runtime checks:
      - `verify_parameterized_reachability_pairs_single_probe_cache_reuse_runtime`
      - `verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_reuse_runtime`
    - Both assert expected row output and cache-hit flags:
      - `CACHE_HIT:TransitiveClosurePairsSingleProbe=true`
      - `CACHE_HIT:GroupedTransitiveClosurePairsSingleProbe=true`

  ### Docs
  - `docs/targets/csharp-query-runtime.md`
    - Documented the new single concrete pair-probe caches and cache names.

  ## Why
  Seeded/memoized closure caching already handles many multi-seed workloads, but repeated exact pair probes still paid
  full traversal cost each time. This PR adds a focused cache for that gap with minimal behavioral risk.

  ## Validation
  - `dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release` ✅
  - New cache-hit behaviors validated on generated projects for both non-grouped and grouped pair probes.
  - Note: full local smoke runs in `C:\tmp` remain sensitive to local temp-file ACL issues (`NuGet.targets ... .tmp
  access denied`), which is an environment issue previously observed.