### PR TITLE
perf(csharp-query): add transitive cache admission controls + diagnostics

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -5484,7 +5484,7 @@ Console.WriteLine("CACHE_HIT_HOT:~w=" + (hotHit ? "true" : "false"));
 Console.WriteLine("CACHE_HIT_COLD:~w=" + (coldHit ? "true" : "false"));
 Console.WriteLine("CACHE_ADMISSIONS:~w=" + admissions.ToString());
 Console.WriteLine("CACHE_ADMISSION_SKIPS:~w=" + admissionSkips.ToString());
-    ', [ModuleClass, SeedLimit, MinRows, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
+    ', [ModuleClass, SeedLimit, MinRows, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
 
 harness_source_with_pair_cache_admission_flag(
         ModuleClass,
@@ -5532,7 +5532,7 @@ Console.WriteLine("CACHE_HIT_HOT:~w=" + (hotHit ? "true" : "false"));
 Console.WriteLine("CACHE_HIT_COLD:~w=" + (coldHit ? "true" : "false"));
 Console.WriteLine("CACHE_ADMISSIONS:~w=" + admissions.ToString());
 Console.WriteLine("CACHE_ADMISSION_SKIPS:~w=" + admissionSkips.ToString());
-    ', [ModuleClass, PairLimit, MinCost, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
+    ', [ModuleClass, PairLimit, MinCost, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
 
 harness_source_with_cache_hit_flag(ModuleClass, Params, Cache, Source) :-
     (   Params == []


### PR DESCRIPTION
  - Adds admission controls for bounded transitive caches to reduce LRU churn from cheap one-off entries.
  - Extends QueryExecutorOptions with:
      - SeededCacheAdmissionMinRows (default 0)
      - PairProbeCacheAdmissionMinCost (default 0)
  - Applies admission gating across seeded and single-pair transitive caches (grouped and non-grouped paths), while
    preserving existing LRU eviction semantics.
  - Extends cache trace diagnostics with:
      - admissions
      - admission_skips
  - Updates QueryExecutionTrace snapshots/string output to include the new counters.
  - Adds runtime coverage in tests/core/test_csharp_query_target.pl:
      - verify_parameterized_reachability_seed_cache_admission_runtime
      - verify_parameterized_reachability_pairs_single_probe_cache_admission_runtime
  - Documents the new options and diagnostics in docs/targets/csharp-query-runtime.md.