### PR TITLE
perf(csharp-query): bound seeded transitive-closure caches

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -70,6 +70,7 @@ The current implementation emits static C# builders that assemble the plan via n
 - The query runtime’s default output order is unspecified (hash-set semantics). For deterministic ordering, use `order_by/...` (and `distinct(strategy(ordered))` when relevant) before `limit/offset`.
 - Cache/index reuse (e.g. `new QueryExecutorOptions(ReuseCaches: true)`) assumes deterministic/pure relations. Disable caches (or clear them via `executor.ClearCaches()`) if underlying facts/providers can change or have side effects.
 - Seeded transitive-closure caches treat the seed list as a set (deduped + order-insensitive), so calls with the same seeds in different orders share a cache entry.
+- Seeded transitive-closure caches are bounded via `QueryExecutorOptions(SeededCacheMaxEntries: ...)` (default `4096` per cache key); set `0` to disable seeded transitive cache reuse while keeping other caches enabled.
 - Single concrete transitive pair probes (`source,target` both bound) now cache exact probe results (`TransitiveClosurePairsSingleProbe` and `GroupedTransitiveClosurePairsSingleProbe`) to avoid repeating one-off BFS checks across repeated calls.
 - Pair-probe caches are bounded via `QueryExecutorOptions(PairProbeCacheMaxEntries: ...)` (default `4096` per cache key); set `0` to disable pair-probe caching while keeping other cache reuse enabled.
 
@@ -116,6 +117,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
   - `await foreach (var row in executor.ExecuteAsync(plan, parameters, trace, cts.Token)) { ... }`
 - Prepared-style cache reuse (useful for repeated parameterized calls):
   - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));`
+  - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true, SeededCacheMaxEntries: 1024));`
   - `var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true, PairProbeCacheMaxEntries: 1024));`
   - `executor.ClearCaches();` (if underlying facts change)
   - See “Ordering, Purity, and Effects” below for ordering/side-effect assumptions.

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -299,8 +299,12 @@ test_csharp_query_target :-
         verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_seed_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime,
+        verify_parameterized_reachability_seed_cache_eviction_runtime,
+        verify_parameterized_reachability_by_target_seed_cache_eviction_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_eviction_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_eviction_runtime,
+        verify_parameterized_grouped_transitive_closure_seed_cache_eviction_runtime,
+        verify_parameterized_grouped_transitive_closure_by_target_seed_cache_eviction_runtime,
         verify_transitive_closure_cache_reuse_runtime,
         verify_grouped_transitive_closure_cache_reuse_runtime,
         verify_mutual_recursion_plan,
@@ -3543,6 +3547,27 @@ verify_parameterized_grouped_transitive_closure_cache_reuse_runtime :-
         [[a, red, cat1]],
         HarnessSource).
 
+verify_parameterized_grouped_transitive_closure_seed_cache_eviction_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, red, cat1]],
+    WarmParams2 = [[a, blue, cat1]],
+    ExecParams = [[a, red, cat1]],
+    harness_source_with_cache_flag_two_warm_exec_seed_limit(
+        ModuleClass,
+        WarmParams,
+        WarmParams2,
+        ExecParams,
+        'GroupedTransitiveClosureSeeded',
+        1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,b,red,cat1',
+         'a,c,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeeded=false'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive_runtime :-
     csharp_query_target:build_query_plan(test_label_cat_reach_param/4, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -3601,6 +3626,27 @@ verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_ru
         ExecParams,
         HarnessSource).
 
+verify_parameterized_grouped_transitive_closure_by_target_seed_cache_eviction_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param_end/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[c, red, cat1]],
+    WarmParams2 = [[e, blue, cat1]],
+    ExecParams = [[c, red, cat1]],
+    harness_source_with_cache_flag_two_warm_exec_seed_limit(
+        ModuleClass,
+        WarmParams,
+        WarmParams2,
+        ExecParams,
+        'GroupedTransitiveClosureSeededByTarget',
+        1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,c,red,cat1',
+         'b,c,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=false'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_reachability_cache_reuse_runtime :-
     csharp_query_target:build_query_plan(test_reachable_param/2, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -3612,6 +3658,27 @@ verify_parameterized_reachability_cache_reuse_runtime :-
         [[alice]],
         HarnessSource).
 
+verify_parameterized_reachability_seed_cache_eviction_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[alice]],
+    WarmParams2 = [[bob]],
+    ExecParams = [[alice]],
+    harness_source_with_cache_flag_two_warm_exec_seed_limit(
+        ModuleClass,
+        WarmParams,
+        WarmParams2,
+        ExecParams,
+        'TransitiveClosureSeeded',
+        1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['alice,bob',
+         'alice,charlie',
+         'CACHE_HIT:TransitiveClosureSeeded=false'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_reachability_by_target_cache_reuse_runtime :-
     csharp_query_target:build_query_plan(test_reachable_param_end/2, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -3621,6 +3688,27 @@ verify_parameterized_reachability_by_target_cache_reuse_runtime :-
          'bob,charlie',
          'CACHE_HIT:TransitiveClosureSeededByTarget=true'],
         [[charlie]],
+        HarnessSource).
+
+verify_parameterized_reachability_by_target_seed_cache_eviction_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param_end/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[charlie]],
+    WarmParams2 = [[bob]],
+    ExecParams = [[charlie]],
+    harness_source_with_cache_flag_two_warm_exec_seed_limit(
+        ModuleClass,
+        WarmParams,
+        WarmParams2,
+        ExecParams,
+        'TransitiveClosureSeededByTarget',
+        1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['alice,charlie',
+         'bob,charlie',
+         'CACHE_HIT:TransitiveClosureSeededByTarget=false'],
+        ExecParams,
         HarnessSource).
 
 verify_parameterized_reachability_pairs_cache_reuse_runtime :-
