### PR TITLE
feat(agent-loop): Binding-driven compilation, Python compile_component/4, data-driven emission helpers

### DIFF
--- a/tools/agent-loop/agent_loop_bindings.pl
+++ b/tools/agent-loop/agent_loop_bindings.pl
@@ -3,6 +3,16 @@
 %% Maps agent-loop predicates to target-language functions via binding/6.
 %% Enables target generators to automatically emit cross-language code.
 %%
+%% Key predicates:
+%%   compile_binding_code/3     — generate target-language code from binding
+%%   binding_dict_name/3        — extract base structure name from binding target
+%%   binding_pattern/3          — get pattern type (dict_lookup, set_membership, etc.)
+%%   emit_binding_metadata_comment/3 — emit per-predicate binding comment
+%%   emit_binding_imports/2     — emit Python imports from binding metadata
+%%
+%% Supported patterns: dict_lookup, set_membership, method_call,
+%%   chained_call(Methods), function_call (default)
+%%
 %% Usage:
 %%   swipl -l agent_loop_bindings.pl -g "agent_loop_binding_summary, halt"
 %%
@@ -12,6 +22,8 @@
     init_agent_loop_bindings/0,
     agent_loop_binding_summary/0,
     compile_binding_code/3,
+    binding_dict_name/3,
+    binding_pattern/3,
     generate_bindings_summary/2,
     emit_binding_imports/2,
     emit_binding_dispatch_comment/2,
@@ -217,19 +229,67 @@ init_agent_loop_bindings :-
 %% Binding Consumers — Code Generation from Bindings
 %% ============================================================================
 
+%% binding_dict_name(+Target, +Pred, -DictName)
+%% Extract the base structure name from a binding's target.
+%% For dict lookups like 'DEFAULT_PRICING[model]', returns 'DEFAULT_PRICING'.
+%% For function calls like 'create_backend_from_config', returns the name as-is.
+binding_dict_name(Target, Pred, DictName) :-
+    binding(Target, Pred, TargetName, _Inputs, _Outputs, _Options),
+    (sub_atom(TargetName, Before, _, _, '[') ->
+        sub_atom(TargetName, 0, Before, _, DictName)
+    ; sub_atom(TargetName, Before, _, _, '.') ->
+        sub_atom(TargetName, 0, Before, _, DictName)
+    ;
+        DictName = TargetName
+    ).
+
+%% binding_pattern(+Target, +Pred, -Pattern)
+%% Get the binding pattern for a predicate, defaulting to function_call.
+binding_pattern(Target, Pred, Pattern) :-
+    binding(Target, Pred, _TName, _Inputs, _Outputs, Options),
+    (member(pattern(P), Options) -> Pattern = P ; Pattern = function_call).
+
 %% compile_binding_code(+Target, +Pred, -Code)
 %% Generate a target-language code snippet for a binding
 compile_binding_code(Target, Pred, Code) :-
     binding(Target, Pred, TargetName, Inputs, Outputs, Options),
     format_binding_code(Target, Pred, TargetName, Inputs, Outputs, Options, Code).
 
