### PR TITLE
perf(csharp-query): bound single-pair transitive probe caches

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -71,6 +71,7 @@ The current implementation emits static C# builders that assemble the plan via n
 - Cache/index reuse (e.g. `new QueryExecutorOptions(ReuseCaches: true)`) assumes deterministic/pure relations. Disable caches (or clear them via `executor.ClearCaches()`) if underlying facts/providers can change or have side effects.
 - Seeded transitive-closure caches treat the seed list as a set (deduped + order-insensitive), so calls with the same seeds in different orders share a cache entry.
 - Single concrete transitive pair probes (`source,target` both bound) now cache exact probe results (`TransitiveClosurePairsSingleProbe` and `GroupedTransitiveClosurePairsSingleProbe`) to avoid repeating one-off BFS checks across repeated calls.
+- Pair-probe caches are bounded via `QueryExecutorOptions(PairProbeCacheMaxEntries: ...)` (default `4096` per cache key); set `0` to disable pair-probe caching while keeping other cache reuse enabled.
 
 ## Current Limitations
 - Tail-recursive optimisation and memoised aggregates still fall back to iterative evaluation without specialised nodes.
@@ -115,6 +116,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
   - `await foreach (var row in executor.ExecuteAsync(plan, parameters, trace, cts.Token)) { ... }`
 - Prepared-style cache reuse (useful for repeated parameterized calls):
   - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));`
+  - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true, PairProbeCacheMaxEntries: 1024));`
   - `executor.ClearCaches();` (if underlying facts change)
   - See “Ordering, Purity, and Effects” below for ordering/side-effect assumptions.
 


### PR DESCRIPTION
  - Adds PairProbeCacheMaxEntries to QueryExecutorOptions (default 4096, 0 disables pair-probe caching).
  - Bounds TransitiveClosurePairsSingleProbe and GroupedTransitiveClosurePairsSingleProbe cache growth by evicting
    oldest entries per cache key.
  - Keeps existing strategy selection logic unchanged; only cache lookup/store behavior is capped.
  - Adds C# query runtime tests covering pair-probe cache eviction for both grouped and non-grouped transitive closure
    pair probes.
  - Updates runtime docs with the new option and usage guidance.