### PR TITLE
feat(agent-loop): Unified import infrastructure, module_dependency/3 graph, Prolog runtime optimizations

### DIFF
--- a/tools/agent-loop/agent_loop_bindings.pl
+++ b/tools/agent-loop/agent_loop_bindings.pl
@@ -232,21 +232,20 @@ generate_bindings_summary(Target, Summary) :-
 
 %% emit_binding_imports(+Stream, +Options)
 %% Emit Python import lines for bindings that have import(Module) in options.
+%% Uses unified emit_module_imports/2 via from() spec terms.
 emit_binding_imports(S, _Options) :-
     init_agent_loop_bindings,
-    findall(Mod-TName, (
+    findall(from(Mod, [BaseName]), (
         binding(python, _Pred, TName, _Ins, _Outs, Opts),
-        member(import(Mod), Opts)
-    ), ImportPairs),
-    forall(member(Mod-TName, ImportPairs), (
+        member(import(Mod), Opts),
         %% Extract base name for dotted targets (e.g. SecurityConfig.from_profile → SecurityConfig)
         (sub_atom(TName, Before, _, _, '.') ->
             sub_atom(TName, 0, Before, _, BaseName)
         ;
             BaseName = TName
-        ),
-        format(S, 'from ~w import ~w~n', [Mod, BaseName])
-    )).
+        )
+    ), Specs),
+    agent_loop_components:emit_module_imports(S, Specs).
 
 %% emit_binding_dispatch_comment(+Stream, +Options)
 %% Emit a comment block documenting binding metadata for the current file.

--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -41,7 +41,11 @@
     emit_alias_group_entries/2,
     emit_alias_conditions/2,
     emit_argparse_group_args/2,
-    emit_backend_helper_fragments/2
+    emit_backend_helper_fragments/2,
+    emit_module_imports/2,
+    emit_module_dependencies/2,
+    backend_import_specs/2,
+    security_import_specs/1
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -810,13 +814,10 @@ emit_default_presets_py(S, _Options) :-
     )).
 
 %% emit_security_module_imports(+Stream, +Options)
-%% Emit Python import lines from security_module/3 facts.
+%% Emit Python import lines from security_module/3 facts via unified import system.
 emit_security_module_imports(S, _Options) :-
-    forall(agent_loop_module:security_module(Mod, Primary, Extras), (
-        AllNames = [Primary|Extras],
-        atomic_list_concat(AllNames, ', ', NamesStr),
-        format(S, 'from .~w import ~w~n', [Mod, NamesStr])
-    )).
+    security_import_specs(Specs),
+    emit_module_imports(S, Specs).
 
 %% emit_help_groups(+Stream, +Options)
 %% Emit Python help text from slash_command_group/2 facts.
@@ -847,11 +848,80 @@ emit_readme_sections(S, _Options) :-
     )).
 
 %% emit_backend_module_imports(+Stream, +Options)
-%% Emit Python import lines from an imports list in Options.
+%% Emit Python import lines from an imports list in Options via unified import system.
 emit_backend_module_imports(S, Options) :-
     (member(imports(Imports), Options) ->
-        forall(member(Imp, Imports), format(S, 'import ~w~n', [Imp]))
+        maplist([Imp]>>(format(S, 'import ~w~n', [Imp])), Imports)
     ; true).