-%% Python code generation
+%% Python code generation — dispatches on pattern type
 format_binding_code(python, _Pred, TargetName, Inputs, Outputs, Options, Code) :-
     (member(pattern(dict_lookup), Options) ->
         %% Dict lookup pattern: result = DICT[key]
         Inputs = [InputName-_|_],
         Outputs = [OutputName-_|_],
         format(atom(Code), '~w = ~w  # ~w -> ~w', [OutputName, TargetName, InputName, OutputName])
+    ; member(pattern(set_membership), Options) ->
+        %% Set membership test: if key in SET_NAME:
+        Inputs = [InputName-_|_],
+        format(atom(Code), 'if ~w in ~w:', [InputName, TargetName])
+    ; member(pattern(method_call), Options) ->
+        %% Method call: result = obj.method(args)
+        Inputs = [ObjName-_|RestInputs],
+        maplist([N-_,N]>>true, RestInputs, ArgNames),
+        (ArgNames = [] ->
+            MethodExpr = TargetName
+        ;
+            atomic_list_concat(ArgNames, ', ', ArgStr),
+            format(atom(MethodExpr), '~w(~w)', [TargetName, ArgStr])
+        ),
+        (Outputs = [OutputName-_|_] ->
+            format(atom(Code), '~w = ~w~w', [OutputName, ObjName, MethodExpr])
+        ;
+            format(atom(Code), '~w~w', [ObjName, MethodExpr])
+        )
+    ; member(pattern(chained_call(Methods)), Options) ->
+        %% Chained method call: result = obj.m1().m2().m3()
+        Inputs = [ObjName-_|_],
+        format_chained_methods(Methods, ChainStr),
+        (Outputs = [OutputName-_|_] ->
+            format(atom(Code), '~w = ~w~w', [OutputName, ObjName, ChainStr])
+        ;
+            format(atom(Code), '~w~w', [ObjName, ChainStr])
+        )
     ; member(import(Mod), Options) ->
         %% Imported function call
         maplist([N-_,N]>>true, Inputs, INames),
@@ -251,6 +311,24 @@ format_binding_code(prolog, _Pred, TargetName, Inputs, Outputs, _Options, Code) 
     append(INames, ONames, AllArgs),
     atomic_list_concat(AllArgs, ', ', ArgStr),
     format(atom(Code), '~w(~w)', [TargetName, ArgStr]).
+
+%% format_chained_methods(+Methods, -ChainStr)
+%% Build a method chain string from a list of method specs.
+format_chained_methods([], '').
+format_chained_methods([Method|Rest], ChainStr) :-
+    (Method = method(Name, Args) ->
+        (Args = [] ->
+            format(atom(Part), '~w()', [Name])
+        ;
+            atomic_list_concat(Args, ', ', ArgStr),
+            format(atom(Part), '~w(~w)', [Name, ArgStr])
+        )
+    ;
+        %% Simple atom method name — no args
+        format(atom(Part), '~w()', [Method])
+    ),
+    format_chained_methods(Rest, RestStr),
+    atom_concat(Part, RestStr, ChainStr).
 
 %% generate_bindings_summary(+Target, -Summary)
 %% Generate a formatted summary of all bindings for a target
@@ -295,12 +373,14 @@ emit_binding_imports(S, _Options) :-
 emit_binding_dispatch_comment(S, _Options) :-
     init_agent_loop_bindings,
     write(S, '# Binding registry metadata:\n'),
-    forall(binding(python, Pred, TName, Inputs, _Outputs, Opts), (
+    findall(Pred-TName-Inputs-Opts,
+        binding(python, Pred, TName, Inputs, _Outputs, Opts), Entries),
+    maplist([Pred-TName-Inputs-Opts]>>(
         maplist([N-_T,N]>>true, Inputs, INames),
         atomic_list_concat(INames, ', ', IStr),
         (member(pure, Opts) -> Eff = pure ; Eff = effectful),
         format(S, '#   ~w -> ~w(~w) [~w]~n', [Pred, TName, IStr, Eff])
-    )),
+    ), Entries),
     write(S, '#\n').
 
 %% emit_binding_metadata_comment(+Stream, +Target, +Pred)
@@ -331,12 +411,16 @@ agent_loop_binding_summary :-
     format("  Prolog bindings: ~w~n", [NPl]),
     %% List each binding
     format("~n  Python:~n"),
-    forall(member(binding(python, Pred, TName, _, _, _), PyBindings),
-        format("    ~w -> ~w~n", [Pred, TName])),
+    maplist([binding(python, Pred, TName, _, _, _)]>>(
+        format("    ~w -> ~w~n", [Pred, TName])
+    ), PyBindings),
     format("~n  Prolog:~n"),
-    forall(member(binding(prolog, Pred, TName, _, _, _), PlBindings),
-        format("    ~w -> ~w~n", [Pred, TName])),
+    maplist([binding(prolog, Pred2, TName2, _, _, _)]>>(
+        format("    ~w -> ~w~n", [Pred2, TName2])
+    ), PlBindings),
     %% Show effects
     format("~n  Effects:~n"),
-    forall(effect(Pred, Effects),
-        format("    ~w: ~w~n", [Pred, Effects])).
+    findall(Pred3-Effects, effect(Pred3, Effects), EffPairs),
+    maplist([Pred3-Effects]>>(
+        format("    ~w: ~w~n", [Pred3, Effects])
+    ), EffPairs).

--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -46,7 +46,9 @@
     emit_module_dependencies/2,
     backend_import_specs/2,
     security_import_specs/1,
-    emit_dependency_diagram/2
+    emit_dependency_diagram/2,
+    write_lines/2,
+    emit_py_dict_from_components/5
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -158,6 +160,14 @@ agent_command_type:compile_component(Name, Config, Options, Code) :-
         ;
             compile_command_fact(slash_command, Name, Config, Code)
         )