@@ -5064,6 +5152,60 @@ var jsonOptions = new JsonSerializerOptions { WriteIndented = false };
    var used = trace.SnapshotCaches().Any(s => s.Cache == "~w" && s.Hits > 0);
    Console.WriteLine("CACHE_HIT:~w=" + (used ? "true" : "false"));
     ', [ModuleClass, PairLimit, WarmLiteral1, WarmLiteral2, ExecLiteral, Cache, Cache]).
+
+harness_source_with_cache_flag_two_warm_exec_seed_limit(ModuleClass, WarmParams1, WarmParams2, ExecParams, Cache, SeedLimit, Source) :-
+    csharp_params_literal(WarmParams1, WarmLiteral1),
+    csharp_params_literal(WarmParams2, WarmLiteral2),
+    csharp_params_literal(ExecParams, ExecLiteral),
+    format(atom(Source),
+'using System;
+ using System.Linq;
+ using System.Globalization;
+ using UnifyWeaver.QueryRuntime;
+ using System.Text.Json;
+ using System.Text.Json.Nodes;
+
+var result = UnifyWeaver.Generated.~w.Build();
+var executor = new QueryExecutor(
+    result.Provider,
+    new QueryExecutorOptions(ReuseCaches: true, SeededCacheMaxEntries: ~w));
+var _planText = QueryPlanExplainer.Explain(result.Plan);
+var warmParameters1 = ~w;
+var warmTrace1 = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, warmParameters1, warmTrace1).ToList();
+var warmParameters2 = ~w;
+var warmTrace2 = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, warmParameters2, warmTrace2).ToList();
+var parameters = ~w;
+var jsonOptions = new JsonSerializerOptions { WriteIndented = false };
+
+ string FormatValue(object? value) => value switch
+ {
+     JsonNode node => node.ToJsonString(jsonOptions),
+     JsonElement element => element.GetRawText(),
+      System.Collections.IEnumerable enumerable when value is not string => "[" + string.Join("|", enumerable.Cast<object?>().Select(FormatValue).OrderBy(s => s, StringComparer.Ordinal)) + "]",
+      IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+      _ => value?.ToString() ?? string.Empty
+  };
+
+ var trace = new QueryExecutionTrace();
+ foreach (var row in executor.Execute(result.Plan, parameters, trace))
+ {
+    var projected = row.Take(result.Plan.Head.Arity)
+                       .Select(FormatValue)
+                       .ToArray();
+
+    if (projected.Length == 0)
+    {
+        continue;
+    }
+
+     Console.WriteLine(string.Join(",", projected));
+   }
+ 
+   var used = trace.SnapshotCaches().Any(s => s.Cache == "~w" && s.Hits > 0);
+   Console.WriteLine("CACHE_HIT:~w=" + (used ? "true" : "false"));
+    ', [ModuleClass, SeedLimit, WarmLiteral1, WarmLiteral2, ExecLiteral, Cache, Cache]).
 
 harness_source_with_cache_hit_flag(ModuleClass, Params, Cache, Source) :-
     (   Params == []


### PR DESCRIPTION
  This PR adds bounded eviction for seeded transitive-closure caches in the C# query runtime to prevent unbounded growth

  - Runtime option:
      - Added SeededCacheMaxEntries to QueryExecutorOptions (default 4096).
      - 0 disables seeded transitive cache reuse while leaving other caches unaffected.
      - Applied bounded cache gating/writes across all seeded transitive cache families:
          - TransitiveClosureSeeded
          - TransitiveClosureSeededByTarget
          - GroupedTransitiveClosureSeeded
          - GroupedTransitiveClosureSeededByTarget
      - Reused the existing bounded row-wrapper cache insertion helper for eviction behavior.
  - Test coverage:
      - Added runtime eviction tests (warm A, warm B, execute A with limit 1) asserting cache miss after eviction for:
          - seeded reachability
          - seeded by-target reachability
          - grouped seeded reachability
          - grouped seeded by-target reachability
      - Added a dedicated harness helper to run two warm executions with SeededCacheMaxEntries.
  - Docs:
      - Documented seeded-cache bounds and SeededCacheMaxEntries usage in the C# runtime target doc.

  ## Why

  Seeded transitive caches previously grew without bounds as unique seed sets accumulated. This change keeps cache
  growth controlled while preserving current behavior by default.

  ## Validation

  - dotnet build src/unifyweaver/targets/csharp_query_runtime/UnifyWeaver.QueryRuntime.Core.csproj -c Release passes.
  - Prolog suite execution was not run locally in this shell because swipl is unavailable.