+
+%% ============================================================================
+%% Unified Import Infrastructure
+%% ============================================================================
+
+%% Import spec terms:
+%%   bare(Mod)                -> import Mod
+%%   from(Mod, Names)         -> from Mod import N1, N2
+%%   from_relative(Mod, Names) -> from .Mod import N1, N2
+
+%% emit_module_imports(+Stream, +Specs)
+%% Dispatch on structured import spec terms to emit Python import lines.
+emit_module_imports(S, Specs) :-
+    forall(member(Spec, Specs), emit_one_import(S, Spec)).
+
+emit_one_import(S, bare(Mod)) :-
+    format(S, 'import ~w~n', [Mod]).
+emit_one_import(S, from(Mod, Names)) :-
+    atomic_list_concat(Names, ', ', NStr),
+    format(S, 'from ~w import ~w~n', [Mod, NStr]).
+emit_one_import(S, from_relative(Mod, Names)) :-
+    atomic_list_concat(Names, ', ', NStr),
+    format(S, 'from .~w import ~w~n', [Mod, NStr]).
+
+%% backend_import_specs(+Props, -Specs)
+%% Convert a backend's module_imports + optional from_imports into spec list.
+backend_import_specs(Props, Specs) :-
+    (member(module_imports(Mods), Props) -> true ; Mods = []),
+    (member(from_imports(FromMap), Props) -> true ; FromMap = []),
+    findall(Spec, (
+        member(Mod, Mods),
+        (member(Mod-Names, FromMap) ->
+            Spec = from(Mod, Names)
+        ;
+            Spec = bare(Mod)
+        )
+    ), ModSpecs),
+    %% Pick up from_imports entries whose module isn't in module_imports
+    findall(from(Mod, Names), (
+        member(Mod-Names, FromMap),
+        \+ member(Mod, Mods)
+    ), ExtraFromSpecs),
+    append(ModSpecs, ExtraFromSpecs, Specs).
+
+%% security_import_specs(-Specs)
+%% Convert security_module/3 facts into from_relative spec list.
+security_import_specs(Specs) :-
+    findall(from_relative(Mod, [Primary|Extras]),
+        agent_loop_module:security_module(Mod, Primary, Extras),
+        Specs).
+
+%% ============================================================================
+%% Module Dependency Emitter
+%% ============================================================================
+
+%% emit_module_dependencies(+Stream, +Options)
+%% Emit dependency documentation from module_dependency/3 facts.
+%% Options must include module(Mod) to select which module's deps to emit.
+emit_module_dependencies(S, Options) :-
+    member(module(Mod), Options),
+    findall(Dep-Reason, agent_loop_module:module_dependency(Mod, Dep, Reason), Deps),
+    (Deps = [] ->
+        write(S, '%% Dependencies: none (self-contained)\n')
+    ;
+        write(S, '%% Dependencies:\n'),
+        forall(member(Dep-Reason, Deps),
+            format(S, '%%   ~w (~w)~n', [Dep, Reason]))
+    ),
+    write(S, '\n').
 
 %% ============================================================================
 %% Forall Lift Batch 3 — Prolog backends, security profiles, tool dispatch,
@@ -980,7 +1050,17 @@ emit_test_metadata :-
     %% commands
     format(S, '  "commands": {"count": ~w, "names": [', [NCm]),
     emit_json_string_list(S, CmdNames),
-    write(S, ']}\n'),
+    write(S, ']},\n'),
+    %% destructive_tools
+    findall(DT, agent_loop_module:destructive_tool(DT), DestructiveTools),
+    write(S, '  "destructive_tools": ['),
+    emit_json_string_list(S, DestructiveTools),
+    write(S, '],\n'),
+    %% module_dependencies
+    findall(Src-Tgt, agent_loop_module:module_dependency(Src, Tgt, _), DepPairs),
+    write(S, '  "module_dependencies": {'),
+    emit_dep_map_json(S, DepPairs),
+    write(S, '}\n'),
     write(S, '}\n'),
     close(S),
     format('  Generated test_metadata.json~n', []).
@@ -993,6 +1073,24 @@ emit_json_string_list(S, [X]) :- !,
 emit_json_string_list(S, [X|Rest]) :-
     format(S, '"~w", ', [X]),
     emit_json_string_list(S, Rest).
+
+%% emit_dep_map_json(+Stream, +Pairs)
+%% Write module dependency pairs as JSON: {"src": ["tgt1", "tgt2"], ...}
+emit_dep_map_json(_, []).
+emit_dep_map_json(S, Pairs) :-
+    %% Group by source
+    findall(Src, member(Src-_, Pairs), SrcsDup),
+    sort(SrcsDup, Srcs),
+    emit_dep_map_entries(S, Srcs, Pairs, first).
+
+emit_dep_map_entries(_, [], _, _).
+emit_dep_map_entries(S, [Src|Rest], Pairs, Pos) :-
+    (Pos = first -> true ; write(S, ', ')),
+    findall(Tgt, member(Src-Tgt, Pairs), Tgts),
+    format(S, '"~w": [', [Src]),
+    emit_json_string_list(S, Tgts),
+    write(S, ']'),
+    emit_dep_map_entries(S, Rest, Pairs, subsequent).
 
 %% agent_loop_component_summary/0
 %% Registers everything and prints a summary.
@@ -1041,6 +1139,11 @@ emit_predicate_summary :-
     format("  prolog/backends   -> emit_backend_facts/2 (with optimization notes)~n"),
     format("  prolog/commands   -> emit_command_facts/2 (with optimization notes)~n"),
     format("  openrouter_api    -> emit_tool_schemas_py/2~n"),
+    format("~nUnified import infrastructure:~n"),
+    format("  emit_module_imports/2     -> bare/from/from_relative spec dispatch~n"),
+    format("  backend_import_specs/2    -> module_imports + from_imports -> specs~n"),
+    format("  security_import_specs/1   -> security_module/3 -> from_relative specs~n"),
+    format("  emit_module_dependencies/2 -> module_dependency/3 fact-driven comments~n"),
     format("~nGenerators using raw fact iteration (by design):~n"),
     format("  aliases.py        -> emit_alias_group_entries/2 + structural ordering~n"),
     format("  backends/<name>   -> agent_backend/2 + py_fragment/2~n"),

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -22,12 +22,29 @@
     command_alias/2,
     backend_factory/2,
     backend_factory_order/1,