+    ; member(target(python), Options) ->
+        member(match_type(MT), Config),
+        member(help_text(HT), Config),
+        (member(options(Opts), Config) -> true ; Opts = []),
+        (member(indent(N), Options) -> true ; N = 4),
+        length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+        format(atom(Code), "~w'~w': {'match': '~w', 'options': ~q, 'help': ~q},",
+               [Indent, Name, MT, Opts, HT])
     ;
         compile_command_fact(slash_command, Name, Config, Code)
     ).
@@ -199,6 +209,13 @@ agent_backend_type:compile_component(Name, Config, Options, Code) :-
         ;
             compile_backend_fact(backend_factory, Name, Config, Code)
         )
+    ; member(target(python), Options) ->
+        member(class_name(ClassName), Config),
+        member(resolve_type(ResolveType), Config),
+        (member(indent(N), Options) -> true ; N = 4),
+        length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+        format(atom(Code), "~w'~w': {'class': '~w', 'resolve': '~w'},",
+               [Indent, Name, ClassName, ResolveType])
     ;
         compile_backend_fact(backend_factory, Name, Config, Code)
     ).
@@ -228,12 +245,21 @@ agent_security_type:validate_config(_Config).
 
 agent_security_type:init_component(_Name, _Config).
 
-agent_security_type:compile_component(Name, Config, _Options, Code) :-
-    with_output_to(atom(Code), (
-        format('security_profile(~q, ', [Name]),
-        agent_loop_module:write_prolog_term(current_output, Config),
-        write(').')
-    )).
+agent_security_type:compile_component(Name, Config, Options, Code) :-
+    (member(target(python), Options) ->
+        (member(indent(N), Options) -> true ; N = 4),
+        length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+        (member(path_validation(PV), Config) -> true ; PV = false),
+        (member(command_validation(CV), Config) -> true ; CV = false),
+        format(atom(Code), "~w'~w': {'path_validation': ~w, 'command_validation': ~w},",
+               [Indent, Name, PV, CV])
+    ;
+        with_output_to(atom(Code), (
+            format('security_profile(~q, ', [Name]),
+            agent_loop_module:write_prolog_term(current_output, Config),
+            write(').')
+        ))
+    ).
 
 %% --- Model cost type ---
 
@@ -1140,7 +1166,7 @@ emit_predicate_summary :-
     format("  config.py         -> emit_api_key_files_py/2, emit_default_presets_py/2~n"),
     format("  config.py         -> emit_cascade_paths/2 [path_type(required|fallback)]~n"),
     format("  agent_loop.py     -> emit_audit_levels/2, emit_cli_overrides/2~n"),
