### PR TITLE
feat(agent-loop): Emit batch 3, Prolog indexing hints for backends/commands, readutil bugfix

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -32,7 +32,16 @@
     emit_security_module_imports/2,
     emit_help_groups/2,
     emit_readme_sections/2,
-    emit_backend_module_imports/2
+    emit_backend_module_imports/2,
+    emit_streaming_capable_facts/2,
+    emit_security_profile_entries/2,
+    emit_tool_schemas_py/2,
+    emit_tool_dispatch_entries/2,
+    emit_cascade_paths/2,
+    emit_alias_group_entries/2,
+    emit_alias_conditions/2,
+    emit_argparse_group_args/2,
+    emit_backend_helper_fragments/2
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -399,6 +408,17 @@ emit_tool_facts(S, _Options) :-
 %% emit_command_facts(+Stream, +Options)
 %% Emit command-related Prolog facts via the component registry.
 emit_command_facts(S, _Options) :-
+    %% Optimization notes and indexing hints
+    findall(_, component(agent_commands, _, slash_command, _), SCs), length(SCs, NSC),
+    findall(_, agent_loop_module:command_alias(_, _), CAs), length(CAs, NCA),
+    emit_optimization_notes(S, [
+        'slash_command/4: first-argument atom-indexed, all distinct',
+        'command_alias/2: first-argument string hash-indexed, all distinct'
+    ]),
+    write(S, '%% Indexing hints (SWI-Prolog auto-indexes first argument):\n'),
+    emit_indexing_directive(S, slash_command/4, NSC),
+    emit_indexing_directive(S, command_alias/2, NCA),
+    write(S, '\n'),
     %% slash_command via compile_component
     write(S, '%% slash_command(+Name, +MatchType, +Options, +HelpText)\n'),
     forall(component(agent_commands, Name, slash_command, _), (
@@ -424,6 +444,21 @@ emit_command_facts(S, _Options) :-
 %% emit_backend_facts(+Stream, +Options)
 %% Emit backend-related Prolog facts via the component registry.
 emit_backend_facts(S, _Options) :-
+    %% Optimization notes and indexing hints
+    emit_optimization_notes(S, [
+        'agent_backend/2: deterministic lookup by backend name',
+        'backend_factory/2: deterministic lookup by factory name',
+        'streaming_capable/1: 3-clause fact table'
+    ]),
+    findall(_, agent_loop_module:agent_backend(_, _), ABs), length(ABs, NAB),
+    findall(_, (component(agent_backends, _, backend, _)), BFs), length(BFs, NBF),
+    findall(_, agent_loop_module:cli_fallbacks(_, _), CFs), length(CFs, NCF),
+    write(S, '%% Indexing hints (SWI-Prolog auto-indexes first argument):\n'),
+    emit_indexing_directive(S, agent_backend/2, NAB),
+    emit_indexing_directive(S, backend_factory/2, NBF),
+    emit_indexing_directive(S, cli_fallbacks/2, NCF),
+    emit_indexing_directive(S, streaming_capable/1),
+    write(S, '\n'),
     %% agent_backend — rich property list not in registry, stays raw
     write(S, '%% agent_backend(+Name, +Properties)\n'),
     forall(agent_loop_module:agent_backend(Name, Props), (
@@ -473,6 +508,8 @@ emit_security_facts(S, Options) :-
         emit_indexing_directive(S, security_profile/2),
         emit_indexing_directive(S, blocked_path/1),
         emit_indexing_directive(S, blocked_path_prefix/1),
+        emit_indexing_directive(S, blocked_home_pattern/1),
+        emit_indexing_directive(S, blocked_command_pattern/2),
         write(S, '\n'),
         write(S, '%% security_profile(+Name, +Properties)\n'),
         forall(component(agent_security, Name, security_profile, _), (
@@ -571,6 +608,11 @@ emit_backend_init_optional(S, _Options) :-
 %% SWI-Prolog's first-argument indexing (auto-applied to fact tables).
 emit_indexing_directive(S, Pred/Arity) :-
     format(S, '%%   ~w/~w: first-argument indexed~n', [Pred, Arity]).
+
+%% emit_indexing_directive(+Stream, +Pred/Arity, +ClauseCount)
+%% Variant with clause count annotation.
+emit_indexing_directive(S, Pred/Arity, Count) :-
+    format(S, '%%   ~w/~w: first-argument indexed (~w clauses)~n', [Pred, Arity, Count]).
 
 %% emit_optimization_notes(+Stream, +Notes)
 %% Emit optimization documentation as Prolog comments.
@@ -812,6 +854,94 @@ emit_backend_module_imports(S, Options) :-
     ; true).
 
 %% ============================================================================
+%% Forall Lift Batch 3 — Prolog backends, security profiles, tool dispatch,
+%% config cascade, aliases, argparse, backend helpers
+%% ============================================================================
+
+%% emit_streaming_capable_facts(+Stream, +Options)
+%% Emit streaming_capable/1 Prolog facts for generate_prolog_backends.
+emit_streaming_capable_facts(S, _Options) :-
+    write(S, '%% streaming_capable(+ResolveType) — which backends support streaming\n'),
+    forall(agent_loop_module:streaming_capable(Type),
+        format(S, 'streaming_capable(~q).~n', [Type])),
+    write(S, '\n').
+
+%% emit_security_profile_entries(+Stream, +Options)
+%% Emit Python SecurityProfile entries from component registry.
+emit_security_profile_entries(S, _Options) :-
+    register_agent_loop_components,
+    forall(component(agent_security, Name, security_profile, Props), (
+        agent_loop_module:generate_profile_entry(S, Name, Props)
+    )).
+
+%% emit_tool_schemas_py(+Stream, +Options)
+%% Emit Python tool schema dicts from tool_spec/2 facts.
+emit_tool_schemas_py(S, _Options) :-
+    forall(agent_loop_module:tool_spec(ToolName, ToolProps), (
+        agent_loop_module:generate_tool_schema_py(S, ToolName, ToolProps)
+    )).
+
+%% emit_tool_dispatch_entries(+Stream, +Options)
+%% Emit self.tools dict entries via compile_component/4.
+emit_tool_dispatch_entries(S, _Options) :-
+    register_agent_loop_components,
+    forall(component(agent_tools, TN, tool_handler, _), (
+        compile_component(agent_tools, TN,
+            [target(python), self_prefix(true), indent(12)], Code),
+        write(S, Code), nl(S)
+    )).
+
+%% emit_cascade_paths(+Stream, +Options)
+%% Emit config cascade path entries. Options: path_type(required|fallback), indent(Str).
+emit_cascade_paths(S, Options) :-
+    (member(path_type(Type), Options) -> true ; Type = required),
+    (member(indent(Indent), Options) -> true ; Indent = ''),
+    findall(P, agent_loop_module:config_search_path(P, Type), Paths),
+    forall(member(Path, Paths), (
+        agent_loop_module:generate_cascade_path_entry(S, Path, Indent)
+    )).
+
+%% emit_alias_group_entries(+Stream, +Options)
+%% Emit Python dict entries for an alias category.
+emit_alias_group_entries(S, Options) :-
+    member(category(Category), Options),
+    agent_loop_module:alias_category(Category, Keys),
+    forall(member(K, Keys), (
+        agent_loop_module:command_alias(K, V),
+        format(S, '    "~w": "~w",~n', [K, V])
+    )).
+
+%% emit_alias_conditions(+Stream, +Options)
+%% Emit alias match conditions for command dispatch.
+%% Options: aliases(List), match_style(exact|prefix_sp).
+emit_alias_conditions(S, Options) :-
+    member(aliases(Aliases), Options),
+    (member(match_style(prefix_sp), Options) ->
+        forall(member(A, Aliases),
+            format(S, ' or cmd.startswith(\'~w \')', [A]))
+    ;
+        forall(member(A, Aliases),
+            format(S, ' or cmd == \'~w\'', [A]))
+    ).
+
+%% emit_argparse_group_args(+Stream, +Options)
+%% Emit parser.add_argument() calls for a group of CLI arguments.
+emit_argparse_group_args(S, Options) :-
+    member(args(ArgNames), Options),
+    forall(member(ArgName, ArgNames), (
+        agent_loop_module:cli_argument(ArgName, Props),
+        agent_loop_module:generate_add_argument(S, Props)
+    )).
+
+%% emit_backend_helper_fragments(+Stream, +Options)
+%% Emit trailing helper method fragments for a backend.
+emit_backend_helper_fragments(S, Options) :-
+    member(backend(BackendName), Options),
+    member(fragments(Frags), Options),
+    forall(member(F, Frags),
+        agent_loop_module:emit_helper_fragment(S, BackendName, F)).
+
+%% ============================================================================
 %% Test Metadata Generation
 %% ============================================================================
 
@@ -890,21 +1020,28 @@ emit_predicate_summary :-
     format("Generators using component/emit paths:~n"),
     format("  costs.py          -> emit_cost_facts/2 [target(python)]~n"),
     format("  tools.py          -> emit_security_facts/2 [blocked_* fact_types]~n"),
-    format("  tools.py          -> generate_tool_dispatch/1 (component iteration)~n"),
+    format("  tools.py          -> emit_tool_dispatch_entries/2 (component iteration)~n"),
     format("  backends/__init__ -> emit_backend_init_imports/2 + emit_backend_init_optional/2~n"),
     format("  backends/<name>   -> emit_backend_module_imports/2 [imports(list)]~n"),
+    format("  backends/<name>   -> emit_backend_helper_fragments/2~n"),
     format("  security/__init__ -> emit_security_module_imports/2~n"),
-    format("  security/profiles -> component(agent_security, ...) iteration~n"),
+    format("  security/profiles -> emit_security_profile_entries/2~n"),
     format("  context.py        -> emit_context_enums/2, emit_message_fields/2~n"),
     format("  config.py         -> emit_agent_config_fields/2, emit_api_key_env_vars_py/2~n"),
     format("  config.py         -> emit_api_key_files_py/2, emit_default_presets_py/2~n"),
+    format("  config.py         -> emit_cascade_paths/2 [path_type(required|fallback)]~n"),
     format("  agent_loop.py     -> emit_audit_levels/2, emit_cli_overrides/2~n"),
     format("  agent_loop.py     -> emit_binding_dispatch_comment/2 (8 bindings)~n"),
     format("  agent_loop.py     -> emit_help_groups/2~n"),
+    format("  agent_loop.py     -> emit_alias_conditions/2, emit_argparse_group_args/2~n"),
     format("  README.md         -> emit_readme_sections/2~n"),
     format("  Prolog generators -> emit_tool/command/backend/security/cost_facts/2~n"),
     format("  prolog/config.pl  -> emit_prolog_config_facts/2 (with indexing hints)~n"),
+    format("  prolog/backends   -> emit_streaming_capable_facts/2~n"),
+    format("  prolog/backends   -> emit_backend_facts/2 (with optimization notes)~n"),
+    format("  prolog/commands   -> emit_command_facts/2 (with optimization notes)~n"),
+    format("  openrouter_api    -> emit_tool_schemas_py/2~n"),
     format("~nGenerators using raw fact iteration (by design):~n"),
-    format("  aliases.py        -> command_alias/2 (structural ordering with comments)~n"),
+    format("  aliases.py        -> emit_alias_group_entries/2 + structural ordering~n"),
     format("  backends/<name>   -> agent_backend/2 + py_fragment/2~n"),
     format("~n").

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -1393,6 +1393,7 @@ generate_prolog_commands :-
     write(S, '    resolve_command/3,\n'),
     write(S, '    handle_slash_command/3\n'),
     write(S, ']).\n\n'),
+    write(S, '%% Dependencies: none (self-contained command definitions)\n\n'),
     %% Emit command facts via component registry
     agent_loop_components:emit_command_facts(S, [target(prolog)]),
     %% Generate resolve_command
@@ -1513,9 +1514,10 @@ generate_prolog_backends :-
     write(S, ':- use_module(library(json)).\n'),
     write(S, ':- use_module(library(readutil)).\n'),
     write(S, ':- use_module(library(process)).\n'),
-    write(S, ':- use_module(library(readutil)).\n'),
     write(S, ':- use_module(library(random)).\n'),
     write(S, ':- discontiguous send_request_streaming_raw/5.\n\n'),
+    write(S, '%% Dependencies: costs (model_pricing/3 for cost tracking)\n'),
+    write(S, '%%              config (api_key_env_var/2 for key resolution)\n\n'),
     %% Emit backend facts via component registry
     agent_loop_components:emit_backend_facts(S, [target(prolog)]),
     %% Generate create_backend
@@ -1689,11 +1691,7 @@ generate_prolog_backends :-
     write(S, '        Usage = _{input_tokens: 0, output_tokens: 0}\n'),
     write(S, '    ).\n\n'),
     %% Streaming capability facts
-    write(S, '%% streaming_capable(+ResolveType) — which backends support streaming\n'),
-    forall(streaming_capable(Type), (
-        format(S, 'streaming_capable(~q).~n', [Type])
-    )),
-    write(S, '\n'),
+    agent_loop_components:emit_streaming_capable_facts(S, [target(prolog)]),
     %% Streaming request dispatch
     write(S, '%% Send a streaming request (falls back to send_request if unsupported)\n'),
     write(S, 'send_request_streaming(Backend, Messages, Tools, Response) :-\n'),
@@ -3003,9 +3001,7 @@ generate_security_profiles :-
     write(S, 'def get_builtin_profiles() -> dict[str, SecurityProfile]:\n'),
     write(S, '    """Return all built-in security profiles."""\n'),
     write(S, '    return {\n'),
-    forall(component(agent_security, Name, security_profile, Props), (
-        generate_profile_entry(S, Name, Props)
-    )),
+    agent_loop_components:emit_security_profile_entries(S, [target(python)]),
     write(S, '    }\n\n\n'),
     %% get_profile()
     write(S, 'def get_profile(name: str) -> SecurityProfile:\n'),
@@ -3537,17 +3533,11 @@ generate_config_cascade(S) :-
     write(S, 'def read_config_cascade(no_fallback: bool = False) -> dict:\n'),
     write(S, '    """Read config from uwsal.json, falling back to coro.json."""\n'),
     write(S, '    candidates = [\n'),
-    findall(P, config_search_path(P, required), RequiredPaths),
-    forall(member(Path, RequiredPaths), (
-        generate_cascade_path_entry(S, Path, '')
-    )),
+    agent_loop_components:emit_cascade_paths(S, [path_type(required), indent('')]),
     write(S, '    ]\n'),
     write(S, '    if not no_fallback:\n'),
     write(S, '        candidates += [\n'),
-    findall(P, config_search_path(P, fallback), FallbackPaths),
-    forall(member(Path, FallbackPaths), (
-        generate_cascade_path_entry(S, Path, '    ')
-    )),
+    agent_loop_components:emit_cascade_paths(S, [path_type(fallback), indent('    ')]),
     write(S, '        ]\n'),
     write(S, '    for path in candidates:\n'),
     write(S, '        try:\n'),
@@ -3703,11 +3693,7 @@ alias_category_comment(_, _).
 %% Write aliases for a simple category
 generate_alias_group(S, Category, Comment) :-
     write(S, Comment),
-    alias_category(Category, Keys),
-    forall(member(K, Keys), (
-        command_alias(K, V),
-        format(S, '    "~w": "~w",~n', [K, V])
-    )).
+    agent_loop_components:emit_alias_group_entries(S, [category(Category)]).
 
 %% Backend is special: has two sub-groups with separate comments
 generate_alias_group_backend(S) :-
@@ -3762,7 +3748,7 @@ generate_single_dispatch(S, exit, exact, Props) :-
     !,
     (member(aliases(Aliases), Props) -> true ; Aliases = []),
     write(S, '        if cmd == \'exit\''),
-    forall(member(A, Aliases), format(S, ' or cmd == \'~w\'', [A])),
+    agent_loop_components:emit_alias_conditions(S, [aliases(Aliases), match_style(exact)]),
     write(S, ':\n'),
     write(S, '            self.running = False\n'),
     write(S, '            return True\n').
@@ -3796,7 +3782,7 @@ generate_single_dispatch(S, Cmd, exact, Props) :-
         format(S, '        # ~w~n', [Comment])
     ; true),
     format(S, '        if cmd == \'~w\'', [Cmd]),
-    forall(member(A, Aliases), format(S, ' or cmd == \'~w\'', [A])),
+    agent_loop_components:emit_alias_conditions(S, [aliases(Aliases), match_style(exact)]),
     write(S, ':\n'),
     format(S, '            return self.~w()~n', [Handler]).
 
@@ -3817,7 +3803,7 @@ generate_single_dispatch(S, Cmd, prefix_sp, Props) :-
         format(S, '        # ~w~n', [Comment])
     ; true),
     format(S, '        if cmd.startswith(\'~w \')', [Cmd]),
-    forall(member(A, Aliases), format(S, ' or cmd.startswith(\'~w \')', [A])),
+    agent_loop_components:emit_alias_conditions(S, [aliases(Aliases), match_style(prefix_sp)]),
     write(S, ':\n'),
     format(S, '            return self.~w(text)~n', [Handler]).
 
@@ -3926,17 +3912,11 @@ generate_argparse_groups(_, [], _) :- !.
 generate_argparse_groups(S, [GroupComment-ArgNames|Rest], first) :- !,
     %% First group: no leading blank line
     format(S, '    # ~w~n', [GroupComment]),
-    forall(member(ArgName, ArgNames), (
-        cli_argument(ArgName, Props),
-        generate_add_argument(S, Props)
-    )),
+    agent_loop_components:emit_argparse_group_args(S, [args(ArgNames)]),
     generate_argparse_groups(S, Rest, not_first).
 generate_argparse_groups(S, [GroupComment-ArgNames|Rest], not_first) :-
     format(S, '~n    # ~w~n', [GroupComment]),
-    forall(member(ArgName, ArgNames), (
-        cli_argument(ArgName, Props),
-        generate_add_argument(S, Props)
-    )),
+    agent_loop_components:emit_argparse_group_args(S, [args(ArgNames)]),
     generate_argparse_groups(S, Rest, not_first).
 
 %% generate_add_argument(S, Props) - emit a single parser.add_argument(...)
@@ -9621,7 +9601,7 @@ generate_send_message_sig(S) :-
 generate_backend_helpers(S, BackendName) :-
     agent_backend(BackendName, Props),
     member(helper_fragments(Frags), Props),
-    forall(member(F, Frags), emit_helper_fragment(S, BackendName, F)),
+    agent_loop_components:emit_backend_helper_fragments(S, [backend(BackendName), fragments(Frags)]),
     member(display_name(DN), Props),
     write_py(S, name_property, [display_name=DN]).
 
@@ -9689,11 +9669,7 @@ generate_describe_fallback(S, _) :-
 generate_tool_dispatch(S) :-
     agent_loop_components:register_agent_loop_components,
     write(S, '\n        self.tools = {\n'),
-    forall(component(agent_tools, TN, tool_handler, _), (
-        compile_component(agent_tools, TN,
-            [target(python), self_prefix(true), indent(12)], Code),
-        write(S, Code), nl(S)
-    )),
+    agent_loop_components:emit_tool_dispatch_entries(S, [target(python)]),
     write(S, '        }\n'),
     write(S, '\n        self.destructive_tools = {'),
     findall(DT, (component(agent_tools, DT, tool_handler, Cfg),
@@ -10189,9 +10165,7 @@ generate_backend_full(S, openrouter_api, _) :-
     %% Generate DEFAULT_TOOL_SCHEMAS from tool_spec/2 facts
     write(S, '# Default tool schemas for function calling (OpenAI format)\n'),
     write(S, 'DEFAULT_TOOL_SCHEMAS = [\n'),
-    forall(tool_spec(ToolName, ToolProps), (
-        generate_tool_schema_py(S, ToolName, ToolProps)
-    )),
+    agent_loop_components:emit_tool_schemas_py(S, [target(python)]),
     write(S, ']\n\n\n'),
     generate_backend_class_decl(S, openrouter_api),
     write(S, '    def __init__(\n        self,\n        api_key: str | None = None,\n'),

--- a/tools/agent-loop/generated/prolog/backends.pl
+++ b/tools/agent-loop/generated/prolog/backends.pl
@@ -22,9 +22,22 @@
 :- use_module(library(json)).
 :- use_module(library(readutil)).
 :- use_module(library(process)).
-:- use_module(library(readutil)).
 :- use_module(library(random)).
 :- discontiguous send_request_streaming_raw/5.
+
+%% Dependencies: costs (model_pricing/3 for cost tracking)
+%%              config (api_key_env_var/2 for key resolution)
+
+%% Optimization notes:
+%%   - agent_backend/2: deterministic lookup by backend name
+%%   - backend_factory/2: deterministic lookup by factory name
+%%   - streaming_capable/1: 3-clause fact table
+
+%% Indexing hints (SWI-Prolog auto-indexes first argument):
+%%   agent_backend/2: first-argument indexed (8 clauses)
+%%   backend_factory/2: first-argument indexed (8 clauses)
+%%   cli_fallbacks/2: first-argument indexed (4 clauses)
+%%   streaming_capable/1: first-argument indexed
 
 %% agent_backend(+Name, +Properties)
 agent_backend(coro, [type(cli), class_name('CoroBackend'), command("claude"), args(["--verbose"]), description("Coro-code CLI backend using single-task mode"), context_format(conversation_history), output_parser(coro_parser), supports_streaming(false), module_imports(['json as _json',os,subprocess,re,tempfile]), class_docstring('Coro-code CLI backend using single-task mode.'), display_name('Coro ({self.command})'), helper_fragments([])]).

--- a/tools/agent-loop/generated/prolog/commands.pl
+++ b/tools/agent-loop/generated/prolog/commands.pl
@@ -11,6 +11,16 @@
     handle_slash_command/3
 ]).
 
+%% Dependencies: none (self-contained command definitions)
+
+%% Optimization notes:
+%%   - slash_command/4: first-argument atom-indexed, all distinct
+%%   - command_alias/2: first-argument string hash-indexed, all distinct
+
+%% Indexing hints (SWI-Prolog auto-indexes first argument):
+%%   slash_command/4: first-argument indexed (23 clauses)
+%%   command_alias/2: first-argument indexed (30 clauses)
+
 %% slash_command(+Name, +MatchType, +Options, +HelpText)
 slash_command(exit, exact, [aliases([quit]), help_display('/exit, /quit')], 'Exit the agent loop').
 slash_command(clear, exact, [], 'Clear conversation context').

--- a/tools/agent-loop/generated/prolog/security.pl
+++ b/tools/agent-loop/generated/prolog/security.pl
@@ -23,6 +23,8 @@ current_security_profile(cautious).
 %%   security_profile/2: first-argument indexed
 %%   blocked_path/1: first-argument indexed
 %%   blocked_path_prefix/1: first-argument indexed
+%%   blocked_home_pattern/1: first-argument indexed
+%%   blocked_command_pattern/2: first-argument indexed
 
 %% security_profile(+Name, +Properties)
 security_profile(open, [description("No restrictions - for trusted manual use"), path_validation(false), command_blocklist(false), command_proxying(disabled), audit_logging(disabled)]).

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -66,6 +66,14 @@ run_tests :-
     test_emit_help_groups,
     test_new_binding_count,
     test_binding_compile_api_key,
+    test_emit_streaming_capable_facts,
+    test_emit_security_profile_entries,
+    test_emit_tool_dispatch_entries,
+    test_emit_cascade_paths,
+    test_emit_alias_conditions,
+    test_emit_argparse_group_args,
+    test_emit_backend_optimization_hints,
+    test_emit_command_optimization_hints,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -917,4 +925,142 @@ test_binding_compile_api_key :-
     assert_true('compile_binding_code for api_key_file', (
         agent_loop_bindings:compile_binding_code(python, api_key_file/2, Code2),
         sub_atom(Code2, _, _, _, 'API_KEY_FILE_PATHS')
+    )).
+
+%% ============================================================================
+%% Batch 3 Emit Predicate Tests
+%% ============================================================================
+
+test_emit_streaming_capable_facts :-
+    format("~nStreaming capable emit:~n"),
+    assert_true('emit_streaming_capable_facts contains streaming_capable', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_streaming_capable_facts(S, [target(prolog)])
+        )),
+        sub_atom(Output, _, _, _, 'streaming_capable(')
+    )),
+    assert_true('emit_streaming_capable_facts contains api type', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_streaming_capable_facts(S2, [target(prolog)])
+        )),
+        sub_atom(Output2, _, _, _, 'streaming_capable(api)')
+    )).
+
+test_emit_security_profile_entries :-
+    format("~nSecurity profile entries emit:~n"),
+    agent_loop_components:register_agent_loop_components,
+    assert_true('emit_security_profile_entries contains cautious', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_security_profile_entries(S, [target(python)])
+        )),
+        sub_atom(Output, _, _, _, 'cautious')
+    )).
+
+test_emit_tool_dispatch_entries :-
+    format("~nTool dispatch entries emit:~n"),
+    agent_loop_components:register_agent_loop_components,
+    assert_true('emit_tool_dispatch_entries contains bash', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_tool_dispatch_entries(S, [target(python)])
+        )),
+        sub_atom(Output, _, _, _, '\'bash\'')
+    )),
+    assert_true('emit_tool_dispatch_entries contains self._execute', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_tool_dispatch_entries(S2, [target(python)])
+        )),
+        sub_atom(Output2, _, _, _, 'self._execute')
+    )).
+
+test_emit_cascade_paths :-
+    format("~nCascade paths emit:~n"),
+    assert_true('emit_cascade_paths required contains uwsal.json', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_cascade_paths(S, [path_type(required), indent('')])
+        )),
+        sub_atom(Output, _, _, _, 'uwsal.json')
+    )),
+    assert_true('emit_cascade_paths fallback exists', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_cascade_paths(S2, [path_type(fallback), indent('    ')])
+        )),
+        atom_length(Output2, Len2),
+        Len2 > 0
+    )).
+
+test_emit_alias_conditions :-
+    format("~nAlias conditions emit:~n"),
+    assert_true('emit_alias_conditions exact generates or cmd ==', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_alias_conditions(S, [aliases([q, x]), match_style(exact)])
+        )),
+        sub_atom(Output, _, _, _, 'or cmd == \'q\'')
+    )),
+    assert_true('emit_alias_conditions prefix_sp generates startswith', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_alias_conditions(S2, [aliases([be]), match_style(prefix_sp)])
+        )),
+        sub_atom(Output2, _, _, _, 'startswith(\'be \')')
+    )).
+
+test_emit_argparse_group_args :-
+    format("~nArgparse group args emit:~n"),
+    assert_true('emit_argparse_group_args contains add_argument', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_argparse_group_args(S, [args([agent])])
+        )),
+        sub_atom(Output, _, _, _, 'add_argument')
+    )).
+
+test_emit_backend_optimization_hints :-
+    format("~nBackend optimization hints:~n"),
+    agent_loop_components:register_agent_loop_components,
+    assert_true('emit_backend_facts includes indexing hints', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_backend_facts(S, [target(prolog)])
+        )),
+        sub_atom(Output, _, _, _, 'Indexing hints')
+    )),
+    assert_true('emit_backend_facts includes agent_backend clause count', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_backend_facts(S2, [target(prolog)])
+        )),
+        sub_atom(Output2, _, _, _, 'agent_backend/2: first-argument indexed (8 clauses)')
+    )).
+
+test_emit_command_optimization_hints :-
+    format("~nCommand optimization hints:~n"),
+    agent_loop_components:register_agent_loop_components,
+    assert_true('emit_command_facts includes indexing hints', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_command_facts(S, [target(prolog)])
+        )),
+        sub_atom(Output, _, _, _, 'Indexing hints')
+    )),
+    assert_true('emit_command_facts includes slash_command clause count', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_command_facts(S2, [target(prolog)])
+        )),
+        sub_atom(Output2, _, _, _, 'slash_command/4: first-argument indexed (23 clauses)')
+    )),
+    assert_true('emit_command_facts includes command_alias clause count', (
+        with_output_to(atom(Output3), (
+            current_output(S3),
+            agent_loop_components:emit_command_facts(S3, [target(prolog)])
+        )),
+        sub_atom(Output3, _, _, _, 'command_alias/2: first-argument indexed (30 clauses)')
     )).


