### PR TITLE
perf(csharp-query): fix single-probe pair-cache admission with duplicate params

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -7162,7 +7162,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (IsSingleConcreteGroupedPairRequest(targetsBySource, sourcesByTarget))
                 {
-                    var probeCount = Math.Max(1, parameters.Count);
+                    var probeCount = ComputeSingleGroupedPairProbeNormalizationCount(parameters, inputPositions, closure.GroupIndices);
                     var seedEntry = targetsBySource.First();
                     var sourceKey = seedEntry.Key.Row;
                     var target = seedEntry.Value.First();
@@ -9623,6 +9623,91 @@ namespace UnifyWeaver.QueryRuntime
             return Math.Max(missedPairs.Count, distinctProbeKeys);
         }
 
+        private static int ComputeSinglePairProbeNormalizationCount(IReadOnlyList<object[]> parameters)
+        {
+            if (parameters.Count == 0)
+            {
+                return 1;
+            }
+
+            var seenPairs = new HashSet<RowWrapper>(StructuralRowWrapperComparer);
+            foreach (var paramTuple in parameters)
+            {
+                if (paramTuple is null || paramTuple.Length < 2)
+                {
+                    continue;
+                }
+
+                var source = paramTuple[0];
+                var target = paramTuple[1];
+                if (!IsConcretePairTarget(target))
+                {
+                    continue;
+                }
+
+                seenPairs.Add(new RowWrapper(new object[] { source!, target! }));
+            }
+
+            return Math.Max(1, seenPairs.Count);
+        }
+
+        private static int ComputeSingleGroupedPairProbeNormalizationCount(
+            IReadOnlyList<object[]> parameters,
+            IReadOnlyList<int> inputPositions,
+            IReadOnlyList<int> groupIndices)
+        {
+            if (parameters.Count == 0)
+            {
+                return 1;
+            }
+
+            var groupCount = groupIndices.Count;
+            var seenPairs = new HashSet<RowWrapper>(StructuralRowWrapperComparer);
+
+            foreach (var paramTuple in parameters)
+            {
+                if (paramTuple is null || paramTuple.Length == 0)
+                {
+                    continue;
+                }
+
+                if (!TryGetParameterValue(paramTuple, inputPositions, 0, out var source))
+                {
+                    continue;
+                }
+
+                if (!TryGetParameterValue(paramTuple, inputPositions, 1, out var target) ||
+                    !IsConcretePairTarget(target))
+                {
+                    continue;
+                }
+
+                var pairKey = new object[groupCount + 2];
+                var completeKey = true;
+                for (var i = 0; i < groupCount; i++)
+                {
+                    if (!TryGetParameterValue(paramTuple, inputPositions, groupIndices[i], out var groupValue))
+                    {
+                        completeKey = false;
+                        break;
+                    }
+
+                    pairKey[i] = groupValue!;
+                }
+
+                if (!completeKey)
+                {
+                    continue;
+                }
+
+                pairKey[groupCount] = source!;
+                pairKey[groupCount + 1] = target!;
+                seenPairs.Add(new RowWrapper(pairKey));
+            }
+
+            return Math.Max(1, seenPairs.Count);
+        }
+
         private static bool TryGetParameterValue(
             object[] tuple,
             IReadOnlyList<int> inputPositions,
@@ -10290,7 +10375,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 if (IsSingleConcretePairRequest(bySource, byTarget))
                 {
-                    var probeCount = Math.Max(1, parameters.Count);
+                    var probeCount = ComputeSinglePairProbeNormalizationCount(parameters);
                     var source = bySource.First().Key;
                     var target = bySource.First().Value.First();
                     var edges = GetFactsList(closure.EdgeRelation, context);

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -327,6 +327,7 @@ test_csharp_query_target :-
         verify_parameterized_reachability_by_target_seed_cache_admission_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_admission_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_admission_normalized_runtime,
+        verify_parameterized_reachability_pairs_single_probe_cache_admission_duplicate_heavy_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_normalized_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_selectivity_runtime,
@@ -336,6 +337,7 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_by_target_seed_cache_admission_selectivity_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_normalized_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_duplicate_heavy_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_admission_normalized_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_admission_selectivity_runtime,
@@ -4137,10 +4139,36 @@ verify_parameterized_reachability_pairs_single_probe_cache_admission_normalized_
         2,
         HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
-        ['CACHE_HIT_HOT:TransitiveClosurePairsSingleProbe=false',
+        ['CACHE_HIT_HOT:TransitiveClosurePairsSingleProbe=true',
          'CACHE_HIT_COLD:TransitiveClosurePairsSingleProbe=false',
-         'CACHE_ADMISSIONS:TransitiveClosurePairsSingleProbe=0',
-         'CACHE_ADMISSION_SKIPS:TransitiveClosurePairsSingleProbe=2'],
+         'CACHE_ADMISSIONS:TransitiveClosurePairsSingleProbe=1',
+         'CACHE_ADMISSION_SKIPS:TransitiveClosurePairsSingleProbe=1'],
+        HotParams,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_single_probe_cache_admission_duplicate_heavy_runtime :-
+    csharp_query_target:build_query_plan(test_admission_reach_pair/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [[a, e], [a, e], [a, e], [a, e], [a, e], [a, e]],
+    WarmColdParams = [[b, e], [b, e], [b, e], [b, e], [b, e], [b, e]],
+    HotParams = [[a, e], [a, e], [a, e], [a, e], [a, e], [a, e]],
+    ColdParams = [[b, e], [b, e], [b, e], [b, e], [b, e], [b, e]],
+    harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'TransitiveClosurePairsSingleProbe',
+        2,
+        2,
+        2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:TransitiveClosurePairsSingleProbe=true',
+         'CACHE_HIT_COLD:TransitiveClosurePairsSingleProbe=false',
+         'CACHE_ADMISSIONS:TransitiveClosurePairsSingleProbe=1',
+         'CACHE_ADMISSION_SKIPS:TransitiveClosurePairsSingleProbe=1'],
         HotParams,
         HarnessSource).
 
@@ -4367,10 +4395,48 @@ verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admissi
         2,
         HarnessSource),
     maybe_run_query_runtime_with_harness(Plan,
-        ['CACHE_HIT_HOT:GroupedTransitiveClosurePairsSingleProbe=false',
+        ['CACHE_HIT_HOT:GroupedTransitiveClosurePairsSingleProbe=true',
          'CACHE_HIT_COLD:GroupedTransitiveClosurePairsSingleProbe=false',
-         'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=0',
-         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=2'],
+         'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=1',
+         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=1'],
+        HotParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_duplicate_heavy_runtime :-
+    csharp_query_target:build_query_plan(test_admission_group_reach_pair/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [
+        [a, e, adm, cata], [a, e, adm, cata], [a, e, adm, cata],
+        [a, e, adm, cata], [a, e, adm, cata], [a, e, adm, cata]
+    ],
+    WarmColdParams = [
+        [b, e, adm, cata], [b, e, adm, cata], [b, e, adm, cata],
+        [b, e, adm, cata], [b, e, adm, cata], [b, e, adm, cata]
+    ],
+    HotParams = [
+        [a, e, adm, cata], [a, e, adm, cata], [a, e, adm, cata],
+        [a, e, adm, cata], [a, e, adm, cata], [a, e, adm, cata]
+    ],
+    ColdParams = [
+        [b, e, adm, cata], [b, e, adm, cata], [b, e, adm, cata],
+        [b, e, adm, cata], [b, e, adm, cata], [b, e, adm, cata]
+    ],
+    harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'GroupedTransitiveClosurePairsSingleProbe',
+        2,
+        2,
+        2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:GroupedTransitiveClosurePairsSingleProbe=true',
+         'CACHE_HIT_COLD:GroupedTransitiveClosurePairsSingleProbe=false',
+         'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=1',
+         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=1'],
         HotParams,
         HarnessSource).
 


### PR DESCRIPTION
  ## Summary
  Fixes single-probe pair-cache admission so duplicate parameters do not artificially lower admission cost-per-probe.

  ## Changes
  - Normalize single-probe admission by **unique concrete probe keys** (not raw parameter count).
  - Apply the normalization in both:
    - `TransitiveClosurePairsSingleProbe`
    - `GroupedTransitiveClosurePairsSingleProbe`
  - Add duplicate-heavy coverage:
    - `verify_parameterized_reachability_pairs_single_probe_cache_admission_duplicate_heavy_runtime`
    - `verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_duplicate_heavy_runtime`
  - Update normalized single-probe admission expectations accordingly.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 ... test_csharp_query_target` passed (`183/183`)
  - `run_csharp_query_runtime_smoke.ps1 -ProjectFilter "cq_test_admissi*"` passed