### PR TITLE
feat(agent-loop): Generalize command/backend/security/cost generators through component registry

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -13,7 +13,9 @@
     agent_loop_component_summary/0,
     emit_tool_facts/2,
     emit_command_facts/2,
-    emit_backend_facts/2
+    emit_backend_facts/2,
+    emit_security_facts/2,
+    emit_cost_facts/2
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -119,14 +121,26 @@ agent_command_type:validate_config(Config) :-
 agent_command_type:init_component(_Name, _Config).
 
 agent_command_type:compile_component(Name, Config, Options, Code) :-
+    (member(target(prolog), Options) ->
+        (member(fact_type(FT), Options) ->
+            compile_command_fact(FT, Name, Config, Code)
+        ;
+            compile_command_fact(slash_command, Name, Config, Code)
+        )
+    ;
+        compile_command_fact(slash_command, Name, Config, Code)
+    ).
+
+%% compile_command_fact(+FactType, +Name, +Config, -Code)
+compile_command_fact(slash_command, Name, Config, Code) :-
     member(match_type(MT), Config),
     member(help_text(HT), Config),
     (member(options(Opts), Config) -> true ; Opts = []),
-    (member(target(prolog), Options) ->
-        format(atom(Code), "slash_command(~q, ~q, ~q, ~q).", [Name, MT, Opts, HT])
-    ;
-        format(atom(Code), "slash_command(~q, ~q, ~q, ~q).", [Name, MT, Opts, HT])
-    ).
+    with_output_to(atom(Code), (
+        format('slash_command(~q, ~q, ', [Name, MT]),
+        agent_loop_module:write_prolog_term(current_output, Opts),
+        format(', ~q).', [HT])
+    )).
 
 %% --- Backend factory type ---
 
@@ -149,10 +163,71 @@ agent_backend_type:init_component(_Name, _Config).
 
 agent_backend_type:compile_component(Name, Config, Options, Code) :-
     (member(target(prolog), Options) ->
-        format(atom(Code), "backend_factory(~q, ~q).", [Name, Config])
+        (member(fact_type(FT), Options) ->
+            compile_backend_fact(FT, Name, Config, Code)
+        ;
+            compile_backend_fact(backend_factory, Name, Config, Code)
+        )
     ;
-        format(atom(Code), "backend_factory(~q, ~q).", [Name, Config])
+        compile_backend_fact(backend_factory, Name, Config, Code)
     ).
+
+%% compile_backend_fact(+FactType, +Name, +Config, -Code)
+compile_backend_fact(backend_factory, Name, Config, Code) :-
+    with_output_to(atom(Code), (
+        format('backend_factory(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(current_output, Config),
+        write(').')
+    )).
+
+%% --- Security profile type ---
+
+:- module_transparent agent_security_type:type_info/1.
+:- module_transparent agent_security_type:validate_config/1.
+:- module_transparent agent_security_type:init_component/2.
+:- module_transparent agent_security_type:compile_component/4.
+
+agent_security_type:type_info(info{
+    name: 'Agent Security Profile',
+    version: '1.0.0',
+    description: 'Security profile with path/command validation rules'
+}).
+
+agent_security_type:validate_config(_Config).
+
+agent_security_type:init_component(_Name, _Config).
+
+agent_security_type:compile_component(Name, Config, _Options, Code) :-
+    with_output_to(atom(Code), (
+        format('security_profile(~q, ', [Name]),
+        agent_loop_module:write_prolog_term(current_output, Config),
+        write(').')
+    )).
+
+%% --- Model cost type ---
+
+:- module_transparent agent_cost_type:type_info/1.
+:- module_transparent agent_cost_type:validate_config/1.
+:- module_transparent agent_cost_type:init_component/2.
+:- module_transparent agent_cost_type:compile_component/4.
+
+agent_cost_type:type_info(info{
+    name: 'Agent Model Cost',
+    version: '1.0.0',
+    description: 'Model pricing for token cost tracking'
+}).
+
+agent_cost_type:validate_config(Config) :-
+    member(input_price(_), Config),
+    member(output_price(_), Config).
+
+agent_cost_type:init_component(_Name, _Config).
+
+agent_cost_type:compile_component(_Name, Config, _Options, Code) :-
+    member(input_price(In), Config),
+    member(output_price(Out), Config),
+    member(model_string(Model), Config),
+    format(atom(Code), "model_pricing(~q, ~w, ~w).", [Model, In, Out]).
 
 %% ============================================================================
 %% Category and Type Registration
@@ -167,6 +242,12 @@ register_agent_loop_categories :-
     ]),
     define_category(agent_backends, "Agent-loop backend definitions", [
         requires_compilation(true)
+    ]),
+    define_category(agent_security, "Agent-loop security profiles", [
+        requires_compilation(true)
+    ]),
+    define_category(agent_costs, "Agent-loop model pricing", [
+        requires_compilation(true)
     ]).
 
 register_agent_loop_types :-
