### PR TITLE
perf(csharp-query): make seeded cache admission rows-per-seed aware

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -328,7 +328,8 @@ namespace UnifyWeaver.QueryRuntime
         int PairProbeCacheMaxEntries = 4096,
         int SeededCacheMaxEntries = 4096,
         int PairProbeCacheAdmissionMinCost = 0,
-        int SeededCacheAdmissionMinRows = 0);
+        int SeededCacheAdmissionMinRows = 0,
+        double SeededCacheAdmissionMinRowsPerSeed = 0);
 
     public sealed record QueryNodeTrace(
         int Id,
@@ -1032,6 +1033,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly int _seededCacheMaxEntries;
         private readonly int _pairProbeCacheAdmissionMinCost;
         private readonly int _seededCacheAdmissionMinRows;
+        private readonly double _seededCacheAdmissionMinRowsPerSeed;
 
         public QueryExecutor(IRelationProvider provider, QueryExecutorOptions? options = null)
         {
@@ -1042,6 +1044,7 @@ namespace UnifyWeaver.QueryRuntime
             _seededCacheMaxEntries = Math.Max(0, options.SeededCacheMaxEntries);
             _pairProbeCacheAdmissionMinCost = Math.Max(0, options.PairProbeCacheAdmissionMinCost);
             _seededCacheAdmissionMinRows = Math.Max(0, options.SeededCacheAdmissionMinRows);
+            _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
         }
 
         public IEnumerable<object[]> Execute(
@@ -7695,7 +7698,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.GroupedTransitiveClosureSeededResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(memoizedRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            memoizedRows.Count,
+                            orderedSeeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(flatSeedKey),
@@ -7796,7 +7802,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.GroupedTransitiveClosureSeededResults.Add(cacheKey, singleStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(singleRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            singleRows.Count,
+                            orderedSeeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(flatSeedKey),
@@ -7865,7 +7874,10 @@ namespace UnifyWeaver.QueryRuntime
                         context.GroupedTransitiveClosureSeededResults.Add(cacheKey, storeBySeed);
                     }
 
-                    var admitSeededCache = ShouldAdmitSeededCacheRows(totalRows.Count);
+                    var admitSeededCache = ShouldAdmitSeededCacheRows(
+                        totalRows.Count,
+                        orderedSeeds.Count,
+                        useRowsPerSeedGate: true);
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(flatSeedKey),
@@ -8104,7 +8116,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.GroupedTransitiveClosureSeededByTargetResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(memoizedRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            memoizedRows.Count,
+                            orderedSeeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(flatSeedKey),
@@ -8208,7 +8223,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.GroupedTransitiveClosureSeededByTargetResults.Add(cacheKey, singleStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(singleRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            singleRows.Count,
+                            orderedSeeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(flatSeedKey),
@@ -8277,7 +8295,10 @@ namespace UnifyWeaver.QueryRuntime
                         context.GroupedTransitiveClosureSeededByTargetResults.Add(cacheKey, storeBySeed);
                     }
 
-                    var admitSeededCache = ShouldAdmitSeededCacheRows(totalRows.Count);
+                    var admitSeededCache = ShouldAdmitSeededCacheRows(
+                        totalRows.Count,
+                        orderedSeeds.Count,
+                        useRowsPerSeedGate: true);
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(flatSeedKey),
@@ -9262,8 +9283,25 @@ namespace UnifyWeaver.QueryRuntime
                 traceKey);
         }
 
-        private bool ShouldAdmitSeededCacheRows(int rowCount) =>
-            rowCount >= _seededCacheAdmissionMinRows;
+        private bool ShouldAdmitSeededCacheRows(
+            int rowCount,
+            int seedCount = 1,
+            bool useRowsPerSeedGate = false)
+        {
+            if (rowCount < _seededCacheAdmissionMinRows)
+            {
+                return false;
+            }
+
+            if (!useRowsPerSeedGate || _seededCacheAdmissionMinRowsPerSeed <= 0d)
+            {
+                return true;
+            }
+
+            var normalizedSeedCount = Math.Max(1, seedCount);
+            var rowsPerSeed = (double)rowCount / normalizedSeedCount;
+            return rowsPerSeed >= _seededCacheAdmissionMinRowsPerSeed;
+        }
 
         private bool ShouldAdmitPairProbeCacheEntry(int forwardCost, int backwardCost) =>
             Math.Min(Math.Max(0, forwardCost), Math.Max(0, backwardCost)) >= _pairProbeCacheAdmissionMinCost;
@@ -9379,7 +9417,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.TransitiveClosureSeededResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(memoizedRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            memoizedRows.Count,
+                            seeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
@@ -9466,7 +9507,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.TransitiveClosureSeededResults.Add(cacheKey, singleStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(singleRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            singleRows.Count,
+                            seeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
@@ -9555,7 +9599,10 @@ namespace UnifyWeaver.QueryRuntime
                         context.TransitiveClosureSeededResults.Add(cacheKey, storeBySeed);
                     }
 
-                    var admitSeededCache = ShouldAdmitSeededCacheRows(totalRows.Count);
+                    var admitSeededCache = ShouldAdmitSeededCacheRows(
+                        totalRows.Count,
+                        seeds.Count,
+                        useRowsPerSeedGate: true);
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),
@@ -9664,7 +9711,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.TransitiveClosureSeededByTargetResults.Add(cacheKey, memoizedStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(memoizedRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            memoizedRows.Count,
+                            seeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             memoizedStoreBySeed,
                             new RowWrapper(seedsKey),
@@ -9751,7 +9801,10 @@ namespace UnifyWeaver.QueryRuntime
                             context.TransitiveClosureSeededByTargetResults.Add(cacheKey, singleStoreBySeed);
                         }
 
-                        var admitSeededCache = ShouldAdmitSeededCacheRows(singleRows.Count);
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            singleRows.Count,
+                            seeds.Count,
+                            useRowsPerSeedGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             singleStoreBySeed,
                             new RowWrapper(seedsKey),
@@ -9840,7 +9893,10 @@ namespace UnifyWeaver.QueryRuntime
                         context.TransitiveClosureSeededByTargetResults.Add(cacheKey, storeBySeed);
                     }
 
-                    var admitSeededCache = ShouldAdmitSeededCacheRows(totalRows.Count);
+                    var admitSeededCache = ShouldAdmitSeededCacheRows(
+                        totalRows.Count,
+                        seeds.Count,
+                        useRowsPerSeedGate: true);
                     TryAdmitLruBoundedRowWrapperCacheEntry(
                         storeBySeed,
                         new RowWrapper(seedsKey),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -321,6 +321,8 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_runtime,
+        verify_parameterized_grouped_transitive_closure_seed_cache_admission_selectivity_runtime,
+        verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_selectivity_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_admission_runtime,
@@ -4039,6 +4041,58 @@ verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_r
         HotParams,
         HarnessSource).
 
+verify_parameterized_grouped_transitive_closure_seed_cache_admission_selectivity_runtime :-
+    csharp_query_target:build_query_plan(test_admission_group_reach_param/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [[a, adm, cata]],
+    WarmColdParams = [[d, adm, cata]],
+    HotParams = [[a, adm, cata]],
+    ColdParams = [[d, adm, cata]],
+    harness_source_with_seed_cache_admission_selectivity_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'GroupedTransitiveClosureSeeded',
+        2,
+        1,
+        2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:GroupedTransitiveClosureSeeded=true',
+         'CACHE_HIT_COLD:GroupedTransitiveClosureSeeded=false',
+         'CACHE_ADMISSIONS:GroupedTransitiveClosureSeeded=1',
+         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosureSeeded=1'],
+        HotParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_selectivity_runtime :-
+    csharp_query_target:build_query_plan(test_admission_group_reach_param_end/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [[e, adm, cata]],
+    WarmColdParams = [[b, adm, cata]],
+    HotParams = [[e, adm, cata]],
+    ColdParams = [[b, adm, cata]],
+    harness_source_with_seed_cache_admission_selectivity_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'GroupedTransitiveClosureSeededByTarget',
+        2,
+        1,
+        2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:GroupedTransitiveClosureSeededByTarget=true',
+         'CACHE_HIT_COLD:GroupedTransitiveClosureSeededByTarget=false',
+         'CACHE_ADMISSIONS:GroupedTransitiveClosureSeededByTarget=1',
+         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosureSeededByTarget=1'],
+        HotParams,
+        HarnessSource).
+
 verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_runtime :-
     csharp_query_target:build_query_plan(test_admission_group_reach_pair/4, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -5763,6 +5817,59 @@ Console.WriteLine("CACHE_HIT_COLD:~w=" + (coldHit ? "true" : "false"));
 Console.WriteLine("CACHE_ADMISSIONS:~w=" + admissions.ToString());
 Console.WriteLine("CACHE_ADMISSION_SKIPS:~w=" + admissionSkips.ToString());
     ', [ModuleClass, SeedLimit, MinRows, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
+
+harness_source_with_seed_cache_admission_selectivity_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        Cache,
+        SeedLimit,
+        MinRows,
+        MinRowsPerSeed,
+        Source) :-
+    csharp_params_literal(WarmHotParams, WarmHotLiteral),
+    csharp_params_literal(WarmColdParams, WarmColdLiteral),
+    csharp_params_literal(HotParams, HotLiteral),
+    csharp_params_literal(ColdParams, ColdLiteral),
+    format(atom(Source),
+'using System;
+ using System.Linq;
+ using UnifyWeaver.QueryRuntime;
+
+var result = UnifyWeaver.Generated.~w.Build();
+var executor = new QueryExecutor(
+    result.Provider,
+    new QueryExecutorOptions(
+        ReuseCaches: true,
+        SeededCacheMaxEntries: ~w,
+        SeededCacheAdmissionMinRows: ~w,
+        SeededCacheAdmissionMinRowsPerSeed: ~w));
+var warmHotParameters = ~w;
+var warmHotTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, warmHotParameters, warmHotTrace).ToList();
+var warmColdParameters = ~w;
+var warmColdTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, warmColdParameters, warmColdTrace).ToList();
+var hotParameters = ~w;
+var hotTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, hotParameters, hotTrace).ToList();
+var coldParameters = ~w;
+var coldTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, coldParameters, coldTrace).ToList();
+
+var hotHit = hotTrace.SnapshotCaches().Any(s => s.Cache == "~w" && s.Hits > 0);
+var coldHit = coldTrace.SnapshotCaches().Any(s => s.Cache == "~w" && s.Hits > 0);
+var admissions = warmHotTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.Admissions)
+    + warmColdTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.Admissions);
+var admissionSkips = warmHotTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.AdmissionSkips)
+    + warmColdTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.AdmissionSkips);
+Console.WriteLine("CACHE_HIT_HOT:~w=" + (hotHit ? "true" : "false"));
+Console.WriteLine("CACHE_HIT_COLD:~w=" + (coldHit ? "true" : "false"));
+Console.WriteLine("CACHE_ADMISSIONS:~w=" + admissions.ToString());
+Console.WriteLine("CACHE_ADMISSION_SKIPS:~w=" + admissionSkips.ToString());
+    ', [ModuleClass, SeedLimit, MinRows, MinRowsPerSeed, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
 
 harness_source_with_pair_cache_admission_flag(
         ModuleClass,


### PR DESCRIPTION
## Summary

This PR improves seeded-cache admission for C# query runtime recursive/transitive-closure execution by adding a **rows-per-seed** admission gate, then adds targeted coverage for grouped and by-target seeded cache behavior.

Previously, seeded admission was controlled only by total row count (`SeededCacheAdmissionMinRows`), which could admit low-selectivity workloads when batched seeds inflated total rows. This change keeps the existing threshold and adds an optional per-seed selectivity gu>

## Runtime Changes

- Added `SeededCacheAdmissionMinRowsPerSeed` to `QueryExecutorOptions` (default `0`, preserving existing behavior when unset).
- Extended seeded admission logic to support:
  - existing minimum total row threshold
  - optional minimum average rows-per-seed threshold
- Wired the updated admission logic into seeded-cache paths, including:
  - transitive closure seeded
  - transitive closure seeded-by-target
  - grouped transitive closure seeded
  - grouped transitive closure seeded-by-target

## Test Coverage

Added/updated coverage in `tests/core/test_csharp_query_target.pl`:

- New grouped seeded admission selectivity test
- New grouped seeded-by-target admission selectivity test
- New harness helper to set `SeededCacheAdmissionMinRowsPerSeed` for runtime verification

These tests validate that selective inputs are admitted while dense/less-selective ones are skipped under the configured per-seed gate.

## Validation

Ran locally:

1. Prolog-only suite:
   - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g "test_csharp_query_target:test_csharp_query_target" -t halt`
2. Targeted runtime smoke:
   - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_cache_admission_selectivity_rowcount2 -ProjectFilter "cq_test_admissi*"`
