### PR TITLE
feat(agent-loop): Deeper compile_component/4 + binding-driven Python generation

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -1347,12 +1347,115 @@ generator_import_specs(backends_base, [
     from(typing, ['Any']),
     from(abc, ['ABC', abstractmethod])
 ]).
+generator_import_specs(costs, [
+    from(dataclasses, [dataclass, field]),
+    from(datetime, [datetime]),
+    from(typing, ['Any']),
+    bare(json), bare(os), bare(sys), bare(time),
+    from(pathlib, ['Path']),
+    from('urllib.request', [urlopen, 'Request']),
+    from('urllib.error', ['URLError'])
+]).
+generator_import_specs(context, [
+    from(dataclasses, [dataclass, field]),
+    from(typing, ['Literal']),
+    from(enum, ['Enum'])
+]).
+generator_import_specs(config, [
+    bare(os), bare(json),
+    from(pathlib, ['Path']),
+    from(dataclasses, [dataclass, field]),
+    from(typing, ['Any'])
+]).
+generator_import_specs(security_profiles, [
+    from(dataclasses, [dataclass, field])
+]).
 
 %% emit_import_specs(+Stream, +Specs)
 %% Emit Python import statements from declarative specs.
 %% Delegates to emit_module_imports/2 (supports bare, from, from_relative).
 emit_import_specs(S, Specs) :-
     emit_module_imports(S, Specs).
+
+%% ============================================================================
+%% Declarative Export Specifications
+%% ============================================================================
+
+%% generator_export_specs(+Generator, -Exports)
+%% Declarative __all__ entries for a generator, data-driven from facts.
+generator_export_specs(security_init, Exports) :-
+    findall(Export, (
+        agent_loop_module:security_module(_, Primary, Extras),
+        member(Export, [Primary|Extras])
+    ), Exports).
+
+%% emit_export_specs(+Stream, +Exports)
+%% Emit a Python __all__ = [...] block from a list of export names.
+emit_export_specs(S, Exports) :-
+    write(S, '__all__ = [\n'),
+    maplist([E]>>(format(S, "    '~w',~n", [E])), Exports),
+    write(S, ']\n').
+
+%% ============================================================================
+%% Fragment Metadata
+%% ============================================================================
+
+%% py_fragment_metadata(+FragmentName, +Properties)
+%% Metadata annotations for py_fragment/2 facts.
+%% Properties: category(Cat), target(Target), imports([ImportSpec, ...])
+%% Enables future composition where generators auto-derive imports from fragments.
+py_fragment_metadata(tools_handler_class_body, [
+    category(tools), target(python),
+    imports([from('backends.base', ['ToolCall'])])
+]).
+py_fragment_metadata(tools_security_config, [
+    category(security), target(python),
+    imports([from('security.audit', ['AuditLogger'])])
+]).
+py_fragment_metadata(tools_validate_path, [
+    category(security), target(python),
+    imports([bare(os)])
+]).
+py_fragment_metadata(tools_is_command_blocked, [
+    category(security), target(python),
+    imports([bare(re)])
+]).
+py_fragment_metadata(context_manager_class, [
+    category(context), target(python),
+    imports([from(dataclasses, [dataclass, field])])
+]).
+py_fragment_metadata(context_helpers, [
+    category(context), target(python),
+    imports([])
+]).
+py_fragment_metadata(config_resolve_api_key_header, [
+    category(config), target(python),
+    imports([bare(os)])
+]).
+py_fragment_metadata(config_load_config, [
+    category(config), target(python),
+    imports([bare(json), from(pathlib, ['Path'])])
+]).
+py_fragment_metadata(security_audit_module, [
+    category(security), target(python),
+    imports([bare(os), bare(json)])
+]).
+py_fragment_metadata(agent_loop_imports, [
+    category(agent_loop), target(python),
+    imports([bare(os), bare(sys), bare(json)])
+]).
+
+%% fragment_imports(+FragmentName, -ImportSpecs)
+%% Get the import specs for a named fragment.
+fragment_imports(Name, Imports) :-
+    py_fragment_metadata(Name, Props),
+    member(imports(Imports), Props).
+
+%% fragment_category(+FragmentName, -Category)
+%% Get the category of a named fragment.
+fragment_category(Name, Category) :-
+    py_fragment_metadata(Name, Props),
+    member(category(Category), Props).
 
 %% ============================================================================
 %% Unified Component Emission
