### PR TITLE
test(csharp-query): add mixed by-target cache reuse coverage

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -292,6 +292,7 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_backward_strategy_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_strategy_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_reuse_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_single_seed_strategy_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_single_seed_strategy_runtime,
         verify_parameterized_reachability_plan,
@@ -310,11 +311,14 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_cache_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_reuse_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_reuse_runtime,
         verify_parameterized_reachability_pairs_cache_reuse_runtime,
         verify_parameterized_reachability_seed_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_seed_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_seed_cache_eviction_runtime,
@@ -3538,6 +3542,18 @@ verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed
         Params,
         BackwardHarnessSource).
 
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_group_probe_dir_mixed_bytarget_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a, z, red, cat1], [p, q, red, cat1]],
+    harness_source_with_cache_flag(ModuleClass, Params, 'GroupedTransitiveClosureSeededByTarget', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=true',
+         'p,q,red,cat1'],
+        Params,
+        HarnessSource).
+
 verify_parameterized_reachability_plan :-
     csharp_query_target:build_query_plan(test_reachable_param/2, [target(csharp_query)], Plan),
     get_dict(is_recursive, Plan, true),
@@ -3644,6 +3660,18 @@ verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_reuse_r
          'CACHE_HIT:TransitiveClosureSeededByTarget=true'],
         Params,
         BackwardHarnessSource).
+
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_probe_dir_mixed_bytarget_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    Params = [[a, z], [p, q]],
+    harness_source_with_cache_flag(ModuleClass, Params, 'TransitiveClosureSeededByTarget', HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z',
+         'CACHE_HIT:TransitiveClosureSeededByTarget=true',
+         'p,q'],
+        Params,
+        HarnessSource).
 
 verify_parameterized_reachability_single_seed_strategy_runtime :-
     csharp_query_target:build_query_plan(test_reachable_param/2, [target(csharp_query)], Plan),
@@ -4027,6 +4055,25 @@ verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_ru
          'a,c,red,cat1',
          'b,c,red,cat1',
          'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_group_probe_dir_mixed_bytarget_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z, red, cat1], [p, q, red, cat1]],
+    ExecParams = [[a, z, red, cat1], [p, q, red, cat1], [p, r, red, cat1]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosureSeededByTarget',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=true',
+         'p,q,red,cat1',
+         'p,r,red,cat1'],
         ExecParams,
         HarnessSource).
 
@@ -5090,6 +5137,24 @@ verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime 
          'alice,charlie',
          'bob,charlie',
          'CACHE_HIT:TransitiveClosureSeededByTarget=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_probe_dir_mixed_bytarget_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z], [p, q]],
+    ExecParams = [[p, q], [a, z]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosureSeededByTarget',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z',
+         'CACHE_HIT:TransitiveClosureSeededByTarget=true',
+         'p,q'],
         ExecParams,
         HarnessSource).
 


### PR DESCRIPTION
  ## Summary
  Add cache reuse guardrail coverage for the dedicated mixed by-target recursive paths in the C# query runtime tests.

  ## What changed
  - Added non-grouped mixed by-target cache reuse coverage
  - Added non-grouped mixed by-target key-order-insensitive coverage
  - Added grouped mixed by-target cache reuse coverage
  - Added grouped mixed by-target overlap-reuse coverage
  - Registered the new tests in `test_csharp_query_target/0`

  ## Why
  We already had dedicated mixed by-target coverage for:
  - positive path reachability
  - admission/selectivity behavior
  - LRU recency / eviction behavior

  The remaining gap was reuse stability. This PR closes that by verifying the mixed by-target seeded caches behave
  correctly when:
  - the same batched request is rerun
  - batch order changes
  - a warmed subset is reused inside a larger overlapping grouped request

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`202/202`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_bytarget_cache_reuse_probe -ProjectFilter "cq_test_probe_d*"`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_bytarget_cache_reuse_group -ProjectFilter "cq_test_group_p*"`
    - Passed