### PR TITLE
test(csharp-query): isolate temp roots and summarize cleanup warnings

### DIFF
--- a/scripts/testing/run_csharp_query_runtime_smoke.ps1
+++ b/scripts/testing/run_csharp_query_runtime_smoke.ps1
@@ -50,6 +50,24 @@ function Resolve-ProjectRoot {
     return $root.Path
 }
 
+function Get-GeneratedQueryProjects {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RootPath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NameFilter = "*"
+    )
+
+    if (-not (Test-Path $RootPath)) {
+        return @()
+    }
+
+    return @(Get-ChildItem -Path $RootPath -Directory -Recurse -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -like $NameFilter -and (Test-Path (Join-Path $_.FullName "expected_rows.txt"))
+    } | Sort-Object -Property FullName -Unique)
+}
+
 function Find-SwiplExe {
     $cmd = Get-Command swipl -ErrorAction SilentlyContinue
     if ($cmd) {
@@ -165,9 +183,7 @@ $env:NUGET_PACKAGES = $nugetPackages
 $env:NUGET_HTTP_CACHE_PATH = $nugetHttpCache
 
 if (-not $SkipCodegen) {
-    $generatedDirs = Get-ChildItem -Path $outputPath -Directory -ErrorAction SilentlyContinue | Where-Object {
-        Test-Path (Join-Path $_.FullName "expected_rows.txt")
-    }
+    $generatedDirs = Get-GeneratedQueryProjects -RootPath $outputPath
     if ($generatedDirs) {
         $generatedDirs | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -191,9 +207,7 @@ if (-not $SkipCodegen) {
 
 Assert-DotnetAvailable
 
-$projects = Get-ChildItem -Path $outputPath -Directory -Filter $ProjectFilter | Where-Object {
-    Test-Path (Join-Path $_.FullName "expected_rows.txt")
-}
+$projects = Get-GeneratedQueryProjects -RootPath $outputPath -NameFilter $ProjectFilter
 
 if (-not $projects) {
     throw "No generated query projects found in '$outputPath' (expected directories containing expected_rows.txt)."
@@ -271,9 +285,7 @@ foreach ($project in $projects) {
 }
 
 if (-not $KeepArtifacts) {
-    Get-ChildItem -Path $outputPath -Directory -ErrorAction SilentlyContinue | Where-Object {
-        Test-Path (Join-Path $_.FullName "expected_rows.txt")
-    } | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    Get-GeneratedQueryProjects -RootPath $outputPath | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 if ($failures -gt 0) {

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -19,6 +19,8 @@
 :- use_module('src/unifyweaver/sources/json_source').
 
 :- dynamic cqt_option/2.
+:- dynamic cqt_run_root/1.
+:- dynamic cqt_cleanup_failure/2.
 :- dynamic user:test_factorial/2.
 :- dynamic user:test_factorial_input/1.
 :- dynamic user:test_fib_param/2.
@@ -181,9 +183,10 @@ test_csharp_query_target :-
     set_prolog_flag(verbose, silent),
     configure_csharp_query_options,
     writeln('=== Testing C# query target ==='),
-    setup_test_data,
-    progress_init,
-    Tests = [
+    setup_call_cleanup(
+        setup_test_data,
+        (   progress_init,
+            Tests = [
         verify_fact_plan,
         verify_join_plan,
         verify_join_ordering_constant_arg_plan,
@@ -394,13 +397,17 @@ test_csharp_query_target :-
         verify_json_null_policy_skip_plan,
         verify_json_null_policy_default_plan,
         verify_json_object_source_plan
-    ],
-    length(Tests, Total),
-    retractall(progress_total(_)),
-    asserta(progress_total(Total)),
-    maplist(run_with_progress, Tests),
-    progress_maybe_report(force),
-    cleanup_test_data,
+            ],
+            length(Tests, Total),
+            retractall(progress_total(_)),
+            asserta(progress_total(Total)),
+            maplist(run_with_progress, Tests),
+            progress_maybe_report(force)
+        ),
+        (   cleanup_test_data,
+            finalize_cqt_run_state
+        )
+    ),
     writeln('=== C# query target tests complete ===').
 
 setup_test_data :-
@@ -6019,7 +6026,7 @@ prepare_temp_dir(Plan, Dir) :-
         atomic_list_concat(['cq_', PredPrefix, '_', ShortUUID], Sub)
     ;   atomic_list_concat(['csharp_query_', PredName, '_', UUID], Sub)
     ),
-    cqt_option(output_dir, Base),
+    cqt_temp_root(Base),
     make_directory_path(Base),
     directory_file_path(Base, Sub, Dir),
     make_directory_path(Dir).
@@ -6032,10 +6039,16 @@ prepare_temp_dir(Dir) :-
         atomic_list_concat(['cq_', ShortUUID], Sub)
     ;   atomic_list_concat(['csharp_query_', UUID], Sub)
     ),
-    cqt_option(output_dir, Base),
+    cqt_temp_root(Base),
     make_directory_path(Base),
     directory_file_path(Base, Sub, Dir),
     make_directory_path(Dir).
+
+cqt_temp_root(Base) :-
+    cqt_run_root(Base),
+    !.
+cqt_temp_root(Base) :-
+    cqt_option(output_dir, Base).
 
 run_dotnet_plan_verbose(Dotnet, Plan, ExpectedRows, Dir) :-
     run_dotnet_plan(Dotnet, Plan, ExpectedRows, Dir),
@@ -6047,12 +6060,86 @@ run_dotnet_plan_verbose(Dotnet, Plan, ExpectedRows, Dir) :-
 finalize_temp_dir(Dir) :-
     (   cqt_option(keep_artifacts, true)
     ->  format('  (kept C# artifacts in ~w)~n', [Dir])
-    ;   catch(
-            delete_directory_and_contents(Dir),
-            Error,
-            format('  (warning: could not cleanup ~w: ~w)~n', [Dir, Error])
-        )
+    ;   catch(delete_directory_and_contents(Dir),
+              Error,
+              record_cqt_cleanup_failure(Dir, Error))
     ).
+
+record_cqt_cleanup_failure(Dir, Error) :-
+    retractall(cqt_cleanup_failure(Dir, _)),
+    assertz(cqt_cleanup_failure(Dir, Error)).
+
+initialize_cqt_run_state :-
+    retractall(cqt_run_root(_)),
+    retractall(cqt_cleanup_failure(_, _)),
+    cqt_option(output_dir, Base),
+    make_directory_path(Base),
+    uuid(UUID),
+    (   current_prolog_flag(windows, true)
+    ->  sub_atom(UUID, 0, 8, _, ShortUUID),
+        atomic_list_concat(['cq_run_', ShortUUID], Subdir)
+    ;   atomic_list_concat(['csharp_query_run_', UUID], Subdir)
+    ),
+    directory_file_path(Base, Subdir, RunRoot),
+    make_directory_path(RunRoot),
+    assertz(cqt_run_root(RunRoot)).
+
+finalize_cqt_run_state :-
+    (   cqt_option(keep_artifacts, true)
+    ->  retractall(cqt_cleanup_failure(_, _))
+    ;   retry_cqt_cleanup_failures(Remaining),
+        summarize_cqt_cleanup_failures(Remaining),
+        cleanup_cqt_run_root
+    ),
+    retractall(cqt_run_root(_)).
+
+retry_cqt_cleanup_failures(Remaining) :-
+    findall(Dir-Error,
+            retract(cqt_cleanup_failure(Dir, Error)),
+            Failures0),
+    sort(Failures0, Failures),
+    retry_cqt_cleanup_failures(Failures, Remaining).
+
+retry_cqt_cleanup_failures([], []).
+retry_cqt_cleanup_failures([Dir-_|Rest], Remaining) :-
+    (   \+ exists_directory(Dir)
+    ->  retry_cqt_cleanup_failures(Rest, Remaining)
+    ;   catch(delete_directory_and_contents(Dir), _, fail)
+    ->  retry_cqt_cleanup_failures(Rest, Remaining)
+    ;   Remaining = [Dir|Tail],
+        retry_cqt_cleanup_failures(Rest, Tail)
+    ).
+
+summarize_cqt_cleanup_failures([]).
+summarize_cqt_cleanup_failures(Remaining) :-
+    length(Remaining, Count),
+    take_upto(3, Remaining, PreviewDirs),
+    atomic_list_concat(PreviewDirs, ', ', Preview),
+    (   cqt_run_root(RunRoot)
+    ->  format('  (cleanup summary: ~w temp dirs remained locked under ~w; first: ~w)~n',
+               [Count, RunRoot, Preview])
+    ;   format('  (cleanup summary: ~w temp dirs remained locked; first: ~w)~n',
+               [Count, Preview])
+    ).
+
+cleanup_cqt_run_root :-
+    (   cqt_run_root(RunRoot),
+        exists_directory(RunRoot)
+    ->  catch(delete_directory_and_contents(RunRoot), _, true)
+    ;   true
+    ).
+
+take_upto(Count, List, Prefix) :-
+    take_upto(Count, List, [], PrefixRev),
+    reverse(PrefixRev, Prefix).
+
+take_upto(0, _, Acc, Acc) :-
+    !.
+take_upto(_, [], Acc, Acc) :-
+    !.
+take_upto(Count, [Item|Rest], Acc, Prefix) :-
+    NextCount is Count - 1,
+    take_upto(NextCount, Rest, [Item|Acc], Prefix).
 
 % Build-first approach (works around dotnet run hang)
 % See: docs/CSHARP_DOTNET_RUN_HANG_SOLUTION.md
@@ -7438,7 +7525,8 @@ configure_csharp_query_options :-
     default_cqt_options(Default),
     maplist(assertz, Default),
     capture_env_overrides,
-    capture_cli_overrides.
+    capture_cli_overrides,
+    initialize_cqt_run_state.
 
 default_cqt_options([
     cqt_option(output_dir, 'tmp'),


### PR DESCRIPTION
  ## Summary
  Improve C# query test harness temp-directory hygiene on Windows by isolating generated artifacts under a per-run root
  and collapsing noisy cleanup failures into a single end-of-run summary.

  ## What changed
  - Added a per-run temp root for `test_csharp_query_target.pl`
    - generated projects now live under `tmp/.../cq_run_<id>/...`
  - Deferred per-test cleanup failures instead of printing one warning per locked directory
  - Added one final cleanup pass and a single summary line for any directories that still remain locked
  - Updated `run_csharp_query_runtime_smoke.ps1` to discover generated projects recursively so the new run-root layout
  works transparently

  ## Why
  The C# query tests were passing, but local Windows/Dropbox runs produced a large volume of:
  - `could not cleanup tmp/cq_test_*`
  - `permission_error(delete,directory,...)`

  Those warnings were mostly noise from transient file locking. This PR keeps successful runs readable without hiding
  real failures:
  - artifacts are isolated per run
  - cleanup gets retried once at the end
  - any remaining locked directories are summarized once instead of flooding the log

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`210/210`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_tempdir_cleanup_hygiene_probe -ProjectFilter "cq_test_probe_d*"`
    - Passed

  ## Result
  The Prolog-only suite no longer emits the old per-directory cleanup warning flood on successful runs, and the smoke
  harness still finds and executes generated projects correctly under the new per-run temp layout.