-    format("  agent_loop.py     -> emit_binding_dispatch_comment/2 (8 bindings)~n"),
+    format("  agent_loop.py     -> emit_binding_dispatch_comment/2 (11 bindings)~n"),
     format("  agent_loop.py     -> emit_help_groups/2~n"),
     format("  agent_loop.py     -> emit_alias_conditions/2, emit_argparse_group_args/2~n"),
     format("  README.md         -> emit_readme_sections/2~n"),
@@ -1155,7 +1181,44 @@ emit_predicate_summary :-
     format("  backend_import_specs/2    -> module_imports + from_imports -> specs~n"),
     format("  security_import_specs/1   -> security_module/3 -> from_relative specs~n"),
     format("  emit_module_dependencies/2 -> module_dependency/3 fact-driven comments~n"),
+    format("~nBinding-driven emission:~n"),
+    format("  costs.py          -> emit_py_dict_from_components/5 (binding_dict_name for DEFAULT_PRICING)~n"),
+    format("  tools_generated   -> binding_dict_name/3 for DESTRUCTIVE_TOOLS~n"),
+    format("  agent_loop.py     -> binding_dict_name/3 for audit_levels~n"),
+    format("~nData-driven helpers:~n"),
+    format("  write_lines/2              -> emit list of strings as lines~n"),
+    format("  emit_py_dict_from_components/5 -> binding + component-driven Python dict~n"),
     format("~nGenerators using raw fact iteration (by design):~n"),
     format("  aliases.py        -> emit_alias_group_entries/2 + structural ordering~n"),
     format("  backends/<name>   -> agent_backend/2 + py_fragment/2~n"),
     format("~n").
+
+%% ============================================================================
+%% Data-driven Emission Helpers
+%% ============================================================================
+
+%% write_lines(+Stream, +Lines)
+%% Write a list of strings as lines to Stream.
+%% Each element is written followed by a newline.
+write_lines(_, []).
+write_lines(S, [Line|Rest]) :-
+    write(S, Line),
+    nl(S),
+    write_lines(S, Rest).
+
+%% emit_py_dict_from_components(+Stream, +Category, +Pred, +Target, +Options)
+%% Emit a complete Python dict by querying binding metadata for the dict name
+%% and compiling each component in Category with target(python).
+%% Pred is the binding predicate (e.g., model_pricing/3) used to look up the dict name.
+%% Options can include indent(N) for component indentation.
+emit_py_dict_from_components(S, Category, Pred, Target, Options) :-
+    agent_loop_bindings:init_agent_loop_bindings,
+    agent_loop_bindings:binding_dict_name(Target, Pred, DictName),
+    format(S, '~w = {~n', [DictName]),
+    findall(Name, component(Category, Name, _, _), Names),
+    maplist([Name]>>(
+        (compile_component(Category, Name, [target(Target)|Options], Code) ->
+            write(S, Code), nl(S)
+        ; true)
+    ), Names),
+    write(S, '}\n').

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -3130,42 +3130,51 @@ generate_costs :-
     output_path(python, 'costs.py', CostsPath),
     open(CostsPath, write, S),
     %% Header and imports
-    write(S, '"""Cost tracking for API usage."""\n\n'),
-    write(S, 'from dataclasses import dataclass, field\n'),
-    write(S, 'from datetime import datetime\n'),
-    write(S, 'from typing import Any\n'),
-    write(S, 'import json\n'),
-    write(S, 'import os\n'),
-    write(S, 'import sys\n'),
-    write(S, 'import time\n'),
-    write(S, 'from pathlib import Path\n'),
-    write(S, 'from urllib.request import urlopen, Request\n'),
-    write(S, 'from urllib.error import URLError\n\n\n'),
+    agent_loop_components:write_lines(S, [
+        '"""Cost tracking for API usage."""',
+        '',
+        'from dataclasses import dataclass, field',
+        'from datetime import datetime',
+        'from typing import Any',
+        'import json',
+        'import os',
+        'import sys',
+        'import time',
+        'from pathlib import Path',
+        'from urllib.request import urlopen, Request',
+        'from urllib.error import URLError',
+        '', ''
+    ]),
     %% Binding metadata for this file
     agent_loop_bindings:emit_binding_metadata_comment(S, python, model_pricing/3),
     nl(S),
