### PR TITLE
feat(agent-loop): Rust Phase 7 — Perplexity review fixes + gemini model validation

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -62,7 +62,7 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 |--------|--------|--------|
 | Python | `generated/python/` (15+ modules) | Full agent loop |
 | Prolog | `generated/prolog/` (8 modules) | Full agent loop |
-| Rust | `generated/rust/` (14 files) | Data + imperative + CLI + config loading + streaming + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes |
+| Rust | `generated/rust/` (14 files) | Data + imperative + CLI + config loading + streaming + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching |
 
 ### Declarative Infrastructure
 
@@ -75,7 +75,7 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 | `emit_config_section/3` clauses | 11 (python + prolog + rust) |
 | `compile_component/4` targets | 3 (python, prolog, rust) |
 | `declare_binding` per target | 11 |
-| Total tests | 654 (576+78 unit + 27 Prolog + 59 Python) |
+| Total tests | 668 (590+78 unit + 27 Prolog + 59 Python) |
 
 ## Backends
 

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -982,6 +982,7 @@ backend_factory(gemini, [
     import_from(backends),
     default_command(gemini),
     default_model('gemini-3-flash-preview'),
+    model_validator(validate_gemini_model),
     cli_args(["--model"]),
     constructor_args([
         arg(command, cmd),
@@ -1731,7 +1732,16 @@ generate_rust_backend_factory(S) :-
                 ArgsLit = '&[]'
             ),
             (member(default_model(Model), Props) ->
-                format(S, '        "~w" => Box::new(CliBackend::new("~w", "~w", ~w, Some("~w".to_string()))),~n', [FN, FN, Cmd, ArgsLit, Model])
+                %% Check for model_validator (e.g. gemini version constraints)
+                (member(model_validator(Validator), FProps) ->
+                    format(S, '        "~w" => {~n', [FN]),
+                    format(S, '            let m = config.model.clone().unwrap_or("~w".to_string());~n', [Model]),
+                    format(S, '            let validated = ~w(&m, "~w");~n', [Validator, Model]),
+                    format(S, '            Box::new(CliBackend::new("~w", "~w", ~w, Some(validated)))~n', [FN, Cmd, ArgsLit]),
+                    format(S, '        }~n', [])
+                ;
+                    format(S, '        "~w" => Box::new(CliBackend::new("~w", "~w", ~w, config.model.clone().or(Some("~w".to_string())))),~n', [FN, FN, Cmd, ArgsLit, Model])
+                )
             ;
                 format(S, '        "~w" => Box::new(CliBackend::new("~w", "~w", ~w, config.model.clone())),~n', [FN, FN, Cmd, ArgsLit])
             )
@@ -3938,33 +3948,41 @@ pub struct ToolSpec {
     pub parameters: &''static [ToolParam],
 }
 
+use std::sync::OnceLock;
+
+/// Cached tool schemas — built once from static TOOL_SPECS.
+static TOOL_SCHEMAS_CACHE: OnceLock<Vec<serde_json::Value>> = OnceLock::new();
+
 /// Generate JSON tool schemas for API requests (OpenAI/Anthropic format).
-pub fn tool_schemas_json() -> Vec<serde_json::Value> {
-    TOOL_SPECS.iter().map(|spec| {
-        let mut properties = serde_json::Map::new();
-        let mut required = Vec::new();
-        for p in spec.parameters {
-            properties.insert(p.name.to_string(), serde_json::json!({
-                "type": p.param_type,
-                "description": p.description,
-            }));
-            if p.required {
-                required.push(serde_json::Value::String(p.name.to_string()));
-            }
-        }
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": spec.name,
-                "description": spec.description,
-                "parameters": {
-                    "type": "object",
-                    "properties": properties,
-                    "required": required,
+/// Cached via OnceLock since TOOL_SPECS is static.
+pub fn tool_schemas_json() -> &''static Vec<serde_json::Value> {
+    TOOL_SCHEMAS_CACHE.get_or_init(|| {
+        TOOL_SPECS.iter().map(|spec| {
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+            for p in spec.parameters {
+                properties.insert(p.name.to_string(), serde_json::json!({
+                    "type": p.param_type,
+                    "description": p.description,
+                }));
+                if p.required {
+                    required.push(serde_json::Value::String(p.name.to_string()));
                 }
             }
-        })
-    }).collect()
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": spec.name,
+                    "description": spec.description,
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": required,
+                    }
+                }
+            })
+        }).collect()
+    })
 }
 
 ').