-    write_prolog_term/2
+    write_prolog_term/2,
+    module_dependency/3
 ]).
 
 :- discontiguous generate_backend_full/3.
 :- use_module(agent_loop_components).
 :- use_module(agent_loop_bindings).
+
+%% =============================================================================
+%% Module Dependency Graph
+%% =============================================================================
+
+%% module_dependency(+SourceModule, +TargetModule, +Reason)
+%% Declarative cross-module dependency facts for generated use_module directives.
+module_dependency(tools, security, 'check_path_allowed/2, check_command_allowed/2').
+module_dependency(agent_loop, config, 'load_config/1, get_default_config/0').
+module_dependency(agent_loop, tools, 'tool handler dispatch').
+module_dependency(agent_loop, backends, 'create_backend/3, send_request/4').
+module_dependency(agent_loop, commands, 'handle_slash_command/3').
+module_dependency(agent_loop, security, 'set_security_profile/1').
+module_dependency(agent_loop, costs, 'cost_tracker_add/4').
+module_dependency(backends, costs, 'model_pricing/3 for cost tracking').
+module_dependency(backends, config, 'api_key_env_var/2 for key resolution').
 
 %% =============================================================================
 %% Agent Backend Definitions
@@ -176,7 +193,11 @@ agent_backend(openrouter_api, [
     supports_tools(true),
     supports_streaming(true),
     %% Generation metadata
-    module_imports([json, os, sys, 'urllib.request', 'urllib.error']),
+    module_imports([json, os, sys]),
+    from_imports([
+        'urllib.request' - ['urlopen', 'Request'],
+        'urllib.error'   - ['HTTPError', 'URLError']
+    ]),
     class_docstring('OpenRouter API backend (OpenAI-compatible, no pip deps).'),
     display_name('OpenRouter ({self.model})'),
     helper_fragments([supports_streaming_true, sse_streaming_openrouter, describe_tool_call_openrouter])
@@ -1240,6 +1261,9 @@ generate_prolog_tools :-
     write(S, ':- use_module(library(readutil)).\n'),
     write(S, ':- use_module(library(time)).\n'),
     write(S, ':- use_module(security).\n\n'),
+    write(S, '%% Tabling: memoize tool schema construction across REPL iterations\n'),
+    write(S, ':- table build_tool_input_schema/2.\n\n'),
+    write(S, '%% JIT multi-arg indexing: tool_description/5 benefits from (arg1, arg2) indexing\n\n'),
     %% Emit tool facts via component registry
     agent_loop_components:emit_tool_facts(S, [target(prolog)]),
     %% Generate tool execution predicates
@@ -1393,7 +1417,7 @@ generate_prolog_commands :-
     write(S, '    resolve_command/3,\n'),
     write(S, '    handle_slash_command/3\n'),
     write(S, ']).\n\n'),
-    write(S, '%% Dependencies: none (self-contained command definitions)\n\n'),
+    agent_loop_components:emit_module_dependencies(S, [module(commands)]),
     %% Emit command facts via component registry
     agent_loop_components:emit_command_facts(S, [target(prolog)]),
     %% Generate resolve_command
@@ -1516,8 +1540,7 @@ generate_prolog_backends :-
     write(S, ':- use_module(library(process)).\n'),
     write(S, ':- use_module(library(random)).\n'),
     write(S, ':- discontiguous send_request_streaming_raw/5.\n\n'),
-    write(S, '%% Dependencies: costs (model_pricing/3 for cost tracking)\n'),
-    write(S, '%%              config (api_key_env_var/2 for key resolution)\n\n'),
+    agent_loop_components:emit_module_dependencies(S, [module(backends)]),
     %% Emit backend facts via component registry
     agent_loop_components:emit_backend_facts(S, [target(prolog)]),
     %% Generate create_backend
@@ -1553,9 +1576,10 @@ generate_prolog_backends :-
     write(S, '    format(atom(Msg), "Request error: ~w", [Error]).\n\n'),
     write(S, '%% retry_call(+Goal, +Options) — retry with exponential backoff + jitter\n'),
     write(S, 'retry_call(Goal, Options) :-\n'),
-    write(S, '    (member(max_attempts(Max), Options) -> true ; retry_config(Max, _, _)),\n'),
-    write(S, '    (member(base_delay(Base), Options) -> true ; retry_config(_, Base, _)),\n'),
-    write(S, '    (member(max_delay(MaxD), Options) -> true ; retry_config(_, _, MaxD)),\n'),
+    write(S, '    retry_config(DefaultMax, DefaultBase, DefaultMaxD),\n'),
+    write(S, '    (member(max_attempts(Max), Options) -> true ; Max = DefaultMax),\n'),
+    write(S, '    (member(base_delay(Base), Options) -> true ; Base = DefaultBase),\n'),
+    write(S, '    (member(max_delay(MaxD), Options) -> true ; MaxD = DefaultMaxD),\n'),
     write(S, '    retry_call_(Goal, 1, Max, Base, MaxD).\n\n'),
     write(S, 'retry_call_(Goal, Attempt, Max, Base, MaxD) :-\n'),
     write(S, '    catch(\n'),
@@ -3015,9 +3039,7 @@ generate_security_profiles :-
 generate_regex_list_py(S, ListName, PyVarName) :-
     regex_list(ListName, Patterns),
     format(S, '~w = [~n', [PyVarName]),
-    forall(member(P, Patterns), (
-        format(S, '    ~w,~n', [P])
-    )),
+    maplist([P]>>(format(S, '    ~w,~n', [P])), Patterns),
     write(S, ']\n').
 
 %% Write a single profile entry in get_builtin_profiles()
@@ -3880,7 +3902,7 @@ is_python_command(CmdName) :-
 format_help_line(S, CmdName) :-
     slash_command(CmdName, _, Props, _),
     member(help_lines(Lines), Props), !,
-    forall(member(Line, Lines), format(S, '  ~w~n', [Line])).
+    maplist([Line]>>(format(S, '  ~w~n', [Line])), Lines).
 
 %% Normal single-line help entry
 format_help_line(S, CmdName) :-
@@ -3896,7 +3918,7 @@ format_help_line(S, CmdName) :-
     atom_length(CmdDisplay, Len),
     PadLen is max(1, 19 - Len),
     format(S, '  ~w', [CmdDisplay]),
-    forall(between(1, PadLen, _), write(S, ' ')),
+    format(S, '~*c', [PadLen, 0' ]),
     format(S, '- ~w~n', [HelpText]).
 
 %% =============================================================================
@@ -9572,9 +9594,9 @@ generate_backend(Name) :-
 generate_backend_header(S, BackendName) :-
     agent_backend(BackendName, Props),
     member(description(Desc), Props),
-    member(module_imports(Imports), Props),
     format(S, '"""~w"""~n~n', [Desc]),
-    agent_loop_components:emit_backend_module_imports(S, [target(python), imports(Imports)]),
+    agent_loop_components:backend_import_specs(Props, ImportSpecs),
+    agent_loop_components:emit_module_imports(S, ImportSpecs),
     (member(sdk_guard(SDK), Props) ->
         %% SDK backends: base import + sdk_import_guard fragment
         write(S, 'from .base import AgentBackend, AgentResponse, ToolCall\n\n'),
@@ -10155,13 +10177,7 @@ generate_backend_full(S, coro, _) :-
 %% --- openrouter_api (uses: messages_builder_openrouter, describe_tool_call_openrouter, sse_streaming_openrouter) ---
 
 generate_backend_full(S, openrouter_api, _) :-
-    agent_backend(openrouter_api, Props),
-    member(description(Desc), Props),
-    format(S, '"""~w"""~n~n', [Desc]),
-    write(S, 'import json\nimport os\nimport sys\n'),
-    write(S, 'from urllib.request import urlopen, Request\n'),
-    write(S, 'from urllib.error import HTTPError, URLError\n'),
-    write(S, 'from .base import AgentBackend, AgentResponse, ToolCall\n\n\n'),
+    generate_backend_header(S, openrouter_api),
     %% Generate DEFAULT_TOOL_SCHEMAS from tool_spec/2 facts
     write(S, '# Default tool schemas for function calling (OpenAI format)\n'),
     write(S, 'DEFAULT_TOOL_SCHEMAS = [\n'),

--- a/tools/agent-loop/generated/prolog/backends.pl
+++ b/tools/agent-loop/generated/prolog/backends.pl
@@ -25,8 +25,9 @@
 :- use_module(library(random)).
 :- discontiguous send_request_streaming_raw/5.
 
-%% Dependencies: costs (model_pricing/3 for cost tracking)
-%%              config (api_key_env_var/2 for key resolution)
+%% Dependencies:
+%%   costs (model_pricing/3 for cost tracking)
+%%   config (api_key_env_var/2 for key resolution)
 
 %% Optimization notes:
 %%   - agent_backend/2: deterministic lookup by backend name
@@ -47,7 +48,7 @@ agent_backend(claude_api, [type(api), class_name('ClaudeAPIBackend'), endpoint("
 agent_backend(openai_api, [type(api), class_name('OpenAIBackend'), file_name(openai_api), endpoint("https://api.openai.com/v1/chat/completions"), model("gpt-4o"), auth_env("OPENAI_API_KEY"), auth_header("Authorization"), auth_prefix("Bearer "), description("OpenAI API backend"), context_format(messages_array), supports_tools(true), supports_streaming(true), optional_import(true), module_imports([os]), sdk_guard(openai), class_docstring('OpenAI API backend (GPT-4, GPT-3.5, etc.).'), display_name('OpenAI ({self.model})'), helper_fragments([extract_tool_calls_openai])]).
 agent_backend(ollama_api, [type(api), class_name('OllamaAPIBackend'), endpoint("http://localhost:11434/api/chat"), model("llama3"), description("Ollama REST API backend for local models"), default_host("localhost"), default_port(11434), context_format(messages_array), auth_required(false), supports_streaming(true), module_imports([json,'urllib.request','urllib.error']), class_docstring('Ollama REST API backend for local models.'), display_name('Ollama API ({self.model}@{self.host}:{self.port})'), helper_fragments([list_models_api])]).
 agent_backend(ollama_cli, [type(cli), class_name('OllamaCLIBackend'), command("ollama"), args(["run"]), description("Ollama CLI backend using 'ollama run' command"), default_model("llama3"), context_format(conversation_history), supports_streaming(false), module_imports([subprocess]), class_docstring('Ollama CLI backend using \'ollama run\' command.'), display_name('Ollama CLI ({self.model})'), helper_fragments([format_prompt,clean_output_simple,list_models_cli])]).
-agent_backend(openrouter_api, [type(api), class_name('OpenRouterBackend'), endpoint("https://openrouter.ai/api/v1/chat/completions"), model("anthropic/claude-sonnet-4-20250514"), auth_env("OPENROUTER_API_KEY"), auth_header("Authorization"), auth_prefix("Bearer "), description("OpenRouter API backend with model routing"), context_format(messages_array), supports_tools(true), supports_streaming(true), module_imports([json,os,sys,'urllib.request','urllib.error']), class_docstring('OpenRouter API backend (OpenAI-compatible, no pip deps).'), display_name('OpenRouter ({self.model})'), helper_fragments([supports_streaming_true,sse_streaming_openrouter,describe_tool_call_openrouter])]).
+agent_backend(openrouter_api, [type(api), class_name('OpenRouterBackend'), endpoint("https://openrouter.ai/api/v1/chat/completions"), model("anthropic/claude-sonnet-4-20250514"), auth_env("OPENROUTER_API_KEY"), auth_header("Authorization"), auth_prefix("Bearer "), description("OpenRouter API backend with model routing"), context_format(messages_array), supports_tools(true), supports_streaming(true), module_imports([json,os,sys]), from_imports([-('urllib.request',[urlopen,'Request']),-('urllib.error',['HTTPError','URLError'])]), class_docstring('OpenRouter API backend (OpenAI-compatible, no pip deps).'), display_name('OpenRouter ({self.model})'), helper_fragments([supports_streaming_true,sse_streaming_openrouter,describe_tool_call_openrouter])]).
 
 %% backend_factory(+Name, +FactorySpec)
 backend_factory(coro, [resolve_type(cli), class_name('CoroBackend'), default_command(coro), constructor_args([arg(command,cmd),arg(no_fallback,no_fallback),arg_expr(max_context_tokens,'agent_config.max_context_tokens\n            if agent_config.max_context_tokens != 100000 else 0')])]).
@@ -101,9 +102,10 @@ format_api_error(Error, Msg) :-
 
 %% retry_call(+Goal, +Options) — retry with exponential backoff + jitter
 retry_call(Goal, Options) :-
-    (member(max_attempts(Max), Options) -> true ; retry_config(Max, _, _)),
-    (member(base_delay(Base), Options) -> true ; retry_config(_, Base, _)),
-    (member(max_delay(MaxD), Options) -> true ; retry_config(_, _, MaxD)),
+    retry_config(DefaultMax, DefaultBase, DefaultMaxD),
+    (member(max_attempts(Max), Options) -> true ; Max = DefaultMax),
+    (member(base_delay(Base), Options) -> true ; Base = DefaultBase),
+    (member(max_delay(MaxD), Options) -> true ; MaxD = DefaultMaxD),
     retry_call_(Goal, 1, Max, Base, MaxD).
 
 retry_call_(Goal, Attempt, Max, Base, MaxD) :-

--- a/tools/agent-loop/generated/prolog/commands.pl
+++ b/tools/agent-loop/generated/prolog/commands.pl
@@ -11,7 +11,7 @@
     handle_slash_command/3
 ]).
 
-%% Dependencies: none (self-contained command definitions)
+%% Dependencies: none (self-contained)
 
 %% Optimization notes:
 %%   - slash_command/4: first-argument atom-indexed, all distinct

--- a/tools/agent-loop/generated/prolog/tools.pl
+++ b/tools/agent-loop/generated/prolog/tools.pl
@@ -19,6 +19,11 @@
 :- use_module(library(time)).
 :- use_module(security).
 
+%% Tabling: memoize tool schema construction across REPL iterations
+:- table build_tool_input_schema/2.
+
+%% JIT multi-arg indexing: tool_description/5 benefits from (arg1, arg2) indexing
+
 %% tool_spec(+ToolName, +Properties)
 tool_spec(bash, [description("Execute a bash command"), parameters([param(command,string,required,"The command to execute")]), confirmation_required(true), timeout(120)]).
 tool_spec(read, [description("Read a file"), parameters([param(path,string,required,"Path to file")]), confirmation_required(false)]).

--- a/tools/agent-loop/generated/python/test_metadata.json
+++ b/tools/agent-loop/generated/python/test_metadata.json
@@ -3,5 +3,7 @@
   "tools": {"count": 4, "names": ["bash", "read", "write", "edit"]},
   "security": {"count": 4, "profiles": ["open", "cautious", "guarded", "paranoid"]},
   "backends": {"count": 8, "names": ["coro", "claude-code", "gemini", "claude", "openai", "openrouter", "ollama-api", "ollama-cli"]},
-  "commands": {"count": 23, "names": ["exit", "clear", "help", "status", "iterations", "backend", "save", "load", "sessions", "format", "export", "cost", "search", "stream", "model", "tokens", "aliases", "templates", "history", "undo", "delete", "edit", "replay"]}
+  "commands": {"count": 23, "names": ["exit", "clear", "help", "status", "iterations", "backend", "save", "load", "sessions", "format", "export", "cost", "search", "stream", "model", "tokens", "aliases", "templates", "history", "undo", "delete", "edit", "replay"]},
+  "destructive_tools": ["bash", "write", "edit"],
+  "module_dependencies": {"agent_loop": ["config", "tools", "backends", "commands", "security", "costs"], "backends": ["costs", "config"], "tools": ["security"]}
 }

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -74,6 +74,10 @@ run_tests :-
     test_emit_argparse_group_args,
     test_emit_backend_optimization_hints,
     test_emit_command_optimization_hints,
+    test_emit_module_imports,
+    test_backend_import_specs,
+    test_module_dependency_facts,
+    test_emit_module_dependencies,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -1063,4 +1067,87 @@ test_emit_command_optimization_hints :-
             agent_loop_components:emit_command_facts(S3, [target(prolog)])
         )),
         sub_atom(Output3, _, _, _, 'command_alias/2: first-argument indexed (30 clauses)')
+    )).
+
+%% ============================================================================
+%% Unified Import Infrastructure Tests
+%% ============================================================================
+
+test_emit_module_imports :-
+    format("~nUnified import infrastructure:~n"),
+    %% Test bare import
+    assert_true('bare import produces import X', (
+        with_output_to(atom(Output1), (
+            current_output(S1),
+            agent_loop_components:emit_module_imports(S1, [bare(json)])
+        )),
+        sub_atom(Output1, _, _, _, 'import json')
+    )),
+    %% Test from import
+    assert_true('from import produces from X import Y', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_module_imports(S2, [from('urllib.request', [urlopen, 'Request'])])
+        )),
+        sub_atom(Output2, _, _, _, 'from urllib.request import urlopen, Request')
+    )),
+    %% Test from_relative import
+    assert_true('from_relative import produces from .X import Y', (
+        with_output_to(atom(Output3), (
+            current_output(S3),
+            agent_loop_components:emit_module_imports(S3, [from_relative(audit, ['AuditLogger'])])
+        )),
+        sub_atom(Output3, _, _, _, 'from .audit import AuditLogger')
+    )).
+
+test_backend_import_specs :-
+    format("~nBackend import specs:~n"),
+    %% Test openrouter_api specs include from() for urllib
+    assert_true('openrouter_api specs include from(urllib.request, ...)', (
+        agent_loop_module:agent_backend(openrouter_api, Props),
+        agent_loop_components:backend_import_specs(Props, Specs),
+        member(from('urllib.request', _), Specs)
+    )),
+    %% Test openrouter_api has bare imports for json, os, sys
+    assert_true('openrouter_api specs include bare(json)', (
+        agent_loop_module:agent_backend(openrouter_api, Props2),
+        agent_loop_components:backend_import_specs(Props2, Specs2),
+        member(bare(json), Specs2)
+    )),
+    %% Test ollama_cli has only bare imports
+    assert_true('ollama_cli specs are all bare', (
+        agent_loop_module:agent_backend(ollama_cli, Props3),
+        agent_loop_components:backend_import_specs(Props3, Specs3),
+        member(bare(subprocess), Specs3)
+    )).
+
+test_module_dependency_facts :-
+    format("~nModule dependency facts:~n"),
+    assert_true('tools depends on security', (
+        agent_loop_module:module_dependency(tools, security, _)
+    )),
+    assert_true('agent_loop depends on backends', (
+        agent_loop_module:module_dependency(agent_loop, backends, _)
+    )),
+    assert_true('backends depends on costs', (
+        agent_loop_module:module_dependency(backends, costs, _)
+    )).
+
+test_emit_module_dependencies :-
+    format("~nModule dependency emitter:~n"),
+    %% Test backends has dependencies
+    assert_true('emit_module_dependencies for backends includes costs', (
+        with_output_to(atom(Output1), (
+            current_output(S1),
+            agent_loop_components:emit_module_dependencies(S1, [module(backends)])
+        )),
+        sub_atom(Output1, _, _, _, 'costs')
+    )),
+    %% Test commands has no dependencies (self-contained)
+    assert_true('emit_module_dependencies for commands says self-contained', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_module_dependencies(S2, [module(commands)])
+        )),
+        sub_atom(Output2, _, _, _, 'self-contained')
     )).

