### PR TITLE
test(csharp-query): complete mixed cache reuse symmetry

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -308,9 +308,11 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_cache_reuse_runtime,
@@ -318,9 +320,11 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_reuse_runtime,
         verify_parameterized_reachability_pairs_cache_reuse_runtime,
         verify_parameterized_reachability_seed_cache_key_order_insensitive_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_reachability_seed_cache_overlap_reuse_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_seed_cache_eviction_runtime,
@@ -4017,6 +4021,24 @@ verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive
         ExecParams,
         HarnessSource).
 
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_group_probe_dir_mixed_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z, red, cat1], [p, q, red, cat1]],
+    ExecParams = [[p, q, red, cat1], [a, z, red, cat1]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosureSeeded',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z,red,cat1',
+         'p,q,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeeded=true'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime :-
     csharp_query_target:build_query_plan(test_label_cat_reach_param_end/4, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -4042,6 +4064,25 @@ verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime
         ['a,b,red,cat1',
          'a,c,red,cat1',
          'b,c,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosureSeeded=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_group_probe_dir_mixed_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z, red, cat1], [p, q, red, cat1]],
+    ExecParams = [[a, z, red, cat1], [p, q, red, cat1], [p, r, red, cat1]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosureSeeded',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z,red,cat1',
+         'p,q,red,cat1',
+         'p,r,red,cat1',
          'CACHE_HIT:GroupedTransitiveClosureSeeded=true'],
         ExecParams,
         HarnessSource).
@@ -5146,6 +5187,24 @@ verify_parameterized_reachability_seed_cache_key_order_insensitive_runtime :-
         ExecParams,
         HarnessSource).
 
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_probe_dir_mixed_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z], [p, q]],
+    ExecParams = [[p, q], [a, z]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosureSeeded',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z',
+         'p,q',
+         'CACHE_HIT:TransitiveClosureSeeded=true'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_reachability_by_target_cache_key_order_insensitive_runtime :-
     csharp_query_target:build_query_plan(test_reachable_param_end/2, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -5187,6 +5246,25 @@ verify_parameterized_reachability_seed_cache_overlap_reuse_runtime :-
     maybe_run_query_runtime_with_harness(Plan,
         ['alice,bob',
          'alice,charlie',
+         'CACHE_HIT:TransitiveClosureSeeded=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_probe_dir_mixed_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z], [p, q]],
+    ExecParams = [[a, z], [p, q], [p, r]],
+    harness_source_with_cache_flag_warm_exec(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosureSeeded',
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z',
+         'p,q',
+         'p,r',
          'CACHE_HIT:TransitiveClosureSeeded=true'],
         ExecParams,
         HarnessSource).


### PR DESCRIPTION
  ## Summary
  Complete the remaining cache-reuse symmetry coverage for the plain mixed seeded recursive paths in the C# query
  runtime tests.

  ## What changed
  - Added grouped mixed cache key-order-insensitive coverage
  - Added grouped mixed cache overlap-reuse coverage
  - Added non-grouped mixed cache key-order-insensitive coverage
  - Added non-grouped mixed cache overlap-reuse coverage
  - Registered all four new cases in `test_csharp_query_target/0`

  ## Why
  Before this PR, the plain mixed seeded path still only had:
  - `cache_reuse`
  - admission/selectivity coverage

  The by-target mixed path already had the full reuse matrix. This PR brings the plain mixed seeded path to parity by
  covering the missing complementary cases:
  - rerun with batch order changed
  - rerun with a warmed subset reused inside a larger overlapping batch
  - both grouped and non-grouped variants

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`208/208`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_cache_reuse_symmetry_probe -ProjectFilter "cq_test_probe_d*"`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_cache_reuse_symmetry_group -ProjectFilter "cq_test_group_p*"`
    - Passed

  ## Notes
  The Prolog suite emitted two existing cleanup warnings for old `tmp/cq_test_*` directories that could not be deleted
  due to local file locking, but the test run completed successfully and the new smoke slices passed.