### PR TITLE
fix(direct-multi-call): implement and fix `direct_multi_call_recursion` Module

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ Orchestrates the compilation of complex recursion patterns. It uses a priority-b
          │                            ▼
          │                  ┌───────────────────────────┐
          │                  │   Try Advanced Patterns   │
-         │                  │  (tail -> linear -> mutual) │
+         │                  │  (tail -> linear -> multicall -> direct_multi_call -> fold -> tree -> mutual) │
          │                  └───────────┬───────────────┘
          │                              │
          └───────────────┬──────────────┘
@@ -147,7 +147,7 @@ Orchestrates the compilation of complex recursion patterns. It uses a priority-b
     *   If the predicate is **non-recursive**, it is handed off to the `stream_compiler`.
     *   If the predicate is **recursive**, it is passed to the `advanced_recursive_compiler`.
 
-8.  **Advanced Pattern Matching:** The advanced compiler attempts to match the predicate against its known patterns in order of specificity: tail recursion, then linear recursion, then mutual recursion (by detecting Strongly Connected Components).
+8.  **Advanced Pattern Matching:** The advanced compiler attempts to match the predicate against its known patterns in priority order: tail recursion, linear recursion, multi-call linear recursion, direct multi-call recursion (clause-analysis approach), fold pattern, tree recursion, and finally mutual recursion (via SCC detection).
 
 9.  **Constraint Analysis:** The compiler queries the `constraint_analyzer` to fetch any constraints for the predicate (e.g. `unique(true)`).
 

--- a/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
+++ b/src/unifyweaver/core/advanced/advanced_recursive_compiler.pl
@@ -27,6 +27,7 @@
 :- use_module('multicall_linear_recursion').
 :- use_module('tree_recursion').
 :- use_module('mutual_recursion').
+:- use_module('direct_multi_call_recursion').
 :- use_module('fold_helper_generator').
 
 %% compile_advanced_recursive(+Pred/Arity, +Options, -BashCode)
@@ -46,6 +47,8 @@ compile_advanced_recursive(Pred/Arity, Options, BashCode) :-
         format('✓ Compiled as linear recursion~n')
     ;   try_multicall_linear_recursion(Pred/Arity, Options, BashCode) ->
         format('✓ Compiled as multi-call linear recursion~n')
+    ;   try_direct_multi_call(Pred/Arity, Options, BashCode) ->
+        format('✓ Compiled as direct multi-call recursion~n')
     ;   try_fold_pattern(Pred/Arity, Options, BashCode) ->
         format('✓ Compiled as fold pattern~n')
     ;   try_tree_recursion(Pred/Arity, Options, BashCode) ->
@@ -80,6 +83,14 @@ try_multicall_linear_recursion(Pred/Arity, Options, BashCode) :-
     can_compile_multicall_linear(Pred/Arity),
     !,
     compile_multicall_linear_recursion(Pred/Arity, Options, BashCode).
+
+%% try_direct_multi_call(+Pred/Arity, +Options, -Code)
+%  Attempt to compile as direct multi-call recursion (clause-analysis approach)
+try_direct_multi_call(Pred/Arity, Options, Code) :-
+    format('  Trying direct multi-call recursion pattern...~n'),
+    can_compile_direct_multi_call(Pred/Arity),
+    !,
+    compile_direct_multi_call(Pred/Arity, Options, Code).
 
 %% try_fold_pattern(+Pred/Arity, +Options, -BashCode)
 %  Attempt to compile as fold pattern (tree recursion with fold helpers)

--- a/src/unifyweaver/core/advanced/direct_multi_call_recursion.pl
+++ b/src/unifyweaver/core/advanced/direct_multi_call_recursion.pl
@@ -21,13 +21,32 @@
 %% compile_direct_multicall_pattern(+Target, +PredStr, +BaseClauses, +RecClause, -Code)
 :- multifile compile_direct_multicall_pattern/5.
 