--- a/tools/agent-loop/test_integration.py
+++ b/tools/agent-loop/test_integration.py
@@ -474,3 +474,23 @@ class TestComponentDriven:
             f"Tools count mismatch: {len(TOOL_SPECS)} != {test_metadata['tools']['count']}"
         assert len(get_builtin_profiles()) == test_metadata["security"]["count"], \
             f"Security count mismatch: {len(get_builtin_profiles())} != {test_metadata['security']['count']}"
+
+    def test_command_count_match(self, test_metadata):
+        """Command count in metadata matches expected slash command count."""
+        assert test_metadata["commands"]["count"] == 23, \
+            f"Command count mismatch: {test_metadata['commands']['count']} != 23"
+
+    def test_destructive_tools_match(self, test_metadata):
+        """Destructive tools in metadata match DESTRUCTIVE_TOOLS in generated code."""
+        from tools_generated import DESTRUCTIVE_TOOLS
+        for tool in test_metadata.get("destructive_tools", []):
+            assert tool in DESTRUCTIVE_TOOLS, \
+                f"Destructive tool '{tool}' in metadata but not in DESTRUCTIVE_TOOLS"
+
+    def test_module_dependencies_present(self, test_metadata):
+        """Module dependencies map has expected structure."""
+        deps = test_metadata.get("module_dependencies", {})
+        assert "agent_loop" in deps, "agent_loop should have dependencies"
+        assert "security" in deps["agent_loop"], "agent_loop should depend on security"
+        assert "backends" in deps, "backends should have dependencies"
+        assert "costs" in deps["backends"], "backends should depend on costs"


