### PR TITLE
fix(targets): F# tail/linear coverage, Elixir mutual calls, C/F# format string bugs

### DIFF
--- a/docs/ADVANCED_RECURSION.md
+++ b/docs/ADVANCED_RECURSION.md
@@ -639,12 +639,12 @@ test_my_predicate :-
 
 ### Multi-Target Test Coverage
 
-The test orchestrator (`test_advanced.pl`) loads 7 target modules and tests compilation across them:
+The test orchestrator (`test_advanced.pl`) loads 8 target modules and tests compilation across them:
 
 | Pattern | bash | r | lua | c | haskell | java | elixir | fsharp |
 |---------|:----:|:-:|:---:|:-:|:-------:|:----:|:------:|:------:|
-| Tail recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Linear recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Tail recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Linear recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Tree recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Mutual recursion | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Multi-call linear | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -653,10 +653,10 @@ The test orchestrator (`test_advanced.pl`) loads 7 target modules and tests comp
 ### Generated Files
 
 Tests generate output in `output/advanced/` across multiple target languages:
-- `count_items.{sh,R,lua,c,hs,java,exs}` - Tail recursion
-- `sum_list.{sh,R,lua,c,hs,java,exs}` - Tail recursion (arithmetic)
-- `list_length.{sh,R,lua,c,hs,java,exs}` - Linear recursion
-- `factorial.{sh,R,lua,c,hs,java,exs}` - Linear recursion (multiplicative)
+- `count_items.{sh,R,lua,c,hs,java,exs,fs}` - Tail recursion
+- `sum_list.{sh,R,lua,c,hs,java,exs,fs}` - Tail recursion (arithmetic)
+- `list_length.{sh,R,lua,c,hs,java,exs,fs}` - Linear recursion
+- `factorial.{sh,R,lua,c,hs,java,exs,fs}` - Linear recursion (multiplicative)
 - `tree_sum.{sh,R,lua}` - Tree recursion (binary tree)
 - `tree_fib.{sh,R,lua,c,hs,java,exs,fs}` - Tree recursion (fibonacci)
 - `even_odd.{sh,R,lua,c,hs,java,exs,fs}` - Mutual recursion

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -37,14 +37,14 @@ Integration tests would verify:
 
 ## Advanced Recursion Pattern Tests
 
-The advanced recursion test suite (`test_advanced.pl`) validates pattern detection and cross-target compilation for 6 recursion patterns. It loads 7 target modules using empty import lists (`use_module(Path, [])`) to register multifile dispatch clauses without predicate name conflicts.
+The advanced recursion test suite (`test_advanced.pl`) validates pattern detection and cross-target compilation for 6 recursion patterns. It loads 8 target modules using empty import lists (`use_module(Path, [])`) to register multifile dispatch clauses without predicate name conflicts.
 
 ### Test Coverage Matrix
 
 | Pattern | Test Predicate | Targets Tested |
 |---------|---------------|----------------|
-| Tail recursion | `count_items/3`, `sum_list/3` | bash, r, lua, c, haskell, java, elixir |
-| Linear recursion | `list_length/2`, `factorial/2` | bash, r, lua, c, haskell, java, elixir |
+| Tail recursion | `count_items/3`, `sum_list/3` | bash, r, lua, c, haskell, java, elixir, fsharp |
+| Linear recursion | `list_length/2`, `factorial/2` | bash, r, lua, c, haskell, java, elixir, fsharp |
 | Tree recursion | `tree_sum/2`, `tree_fib/2` | bash, r, lua, c, haskell, java, elixir, fsharp |
 | Mutual recursion | `is_even/1`, `is_odd/1` | bash, r, lua, c, haskell, java, elixir, fsharp |
 | Multi-call linear | `test_fib/2` | bash, r, lua, c, haskell, java, elixir, fsharp |

--- a/src/unifyweaver/core/advanced/linear_recursion.pl
+++ b/src/unifyweaver/core/advanced/linear_recursion.pl
@@ -660,7 +660,10 @@ test_linear_recursion :-
         writeln('  ✓ Compiled to output/advanced/list_length.java (java)'),
         compile_linear_recursion(list_length/2, [target(elixir)], Code1E),
         write_bash_file('output/advanced/list_length.exs', Code1E),
-        writeln('  ✓ Compiled to output/advanced/list_length.exs (elixir)')
+        writeln('  ✓ Compiled to output/advanced/list_length.exs (elixir)'),
+        compile_linear_recursion(list_length/2, [target(fsharp)], Code1Fs),
+        write_bash_file('output/advanced/list_length.fs', Code1Fs),
+        writeln('  ✓ Compiled to output/advanced/list_length.fs (fsharp)')
     ;   writeln('  ✗ FAIL - should detect linear recursion')
     ),
 