+%% get_recursive_call_count(+Pred/Arity, -MaxCount)
+%  Count max recursive calls per clause for a predicate
+get_recursive_call_count(Pred/Arity, MaxCount) :-
+    functor(Head, Pred, Arity),
+    findall(Count,
+        (user:clause(Head, Body),
+         contains_call_to(Body, Pred),
+         count_recursive_calls(Body, Pred, Count)),
+        Counts),
+    (Counts = [] -> MaxCount = 0 ; max_list(Counts, MaxCount)).
+
+%% get_multi_call_info(+Pred/Arity, -Info)
+%  Gather multi-call analysis info. Only Count is currently used.
+get_multi_call_info(Pred/Arity, multi_call(Count, true, true, true)) :-
+    get_recursive_call_count(Pred/Arity, Count).
+
 %% can_compile_direct_multi_call(+Pred/Arity)
 %  Check if predicate can be compiled as direct multi-call recursion
 can_compile_direct_multi_call(Pred/Arity) :-
-    % Must be linear recursive streamable (includes multi-call check)
-    is_linear_recursive_streamable(Pred/Arity),
-    % Must have 2+ recursive calls
-    get_recursive_call_count(Pred/Arity, Count),
+    Arity =:= 2,
+    functor(Head, Pred, Arity),
+    findall(clause(Head, Body), user:clause(Head, Body), Clauses),
+    % Must have at least one recursive clause with 2+ calls
+    member(clause(_, RecBody), Clauses),
+    contains_call_to(RecBody, Pred),
+    count_recursive_calls(RecBody, Pred, Count),
     Count >= 2.
 
 %% compile_direct_multi_call(+Pred/Arity, +Options, -BashCode)
@@ -85,6 +104,7 @@ generate_direct_binary_bash(PredStr, BaseClauses, RecClause, BashCode) :-
     extract_base_cases(BaseClauses, PredStr, BaseCasesCode),
 
     % Extract recursive case structure
+    atom_string(Pred, PredStr),
     extract_recursive_case(RecClause, Pred, PredStr, RecursiveCaseCode),
 
     % Generate bash code
@@ -187,11 +207,32 @@ extract_recursive_case(clause(Head, Body), Pred, PredStr, BashCode) :-
 
 %% extract_body_components(+Body, +Pred, -Computations, -RecCalls, -Aggregation)
 %  Parse body into: argument computations, recursive calls, result aggregation
+%  The aggregation is the `_ is _` goal whose expression references output
+%  variables from recursive calls (e.g., F is F1 + F2 where F1, F2 are
+%  bound by fib(N1, F1), fib(N2, F2)).
 extract_body_components(Body, Pred, Computations, RecCalls, Aggregation) :-
     extract_goals_ordered(Body, Goals),
-    partition(is_computation, Goals, Computations, Rest1),
-    partition(is_recursive_call(Pred), Rest1, RecCalls, Rest2),
-    (   Rest2 = [Aggregation|_] -> true ; Aggregation = true).
+    % First identify recursive calls
+    partition(is_recursive_call(Pred), Goals, RecCalls, NonRecGoals),
+    % Separate is-goals from conditions/guards
+    partition(is_computation, NonRecGoals, IsGoals, _Conditions),
+    % Among is-goals, find the aggregation: the one whose expression
+    % references an output variable from a recursive call (by identity).
+    % NOTE: We check directly against RecCalls rather than using findall,
+    % because findall copies variables and breaks identity (==) checks.
+    (   select(AggGoal, IsGoals, CompGoals),
+        AggGoal = (_ is AggExpr),
+        term_variables(AggExpr, ExprVars),
+        member(EV, ExprVars),
+        member(Call, RecCalls),
+        Call =.. [_|CallArgs],
+        last(CallArgs, OutVar),
+        EV == OutVar
+    ->  Aggregation = AggGoal,
+        Computations = CompGoals
+    ;   Computations = IsGoals,
+        Aggregation = true
+    ).
 
 is_computation(_ is _).
 
@@ -243,6 +284,12 @@ translate_expr_to_bash(N - 2, '$(($input - 2))') :- var(N), !.
 translate_expr_to_bash(N - 3, '$(($input - 3))') :- var(N), !.
 translate_expr_to_bash(N - K, BashExpr) :- var(N), integer(K), !,
     format(string(BashExpr), '$(($input - ~w))', [K]).
+% SWI-Prolog stores N-K as N+(-K) in clause database, so handle N+K too
+translate_expr_to_bash(N + K, BashExpr) :- var(N), integer(K), K < 0, !,
+    AbsK is abs(K),
+    format(string(BashExpr), '$(($input - ~w))', [AbsK]).
+translate_expr_to_bash(N + K, BashExpr) :- var(N), integer(K), !,
+    format(string(BashExpr), '$(($input + ~w))', [K]).
 translate_expr_to_bash(Expr, '$(($input))') :- var(Expr), !.
 
 %% generate_recursive_calls_bash(+RecCalls, +PredStr, -BashCode)
