### PR TITLE
feat(agent-loop): Polish Prolog target + extract trapped data

### DIFF
--- a/tools/agent-loop/generated/prolog/config.pl
+++ b/tools/agent-loop/generated/prolog/config.pl
@@ -10,12 +10,14 @@
     api_key_env_var/2,
     api_key_file/2,
     parse_cli_args/2,
+    example_agent_config/3,
+    config_search_path/2,
     load_config/2,
     resolve_api_key/3
 ]).
 
 :- use_module(library(optparse)).
-:- use_module(library(http/json)).
+:- use_module(library(json)).
 
 %% cli_argument(+Name, +Options)
 cli_argument(agent, [long('--agent'), short('-a'), default(none), help('Agent variant from config file (e.g., yolo, claude-opus, ollama)')]).
@@ -99,6 +101,24 @@ api_key_env_var(gemini, 'GEMINI_API_KEY').
 %% api_key_file(+Backend, +FilePath)
 api_key_file(claude, '~/.anthropic/api_key').
 api_key_file(openai, '~/.openai/api_key').
+
+%% example_agent_config(+Name, +Backend, +Properties)
+example_agent_config('claude-sonnet', 'claude-code', [=(model,sonnet), =(tools,["bash","read","write","edit"]), =(context_mode,continue)]).
+example_agent_config('claude-opus', 'claude-code', [=(model,opus), =(system_prompt,"You are a senior software engineer. Be thorough.")]).
+example_agent_config(yolo, 'claude-code', [=(model,haiku), =(auto_tools,true), =(system_prompt,"Be fast and take action without asking.")]).
+example_agent_config(gemini, gemini, [=(model,'gemini-2.5-flash')]).
+example_agent_config('ollama-local', 'ollama-api', [=(model,llama3), =(host,localhost), =(port,11434)]).
+example_agent_config('ollama-remote', 'ollama-api', [=(model,codellama), =(host,'192.168.1.100'), =(port,11434)]).
+example_agent_config('claude-api', claude, [=(model,'claude-sonnet-4-20250514'), =(api_key,'$ANTHROPIC_API_KEY')]).
+example_agent_config(openai, openai, [=(model,'gpt-4o'), =(api_key,'$OPENAI_API_KEY')]).
+example_agent_config('openai-mini', openai, [=(model,'gpt-4o-mini'), =(api_key,'$OPENAI_API_KEY')]).
+example_agent_config('coding-assistant', 'claude-code', [=(model,sonnet), =(agent_md,"./agents/coding.md"), =(skills,["./skills/git.md","./skills/testing.md"]), =(tools,["bash","read","write","edit"]), =(system_prompt,"You are a coding assistant focused on clean, tested code.")]).
+
+%% config_search_path(+Path, +Category)
+config_search_path('uwsal.json', required).
+config_search_path('~/uwsal.json', required).
+config_search_path('coro.json', fallback).
+config_search_path('~/coro.json', fallback).
 
 %% Parse CLI arguments using SWI-Prolog optparse
 parse_cli_args(Argv, Options) :-


### PR DESCRIPTION
## Summary

Three improvements to the agent-loop code generator, all in `agent_loop_module.pl`:

1. **Extract trapped data from py_fragments** — Three fragments contained hardcoded data that duplicated existing Prolog facts. Replaced with generators that produce identical Python output from facts:
   - `config_save_example` → 10 `example_agent_config/3` facts + `generate_config_save_example/1`
   - `config_read_cascade` → 4 `config_search_path/3` facts + `generate_config_cascade/1`
   - Default tool list in `tools_handler_class_header` → derived from `tool_handler/2` via `{{default_tools}}` substitution

2. **Prolog target quality fixes**:
   - Fix deprecated `library(http/json)` → `library(json)` in backends.pl and config.pl generators
   - Add `catch/3` error handling around HTTP API calls
   - Add `extract_response/2` for normalizing OpenAI (`choices[0].message`) and Anthropic (`content` array) response formats
   - CLI backend exit status checking with error reporting
   - Emit new facts (`example_agent_config/3`, `config_search_path/2`) in generated Prolog config.pl

3. **Implement Prolog slash commands end-to-end**:
   - `/cost` — show API cost tracking
   - `/backend` — show current backend, list available
   - `/iterations [N]` — show/set max iterations with `max_iterations/1` dynamic predicate
   - `/aliases` — list command aliases
   - `/history [N]` — show last N messages with truncation
   - `/stream` — stub (not yet supported)
   - Compound alias resolution (e.g. `/yolo` → `/backend yolo`)
   - Prefix command argument extraction from user input
   - Grouped `/help` display using `slash_command_group/2`
   - Iteration tracking in tool call loop with pause/resume

## Verification

- Python zero-diff maintained (all generated Python matches prototype/)
- Prolog loads cleanly with no warnings: `swipl -l main.pl -g halt`
- Tool execution: `execute_tool(bash, _{command: 'echo hi'}, R)` → `ok(hi)`
- Security: `check_path_allowed('/etc/shadow', R)` → `blocked(Blocked path)`
- Cost tracking: `cost_tracker_init(t), cost_tracker_add(t, 'gpt-4o', 100, 50)` → works
- Command parsing: `/backend` → `call_handler(_handle_backend_command, )`
- Alias resolution: `yolo` → `Cmd=backend Args=yolo`

## Stats

- 5 files changed, +592 / -176 lines
- 14 new Prolog facts (10 example_agent_config + 4 config_search_path)
- 7 slash commands implemented (up from 0)
