### PR TITLE
feat(agent-loop): Deeper component/binding integration, translate_goal adapter, binding parity + coverage

### DIFF
--- a/tools/agent-loop/agent_loop_bindings.pl
+++ b/tools/agent-loop/agent_loop_bindings.pl
@@ -27,7 +27,10 @@
     generate_bindings_summary/2,
     emit_binding_imports/2,
     emit_binding_dispatch_comment/2,
-    emit_binding_metadata_comment/3
+    emit_binding_metadata_comment/3,
+    translate_agent_goal/2,
+    translate_agent_goal/3,
+    translate_agent_goals/3
 ]).
 
 :- reexport('../../src/unifyweaver/core/binding_registry', [
@@ -209,6 +212,13 @@ register_prolog_bindings :-
         [path-string],
         [pure, deterministic]),
 
+    %% default_agent_preset/3 -> direct fact access
+    declare_binding(prolog, default_agent_preset/3,
+        default_agent_preset,
+        [name-atom],
+        [backend-atom, overrides-list],
+        [pure, deterministic]),
+
     %% destructive_tool/1 -> direct fact access
     declare_binding(prolog, destructive_tool/1,
         destructive_tool,
@@ -329,6 +339,37 @@ format_chained_methods([Method|Rest], ChainStr) :-
     ),
     format_chained_methods(Rest, RestStr),
     atom_concat(Part, RestStr, ChainStr).
+
+%% ============================================================================
+%% Goal Translation — Agent-loop adapter for binding-driven code generation
+%% ============================================================================
+
+%% translate_agent_goal(+Goal, -Code)
+%% Translate a Prolog goal term into Python code using the binding registry.
+%% Mirrors the main compiler's translate_goal/2 (python_target.pl:4304-4327)
+%% but works locally with agent-loop bindings.
+translate_agent_goal(Goal, Code) :-
+    translate_agent_goal(python, Goal, Code).
+
+%% translate_agent_goal(+Target, +Goal, -Code)
+%% Translate a Prolog goal term into target-language code.
+translate_agent_goal(Target, Goal, Code) :-
+    init_agent_loop_bindings,
+    functor(Goal, Pred, Arity),
+    binding(Target, Pred/Arity, _TargetName, _Inputs, _Outputs, _Options), !,
+    compile_binding_code(Target, Pred/Arity, Code).
+
+%% translate_agent_goals(+Goals, +Target, -CodeBlock)
+%% Translate a list of Prolog goals into a multi-line code block.
+translate_agent_goals([], _Target, '').
+translate_agent_goals([Goal|Rest], Target, CodeBlock) :-
+    translate_agent_goal(Target, Goal, Code),
+    translate_agent_goals(Rest, Target, RestCode),
+    (RestCode == '' ->
+        CodeBlock = Code
+    ;
+        atomic_list_concat([Code, '\n', RestCode], CodeBlock)
+    ).
 
 %% generate_bindings_summary(+Target, -Summary)
 %% Generate a formatted summary of all bindings for a target

--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -48,7 +48,9 @@
     security_import_specs/1,
     emit_dependency_diagram/2,
     write_lines/2,
-    emit_py_dict_from_components/5
+    emit_py_dict_from_components/5,
+    emit_py_set_from_components/5,
+    emit_prolog_facts_from_components/4
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -94,13 +96,19 @@ agent_tool_type:compile_component(Name, Config, Options, Code) :-
             compile_tool_all_facts(Name, Config, Code)
         )
     ; member(target(python), Options) ->
-        member(handler(H), Config),
-        (member(indent(N), Options) -> true ; N = 4),
-        (member(self_prefix(true), Options) ->
-            format(atom(HStr), "self.~w", [H])
-        ;   atom_string(H, HStr)),
-        length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
-        format(atom(Code), "~w'~w': ~w,", [Indent, Name, HStr])
+        (member(fact_type(tool_spec), Options) ->
+            compile_tool_spec_python(Name, Config, Options, Code)
+        ; member(fact_type(destructive_tool), Options) ->
+            compile_destructive_tool_python(Name, Config, Options, Code)
+        ;
+            member(handler(H), Config),
+            (member(indent(N), Options) -> true ; N = 4),
+            (member(self_prefix(true), Options) ->
+                format(atom(HStr), "self.~w", [H])
+            ;   atom_string(H, HStr)),
+            length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+            format(atom(Code), "~w'~w': ~w,", [Indent, Name, HStr])
+        )
     ;
         member(handler(H), Config),
         format(atom(Code), "tool_handler(~q, ~q).", [Name, H])