@@ -278,10 +325,53 @@ translate_aggregation_expr(A + B + C, BashExpr) :-
 test_direct_multi_call :-
     format('~n=== Testing Direct Multi-Call Compilation ===~n', []),
 
-    % Test fibonacci
-    (   can_compile_direct_multi_call(fib/2) ->
-        format('✓ fib/2 can use direct multi-call~n', [])
-    ;   format('✗ fib/2 cannot use direct multi-call~n', [])
+    % Setup output directory
+    (   exists_directory('output/advanced') -> true
+    ;   make_directory('output/advanced')
+    ),
+
+    % Clear test predicates
+    catch(abolish(test_dfib/2), _, true),
+
+    % Define fibonacci
+    assertz(user:test_dfib(0, 0)),
+    assertz(user:test_dfib(1, 1)),
+    assertz(user:(test_dfib(N, F) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        test_dfib(N1, F1),
+        test_dfib(N2, F2),
+        F is F1 + F2
+    )),
+
+    % Test 1: Detection
+    writeln('Test 1: Detect fibonacci as direct multi-call'),
+    (   can_compile_direct_multi_call(test_dfib/2) ->
+        writeln('  ✓ PASS - fibonacci detected')
+    ;   writeln('  ✗ FAIL - should detect fibonacci')
+    ),
+
+    % Test 2: Bash compilation
+    writeln('Test 2: Compile fibonacci to bash'),
+    (   compile_direct_multi_call(test_dfib/2, [target(bash)], BashCode) ->
+        write_output_file('output/advanced/fib_direct.sh', BashCode),
+        writeln('  ✓ Compiled to output/advanced/fib_direct.sh (bash)')
+    ;   writeln('  ✗ FAIL - bash compilation failed')
+    ),
+
+    % Test 3: R compilation
+    writeln('Test 3: Compile fibonacci to R'),
+    (   compile_direct_multi_call(test_dfib/2, [target(r)], RCode) ->
+        write_output_file('output/advanced/fib_direct.R', RCode),
+        writeln('  ✓ Compiled to output/advanced/fib_direct.R (r)')
+    ;   writeln('  ✗ FAIL - R compilation failed')
     ),
 
     format('~n=== Tests Complete ===~n', []).
+
+%% Helper to write output files
+write_output_file(Path, Content) :-
+    open(Path, write, Stream),
+    write(Stream, Content),
+    close(Stream).

--- a/src/unifyweaver/targets/r_target.pl
+++ b/src/unifyweaver/targets/r_target.pl
@@ -803,7 +803,7 @@ multicall_aggregation_r(_ + _ + _, 3, Code) :-
 
 direct_multi_call_recursion:compile_direct_multicall_pattern(r, PredStr, BaseClauses, RecClause, RCode) :-
     % Extract base cases for R
-    direct_extract_base_cases_r(BaseClauses, BaseCasesCode),
+    direct_extract_base_cases_r(BaseClauses, PredStr, BaseCasesCode),
 
     % Extract recursive case structure
     RecClause = clause(RecHead, RecBody),
@@ -853,15 +853,15 @@ if (!interactive()) {
     BaseCasesCode, ComputationsCode, RecCallsCode, AggregationCode,
     PredStr, PredStr]).
 
-%% direct_extract_base_cases_r(+BaseClauses, -RCode)
-direct_extract_base_cases_r(BaseClauses, RCode) :-
+%% direct_extract_base_cases_r(+BaseClauses, +PredStr, -RCode)
+direct_extract_base_cases_r(BaseClauses, PredStr, RCode) :-
     findall(BaseCode, (
         member(clause(Head, _Body), BaseClauses),
         Head =.. [_Pred, BaseInput, BaseOutput],
         format(string(BaseCode),
 '    # Base case: ~w -> ~w
     if (input == ~w) { ~w_memo[[key]] <<- ~w; return(~w) }',
-            [BaseInput, BaseOutput, BaseInput, '_direct', BaseOutput, BaseOutput])
+            [BaseInput, BaseOutput, BaseInput, PredStr, BaseOutput, BaseOutput])
     ), BaseCodes),
     atomic_list_concat(BaseCodes, '\n', RCode).
 
