### PR TITLE
test(csharp-query): complete mixed by-target cache reuse symmetry

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -309,6 +309,7 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime,
@@ -321,6 +322,7 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_seed_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_seed_cache_eviction_runtime,
         verify_parameterized_reachability_by_target_seed_cache_eviction_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_eviction_runtime,
@@ -4058,6 +4060,24 @@ verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_ru
         ExecParams,
         HarnessSource).
 
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_group_probe_dir_mixed_bytarget_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z, red, cat1], [p, q, red, cat1]],
+    ExecParams = [[p, q, red, cat1], [a, z, red, cat1]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosureSeededByTarget',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeededByTarget=true',
+         'p,q,red,cat1'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime :-
     csharp_query_target:build_query_plan(test_group_probe_dir_mixed_bytarget_reach/4, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -5181,6 +5201,25 @@ verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime :-
         ['alice,charlie',
          'bob,charlie',
          'CACHE_HIT:TransitiveClosureSeededByTarget=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_probe_dir_mixed_bytarget_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z], [p, q]],
+    ExecParams = [[a, z], [p, q], [p, r]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosureSeededByTarget',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z',
+         'CACHE_HIT:TransitiveClosureSeededByTarget=true',
+         'p,q',
+         'p,r'],
         ExecParams,
         HarnessSource).
 


### PR DESCRIPTION
  ## Summary
  Complete the remaining mixed by-target cache reuse symmetry coverage in the C# query runtime tests.

  ## What changed
  - Added grouped mixed by-target key-order-insensitive coverage
  - Added non-grouped mixed by-target overlap-reuse coverage
  - Registered both new cases in `test_csharp_query_target/0`

  ## Why
  Before this PR, the mixed by-target reuse matrix was still missing the complementary pair of cases:

  - already covered:
    - non-grouped mixed by-target `cache_reuse`
    - non-grouped mixed by-target `key_order_insensitive`
    - grouped mixed by-target `cache_reuse`
    - grouped mixed by-target `overlap_reuse`

  - added here:
    - grouped mixed by-target `key_order_insensitive`
    - non-grouped mixed by-target `overlap_reuse`

  This closes the remaining reuse-symmetry gap for the dedicated mixed by-target fixtures.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`204/204`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_bytarget_reuse_symmetry_probe -ProjectFilter "cq_test_probe_d*"`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_bytarget_reuse_symmetry_group -ProjectFilter "cq_test_group_p*"`
    - Passed

  ## Notes
  Initial smoke runs using `C:\tmp` hit local filesystem access errors during `dotnet` temp-file creation. Rerunning the
  same smoke slices under repo-local `tmp/` output directories passed cleanly.