-    %% DEFAULT_PRICING dict — generated from model_pricing/3 facts
+    %% DEFAULT_PRICING dict — binding-driven + component-driven emission
     write(S, '# Pricing per 1M tokens (auto-generated from Prolog facts)\n'),
-    write(S, 'DEFAULT_PRICING = {\n'),
-    agent_loop_components:emit_cost_facts(S, [target(python)]),
-    write(S, '}\n\n\n'),
+    agent_loop_components:emit_py_dict_from_components(S, agent_costs, model_pricing/3, python, []),
+    write(S, '\n\n'),
     %% UsageRecord dataclass
-    write(S, '@dataclass\n'),
-    write(S, 'class UsageRecord:\n'),
-    write(S, '    """Record of a single API call."""\n'),
-    write(S, '    timestamp: str\n'),
-    write(S, '    model: str\n'),
-    write(S, '    input_tokens: int\n'),
-    write(S, '    output_tokens: int\n'),
-    write(S, '    input_cost: float\n'),
-    write(S, '    output_cost: float\n'),
-    write(S, '    total_cost: float\n\n\n'),
+    agent_loop_components:write_lines(S, [
+        '@dataclass',
+        'class UsageRecord:',
+        '    """Record of a single API call."""',
+        '    timestamp: str',
+        '    model: str',
+        '    input_tokens: int',
+        '    output_tokens: int',
+        '    input_cost: float',
+        '    output_cost: float',
+        '    total_cost: float',
+        '', ''
+    ]),
     %% CostTracker class — hybrid (structure from facts, methods embedded)
-    write(S, '@dataclass\n'),
-    write(S, 'class CostTracker:\n'),
-    write(S, '    """Track API costs for a session."""\n\n'),
-    write(S, '    pricing: dict = field(default_factory=lambda: DEFAULT_PRICING.copy())\n'),
-    write(S, '    records: list[UsageRecord] = field(default_factory=list)\n'),
+    agent_loop_components:write_lines(S, [
+        '@dataclass',
+        'class CostTracker:',
+        '    """Track API costs for a session."""',
+        '',
+        '    pricing: dict = field(default_factory=lambda: DEFAULT_PRICING.copy())',
+        '    records: list[UsageRecord] = field(default_factory=list)'
+    ]),
     write(S, '    total_input_tokens: int = 0\n'),
     write(S, '    total_output_tokens: int = 0\n'),
     write(S, '    total_cost: float = 0.0\n\n'),
@@ -3338,7 +3347,8 @@ generate_tools :-
     findall(Name, tool_spec(Name, _), Tools),
     generate_tool_specs(S, Tools),
     write(S, '}\n\n'),
-    write(S, 'DESTRUCTIVE_TOOLS = {\n'),
+    agent_loop_bindings:binding_dict_name(python, destructive_tool/1, DestrSetName),
+    format(S, '~w = {~n', [DestrSetName]),
     generate_destructive_list(S, Tools),
     write(S, '}\n'),
     close(S),
@@ -4086,9 +4096,12 @@ generate_fallback_entries(S, [BT|Rest]) :-
     generate_fallback_entries(S, Rest).
 
 %% generate_audit_levels_dict(S) - emit audit_levels dict from audit_profile_level/2 facts
+%% Uses binding_dict_name/3 to derive the Python variable name from binding metadata.
 generate_audit_levels_dict(S) :-
+    agent_loop_bindings:init_agent_loop_bindings,
+    agent_loop_bindings:binding_dict_name(python, audit_profile_level/2, DictName),
     write(S, '\n    # Create audit logger based on security profile\n'),
