### PR TITLE
fix(compiler): multifile target dispatch, skip() crash, R %in% typo

### DIFF
--- a/src/unifyweaver/core/preferences.pl
+++ b/src/unifyweaver/core/preferences.pl
@@ -102,8 +102,27 @@ merge_opts(Base, Override, Merged) :-
     pairs_values(Pairs, Merged).
 
 index_by_key(Options, Dict) :-
-    maplist(to_kv, Options, Pairs),
+    consolidate_list_options(Options, Consolidated),
+    maplist(to_kv, Consolidated, Pairs),
     dict_create(Dict, opts, Pairs).
+
+%% consolidate_list_options(+Options, -Consolidated)
+%  Merge multiple skip(X) options into a single skip([X1,X2,...]) so that
+%  dict_create doesn't crash on duplicate functor/arity keys.
+consolidate_list_options(Options, Consolidated) :-
+    % Collect all skip atoms and skip lists
+    findall(S, (member(skip(S), Options), atom(S)), SkipAtoms),
+    findall(S, (member(skip(SL), Options), is_list(SL), member(S, SL)), SkipListItems),
+    append(SkipAtoms, SkipListItems, AllSkips),
+    % Remove all skip() options from the list
+    exclude(is_skip_option, Options, Rest),
+    % Add back consolidated skip if non-empty
+    (   AllSkips \= [] ->
+        Consolidated = [skip(AllSkips)|Rest]
+    ;   Consolidated = Rest
+    ).
+
+is_skip_option(skip(_)).
 
 to_kv(Opt, Key-Opt) :-
     functor(Opt, F, A),

--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -26,6 +26,14 @@
 :- use_module('../targets/clojure_target', [compile_predicate_to_clojure/3]).
 :- use_module('../targets/jython_target', [compile_predicate_to_jython/3]).
 :- use_module('../targets/elixir_target', [compile_predicate_to_elixir/3]).
+:- use_module('../targets/r_target', []).        % registers multifile tail/linear patterns for R
+:- use_module('../targets/c_target', []).        % registers multifile tail/linear patterns for C
+:- use_module('../targets/haskell_target', []).  % registers multifile tail/linear patterns for Haskell
+:- use_module('../targets/fsharp_target', []).   % registers multifile tail/linear patterns for F#
+:- use_module('../targets/lua_target', []).      % registers multifile tail/linear patterns for Lua
+:- use_module('../targets/cpp_target', []).      % registers multifile tail/linear patterns for C++
+:- use_module('../targets/ruby_target', []).     % registers multifile tail/linear patterns for Ruby
+:- use_module('../targets/perl_target', []).     % registers multifile tail/linear patterns for Perl
 :- use_module(template_system).
 :- use_module(library(lists)).
 :- use_module(constraint_analyzer).
@@ -76,8 +84,7 @@ merge_options(RuntimeOpts, Constraints, Merged) :-
             FunctorName \= unordered
         ),
         OtherRuntimeOpts),
-    append(AllConstraints0, OtherRuntimeOpts, AllConstraints),
-    list_to_set(AllConstraints, Merged).
+    append(AllConstraints0, OtherRuntimeOpts, Merged).
 
 %% compile_dispatch(+Pred/Arity, +FinalOptions, +Target, -GeneratedCode)
 %  Target-aware compilation logic, now called after validation.
@@ -1602,7 +1609,7 @@ add_~w <- function(from_node, to_node) {
         queue <- queue[-1]
         neighbors <- tryCatch(get(current, envir = ~w_graph), error = function(e) c())
         for (next_node in neighbors) {
-            if (!(next_node %%in%% visited)) {
+            if (!(next_node %in% visited)) {
                 visited <- c(visited, next_node)
                 queue <- c(queue, next_node)
                 results <- c(results, next_node)
@@ -1624,7 +1631,7 @@ add_~w <- function(from_node, to_node) {
         neighbors <- tryCatch(get(current, envir = ~w_graph), error = function(e) c())
         for (next_node in neighbors) {
             if (next_node == target) return(TRUE)
-            if (!(next_node %%in%% visited)) {
+            if (!(next_node %in% visited)) {
                 visited <- c(visited, next_node)
                 queue <- c(queue, next_node)
             }


### PR DESCRIPTION
## Summary

  - **Missing multifile dispatch for 8 targets** — R, C, Haskell, F#, Lua, C++, Ruby, and Perl registered `compile_tail_pattern` and
  `compile_linear_pattern` via multifile clauses, but `recursive_compiler.pl` never imported their modules, so those patterns were
  never loaded. `skip(transitive_closure)` with `target(r)` would fail with "No tail recursion support for target r" even though
  `r_target.pl` defines it.
  - **Multiple `skip()` options crash** — `[skip(transitive_closure), skip(tail_recursion)]` crashed with `dict_create: Duplicate key
   'skip/1'` in `preferences.pl`. Fix: consolidate multiple `skip(X)` atoms into a single `skip([X1,X2,...])` list before dict
  indexing.
  - **R `%in%` operator rendered as `%%in%%`** — The transitive closure R template used `%%in%%` assuming C-style `%` escaping, but
  SWI-Prolog `format/3` uses `~` for escaping. `%` has no special meaning, so `%%in%%` output literally. Fixed to `%in%`.
  - Updated sci-repl submodule with ancestor/transitive closure workbook demo

  ## Files changed

  - `recursive_compiler.pl` — Added 8 missing target imports (`use_module` with `[]`); fixed `%%in%%` → `%in%`
  - `preferences.pl` — `consolidate_list_options/2` merges duplicate `skip()` options before `dict_create`
  - `examples/sci-repl/prototype` — Submodule pointer update (workbook + test additions)

  ## Test plan

  - [x] `[skip(transitive_closure), skip(tail_recursion)]` no longer crashes
  - [x] `ancestor/2` with `target(r), skip(transitive_closure)` now dispatches to tail recursion
  - [x] R transitive closure output contains `%in%` (not `%%in%%`)
  - [x] `skip([transitive_closure, tail_recursion])` list form still works
  - [x] All 17 pattern matcher tests pass

  🤖 Generated with [Claude Code](https://claude.com/claude-code)