### PR TITLE
feat(agent-loop): Wire config sections, regex_list_variable facts, fragment expansion, target-polymorphic profile fields, Prolog module header emitter

### DIFF
--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -69,7 +69,9 @@
     generator_fragments/2,
     derive_fragment_imports/2,
     validate_generator_imports/2,
-    emit_config_section/3
+    emit_config_section/3,
+    emit_prolog_module_header/3,
+    emit_prolog_declarations/2
 ]).
 
 :- reexport('../../src/unifyweaver/core/component_registry', [
@@ -1421,13 +1423,22 @@ emit_export_specs(S, Exports) :-
 %% ============================================================================
 
 %% emit_security_profile_fields(+Stream, +Options)
-%% Emit Python dataclass fields from security_profile_field/4 facts.
-%% Groups fields by layer, emitting blank lines and comment headers between groups.
-emit_security_profile_fields(S, _Options) :-
+%% Target-polymorphic emission of security profile field schema.
+%% Python: dataclass fields with type annotations, defaults, and layer comments.
+%% Prolog: security_profile_field/4 facts.
+emit_security_profile_fields(S, Options) :-
+    extract_target(Options, Target),
     findall(field(Name, Type, Default, Props),
         agent_loop_module:security_profile_field(Name, Type, Default, Props),
         Fields),
-    emit_profile_fields_loop(S, Fields, none).
+    (Target == python ->
+        emit_profile_fields_loop(S, Fields, none)
+    ;
+        maplist([field(Name, Type, Default, Props)]>>(
+            format(S, "security_profile_field(~q, ~q, ~q, ~q).~n",
+                   [Name, Type, Default, Props])
+        ), Fields)
+    ).
 
 emit_profile_fields_loop(_, [], _).
 emit_profile_fields_loop(S, [field(Name, Type, Default, Props)|Rest], PrevLayer) :-
@@ -1495,6 +1506,20 @@ py_fragment_metadata(agent_loop_imports, [
     category(agent_loop), target(python),
     imports([bare(os), bare(sys), bare(json)])
 ]).
+py_fragment_metadata(security_proxy_module, [
+    category(security), target(python),
+    imports([bare(os), bare(re), bare(shlex), from(dataclasses, [dataclass, field])])
+]).
+py_fragment_metadata(security_path_proxy_module, [
+    category(security), target(python),
+    imports([bare(os), bare(stat), from(pathlib, ['Path']), from(dataclasses, [dataclass, field])])
+]).
+py_fragment_metadata(security_proot_sandbox_module, [
+    category(security), target(python),
+    imports([bare(os), bare(shlex), bare(shutil), from(dataclasses, [dataclass, field]), from(pathlib, ['Path'])])
+]).
+py_fragment_metadata(aliases_class_header, [category(aliases), target(python), imports([])]).
+py_fragment_metadata(aliases_class_footer, [category(aliases), target(python), imports([])]).
 
 %% fragment_imports(+FragmentName, -ImportSpecs)
 %% Get the import specs for a named fragment.
@@ -1518,6 +1543,22 @@ generator_fragments(tools, [tools_handler_class_body, tools_security_config,
                             tools_validate_path, tools_is_command_blocked]).
 generator_fragments(config, [config_resolve_api_key_header, config_load_config]).
 generator_fragments(context, [context_manager_class, context_helpers]).
+generator_fragments(security_audit, [security_audit_module]).
+generator_fragments(security_proxy, [security_proxy_module]).
+generator_fragments(security_path_proxy, [security_path_proxy_module]).
+generator_fragments(security_proot, [security_proot_sandbox_module]).
+generator_fragments(aliases, [aliases_class_header, aliases_class_footer]).
+generator_fragments(agent_loop_main, [
+    handler_iterations_command, handler_backend_command,
+    handler_save_command, handler_load_command,
+    handler_sessions_command, handler_format_command,
+    handler_export_command, handler_cost_command,
+    handler_search_command, handler_stream_command,
+    handler_aliases_command, handler_templates_command,
+    handler_history_command, handler_undo_command,
+    handler_delete_command, handler_edit_command,
+    handler_replay_command
+]).
 
 %% derive_fragment_imports(+Generator, -DerivedImports)
 %% Collects all import specs from a generator's fragments and deduplicates.
@@ -1571,6 +1612,46 @@ emit_config_section(S, default_presets, Options) :-
         findall(N-B-P, agent_loop_module:default_agent_preset(N, B, P), Presets),
         maplist([N-B-P]>>(format(S, "default_agent_preset(~q, ~q, ~q).~n", [N, B, P])), Presets)
     ).
+
+%% ============================================================================
+%% Prolog Module Header Emission
+%% ============================================================================
+
+%% emit_prolog_module_header(+Stream, +Module, +Options)
+%% Emit a Prolog module declaration with exports and use_module directives.
+%% Options: exports(List), use_modules(List)
+emit_prolog_module_header(S, Module, Options) :-
+    (member(exports(Exports), Options) ->
+        format(S, ':- module(~w, [~n', [Module]),
+        length(Exports, Len),
+        emit_module_export_list(S, Exports, 1, Len),
+        write(S, ']).\n\n')
+    ; true),
+    (member(use_modules(UseMods), Options) ->
+        maplist([UM]>>(format(S, ':- use_module(~w).~n', [UM])), UseMods),
+        nl(S)
+    ; true).
+
+emit_module_export_list(_, [], _, _).
+emit_module_export_list(S, [E], I, I) :-
+    format(S, '    ~w~n', [E]).
+emit_module_export_list(S, [E|Rest], Pos, Len) :-
+    Rest \= [],
+    format(S, '    ~w,~n', [E]),
+    Pos1 is Pos + 1,
+    emit_module_export_list(S, Rest, Pos1, Len).
+
+%% emit_prolog_declarations(+Stream, +Options)
+%% Emit Prolog declaration directives (det, dynamic).
+%% Options: det(List), dynamic(List)
+emit_prolog_declarations(S, Options) :-
+    (member(det(Dets), Options) ->
+        maplist([D]>>(format(S, ':- det(~w).~n', [D])), Dets),
+        nl(S)
+    ; true),
+    (member(dynamic(Dyns), Options) ->
+        maplist([D]>>(format(S, ':- dynamic ~w.~n', [D])), Dyns)
+    ; true).
 
 %% ============================================================================
 %% Unified Component Emission

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -368,6 +368,17 @@ regex_list(paranoid_confirm, [
     "r'^node\\s+[^-].*\\.js$'"
 ]).
 
+%% regex_list_variable(+PrologName, +PythonVariable)
+%% Declarative mapping from Prolog regex_list names to Python variable names.
+regex_list_variable(guarded_extra_blocks, '_GUARDED_EXTRA_BLOCKS').
+regex_list_variable(paranoid_safe, '_PARANOID_SAFE').
+regex_list_variable(paranoid_confirm, '_PARANOID_CONFIRM').
+regex_list_variable(paranoid_allowed, '_PARANOID_ALLOWED').
+
+%% regex_list_combined(+PythonVariable, +Source1, +Source2)
+%% Declares a combined Python variable as the concatenation of two regex list variables.
+regex_list_combined('_PARANOID_ALLOWED', '_PARANOID_SAFE', '_PARANOID_CONFIRM').
+
 %% =============================================================================
 %% Model Pricing Definitions
 %% =============================================================================
@@ -1510,23 +1521,20 @@ generate_prolog_security :-
     output_path(prolog, 'security.pl', Path),
     open(Path, write, S),
     write_prolog_header(S, security, 'Security profiles and path/command validation'),
-    write(S, ':- module(security, [\n'),
-    write(S, '    security_profile/2,\n'),
-    write(S, '    blocked_path/1,\n'),
-    write(S, '    blocked_path_prefix/1,\n'),
-    write(S, '    blocked_home_pattern/1,\n'),
-    write(S, '    blocked_command_pattern/2,\n'),
-    write(S, '    is_path_blocked/1,\n'),
-    write(S, '    is_command_blocked/2,\n'),
-    write(S, '    check_path_allowed/2,\n'),
-    write(S, '    check_command_allowed/2,\n'),
-    write(S, '    set_security_profile/1\n'),
-    write(S, ']).\n\n'),
-    write(S, ':- use_module(library(pcre)).\n\n'),
+    agent_loop_components:emit_prolog_module_header(S, security, [
+        exports([
+            security_profile/2, blocked_path/1, blocked_path_prefix/1,
+            blocked_home_pattern/1, blocked_command_pattern/2,
+            is_path_blocked/1, is_command_blocked/2,
+            check_path_allowed/2, check_command_allowed/2,
+            set_security_profile/1
+        ]),
+        use_modules([library(pcre)])
+    ]),
     agent_loop_components:emit_module_dependencies(S, [module(security)]),
-    write(S, ':- det(check_path_allowed/2).\n'),
-    write(S, ':- det(check_command_allowed/2).\n'),
-    write(S, ':- det(set_security_profile/1).\n\n'),
+    agent_loop_components:emit_prolog_declarations(S, [
+        det([check_path_allowed/2, check_command_allowed/2, set_security_profile/1])
+    ]),
     write(S, ':- dynamic current_security_profile/1.\n'),
     write(S, 'current_security_profile(cautious).\n\n'),
     %% Emit security facts via component registry
@@ -3018,14 +3026,18 @@ generate_security_profiles :-
     write(S, '\n\n'),
     %% Regex lists
     write(S, '# ── Built-in profiles ─────────────────────────────────────────────────────\n\n'),
-    generate_regex_list_py(S, guarded_extra_blocks, '_GUARDED_EXTRA_BLOCKS'),
-    write(S, '\n'),
-    generate_regex_list_py(S, paranoid_safe, '_PARANOID_SAFE'),
-    write(S, '\n'),
-    generate_regex_list_py(S, paranoid_confirm, '_PARANOID_CONFIRM'),
-    write(S, '\n'),
-    write(S, '# Combined allowlist (safe + confirm)\n'),
-    write(S, '_PARANOID_ALLOWED = _PARANOID_SAFE + _PARANOID_CONFIRM\n\n\n'),
+    %% Emit regex lists — data-driven from regex_list_variable/2 facts
+    findall(LN-PV, (regex_list_variable(LN, PV), regex_list(LN, _)), RLVars),
+    maplist([LN-PV]>>(
+        generate_regex_list_py(S, LN, PV),
+        write(S, '\n')
+    ), RLVars),
+    %% Emit combined regex list variables
+    findall(combo(CV, Src1, Src2), regex_list_combined(CV, Src1, Src2), Combos),
+    maplist([combo(CV, Src1, Src2)]>>(
+        write(S, '# Combined allowlist (safe + confirm)\n'),
+        format(S, '~w = ~w + ~w~n~n~n', [CV, Src1, Src2])
+    ), Combos),
     %% get_builtin_profiles()
     write(S, 'def get_builtin_profiles() -> dict[str, SecurityProfile]:\n'),
     write(S, '    """Return all built-in security profiles."""\n'),
@@ -3080,13 +3092,9 @@ emit_profile_field_value(S, FieldName, 'str', Value) :-
 emit_profile_field_value(S, FieldName, 'int | None', Value) :-
     format(S, '            ~w=~w,~n', [FieldName, Value]).
 emit_profile_field_value(S, FieldName, 'list[str]', Value) :-
-    %% List fields reference named regex list variables
-    (Value = guarded_extra_blocks ->
-        format(S, '            ~w=list(_GUARDED_EXTRA_BLOCKS),~n', [FieldName])
-    ; Value = paranoid_allowed ->
-        format(S, '            ~w=list(_PARANOID_ALLOWED),~n', [FieldName])
-    ; Value = paranoid_safe ->
-        format(S, '            ~w=list(_PARANOID_SAFE),~n', [FieldName])
+    %% List fields — look up Python variable name from declarative facts
+    (regex_list_variable(Value, PyVar) ->
+        format(S, '            ~w=list(~w),~n', [FieldName, PyVar])
     ;
         format(S, '            ~w=~w,~n', [FieldName, Value])
     ).
@@ -3365,12 +3373,12 @@ generate_config :-
     write_py(S, config_resolve_api_key_header),
     %% Generate env_vars dict from api_key_env_var/2 facts
     write(S, '    env_vars = {\n'),
-    agent_loop_components:emit_api_key_env_vars_py(S, [target(python)]),
+    agent_loop_components:emit_config_section(S, api_key_env_vars, [target(python)]),
     write(S, '    }\n'),
     write_py(S, config_resolve_api_key_middle),
     %% Generate file_locations dict from api_key_file/2 facts
     write(S, '    file_locations = {\n'),
-    agent_loop_components:emit_api_key_files_py(S, [target(python)]),
+    agent_loop_components:emit_config_section(S, api_key_files, [target(python)]),
     write(S, '    }\n'),
     write_py(S, config_resolve_api_key_footer),
     write(S, '\n'),
@@ -3409,7 +3417,7 @@ generate_config :-
     write(S, 'def get_default_config() -> Config:\n'),
     write(S, '    """Get a default configuration with common presets."""\n'),
     write(S, '    config = Config()\n\n'),
-    agent_loop_components:emit_default_presets_py(S, [target(python)]),
+    agent_loop_components:emit_config_section(S, default_presets, [target(python)]),
     write(S, '    return config\n\n\n'),
     %% save_example_config (generated from example_agent_config/3 facts)
     generate_config_save_example(S),

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -136,6 +136,16 @@ run_tests :-
     test_validate_generator_imports,
     test_emit_config_section,
     test_backends_init_export_roundtrip,
+    test_regex_list_variable_facts,
+    test_regex_list_combined_facts,
+    test_regex_list_in_field_value,
+    test_generator_fragments_security,
+    test_generator_fragments_aliases,
+    test_generator_fragments_agent_loop_main,
+    test_emit_security_profile_fields_prolog,
+    test_emit_prolog_module_header,
+    test_emit_prolog_declarations,
+    test_config_section_wiring,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -2376,3 +2386,153 @@ test_backends_init_export_roundtrip :-
         sub_atom(Output, _, _, _, 'AgentBackend')),
     assert_true('has CoroBackend in output',
         sub_atom(Output, _, _, _, 'CoroBackend')).
+
+%% ============================================================================
+%% Wire-Generalize Tests
+%% ============================================================================
+
+test_regex_list_variable_facts :-
+    format("~nregex_list_variable facts:~n"),
+    assert_true('guarded_extra_blocks mapped',
+        agent_loop_module:regex_list_variable(guarded_extra_blocks, '_GUARDED_EXTRA_BLOCKS')),
+    assert_true('paranoid_safe mapped',
+        agent_loop_module:regex_list_variable(paranoid_safe, '_PARANOID_SAFE')),
+    assert_true('paranoid_confirm mapped',
+        agent_loop_module:regex_list_variable(paranoid_confirm, '_PARANOID_CONFIRM')),
+    assert_true('paranoid_allowed mapped',
+        agent_loop_module:regex_list_variable(paranoid_allowed, '_PARANOID_ALLOWED')),
+    aggregate_all(count, agent_loop_module:regex_list_variable(_, _), Count),
+    assert_true('exactly 4 facts', Count =:= 4).
+
+test_regex_list_combined_facts :-
+    format("~nregex_list_combined facts:~n"),
+    assert_true('paranoid_allowed is combined',
+        agent_loop_module:regex_list_combined('_PARANOID_ALLOWED', '_PARANOID_SAFE', '_PARANOID_CONFIRM')),
+    aggregate_all(count, agent_loop_module:regex_list_combined(_, _, _), CCount),
+    assert_true('exactly 1 combined fact', CCount =:= 1).
+
+test_regex_list_in_field_value :-
+    format("~nregex_list_in_field_value:~n"),
+    %% Test that emit_profile_field_value uses regex_list_variable lookup
+    new_memory_file(MF1), open_memory_file(MF1, write, S1),
+    agent_loop_module:emit_profile_field_value(S1, blocked_commands, 'list[str]', guarded_extra_blocks),
+    close(S1), memory_file_to_atom(MF1, Out1), free_memory_file(MF1),
+    assert_true('guarded maps to _GUARDED_EXTRA_BLOCKS',
+        sub_atom(Out1, _, _, _, '_GUARDED_EXTRA_BLOCKS')),
+    new_memory_file(MF2), open_memory_file(MF2, write, S2),
+    agent_loop_module:emit_profile_field_value(S2, allowed_commands, 'list[str]', paranoid_allowed),
+    close(S2), memory_file_to_atom(MF2, Out2), free_memory_file(MF2),
+    assert_true('paranoid_allowed maps to _PARANOID_ALLOWED',
+        sub_atom(Out2, _, _, _, '_PARANOID_ALLOWED')),
+    new_memory_file(MF3), open_memory_file(MF3, write, S3),
+    agent_loop_module:emit_profile_field_value(S3, test_field, 'list[str]', unknown_list),
+    close(S3), memory_file_to_atom(MF3, Out3), free_memory_file(MF3),
+    assert_true('unknown falls through',
+        sub_atom(Out3, _, _, _, 'unknown_list')).
+
+test_generator_fragments_security :-
+    format("~ngenerator_fragments security:~n"),
+    assert_true('security_audit has fragments',
+        agent_loop_components:generator_fragments(security_audit, _)),
+    assert_true('security_proxy has fragments',
+        agent_loop_components:generator_fragments(security_proxy, _)),
+    assert_true('security_path_proxy has fragments',
+        agent_loop_components:generator_fragments(security_path_proxy, _)),
+    %% Verify all fragment names are real py_fragment/2 facts
+    agent_loop_components:generator_fragments(security_proot, PrFrags),
+    assert_true('security_proot fragments are real py_fragments',
+        forall(member(F, PrFrags), agent_loop_module:py_fragment(F, _))).
+
+test_generator_fragments_aliases :-
+    format("~ngenerator_fragments aliases:~n"),
+    agent_loop_components:generator_fragments(aliases, AFrags),
+    assert_true('aliases has 2 fragments', length(AFrags, 2)),
+    assert_true('aliases has header', member(aliases_class_header, AFrags)),
+    assert_true('aliases has footer', member(aliases_class_footer, AFrags)).
+
+test_generator_fragments_agent_loop_main :-
+    format("~ngenerator_fragments agent_loop_main:~n"),
+    agent_loop_components:generator_fragments(agent_loop_main, MainFrags),
+    length(MainFrags, MainLen),
+    assert_true('agent_loop_main has >= 15 fragments', MainLen >= 15),
+    assert_true('has handler_backend_command',
+        member(handler_backend_command, MainFrags)),
+    %% Verify all are real py_fragment/2 facts
+    assert_true('all main fragments are real py_fragments',
+        forall(member(F, MainFrags), agent_loop_module:py_fragment(F, _))).
+
+test_emit_security_profile_fields_prolog :-
+    format("~nemit_security_profile_fields prolog:~n"),
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:emit_security_profile_fields(S, [target(prolog)]),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('prolog has security_profile_field(name',
+        sub_atom(Output, _, _, _, 'security_profile_field(name')),
+    assert_true('prolog has path_validation',
+        sub_atom(Output, _, _, _, 'path_validation')),
+    assert_true('no Python name: str in prolog output',
+        \+ sub_atom(Output, _, _, _, 'name: str')),
+    %% Count facts matches source
+    aggregate_all(count, agent_loop_module:security_profile_field(_, _, _, _), SrcCount),
+    findall(1, sub_atom(Output, _, _, _, 'security_profile_field('), Ones),
+    length(Ones, OutCount),
+    assert_true('prolog fact count matches source', SrcCount =:= OutCount).
+
+test_emit_prolog_module_header :-
+    format("~nemit_prolog_module_header:~n"),
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:emit_prolog_module_header(S, test_mod, [
+        exports([foo/1, bar/2, baz/3]),
+        use_modules([library(lists)])
+    ]),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('has module declaration',
+        sub_atom(Output, _, _, _, ':- module(test_mod')),
+    assert_true('has foo/1 export',
+        sub_atom(Output, _, _, _, 'foo/1')),
+    assert_true('last export has no comma (baz/3 then newline)',
+        sub_atom(Output, _, _, _, '    baz/3\n')),
+    assert_true('has use_module',
+        sub_atom(Output, _, _, _, ':- use_module(library(lists))')).
+
+test_emit_prolog_declarations :-
+    format("~nemit_prolog_declarations:~n"),
+    new_memory_file(MF), open_memory_file(MF, write, S),
+    agent_loop_components:emit_prolog_declarations(S, [
+        det([check_foo/2, check_bar/1]),
+        dynamic([current_state/1])
+    ]),
+    close(S), memory_file_to_atom(MF, Output), free_memory_file(MF),
+    assert_true('has det directive',
+        sub_atom(Output, _, _, _, ':- det(check_foo/2)')),
+    assert_true('has dynamic directive',
+        sub_atom(Output, _, _, _, ':- dynamic current_state/1')),
+    assert_true('has check_bar det',
+        sub_atom(Output, _, _, _, ':- det(check_bar/1)')).
+
+test_config_section_wiring :-
+    format("~nconfig_section_wiring:~n"),
+    %% Verify emit_config_section(python) produces same as direct _py call
+    new_memory_file(MF1), open_memory_file(MF1, write, S1),
+    agent_loop_components:emit_api_key_env_vars_py(S1, [target(python)]),
+    close(S1), memory_file_to_atom(MF1, Direct), free_memory_file(MF1),
+    new_memory_file(MF2), open_memory_file(MF2, write, S2),
+    agent_loop_components:emit_config_section(S2, api_key_env_vars, [target(python)]),
+    close(S2), memory_file_to_atom(MF2, Via), free_memory_file(MF2),
+    assert_true('api_key_env_vars: section matches direct', Direct == Via),
+    %% api_key_files
+    new_memory_file(MF3), open_memory_file(MF3, write, S3),
+    agent_loop_components:emit_api_key_files_py(S3, [target(python)]),
+    close(S3), memory_file_to_atom(MF3, Direct2), free_memory_file(MF3),
+    new_memory_file(MF4), open_memory_file(MF4, write, S4),
+    agent_loop_components:emit_config_section(S4, api_key_files, [target(python)]),
+    close(S4), memory_file_to_atom(MF4, Via2), free_memory_file(MF4),
+    assert_true('api_key_files: section matches direct', Direct2 == Via2),
+    %% default_presets
+    new_memory_file(MF5), open_memory_file(MF5, write, S5),
+    agent_loop_components:emit_default_presets_py(S5, [target(python)]),
+    close(S5), memory_file_to_atom(MF5, Direct3), free_memory_file(MF5),
+    new_memory_file(MF6), open_memory_file(MF6, write, S6),
+    agent_loop_components:emit_config_section(S6, default_presets, [target(python)]),
+    close(S6), memory_file_to_atom(MF6, Via3), free_memory_file(MF6),
+    assert_true('default_presets: section matches direct', Direct3 == Via3).


### PR DESCRIPTION
Continues the declarative generalization push by wiring existing infrastructure into generators and expanding coverage. All changes preserve bit-for-bit identical generated output. 5 items implemented.

### Changes

#### 1. `regex_list_variable/2` + `regex_list_combined/3` facts (`agent_loop_module.pl`)
- 4 `regex_list_variable/2` facts mapping Prolog names to Python variable names (`guarded_extra_blocks` → `_GUARDED_EXTRA_BLOCKS`, etc.)
- 1 `regex_list_combined/3` fact for `_PARANOID_ALLOWED = _PARANOID_SAFE + _PARANOID_CONFIRM`
- Simplified `emit_profile_field_value/4` for `list[str]` — replaced 3-branch hardcoded matching with single `regex_list_variable` lookup

#### 2. Wire `emit_config_section/3` into `generate_config` + refactor regex list emission (`agent_loop_module.pl`)
- Replaced 3 direct `emit_api_key_env_vars_py`/`emit_api_key_files_py`/`emit_default_presets_py` calls with `emit_config_section` (target-polymorphic)
- Replaced 4 manual `generate_regex_list_py` calls + hardcoded combined list write with `findall + maplist` over `regex_list_variable/2` facts

#### 3. Expanded `generator_fragments/2` + `py_fragment_metadata/2` (`agent_loop_components.pl`)
- 6 new `generator_fragments/2` clauses: `security_audit`, `security_proxy`, `security_path_proxy`, `security_proot`, `aliases`, `agent_loop_main` (17 handler fragments)
- Total generators with fragment mappings: **9** (was 3)
- 5 new `py_fragment_metadata/2` entries with accurate import specs

#### 4. Target-polymorphic `emit_security_profile_fields/2` (`agent_loop_components.pl`)
- Now uses `extract_target(Options, Target)` instead of ignoring options
- Python path unchanged (dataclass fields with layer grouping)
- New Prolog path emits `security_profile_field/4` facts
- Not wired into any Prolog generator yet (preserves output)

#### 5. `emit_prolog_module_header/3` + `emit_prolog_declarations/2` (`agent_loop_components.pl` + `agent_loop_module.pl`)
- `emit_prolog_module_header/3` — emits `:- module(Name, [exports...]).` + `:- use_module(...)` with correct trailing comma handling
- `emit_prolog_declarations/2` — emits `:- det(...)` and `:- dynamic ...` directives
- Wired into `generate_prolog_security`, replacing **~15 hardcoded write calls**
- Helper `emit_module_export_list/4` handles last-element-no-comma formatting

### Tests

| Category | New Predicates | New Assertions |
|----------|---------------|----------------|
| regex_list_variable facts | 1 | 5 |
| regex_list_combined facts | 1 | 2 |
| regex_list in field value | 1 | 3 |
| generator_fragments security | 1 | 4 |
| generator_fragments aliases | 1 | 3 |
| generator_fragments agent_loop_main | 1 | 3 |
| emit_security_profile_fields prolog | 1 | 4 |
| emit_prolog_module_header | 1 | 4 |
| emit_prolog_declarations | 1 | 3 |
| config_section_wiring | 1 | 3 |
| **Total new** | **10** | **34** |

### Test results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit | 358 | all pass |
| Prolog integration | 27 | all pass |
| Python integration | 59 | all pass |
| **Total** | **444** | **0 failures** |

### Output equivalence

All 4 key generated files verified bit-for-bit identical via md5sum:
- `generated/prolog/security.pl`
- `generated/python/security/profiles.py`
- `generated/python/config.py`
- `generated/python/backends/__init__.py`

### Files changed

| File | Lines | Summary |
|------|-------|---------|
| `agent_loop_components.pl` | +91/−0 | 6 generator_fragments, 5 py_fragment_metadata, target-polymorphic emit_security_profile_fields, emit_prolog_module_header/3, emit_prolog_declarations/2 |
| `agent_loop_module.pl` | +37/−39 | regex_list_variable/2 + regex_list_combined/3 facts, wire emit_config_section, refactor regex list emission, simplify emit_profile_field_value, refactor generate_prolog_security |
| `test_agent_loop.pl` | +160/−0 | 10 new test predicates, 34 assertions |

### Previous PRs

Builds on PR #750 (`feat/agent-loop-composable-gen`). Test count progression: 218 → 236 → 259 → 282 → 311 → 340 → 377 → 410 → **444**.
