### PR TITLE
refactor(agent-loop): Wire component registry into Prolog generators

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -10,7 +10,10 @@
 
 :- module(agent_loop_components, [
     register_agent_loop_components/0,
-    agent_loop_component_summary/0
+    agent_loop_component_summary/0,
+    emit_tool_facts/2,
+    emit_command_facts/2,
+    emit_backend_facts/2
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -187,6 +190,108 @@ register_agent_loop_components :-
     register_tool_components,
     register_command_components,
     register_backend_components.
+
+%% ============================================================================
+%% Stream Emitters — Write Prolog facts via the component registry
+%% ============================================================================
+
+%% emit_tool_facts(+Stream, +Options)
+%% Emit tool-related Prolog facts via the component registry.
+emit_tool_facts(S, _Options) :-
+    %% tool_spec via component registry
+    write(S, '%% tool_spec(+ToolName, +Properties)\n'),
+    forall(component(agent_tools, Name, tool_handler, _Config), (
+        agent_loop_module:tool_spec(Name, Props),
+        format(S, 'tool_spec(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(S, Props),
+        write(S, ').\n')
+    )),
+    write(S, '\n'),
+    %% tool_handler via component registry
+    write(S, '%% tool_handler(+ToolName, +HandlerPredicate)\n'),
+    forall(component(agent_tools, Name, tool_handler, Config), (
+        member(handler(Handler), Config),
+        format(S, 'tool_handler(~q, ~q).~n', [Name, Handler])
+    )),
+    write(S, '\n'),
+    %% destructive_tool via component registry
+    write(S, '%% destructive_tool(+ToolName)\n'),
+    forall((component(agent_tools, Name, tool_handler, Config),
+            member(destructive(true), Config)), (
+        format(S, 'destructive_tool(~q).~n', [Name])
+    )),
+    write(S, '\n'),
+    %% tool_description — different shape, stays as raw fact iteration
+    write(S, '%% tool_description(+Backend, +ToolName, +Verb, +ParamKey, +DisplayMode)\n'),
+    forall(agent_loop_module:tool_description(Backend, TN, Verb, PK, DM), (
+        format(S, 'tool_description(~q, ~q, ~q, ~q, ', [Backend, TN, Verb, PK]),
+        agent_loop_module:write_prolog_term(S, DM),
+        write(S, ').\n')
+    )),
+    write(S, '\n').
+
+%% emit_command_facts(+Stream, +Options)
+%% Emit command-related Prolog facts via the component registry.
+emit_command_facts(S, _Options) :-
+    %% slash_command via component registry
+    write(S, '%% slash_command(+Name, +MatchType, +Options, +HelpText)\n'),
+    forall(component(agent_commands, Name, slash_command, Config), (
+        member(match_type(Match), Config),
+        member(help_text(Help), Config),
+        (member(options(Opts), Config) -> true ; Opts = []),
+        format(S, 'slash_command(~q, ~q, ', [Name, Match]),
+        agent_loop_module:write_prolog_term(S, Opts),
+        format(S, ', ~q).~n', [Help])
+    )),
+    write(S, '\n'),
+    %% command_alias — cross-cutting, stays as raw fact iteration
+    write(S, '%% command_alias(+Alias, +CanonicalName)\n'),
+    forall(agent_loop_module:command_alias(Alias, Canonical), (
+        format(S, 'command_alias(~q, ~q).~n', [Alias, Canonical])
+    )),
+    write(S, '\n'),
+    %% slash_command_group — cross-cutting, stays as raw fact iteration
+    write(S, '%% slash_command_group(+GroupName, +CommandList)\n'),
+    forall(agent_loop_module:slash_command_group(Group, Cmds), (
+        format(S, 'slash_command_group(~q, ', [Group]),
+        agent_loop_module:write_prolog_term(S, Cmds),
+        write(S, ').\n')
+    )),
+    write(S, '\n').
+
+%% emit_backend_facts(+Stream, +Options)
+%% Emit backend-related Prolog facts via the component registry.
+emit_backend_facts(S, _Options) :-
+    %% agent_backend — rich property list not in registry, stays raw
+    write(S, '%% agent_backend(+Name, +Properties)\n'),
+    forall(agent_loop_module:agent_backend(Name, Props), (
+        format(S, 'agent_backend(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(S, Props),
+        write(S, ').\n')
+    )),
+    write(S, '\n'),
+    %% backend_factory via component registry
+    write(S, '%% backend_factory(+Name, +FactorySpec)\n'),
+    forall(component(agent_backends, Name, backend, Config), (
+        format(S, 'backend_factory(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(S, Config),
+        write(S, ').\n')
+    )),
+    write(S, '\n'),
+    %% backend_factory_order — singleton, stays raw
+    (agent_loop_module:backend_factory_order(Order) ->
+        format(S, 'backend_factory_order(', []),
+        agent_loop_module:write_prolog_term(S, Order),
+        write(S, ').\n\n')
+    ; true),
+    %% cli_fallbacks — stays raw
+    write(S, '%% cli_fallbacks(+BackendName, +FallbackList)\n'),
+    forall(agent_loop_module:cli_fallbacks(Name, Fallbacks), (
+        format(S, 'cli_fallbacks(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(S, Fallbacks),
+        write(S, ').\n')
+    )),
+    write(S, '\n').
 
 %% agent_loop_component_summary/0
 %% Registers everything and prints a summary.

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -21,10 +21,12 @@
     slash_command/4,
     command_alias/2,
     backend_factory/2,
-    backend_factory_order/1
+    backend_factory_order/1,
+    write_prolog_term/2
 ]).
 
 :- discontiguous generate_backend_full/3.
+:- use_module(agent_loop_components).
 
 %% =============================================================================
 %% Agent Backend Definitions
@@ -1064,6 +1066,7 @@ generate_all(prolog) :-
 %% =============================================================================
 
 generate_prolog_modules :-
+    agent_loop_components:register_agent_loop_components,
     generate_prolog_costs,
     generate_prolog_config,
     generate_prolog_tools,
@@ -1304,34 +1307,8 @@ generate_prolog_tools :-
     write(S, ':- use_module(library(readutil)).\n'),
     write(S, ':- use_module(library(time)).\n'),
     write(S, ':- use_module(security).\n\n'),
-    %% Emit tool_spec facts
-    write(S, '%% tool_spec(+ToolName, +Properties)\n'),
-    forall(tool_spec(Name, Props), (
-        format(S, 'tool_spec(~q, ', [Name]),
-        write_prolog_term(S, Props),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
-    %% Emit tool_handler facts
-    write(S, '%% tool_handler(+ToolName, +HandlerPredicate)\n'),
-    forall(tool_handler(Name, Handler), (
-        format(S, 'tool_handler(~q, ~q).~n', [Name, Handler])
-    )),
-    write(S, '\n'),
-    %% Emit destructive_tool facts
-    write(S, '%% destructive_tool(+ToolName)\n'),
-    forall(destructive_tool(Name), (
-        format(S, 'destructive_tool(~q).~n', [Name])
-    )),
-    write(S, '\n'),
-    %% Emit tool_description facts
-    write(S, '%% tool_description(+Backend, +ToolName, +Verb, +ParamKey, +DisplayMode)\n'),
-    forall(tool_description(Backend, TN, Verb, PK, DM), (
-        format(S, 'tool_description(~q, ~q, ~q, ~q, ', [Backend, TN, Verb, PK]),
-        write_prolog_term(S, DM),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
+    %% Emit tool facts via component registry
+    agent_loop_components:emit_tool_facts(S, [target(prolog)]),
     %% Generate tool execution predicates
     write(S, '%% Execute a tool by name\n'),
     write(S, 'execute_tool(ToolName, Params, Result) :-\n'),
@@ -1483,28 +1460,8 @@ generate_prolog_commands :-
     write(S, '    resolve_command/3,\n'),
     write(S, '    handle_slash_command/3\n'),
     write(S, ']).\n\n'),
-    %% Emit slash_command facts
-    write(S, '%% slash_command(+Name, +MatchType, +Options, +HelpText)\n'),
-    forall(slash_command(Name, Match, Opts, Help), (
-        format(S, 'slash_command(~q, ~q, ', [Name, Match]),
-        write_prolog_term(S, Opts),
-        format(S, ', ~q).~n', [Help])
-    )),
-    write(S, '\n'),
-    %% Emit command_alias facts
-    write(S, '%% command_alias(+Alias, +CanonicalName)\n'),
-    forall(command_alias(Alias, Canonical), (
-        format(S, 'command_alias(~q, ~q).~n', [Alias, Canonical])
-    )),
-    write(S, '\n'),
-    %% Emit slash_command_group facts
-    write(S, '%% slash_command_group(+GroupName, +CommandList)\n'),
-    forall(slash_command_group(Group, Cmds), (
-        format(S, 'slash_command_group(~q, ', [Group]),
-        write_prolog_term(S, Cmds),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
+    %% Emit command facts via component registry
+    agent_loop_components:emit_command_facts(S, [target(prolog)]),
     %% Generate resolve_command
     write(S, '%% Resolve aliases — may return "command args" for compound aliases\n'),
     write(S, 'resolve_command(Input, Command, ExtraArgs) :-\n'),
@@ -1656,36 +1613,8 @@ generate_prolog_backends :-
     write(S, ':- use_module(library(readutil)).\n'),
     write(S, ':- use_module(library(random)).\n'),
     write(S, ':- discontiguous send_request_streaming_raw/5.\n\n'),
-    %% Emit agent_backend facts
-    write(S, '%% agent_backend(+Name, +Properties)\n'),
-    forall(agent_backend(Name, Props), (
-        format(S, 'agent_backend(~q, ', [Name]),
-        write_prolog_term(S, Props),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
-    %% Emit backend_factory facts
-    write(S, '%% backend_factory(+Name, +FactorySpec)\n'),
-    forall(backend_factory(Name, Spec), (
-        format(S, 'backend_factory(~q, ', [Name]),
-        write_prolog_term(S, Spec),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
-    %% Emit backend_factory_order
-    (backend_factory_order(Order) ->
-        format(S, 'backend_factory_order(', []),
-        write_prolog_term(S, Order),
-        write(S, ').\n\n')
-    ; true),
-    %% Emit cli_fallbacks
-    write(S, '%% cli_fallbacks(+BackendName, +FallbackList)\n'),
-    forall(cli_fallbacks(Name, Fallbacks), (
-        format(S, 'cli_fallbacks(~q, ', [Name]),
-        write_prolog_term(S, Fallbacks),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
+    %% Emit backend facts via component registry
+    agent_loop_components:emit_backend_facts(S, [target(prolog)]),
     %% Generate create_backend
     write(S, '%% Create a backend configuration from factory specs\n'),
     write(S, 'create_backend(Name, Options, Backend) :-\n'),

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -42,6 +42,9 @@ run_tests :-
     test_retryable_error_clauses,
     test_security_enforcement_wiring,
     test_tool_parameter_schemas,
+    test_emit_tool_facts,
+    test_emit_command_facts,
+    test_emit_backend_facts,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -379,4 +382,73 @@ test_tool_parameter_schemas :-
         member(parameters(EParams), EProps),
         length(EParams, 3),
         forall(member(param(_, _, Req, _), EParams), Req = required)
+    )).
+
+%% ============================================================================
+%% Test 17: Emit Tool Facts via Component Registry
+%% ============================================================================
+
+test_emit_tool_facts :-
+    format("~nEmit tool facts:~n"),
+    register_agent_loop_components,
+    with_output_to(atom(Output), (
+        current_output(S),
+        agent_loop_components:emit_tool_facts(S, [target(prolog)])
+    )),
+    assert_true('tool_spec(bash,...) emitted', (
+        sub_atom(Output, _, _, _, 'tool_spec(bash')
+    )),
+    assert_true('tool_handler(bash,...) emitted', (
+        sub_atom(Output, _, _, _, 'tool_handler(bash')
+    )),
+    assert_true('destructive_tool emitted', (
+        sub_atom(Output, _, _, _, 'destructive_tool(')
+    )),
+    assert_true('tool_description emitted', (
+        sub_atom(Output, _, _, _, 'tool_description(')
+    )).
+
+%% ============================================================================
+%% Test 18: Emit Command Facts via Component Registry
+%% ============================================================================
+
+test_emit_command_facts :-
+    format("~nEmit command facts:~n"),
+    register_agent_loop_components,
+    with_output_to(atom(Output), (
+        current_output(S),
+        agent_loop_components:emit_command_facts(S, [target(prolog)])
+    )),
+    assert_true('slash_command(help,...) emitted', (
+        sub_atom(Output, _, _, _, 'slash_command(help')
+    )),
+    assert_true('command_alias emitted', (
+        sub_atom(Output, _, _, _, 'command_alias(')
+    )),
+    assert_true('slash_command_group emitted', (
+        sub_atom(Output, _, _, _, 'slash_command_group(')
+    )).
+
+%% ============================================================================
+%% Test 19: Emit Backend Facts via Component Registry
+%% ============================================================================
+
+test_emit_backend_facts :-
+    format("~nEmit backend facts:~n"),
+    register_agent_loop_components,
+    with_output_to(atom(Output), (
+        current_output(S),
+        agent_loop_components:emit_backend_facts(S, [target(prolog)])
+    )),
+    assert_true('agent_backend emitted', (
+        sub_atom(Output, _, _, _, 'agent_backend(')
+    )),
+    assert_true('backend_factory emitted', (
+        sub_atom(Output, _, _, _, 'backend_factory(')
+    )),
+    assert_true('backend_factory_order emitted', (
+        sub_atom(Output, _, _, _, 'backend_factory_order(')
+    )),
+    assert_true('cli_fallbacks emitted', (
+        sub_atom(Output, _, _, _, 'cli_fallbacks(')
     )).


### PR DESCRIPTION
## Summary

- Replaced 9 raw `forall` fact-iteration loops across 3 Prolog generators with component-registry-driven `emit_*_facts/2` predicates
- Generators now consume `component/4` from the registry instead of iterating source facts directly — bridging the gap between the declared component system and actual code generation
- Generated output is byte-identical (zero behavioral change)
- 11 new test assertions (60 total, all passing)

## Details

### Problem

The component registry (`agent_loop_components.pl`) declared 35 components across 3 categories with `compile_component/4` implementations, but was **never used by the actual generators**. The generators in `agent_loop_module.pl` iterated raw facts directly with `forall` loops, making the registry purely decorative.

### Solution

Created 3 stream-emitter predicates in `agent_loop_components.pl` that iterate the component registry and write Prolog facts to a stream:

| Emitter | Registry Source | Raw Fact Fallbacks |
|---------|----------------|-------------------|
| `emit_tool_facts/2` | `component(agent_tools, ...)` for `tool_spec`, `tool_handler`, `destructive_tool` | `tool_description/5` (different shape) |
| `emit_command_facts/2` | `component(agent_commands, ...)` for `slash_command` | `command_alias/2`, `slash_command_group/2` (cross-cutting) |
| `emit_backend_facts/2` | `component(agent_backends, ...)` for `backend_factory` | `agent_backend/2`, `backend_factory_order/1`, `cli_fallbacks/2` (rich props not in registry) |

### Generator Changes

Replaced `forall` loops in 3 generators with single emit calls:

| Generator | Before | After |
|-----------|--------|-------|
| `generate_prolog_tools` | 4 `forall` loops (27 lines) | `emit_tool_facts(S, [target(prolog)])` |
| `generate_prolog_commands` | 3 `forall` loops (22 lines) | `emit_command_facts(S, [target(prolog)])` |
| `generate_prolog_backends` | 4 `forall` loops (29 lines) | `emit_backend_facts(S, [target(prolog)])` |

### Supporting Changes

- Exported `write_prolog_term/2` from `agent_loop_module` so the components module can format complex nested terms
- Added `register_agent_loop_components` call at the start of `generate_prolog_modules` (before any file streams open)
- Added `use_module(agent_loop_components)` import

### What's NOT Changed

- Python generators (zero-diff constraint)
- Hand-written handler blocks (bash with security/timeout, read/write/edit with path checks)
- Security and cost fact emission (low ROI for registry integration)
- Binding system usage (deferred to future work)

### New Tests

| # | Test | Assertions |
|---|------|------------|
| 17 | `test_emit_tool_facts` | `tool_spec(bash`, `tool_handler(bash`, `destructive_tool(`, `tool_description(` present in output |
| 18 | `test_emit_command_facts` | `slash_command(help`, `command_alias(`, `slash_command_group(` present |
| 19 | `test_emit_backend_facts` | `agent_backend(`, `backend_factory(`, `backend_factory_order(`, `cli_fallbacks(` present |

## Verification

- Python zero-diff maintained
- Prolog loads cleanly (`swipl -l main.pl -g halt` — no warnings)
- Generated `tools.pl`, `commands.pl`, `backends.pl` are byte-identical before/after
- 10 bindings registered (5 Python + 5 Prolog)
- 35 components (4 tools, 23 commands, 8 backends)
- 60/60 tests pass
- 3 files changed, +188 / -82 lines

## Test plan

- [ ] `swipl -g "generate_all, halt" agent_loop_module.pl` — all targets regenerate
- [ ] `diff prototype/agent_loop.py generated/python/agent_loop.py` — zero diff
- [ ] `swipl -l generated/prolog/main.pl -g halt` — no warnings
- [ ] `swipl -l test_agent_loop.pl -g "run_tests, halt"` — 60/60 pass
- [ ] `swipl -l agent_loop_bindings.pl -g "agent_loop_binding_summary, halt"` — 10 bindings
- [ ] `swipl -l agent_loop_components.pl -g "agent_loop_component_summary, halt"` — 35 components