@@ -133,6 +141,36 @@ compile_tool_all_facts(Name, Config, Code) :-
         compile_tool_fact(FT, Name, Config, Fact)
     ), Facts),
     atomic_list_concat(Facts, '\n', Code).
+
+%% compile_tool_spec_python(+Name, +Config, +Options, -Code)
+%% Emit a Python dict entry for TOOL_SPECS with description and parameters.
+compile_tool_spec_python(Name, Config, Options, Code) :-
+    member(tool_spec_props(Props), Config),
+    Props \= [],
+    member(description(Desc), Props),
+    member(parameters(Params), Props),
+    (member(indent(N), Options) -> true ; N = 4),
+    length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+    with_output_to(atom(Code), (
+        format('~w"~w": {~n', [Indent, Name]),
+        format('~w    "description": "~w",~n', [Indent, Desc]),
+        format('~w    "parameters": [~n', [Indent]),
+        maplist([param(PName, PType, PReq, PDesc)]>>(
+            (PReq = required -> PyReq = 'True' ; PyReq = 'False'),
+            format('~w        {"name": "~w", "type": "~w", "required": ~w, "description": "~w"},~n',
+                   [Indent, PName, PType, PyReq, PDesc])
+        ), Params),
+        format('~w    ]~n', [Indent]),
+        format('~w},', [Indent])
+    )).
+
+%% compile_destructive_tool_python(+Name, +Config, +Options, -Code)
+%% Emit a Python set entry for DESTRUCTIVE_TOOLS (only if destructive).
+compile_destructive_tool_python(Name, Config, Options, Code) :-
+    member(destructive(true), Config),
+    (member(indent(N), Options) -> true ; N = 4),
+    length(Spaces, N), maplist(=(0' ), Spaces), atom_chars(Indent, Spaces),
+    format(atom(Code), '~w"~w",', [Indent, Name]).
 
 %% --- Slash command type ---
 
@@ -253,6 +291,12 @@ agent_security_type:compile_component(Name, Config, Options, Code) :-
         (member(command_validation(CV), Config) -> true ; CV = false),
         format(atom(Code), "~w'~w': {'path_validation': ~w, 'command_validation': ~w},",
                [Indent, Name, PV, CV])
+    ; member(target(prolog), Options) ->
+        with_output_to(atom(Code), (
+            format('security_profile(~q, ', [Name]),
+            agent_loop_module:write_prolog_term(current_output, Config),
+            write(').')
+        ))
     ;
         with_output_to(atom(Code), (
             format('security_profile(~q, ', [Name]),
@@ -286,6 +330,8 @@ agent_cost_type:compile_component(_Name, Config, Options, Code) :-
     member(model_string(Model), Config),
     (member(target(python), Options) ->
         format(atom(Code), '    "~w": {"input": ~w, "output": ~w},', [Model, In, Out])
+    ; member(target(prolog), Options) ->
+        format(atom(Code), "model_pricing(~q, ~w, ~w).", [Model, In, Out])
     ;
         format(atom(Code), "model_pricing(~q, ~w, ~w).", [Model, In, Out])
     ).
@@ -1210,15 +1256,58 @@ write_lines(S, [Line|Rest]) :-
 %% Emit a complete Python dict by querying binding metadata for the dict name
 %% and compiling each component in Category with target(python).
 %% Pred is the binding predicate (e.g., model_pricing/3) used to look up the dict name.
-%% Options can include indent(N) for component indentation.
+%% Options:
+%%   dict_name(Name)    — override binding-derived dict name
+%%   outer_indent(N)    — indent the wrapper { } lines by N spaces
+%%   indent(N)          — indent each entry by N spaces (passed to compile_component)
+%%   fact_type(FT)      — select specific fact type for compilation
 emit_py_dict_from_components(S, Category, Pred, Target, Options) :-
     agent_loop_bindings:init_agent_loop_bindings,
-    agent_loop_bindings:binding_dict_name(Target, Pred, DictName),
-    format(S, '~w = {~n', [DictName]),
+    (member(dict_name(DictName), Options) ->
+        true
+    ;
+        agent_loop_bindings:binding_dict_name(Target, Pred, DictName)
+    ),
+    (member(outer_indent(OI), Options) -> true ; OI = 0),
+    length(OSpaces, OI), maplist(=(0' ), OSpaces), atom_chars(OIndent, OSpaces),
+    format(S, '~w~w = {~n', [OIndent, DictName]),
     findall(Name, component(Category, Name, _, _), Names),
     maplist([Name]>>(
         (compile_component(Category, Name, [target(Target)|Options], Code) ->
             write(S, Code), nl(S)
         ; true)
     ), Names),
-    write(S, '}\n').
+    format(S, '~w}~n', [OIndent]).
+
+%% emit_py_set_from_components(+Stream, +Category, +Pred, +Target, +Options)
+%% Emit a complete Python set by querying binding metadata for the set name
+%% and compiling each component in Category with target(python).
+%% Options: same as emit_py_dict_from_components.
+emit_py_set_from_components(S, Category, Pred, Target, Options) :-
+    agent_loop_bindings:init_agent_loop_bindings,
+    (member(dict_name(SetName), Options) ->
+        true
+    ;
+        agent_loop_bindings:binding_dict_name(Target, Pred, SetName)
+    ),
+    (member(outer_indent(OI), Options) -> true ; OI = 0),
+    length(OSpaces, OI), maplist(=(0' ), OSpaces), atom_chars(OIndent, OSpaces),
+    format(S, '~w~w = {~n', [OIndent, SetName]),
+    findall(Name, component(Category, Name, _, _), Names),
+    maplist([Name]>>(
+        (compile_component(Category, Name, [target(Target)|Options], Code) ->
+            write(S, Code), nl(S)
+        ; true)
+    ), Names),
+    format(S, '~w}~n', [OIndent]).
+
+%% emit_prolog_facts_from_components(+Stream, +Category, +FactType, +Options)
+%% Emit Prolog facts by iterating components in Category and compiling each
+%% with target(prolog). FactType selects the specific fact type for compilation.
+emit_prolog_facts_from_components(S, Category, FactType, Options) :-
+    findall(Name, component(Category, Name, _, _), Names),
+    maplist([Name]>>(
+        (compile_component(Category, Name, [target(prolog), fact_type(FactType)|Options], Code) ->
+            write(S, Code), nl(S)
+        ; true)
+    ), Names).

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -1190,27 +1190,28 @@ generate_prolog_config :-
     output_path(prolog, 'config.pl', Path),
     open(Path, write, S),
     write_prolog_header(S, config, 'CLI argument parsing and configuration'),
-    write(S, ':- module(config, [\n'),
-    write(S, '    cli_argument/2,\n'),
-    write(S, '    agent_config_field/4,\n'),
-    write(S, '    default_agent_preset/3,\n'),
-    write(S, '    api_key_env_var/2,\n'),
-    write(S, '    api_key_file/2,\n'),
-    write(S, '    parse_cli_args/2,\n'),
-    write(S, '    example_agent_config/3,\n'),
-    write(S, '    config_search_path/2,\n'),
-    write(S, '    config_field_json_default/2,\n'),
-    write(S, '    config_dir_file_name/1,\n'),
-    write(S, '    audit_profile_level/2,\n'),
-    write(S, '    load_config/2,\n'),
-    write(S, '    resolve_api_key/3\n'),
-    write(S, ']).\n\n'),
-    write(S, ':- use_module(library(optparse)).\n'),
-    write(S, ':- use_module(library(json)).\n\n'),
-    %% Determinism annotations for single-clause rules
-    write(S, ':- det(parse_cli_args/2).\n'),
-    write(S, ':- det(load_config/2).\n'),
-    write(S, ':- det(resolve_api_key/3).\n\n'),
+    agent_loop_components:write_lines(S, [
+        ':- module(config, [',
+        '    cli_argument/2,',
+        '    agent_config_field/4,',
+        '    default_agent_preset/3,',
+        '    api_key_env_var/2,',
+        '    api_key_file/2,',
+        '    parse_cli_args/2,',
+        '    example_agent_config/3,',
+        '    config_search_path/2,',
+        '    config_field_json_default/2,',
+        '    config_dir_file_name/1,',
+        '    audit_profile_level/2,',
+        '    load_config/2,',
+        '    resolve_api_key/3',
+        ']).', '',
+        ':- use_module(library(optparse)).',
+        ':- use_module(library(json)).', '',
+        ':- det(parse_cli_args/2).',
+        ':- det(load_config/2).',
+        ':- det(resolve_api_key/3).', ''
+    ]),
     agent_loop_components:emit_module_dependencies(S, [module(config)]),
     %% Emit all config facts via centralized emit predicate
     agent_loop_components:emit_prolog_config_facts(S, [target(prolog)]),
@@ -3016,7 +3017,10 @@ generate_security_profiles :-
     write(S, 'Each profile defines a complete security posture: what\'s blocked, what\'s\n'),
     write(S, 'proxied, what\'s logged, and what isolation is applied.\n'),
     write(S, '"""\n\n'),
-    write(S, 'from dataclasses import dataclass, field\n\n\n'),
+    write(S, 'from dataclasses import dataclass, field\n\n'),
+    %% Binding metadata for this file
+    agent_loop_bindings:emit_binding_metadata_comment(S, python, security_profile/2),
+    nl(S),
     %% SecurityProfile dataclass
     write(S, '@dataclass\n'),
     write(S, 'class SecurityProfile:\n'),
@@ -3343,14 +3347,11 @@ generate_tools :-
     agent_loop_bindings:emit_binding_metadata_comment(S, python, tool_handler/2),
     agent_loop_bindings:emit_binding_metadata_comment(S, python, destructive_tool/1),
     nl(S),
-    write(S, 'TOOL_SPECS = {\n'),
-    findall(Name, tool_spec(Name, _), Tools),
-    generate_tool_specs(S, Tools),
-    write(S, '}\n\n'),
-    agent_loop_bindings:binding_dict_name(python, destructive_tool/1, DestrSetName),
-    format(S, '~w = {~n', [DestrSetName]),
-    generate_destructive_list(S, Tools),
-    write(S, '}\n'),
+    agent_loop_components:emit_py_dict_from_components(S, agent_tools, tool_handler/2, python,
+        [fact_type(tool_spec), dict_name('TOOL_SPECS')]),
+    nl(S),
+    agent_loop_components:emit_py_set_from_components(S, agent_tools, destructive_tool/1, python,
+        [fact_type(destructive_tool)]),
     close(S),
     format('  Generated tools_generated.py~n', []).
 
@@ -3391,10 +3392,12 @@ generate_destructive_list(S, [Name|Rest]) :-
 generate_context :-
     output_path(python, 'context.py', CtxPath),
     open(CtxPath, write, S),
-    write(S, '"""Context manager for conversation history."""\n\n'),
-    write(S, 'from dataclasses import dataclass, field\n'),
-    write(S, 'from typing import Literal\n'),
-    write(S, 'from enum import Enum\n\n\n'),
+    agent_loop_components:write_lines(S, [
+        '"""Context manager for conversation history."""', '',
+        'from dataclasses import dataclass, field',
+        'from typing import Literal',
+        'from enum import Enum', '', ''
+    ]),
     %% Generate enums from context_enum/3 facts
     agent_loop_components:emit_context_enums(S, [target(python)]),
     %% Generate Message dataclass from message_field/3 facts
@@ -3417,9 +3420,17 @@ generate_context :-
 generate_config :-
     output_path(python, 'config.py', CfgPath),
     open(CfgPath, write, S),
-    write(S, '"""Configuration system for agent loop variants."""\n\n'),
-    write(S, 'import os\nimport json\nfrom pathlib import Path\n'),
-    write(S, 'from dataclasses import dataclass, field\nfrom typing import Any\n\n\n'),
+    agent_loop_components:write_lines(S, [
+        '"""Configuration system for agent loop variants."""', '',
+        'import os', 'import json', 'from pathlib import Path',
+        'from dataclasses import dataclass, field', 'from typing import Any', '', ''
+    ]),
+    %% Binding metadata for this file
+    agent_loop_bindings:emit_binding_metadata_comment(S, python, api_key_env_var/2),
+    agent_loop_bindings:emit_binding_metadata_comment(S, python, api_key_file/2),
+    agent_loop_bindings:emit_binding_metadata_comment(S, python, default_agent_preset/3),
+    agent_loop_bindings:emit_binding_metadata_comment(S, python, config_search_path/2),
+    nl(S),
     %% Config cascade function (generated from config_search_path/3 facts)
     generate_config_cascade(S),
     write(S, '\n\n'),
@@ -3445,12 +3456,17 @@ generate_config :-
     agent_loop_components:emit_agent_config_fields(S, [target(python)]),
     write(S, '\n\n'),
     %% Config dataclass (simple, inline)
-    write(S, '@dataclass\nclass Config:\n    """Root configuration with multiple agent variants."""\n'),
-    write(S, '    default: str = "default"\n'),
-    write(S, '    agents: dict[str, AgentConfig] = field(default_factory=dict)\n\n'),
-    write(S, '    # Global settings\n'),
-    write(S, '    config_dir: str = ""\n'),
-    write(S, '    skills_dir: str = ""\n\n\n'),
+    agent_loop_components:write_lines(S, [
+        '@dataclass',
+        'class Config:',
+        '    """Root configuration with multiple agent variants."""',
+        '    default: str = "default"',
+        '    agents: dict[str, AgentConfig] = field(default_factory=dict)',
+        '',
+        '    # Global settings',
+        '    config_dir: str = ""',
+        '    skills_dir: str = ""', '', ''
+    ]),
     %% _resolve_env_var (imperative fragment)
     write_py(S, config_resolve_env_var),
     write(S, '\n'),

--- a/tools/agent-loop/generated/python/config.py
+++ b/tools/agent-loop/generated/python/config.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+# Binding: api_key_env_var/2 -> API_KEY_ENV_VARS[backend](backend) [dict_lookup]
+# Binding: api_key_file/2 -> API_KEY_FILE_PATHS[backend](backend) [dict_lookup]
+# Binding: default_agent_preset/3 -> get_default_config().agents[name](name) [dict_lookup]
+# Binding: config_search_path/2 -> CONFIG_SEARCH_PATHS[path_type](path_type) [dict_lookup]
+
 def read_config_cascade(no_fallback: bool = False) -> dict:
     """Read config from uwsal.json, falling back to coro.json."""
     candidates = [

--- a/tools/agent-loop/generated/python/security/profiles.py
+++ b/tools/agent-loop/generated/python/security/profiles.py
@@ -6,6 +6,7 @@ proxied, what's logged, and what isolation is applied.
 
 from dataclasses import dataclass, field
 
+# Binding: security_profile/2 -> SecurityConfig.from_profile(name) [function_call]
 
 @dataclass
 class SecurityProfile:

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -88,6 +88,17 @@ run_tests :-
     test_compile_component_python_targets,
     test_write_lines_helper,
     test_no_forall_in_bindings,
+    test_compile_tool_spec_python,
+    test_compile_destructive_tool_python,
+    test_emit_py_set_from_components,
+    test_explicit_prolog_security_compile,
+    test_explicit_prolog_cost_compile,
+    test_emit_prolog_facts_from_components,
+    test_translate_agent_goal,
+    test_translate_agent_goals,
+    test_binding_parity,
+    test_binding_metadata_coverage,
+    test_write_lines_multiline_equiv,
     test_dependency_diagram_output,
     test_module_dependencies_complete,
     %% Report
@@ -129,7 +140,7 @@ test_binding_registration :-
     length(PyBindings, NPy),
     length(PlBindings, NPl),
     assert_eq('Python binding count', NPy, 11),
-    assert_eq('Prolog binding count', NPl, 10).
+    assert_eq('Prolog binding count', NPl, 11).
 
 %% ============================================================================
 %% Test 2: Component Registration
@@ -292,7 +303,7 @@ test_bindings_summary :-
     assert_true('Prolog summary generated', (
         generate_bindings_summary(prolog, PlSummary),
         atom(PlSummary),
-        sub_atom(PlSummary, _, _, _, 'prolog bindings (10)')
+        sub_atom(PlSummary, _, _, _, 'prolog bindings (11)')
     )).
 
 %% ============================================================================
@@ -921,9 +932,9 @@ test_new_binding_count :-
         bindings_for_target(python, PyBindings),
         length(PyBindings, 11)
     )),
-    assert_true('Prolog bindings count is 10', (
+    assert_true('Prolog bindings count is 11', (
         bindings_for_target(prolog, PlBindings),
-        length(PlBindings, 10)
+        length(PlBindings, 11)
     )),
     assert_true('api_key_env_var has Python binding', (
         bindings_for_predicate(api_key_env_var/2, Bindings),
@@ -1420,4 +1431,220 @@ test_no_forall_in_bindings :-
     assert_true('agent_loop_bindings.pl has no forall calls', (
         read_file_to_string('agent_loop_bindings.pl', Content, []),
         \+ sub_string(Content, _, _, _, "forall(")
+    )).
+
+%% ============================================================================
+%% Compile tool_spec Python
+%% ============================================================================
+
+test_compile_tool_spec_python :-
+    format("~nCompile tool_spec Python:~n"),
+    register_agent_loop_components,
+    assert_true('tool_spec Python compile produces dict entry', (
+        compile_component(agent_tools, bash, [target(python), fact_type(tool_spec)], Code),
+        sub_atom(Code, _, _, _, '"bash"'),
+        sub_atom(Code, _, _, _, '"description"')
+    )),
+    assert_true('tool_spec Python compile includes parameters', (
+        compile_component(agent_tools, write, [target(python), fact_type(tool_spec)], Code2),
+        sub_atom(Code2, _, _, _, '"parameters"')
+    )).
+
+%% ============================================================================
+%% Compile destructive_tool Python
+%% ============================================================================
+
+test_compile_destructive_tool_python :-
+    format("~nCompile destructive_tool Python:~n"),
+    register_agent_loop_components,
+    assert_true('destructive_tool Python compile produces set entry for bash', (
+        compile_component(agent_tools, bash, [target(python), fact_type(destructive_tool)], Code),
+        sub_atom(Code, _, _, _, '"bash"')
+    )),
+    assert_true('destructive_tool Python compile fails for non-destructive', (
+        \+ compile_component(agent_tools, read, [target(python), fact_type(destructive_tool)], _)
+    )).
+
+%% ============================================================================
+%% Emit py set from components
+%% ============================================================================
+
+test_emit_py_set_from_components :-
+    format("~nEmit py set from components:~n"),
+    register_agent_loop_components,
+    agent_loop_bindings:init_agent_loop_bindings,
+    assert_true('emit_py_set produces DESTRUCTIVE_TOOLS set', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_py_set_from_components(S, agent_tools,
+                destructive_tool/1, python, [fact_type(destructive_tool)])
+        )),
+        sub_atom(Output, _, _, _, 'DESTRUCTIVE_TOOLS'),
+        sub_atom(Output, _, _, _, '"bash"')
+    )),
+    assert_true('emit_py_dict with dict_name override', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_py_dict_from_components(S2, agent_tools,
+                tool_handler/2, python, [fact_type(tool_spec), dict_name('TOOL_SPECS')])
+        )),
+        sub_atom(Output2, _, _, _, 'TOOL_SPECS'),
+        sub_atom(Output2, _, _, _, '"bash"')
+    )).
+
+%% ============================================================================
+%% Explicit Prolog security compile
+%% ============================================================================
+
+test_explicit_prolog_security_compile :-
+    format("~nExplicit Prolog security compile:~n"),
+    register_agent_loop_components,
+    assert_true('security compile_component with target(prolog)', (
+        compile_component(agent_security, cautious, [target(prolog)], Code),
+        sub_atom(Code, _, _, _, 'security_profile'),
+        sub_atom(Code, _, _, _, 'cautious')
+    )).
+
+%% ============================================================================
+%% Explicit Prolog cost compile
+%% ============================================================================
+
+test_explicit_prolog_cost_compile :-
+    format("~nExplicit Prolog cost compile:~n"),
+    register_agent_loop_components,
+    assert_true('cost compile_component with target(prolog)', (
+        compile_component(agent_costs, opus, [target(prolog)], Code),
+        sub_atom(Code, _, _, _, 'model_pricing'),
+        sub_atom(Code, _, _, _, 'opus')
+    )).
+
+%% ============================================================================
+%% Emit Prolog facts from components
+%% ============================================================================
+
+test_emit_prolog_facts_from_components :-
+    format("~nEmit Prolog facts from components:~n"),
+    register_agent_loop_components,
+    assert_true('emit_prolog_facts emits cost facts', (
+        with_output_to(atom(Output), (
+            current_output(S),
+            agent_loop_components:emit_prolog_facts_from_components(S, agent_costs, model_pricing, [])
+        )),
+        sub_atom(Output, _, _, _, 'model_pricing'),
+        sub_atom(Output, _, _, _, 'opus')
+    )),
+    assert_true('emit_prolog_facts emits security facts', (
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:emit_prolog_facts_from_components(S2, agent_security, security_profile, [])
+        )),
+        sub_atom(Output2, _, _, _, 'security_profile'),
+        sub_atom(Output2, _, _, _, 'cautious')
+    )).
+
+%% ============================================================================
+%% Translate agent goal
+%% ============================================================================
+
+test_translate_agent_goal :-
+    format("~nTranslate agent goal:~n"),
+    agent_loop_bindings:init_agent_loop_bindings,
+    assert_true('translate_agent_goal for model_pricing', (
+        agent_loop_bindings:translate_agent_goal(model_pricing(opus, _, _), Code),
+        sub_atom(Code, _, _, _, 'DEFAULT_PRICING')
+    )),
+    assert_true('translate_agent_goal for destructive_tool', (
+        agent_loop_bindings:translate_agent_goal(destructive_tool(bash), Code2),
+        sub_atom(Code2, _, _, _, 'DESTRUCTIVE_TOOLS')
+    )),
+    assert_true('translate_agent_goal for tool_handler', (
+        agent_loop_bindings:translate_agent_goal(tool_handler(bash, _), Code3),
+        sub_atom(Code3, _, _, _, 'TOOL_HANDLERS')
+    )),
+    assert_true('translate_agent_goal Prolog target', (
+        agent_loop_bindings:translate_agent_goal(prolog, model_pricing(opus, _, _), Code4),
+        sub_atom(Code4, _, _, _, 'model_pricing')
+    )).
+
+%% ============================================================================
+%% Translate agent goals list
+%% ============================================================================
+
+test_translate_agent_goals :-
+    format("~nTranslate agent goals list:~n"),
+    agent_loop_bindings:init_agent_loop_bindings,
+    assert_true('translate_agent_goals multi-goal', (
+        agent_loop_bindings:translate_agent_goals(
+            [model_pricing(opus, _, _), tool_handler(bash, _)],
+            python,
+            CodeBlock
+        ),
+        sub_atom(CodeBlock, _, _, _, 'DEFAULT_PRICING'),
+        sub_atom(CodeBlock, _, _, _, 'TOOL_HANDLERS')
+    )),
+    assert_true('translate_agent_goals empty list', (
+        agent_loop_bindings:translate_agent_goals([], python, Code),
+        Code == ''
+    )).
+
+%% ============================================================================
+%% Binding parity
+%% ============================================================================
+
+test_binding_parity :-
+    format("~nBinding parity:~n"),
+    agent_loop_bindings:init_agent_loop_bindings,
+    findall(Pred, binding(python, Pred, _, _, _, _), PyPreds),
+    findall(Pred, binding(prolog, Pred, _, _, _, _), PlPreds),
+    length(PyPreds, PyCount),
+    length(PlPreds, PlCount),
+    assert_eq('Python and Prolog binding counts match', PyCount, PlCount),
+    sort(PyPreds, PySorted),
+    sort(PlPreds, PlSorted),
+    assert_true('Python and Prolog cover same predicates', (
+        PySorted == PlSorted
+    )).
+
+%% ============================================================================
+%% Binding metadata coverage
+%% ============================================================================
+
+test_binding_metadata_coverage :-
+    format("~nBinding metadata coverage:~n"),
+    assert_true('costs.py has binding metadata', (
+        read_file_to_string('generated/python/costs.py', C1, []),
+        sub_string(C1, _, _, _, "# Binding:")
+    )),
+    assert_true('tools_generated.py has binding metadata', (
+        read_file_to_string('generated/python/tools_generated.py', C2, []),
+        sub_string(C2, _, _, _, "# Binding:")
+    )),
+    assert_true('config.py has binding metadata', (
+        read_file_to_string('generated/python/config.py', C3, []),
+        sub_string(C3, _, _, _, "# Binding:")
+    )),
+    assert_true('security/profiles.py has binding metadata', (
+        read_file_to_string('generated/python/security/profiles.py', C4, []),
+        sub_string(C4, _, _, _, "# Binding:")
+    )).
+
+%% ============================================================================
+%% write_lines multiline equivalence
+%% ============================================================================
+
+test_write_lines_multiline_equiv :-
+    format("~nwrite_lines multiline equivalence:~n"),
+    assert_true('write_lines matches sequential writes', (
+        with_output_to(atom(Output1), (
+            current_output(S1),
+            write(S1, 'line1\n'),
+            write(S1, 'line2\n'),
+            write(S1, '\n'),
+            write(S1, 'line3\n')
+        )),
+        with_output_to(atom(Output2), (
+            current_output(S2),
+            agent_loop_components:write_lines(S2, ['line1', 'line2', '', 'line3'])
+        )),
+        Output1 == Output2
     )).


### PR DESCRIPTION
## Description

Deepens the integration between the component registry, binding system, and code generators — replacing more manual emission with declarative, data-driven patterns.

### Changes

#### 1. Expanded emit_py_dict_from_components (`agent_loop_components.pl`)
- Add `dict_name(Name)` option to override binding-derived variable names
- Add `outer_indent(N)` option for indenting wrapper `{ }` lines
- Add `emit_py_set_from_components/5` for Python set emission (e.g., `DESTRUCTIVE_TOOLS = {...}`)
- Add `emit_prolog_facts_from_components/4` for Prolog fact emission from components
- Add Python `fact_type(tool_spec)` compile branch — emits JSON schema dict entries with description and parameters
- Add Python `fact_type(destructive_tool)` compile branch — emits set entries (only for destructive tools)
- Wire into `generate_tools`: replaces manual `generate_tool_specs/2` and `generate_destructive_list/2`

#### 2. Explicit Prolog compile_component/4 branches (`agent_loop_components.pl`)
- Add `member(target(prolog), Options)` guard to `agent_security_type` (was catch-all)
- Add `member(target(prolog), Options)` guard to `agent_cost_type` (was catch-all)
- All 5 component types now have explicit Prolog and Python target branches

#### 3. translate_agent_goal adapter (`agent_loop_bindings.pl`)
- Add `translate_agent_goal/2` — translates Prolog goal to Python code via binding registry (default target: python)
- Add `translate_agent_goal/3` — same with explicit target parameter
- Add `translate_agent_goals/3` — translates a list of goals into a multi-line code block
- Mirrors the main compiler's `translate_goal/2` (python_target.pl:4304-4327) but works locally with agent-loop bindings

#### 4. Binding parity and coverage (`agent_loop_bindings.pl`, `agent_loop_module.pl`)
- Add missing Prolog binding for `default_agent_preset/3` — Python and Prolog now both have 11 bindings covering the same predicates
- Add `emit_binding_metadata_comment` to `generate_config` (4 bindings: api_key_env_var, api_key_file, default_agent_preset, config_search_path)
- Add `emit_binding_metadata_comment` to `generate_security_profiles` (security_profile/2)
- 6 generated Python files now carry binding metadata comments

#### 5. write_lines/2 conversions (`agent_loop_module.pl`)
- Convert `generate_context` header (4 write/2 calls → write_lines)
- Convert `generate_config` header (3 write/2 calls → write_lines)
- Convert `generate_config` Config dataclass (6 write/2 calls → write_lines)
- Convert `generate_prolog_config` module declaration (20+ write/2 calls → write_lines)

### Tests

| Category | New Predicates | New Assertions |
|----------|---------------|----------------|
| tool_spec/destructive Python compile | 2 | 4 |
| emit_py_set + dict_name override | 1 | 2 |
| Explicit Prolog security/cost compile | 2 | 2 |
| emit_prolog_facts_from_components | 1 | 2 |
| translate_agent_goal/goals | 2 | 6 |
| Binding parity | 1 | 2 |
| Binding metadata coverage | 1 | 4 |
| write_lines equivalence | 1 | 1 |
| **Total new** | **11** | **23** |

### Test results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit | 196 | all pass |
| Prolog integration | 27 | all pass |
| Python integration | 59 | all pass |
| **Total** | **282** | **0 failures** |

### Files changed

| File | Lines | Summary |
|------|-------|---------|
| `agent_loop_bindings.pl` | +37 | translate_agent_goal adapter, missing Prolog binding |
| `agent_loop_components.pl` | +105 | emit helpers, tool_spec/destructive Python, explicit Prolog branches |
| `agent_loop_module.pl` | +53/−51 | Component-driven generate_tools, write_lines, metadata comments |
| `test_agent_loop.pl` | +228 | 11 new test predicates, 23 assertions, updated binding counts |
| `generated/python/config.py` | +5 | Binding metadata comments |
| `generated/python/security/profiles.py` | +1 | Binding metadata comment |

### Previous PRs

Builds on PR #744 (`feat/agent-loop-binding-compilation-polish`) and PR #743 (`feat/agent-loop-forall-det-binding`). Test count progression: 218 → 236 → 259 → **282**.
