### PR TITLE
feat(agent-loop): Deeper compile_component/4 + binding-driven Python generation

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -52,14 +52,52 @@ agent_tool_type:validate_config(Config) :-
 agent_tool_type:init_component(_Name, _Config).
 
 agent_tool_type:compile_component(Name, Config, Options, Code) :-
-    member(handler(H), Config),
     (member(target(prolog), Options) ->
-        format(atom(Code), "tool_handler(~q, ~q).", [Name, H])
+        (member(fact_type(FT), Options) ->
+            compile_tool_fact(FT, Name, Config, Code)
+        ;
+            compile_tool_all_facts(Name, Config, Code)
+        )
     ; member(target(python), Options) ->
-        format(atom(Code), "    '~w': ~w,", [Name, H])
+        member(handler(H), Config),
+        (member(indent(N), Options) -> true ; N = 4),
+        (member(self_prefix(true), Options) ->
+            format(atom(HStr), "self.~w", [H])
+        ;   atom_string(H, HStr)),
+        length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+        format(atom(Code), "~w'~w': ~w,", [Indent, Name, HStr])
     ;
+        member(handler(H), Config),
         format(atom(Code), "tool_handler(~q, ~q).", [Name, H])
     ).
+
+%% compile_tool_fact(+FactType, +Name, +Config, -Code)
+%% Generate a single Prolog fact line for a tool component.
+compile_tool_fact(tool_spec, Name, Config, Code) :-
+    member(tool_spec_props(Props), Config),
+    Props \= [],
+    with_output_to(atom(Code), (
+        format('tool_spec(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(current_output, Props),
+        write(').')
+    )).
+
+compile_tool_fact(tool_handler, Name, Config, Code) :-
+    member(handler(H), Config),
+    format(atom(Code), "tool_handler(~q, ~q).", [Name, H]).
+
+compile_tool_fact(destructive_tool, Name, Config, Code) :-
+    member(destructive(true), Config),
+    format(atom(Code), "destructive_tool(~q).", [Name]).
+
+%% compile_tool_all_facts(+Name, +Config, -Code)
+%% Generate all Prolog fact lines for a tool, joined with newlines.
+compile_tool_all_facts(Name, Config, Code) :-
+    findall(Fact, (
+        member(FT, [tool_spec, tool_handler, destructive_tool]),
+        compile_tool_fact(FT, Name, Config, Fact)
+    ), Facts),
+    atomic_list_concat(Facts, '\n', Code).
 
 %% --- Slash command type ---
 
@@ -151,12 +189,13 @@ register_tool_components :-
     forall(agent_loop_module:tool_handler(Name, Handler), (
         (agent_loop_module:tool_spec(Name, Props) ->
             (member(description(Desc), Props) -> true ; Desc = "")
-        ; Desc = ""),
+        ; Props = [], Desc = ""),
         (agent_loop_module:destructive_tool(Name) -> Destr = true ; Destr = false),
         declare_component(agent_tools, Name, tool_handler, [
             handler(Handler),
             description(Desc),
             destructive(Destr),
+            tool_spec_props(Props),
             initialization(eager)
         ])
     )).
@@ -198,30 +237,30 @@ register_agent_loop_components :-
 %% emit_tool_facts(+Stream, +Options)
 %% Emit tool-related Prolog facts via the component registry.
 emit_tool_facts(S, _Options) :-
-    %% tool_spec via component registry
+    %% tool_spec via compile_component
     write(S, '%% tool_spec(+ToolName, +Properties)\n'),