@@ -1450,3 +1553,76 @@ emit_py_set_from_components(S, Cat, Pred, Target, Opts) :-
 %% Backward-compatible wrapper — delegates to emit_from_components/6 with facts format.
 emit_prolog_facts_from_components(S, Cat, FactType, Opts) :-
     emit_from_components(S, Cat, _Pred, prolog, facts, [fact_type(FactType)|Opts]).
+
+%% ============================================================================
+%% Declarative Security Validation Rules
+%% ============================================================================
+%%
+%% These facts declare how security checks map to data categories.
+%% The compile predicates emit target-specific validation logic from them.
+
+%% path_check_rule(+RuleName, +CheckType, +Properties)
+%% Declarative security path validation rules.
+path_check_rule(exact_match,   blocked_path,        [comment("Exact blocked path match")]).
+path_check_rule(prefix_match,  blocked_path_prefix, [comment("Blocked path prefix match")]).
+path_check_rule(home_pattern,  blocked_home_pattern, [comment("Home directory pattern match")]).
+
+%% command_check_rule(+RuleName, +CheckType, +Properties)
+%% Declarative security command validation rules.
+command_check_rule(regex_match, blocked_command_pattern, [comment("Command regex pattern match")]).
+
+%% compile_path_check_rules(+Stream, +Target, +Options)
+%% Emit path validation logic for the given target, driven by path_check_rule/3 facts.
+compile_path_check_rules(S, python, _Options) :-
+    findall(CheckType-Props, path_check_rule(_, CheckType, Props), Rules),
+    maplist([CT-Ps]>>(
+        member(comment(Comment), Ps),
+        format(S, "    # ~w~n", [Comment]),
+        compile_path_check_python(S, CT)
+    ), Rules).
+compile_path_check_rules(S, prolog, _Options) :-
+    findall(RN-CT-Ps, path_check_rule(RN, CT, Ps), Rules),
+    maplist([RuleName-CheckType-Props]>>(
+        member(comment(Comment), Props),
+        format(S, "%% ~w: ~w~n", [RuleName, Comment]),
+        compile_path_check_prolog(S, CheckType)
+    ), Rules).
+
+compile_path_check_python(S, blocked_path) :-
+    write(S, '    if abs_path in _BLOCKED_PATHS:\n'),
+    write(S, '        return True\n').
+compile_path_check_python(S, blocked_path_prefix) :-
+    write(S, '    for prefix in _BLOCKED_PATH_PREFIXES:\n'),
+    write(S, '        if abs_path.startswith(prefix):\n'),
+    write(S, '            return True\n').
+compile_path_check_python(S, blocked_home_pattern) :-
+    write(S, '    home = os.path.expanduser("~")\n'),
+    write(S, '    for pattern in _BLOCKED_HOME_PATTERNS:\n'),
+    write(S, '        if abs_path.startswith(os.path.join(home, pattern)):\n'),
+    write(S, '            return True\n').
+
+compile_path_check_prolog(S, blocked_path) :-
+    write(S, 'is_path_blocked(Path) :- blocked_path(Path), !.\n').
+compile_path_check_prolog(S, blocked_path_prefix) :-
+    write(S, 'is_path_blocked(Path) :- blocked_path_prefix(Prefix), atom_concat(Prefix, _, Path), !.\n').
+compile_path_check_prolog(S, blocked_home_pattern) :-
+    write(S, 'is_path_blocked(Path) :- blocked_home_pattern(Pat), expand_home(Pat, Full), atom_concat(Full, _, Path), !.\n').
+
+%% compile_command_check_rules(+Stream, +Target, +Options)
+%% Emit command validation logic for the given target, driven by command_check_rule/3 facts.
+compile_command_check_rules(S, python, _Options) :-
+    findall(Props, command_check_rule(_, _, Props), Rules),
+    maplist([Ps]>>(
+        member(comment(Comment), Ps),
+        format(S, "    # ~w~n", [Comment]),
+        write(S, '    for pattern, desc in _BLOCKED_COMMAND_PATTERNS:\n'),
+        write(S, '        if re.search(pattern, command):\n'),
+        write(S, '            return True, desc\n')
+    ), Rules).
+compile_command_check_rules(S, prolog, _Options) :-
+    findall(RN-Ps, command_check_rule(RN, _, Ps), Rules),
+    maplist([RuleName-Props]>>(
+        member(comment(Comment), Props),
+        format(S, "%% ~w: ~w~n", [RuleName, Comment]),
+        write(S, 'is_command_blocked(Cmd, Desc) :- blocked_command_pattern(Regex, Desc), re_match(Regex, Cmd), !.\n')
+    ), Rules).

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -2989,14 +2989,10 @@ generate_security_init :-
     write(S, '"""\n\n'),
     %% Imports — one import line per module, comma-separated exports
     agent_loop_components:emit_security_module_imports(S, [target(python)]),