@@ -178,6 +259,12 @@ register_agent_loop_types :-
     ]),
     register_component_type(agent_backends, backend, agent_backend_type, [
         description("Agent backend factory")
+    ]),
+    register_component_type(agent_security, security_profile, agent_security_type, [
+        description("Security profile definition")
+    ]),
+    register_component_type(agent_costs, model_pricing, agent_cost_type, [
+        description("Model token pricing")
     ]).
 
 %% ============================================================================
@@ -217,6 +304,23 @@ register_backend_components :-
         declare_component(agent_backends, Name, backend, Spec)
     )).
 
+%% Populate security components from security_profile/2
+register_security_components :-
+    forall(agent_loop_module:security_profile(Name, Props), (
+        declare_component(agent_security, Name, security_profile, Props)
+    )).
+
+%% Populate cost components from model_pricing/3
+register_cost_components :-
+    forall(agent_loop_module:model_pricing(Model, In, Out), (
+        (atom(Model) -> ModelAtom = Model ; atom_string(ModelAtom, Model)),
+        declare_component(agent_costs, ModelAtom, model_pricing, [
+            input_price(In),
+            output_price(Out),
+            model_string(Model)
+        ])
+    )).
+
 %% ============================================================================
 %% Master Registration
 %% ============================================================================
@@ -228,7 +332,9 @@ register_agent_loop_components :-
     register_agent_loop_types,
     register_tool_components,
     register_command_components,
-    register_backend_components.
+    register_backend_components,
+    register_security_components,
+    register_cost_components.
 
 %% ============================================================================
 %% Stream Emitters — Write Prolog facts via the component registry
@@ -272,15 +378,11 @@ emit_tool_facts(S, _Options) :-
 %% emit_command_facts(+Stream, +Options)
 %% Emit command-related Prolog facts via the component registry.
 emit_command_facts(S, _Options) :-
-    %% slash_command via component registry
+    %% slash_command via compile_component
     write(S, '%% slash_command(+Name, +MatchType, +Options, +HelpText)\n'),
-    forall(component(agent_commands, Name, slash_command, Config), (
-        member(match_type(Match), Config),
-        member(help_text(Help), Config),
-        (member(options(Opts), Config) -> true ; Opts = []),
-        format(S, 'slash_command(~q, ~q, ', [Name, Match]),
-        agent_loop_module:write_prolog_term(S, Opts),
-        format(S, ', ~q).~n', [Help])
+    forall(component(agent_commands, Name, slash_command, _), (
+        compile_component(agent_commands, Name, [target(prolog), fact_type(slash_command)], Code),
+        write(S, Code), nl(S)
     )),
     write(S, '\n'),
     %% command_alias — cross-cutting, stays as raw fact iteration
@@ -309,12 +411,11 @@ emit_backend_facts(S, _Options) :-
         write(S, ').\n')
     )),
     write(S, '\n'),
-    %% backend_factory via component registry
+    %% backend_factory via compile_component
     write(S, '%% backend_factory(+Name, +FactorySpec)\n'),
-    forall(component(agent_backends, Name, backend, Config), (
-        format(S, 'backend_factory(~q, ', [Name]),
-        agent_loop_module:write_prolog_term(S, Config),
-        write(S, ').\n')
+    forall(component(agent_backends, Name, backend, _), (
+        compile_component(agent_backends, Name, [target(prolog), fact_type(backend_factory)], Code),
+        write(S, Code), nl(S)
     )),
     write(S, '\n'),
     %% backend_factory_order — singleton, stays raw
@@ -332,6 +433,50 @@ emit_backend_facts(S, _Options) :-
     )),
     write(S, '\n').
 