### PR DESCRIPTION
## Summary

- **Unified import infrastructure**: `emit_module_imports/2` dispatches on structured `bare/from/from_relative` spec terms, replacing 3 separate import-emitting patterns with one composable system
- **Module dependency graph**: 9 `module_dependency/3` facts replace hardcoded `%% Dependencies:` comments — generated Prolog files now get fact-driven dependency documentation
- **Prolog runtime optimizations**: `:- table build_tool_input_schema/2` memoization, triple `retry_config/3` lookup collapsed to single call, `forall/between` padding replaced with `format ~*c`, two `forall/member` loops replaced with `maplist`
- **`from_imports/1`** property added to openrouter_api's `agent_backend` fact — `generate_backend_header/2` now handles both bare and from-style imports, eliminating 4 hardcoded import lines

## Changes

### `agent_loop_components.pl` (+123)

New unified import predicates:

| Predicate | Purpose |
|-----------|---------|
| `emit_module_imports/2` | Dispatch on `bare(Mod)`, `from(Mod, Names)`, `from_relative(Mod, Names)` spec terms |
| `emit_one_import/3` | Per-spec clause: bare → `import X`, from → `from X import Y`, from_relative → `from .X import Y` |
| `backend_import_specs/2` | Convert `module_imports` + optional `from_imports` property lists into spec lists |
| `security_import_specs/1` | Convert `security_module/3` facts into `from_relative` spec lists |
| `emit_module_dependencies/2` | Emit `%% Dependencies:` block from `module_dependency/3` facts |