-    %% __all__
-    write(S, '\n__all__ = [\n'),
-    findall(Export, (
-        security_module(_, Primary, Extras),
-        member(Export, [Primary|Extras])
-    ), AllExports),
-    write_quoted_list(S, AllExports),
-    write(S, ']\n'),
+    %% __all__ (declarative via generator_export_specs)
+    write(S, '\n'),
+    agent_loop_components:generator_export_specs(security_init, AllExports),
+    agent_loop_components:emit_export_specs(S, AllExports),
     close(S),
     format('  Generated security/__init__.py~n', []).
 
@@ -3011,7 +3007,10 @@ generate_security_profiles :-
     write(S, 'Each profile defines a complete security posture: what\'s blocked, what\'s\n'),
     write(S, 'proxied, what\'s logged, and what isolation is applied.\n'),
     write(S, '"""\n\n'),
-    write(S, 'from dataclasses import dataclass, field\n\n'),
+    %% Imports (declarative via generator_import_specs)
+    agent_loop_components:generator_import_specs(security_profiles, ProfImports),
+    agent_loop_components:emit_import_specs(S, ProfImports),
+    write(S, '\n'),
     %% Binding metadata for this file
     agent_loop_bindings:emit_binding_metadata_comment(S, python, security_profile/2),
     nl(S),
@@ -3127,22 +3126,11 @@ generate_profile_entry(S, Name, Props) :-
 generate_costs :-
     output_path(python, 'costs.py', CostsPath),
     open(CostsPath, write, S),