@@ -691,7 +694,10 @@ test_linear_recursion :-
         writeln('  ✓ Compiled to output/advanced/factorial.java (java)'),
         compile_linear_recursion(factorial/2, [target(elixir)], Code2E),
         write_bash_file('output/advanced/factorial.exs', Code2E),
-        writeln('  ✓ Compiled to output/advanced/factorial.exs (elixir)')
+        writeln('  ✓ Compiled to output/advanced/factorial.exs (elixir)'),
+        compile_linear_recursion(factorial/2, [target(fsharp)], Code2Fs),
+        write_bash_file('output/advanced/factorial.fs', Code2Fs),
+        writeln('  ✓ Compiled to output/advanced/factorial.fs (fsharp)')
     ;   writeln('  ⚠ Pattern not detected (expected for factorial)')
     ),
 

--- a/src/unifyweaver/core/advanced/tail_recursion.pl
+++ b/src/unifyweaver/core/advanced/tail_recursion.pl
@@ -266,7 +266,10 @@ test_tail_recursion :-
         writeln('  ✓ Compiled to output/advanced/count_items.java (java)'),
         compile_tail_recursion(count_items/3, [target(elixir)], Code1E),
         write_bash_file('output/advanced/count_items.exs', Code1E),
-        writeln('  ✓ Compiled to output/advanced/count_items.exs (elixir)')
+        writeln('  ✓ Compiled to output/advanced/count_items.exs (elixir)'),
+        compile_tail_recursion(count_items/3, [target(fsharp)], Code1Fs),
+        write_bash_file('output/advanced/count_items.fs', Code1Fs),
+        writeln('  ✓ Compiled to output/advanced/count_items.fs (fsharp)')
     ;   writeln('  ✗ FAIL - should detect tail recursion')
     ),
 
@@ -297,7 +300,10 @@ test_tail_recursion :-
         writeln('  ✓ Compiled to output/advanced/sum_list.java (java)'),
         compile_tail_recursion(sum_list/3, [target(elixir)], Code2E),
         write_bash_file('output/advanced/sum_list.exs', Code2E),
-        writeln('  ✓ Compiled to output/advanced/sum_list.exs (elixir)')
+        writeln('  ✓ Compiled to output/advanced/sum_list.exs (elixir)'),
+        compile_tail_recursion(sum_list/3, [target(fsharp)], Code2Fs),
+        write_bash_file('output/advanced/sum_list.fs', Code2Fs),
+        writeln('  ✓ Compiled to output/advanced/sum_list.fs (fsharp)')
     ;   writeln('  ✗ FAIL - should detect tail recursion')
     ),
 

