### PR TITLE
perf(csharp-query): normalize pair-probe cache admission by probe count

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -328,6 +328,7 @@ namespace UnifyWeaver.QueryRuntime
         int PairProbeCacheMaxEntries = 4096,
         int SeededCacheMaxEntries = 4096,
         int PairProbeCacheAdmissionMinCost = 0,
+        double PairProbeCacheAdmissionMinCostPerProbe = 0,
         int SeededCacheAdmissionMinRows = 0,
         double SeededCacheAdmissionMinRowsPerSeed = 0);
 
@@ -1032,6 +1033,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly int _pairProbeCacheMaxEntries;
         private readonly int _seededCacheMaxEntries;
         private readonly int _pairProbeCacheAdmissionMinCost;
+        private readonly double _pairProbeCacheAdmissionMinCostPerProbe;
         private readonly int _seededCacheAdmissionMinRows;
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
 
@@ -1043,6 +1045,7 @@ namespace UnifyWeaver.QueryRuntime
             _pairProbeCacheMaxEntries = Math.Max(0, options.PairProbeCacheMaxEntries);
             _seededCacheMaxEntries = Math.Max(0, options.SeededCacheMaxEntries);
             _pairProbeCacheAdmissionMinCost = Math.Max(0, options.PairProbeCacheAdmissionMinCost);
+            _pairProbeCacheAdmissionMinCostPerProbe = Math.Max(0d, options.PairProbeCacheAdmissionMinCostPerProbe);
             _seededCacheAdmissionMinRows = Math.Max(0, options.SeededCacheAdmissionMinRows);
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
         }
@@ -7159,6 +7162,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (IsSingleConcreteGroupedPairRequest(targetsBySource, sourcesByTarget))
                 {
+                    var probeCount = Math.Max(1, parameters.Count);
                     var seedEntry = targetsBySource.First();
                     var sourceKey = seedEntry.Key.Row;
                     var target = seedEntry.Value.First();
@@ -7231,7 +7235,11 @@ namespace UnifyWeaver.QueryRuntime
                             context.GroupedTransitiveClosurePairProbeResults.Add(groupedCacheKey, pairStore);
                         }
 
-                        var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(forwardCost, backwardCost);
+                        var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(
+                            forwardCost,
+                            backwardCost,
+                            probeCount,
+                            useCostPerProbeGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             pairStore,
                             new RowWrapper(groupedPairKey),
@@ -9303,8 +9311,27 @@ namespace UnifyWeaver.QueryRuntime
             return rowsPerSeed >= _seededCacheAdmissionMinRowsPerSeed;
         }
 
-        private bool ShouldAdmitPairProbeCacheEntry(int forwardCost, int backwardCost) =>
-            Math.Min(Math.Max(0, forwardCost), Math.Max(0, backwardCost)) >= _pairProbeCacheAdmissionMinCost;
+        private bool ShouldAdmitPairProbeCacheEntry(
+            int forwardCost,
+            int backwardCost,
+            int probeCount = 1,
+            bool useCostPerProbeGate = false)
+        {
+            var minCost = Math.Min(Math.Max(0, forwardCost), Math.Max(0, backwardCost));
+            if (minCost < _pairProbeCacheAdmissionMinCost)
+            {
+                return false;
+            }
+
+            if (!useCostPerProbeGate || _pairProbeCacheAdmissionMinCostPerProbe <= 0d)
+            {
+                return true;
+            }
+
+            var normalizedProbeCount = Math.Max(1, probeCount);
+            var costPerProbe = (double)minCost / normalizedProbeCount;
+            return costPerProbe >= _pairProbeCacheAdmissionMinCostPerProbe;
+        }
 
         private static bool TryGetParameterValue(
             object[] tuple,
@@ -9973,6 +10000,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (IsSingleConcretePairRequest(bySource, byTarget))
                 {
+                    var probeCount = Math.Max(1, parameters.Count);
                     var source = bySource.First().Key;
                     var target = bySource.First().Value.First();
                     var edges = GetFactsList(closure.EdgeRelation, context);
@@ -10024,7 +10052,11 @@ namespace UnifyWeaver.QueryRuntime
                             context.TransitiveClosurePairProbeResults.Add(pairCacheKey, pairStore);
                         }
 
-                        var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(forwardCost, backwardCost);
+                        var admitPairProbeCache = ShouldAdmitPairProbeCacheEntry(
+                            forwardCost,
+                            backwardCost,
+                            probeCount,
+                            useCostPerProbeGate: true);
                         TryAdmitLruBoundedRowWrapperCacheEntry(
                             pairStore,
                             new RowWrapper(pairProbeKey),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -318,12 +318,14 @@ test_csharp_query_target :-
         verify_parameterized_reachability_seed_cache_admission_runtime,
         verify_parameterized_reachability_by_target_seed_cache_admission_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_admission_runtime,
+        verify_parameterized_reachability_pairs_single_probe_cache_admission_normalized_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_admission_selectivity_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_selectivity_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_normalized_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_admission_runtime,
         verify_transitive_closure_cache_reuse_runtime,
@@ -3966,6 +3968,32 @@ verify_parameterized_reachability_pairs_single_probe_cache_admission_runtime :-
         HotParams,
         HarnessSource).
 
+verify_parameterized_reachability_pairs_single_probe_cache_admission_normalized_runtime :-
+    csharp_query_target:build_query_plan(test_admission_reach_pair/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [[a, e], [a, e]],
+    WarmColdParams = [[b, e], [b, e]],
+    HotParams = [[a, e], [a, e]],
+    ColdParams = [[b, e], [b, e]],
+    harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'TransitiveClosurePairsSingleProbe',
+        2,
+        2,
+        2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:TransitiveClosurePairsSingleProbe=false',
+         'CACHE_HIT_COLD:TransitiveClosurePairsSingleProbe=false',
+         'CACHE_ADMISSIONS:TransitiveClosurePairsSingleProbe=0',
+         'CACHE_ADMISSION_SKIPS:TransitiveClosurePairsSingleProbe=2'],
+        HotParams,
+        HarnessSource).
+
 verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_runtime :-
     csharp_query_target:build_query_plan(test_probe_dir_mixed_reach/2, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -4115,6 +4143,32 @@ verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admissi
          'CACHE_HIT_COLD:GroupedTransitiveClosurePairsSingleProbe=false',
          'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=1',
          'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=1'],
