### PR TITLE
Expand advanced recursion test coverage and fix F# mutual recursion bug

### DIFF
--- a/docs/ADVANCED_RECURSION.md
+++ b/docs/ADVANCED_RECURSION.md
@@ -15,8 +15,10 @@ The `advanced/` module extends UnifyWeaver's basic recursion support with sophis
 **Priority-Based Compilation**: Try simpler patterns before complex ones
 1. **Tail recursion** → Compile to iterative loops
 2. **Linear recursion** → Compile with memoization (handles 1+ independent calls)
-3. **Tree recursion** → Compile structural decomposition patterns
-4. **Mutual recursion** → Detect via SCC, compile with shared memo tables
+3. **Multi-call linear** → Multiple independent recursive calls (e.g., fibonacci)
+4. **Direct multi-call** → Direct recursive calls with memoization
+5. **Tree recursion** → Compile structural decomposition patterns
+6. **Mutual recursion** → Detect via SCC, compile with shared memo tables
 
 **Separation of Concerns**: Advanced patterns isolated from basic compiler
 - Basic recursion (transitive closures) stays in `recursive_compiler.pl`
@@ -27,15 +29,18 @@ The `advanced/` module extends UnifyWeaver's basic recursion support with sophis
 
 ```
 src/unifyweaver/core/advanced/
-├── advanced_recursive_compiler.pl   # Orchestrator (main entry point)
-├── call_graph.pl                   # Build predicate dependency graphs
-├── scc_detection.pl                # Tarjan's SCC algorithm
-├── pattern_matchers.pl             # Pattern detection utilities
-├── tail_recursion.pl               # Tail recursion → loop compiler
-├── linear_recursion.pl             # Linear recursion → memoized compiler
-├── tree_recursion.pl               # Tree recursion → structural compiler
-├── mutual_recursion.pl             # Mutual recursion → joint memo compiler
-└── test_advanced.pl                # Comprehensive test suite
+├── advanced_recursive_compiler.pl     # Orchestrator (main entry point)
+├── call_graph.pl                     # Build predicate dependency graphs
+├── scc_detection.pl                  # Tarjan's SCC algorithm
+├── pattern_matchers.pl               # Pattern detection utilities
+├── tail_recursion.pl                 # Tail recursion → loop compiler
+├── linear_recursion.pl               # Linear recursion → memoized compiler
+├── tree_recursion.pl                 # Tree recursion → structural compiler
+├── mutual_recursion.pl               # Mutual recursion → joint memo compiler
+├── multicall_linear_recursion.pl     # Multi-call linear (e.g., fibonacci)
+├── direct_multi_call_recursion.pl    # Direct multi-call with memoization
+├── test_advanced.pl                  # Test orchestrator (loads targets)
+└── test_runner_generator.pl          # Generates bash test runner scripts
 ```
 
 ## Pattern Detection
@@ -625,16 +630,38 @@ test_my_predicate :-
 ?- test_pattern_matchers.
 ?- test_tail_recursion.
 ?- test_linear_recursion.
+?- test_tree_recursion.
 ?- test_mutual_recursion.