-    write(S, '    audit_levels = {\n'),
+    format(S, '    ~w = {~n', [DictName]),
     agent_loop_components:emit_audit_levels(S, [target(python)]),
     write(S, '    }\n').
 

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -83,6 +83,11 @@ run_tests :-
     test_binding_metadata_in_generated,
     test_target_level_maplist_in_generated,
     test_no_forall_in_components,
+    test_binding_patterns_extended,
+    test_binding_dict_name,
+    test_compile_component_python_targets,
+    test_write_lines_helper,
+    test_no_forall_in_bindings,
     test_dependency_diagram_output,
     test_module_dependencies_complete,
     %% Report
@@ -1315,5 +1320,104 @@ test_no_forall_in_components :-
     format("~nNo forall in components:~n"),
     assert_true('agent_loop_components.pl has no forall calls', (
         read_file_to_string('agent_loop_components.pl', Content, []),
+        \+ sub_string(Content, _, _, _, "forall(")
+    )).
+
+%% ============================================================================
+%% Extended binding patterns: method_call, chained_call, set_membership
+%% ============================================================================
+
+test_binding_patterns_extended :-
+    format("~nExtended binding patterns:~n"),
+    init_agent_loop_bindings,
+    %% set_membership pattern
+    assert_true('set_membership generates if-in', (
+        compile_binding_code(python, destructive_tool/1, Code),
+        sub_atom(Code, _, _, _, 'in DESTRUCTIVE_TOOLS')
+    )),
+    %% dict_lookup pattern
+    assert_true('dict_lookup generates assignment', (
+        compile_binding_code(python, model_pricing/3, Code2),
+        sub_atom(Code2, _, _, _, 'DEFAULT_PRICING')
+    )),
+    %% binding_pattern/3 query
+    assert_true('binding_pattern returns dict_lookup for model_pricing', (
+        agent_loop_bindings:binding_pattern(python, model_pricing/3, dict_lookup)
+    )),
+    assert_true('binding_pattern returns set_membership for destructive_tool', (
+        agent_loop_bindings:binding_pattern(python, destructive_tool/1, set_membership)
+    )).
+
+%% ============================================================================
+%% binding_dict_name/3 tests
+%% ============================================================================
+
+test_binding_dict_name :-
+    format("~nBinding dict name:~n"),
+    init_agent_loop_bindings,
+    assert_true('binding_dict_name extracts DEFAULT_PRICING from model_pricing/3', (
+        agent_loop_bindings:binding_dict_name(python, model_pricing/3, 'DEFAULT_PRICING')
+    )),
+    assert_true('binding_dict_name extracts audit_levels from audit_profile_level/2', (
+        agent_loop_bindings:binding_dict_name(python, audit_profile_level/2, audit_levels)
+    )),
+    assert_true('binding_dict_name returns DESTRUCTIVE_TOOLS for destructive_tool/1', (
+        agent_loop_bindings:binding_dict_name(python, destructive_tool/1, 'DESTRUCTIVE_TOOLS')
+    )).
+
+%% ============================================================================
+%% compile_component/4 Python target tests
+%% ============================================================================
+
+test_compile_component_python_targets :-
+    format("~nCompile component Python targets:~n"),
+    register_agent_loop_components,
+    %% Command component Python
+    assert_true('command compile_component with target(python) produces dict entry', (
+        compile_component(agent_commands, help, [target(python)], Code),
+        sub_atom(Code, _, _, _, 'help')
+    )),
+    %% Backend component Python
+    assert_true('backend compile_component with target(python) produces dict entry', (
+        compile_component(agent_backends, coro, [target(python)], Code2),
+        sub_atom(Code2, _, _, _, 'coro')
+    )),
+    %% Security component Python
+    assert_true('security compile_component with target(python) produces dict entry', (
+        compile_component(agent_security, cautious, [target(python)], Code3),
+        sub_atom(Code3, _, _, _, 'cautious')
+    )).
+
+%% ============================================================================
+%% write_lines/2 helper test
+%% ============================================================================
+
+test_write_lines_helper :-
+    format("~nwrite_lines helper:~n"),
+    assert_true('write_lines emits multiple lines', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:write_lines(S, ['line1', 'line2', 'line3'])
+        )),
+        sub_atom(Output, _, _, _, 'line1'),
+        sub_atom(Output, _, _, _, 'line2'),
+        sub_atom(Output, _, _, _, 'line3')
+    )),
+    assert_true('write_lines empty list produces no output', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:write_lines(S2, [])
+        )),
+        Output2 == ''
+    )).
+
+%% ============================================================================
+%% No forall in bindings
+%% ============================================================================
+
+test_no_forall_in_bindings :-
+    format("~nNo forall in bindings:~n"),
+    assert_true('agent_loop_bindings.pl has no forall calls', (
+        read_file_to_string('agent_loop_bindings.pl', Content, []),
         \+ sub_string(Content, _, _, _, "forall(")
     )).