+        HotParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_normalized_runtime :-
+    csharp_query_target:build_query_plan(test_admission_group_reach_pair/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [[a, e, adm, cata], [a, e, adm, cata]],
+    WarmColdParams = [[b, e, adm, cata], [b, e, adm, cata]],
+    HotParams = [[a, e, adm, cata], [a, e, adm, cata]],
+    ColdParams = [[b, e, adm, cata], [b, e, adm, cata]],
+    harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'GroupedTransitiveClosurePairsSingleProbe',
+        2,
+        2,
+        2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:GroupedTransitiveClosurePairsSingleProbe=false',
+         'CACHE_HIT_COLD:GroupedTransitiveClosurePairsSingleProbe=false',
+         'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=0',
+         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=2'],
         HotParams,
         HarnessSource).
 
@@ -5918,6 +5972,59 @@ Console.WriteLine("CACHE_HIT_COLD:~w=" + (coldHit ? "true" : "false"));
 Console.WriteLine("CACHE_ADMISSIONS:~w=" + admissions.ToString());
 Console.WriteLine("CACHE_ADMISSION_SKIPS:~w=" + admissionSkips.ToString());
     ', [ModuleClass, PairLimit, MinCost, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
+
+harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        Cache,
+        PairLimit,
+        MinCost,
+        MinCostPerProbe,
+        Source) :-
+    csharp_params_literal(WarmHotParams, WarmHotLiteral),
+    csharp_params_literal(WarmColdParams, WarmColdLiteral),
+    csharp_params_literal(HotParams, HotLiteral),
+    csharp_params_literal(ColdParams, ColdLiteral),
+    format(atom(Source),
+'using System;
+ using System.Linq;
+ using UnifyWeaver.QueryRuntime;
+
+var result = UnifyWeaver.Generated.~w.Build();
+var executor = new QueryExecutor(
+    result.Provider,
+    new QueryExecutorOptions(
+        ReuseCaches: true,
+        PairProbeCacheMaxEntries: ~w,
+        PairProbeCacheAdmissionMinCost: ~w,
+        PairProbeCacheAdmissionMinCostPerProbe: ~w));
+var warmHotParameters = ~w;
+var warmHotTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, warmHotParameters, warmHotTrace).ToList();
+var warmColdParameters = ~w;
+var warmColdTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, warmColdParameters, warmColdTrace).ToList();
+var hotParameters = ~w;
+var hotTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, hotParameters, hotTrace).ToList();
+var coldParameters = ~w;
+var coldTrace = new QueryExecutionTrace();
+_ = executor.Execute(result.Plan, coldParameters, coldTrace).ToList();
+
+var hotHit = hotTrace.SnapshotCaches().Any(s => s.Cache == "~w" && s.Hits > 0);
+var coldHit = coldTrace.SnapshotCaches().Any(s => s.Cache == "~w" && s.Hits > 0);
+var admissions = warmHotTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.Admissions)
+    + warmColdTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.Admissions);
+var admissionSkips = warmHotTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.AdmissionSkips)
+    + warmColdTrace.SnapshotCaches().Where(s => s.Cache == "~w").Sum(s => s.AdmissionSkips);
+Console.WriteLine("CACHE_HIT_HOT:~w=" + (hotHit ? "true" : "false"));
+Console.WriteLine("CACHE_HIT_COLD:~w=" + (coldHit ? "true" : "false"));
+Console.WriteLine("CACHE_ADMISSIONS:~w=" + admissions.ToString());
+Console.WriteLine("CACHE_ADMISSION_SKIPS:~w=" + admissionSkips.ToString());
+    ', [ModuleClass, PairLimit, MinCost, MinCostPerProbe, WarmHotLiteral, WarmColdLiteral, HotLiteral, ColdLiteral, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache, Cache]).
 
 harness_source_with_cache_hit_flag(ModuleClass, Params, Cache, Source) :-
     (   Params == []


### PR DESCRIPTION
  This PR tightens pair-probe cache admission so batched duplicate probes do not get admitted just because total probe
  cost is high.

  Changes:

  - Adds PairProbeCacheAdmissionMinCostPerProbe to QueryExecutorOptions in src/unifyweaver/targets/csharp_query_runtime/
    QueryRuntime.cs.
  - Extends pair-probe admission logic to support normalized gating:
      - keeps existing absolute gate (PairProbeCacheAdmissionMinCost)
      - adds optional per-probe gate (min(forwardCost, backwardCost) / probeCount)
  - Wires probe-count-aware admission into both single-concrete pair fast paths:
      - TransitiveClosurePairsSingleProbe
      - GroupedTransitiveClosurePairsSingleProbe
  - Adds coverage in tests/core/test_csharp_query_target.pl:
      - verify_parameterized_reachability_pairs_single_probe_cache_admission_normalized_runtime
      - verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_normalized_runtime
      - new harness helper for normalized pair admission options.

  Validation:

  - SKIP_CSHARP_EXECUTION=1 ... test_csharp_query_target passed.
  - Admission-focused smoke run passed:
      - pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
        csharp_query_smoke_pair_probe_admission_normalized -ProjectFilter "cq_test_admissi*"