### PR TITLE
feat(agent-loop): Complete Prolog runnability + component integration

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -1,0 +1,202 @@
+%% agent_loop_components.pl — Component registry integration for agent-loop
+%%
+%% Bridges agent-loop facts (tool_handler/2, slash_command/4, backend_factory/2)
+%% into the UnifyWeaver component registry for cross-system discoverability.
+%%
+%% Usage:
+%%   swipl -l agent_loop_components.pl -g "agent_loop_component_summary, halt"
+%%
+%% This module is an optional overlay — generated Prolog files remain standalone.
+
+:- module(agent_loop_components, [
+    register_agent_loop_components/0,
+    agent_loop_component_summary/0
+]).
+
+:- reexport('../../src/unifyweaver/core/component_registry', [
+    compile_component/4,
+    list_components/2,
+    component/4
+]).
+
+:- use_module('../../src/unifyweaver/core/component_registry').
+:- use_module(agent_loop_module).
+
+%% ============================================================================
+%% Inline Type Modules
+%% ============================================================================
+%%
+%% Each type module implements: type_info/1, validate_config/1,
+%% init_component/2, compile_component/4
+%% These are defined as module-qualified clauses below.
+
+%% --- Tool handler type ---
+
+:- module_transparent agent_tool_type:type_info/1.
+:- module_transparent agent_tool_type:validate_config/1.
+:- module_transparent agent_tool_type:init_component/2.
+:- module_transparent agent_tool_type:compile_component/4.
+
+agent_tool_type:type_info(info{
+    name: 'Agent Tool Handler',
+    version: '1.0.0',
+    description: 'Maps tool names to handler predicates'
+}).
+
+agent_tool_type:validate_config(Config) :-
+    member(handler(_), Config).
+
+agent_tool_type:init_component(_Name, _Config).
+
+agent_tool_type:compile_component(Name, Config, Options, Code) :-
+    member(handler(H), Config),
+    (member(target(prolog), Options) ->
+        format(atom(Code), "tool_handler(~q, ~q).", [Name, H])
+    ; member(target(python), Options) ->
+        format(atom(Code), "    '~w': ~w,", [Name, H])
+    ;
+        format(atom(Code), "tool_handler(~q, ~q).", [Name, H])
+    ).
+
+%% --- Slash command type ---
+
+:- module_transparent agent_command_type:type_info/1.
+:- module_transparent agent_command_type:validate_config/1.
+:- module_transparent agent_command_type:init_component/2.
+:- module_transparent agent_command_type:compile_component/4.
+
+agent_command_type:type_info(info{
+    name: 'Agent Slash Command',
+    version: '1.0.0',
+    description: 'Slash command definition for the agent loop'
+}).
+
+agent_command_type:validate_config(Config) :-
+    member(match_type(_), Config),
+    member(help_text(_), Config).
+
+agent_command_type:init_component(_Name, _Config).
+
+agent_command_type:compile_component(Name, Config, Options, Code) :-
+    member(match_type(MT), Config),
+    member(help_text(HT), Config),
+    (member(options(Opts), Config) -> true ; Opts = []),
+    (member(target(prolog), Options) ->
+        format(atom(Code), "slash_command(~q, ~q, ~q, ~q).", [Name, MT, Opts, HT])
+    ;
+        format(atom(Code), "slash_command(~q, ~q, ~q, ~q).", [Name, MT, Opts, HT])
+    ).
+
+%% --- Backend factory type ---
+
+:- module_transparent agent_backend_type:type_info/1.
+:- module_transparent agent_backend_type:validate_config/1.
+:- module_transparent agent_backend_type:init_component/2.
+:- module_transparent agent_backend_type:compile_component/4.
+
+agent_backend_type:type_info(info{
+    name: 'Agent Backend',
+    version: '1.0.0',
+    description: 'Backend factory for LLM requests'
+}).
+
+agent_backend_type:validate_config(Config) :-
+    member(resolve_type(_), Config),
+    member(class_name(_), Config).
+
+agent_backend_type:init_component(_Name, _Config).
+
+agent_backend_type:compile_component(Name, Config, Options, Code) :-
+    (member(target(prolog), Options) ->
+        format(atom(Code), "backend_factory(~q, ~q).", [Name, Config])
+    ;
+        format(atom(Code), "backend_factory(~q, ~q).", [Name, Config])
+    ).
+
+%% ============================================================================
+%% Category and Type Registration
+%% ============================================================================
+
+register_agent_loop_categories :-
+    define_category(agent_tools, "Agent-loop tool definitions", [
+        requires_compilation(true)
+    ]),
+    define_category(agent_commands, "Agent-loop slash commands", [
+        requires_compilation(true)
+    ]),
+    define_category(agent_backends, "Agent-loop backend definitions", [
+        requires_compilation(true)
+    ]).
+
+register_agent_loop_types :-
+    register_component_type(agent_tools, tool_handler, agent_tool_type, [
+        description("Tool handler mapping")
+    ]),
+    register_component_type(agent_commands, slash_command, agent_command_type, [
+        description("Slash command definition")
+    ]),
+    register_component_type(agent_backends, backend, agent_backend_type, [
+        description("Agent backend factory")
+    ]).
+
+%% ============================================================================
+%% Instance Population from Existing Facts
+%% ============================================================================
+
+%% Populate tool components from tool_handler/2 + tool_spec/2 + destructive_tool/1
+register_tool_components :-
+    forall(agent_loop_module:tool_handler(Name, Handler), (
+        (agent_loop_module:tool_spec(Name, Props) ->
+            (member(description(Desc), Props) -> true ; Desc = "")
+        ; Desc = ""),
+        (agent_loop_module:destructive_tool(Name) -> Destr = true ; Destr = false),
+        declare_component(agent_tools, Name, tool_handler, [
+            handler(Handler),
+            description(Desc),
+            destructive(Destr),
+            initialization(eager)
+        ])
+    )).
+
+%% Populate command components from slash_command/4
+register_command_components :-
+    forall(agent_loop_module:slash_command(Name, MatchType, Opts, Help), (
+        declare_component(agent_commands, Name, slash_command, [
+            match_type(MatchType),
+            options(Opts),
+            help_text(Help),
+            initialization(eager)
+        ])
+    )).
+
+%% Populate backend components from backend_factory/2
+register_backend_components :-
+    forall(agent_loop_module:backend_factory(Name, Spec), (
+        declare_component(agent_backends, Name, backend, Spec)
+    )).
+
+%% ============================================================================
+%% Master Registration
+%% ============================================================================
+
+%% register_agent_loop_components/0
+%% Registers all categories, types, and populates instances from existing facts.
+register_agent_loop_components :-
+    register_agent_loop_categories,
+    register_agent_loop_types,
+    register_tool_components,
+    register_command_components,
+    register_backend_components.
+
+%% agent_loop_component_summary/0
+%% Registers everything and prints a summary.
+agent_loop_component_summary :-
+    register_agent_loop_components,
+    list_components(agent_tools, Tools),
+    list_components(agent_commands, Cmds),
+    list_components(agent_backends, Backends),
+    length(Tools, NT), length(Cmds, NC), length(Backends, NB),
+    format("~nAgent-loop components registered:~n"),
+    format("  Tools:    ~w ~w~n", [NT, Tools]),
+    format("  Commands: ~w ~w~n", [NC, Cmds]),
+    format("  Backends: ~w ~w~n", [NB, Backends]).

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -12,9 +12,16 @@
     generate_module/1,
     agent_backend/2,
     tool_spec/2,