+?- test_multicall_linear.
+?- test_direct_multi_call.
 ?- test_advanced_compiler.
 ```
 
+### Multi-Target Test Coverage
+
+The test orchestrator (`test_advanced.pl`) loads 7 target modules and tests compilation across them:
+
+| Pattern | bash | r | lua | c | haskell | java | elixir | fsharp |
+|---------|:----:|:-:|:---:|:-:|:-------:|:----:|:------:|:------:|
+| Tail recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Linear recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Tree recursion | ✅ | ✅ | ✅ | — | — | — | — | — |
+| Mutual recursion | ✅ | ✅ | ✅ | — | — | — | ✅ | ✅ |
+| Multi-call linear | ✅ | ✅ | ✅ | — | — | — | — | — |
+| Direct multi-call | ✅ | ✅ | ✅ | — | — | — | — | — |
+
 ### Generated Files
 
-Tests generate bash scripts in `output/advanced/`:
-- `count_items.sh` - Tail recursion example
-- `list_length.sh` - Linear recursion example
-- `even_odd.sh` - Mutual recursion example
+Tests generate output in `output/advanced/` across multiple target languages:
+- `count_items.{sh,R,lua,c,hs,java,exs}` - Tail recursion
+- `sum_list.{sh,R,lua,c,hs,java,exs}` - Tail recursion (arithmetic)
+- `list_length.{sh,R,lua,c,hs,java,exs}` - Linear recursion
+- `factorial.{sh,R,lua,c,hs,java,exs}` - Linear recursion (multiplicative)
+- `tree_sum.{sh,R,lua}` - Tree recursion (binary tree)
+- `tree_fib.{sh,R,lua}` - Tree recursion (fibonacci)
+- `even_odd.{sh,R,lua,exs,fs}` - Mutual recursion
+- `fib_multicall.{sh,R,lua}` - Multi-call linear
+- `fib_direct.{sh,R,lua}` - Direct multi-call
 
 ## Future Work
 
@@ -819,4 +846,4 @@ assertz(user:(is_even(N) :- ...)).
 
 ---
 
-*Last updated: 2025-10-11*
+*Last updated: 2026-03-11*

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -35,6 +35,40 @@ Integration tests would verify:
 
 ---
 
+## Advanced Recursion Pattern Tests
+
+The advanced recursion test suite (`test_advanced.pl`) validates pattern detection and cross-target compilation for 6 recursion patterns. It loads 7 target modules using empty import lists (`use_module(Path, [])`) to register multifile dispatch clauses without predicate name conflicts.
+
+### Test Coverage Matrix
+
+| Pattern | Test Predicate | Targets Tested |
+|---------|---------------|----------------|
+| Tail recursion | `count_items/3`, `sum_list/3` | bash, r, lua, c, haskell, java, elixir |
+| Linear recursion | `list_length/2`, `factorial/2` | bash, r, lua, c, haskell, java, elixir |
+| Tree recursion | `tree_sum/2`, `tree_fib/2` | bash, r, lua |
+| Mutual recursion | `is_even/1`, `is_odd/1` | bash, r, lua, elixir, fsharp |
+| Multi-call linear | `test_fib/2` | bash, r, lua |
+| Direct multi-call | `test_dfib/2` | bash, r, lua |
+
+### Infrastructure Tests
+
+| Module | What's Tested |
+|--------|---------------|
+| Call Graph | Predicate dependency graph construction, self-recursion, mutual edges |
+| SCC Detection | Tarjan's algorithm, separate SCCs, topological ordering |
+| Pattern Matchers | Tail/linear detection, recursive call counting, forbid mechanism, fold patterns |
+| Advanced Compiler | End-to-end orchestration (tail → linear → multicall → tree → mutual) |
+
+### Running
+
+```bash
+swipl -g "use_module('src/unifyweaver/core/advanced/test_advanced'), test_all_advanced" -t halt
+```
+
+All 10 module test suites run sequentially. Generated output files appear in `output/advanced/`.
+
+---
+
 ## Phase 6: Deployment Glue
 
 ### Phase 6a-b: Deployment Foundation

--- a/src/unifyweaver/targets/fsharp_target.pl
+++ b/src/unifyweaver/targets/fsharp_target.pl
@@ -568,7 +568,7 @@ mutual_recursion:compile_mutual_pattern(fsharp, Predicates, MemoEnabled, MemoStr
         format(string(MemoDecl),
 'open System.Collections.Generic
 
-let private memo = Dictionary<string, bool>()')
+let private memo = Dictionary<string, bool>()', [])
     ;   MemoDecl = '// Shared memoization disabled'
     ),
     format(string(HeaderCode),


### PR DESCRIPTION
## Summary

- Expand advanced recursion test coverage from 3 to 7 targets for tail/linear patterns, wire orphaned multicall modules into the test orchestrator, and add missing test cases (fibonacci tree, elixir/fsharp mutual)
- Fix pre-existing `format/2` vs `format/3` arity bug in `fsharp_target.pl` that prevented F# mutual recursion compilation
- Update documentation with multi-target coverage matrix and advanced recursion test section

## Test Coverage Expansion

| Pattern | Before | After |
|---------|--------|-------|
| Tail recursion | 3 targets (bash, r, lua) | 7 targets (+c, haskell, java, elixir) |
| Linear recursion | 3 targets (bash, r, lua) | 7 targets (+c, haskell, java, elixir) |
| Tree recursion | tree_sum only | +fibonacci test (bash, r, lua) |
| Mutual recursion | 3 targets (bash, r, lua) | 5 targets (+elixir, fsharp) |
| Multi-call linear | detection only, not wired | 3 compilation tests, wired into orchestrator |
| Direct multi-call | 2 targets, not exported | 3 targets (+lua), exported, wired |

## F# Bug Fix

**Root cause**: Line 568 of `fsharp_target.pl` had:
```prolog
format(string(MemoDecl), '...template...')
```
This is `format/2` — SWI-Prolog interprets `string(MemoDecl)` as the format string (not the output target), producing `type_error(text, string(_))`.

**Fix**: Add empty args list to make it `format/3`:
```prolog
format(string(MemoDecl), '...template...', [])
```

## Files Changed

| File | Change |
|------|--------|
| `src/unifyweaver/targets/fsharp_target.pl` | Fix `format/2` → `format/3` arity bug |
| `src/unifyweaver/core/advanced/test_advanced.pl` | Wire multicall/direct_multicall, load 7 target modules |
| `src/unifyweaver/core/advanced/tail_recursion.pl` | Add Tier 2 targets (c, haskell, java, elixir) |
| `src/unifyweaver/core/advanced/linear_recursion.pl` | Add Tier 2 targets (c, haskell, java, elixir) |
| `src/unifyweaver/core/advanced/tree_recursion.pl` | Add fibonacci tree test |
| `src/unifyweaver/core/advanced/mutual_recursion.pl` | Add elixir, fsharp targets |
| `src/unifyweaver/core/advanced/multicall_linear_recursion.pl` | Add compilation tests (bash, r, lua) |
| `src/unifyweaver/core/advanced/direct_multi_call_recursion.pl` | Export test, add lua target |
| `docs/ADVANCED_RECURSION.md` | Add multicall modules, multi-target coverage matrix |
| `docs/TEST_COVERAGE.md` | Add advanced recursion test coverage section |

## Test Plan

```bash
swipl -g "use_module('src/unifyweaver/core/advanced/test_advanced'), test_all_advanced" -t halt
```

All 10 module test suites pass: Call Graph, SCC Detection, Pattern Matchers, Tail Recursion (7 targets), Linear Recursion (7 targets), Tree Recursion (4 tests), Mutual Recursion (5 targets), Multi-Call Linear (3 targets), Direct Multi-Call (3 targets), Advanced Compiler Integration.