@@ -4145,9 +4163,23 @@ impl ContextManager {
         self.messages.is_empty()
     }
 
-    /// Total character count across all messages.
+    /// Character count for a single message, including tool call estimates.
+    fn message_char_count(m: &Message) -> usize {
+        let mut n = m.content.len();
+        if let Some(ref tcs) = m.tool_calls {
+            for tc in tcs {
+                n += 100; // base overhead: name + id + JSON structure
+                for v in tc.arguments.values() {
+                    n += v.to_string().len();
+                }
+            }
+        }
+        n
+    }
+
+    /// Total character count across all messages (includes tool call estimates).
     pub fn char_count(&self) -> usize {
-        self.messages.iter().map(|m| m.content.len()).sum()
+        self.messages.iter().map(Self::message_char_count).sum()
     }
 
     /// Total word count across all messages.
@@ -4163,29 +4195,47 @@ impl ContextManager {
     }
 
     /// Trim messages to stay within all configured limits.
+    /// Uses drain(..k) instead of remove(0) for O(n) performance.
     pub fn trim_if_needed(&mut self) {
         // Message count limit (sliding window)
         if self.max_messages > 0 && self.messages.len() > self.max_messages {
             let excess = self.messages.len() - self.max_messages;
             self.messages.drain(..excess);
         }
-        // Token limit
-        if self.max_context_tokens > 0 {
-            while self.messages.len() > 1 && self.estimate_tokens() > self.max_context_tokens as usize {
-                self.messages.remove(0);
+        // Token limit — compute cutpoint then drain once
+        if self.max_context_tokens > 0 && self.estimate_tokens() > self.max_context_tokens as usize {
+            let limit = self.max_context_tokens as usize;
+            let mut k = 0;
+            while k < self.messages.len().saturating_sub(1) {
+                let remaining: usize = self.messages[k..].iter().map(Self::message_char_count).sum();
+                if remaining / 4 <= limit { break; }
+                k += 1;
             }
+            if k > 0 { self.messages.drain(..k); }
         }
         // Character limit
-        if self.max_chars > 0 {
-            while self.messages.len() > 1 && self.char_count() > self.max_chars as usize {
-                self.messages.remove(0);
+        if self.max_chars > 0 && self.char_count() > self.max_chars as usize {
+            let limit = self.max_chars as usize;
+            let mut k = 0;
+            let mut drop_chars = 0usize;
+            let total = self.char_count();
+            while k < self.messages.len().saturating_sub(1) && total - drop_chars > limit {
+                drop_chars += Self::message_char_count(&self.messages[k]);
+                k += 1;
             }
+            if k > 0 { self.messages.drain(..k); }
         }
         // Word limit
-        if self.max_words > 0 {
-            while self.messages.len() > 1 && self.word_count() > self.max_words as usize {
-                self.messages.remove(0);
+        if self.max_words > 0 && self.word_count() > self.max_words as usize {
+            let limit = self.max_words as usize;
+            let mut k = 0;
+            let mut drop_words = 0usize;
+            let total = self.word_count();
+            while k < self.messages.len().saturating_sub(1) && total - drop_words > limit {
+                drop_words += self.messages[k].content.split_whitespace().count();
+                k += 1;
             }
+            if k > 0 { self.messages.drain(..k); }
         }
     }
 }
@@ -4209,6 +4259,42 @@ pub trait AgentBackend {
 ').
 
 rust_fragment(backend_cli_impl, '
+
+/// Extract a numeric version from a gemini model name (e.g. "gemini-3-flash-preview" -> 3.0).
+fn extract_gemini_version(model: &str) -> Option<f64> {
+    for part in model.split(''-'') {
+        if let Ok(v) = part.parse::<f64>() {
+            return Some(v);
+        }
+        // Handle versions like "2.5" embedded in hyphenated segments
+        if part.contains(''.'') {
+            if let Ok(v) = part.parse::<f64>() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Validate a gemini model meets minimum version requirements.
+/// Flash models require version >= 3, Pro models require version >= 2.5.
+fn validate_gemini_model(model: &str, default: &str) -> String {
+    if model.contains("flash") {
+        if let Some(ver) = extract_gemini_version(model) {
+            if ver >= 3.0 { return model.to_string(); }
+        }
+        eprintln!("Warning: gemini flash requires version >= 3, using {}", default);
+        return default.to_string();
+    }
+    if model.contains("pro") {
+        if let Some(ver) = extract_gemini_version(model) {
+            if ver >= 2.5 { return model.to_string(); }
+        }
+        eprintln!("Warning: gemini pro requires version >= 2.5, using {}", default);
+        return default.to_string();
+    }
+    model.to_string()
+}
 
 /// CLI-based backend that shells out to a command.
 pub struct CliBackend {
@@ -4245,7 +4331,17 @@ impl AgentBackend for CliBackend {
 
         match cmd.output() {
             Ok(output) => {
-                let content = String::from_utf8_lossy(&output.stdout).to_string();
+                let mut content = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr_text = String::from_utf8_lossy(&output.stderr);
+                if !stderr_text.is_empty() {
+                    if content.trim().is_empty() {
+                        // No stdout — surface stderr as the response (error case)
+                        content = format!("stderr: {}", stderr_text);
+                    } else {
+                        // Both present — log stderr as diagnostic
+                        eprintln!("[{}] stderr: {}", self.backend_name, stderr_text.trim());
+                    }
+                }
                 AgentResponse {
                     content,
                     model: self.backend_name.clone(),
@@ -5043,6 +5139,9 @@ pub fn send_streaming(
                 }
             }
             println!();
+            // TODO: SSE stream chunks typically don''t include usage metadata.
+            // Some APIs (OpenAI, Anthropic) send usage in the final chunk —
+            // parse stream_options.include_usage when available.
             (full_content, 0, 0)
         }
         Err(e) => {

--- a/tools/agent-loop/generated/rust/src/backends.rs
+++ b/tools/agent-loop/generated/rust/src/backends.rs
@@ -21,6 +21,42 @@ pub trait AgentBackend {
 
 
 
+/// Extract a numeric version from a gemini model name (e.g. "gemini-3-flash-preview" -> 3.0).
+fn extract_gemini_version(model: &str) -> Option<f64> {
+    for part in model.split('-') {
+        if let Ok(v) = part.parse::<f64>() {
+            return Some(v);
+        }
+        // Handle versions like "2.5" embedded in hyphenated segments
+        if part.contains('.') {
+            if let Ok(v) = part.parse::<f64>() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Validate a gemini model meets minimum version requirements.
+/// Flash models require version >= 3, Pro models require version >= 2.5.
+fn validate_gemini_model(model: &str, default: &str) -> String {
+    if model.contains("flash") {
+        if let Some(ver) = extract_gemini_version(model) {
+            if ver >= 3.0 { return model.to_string(); }
+        }
+        eprintln!("Warning: gemini flash requires version >= 3, using {}", default);
+        return default.to_string();
+    }
+    if model.contains("pro") {
+        if let Some(ver) = extract_gemini_version(model) {
+            if ver >= 2.5 { return model.to_string(); }
+        }
+        eprintln!("Warning: gemini pro requires version >= 2.5, using {}", default);
+        return default.to_string();
+    }
+    model.to_string()
+}
+
 /// CLI-based backend that shells out to a command.
 pub struct CliBackend {
     pub backend_name: String,
@@ -56,7 +92,17 @@ impl AgentBackend for CliBackend {
 
         match cmd.output() {
             Ok(output) => {
-                let content = String::from_utf8_lossy(&output.stdout).to_string();
+                let mut content = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr_text = String::from_utf8_lossy(&output.stderr);
+                if !stderr_text.is_empty() {
+                    if content.trim().is_empty() {
+                        // No stdout — surface stderr as the response (error case)
+                        content = format!("stderr: {}", stderr_text);
+                    } else {
+                        // Both present — log stderr as diagnostic
+                        eprintln!("[{}] stderr: {}", self.backend_name, stderr_text.trim());
+                    }
+                }
                 AgentResponse {
                     content,
                     model: self.backend_name.clone(),
@@ -146,6 +192,9 @@ pub fn send_streaming(
                 }
             }
             println!();
+            // TODO: SSE stream chunks typically don't include usage metadata.
+            // Some APIs (OpenAI, Anthropic) send usage in the final chunk —
+            // parse stream_options.include_usage when available.
             (full_content, 0, 0)
         }
         Err(e) => {
@@ -364,8 +413,12 @@ impl AgentBackend for ApiBackend {
 pub fn create_backend(config: &AgentConfig) -> Box<dyn AgentBackend> {
     match config.backend.as_str() {
         "coro" => Box::new(CliBackend::new("coro", "claude", &[], config.model.clone())),
-        "claude-code" => Box::new(CliBackend::new("claude-code", "claude", &["--print", "--model"], Some("sonnet".to_string()))),
-        "gemini" => Box::new(CliBackend::new("gemini", "gemini", &["--model"], Some("gemini-2.5-flash".to_string()))),
+        "claude-code" => Box::new(CliBackend::new("claude-code", "claude", &["--print", "--model"], config.model.clone().or(Some("sonnet".to_string())))),
+        "gemini" => {
+            let m = config.model.clone().unwrap_or("gemini-2.5-flash".to_string());
+            let validated = validate_gemini_model(&m, "gemini-2.5-flash");
+            Box::new(CliBackend::new("gemini", "gemini", &["--model"], Some(validated)))
+        }
         "claude" => {
             let key = std::env::var("ANTHROPIC_API_KEY").ok().or(config.api_key.clone());
             let model = config.model.clone().unwrap_or_default();
@@ -382,7 +435,7 @@ pub fn create_backend(config: &AgentConfig) -> Box<dyn AgentBackend> {
             Box::new(ApiBackend::new("openrouter", "https://openrouter.ai/api/v1/chat/completions", key, &model, config.stream, "openai"))
         }
         "ollama-api" => Box::new(ApiBackend::new("ollama-api", "http://localhost:11434/api/chat", None, &config.model.clone().unwrap_or_default(), config.stream, "openai")),
-        "ollama-cli" => Box::new(CliBackend::new("ollama-cli", "ollama", &[], Some("llama3".to_string()))),
+        "ollama-cli" => Box::new(CliBackend::new("ollama-cli", "ollama", &[], config.model.clone().or(Some("llama3".to_string())))),
         _ => panic!("Unknown backend: {}", config.backend),
     }
 }

--- a/tools/agent-loop/generated/rust/src/context.rs
+++ b/tools/agent-loop/generated/rust/src/context.rs
@@ -100,9 +100,23 @@ impl ContextManager {
         self.messages.is_empty()
     }
 
-    /// Total character count across all messages.
+    /// Character count for a single message, including tool call estimates.
+    fn message_char_count(m: &Message) -> usize {
+        let mut n = m.content.len();
+        if let Some(ref tcs) = m.tool_calls {
+            for tc in tcs {
+                n += 100; // base overhead: name + id + JSON structure
+                for v in tc.arguments.values() {
+                    n += v.to_string().len();
+                }
+            }
+        }
+        n
+    }
+
+    /// Total character count across all messages (includes tool call estimates).
     pub fn char_count(&self) -> usize {
-        self.messages.iter().map(|m| m.content.len()).sum()
+        self.messages.iter().map(Self::message_char_count).sum()
     }
 
     /// Total word count across all messages.
@@ -118,29 +132,47 @@ impl ContextManager {
     }
 
     /// Trim messages to stay within all configured limits.
+    /// Uses drain(..k) instead of remove(0) for O(n) performance.
     pub fn trim_if_needed(&mut self) {
         // Message count limit (sliding window)
         if self.max_messages > 0 && self.messages.len() > self.max_messages {
             let excess = self.messages.len() - self.max_messages;
             self.messages.drain(..excess);
         }
-        // Token limit
-        if self.max_context_tokens > 0 {
-            while self.messages.len() > 1 && self.estimate_tokens() > self.max_context_tokens as usize {
-                self.messages.remove(0);
+        // Token limit — compute cutpoint then drain once
+        if self.max_context_tokens > 0 && self.estimate_tokens() > self.max_context_tokens as usize {
+            let limit = self.max_context_tokens as usize;
+            let mut k = 0;
+            while k < self.messages.len().saturating_sub(1) {
+                let remaining: usize = self.messages[k..].iter().map(Self::message_char_count).sum();
+                if remaining / 4 <= limit { break; }
+                k += 1;
             }
+            if k > 0 { self.messages.drain(..k); }
         }
         // Character limit
-        if self.max_chars > 0 {
-            while self.messages.len() > 1 && self.char_count() > self.max_chars as usize {
-                self.messages.remove(0);
+        if self.max_chars > 0 && self.char_count() > self.max_chars as usize {
+            let limit = self.max_chars as usize;
+            let mut k = 0;
+            let mut drop_chars = 0usize;
+            let total = self.char_count();
+            while k < self.messages.len().saturating_sub(1) && total - drop_chars > limit {
+                drop_chars += Self::message_char_count(&self.messages[k]);
+                k += 1;
             }
+            if k > 0 { self.messages.drain(..k); }
         }
         // Word limit
-        if self.max_words > 0 {
-            while self.messages.len() > 1 && self.word_count() > self.max_words as usize {
-                self.messages.remove(0);
+        if self.max_words > 0 && self.word_count() > self.max_words as usize {
+            let limit = self.max_words as usize;
+            let mut k = 0;
+            let mut drop_words = 0usize;
+            let total = self.word_count();
+            while k < self.messages.len().saturating_sub(1) && total - drop_words > limit {
+                drop_words += self.messages[k].content.split_whitespace().count();
+                k += 1;
             }
+            if k > 0 { self.messages.drain(..k); }
         }
     }
 }

--- a/tools/agent-loop/generated/rust/src/tools.rs
+++ b/tools/agent-loop/generated/rust/src/tools.rs
@@ -24,33 +24,41 @@ pub struct ToolSpec {
     pub parameters: &'static [ToolParam],
 }
 
+use std::sync::OnceLock;
+
+/// Cached tool schemas — built once from static TOOL_SPECS.
+static TOOL_SCHEMAS_CACHE: OnceLock<Vec<serde_json::Value>> = OnceLock::new();
+
 /// Generate JSON tool schemas for API requests (OpenAI/Anthropic format).
-pub fn tool_schemas_json() -> Vec<serde_json::Value> {
-    TOOL_SPECS.iter().map(|spec| {
-        let mut properties = serde_json::Map::new();
-        let mut required = Vec::new();
-        for p in spec.parameters {
-            properties.insert(p.name.to_string(), serde_json::json!({
-                "type": p.param_type,
-                "description": p.description,
-            }));
-            if p.required {
-                required.push(serde_json::Value::String(p.name.to_string()));
-            }
-        }
-        serde_json::json!({
-            "type": "function",
-            "function": {
-                "name": spec.name,
-                "description": spec.description,
-                "parameters": {
-                    "type": "object",
-                    "properties": properties,
-                    "required": required,
+/// Cached via OnceLock since TOOL_SPECS is static.
+pub fn tool_schemas_json() -> &'static Vec<serde_json::Value> {
+    TOOL_SCHEMAS_CACHE.get_or_init(|| {
+        TOOL_SPECS.iter().map(|spec| {
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+            for p in spec.parameters {
+                properties.insert(p.name.to_string(), serde_json::json!({
+                    "type": p.param_type,
+                    "description": p.description,
+                }));
+                if p.required {
+                    required.push(serde_json::Value::String(p.name.to_string()));
                 }
             }
-        })
-    }).collect()
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": spec.name,
+                    "description": spec.description,
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": required,
+                    }
+                }
+            })
+        }).collect()
+    })
 }
 
 pub static TOOL_SPECS: &[ToolSpec] = &[

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -201,6 +201,15 @@ run_tests :-
     test_rust_context_modes,
     test_rust_context_trim,
     test_rust_phase6_generation,
+    %% Phase 7
+    test_rust_cli_model_override,
+    test_rust_cli_stderr,
+    test_rust_streaming_todo,
+    test_rust_trim_drain,
+    test_rust_char_count_tools,
+    test_rust_schemas_cache,
+    test_rust_gemini_validation,
+    test_rust_phase7_generation,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -3920,4 +3929,92 @@ test_rust_phase6_generation :-
     )),
     assert_true('main.rs has single-prompt mode', (
         sub_string(MainContent6, _, _, _, "get_one::<String>(\"prompt\")")
+    )).
+
+%% =========================================================================
+%% Phase 7 Tests — Perplexity review fixes + gemini model validation
+%% =========================================================================
+
+test_rust_cli_model_override :-
+    format("~nRust CLI model override:~n"),
+    agent_loop_module:output_path(rust, 'backends.rs', BackendsPath),
+    read_file_to_string(BackendsPath, BackendsContent, []),
+    assert_true('claude-code uses config.model.clone().or()', (
+        sub_string(BackendsContent, _, _, _, "config.model.clone().or(Some(\"sonnet\"")
+    )),
+    assert_true('ollama-cli uses config.model.clone().or()', (
+        sub_string(BackendsContent, _, _, _, "config.model.clone().or(Some(\"llama3\"")
+    )).
+
+test_rust_cli_stderr :-
+    format("~nRust CLI stderr handling:~n"),
+    agent_loop_module:output_path(rust, 'backends.rs', BackendsPath),
+    read_file_to_string(BackendsPath, BackendsContent, []),
+    assert_true('CliBackend reads stderr_text', (
+        sub_string(BackendsContent, _, _, _, "stderr_text")
+    )),
+    assert_true('CliBackend surfaces stderr when stdout empty', (
+        sub_string(BackendsContent, _, _, _, "content.trim().is_empty()")
+    )).
+
+test_rust_streaming_todo :-
+    format("~nRust streaming TODO:~n"),
+    agent_loop_module:output_path(rust, 'backends.rs', BackendsPath),
+    read_file_to_string(BackendsPath, BackendsContent, []),
+    assert_true('send_streaming has TODO comment for token counts', (
+        sub_string(BackendsContent, _, _, _, "TODO: SSE stream chunks")
+    )).
+
+test_rust_trim_drain :-
+    format("~nRust trim drain:~n"),
+    agent_loop_module:output_path(rust, 'context.rs', ContextPath),
+    read_file_to_string(ContextPath, ContextContent, []),
+    assert_true('trim_if_needed uses drain pattern', (
+        sub_string(ContextContent, _, _, _, "self.messages.drain(..k)")
+    )),
+    assert_true('no self.messages.remove(0) calls', (
+        \+ sub_string(ContextContent, _, _, _, "self.messages.remove(0)")
+    )).
+
+test_rust_char_count_tools :-
+    format("~nRust char_count with tool calls:~n"),
+    agent_loop_module:output_path(rust, 'context.rs', ContextPath),
+    read_file_to_string(ContextPath, ContextContent, []),
+    assert_true('message_char_count includes tool_calls', (
+        sub_string(ContextContent, _, _, _, "fn message_char_count")
+    )).
+
+test_rust_schemas_cache :-
+    format("~nRust schemas cache:~n"),
+    agent_loop_module:output_path(rust, 'tools.rs', ToolsPath),
+    read_file_to_string(ToolsPath, ToolsContent, []),
+    assert_true('tool_schemas_json uses OnceLock', (
+        sub_string(ToolsContent, _, _, _, "OnceLock")
+    )),
+    assert_true('TOOL_SCHEMAS_CACHE static exists', (
+        sub_string(ToolsContent, _, _, _, "TOOL_SCHEMAS_CACHE")
+    )).
+
+test_rust_gemini_validation :-
+    format("~nRust gemini validation:~n"),
+    agent_loop_module:output_path(rust, 'backends.rs', BackendsPath),
+    read_file_to_string(BackendsPath, BackendsContent, []),
+    assert_true('validate_gemini_model function exists', (
+        sub_string(BackendsContent, _, _, _, "fn validate_gemini_model")
+    )),
+    assert_true('extract_gemini_version helper exists', (
+        sub_string(BackendsContent, _, _, _, "fn extract_gemini_version")
+    )).
+
+test_rust_phase7_generation :-
+    format("~nRust phase 7 generation:~n"),
+    agent_loop_module:output_path(rust, 'backends.rs', BackendsPath7),
+    read_file_to_string(BackendsPath7, BackendsContent7, []),
+    assert_true('gemini branch calls validate_gemini_model', (
+        sub_string(BackendsContent7, _, _, _, "validate_gemini_model(&m")
+    )),
+    agent_loop_module:output_path(rust, 'context.rs', ContextPath7),
+    read_file_to_string(ContextPath7, ContextContent7, []),
+    assert_true('trim uses drain not remove', (
+        sub_string(ContextContent7, _, _, _, "drain(..k)")
     )).


### PR DESCRIPTION
## Summary

Addresses all 6 issues identified by Perplexity's code review of Phase 6 (PR #774), plus gemini model version constraints requested by the user.

### Fixes

1. **CLI backends respect `config.model`** — `create_backend` now uses `config.model.clone().or(Some("default".to_string()))` instead of hardcoding. The `--model` flag actually works for all CLI backends now.

2. **CliBackend stderr handling** — When stdout is empty and stderr has content, stderr is surfaced as the response (error case). When both have content, stderr is logged via `eprintln` as a diagnostic.

3. **Streaming token counts documented** — `send_streaming` now has a clear TODO comment explaining why tokens return `(content, 0, 0)` and noting the future path (parse `stream_options.include_usage` from final SSE chunk).

4. **`trim_if_needed` O(n) with `drain`** — Replaced `while { self.messages.remove(0) }` loops (O(n^2)) with cutpoint computation + single `drain(..k)` call (O(n)). Applied to all three limit types (tokens, chars, words).

5. **`char_count` includes tool calls** — New `message_char_count` helper estimates tool call size as 100 chars base overhead + sum of argument value string lengths. Avoids `serde_json::to_string` allocation in hot loops.

6. **`tool_schemas_json` cached with `OnceLock`** — Uses `std::sync::OnceLock` (stdlib, no external crate) to build tool schemas exactly once. Returns `&'static Vec<serde_json::Value>`.

### Gemini model validation

- `validate_gemini_model(model, default)` enforces minimum version constraints:
  - Flash models require version >= 3 (rejects gemini-2.0-flash, etc.)
  - Pro models require version >= 2.5 (rejects gemini-1.5-pro, etc.)
  - Unknown variants pass through unchanged
- `extract_gemini_version` parses version numbers from hyphenated model names
- New `model_validator` property on `backend_factory/2` facts for extensible validation
- Wired into gemini branch of `create_backend` factory

## Test plan

- [x] 668 tests pass (14 new Phase 7 assertions), 1 pre-existing env-specific failure (pytest not installed)
- [x] `cargo check` — 0 warnings
- [x] md5sum baseline: only expected Rust files changed (backends, context, tools)
- [x] No Python or Prolog generated files touched

## Metrics

| Metric | Phase 6 | Phase 7 |
|--------|---------|---------|
| Tests | 654 | 668 (+14) |
| `remove(0)` calls | 3 | 0 |
| `drain` calls | 1 | 4 |
| Tool schema builds per session | N (per message) | 1 (OnceLock) |
| Gemini model validation | none | flash >= v3, pro >= v2.5 |
| CLI model override | hardcoded default | config.model.or(default) |
| stderr handling | silently dropped | surfaced/logged |

## Files changed (6 files, +369/-80)

| File | Changes |
|------|---------|
| `agent_loop_module.pl` | `generate_rust_backend_factory`: config.model.or() + model_validator; `backend_cli_impl`: validate_gemini_model + stderr handling; `streaming_handler`: TODO comment; `context_manager`: drain + message_char_count; `tools_types`: OnceLock cache |
| `test_agent_loop.pl` | 8 new test predicates, 14 assertions |
| `README.md` | Updated test count (668) and Rust feature list |
| `generated/rust/src/backends.rs` | model override, gemini validation, stderr handling, streaming TODO |
| `generated/rust/src/context.rs` | drain pattern, message_char_count with tool call estimates |
| `generated/rust/src/tools.rs` | OnceLock cache for tool_schemas_json |