-    %% Header and imports
-    agent_loop_components:write_lines(S, [
-        '"""Cost tracking for API usage."""',
-        '',
-        'from dataclasses import dataclass, field',
-        'from datetime import datetime',
-        'from typing import Any',
-        'import json',
-        'import os',
-        'import sys',
-        'import time',
-        'from pathlib import Path',
-        'from urllib.request import urlopen, Request',
-        'from urllib.error import URLError',
-        '', ''
-    ]),
+    %% Header and imports (declarative via generator_import_specs)
+    write(S, '"""Cost tracking for API usage."""\n\n'),
+    agent_loop_components:generator_import_specs(costs, CostsImports),
+    agent_loop_components:emit_import_specs(S, CostsImports),
+    write(S, '\n\n'),
     %% Binding metadata for this file
     agent_loop_bindings:emit_binding_metadata_comment(S, python, model_pricing/3),
     agent_loop_bindings:emit_binding_equivalence_comments(S, python, [
@@ -3360,12 +3348,11 @@ generate_tools :-
 generate_context :-
     output_path(python, 'context.py', CtxPath),
     open(CtxPath, write, S),
-    agent_loop_components:write_lines(S, [
-        '"""Context manager for conversation history."""', '',
-        'from dataclasses import dataclass, field',
-        'from typing import Literal',
-        'from enum import Enum', '', ''
-    ]),
+    %% Header and imports (declarative via generator_import_specs)
+    write(S, '"""Context manager for conversation history."""\n\n'),
+    agent_loop_components:generator_import_specs(context, ContextImports),
+    agent_loop_components:emit_import_specs(S, ContextImports),
+    write(S, '\n\n'),
     %% Generate enums from context_enum/3 facts
     agent_loop_components:emit_context_enums(S, [target(python)]),
     %% Generate Message dataclass from message_field/3 facts
@@ -3388,11 +3375,11 @@ generate_context :-
 generate_config :-
     output_path(python, 'config.py', CfgPath),
     open(CfgPath, write, S),
-    agent_loop_components:write_lines(S, [
-        '"""Configuration system for agent loop variants."""', '',
-        'import os', 'import json', 'from pathlib import Path',
-        'from dataclasses import dataclass, field', 'from typing import Any', '', ''
-    ]),
+    %% Header and imports (declarative via generator_import_specs)
+    write(S, '"""Configuration system for agent loop variants."""\n\n'),
+    agent_loop_components:generator_import_specs(config, ConfigImports),
+    agent_loop_components:emit_import_specs(S, ConfigImports),
+    write(S, '\n\n'),
     %% Binding metadata for this file
     agent_loop_bindings:emit_binding_metadata_comment(S, python, api_key_env_var/2),
     agent_loop_bindings:emit_binding_metadata_comment(S, python, api_key_file/2),

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -117,6 +117,15 @@ run_tests :-
     test_binding_equivalence_comments,
     test_extract_target_helper,
     test_all_entry_backend_compile,
+    test_generator_import_specs_extended,
+    test_generator_export_specs,
+    test_py_fragment_metadata,
+    test_fragment_imports_helper,
+    test_path_check_rule_facts,
+    test_command_check_rule_facts,
+    test_compile_path_check_rules_python,
+    test_compile_path_check_rules_prolog,
+    test_source_component_equivalence,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -2086,3 +2095,149 @@ test_all_entry_backend_compile :-
     assert_true('all_entry entries has backend', sub_atom(Output, _, _, _, 'CoroBackend')),
     %% Optional backends should NOT appear
     assert_true('all_entry excludes optional', \+ sub_atom(Output, _, _, _, 'ClaudeAPIBackend')).
+
+%% ============================================================================
+%% Tests for deeper declarative generalization (PR #748)
+%% ============================================================================
+
+test_generator_import_specs_extended :-
+    format("~ngenerator_import_specs extended:~n"),
+    %% Verify specs exist for the 4 newly added generators
+    assert_true('costs specs exist',
+        agent_loop_components:generator_import_specs(costs, _)),
+    assert_true('context specs exist',
+        agent_loop_components:generator_import_specs(context, _)),
+    assert_true('config specs exist',
+        agent_loop_components:generator_import_specs(config, _)),
+    assert_true('security_profiles specs exist',
+        agent_loop_components:generator_import_specs(security_profiles, _)),
+    %% Verify costs specs emit correct output
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:generator_import_specs(costs, CostsSpecs),
+    agent_loop_components:emit_import_specs(S, CostsSpecs),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('costs has import json', sub_atom(Output, _, _, _, 'import json')),
+    assert_true('costs has from dataclasses', sub_atom(Output, _, _, _, 'from dataclasses import')).
+
+test_generator_export_specs :-
+    format("~ngenerator_export_specs:~n"),
+    %% Verify security_init export specs
+    agent_loop_components:generator_export_specs(security_init, Exports),
+    assert_true('exports non-empty', Exports \= []),
+    assert_true('exports has AuditLogger', member('AuditLogger', Exports)),
+    assert_true('exports has SecurityProfile', member('SecurityProfile', Exports)),
+    %% Verify emit_export_specs output
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:emit_export_specs(S, Exports),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('export has __all__', sub_atom(Output, _, _, _, '__all__ = [')).
+
+test_py_fragment_metadata :-
+    format("~npy_fragment_metadata:~n"),
+    %% Verify metadata facts exist
+    assert_true('tools_handler has metadata',
+        agent_loop_components:py_fragment_metadata(tools_handler_class_body, _)),
+    assert_true('context_manager has metadata',
+        agent_loop_components:py_fragment_metadata(context_manager_class, _)),
+    assert_true('security_audit has metadata',
+        agent_loop_components:py_fragment_metadata(security_audit_module, _)),
+    %% Verify category extraction
+    agent_loop_components:fragment_category(tools_handler_class_body, Cat),
+    assert_true('tools_handler category is tools', Cat == tools),
+    %% Count metadata facts (at least 10)
+    aggregate_all(count,
+        agent_loop_components:py_fragment_metadata(_, _), Count),
+    assert_true('at least 10 metadata facts', Count >= 10).
+
+test_fragment_imports_helper :-
+    format("~nfragment_imports helper:~n"),
+    %% Verify imports for tools_handler_class_body
+    agent_loop_components:fragment_imports(tools_handler_class_body, Imports),
+    assert_true('tools_handler has imports', Imports \= []),
+    assert_true('tools_handler imports backends.base',
+        member(from('backends.base', _), Imports)),
+    %% Verify config_load_config imports
+    agent_loop_components:fragment_imports(config_load_config, CfgImports),
+    assert_true('config_load has json import', member(bare(json), CfgImports)).
+
+test_path_check_rule_facts :-
+    format("~npath_check_rule facts:~n"),
+    %% Verify all 3 rules exist
+    assert_true('exact_match rule exists',
+        agent_loop_components:path_check_rule(exact_match, blocked_path, _)),
+    assert_true('prefix_match rule exists',
+        agent_loop_components:path_check_rule(prefix_match, blocked_path_prefix, _)),
+    assert_true('home_pattern rule exists',
+        agent_loop_components:path_check_rule(home_pattern, blocked_home_pattern, _)),
+    %% Verify count
+    aggregate_all(count, agent_loop_components:path_check_rule(_, _, _), Count),
+    assert_true('exactly 3 path rules', Count =:= 3).
+
+test_command_check_rule_facts :-
+    format("~ncommand_check_rule facts:~n"),
+    assert_true('regex_match rule exists',
+        agent_loop_components:command_check_rule(regex_match, blocked_command_pattern, _)),
+    aggregate_all(count, agent_loop_components:command_check_rule(_, _, _), CCount),
+    assert_true('exactly 1 command rule', CCount =:= 1).
+
+test_compile_path_check_rules_python :-
+    format("~ncompile_path_check_rules python:~n"),
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:compile_path_check_rules(S, python, []),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('python has _BLOCKED_PATHS check',
+        sub_atom(Output, _, _, _, '_BLOCKED_PATHS')),
+    assert_true('python has prefix check',
+        sub_atom(Output, _, _, _, 'startswith(prefix)')),
+    assert_true('python has home expanduser',
+        sub_atom(Output, _, _, _, 'expanduser')),
+    assert_true('python has comment',
+        sub_atom(Output, _, _, _, '# Exact blocked path match')),
+    assert_true('python has return True',
+        sub_atom(Output, _, _, _, 'return True')).
+
+test_compile_path_check_rules_prolog :-
+    format("~ncompile_path_check_rules prolog:~n"),
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:compile_path_check_rules(S, prolog, []),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('prolog has is_path_blocked',
+        sub_atom(Output, _, _, _, 'is_path_blocked')),
+    assert_true('prolog has blocked_path',
+        sub_atom(Output, _, _, _, 'blocked_path(Path)')),
+    assert_true('prolog has atom_concat',
+        sub_atom(Output, _, _, _, 'atom_concat')),
+    assert_true('prolog has expand_home',
+        sub_atom(Output, _, _, _, 'expand_home')).
+
+test_source_component_equivalence :-
+    format("~nsource-component equivalence:~n"),
+    agent_loop_components:register_agent_loop_components,
+    %% blocked_path count should match
+    aggregate_all(count, agent_loop_module:blocked_path(_), SrcBP),
+    aggregate_all(count, (
+        component(agent_security_rules, _, _, Cfg),
+        member(rule_type(blocked_path), Cfg)
+    ), CompBP),
+    assert_true('blocked_path count matches', SrcBP =:= CompBP),
+    %% blocked_path_prefix count should match
+    aggregate_all(count, agent_loop_module:blocked_path_prefix(_), SrcBPP),
+    aggregate_all(count, (
+        component(agent_security_rules, _, _, Cfg2),
+        member(rule_type(blocked_path_prefix), Cfg2)
+    ), CompBPP),
+    assert_true('blocked_path_prefix count matches', SrcBPP =:= CompBPP),
+    %% blocked_home_pattern count should match
+    aggregate_all(count, agent_loop_module:blocked_home_pattern(_), SrcBHP),
+    aggregate_all(count, (
+        component(agent_security_rules, _, _, Cfg3),
+        member(rule_type(blocked_home_pattern), Cfg3)
+    ), CompBHP),
+    assert_true('blocked_home_pattern count matches', SrcBHP =:= CompBHP),
+    %% blocked_command_pattern count should match
+    aggregate_all(count, agent_loop_module:blocked_command_pattern(_, _), SrcBCP),
+    aggregate_all(count, (
+        component(agent_security_rules, _, _, Cfg4),
+        member(rule_type(blocked_command_pattern), Cfg4)
+    ), CompBCP),
+    assert_true('blocked_command_pattern count matches', SrcBCP =:= CompBCP).


### PR DESCRIPTION
Expands the declarative infrastructure to cover more generators and introduces fragment metadata, export specs, and target-polymorphic security validation rules.

### Changes

#### 1. Expanded `generator_import_specs/2` (`agent_loop_components.pl` + `agent_loop_module.pl`)
- 4 new `generator_import_specs` clauses: `costs`, `context`, `config`, `security_profiles`
- Wired into 4 generators, replacing 12+ hardcoded `write`/`write_lines` import calls
- Total generators with declarative imports: **7** (tools, aliases, backends_base, costs, context, config, security_profiles)

#### 2. `generator_export_specs/2` + `emit_export_specs/2` (`agent_loop_components.pl` + `agent_loop_module.pl`)
- `generator_export_specs(security_init, Exports)` — data-driven from `security_module/3` facts
- `emit_export_specs/2` — emits `__all__ = [...]` with consistent formatting
- Wired into `generate_security_init`, replacing `findall`/`write_quoted_list`

#### 3. `py_fragment_metadata/2` + helpers (`agent_loop_components.pl`)
- 10 `py_fragment_metadata/2` facts annotating key fragments with category, target, and imports
- `fragment_imports/2` — extract import specs from a fragment's metadata
- `fragment_category/2` — extract category from a fragment's metadata
- Infrastructure for future composition where generators auto-derive imports from fragments

#### 4. Declarative security validation rules (`agent_loop_components.pl`)
- `path_check_rule/3` — 3 rules: `exact_match`, `prefix_match`, `home_pattern`
- `command_check_rule/2` — 1 rule: `regex_match`
- `compile_path_check_rules/3` — emits path validation logic for Python or Prolog
- `compile_command_check_rules/3` — emits command validation logic for Python or Prolog
- Comments-first compilation: each rule emits a descriptive comment before the check logic

#### 5. Tests (`test_agent_loop.pl`)
- 9 new test predicates, 37 new assertions
- Source-to-component equivalence test validates that component counts match source fact counts

### Tests

| Category | New Predicates | New Assertions |
|----------|---------------|----------------|
| extended import specs | 1 | 6 |
| export specs | 1 | 5 |
| fragment metadata | 1 | 5 |
| fragment imports helper | 1 | 3 |
| path check rule facts | 1 | 4 |
| command check rule facts | 1 | 2 |
| compile path checks (Python) | 1 | 5 |
| compile path checks (Prolog) | 1 | 4 |
| source-component equivalence | 1 | 4 |
| **Total new** | **9** | **37** |

### Test results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit | 291 | all pass |
| Prolog integration | 27 | all pass |
| Python integration | 59 | all pass |
| **Total** | **377** | **0 failures** |

### Files changed

| File | Lines | Summary |
|------|-------|---------|
| `agent_loop_components.pl` | +176/−0 | 4 import specs, export specs, 10 fragment metadata, path/command check rules + compile |
| `agent_loop_module.pl` | +23/−36 | Wire import specs in 4 generators, wire export specs in security_init |
| `test_agent_loop.pl` | +155/−0 | 9 new test predicates, 37 assertions |

### Previous PRs

Builds on PR #747 (`feat/agent-loop-generalize-emit`). Test count progression: 218 → 236 → 259 → 282 → 311 → 340 → **377**.