+%% emit_security_facts(+Stream, +Options)
+%% Emit security-related Prolog facts via the component registry.
+emit_security_facts(S, _Options) :-
+    %% security_profile via compile_component
+    write(S, '%% security_profile(+Name, +Properties)\n'),
+    forall(component(agent_security, Name, security_profile, _), (
+        compile_component(agent_security, Name, [target(prolog)], Code),
+        write(S, Code), nl(S)
+    )),
+    write(S, '\n'),
+    %% blocked_path — simple enumeration, stays raw
+    write(S, '%% blocked_path(+AbsolutePath)\n'),
+    forall(agent_loop_module:blocked_path(P), (
+        format(S, 'blocked_path(~q).~n', [P])
+    )),
+    write(S, '\n'),
+    %% blocked_path_prefix — stays raw
+    write(S, '%% blocked_path_prefix(+Prefix)\n'),
+    forall(agent_loop_module:blocked_path_prefix(P), (
+        format(S, 'blocked_path_prefix(~q).~n', [P])
+    )),
+    write(S, '\n'),
+    %% blocked_home_pattern — stays raw
+    write(S, '%% blocked_home_pattern(+Pattern)\n'),
+    forall(agent_loop_module:blocked_home_pattern(P), (
+        format(S, 'blocked_home_pattern(~q).~n', [P])
+    )),
+    write(S, '\n'),
+    %% blocked_command_pattern — stays raw
+    write(S, '%% blocked_command_pattern(+Regex, +Description)\n'),
+    forall(agent_loop_module:blocked_command_pattern(Regex, Desc), (
+        format(S, 'blocked_command_pattern(~q, ~q).~n', [Regex, Desc])
+    )),
+    write(S, '\n').
+
+%% emit_cost_facts(+Stream, +Options)
+%% Emit cost-related Prolog facts via the component registry.
+emit_cost_facts(S, _Options) :-
+    write(S, '%% model_pricing(+Model, +InputPricePerMTok, +OutputPricePerMTok)\n'),
+    forall(component(agent_costs, Model, model_pricing, _), (
+        compile_component(agent_costs, Model, [target(prolog)], Code),
+        write(S, Code), nl(S)
+    )).
+
 %% agent_loop_component_summary/0
 %% Registers everything and prints a summary.
 agent_loop_component_summary :-
@@ -339,8 +484,13 @@ agent_loop_component_summary :-
     list_components(agent_tools, Tools),
     list_components(agent_commands, Cmds),
     list_components(agent_backends, Backends),
+    list_components(agent_security, Sec),
+    list_components(agent_costs, Costs),
     length(Tools, NT), length(Cmds, NC), length(Backends, NB),
+    length(Sec, NS), length(Costs, NCo),
     format("~nAgent-loop components registered:~n"),
     format("  Tools:    ~w ~w~n", [NT, Tools]),
     format("  Commands: ~w ~w~n", [NC, Cmds]),
-    format("  Backends: ~w ~w~n", [NB, Backends]).
+    format("  Backends: ~w ~w~n", [NB, Backends]),
+    format("  Security: ~w ~w~n", [NS, Sec]),
+    format("  Costs:    ~w~n", [NCo]).

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -1123,11 +1123,8 @@ generate_prolog_costs :-
     write(S, '    cost_tracker_total/2,\n'),
     write(S, '    cost_tracker_format/2\n'),
     write(S, ']).\n\n'),
-    %% Emit all model_pricing facts
-    write(S, '%% model_pricing(+Model, +InputPricePerMTok, +OutputPricePerMTok)\n'),
-    forall(model_pricing(Model, In, Out), (
-        format(S, 'model_pricing(~q, ~w, ~w).~n', [Model, In, Out])
-    )),
+    %% Emit cost facts via component registry
+    agent_loop_components:emit_cost_facts(S, [target(prolog)]),
     %% Emit cost tracker implementation
     write(S, '\n%% Cost tracker using dynamic state\n'),
     write(S, ':- dynamic cost_state/3.  %% cost_state(TrackerID, TotalInputTokens, TotalOutputTokens)\n\n'),
@@ -1520,38 +1517,8 @@ generate_prolog_security :-
     write(S, ':- use_module(library(pcre)).\n\n'),
     write(S, ':- dynamic current_security_profile/1.\n'),
     write(S, 'current_security_profile(cautious).\n\n'),