-    forall(component(agent_tools, Name, tool_handler, _Config), (
-        agent_loop_module:tool_spec(Name, Props),
-        format(S, 'tool_spec(~q, ', [Name]),
-        agent_loop_module:write_prolog_term(S, Props),
-        write(S, ').\n')
+    forall(component(agent_tools, Name, tool_handler, _), (
+        (compile_component(agent_tools, Name, [target(prolog), fact_type(tool_spec)], Code) ->
+            write(S, Code), nl(S)
+        ; true)
     )),
     write(S, '\n'),
-    %% tool_handler via component registry
+    %% tool_handler via compile_component
     write(S, '%% tool_handler(+ToolName, +HandlerPredicate)\n'),
-    forall(component(agent_tools, Name, tool_handler, Config), (
-        member(handler(Handler), Config),
-        format(S, 'tool_handler(~q, ~q).~n', [Name, Handler])
+    forall(component(agent_tools, Name, tool_handler, _), (
+        compile_component(agent_tools, Name, [target(prolog), fact_type(tool_handler)], Code),
+        write(S, Code), nl(S)
     )),
     write(S, '\n'),
-    %% destructive_tool via component registry
+    %% destructive_tool via compile_component
     write(S, '%% destructive_tool(+ToolName)\n'),
-    forall((component(agent_tools, Name, tool_handler, Config),
-            member(destructive(true), Config)), (
-        format(S, 'destructive_tool(~q).~n', [Name])
+    forall((component(agent_tools, Name, tool_handler, Cfg),
+            member(destructive(true), Cfg)), (
+        compile_component(agent_tools, Name, [target(prolog), fact_type(destructive_tool)], Code),
+        write(S, Code), nl(S)
     )),
     write(S, '\n'),
-    %% tool_description — different shape, stays as raw fact iteration
+    %% tool_description — stays as raw fact iteration (cross-cutting shape)
     write(S, '%% tool_description(+Backend, +ToolName, +Verb, +ParamKey, +DisplayMode)\n'),
     forall(agent_loop_module:tool_description(Backend, TN, Verb, PK, DM), (
         format(S, 'tool_description(~q, ~q, ~q, ~q, ', [Backend, TN, Verb, PK]),

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -9867,13 +9867,17 @@ generate_describe_fallback(S, _) :-
 %% --- generate_tool_dispatch/1: emit self.tools dict + self.destructive_tools set ---
 
 generate_tool_dispatch(S) :-
+    agent_loop_components:register_agent_loop_components,
     write(S, '\n        self.tools = {\n'),
-    forall(tool_handler(TN, MN), (
-        format(S, '            \'~w\': self.~w,~n', [TN, MN])
+    forall(component(agent_tools, TN, tool_handler, _), (
+        compile_component(agent_tools, TN,
+            [target(python), self_prefix(true), indent(12)], Code),
+        write(S, Code), nl(S)
     )),
     write(S, '        }\n'),
     write(S, '\n        self.destructive_tools = {'),
-    findall(DT, destructive_tool(DT), DTs),
+    findall(DT, (component(agent_tools, DT, tool_handler, Cfg),
+                 member(destructive(true), Cfg)), DTs),
     write_set_elements(S, DTs),
     write(S, '}\n').
 

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -45,6 +45,8 @@ run_tests :-
     test_emit_tool_facts,
     test_emit_command_facts,
     test_emit_backend_facts,
+    test_compile_component_multi_fact,
+    test_python_tool_dispatch_via_components,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -451,4 +453,75 @@ test_emit_backend_facts :-
     )),
     assert_true('cli_fallbacks emitted', (
         sub_atom(Output, _, _, _, 'cli_fallbacks(')
+    )).
+
+%% ============================================================================
+%% Test 20: Compile Component Multi-Fact Output
+%% ============================================================================
+
+test_compile_component_multi_fact :-
+    format("~nCompile component multi-fact:~n"),
+    register_agent_loop_components,
+    %% Full multi-fact output for bash (prolog target, no fact_type)
+    assert_true('bash full multi-fact has tool_spec', (
+        compile_component(agent_tools, bash, [target(prolog)], Code),
+        sub_atom(Code, _, _, _, 'tool_spec(bash')
+    )),
+    assert_true('bash full multi-fact has tool_handler', (
+        compile_component(agent_tools, bash, [target(prolog)], Code2),
+        sub_atom(Code2, _, _, _, 'tool_handler(bash')
+    )),
+    assert_true('bash full multi-fact has destructive_tool', (
+        compile_component(agent_tools, bash, [target(prolog)], Code3),
+        sub_atom(Code3, _, _, _, 'destructive_tool(bash')
+    )),
+    %% Selective fact_type: tool_handler only
+    assert_true('bash tool_handler only via fact_type', (
+        compile_component(agent_tools, bash,
+            [target(prolog), fact_type(tool_handler)], HCode),
+        sub_atom(HCode, _, _, _, 'tool_handler(bash'),
+        \+ sub_atom(HCode, _, _, _, 'tool_spec(')
+    )),
+    %% read is NOT destructive — full output should NOT have destructive_tool
+    assert_true('read has no destructive_tool', (
+        compile_component(agent_tools, read, [target(prolog)], RCode),
+        \+ sub_atom(RCode, _, _, _, 'destructive_tool(')
+    )).
+
+%% ============================================================================
+%% Test 21: Python Tool Dispatch via Components
+%% ============================================================================
+
+test_python_tool_dispatch_via_components :-
+    format("~nPython tool dispatch via components:~n"),
+    register_agent_loop_components,
+    %% Python compile_component with self_prefix
+    assert_true('bash python self_prefix', (
+        compile_component(agent_tools, bash,
+            [target(python), self_prefix(true), indent(12)], PyCode),
+        sub_atom(PyCode, _, _, _, 'self._execute_bash')
+    )),
+    %% Python compile_component indentation
+    assert_true('python indent(12) produces 12 spaces', (
+        compile_component(agent_tools, bash,
+            [target(python), self_prefix(true), indent(12)], PyCode2),
+        atom_chars(PyCode2, Chars),
+        append(Spaces, ['\''|_], Chars),
+        length(Spaces, 12),
+        forall(member(Sp, Spaces), Sp = ' ')
+    )),
+    %% Capture generate_tool_dispatch output
+    assert_true('generate_tool_dispatch has bash entry', (
+        with_output_to(atom(DispOutput), (
+            current_output(DS),
+            agent_loop_module:generate_tool_dispatch(DS)
+        )),
+        sub_atom(DispOutput, _, _, _, '\'bash\': self._execute_bash,')
+    )),
+    assert_true('generate_tool_dispatch has destructive_tools', (
+        with_output_to(atom(DispOutput2), (
+            current_output(DS2),
+            agent_loop_module:generate_tool_dispatch(DS2)
+        )),
+        sub_atom(DispOutput2, _, _, _, 'self.destructive_tools = {')
     )).


### PR DESCRIPTION
## Summary

- Enhanced `compile_component/4` to produce multi-fact Prolog output using `compile_tool_fact/4` with `atomic_list_concat` and `with_output_to` patterns from the compiler framework
- Added Python target support with `self_prefix(true)` and `indent(N)` options for context-aware code generation
- Replaced raw `forall(tool_handler(...), ...)` in `generate_tool_dispatch/1` with component-registry iteration via `compile_component`
- Refactored `emit_tool_facts/2` to use `compile_component` with `fact_type` selectors instead of inline formatting
- Enriched tool component Config with `tool_spec_props(Props)` for full spec data access
- 9 new test assertions (69 total, all passing)

## Details

### Problem

After PR #728, Prolog generators used the component registry via `emit_*_facts/2`, but:
1. `compile_component/4` only produced single-line output — tool components need 3 fact types (`tool_spec`, `tool_handler`, `destructive_tool`)
2. `emit_tool_facts/2` still formatted output inline rather than delegating to `compile_component`
3. Python `generate_tool_dispatch/1` still used raw `forall(tool_handler(TN, MN), ...)` bypassing the registry entirely

### Solution: Deeper compile_component/4 (Task 3)

Enhanced `agent_tool_type:compile_component/4` with three modes:

| Mode | Options | Output |
|------|---------|--------|
| Full multi-fact | `[target(prolog)]` | All facts joined with `\n` via `atomic_list_concat` |
| Selective | `[target(prolog), fact_type(tool_handler)]` | Single fact line |
| Python dispatch | `[target(python), self_prefix(true), indent(12)]` | `            'bash': self._execute_bash,` |

New helper predicates:
- `compile_tool_fact/4` — generates individual fact types (`tool_spec`, `tool_handler`, `destructive_tool`)
- `compile_tool_all_facts/3` — collects all applicable facts via `findall` + `atomic_list_concat`

`compile_tool_fact(tool_spec, ...)` uses `with_output_to/2` + `write_prolog_term/2` to produce byte-identical formatting.

### Solution: Binding-Driven Python Generation (Task 1)

Replaced `generate_tool_dispatch/1` to use component iteration:

| Before | After |
|--------|-------|
| `forall(tool_handler(TN, MN), format(...))` | `forall(component(agent_tools, TN, ...), compile_component(..., [target(python), self_prefix(true), indent(12)], Code))` |
| `findall(DT, destructive_tool(DT), DTs)` | `findall(DT, (component(agent_tools, DT, ..., Cfg), member(destructive(true), Cfg)), DTs)` |

### Supporting Changes

- `register_tool_components/0`: Enriched Config with `tool_spec_props(Props)` so `compile_component` has access to full tool spec data without querying raw facts
- `emit_tool_facts/2`: Refactored to call `compile_component` with `fact_type` selectors for all 3 tool fact types

### New Tests

| # | Test | Assertions |
|---|------|------------|
| 20 | `test_compile_component_multi_fact` | bash full multi-fact has tool_spec/tool_handler/destructive_tool; selective fact_type returns only requested fact; read has no destructive_tool |
| 21 | `test_python_tool_dispatch_via_components` | self_prefix produces `self._execute_bash`; indent(12) produces 12 leading spaces; generate_tool_dispatch output matches expected format; destructive_tools set present |

## Verification

- Python zero-diff maintained (`diff prototype/agent_loop.py generated/python/agent_loop.py` — empty)
- Prolog `tools.pl` byte-identical before/after
- Prolog loads cleanly (`swipl -l main.pl -g halt` — no warnings)
- 69/69 tests pass
- 3 files changed, +138 / -22 lines

## Test plan

- [ ] `swipl -g "generate_all, halt" agent_loop_module.pl` — both targets regenerate
- [ ] `diff prototype/agent_loop.py generated/python/agent_loop.py` — zero diff
- [ ] `diff` generated `tools.pl` before/after — byte-identical
- [ ] `swipl -l generated/prolog/main.pl -g halt` — no warnings
- [ ] `swipl -l test_agent_loop.pl -g "run_tests, halt"` — 69/69 pass