### PR DESCRIPTION
## Summary

- **12 forall loops lifted** from `agent_loop_module.pl` into 9 new emit predicates in `agent_loop_components.pl`, removing 47 lines from the main generator
- **Prolog-target optimization coverage completed**: `backends.pl` and `commands.pl` now include optimization notes and indexing hints with clause counts — all 5 generated Prolog fact files now have indexing documentation
- **Bug fix**: duplicate `:- use_module(library(readutil))` removed from `generate_prolog_backends`
- **`emit_indexing_directive/3`** variant added with clause count annotation, dynamically computed via `findall`/`length`

## Changes

### `agent_loop_components.pl` (+145)

9 new emit predicates:

| Predicate | Target | Replaces |
|-----------|--------|----------|
| `emit_streaming_capable_facts/2` | Prolog | `streaming_capable/1` forall in `generate_prolog_backends` |
| `emit_security_profile_entries/2` | Python | `component(agent_security, ...)` forall in `generate_security_profiles` |
| `emit_tool_schemas_py/2` | Python | `tool_spec/2` forall in `generate_backend_full/3` (openrouter_api) |
| `emit_tool_dispatch_entries/2` | Python | `component(agent_tools, ...)` + `compile_component/4` forall in `generate_tool_dispatch` |
| `emit_cascade_paths/2` | Python | 2 `config_search_path` foralls in `generate_config_cascade` |
| `emit_alias_group_entries/2` | Python | `alias_category` forall in `generate_alias_group` |
| `emit_alias_conditions/2` | Python | 3 alias-condition foralls in `generate_single_dispatch` (exit, exact, prefix_sp) |
| `emit_argparse_group_args/2` | Python | 2 `cli_argument` foralls in `generate_argparse_groups` |
| `emit_backend_helper_fragments/2` | Python | `helper_fragments` forall in `generate_backend_helpers` |