-    %% Emit security_profile facts
-    write(S, '%% security_profile(+Name, +Properties)\n'),
-    forall(security_profile(Name, Props), (
-        format(S, 'security_profile(~q, ', [Name]),
-        write_prolog_term(S, Props),
-        write(S, ').\n')
-    )),
-    write(S, '\n'),
-    %% Emit blocked_path facts
-    write(S, '%% blocked_path(+AbsolutePath)\n'),
-    forall(blocked_path(P), (
-        format(S, 'blocked_path(~q).~n', [P])
-    )),
-    write(S, '\n'),
-    %% Emit blocked_path_prefix facts
-    write(S, '%% blocked_path_prefix(+Prefix)\n'),
-    forall(blocked_path_prefix(P), (
-        format(S, 'blocked_path_prefix(~q).~n', [P])
-    )),
-    write(S, '\n'),
-    %% Emit blocked_home_pattern facts
-    write(S, '%% blocked_home_pattern(+Pattern)\n'),
-    forall(blocked_home_pattern(P), (
-        format(S, 'blocked_home_pattern(~q).~n', [P])
-    )),
-    write(S, '\n'),
-    %% Emit blocked_command_pattern facts
-    write(S, '%% blocked_command_pattern(+Regex, +Description)\n'),
-    forall(blocked_command_pattern(Regex, Desc), (
-        format(S, 'blocked_command_pattern(~q, ~q).~n', [Regex, Desc])
-    )),
-    write(S, '\n'),
+    %% Emit security facts via component registry
+    agent_loop_components:emit_security_facts(S, [target(prolog)]),
     %% Generate check predicates
     write(S, '%% Check if a file path is allowed under current profile\n'),
     write(S, 'check_path_allowed(Path, Result) :-\n'),
@@ -4255,6 +4222,7 @@ fallback_comment(_, '').
 
 %% generate_backend_factory_fn(S) - emit the create_backend_from_config function
 generate_backend_factory_fn(S) :-
+    agent_loop_components:register_agent_loop_components,
     %% Function signature
     write(S, 'def create_backend_from_config(agent_config: AgentConfig, config_dir: str = "",\n'),
     write(S, '                               sandbox: bool = False, approval_mode: str = "yolo",\n'),
@@ -4276,7 +4244,7 @@ generate_backend_factory_fn(S) :-
 %% generate_factory_chain(S, Backends, FirstFlag)
 generate_factory_chain(_, [], _) :- !.
 generate_factory_chain(S, [BT|Rest], FirstFlag) :-
-    backend_factory(BT, Props),
+    component(agent_backends, BT, backend, Props),
     generate_factory_branch(S, BT, Props, FirstFlag),
     generate_factory_chain(S, Rest, not_first).
 

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -47,6 +47,10 @@ run_tests :-
     test_emit_backend_facts,
     test_compile_component_multi_fact,
     test_python_tool_dispatch_via_components,
+    test_compile_command_component,
+    test_compile_backend_component,
+    test_security_component_registration,
+    test_cost_component_registration,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -524,4 +528,81 @@ test_python_tool_dispatch_via_components :-
             agent_loop_module:generate_tool_dispatch(DS2)
         )),
         sub_atom(DispOutput2, _, _, _, 'self.destructive_tools = {')