--- a/tools/agent-loop/test_prolog_integration.pl
+++ b/tools/agent-loop/test_prolog_integration.pl
@@ -13,6 +13,7 @@
 :- use_module(generated/prolog/commands).
 :- use_module(generated/prolog/security).
 :- use_module(generated/prolog/backends).
+:- use_module(generated/prolog/config).
 
 :- dynamic pl_test_passed/1, pl_test_failed/1.
 
@@ -25,6 +26,8 @@ run_prolog_tests :-
     test_commands_module,
     test_security_module,
     test_backends_module,
+    test_cost_tracker_runtime,
+    test_config_runtime,
     %% Report
     aggregate_all(count, pl_test_passed(_), Passed),
     aggregate_all(count, pl_test_failed(_), Failed),
@@ -137,4 +140,67 @@ test_backends_module :-
     pl_assert_true('backend_factory_order has 8', (
         backends:backend_factory_order(Order),
         length(Order, 8)
+    )).
+
+%% ============================================================================
+%% Runtime tests: cost_tracker
+%% ============================================================================
+
+test_cost_tracker_runtime :-
+    format("~ncost_tracker runtime:~n"),
+    %% Init a test tracker
+    costs:cost_tracker_init(test_runtime),
+    pl_assert_true('cost_tracker_init creates zero state', (
+        costs:cost_tracker_total(test_runtime, tokens(0, 0))
+    )),
+    %% Add usage — suppress output
+    with_output_to(string(_), (
+        costs:cost_tracker_add(test_runtime, "opus", 100, 50)
+    )),
+    pl_assert_true('cost_tracker_add accumulates tokens', (
+        costs:cost_tracker_total(test_runtime, tokens(100, 50))
+    )),
+    %% Add more
+    with_output_to(string(_), (
+        costs:cost_tracker_add(test_runtime, "haiku", 200, 100)
+    )),
+    pl_assert_true('cost_tracker_add accumulates across calls', (
+        costs:cost_tracker_total(test_runtime, tokens(300, 150))
+    )),
+    %% Format
+    costs:cost_tracker_format(test_runtime, Formatted),
+    pl_assert_true('cost_tracker_format produces readable string', (
+        sub_string(Formatted, _, _, _, "300 input"),
+        sub_string(Formatted, _, _, _, "150 output")
+    )),
+    %% Clean up
+    costs:cost_tracker_init(test_runtime).
+
+%% ============================================================================
+%% Runtime tests: config module
+%% ============================================================================
+
+test_config_runtime :-
+    format("~nconfig runtime:~n"),
+    %% resolve_api_key with explicit key
+    config:resolve_api_key(claude, 'test-key-123', Key),
+    pl_assert_eq('resolve_api_key explicit returns explicit', Key, 'test-key-123'),
+    %% resolve_api_key with no key available (nonexistent backend)
+    config:resolve_api_key(nonexistent_backend, none, Key2),
+    pl_assert_eq('resolve_api_key fallback returns none', Key2, none),
+    %% load_config with nonexistent file
+    config:load_config('/tmp/nonexistent_agent_config.json', Config),
+    pl_assert_true('load_config nonexistent returns empty dict', is_dict(Config)),
+    %% cli_argument fact lookup
+    pl_assert_true('cli_argument backend has choices', (
+        config:cli_argument(backend, Props),
+        member(choices(_), Props)
+    )),
+    %% default_agent_preset lookup
+    pl_assert_true('default_agent_preset yolo uses claude-code', (
+        config:default_agent_preset(yolo, 'claude-code', _)
+    )),
+    %% audit_profile_level lookup
+    pl_assert_true('audit_profile_level paranoid is forensic', (
+        config:audit_profile_level(paranoid, forensic)
     )).