Also adds:
- `emit_indexing_directive/3` — variant with clause count: `%%   pred/N: first-argument indexed (M clauses)`
- Indexing hints + optimization notes in `emit_backend_facts/2` (4 predicates with dynamic clause counts)
- Indexing hints + optimization notes in `emit_command_facts/2` (2 predicates with dynamic clause counts)
- 2 additional indexing hints in `emit_security_facts/2` (`blocked_home_pattern/1`, `blocked_command_pattern/2`)
- Updated `emit_predicate_summary/0` to reflect 31 emit paths

### `agent_loop_module.pl` (−47)

All 12 forall blocks replaced with single-line emit calls. Fixed duplicate `use_module(library(readutil))` in `generate_prolog_backends`. Added `%% Dependencies:` comments to backends and commands generators.

### `test_agent_loop.pl` (+146)

8 new test predicates (15 assertions):

| Test | Validates |
|------|-----------|
| `test_emit_streaming_capable_facts` | Output contains `streaming_capable(` and `streaming_capable(api)` |
| `test_emit_security_profile_entries` | Output contains `cautious` |
| `test_emit_tool_dispatch_entries` | Output contains `'bash'` and `self._execute` |
| `test_emit_cascade_paths` | Required paths contain `uwsal.json`; fallback paths non-empty |
| `test_emit_alias_conditions` | Exact style produces `or cmd == 'q'`; prefix_sp produces `startswith('be ')` |
| `test_emit_argparse_group_args` | Output contains `add_argument` |
| `test_emit_backend_optimization_hints` | `emit_backend_facts` includes `Indexing hints` and `agent_backend/2: first-argument indexed (8 clauses)` |
| `test_emit_command_optimization_hints` | `emit_command_facts` includes `slash_command/4: first-argument indexed (23 clauses)` and `command_alias/2: first-argument indexed (30 clauses)` |

