### PR TITLE
fix(r-target): add CLI main blocks to tail and linear recursion R Templates…

### DIFF
--- a/src/unifyweaver/targets/r_target.pl
+++ b/src/unifyweaver/targets/r_target.pl
@@ -657,6 +657,15 @@ tail_ternary_loop_r(PredStr, _AccPos, StepOp, RCode) :-
         "}",
         "{{pred}}_eval <- function(input) {",
         "    return({{pred}}(input, 0))",
+        "}",
+        "",
+        "# Run when script executed directly",
+        "if (!interactive()) {",
+        "    args <- commandArgs(TRUE)",
+        "    if (length(args) >= 1) {",
+        "        items <- as.numeric(unlist(strsplit(args[1], \",\")))",
+        "        cat({{pred}}_eval(items), \"\\n\")",
+        "    }",
         "}"
     ],
     atomic_list_concat(TemplateLines, '\n', Template),
@@ -677,6 +686,15 @@ tail_binary_loop_r(PredStr, RCode) :-
         "        return(count == expected)",
         "    }",
         "    return(count)",
+        "}",
+        "",
+        "# Run when script executed directly",
+        "if (!interactive()) {",
+        "    args <- commandArgs(TRUE)",
+        "    if (length(args) >= 1) {",
+        "        items <- as.numeric(unlist(strsplit(args[1], \",\")))",
+        "        cat({{pred}}(items), \"\\n\")",
+        "    }",
         "}"
     ],
     atomic_list_concat(TemplateLines, '\n', Template),
@@ -987,7 +1005,13 @@ linear_numeric_fold_r(PredStr, BaseInput, BaseOutput, _FoldExpr, MemoEnabled, Me
         return(result)
     }
 }
-', [PredStr, MemoDecl, PredStr, RFoldOp, PredStr, MemoCheckCode, BaseInput, BaseOutput, MemoStoreCode, PredStr, BaseOutput, MemoStoreCode]).
+
+# Run when script executed directly
+if (!interactive()) {
+    args <- commandArgs(TRUE)
+    if (length(args) >= 1) cat(~w(as.integer(args[1])), "\\n")
+}
+', [PredStr, MemoDecl, PredStr, RFoldOp, PredStr, MemoCheckCode, BaseInput, BaseOutput, MemoStoreCode, PredStr, BaseOutput, MemoStoreCode, PredStr]).
 
 %% linear_list_fold_r(+PredStr, +BaseInput, +BaseOutput, +_FoldExpr, +MemoEnabled, +MemoStrategy, -RCode)
 linear_list_fold_r(PredStr, BaseInput, BaseOutput, _FoldExpr, MemoEnabled, MemoStrategy, RCode) :-
@@ -1049,7 +1073,16 @@ linear_list_fold_r(PredStr, BaseInput, BaseOutput, _FoldExpr, MemoEnabled, MemoS
         return(result)
     }
 }
-', [PredStr, MemoDecl, PredStr, RFoldOp, PredStr, MemoCheckCode, BaseInput, BaseOutput, MemoStoreCode, PredStr, BaseOutput, MemoStoreCode]).
+
+# Run when script executed directly
+if (!interactive()) {
+    args <- commandArgs(TRUE)
+    if (length(args) >= 1) {
+        items <- as.numeric(unlist(strsplit(args[1], ",")))
+        cat(~w(items), "\\n")
+    }
+}
+', [PredStr, MemoDecl, PredStr, RFoldOp, PredStr, MemoCheckCode, BaseInput, BaseOutput, MemoStoreCode, PredStr, BaseOutput, MemoStoreCode, PredStr]).
 
 %% linear_generic_r(+PredStr, +Arity, +BaseClauses, +RecClauses, +MemoEnabled, +MemoStrategy, -RCode)
 linear_generic_r(PredStr, Arity, _BaseClauses, _RecClauses, MemoEnabled, _MemoStrategy, RCode) :-


### PR DESCRIPTION
## Summary

- Add `if (!interactive())` main blocks to 4 R templates that were missing them: tail ternary, tail binary, linear numeric fold, and linear list fold
- Generated R scripts (e.g., `factorial.R`, `sum_list.R`, `count_items.R`) can now be run directly with `Rscript <file> <args>` instead of requiring `source()` and manual function calls

## Before

```
$ Rscript output/advanced/factorial.R 6
(no output)

$ Rscript -e "source('output/advanced/factorial.R'); cat(factorial(6), '\n')"
720
```

## After

```
$ Rscript output/advanced/factorial.R 6
720

$ Rscript output/advanced/sum_list.R 1,2,3,4,5
15

$ Rscript output/advanced/count_items.R 10,20,30
3
```

## Test plan

- [x] `factorial.R 6` → 720
- [x] `sum_list.R 1,2,3,4,5` → 15
- [x] `count_items.R 10,20,30` → 3
- [x] `list_length.R 1,2,3,4` → 4
- [x] Existing scripts unaffected: tree_sum→6, even_odd→TRUE, fib_multicall(10)→55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
.