+    tool_handler/2,
+    destructive_tool/1,
     security_profile/2,
     model_pricing/3,
-    security_module/3
+    security_module/3,
+    audit_profile_level/2,
+    slash_command/4,
+    command_alias/2,
+    backend_factory/2,
+    backend_factory_order/1
 ]).
 
 :- discontiguous generate_backend_full/3.
@@ -269,6 +276,13 @@ security_profile(paranoid, [
     max_file_read_size(1048576),
     max_file_write_size(10485760)
 ]).
+
+%% audit_profile_level(+ProfileName, +AuditLevel)
+%% Maps security profile to audit logging level.
+audit_profile_level(open, disabled).
+audit_profile_level(cautious, basic).
+audit_profile_level(guarded, detailed).
+audit_profile_level(paranoid, forensic).
 
 %% Regex lists referenced by profiles
 regex_list(guarded_extra_blocks, [
@@ -1115,6 +1129,7 @@ generate_prolog_config :-
     write(S, '    config_search_path/2,\n'),
     write(S, '    config_field_json_default/2,\n'),
     write(S, '    config_dir_file_name/1,\n'),
+    write(S, '    audit_profile_level/2,\n'),
     write(S, '    load_config/2,\n'),
     write(S, '    resolve_api_key/3\n'),
     write(S, ']).\n\n'),
@@ -1180,6 +1195,13 @@ generate_prolog_config :-
     write(S, '%% Standard config file names searched by load_config_from_dir.\n'),
     forall(config_dir_file_name(FN), (
         format(S, 'config_dir_file_name(~q).~n', [FN])
+    )),
+    write(S, '\n'),
+    %% Emit audit_profile_level facts
+    write(S, '%% audit_profile_level(+Profile, +AuditLevel)\n'),
+    write(S, '%% Maps security profile to audit logging level.\n'),
+    forall(audit_profile_level(P, L), (
+        format(S, 'audit_profile_level(~q, ~q).~n', [P, L])
     )),
     write(S, '\n'),
     %% Generate parse_cli_args using optparse
@@ -1685,13 +1707,18 @@ generate_prolog_agent_loop :-
     write(S, ':- use_module(backends).\n'),
     write(S, ':- use_module(commands).\n'),
     write(S, ':- use_module(security).\n'),
-    write(S, ':- use_module(costs).\n\n'),
+    write(S, ':- use_module(costs).\n'),
+    write(S, ':- use_module(library(json)).\n'),
+    write(S, ':- use_module(library(filesex)).\n\n'),
     write(S, ':- dynamic conversation/1.\n'),
     write(S, ':- dynamic conversation_undo/1.\n'),
     write(S, ':- dynamic max_iterations/1.\n'),
     write(S, ':- dynamic current_backend/1.\n'),
+    write(S, ':- dynamic current_format/1.\n'),
     write(S, 'conversation([]).\n'),
-    write(S, 'max_iterations(0).\n\n'),
+    write(S, 'max_iterations(0).\n'),
+    write(S, 'current_format(plain).\n'),
+    write(S, 'sessions_dir(Dir) :- expand_file_name("~/.agent-loop/sessions", [Dir]).\n\n'),
     %% Main entry
     write(S, '%% Entry point with default options\n'),
     write(S, 'agent_loop :- agent_loop([]).\n\n'),
@@ -1975,6 +2002,129 @@ generate_prolog_agent_loop :-
     write(S, '            format("Invalid index. Messages: 0-~w~n", [Len])\n'),
     write(S, '        )\n'),
     write(S, '    ).\n'),
+    %% /save command — save conversation to session file
+    write(S, 'handle_action(call_handler(\'_handle_save_command\', Args), Backend) :-\n'),
+    write(S, '    conversation(Msgs),\n'),
+    write(S, '    get_dict(name, Backend, BName),\n'),
+    write(S, '    length(Msgs, MsgCount),\n'),
+    write(S, '    get_time(Now), stamp_date_time(Now, DT, local),\n'),
+    write(S, '    format_time(atom(SessionId), "%Y%m%d_%H%M%S", DT),\n'),
+    write(S, '    (Args = "" -> Name = SessionId ; atom_string(Name, Args)),\n'),
+    write(S, '    sessions_dir(SDir),\n'),
+    write(S, '    make_directory_path(SDir),\n'),
+    write(S, '    format(atom(FileName), "~w/~w.json", [SDir, SessionId]),\n'),
+    write(S, '    SessionData = _{metadata: _{id: SessionId, name: Name, backend: BName, message_count: MsgCount}, messages: Msgs},\n'),
+    write(S, '    setup_call_cleanup(\n'),
+    write(S, '        open(FileName, write, Out),\n'),
+    write(S, '        json_write_dict(Out, SessionData, []),\n'),
+    write(S, '        close(Out)),\n'),
+    write(S, '    format("Saved session: ~w (~w messages)~n", [SessionId, MsgCount]).\n'),
+    %% /load command — load session from file
+    write(S, 'handle_action(call_handler(\'_handle_load_command\', Args), _) :-\n'),
+    write(S, '    (Args = "" ->\n'),
+    write(S, '        write("Usage: /load <session_id>"), nl\n'),
+    write(S, '    ;\n'),
+    write(S, '        atom_string(SessionId, Args),\n'),
+    write(S, '        sessions_dir(SDir),\n'),
+    write(S, '        format(atom(FileName), "~w/~w.json", [SDir, SessionId]),\n'),
+    write(S, '        (exists_file(FileName) ->\n'),
+    write(S, '            setup_call_cleanup(\n'),
+    write(S, '                open(FileName, read, In),\n'),
+    write(S, '                json_read_dict(In, Data),\n'),
+    write(S, '                close(In)),\n'),
+    write(S, '            get_dict(messages, Data, Msgs),\n'),
+    write(S, '            retractall(conversation(_)),\n'),
+    write(S, '            assert(conversation(Msgs)),\n'),
+    write(S, '            length(Msgs, Len),\n'),
+    write(S, '            (get_dict(metadata, Data, Meta), get_dict(name, Meta, Name) -> true ; Name = SessionId),\n'),
+    write(S, '            format("Loaded session: ~w (~w messages)~n", [Name, Len])\n'),
+    write(S, '        ;\n'),
+    write(S, '            format("Session not found: ~w~n", [SessionId])\n'),
+    write(S, '        )\n'),
+    write(S, '    ).\n'),
+    %% /sessions command — list saved sessions
+    write(S, 'handle_action(call_handler(\'_handle_sessions_command\', _), _) :-\n'),
+    write(S, '    sessions_dir(SDir),\n'),
+    write(S, '    (exists_directory(SDir) ->\n'),
+    write(S, '        directory_files(SDir, AllFiles),\n'),
+    write(S, '        include(json_file, AllFiles, JsonFiles),\n'),
+    write(S, '        (JsonFiles = [] ->\n'),
+    write(S, '            write("No saved sessions."), nl\n'),
+    write(S, '        ;\n'),
+    write(S, '            write("Saved sessions:"), nl,\n'),
+    write(S, '            forall(member(F, JsonFiles), (\n'),
+    write(S, '                format(atom(FullPath), "~w/~w", [SDir, F]),\n'),
+    write(S, '                catch((\n'),
+    write(S, '                    setup_call_cleanup(\n'),
+    write(S, '                        open(FullPath, read, In),\n'),
+    write(S, '                        json_read_dict(In, Data),\n'),
+    write(S, '                        close(In)),\n'),
+    write(S, '                    get_dict(metadata, Data, Meta),\n'),
+    write(S, '                    get_dict(id, Meta, Id),\n'),
+    write(S, '                    get_dict(name, Meta, Name),\n'),
+    write(S, '                    get_dict(message_count, Meta, MC),\n'),
+    write(S, '                    format("  ~w: ~w (~w msgs)~n", [Id, Name, MC])\n'),
+    write(S, '                ), _, (\n'),
+    write(S, '                    file_name_extension(Base, _, F),\n'),
+    write(S, '                    format("  ~w: (unreadable)~n", [Base])\n'),
+    write(S, '                ))\n'),
+    write(S, '            ))\n'),
+    write(S, '        )\n'),
+    write(S, '    ; write("No saved sessions."), nl).\n'),
+    %% /format command — get/set context format
+    write(S, 'handle_action(call_handler(\'_handle_format_command\', Args), _) :-\n'),
+    write(S, '    (Args = "" ->\n'),
+    write(S, '        current_format(Fmt),\n'),
+    write(S, '        format("Current format: ~w~nAvailable: plain, markdown, json, xml~n", [Fmt])\n'),
+    write(S, '    ;\n'),
+    write(S, '        atom_string(NewFmt, Args),\n'),
+    write(S, '        (member(NewFmt, [plain, markdown, json, xml]) ->\n'),
+    write(S, '            retractall(current_format(_)),\n'),
+    write(S, '            assert(current_format(NewFmt)),\n'),
+    write(S, '            format("Format set to: ~w~n", [NewFmt])\n'),
+    write(S, '        ;\n'),
+    write(S, '            format("Unknown format: ~w~nAvailable: plain, markdown, json, xml~n", [NewFmt])\n'),
+    write(S, '        )\n'),
+    write(S, '    ).\n'),
+    %% /export command — export conversation to file
+    write(S, 'handle_action(call_handler(\'_handle_export_command\', Args), _) :-\n'),
+    write(S, '    (Args = "" ->\n'),
+    write(S, '        write("Usage: /export <path> (.md, .html, .json, .txt)"), nl\n'),
+    write(S, '    ;\n'),
+    write(S, '        atom_string(FilePath, Args),\n'),
+    write(S, '        conversation(Msgs),\n'),
+    write(S, '        length(Msgs, Len),\n'),
+    write(S, '        file_name_extension(_, Ext, FilePath),\n'),
+    write(S, '        (export_conversation(Ext, Msgs, Content) ->\n'),
+    write(S, '            setup_call_cleanup(\n'),
+    write(S, '                open(FilePath, write, Out),\n'),
+    write(S, '                write(Out, Content),\n'),
+    write(S, '                close(Out)),\n'),
+    write(S, '            format("Exported ~w messages to ~w~n", [Len, FilePath])\n'),
+    write(S, '        ;\n'),
+    write(S, '            format("Unsupported format: .~w (use .md, .html, .json, .txt)~n", [Ext])\n'),
+    write(S, '        )\n'),
+    write(S, '    ).\n'),
+    %% /search command — search across saved sessions
+    write(S, 'handle_action(call_handler(\'_handle_search_command\', Args), _) :-\n'),
+    write(S, '    (Args = "" ->\n'),
+    write(S, '        write("Usage: /search <query>"), nl\n'),
+    write(S, '    ;\n'),
+    write(S, '        sessions_dir(SDir),\n'),
+    write(S, '        (exists_directory(SDir) ->\n'),
+    write(S, '            directory_files(SDir, AllFiles),\n'),
+    write(S, '            include(json_file, AllFiles, JsonFiles),\n'),
+    write(S, '            atom_string(Query, Args),\n'),
+    write(S, '            format("Search results for \'~w\':~n", [Query]),\n'),
+    write(S, '            search_sessions(SDir, JsonFiles, Query, 0, Found),\n'),
+    write(S, '            (Found =:= 0 -> format("  No results for: ~w~n", [Query]) ; true)\n'),
+    write(S, '        ;\n'),
+    write(S, '            write("No sessions directory found."), nl\n'),
+    write(S, '        )\n'),
+    write(S, '    ).\n'),
+    %% /templates command (stub)
+    write(S, 'handle_action(call_handler(\'_handle_templates_command\', _), _) :-\n'),
+    write(S, '    write("No templates loaded."), nl.\n'),
     %% Catch-all for unimplemented handlers
     write(S, 'handle_action(not_a_command, _) :- write("Unknown command."), nl.\n'),
     write(S, 'handle_action(unknown(Cmd), _) :- format("Unknown command: /~w~n", [Cmd]).\n'),
@@ -2016,7 +2166,70 @@ generate_prolog_agent_loop :-
     write(S, '    replace_at(Rest, Target, NewContent, NextIdx, Result).\n'),
     write(S, 'replace_at([H|Rest], Target, NewContent, Idx, [H|Result]) :-\n'),
     write(S, '    NextIdx is Idx + 1,\n'),
-    write(S, '    replace_at(Rest, Target, NewContent, NextIdx, Result).\n'),
+    write(S, '    replace_at(Rest, Target, NewContent, NextIdx, Result).\n\n'),
+    %% Helper: filter JSON files
+    write(S, '%% Filter for .json files\n'),
+    write(S, 'json_file(F) :- file_name_extension(_, json, F).\n\n'),
+    %% Export conversation helpers
+    write(S, '%% Export conversation to different formats\n'),
+    write(S, 'export_conversation(json, Msgs, Content) :-\n'),
+    write(S, '    with_output_to(string(Content), json_write_dict(current_output, Msgs, [])).\n'),
+    write(S, 'export_conversation(md, Msgs, Content) :-\n'),
+    write(S, '    with_output_to(string(Content), (\n'),
+    write(S, '        write("# Conversation\\n\\n"),\n'),
+    write(S, '        forall(member(Msg, Msgs), (\n'),
+    write(S, '            get_dict(role, Msg, Role),\n'),
+    write(S, '            get_dict(content, Msg, C),\n'),
+    write(S, '            (Role = "user" -> write("**You:**") ; write("**Assistant:**")),\n'),
+    write(S, '            nl, nl, write(C), nl, nl\n'),
+    write(S, '        ))\n'),
+    write(S, '    )).\n'),
+    write(S, 'export_conversation(txt, Msgs, Content) :-\n'),
+    write(S, '    with_output_to(string(Content), (\n'),
+    write(S, '        forall(member(Msg, Msgs), (\n'),
+    write(S, '            get_dict(role, Msg, Role),\n'),
+    write(S, '            get_dict(content, Msg, C),\n'),
+    write(S, '            format("~w: ~w~n~n", [Role, C])\n'),
+    write(S, '        ))\n'),
+    write(S, '    )).\n'),
+    write(S, 'export_conversation(html, Msgs, Content) :-\n'),
+    write(S, '    with_output_to(string(Content), (\n'),
+    write(S, '        write("<html><body>\\n"),\n'),
+    write(S, '        forall(member(Msg, Msgs), (\n'),
+    write(S, '            get_dict(role, Msg, Role),\n'),
+    write(S, '            get_dict(content, Msg, C),\n'),
+    write(S, '            format("<div class=\\"~w\\"><b>~w:</b><p>~w</p></div>\\n", [Role, Role, C])\n'),
+    write(S, '        )),\n'),
+    write(S, '        write("</body></html>\\n")\n'),
+    write(S, '    )).\n\n'),
+    %% Session search helpers
+    write(S, '%% Search across saved session files\n'),
+    write(S, 'search_sessions(_, [], _, Found, Found).\n'),
+    write(S, 'search_sessions(SDir, [F|Rest], Query, Acc, Found) :-\n'),
+    write(S, '    format(atom(Path), "~w/~w", [SDir, F]),\n'),
+    write(S, '    catch((\n'),
+    write(S, '        setup_call_cleanup(open(Path, read, In), json_read_dict(In, Data), close(In)),\n'),
+    write(S, '        get_dict(messages, Data, Msgs),\n'),
+    write(S, '        get_dict(metadata, Data, Meta),\n'),
+    write(S, '        get_dict(id, Meta, SessId),\n'),
+    write(S, '        search_messages(SessId, Msgs, Query, Acc, Acc1)\n'),
+    write(S, '    ), _, Acc1 = Acc),\n'),
+    write(S, '    search_sessions(SDir, Rest, Query, Acc1, Found).\n\n'),
+    write(S, 'search_messages(_, [], _, Acc, Acc).\n'),
+    write(S, 'search_messages(SessId, [Msg|Rest], Query, Acc, Found) :-\n'),
+    write(S, '    get_dict(content, Msg, Content),\n'),
+    write(S, '    get_dict(role, Msg, Role),\n'),
+    write(S, '    (sub_string(Content, _, _, _, Query) ->\n'),
+    write(S, '        (Role = "user" -> RLabel = "You" ; RLabel = "Asst"),\n'),
+    write(S, '        (string_length(Content, CL), CL > 60 ->\n'),
+    write(S, '            sub_string(Content, 0, 60, _, Snippet),\n'),
+    write(S, '            format("  [~w] ~w: ~w...~n", [SessId, RLabel, Snippet])\n'),
+    write(S, '        ;\n'),
+    write(S, '            format("  [~w] ~w: ~w~n", [SessId, RLabel, Content])\n'),
+    write(S, '        ),\n'),
+    write(S, '        Acc1 is Acc + 1\n'),
+    write(S, '    ; Acc1 = Acc),\n'),
+    write(S, '    search_messages(SessId, Rest, Query, Acc1, Found).\n'),
     close(S),
     format('  Generated prolog/agent_loop.pl~n', []).
 
@@ -3307,6 +3520,15 @@ generate_fallback_entries(S, [BT|Rest]) :-
     ),
     generate_fallback_entries(S, Rest).
 
+%% generate_audit_levels_dict(S) - emit audit_levels dict from audit_profile_level/2 facts
+generate_audit_levels_dict(S) :-
+    write(S, '\n    # Create audit logger based on security profile\n'),
+    write(S, '    audit_levels = {\n'),
+    forall(audit_profile_level(Profile, Level), (
+        format(S, '        \'~w\': \'~w\',~n', [Profile, Level])
+    )),
+    write(S, '    }\n').
+
 %% Comments for each fallback entry
 fallback_comment(coro, '               # no fallback (different CLI interface)') :- !.
 fallback_comment('claude-code', '        # no fallback') :- !.
@@ -3510,7 +3732,9 @@ generate_agent_loop_main :-
     %% Blank line separator (line 1181)
     nl(S),
     %% 12. Main body: args parsing + run logic (lines 1182-1433)
-    write_py(S, agent_loop_main_body),
+    write_py(S, agent_loop_main_body_pre_audit),
+    generate_audit_levels_dict(S),
+    write_py(S, agent_loop_main_body_post_audit),
     close(S),
     format('  Generated agent_loop.py~n', []).
 
@@ -8580,7 +8804,7 @@ def _resolve_command(backend_type: str, configured: str | None,
 ').
 
 
-py_fragment(agent_loop_main_body, '    args = parser.parse_args()
+py_fragment(agent_loop_main_body_pre_audit, '    args = parser.parse_args()
 
     # Handle --init-config
     if args.init_config:
@@ -8748,15 +8972,9 @@ py_fragment(agent_loop_main_body, '    args = parser.parse_args()
         security.proot_allowed_dirs.append(d)
     for d in security_cfg.get(\'proot_allowed_dirs\', []):
         security.proot_allowed_dirs.append(d)
+').
 
-    # Create audit logger based on security profile
-    audit_levels = {
-        \'open\': \'disabled\',
-        \'cautious\': \'basic\',
-        \'guarded\': \'detailed\',
-        \'paranoid\': \'forensic\',
-    }
-    audit_level = audit_levels.get(security_profile, \'basic\')
+py_fragment(agent_loop_main_body_post_audit, '    audit_level = audit_levels.get(security_profile, \'basic\')
     audit_log_dir = security_cfg.get(\'audit_log_dir\')
     audit_logger = AuditLogger(log_dir=audit_log_dir, level=audit_level)
 

--- a/tools/agent-loop/generated/prolog/agent_loop.pl
+++ b/tools/agent-loop/generated/prolog/agent_loop.pl
@@ -14,13 +14,18 @@
 :- use_module(commands).
 :- use_module(security).
 :- use_module(costs).
+:- use_module(library(json)).
+:- use_module(library(filesex)).
 
 :- dynamic conversation/1.
 :- dynamic conversation_undo/1.
 :- dynamic max_iterations/1.
 :- dynamic current_backend/1.
+:- dynamic current_format/1.
 conversation([]).
 max_iterations(0).
+current_format(plain).
+sessions_dir(Dir) :- expand_file_name("~/.agent-loop/sessions", [Dir]).
 
 %% Entry point with default options
 agent_loop :- agent_loop([]).
@@ -297,6 +302,122 @@ handle_action(call_handler('_handle_replay_command', Args), Backend) :-
             format("Invalid index. Messages: 0-~w~n", [Len])
         )
     ).
+handle_action(call_handler('_handle_save_command', Args), Backend) :-
+    conversation(Msgs),
+    get_dict(name, Backend, BName),
+    length(Msgs, MsgCount),
+    get_time(Now), stamp_date_time(Now, DT, local),
+    format_time(atom(SessionId), "%Y%m%d_%H%M%S", DT),
+    (Args = "" -> Name = SessionId ; atom_string(Name, Args)),
+    sessions_dir(SDir),
+    make_directory_path(SDir),
+    format(atom(FileName), "~w/~w.json", [SDir, SessionId]),
+    SessionData = _{metadata: _{id: SessionId, name: Name, backend: BName, message_count: MsgCount}, messages: Msgs},
+    setup_call_cleanup(
+        open(FileName, write, Out),
+        json_write_dict(Out, SessionData, []),
+        close(Out)),
+    format("Saved session: ~w (~w messages)~n", [SessionId, MsgCount]).
+handle_action(call_handler('_handle_load_command', Args), _) :-
+    (Args = "" ->
+        write("Usage: /load <session_id>"), nl
+    ;
+        atom_string(SessionId, Args),
+        sessions_dir(SDir),
+        format(atom(FileName), "~w/~w.json", [SDir, SessionId]),
+        (exists_file(FileName) ->
+            setup_call_cleanup(
+                open(FileName, read, In),
+                json_read_dict(In, Data),
+                close(In)),
+            get_dict(messages, Data, Msgs),
+            retractall(conversation(_)),
+            assert(conversation(Msgs)),
+            length(Msgs, Len),
+            (get_dict(metadata, Data, Meta), get_dict(name, Meta, Name) -> true ; Name = SessionId),
+            format("Loaded session: ~w (~w messages)~n", [Name, Len])
+        ;
+            format("Session not found: ~w~n", [SessionId])
+        )
+    ).
+handle_action(call_handler('_handle_sessions_command', _), _) :-
+    sessions_dir(SDir),
+    (exists_directory(SDir) ->
+        directory_files(SDir, AllFiles),
+        include(json_file, AllFiles, JsonFiles),
+        (JsonFiles = [] ->
+            write("No saved sessions."), nl
+        ;
+            write("Saved sessions:"), nl,
+            forall(member(F, JsonFiles), (
+                format(atom(FullPath), "~w/~w", [SDir, F]),
+                catch((
+                    setup_call_cleanup(
+                        open(FullPath, read, In),
+                        json_read_dict(In, Data),
+                        close(In)),
+                    get_dict(metadata, Data, Meta),
+                    get_dict(id, Meta, Id),
+                    get_dict(name, Meta, Name),
+                    get_dict(message_count, Meta, MC),
+                    format("  ~w: ~w (~w msgs)~n", [Id, Name, MC])
+                ), _, (
+                    file_name_extension(Base, _, F),
+                    format("  ~w: (unreadable)~n", [Base])
+                ))
+            ))
+        )
+    ; write("No saved sessions."), nl).
+handle_action(call_handler('_handle_format_command', Args), _) :-
+    (Args = "" ->
+        current_format(Fmt),
+        format("Current format: ~w~nAvailable: plain, markdown, json, xml~n", [Fmt])
+    ;
+        atom_string(NewFmt, Args),
+        (member(NewFmt, [plain, markdown, json, xml]) ->
+            retractall(current_format(_)),
+            assert(current_format(NewFmt)),
+            format("Format set to: ~w~n", [NewFmt])
+        ;
+            format("Unknown format: ~w~nAvailable: plain, markdown, json, xml~n", [NewFmt])
+        )
+    ).
+handle_action(call_handler('_handle_export_command', Args), _) :-
+    (Args = "" ->
+        write("Usage: /export <path> (.md, .html, .json, .txt)"), nl
+    ;
+        atom_string(FilePath, Args),
+        conversation(Msgs),
+        length(Msgs, Len),
+        file_name_extension(_, Ext, FilePath),
+        (export_conversation(Ext, Msgs, Content) ->
+            setup_call_cleanup(
+                open(FilePath, write, Out),
+                write(Out, Content),
+                close(Out)),
+            format("Exported ~w messages to ~w~n", [Len, FilePath])
+        ;
+            format("Unsupported format: .~w (use .md, .html, .json, .txt)~n", [Ext])
+        )
+    ).
+handle_action(call_handler('_handle_search_command', Args), _) :-
+    (Args = "" ->
+        write("Usage: /search <query>"), nl
+    ;
+        sessions_dir(SDir),
+        (exists_directory(SDir) ->
+            directory_files(SDir, AllFiles),
+            include(json_file, AllFiles, JsonFiles),
+            atom_string(Query, Args),
+            format("Search results for '~w':~n", [Query]),
+            search_sessions(SDir, JsonFiles, Query, 0, Found),
+            (Found =:= 0 -> format("  No results for: ~w~n", [Query]) ; true)
+        ;
+            write("No sessions directory found."), nl
+        )
+    ).
+handle_action(call_handler('_handle_templates_command', _), _) :-
+    write("No templates loaded."), nl.
 handle_action(not_a_command, _) :- write("Unknown command."), nl.
 handle_action(unknown(Cmd), _) :- format("Unknown command: /~w~n", [Cmd]).
 handle_action(call_handler(Handler, _Args), _) :-
@@ -338,3 +459,67 @@ replace_at([Msg|Rest], Target, NewContent, Idx, [NewMsg|Result]) :-
 replace_at([H|Rest], Target, NewContent, Idx, [H|Result]) :-
     NextIdx is Idx + 1,
     replace_at(Rest, Target, NewContent, NextIdx, Result).
+
+%% Filter for .json files
+json_file(F) :- file_name_extension(_, json, F).
+
+%% Export conversation to different formats
+export_conversation(json, Msgs, Content) :-
+    with_output_to(string(Content), json_write_dict(current_output, Msgs, [])).
+export_conversation(md, Msgs, Content) :-
+    with_output_to(string(Content), (
+        write("# Conversation\n\n"),
+        forall(member(Msg, Msgs), (
+            get_dict(role, Msg, Role),
+            get_dict(content, Msg, C),
+            (Role = "user" -> write("**You:**") ; write("**Assistant:**")),
+            nl, nl, write(C), nl, nl
+        ))
+    )).
+export_conversation(txt, Msgs, Content) :-
+    with_output_to(string(Content), (
+        forall(member(Msg, Msgs), (
+            get_dict(role, Msg, Role),
+            get_dict(content, Msg, C),
+            format("~w: ~w~n~n", [Role, C])
+        ))
+    )).
+export_conversation(html, Msgs, Content) :-
+    with_output_to(string(Content), (
+        write("<html><body>\n"),
+        forall(member(Msg, Msgs), (
+            get_dict(role, Msg, Role),
+            get_dict(content, Msg, C),
+            format("<div class=\"~w\"><b>~w:</b><p>~w</p></div>\n", [Role, Role, C])
+        )),
+        write("</body></html>\n")
+    )).
+
+%% Search across saved session files
+search_sessions(_, [], _, Found, Found).
+search_sessions(SDir, [F|Rest], Query, Acc, Found) :-
+    format(atom(Path), "~w/~w", [SDir, F]),
+    catch((
+        setup_call_cleanup(open(Path, read, In), json_read_dict(In, Data), close(In)),
+        get_dict(messages, Data, Msgs),
+        get_dict(metadata, Data, Meta),
+        get_dict(id, Meta, SessId),
+        search_messages(SessId, Msgs, Query, Acc, Acc1)
+    ), _, Acc1 = Acc),
+    search_sessions(SDir, Rest, Query, Acc1, Found).
+
+search_messages(_, [], _, Acc, Acc).
+search_messages(SessId, [Msg|Rest], Query, Acc, Found) :-
+    get_dict(content, Msg, Content),
+    get_dict(role, Msg, Role),
+    (sub_string(Content, _, _, _, Query) ->
+        (Role = "user" -> RLabel = "You" ; RLabel = "Asst"),
+        (string_length(Content, CL), CL > 60 ->
+            sub_string(Content, 0, 60, _, Snippet),
+            format("  [~w] ~w: ~w...~n", [SessId, RLabel, Snippet])
+        ;
+            format("  [~w] ~w: ~w~n", [SessId, RLabel, Content])
+        ),
+        Acc1 is Acc + 1
+    ; Acc1 = Acc),
+    search_messages(SessId, Rest, Query, Acc1, Found).

--- a/tools/agent-loop/generated/prolog/config.pl
+++ b/tools/agent-loop/generated/prolog/config.pl
@@ -14,6 +14,7 @@
     config_search_path/2,
     config_field_json_default/2,
     config_dir_file_name/1,
+    audit_profile_level/2,
     load_config/2,
     resolve_api_key/3
 ]).
@@ -147,6 +148,13 @@ config_dir_file_name('agents.json').
 config_dir_file_name('.agents.yaml').
 config_dir_file_name('.agents.yml').
 config_dir_file_name('.agents.json').
+
+%% audit_profile_level(+Profile, +AuditLevel)
+%% Maps security profile to audit logging level.
+audit_profile_level(open, disabled).
+audit_profile_level(cautious, basic).
+audit_profile_level(guarded, detailed).
+audit_profile_level(paranoid, forensic).
 
 %% Parse CLI arguments using SWI-Prolog optparse
 parse_cli_args(Argv, Options) :-


### PR DESCRIPTION
## Summary

Three workstreams bringing the Prolog agent-loop target to feature completeness and wiring it into the UnifyWeaver component registry.

### 1. Fragment extraction: audit_levels dict

Extracted the `audit_levels` dict (4 entries mapping security profiles to audit levels) from `agent_loop_main_body` into:
- New `audit_profile_level/2` facts (4 facts)
- `generate_audit_levels_dict/1` generator
- Fragment split: `agent_loop_main_body` → `_pre_audit` + generated + `_post_audit`
- Emitted in Prolog `config.pl` target

### 2. Complete Prolog slash commands (21/21)

All 7 remaining handlers implemented:

| Command | Description |
|---------|-------------|
| `/save [name]` | Serialize conversation to JSON session file |
| `/load <id>` | Restore conversation from session file |
| `/sessions` | List saved session files with metadata |
| `/format [type]` | Get/set context format (plain/markdown/json/xml) |
| `/export <path>` | Export to .md/.html/.json/.txt |
| `/search <query>` | Full-text search across saved sessions |
| `/templates` | Stub (Python-side feature) |

Infrastructure: `library(json)`, `library(filesex)` imports, `current_format/1` dynamic state, `sessions_dir/1`, and 6 helper predicates.

### 3. Component registry integration

New file `agent_loop_components.pl` — optional overlay that bridges agent-loop facts into UnifyWeaver's component registry:

- 3 categories: `agent_tools`, `agent_commands`, `agent_backends`
- 3 inline type modules with `compile_component/4` (emits Prolog or Python)
- 33 components registered: 4 tools, 21 commands, 8 backends
- Module exports expanded: `tool_handler/2`, `destructive_tool/1`, `slash_command/4`, `command_alias/2`, `backend_factory/2`, `backend_factory_order/1`, `audit_profile_level/2`

```
$ swipl -l agent_loop_components.pl -g "agent_loop_component_summary, halt"
Agent-loop components registered:
  Tools:    4 [bash,read,write,edit]
  Commands: 21 [exit,clear,help,...,replay]
  Backends: 8 [coro,claude-code,...,ollama-cli]
```

## Verification

- Python zero-diff maintained
- Prolog loads cleanly: `swipl -l main.pl -g halt` — no warnings
- Component registration: 33 instances across 3 categories
- `compile_component` tested for both Prolog and Python targets
- 4 files changed, +627 / -14 lines