### Generated files

- `generated/prolog/backends.pl` (+15) — dependency docs, optimization notes, 4 indexing hints with clause counts, removed duplicate `use_module(readutil)`
- `generated/prolog/commands.pl` (+10) — dependency docs, optimization notes, 2 indexing hints with clause counts
- `generated/prolog/security.pl` (+2) — 2 additional indexing hints

## Prolog indexing coverage (now complete)

| Generated file | Predicates with hints | Status |
|---|---|---|
| `config.pl` | 5 (cli_argument, api_key_env_var, api_key_file, audit_profile_level, config_field_json_default) | Since PR #736 |
| `costs.pl` | 1 (model_pricing) | Since PR #736 |
| `security.pl` | 5 (security_profile, blocked_path, blocked_path_prefix, blocked_home_pattern, blocked_command_pattern) | **Completed this PR** |
| `backends.pl` | 4 (agent_backend, backend_factory, cli_fallbacks, streaming_capable) | **New this PR** |
| `commands.pl` | 2 (slash_command, command_alias) | **New this PR** |

## Test results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit tests | 122/122 | Pass (+15 new) |
| Python integration tests | 55/55 | Pass |
| Prolog integration tests | 17/17 | Pass |
| Generated Python files | byte-identical | Pass |
| Generated Prolog files | gain indexing hints + bugfix (intentional) | Pass |

6 files changed, +329/−47

## Test plan

- [ ] `swipl -g "generate_all, halt" agent_loop_module.pl` — both targets regenerate
- [ ] `cd generated/python && python3 -m pytest ../../test_integration.py -v` — 55 pass
- [ ] `swipl -l test_agent_loop.pl -g "run_tests, halt"` — 122/122 pass
- [ ] `swipl -l test_prolog_integration.pl -g "run_prolog_tests, halt"` — 17/17 pass
- [ ] `grep 'Indexing hints' generated/prolog/backends.pl` — present
- [ ] `grep 'Indexing hints' generated/prolog/commands.pl` — present
- [ ] `grep -c 'use_module(library(readutil))' generated/prolog/backends.pl` — returns 1 (not 2)