+    )).
+
+%% ============================================================================
+%% Test 22: Compile Command Component
+%% ============================================================================
+
+test_compile_command_component :-
+    format("~nCompile command component:~n"),
+    register_agent_loop_components,
+    %% slash_command fact_type produces correct output
+    assert_true('help command via compile_component', (
+        compile_component(agent_commands, help,
+            [target(prolog), fact_type(slash_command)], Code),
+        sub_atom(Code, _, _, _, 'slash_command(help'),
+        sub_atom(Code, _, _, _, 'exact')
+    )),
+    %% iterations command has match_type prefix
+    assert_true('iterations command has prefix match_type', (
+        compile_component(agent_commands, iterations,
+            [target(prolog), fact_type(slash_command)], Code2),
+        sub_atom(Code2, _, _, _, 'prefix')
+    )).
+
+%% ============================================================================
+%% Test 23: Compile Backend Component
+%% ============================================================================
+
+test_compile_backend_component :-
+    format("~nCompile backend component:~n"),
+    register_agent_loop_components,
+    %% backend_factory fact_type
+    assert_true('claude backend via compile_component', (
+        compile_component(agent_backends, claude,
+            [target(prolog), fact_type(backend_factory)], Code),
+        sub_atom(Code, _, _, _, 'backend_factory(claude')
+    )),
+    %% coro backend produces backend_factory
+    assert_true('coro backend via compile_component', (
+        compile_component(agent_backends, coro,
+            [target(prolog), fact_type(backend_factory)], Code2),
+        sub_atom(Code2, _, _, _, 'backend_factory(coro')
+    )).
+
+%% ============================================================================
+%% Test 24: Security Component Registration
+%% ============================================================================
+
+test_security_component_registration :-
+    format("~nSecurity component registration:~n"),
+    register_agent_loop_components,
+    %% 4 security profiles registered
+    assert_true('4 security profiles registered', (
+        findall(N, component(agent_security, N, security_profile, _), Ns),
+        length(Ns, 4)
+    )),
+    %% compile_component produces security_profile(cautious,...
+    assert_true('cautious profile via compile_component', (
+        compile_component(agent_security, cautious, [target(prolog)], Code),
+        sub_atom(Code, _, _, _, 'security_profile(cautious')
+    )).
+
+%% ============================================================================
+%% Test 25: Cost Component Registration
+%% ============================================================================
+
+test_cost_component_registration :-
+    format("~nCost component registration:~n"),
+    register_agent_loop_components,
+    %% 16 model costs registered
+    assert_true('16 model costs registered', (
+        findall(M, component(agent_costs, M, model_pricing, _), Ms),
+        length(Ms, 16)
+    )),
+    %% compile_component produces model_pricing(
+    assert_true('opus cost via compile_component', (
+        compile_component(agent_costs, opus, [target(prolog)], Code),
+        sub_atom(Code, _, _, _, 'model_pricing(')
     )).


### PR DESCRIPTION
## Summary

Extends the `compile_component/4` pattern (from #730) to all remaining generator domains — commands, backends, security profiles, and model pricing. Replaces 7 raw `forall` loops in `agent_loop_module.pl` with `emit_*_facts/2` calls routed through the component registry. Wires the Python backend factory chain through component iteration.

## Changes

### `agent_loop_components.pl` (+178/−18)

- **Deeper `agent_command_type:compile_component/4`** — `fact_type` dispatch to `compile_command_fact(slash_command, ...)` using `with_output_to` + `write_prolog_term` for byte-identical output
- **Deeper `agent_backend_type:compile_component/4`** — `fact_type` dispatch to `compile_backend_fact(backend_factory, ...)` with same pattern
- **New `agent_security_type` module** — `compile_component/4` for `security_profile` facts
- **New `agent_cost_type` module** — `compile_component/4` for `model_pricing` facts (string→atom name conversion at registration, original preserved via `model_string/1`)
- **New categories**: `agent_security`, `agent_costs` with type registrations
- **New emitters**: `emit_security_facts/2`, `emit_cost_facts/2`
- **Refactored**: `emit_command_facts/2` and `emit_backend_facts/2` now use `compile_component` for per-component facts

### `agent_loop_module.pl` (+5/−43)

- `generate_prolog_costs`: 1 `forall` → `emit_cost_facts/2`
- `generate_prolog_security`: 5 `forall` loops → `emit_security_facts/2`
- `generate_factory_chain/3`: `backend_factory(BT, Props)` → `component(agent_backends, BT, backend, Props)`
- `generate_backend_factory_fn/1`: Calls `register_agent_loop_components` before generation

### `test_agent_loop.pl` (+81)

| # | Test | Assertions |
|---|------|------------|
| 22 | `test_compile_command_component` | `help` produces `slash_command(help, exact, ...)`; `iterations` has `prefix` match_type |
| 23 | `test_compile_backend_component` | `claude` and `coro` backends produce `backend_factory(...)` via compile_component |
| 24 | `test_security_component_registration` | 4 profiles registered; `cautious` compiles to `security_profile(cautious, ...)` |
| 25 | `test_cost_component_registration` | 16 model costs registered; `opus` compiles to `model_pricing(...)` |

## What stays raw (by design)

Cross-cutting facts that don't fit the named-component pattern:
- `command_alias/2`, `slash_command_group/2` — keyed by alias/group, not command
- `agent_backend/2` — rich property lists used across many generators
- `backend_factory_order/1` — singleton ordering
- `cli_fallbacks/2` — keyed by backend but different shape
- `blocked_path/1`, `blocked_path_prefix/1`, `blocked_home_pattern/1`, `blocked_command_pattern/2` — simple enumerations

## Verification

- 77/77 tests pass (8 new)
- Python zero-diff (`diff prototype/agent_loop.py generated/python/agent_loop.py`)
- All 5 Prolog files byte-identical: tools.pl, commands.pl, backends.pl, security.pl, costs.pl
- `swipl -l generated/prolog/main.pl -g halt` — clean load, no warnings
- 3 files changed, +260/−61

## Test plan

- [ ] `swipl -g "generate_all, halt" agent_loop_module.pl` — both targets regenerate
- [ ] `diff prototype/agent_loop.py generated/python/agent_loop.py` — zero diff
- [ ] `diff` all 5 generated `.pl` files before/after — byte-identical
- [ ] `swipl -l generated/prolog/main.pl -g halt` — no warnings
- [ ] `swipl -l test_agent_loop.pl -g "run_tests, halt"` — 77/77 pass