--- a/src/unifyweaver/targets/c_target.pl
+++ b/src/unifyweaver/targets/c_target.pl
@@ -956,7 +956,7 @@ int ~w(int n) {
 
 int main(int argc, char *argv[]) {
     memset(memo_set, 0, sizeof(memo_set));
-    if (argc >= 2) printf("%%d\\n", ~w(atoi(argv[1])));
+    if (argc >= 2) printf("%d\\n", ~w(atoi(argv[1])));
     return 0;
 }
 ', [PredStr, PredStr, PredStr, PredStr]).
@@ -993,7 +993,7 @@ int ~w(int n) {
 
 int main(int argc, char *argv[]) {
     memset(memo_set, 0, sizeof(memo_set));
-    if (argc >= 2) printf("%%d\\n", ~w(atoi(argv[1])));
+    if (argc >= 2) printf("%d\\n", ~w(atoi(argv[1])));
     return 0;
 }
 ', [PredStr, BaseCaseStr, PredStr, PredStr, PredStr]).
@@ -1039,7 +1039,7 @@ int ~w(int input) {
 
 int main(int argc, char *argv[]) {
     memset(memo_set, 0, sizeof(memo_set));
-    if (argc >= 2) printf("%%d\\n", ~w(atoi(argv[1])));
+    if (argc >= 2) printf("%d\\n", ~w(atoi(argv[1])));
     return 0;
 }
 ', [PredStr, BaseCaseStr, ComputationsCode, RecCallsCode, AggCode, PredStr]).
@@ -1252,7 +1252,7 @@ mutual_dispatch_c(Predicates, Code) :-
         member(Pred/_Arity, Predicates),
         atom_string(Pred, PredStr),
         format(string(DispLine),
-'    if (argc >= 3 && strcmp(argv[1], "~w") == 0) printf("%%d\\n", ~w(atoi(argv[2])));',
+'    if (argc >= 3 && strcmp(argv[1], "~w") == 0) printf("%d\\n", ~w(atoi(argv[2])));',
             [PredStr, PredStr])
     ), Lines),
     atomic_list_concat(Lines, '\n', Code).

--- a/src/unifyweaver/targets/elixir_target.pl
+++ b/src/unifyweaver/targets/elixir_target.pl
@@ -393,8 +393,24 @@ translate_goal_elixir(is(Var, Expr), VM, Code) :-
 
 translate_goal_elixir(true, _VM, "      # true") :- !.
 
+% Handle predicate calls (e.g., mutual recursive calls like is_odd(N1))
+translate_goal_elixir(Goal, VM, Code) :-
+    compound(Goal),
+    Goal =.. [Pred|Args],
+    Pred \= ',',
+    Pred \= ';',
+    maplist(translate_call_arg_elixir(VM), Args, ElixirArgs),
+    atomic_list_concat(ElixirArgs, ', ', ArgsStr),
+    format(string(Code), "      ~w(~w)", [Pred, ArgsStr]),
+    !.
+
 translate_goal_elixir(Goal, _VM, Code) :-
     format(string(Code), "      # TODO: translate ~w", [Goal]).
+
+%% translate_call_arg_elixir(+VM, +Arg, -ElixirArg)
+%  Translate a predicate call argument to Elixir.
+translate_call_arg_elixir(VM, Arg, ElixirArg) :-
+    expr_to_elixir(Arg, VM, ElixirArg).
 
 %% ============================================
 %% EXPRESSIONS AND VARIABLES

--- a/src/unifyweaver/targets/fsharp_target.pl
+++ b/src/unifyweaver/targets/fsharp_target.pl
@@ -750,7 +750,7 @@ let rec ~w n =
 [<EntryPoint>]
 let main argv =
     if argv.Length >= 1 then
-        printfn "%%d" (~w (int argv.[0]))
+        printfn "%d" (~w (int argv.[0]))
     0
 ', [PredStr, PredStr, PredStr, PredStr]).
 
@@ -787,7 +787,7 @@ let rec ~w n =
 [<EntryPoint>]
 let main argv =
     if argv.Length >= 1 then
-        printfn "%%d" (~w (int argv.[0]))
+        printfn "%d" (~w (int argv.[0]))
     0
 ', [PredStr, BaseCaseStr, PredStr, PredStr, PredStr]).
 
@@ -825,6 +825,6 @@ let rec ~w input =
 [<EntryPoint>]
 let main argv =
     if argv.Length >= 1 then
-        printfn "%%d" (~w (int argv.[0]))
+        printfn "%d" (~w (int argv.[0]))
     0
 ', [PredStr, BaseCaseStr, PredStr, PredStr, PredStr]).


### PR DESCRIPTION
## Summary

- **F# tail/linear test coverage**: Added F# compile calls to `tail_recursion.pl` (count_items, sum_list) and `linear_recursion.pl` (list_length, factorial). F# now has full coverage across all 6 recursion patterns (tail, linear, tree, multicall, direct_multicall, mutual).

- **Elixir mutual recursion fix**: The Elixir target's `translate_goal_elixir/3` catch-all clause was generating `# TODO: translate is_odd(...)` comments instead of actual function calls. Added a compound goal handler that decomposes predicate calls via `=../2` and generates proper Elixir calls like `is_odd(v__30322)`.

- **C/F# format string fix**: Prolog's `format/3` does not treat `%` as special (only `~`), so `%%d` in templates produced literal `%%d` in C output, which C's `printf` interprets as `%` + `d`. Fixed 4 occurrences in `c_target.pl` and 3 in `fsharp_target.pl` to use `%d` directly.

- **Docs updated**: Coverage matrices in `ADVANCED_RECURSION.md` and `TEST_COVERAGE.md` now reflect full 8-target F# coverage, updated target module count (7 → 8), and generated file lists include `.fs` extension.

## Test plan

- [x] All 10 Prolog test modules pass (`test_all_advanced`)
- [x] C output validated: `factorial(5)=120`, `factorial(0)=1`
- [x] R output validated: `factorial(5)=120`, `factorial(0)=1`
- [x] Generated C files use `printf("%d\n", ...)` (not `%%d`)
- [x] Generated F# files use `printfn "%d"` (not `%%d`)
- [x] Generated Elixir even_odd.exs contains `is_odd(v__30322)` calls (not TODO comments)

## Files changed (7)

| File | Change |
|------|--------|
| `src/unifyweaver/core/advanced/tail_recursion.pl` | Add fsharp compile calls to Tests 1-2 |
| `src/unifyweaver/core/advanced/linear_recursion.pl` | Add fsharp compile calls to Tests 1-2 |
| `src/unifyweaver/targets/elixir_target.pl` | Add compound goal handler for mutual recursive calls |
| `src/unifyweaver/targets/c_target.pl` | Fix `%%d` → `%d` in printf format strings (4 occurrences) |
| `src/unifyweaver/targets/fsharp_target.pl` | Fix `%%d` → `%d` in printfn format strings (3 occurrences) |
| `docs/ADVANCED_RECURSION.md` | Update coverage matrix, file list, target count |
| `docs/TEST_COVERAGE.md` | Update coverage matrix, target count |