@@ -906,21 +906,40 @@ direct_translate_aggregation_expr_r(A * B, RExpr) :-
     format(string(RExpr), '~w * ~w', [AName, BName]).
 
 %% direct_var_to_r_name(+Var, -RName)
+%  Convert Prolog variable to valid R identifier.
+%  R identifiers must start with a letter or dot-not-followed-by-digit.
+%  Prolog internal var names like _G12345 become v12345 in R.
 direct_var_to_r_name(Var, RName) :-
     (   var(Var) ->
         term_string(Var, VarStr),
         atom_string(VarAtom, VarStr),
-        downcase_atom(VarAtom, RName)
+        downcase_atom(VarAtom, LowerName),
+        ensure_r_identifier(LowerName, RName)
     ;   atom(Var) ->
-        downcase_atom(Var, RName)
+        downcase_atom(Var, LowerName),
+        ensure_r_identifier(LowerName, RName)
     ;   term_string(Var, VarStr),
         atom_string(VarAtom, VarStr),
-        downcase_atom(VarAtom, RName)
+        downcase_atom(VarAtom, LowerName),
+        ensure_r_identifier(LowerName, RName)
+    ).
+
+%% ensure_r_identifier(+Name, -ValidName)
+%  Prefix with 'v' if name starts with underscore or digit (invalid in R)
+ensure_r_identifier(Name, ValidName) :-
+    atom_chars(Name, [First|Rest]),
+    (   (First = '_' ; char_type(First, digit)) ->
+        atom_chars(ValidName, [v|Rest])
+    ;   ValidName = Name
     ).
 
 %% direct_translate_expr_to_r(+Expr, -RExpr)
 direct_translate_expr_to_r(N - K, RExpr) :- var(N), integer(K), !,
     format(string(RExpr), 'input - ~w', [K]).
+% SWI-Prolog stores N-K as N+(-K) in clause database
+direct_translate_expr_to_r(N + K, RExpr) :- var(N), integer(K), K < 0, !,
+    AbsK is abs(K),
+    format(string(RExpr), 'input - ~w', [AbsK]).
 direct_translate_expr_to_r(N + K, RExpr) :- var(N), integer(K), !,
     format(string(RExpr), 'input + ~w', [K]).
 direct_translate_expr_to_r(Expr, 'input') :- var(Expr), !.


### PR DESCRIPTION
## Summary

- Fix 5 bugs in `direct_multi_call_recursion.pl` that prevented the module from working: missing predicates, broken detection logic, findall variable-copy bug in aggregation detection, singleton variable, and SWI-Prolog `N-1` → `N+(-1)` clause storage mismatch
- Fix 3 bugs in the R target's direct multicall section: hardcoded memo env name, missing negative-K expression handling, and invalid R identifiers starting with `_`
- Integrate the module into the `advanced_recursive_compiler.pl` pipeline as a new `try_direct_multi_call` step
- Update `ARCHITECTURE.md` with full compilation priority chain

## Before

```
$ swipl -g "direct_multi_call_recursion:test_direct_multi_call" -t halt
Test 1: Detect fibonacci as direct multi-call
  ✗ FAIL - should detect fibonacci
Test 2: Compile fibonacci to bash
  ✗ FAIL - bash compilation failed
Test 3: Compile fibonacci to R
  ✗ FAIL - R compilation failed
```

## After

```
$ swipl -g "direct_multi_call_recursion:test_direct_multi_call" -t halt
Test 1: Detect fibonacci as direct multi-call
  ✓ PASS - fibonacci detected
Test 2: Compile fibonacci to bash
  ✓ Compiled to output/advanced/fib_direct.sh (bash)
Test 3: Compile fibonacci to R
  ✓ Compiled to output/advanced/fib_direct.R (r)

$ Rscript output/advanced/fib_direct.R 10
55

$ Rscript output/advanced/fib_direct.R 20
6765
```

## Test plan

- [x] `fib_direct.R 0` → 0
- [x] `fib_direct.R 1` → 1
- [x] `fib_direct.R 7` → 13
- [x] `fib_direct.R 10` → 55
- [x] `fib_direct.R 20` → 6765
- [x] Existing scripts unaffected: `factorial.R 6` → 720, `sum_list.R 1,2,3,4,5` → 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
