### PR TITLE
ci: harden SWI-Prolog installation with retry, rollback, and diagnostics

### DIFF
--- a/scripts/ci/install_swi_prolog.sh
+++ b/scripts/ci/install_swi_prolog.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 PPA="ppa:swi-prolog/stable"
 
+log() {
+  echo "INFO: $*" >&2
+}
+
+warn() {
+  echo "WARN: $*" >&2
+}
+
+error() {
+  echo "ERROR: $*" >&2
+}
+
 retry() {
   local attempts="$1"
   local delay_seconds="$2"
@@ -19,33 +31,83 @@ retry() {
       return "$exit_code"
     fi
 
-    echo "WARN: command failed (attempt ${attempt}/${attempts}, exit=${exit_code}): $*" >&2
+    warn "command failed (attempt ${attempt}/${attempts}, exit=${exit_code}): $*"
     sleep "$delay_seconds"
     attempt=$((attempt + 1))
     delay_seconds=$((delay_seconds * 2))
   done
 }
 
+print_runner_diagnostics() {
+  if [ -f /etc/os-release ]; then
+    log "Runner OS metadata:"
+    sed 's/^/  /' /etc/os-release || true
+  fi
+}
+
+print_swi_diagnostics() {
+  if command -v swipl >/dev/null 2>&1; then
+    log "SWI-Prolog version:"
+    swipl --version || true
+  else
+    warn "swipl is not on PATH after installation."
+  fi
+
+  if command -v apt-cache >/dev/null 2>&1; then
+    log "apt-cache policy swi-prolog:"
+    apt-cache policy swi-prolog | sed 's/^/  /' || true
+  fi
+
+  if command -v dpkg-query >/dev/null 2>&1; then
+    log "Installed swi-prolog package version:"
+    dpkg-query -W -f='  ${Version}\n' swi-prolog 2>/dev/null || true
+  fi
+}
+
+remove_ppa_and_refresh() {
+  warn "Removing ${PPA} and refreshing apt indexes..."
+  timeout 90 sudo apt-add-repository --remove "$PPA" -y || true
+  retry 3 5 sudo apt-get update -qq
+}
+
+print_runner_diagnostics
 retry 3 5 sudo apt-get update -qq
 retry 3 5 sudo apt-get install -y --no-install-recommends software-properties-common
 
 added=0
-if retry 2 5 timeout 90 sudo apt-add-repository "$PPA" -y; then
+if retry 3 5 timeout 120 sudo apt-add-repository "$PPA" -y; then
   added=1
+  log "Added ${PPA}."
 else
-  echo "WARN: Could not add ${PPA}; installing SWI-Prolog from Ubuntu repo." >&2
+  warn "Could not add ${PPA}; installing SWI-Prolog from default Ubuntu repo."
 fi
 
 if ! retry 3 5 sudo apt-get update -qq; then
   if [ "$added" -eq 1 ]; then
-    echo "WARN: apt-get update failed after adding ${PPA}; removing PPA and retrying..." >&2
-    sudo apt-add-repository --remove "$PPA" -y || true
-    retry 3 5 sudo apt-get update -qq
+    warn "apt-get update failed after adding ${PPA}; falling back to default Ubuntu repo."
+    remove_ppa_and_refresh
+    added=0
   else
-    echo "ERROR: apt-get update failed." >&2
+    error "apt-get update failed before SWI-Prolog installation."
     exit 1
   fi
 fi
 
-retry 3 5 sudo apt-get install -y --no-install-recommends swi-prolog
+if ! retry 3 5 sudo apt-get install -y --no-install-recommends swi-prolog; then
+  if [ "$added" -eq 1 ]; then
+    warn "SWI-Prolog install failed with ${PPA}; retrying from default Ubuntu repo."
+    remove_ppa_and_refresh
+    added=0
+    retry 3 5 sudo apt-get install -y --no-install-recommends swi-prolog
+  else
+    error "Failed to install swi-prolog from default Ubuntu repo."
+    exit 1
+  fi
+fi
 
+if ! command -v swipl >/dev/null 2>&1; then
+  error "swi-prolog install completed but swipl is not available on PATH."
+  exit 1
+fi
+
+print_swi_diagnostics


### PR DESCRIPTION
  This PR makes CI more resilient when ppa:swi-prolog/stable is temporarily unavailable (for example Launchpad 503s),
  and improves failure visibility.

  - Updated scripts/ci/install_swi_prolog.sh to:
  - Strengthen retry/backoff for:
      - apt-get update
      - apt-get install software-properties-common
      - apt-add-repository ppa:swi-prolog/stable
  - Increase PPA add robustness (retry 3 + timeout 120).
  - Add fallback behavior:
      - If adding the PPA fails, continue with default Ubuntu repo.
      - If apt-get update fails after PPA add, remove PPA and retry from default repo.
      - If swi-prolog install fails after PPA add, remove PPA and retry install from default repo.
  - Add post-install validation and diagnostics:
      - Verify swipl is on PATH.
      - Print swipl --version.
      - Print apt-cache policy swi-prolog.
      - Print installed package version via dpkg-query.
      - Print runner OS metadata from /etc/os-release.

  ### Why

  Recent CI failures were caused by transient Launchpad/PPA outages, not code regressions. This change reduces false-red
  builds and makes root cause obvious from logs.

  ### Impact

  - No product/runtime behavior changes.
  - CI install step is more fault-tolerant and easier to debug.