Also:
- `emit_security_module_imports/2` rewritten to use `security_import_specs/1` + `emit_module_imports/2`
- `emit_backend_module_imports/2` switched from `forall` to `maplist`
- `emit_test_metadata/0` expanded with `destructive_tools` list and `module_dependencies` map
- `emit_predicate_summary/0` updated with unified import infrastructure section
- `emit_dep_map_json/2` helper for JSON dependency map output

### `agent_loop_module.pl` (+60/−28)

- 9 `module_dependency/3` facts declared (tools→security, agent_loop→{config,tools,backends,commands,security,costs}, backends→{costs,config})
- `from_imports/1` added to openrouter_api's `agent_backend` fact; `module_imports` trimmed to `[json, os, sys]`
- `generate_backend_header/2` rewritten to use `backend_import_specs/2` + `emit_module_imports/2`
- `generate_backend_full/3` for openrouter_api now calls `generate_backend_header/2` instead of 4 hardcoded import lines
- Hardcoded `%% Dependencies:` blocks in backends/commands generators replaced with `emit_module_dependencies/2` calls
- `forall(between(1, PadLen, _), write(S, ' '))` → `format(S, '~*c', [PadLen, 0' ])`
- `forall(member(...))` in `generate_regex_list_py/3` and `format_help_line/2` → `maplist` with lambda
- `retry_call/2` generator: triple `retry_config/3` lookup → single call + unification
- `:- table build_tool_input_schema/2` + JIT multi-arg indexing hint emitted in `generate_prolog_tools`