### PR DESCRIPTION
## Description

Extends the agent-loop code generator with binding-driven compilation, Python target support for all component types, and data-driven emission helpers — reducing manual `format/2` sequences in favor of declarative patterns.

### Changes

#### Binding registry expansion (`agent_loop_bindings.pl`)
- Add 3 new binding patterns: `set_membership`, `method_call`, `chained_call(Methods)`
- Add `binding_dict_name/3` — extracts base structure name from binding target (e.g., `DEFAULT_PRICING[model]` → `DEFAULT_PRICING`)
- Add `binding_pattern/3` — retrieves pattern type for a binding with `function_call` default
- Extend `format_binding_code/7` to dispatch on all new pattern types
- Add `format_chained_methods/2` helper for method chain code generation
- Convert 3 remaining `forall` sites to `findall`+`maplist` in `emit_binding_dispatch_comment/2` and `agent_loop_binding_summary/0`
- Update module header documentation with key predicates and supported patterns

#### Python compile_component/4 (`agent_loop_components.pl`)
- Add Python target branch to `agent_command_type:compile_component/4` — emits dict entries with match/options/help
- Add Python target branch to `agent_backend_type:compile_component/4` — emits dict entries with class/resolve
- Add Python target branch to `agent_security_type:compile_component/4` — emits dict entries with path_validation/command_validation
- All 5 component types now fully support Python compilation

#### Data-driven emission helpers (`agent_loop_components.pl`)
- Add `write_lines/2` — emits a list of lines to a stream
- Add `emit_py_dict_from_components/5` — combines `binding_dict_name` + `compile_component` to emit complete Python dicts from the component registry
- Update `emit_predicate_summary` with binding-driven and data-driven helper documentation

#### Generator wiring (`agent_loop_module.pl`)
- Wire `binding_dict_name/3` into `generate_audit_levels_dict`, `generate_costs`, `generate_tools`
- Replace manual `DEFAULT_PRICING` dict emission with `emit_py_dict_from_components/5`
- Convert costs.py header imports and field definitions to use `write_lines/2`

#### Tests
- **13 new Prolog unit tests**: `test_binding_patterns_extended` (4), `test_binding_dict_name` (3), `test_compile_component_python_targets` (3), `test_write_lines_helper` (2), `test_no_forall_in_bindings` (1)
- **10 new Prolog integration tests**: `test_cost_tracker_runtime` (4 assertions), `test_config_runtime` (6 assertions)

### Test results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit | 173 | all pass |
| Prolog integration | 27 | all pass |
| Python integration | 59 | all pass |
| **Total** | **259** | **0 failures** |

### Files changed

| File | Lines | Summary |
|------|-------|---------|
| `agent_loop_bindings.pl` | +92 | New patterns, utilities, forall→maplist, docs |
| `agent_loop_components.pl` | +73 | Python compile targets, data-driven helpers |
| `agent_loop_module.pl` | +38/−38 | Binding-driven wiring, write_lines usage |
| `test_agent_loop.pl` | +104 | 13 new unit tests |
| `test_prolog_integration.pl` | +66 | 10 new integration assertions |

### Previous PR

Builds on PR #743 (`feat/agent-loop-forall-det-binding`): forall→maplist everywhere, `:- det` expansion, binding metadata comments — 236 tests.