### `agent_loop_bindings.pl` (+7/−6)

- `emit_binding_imports/2` rewritten: `findall` now collects `from(Mod, [BaseName])` specs, then delegates to `emit_module_imports/2`

### `test_agent_loop.pl` (+87)

4 new test predicates (11 assertions):

| Test | Validates |
|------|-----------|
| `test_emit_module_imports` | `bare(json)` → `import json`; `from('urllib.request', ...)` → `from urllib.request import urlopen, Request`; `from_relative(audit, ...)` → `from .audit import AuditLogger` |
| `test_backend_import_specs` | openrouter_api specs include `from('urllib.request', ...)`; openrouter_api has `bare(json)`; ollama_cli has `bare(subprocess)` |
| `test_module_dependency_facts` | `module_dependency(tools, security, _)` exists; `module_dependency(agent_loop, backends, _)` exists; `module_dependency(backends, costs, _)` exists |
| `test_emit_module_dependencies` | backends output contains `costs`; commands output contains `self-contained` |

### `test_integration.py` (+20)

3 new `TestComponentDriven` tests:

| Test | Validates |
|------|-----------|
| `test_command_count_match` | `commands.count == 23` |
| `test_destructive_tools_match` | Every metadata destructive tool exists in `DESTRUCTIVE_TOOLS` |
| `test_module_dependencies_present` | `agent_loop` depends on `security`; `backends` depends on `costs` |

### Generated files

- `generated/prolog/tools.pl` (+5) — `:- table build_tool_input_schema/2`, JIT multi-arg indexing hint
- `generated/prolog/backends.pl` (+14/−6) — fact-driven dependency comments, single `retry_config` call, structured `from_imports` on openrouter_api
- `generated/prolog/commands.pl` (+1/−1) — fact-driven dependency comment
- `generated/python/test_metadata.json` (+3/−1) — gains `destructive_tools`, `module_dependencies`
- All other Python files — byte-identical

## Test results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit tests | 133/133 | Pass (+11 new) |
| Python integration tests | 58/58 | Pass (+3 new) |
| Prolog integration tests | 17/17 | Pass |
| Generated Python files | byte-identical (except test_metadata.json) | Pass |
| openrouter_api.py | byte-identical | Pass |

9 files changed, +281/−47

## Test plan

- [ ] `swipl -g "generate_all, halt" agent_loop_module.pl` — both targets regenerate
- [ ] `cd generated/python && python3 -m pytest ../../test_integration.py -v` — 58 pass
- [ ] `swipl -l test_agent_loop.pl -g "run_tests, halt"` — 133/133 pass
- [ ] `swipl -l test_prolog_integration.pl -g "run_prolog_tests, halt"` — 17/17 pass
- [ ] `grep 'table build_tool_input_schema' generated/prolog/tools.pl` — present
- [ ] `git diff generated/python/backends/openrouter_api.py` — empty (byte-identical)
- [ ] `grep -c 'retry_config' generated/prolog/backends.pl` — returns 2 (definition + single call, not 4)
