### PR TITLE
fix(java,haskell): Java output filenames match class names, Haskell base case dedup

### DIFF
--- a/src/unifyweaver/core/advanced/direct_multi_call_recursion.pl
+++ b/src/unifyweaver/core/advanced/direct_multi_call_recursion.pl
@@ -396,8 +396,7 @@ test_direct_multi_call :-
     % Test 7: Java compilation
     writeln('Test 7: Compile fibonacci to Java'),
     (   compile_direct_multi_call(test_dfib/2, [target(java)], JavaCode) ->
-        write_output_file('output/advanced/fib_direct.java', JavaCode),
-        writeln('  ✓ Compiled to output/advanced/fib_direct.java (java)')
+        write_java_file('output/advanced', JavaCode)
     ;   writeln('  ✗ FAIL - Java compilation failed')
     ),
 
@@ -424,3 +423,18 @@ write_output_file(Path, Content) :-
     open(Path, write, Stream),
     write(Stream, Content),
     close(Stream).
+
+%% Write Java file using class name from generated code
+write_java_file(Dir, Code) :-
+    (   sub_string(Code, B, _, _, "public class "),
+        B1 is B + 13,
+        sub_string(Code, B1, _, _, Rest),
+        sub_string(Rest, SpacePos, 1, _, " "),
+        sub_string(Rest, 0, SpacePos, _, ClassName)
+    ->  atomic_list_concat([Dir, '/', ClassName, '.java'], FilePath),
+        open(FilePath, write, Stream),
+        write(Stream, Code),
+        close(Stream),
+        format('  ✓ Compiled to ~w (java)~n', [FilePath])
+    ;   writeln('  ✗ FAIL - could not extract Java class name from generated code')
+    ).

--- a/src/unifyweaver/core/advanced/linear_recursion.pl
+++ b/src/unifyweaver/core/advanced/linear_recursion.pl
@@ -699,8 +699,7 @@ test_linear_recursion :-
         write_bash_file('output/advanced/list_length.hs', Code1H),
         writeln('  ✓ Compiled to output/advanced/list_length.hs (haskell)'),
         compile_linear_recursion(list_length/2, [target(java)], Code1J),
-        write_bash_file('output/advanced/list_length.java', Code1J),
-        writeln('  ✓ Compiled to output/advanced/list_length.java (java)'),
+        write_java_file('output/advanced', Code1J),
         compile_linear_recursion(list_length/2, [target(elixir)], Code1E),
         write_bash_file('output/advanced/list_length.exs', Code1E),
         writeln('  ✓ Compiled to output/advanced/list_length.exs (elixir)'),
@@ -733,8 +732,7 @@ test_linear_recursion :-
         write_bash_file('output/advanced/factorial.hs', Code2H),
         writeln('  ✓ Compiled to output/advanced/factorial.hs (haskell)'),
         compile_linear_recursion(factorial/2, [target(java)], Code2J),
-        write_bash_file('output/advanced/factorial.java', Code2J),
-        writeln('  ✓ Compiled to output/advanced/factorial.java (java)'),
+        write_java_file('output/advanced', Code2J),
         compile_linear_recursion(factorial/2, [target(elixir)], Code2E),
         write_bash_file('output/advanced/factorial.exs', Code2E),
         writeln('  ✓ Compiled to output/advanced/factorial.exs (elixir)'),
@@ -754,3 +752,18 @@ write_bash_file(Path, Content) :-
     % Make executable
     atom_concat('chmod +x ', Path, ChmodCmd),
     shell(ChmodCmd).
+
+%% Write Java file using class name from generated code
+write_java_file(Dir, Code) :-
+    (   sub_string(Code, B, _, _, "public class "),
+        B1 is B + 13,
+        sub_string(Code, B1, _, _, Rest),
+        sub_string(Rest, SpacePos, 1, _, " "),
+        sub_string(Rest, 0, SpacePos, _, ClassName)
+    ->  atomic_list_concat([Dir, '/', ClassName, '.java'], FilePath),
+        open(FilePath, write, Stream),
+        write(Stream, Code),
+        close(Stream),
+        format('  ✓ Compiled to ~w (java)~n', [FilePath])
+    ;   writeln('  ✗ FAIL - could not extract Java class name from generated code')
+    ).

--- a/src/unifyweaver/core/advanced/multicall_linear_recursion.pl
+++ b/src/unifyweaver/core/advanced/multicall_linear_recursion.pl
@@ -313,8 +313,7 @@ test_multicall_linear :-
     % Test 7: Compile to Java
     writeln('Test 7: Compile fibonacci (multi-call linear) to Java'),
     (   compile_multicall_linear_recursion(test_fib/2, [target(java)], MCJavaCode) ->
-        write_output_file('output/advanced/fib_multicall.java', MCJavaCode),
-        writeln('  ✓ Compiled to output/advanced/fib_multicall.java (java)')
+        write_java_file('output/advanced', MCJavaCode)
     ;   writeln('  ✗ FAIL - Java compilation failed')
     ),
 
@@ -341,6 +340,21 @@ write_output_file(Path, Content) :-
     open(Path, write, Stream),
     write(Stream, Content),
     close(Stream).
+
+%% Write Java file using class name from generated code
+write_java_file(Dir, Code) :-
+    (   sub_string(Code, B, _, _, "public class "),
+        B1 is B + 13,
+        sub_string(Code, B1, _, _, Rest),
+        sub_string(Rest, SpacePos, 1, _, " "),
+        sub_string(Rest, 0, SpacePos, _, ClassName)
+    ->  atomic_list_concat([Dir, '/', ClassName, '.java'], FilePath),
+        open(FilePath, write, Stream),
+        write(Stream, Code),
+        close(Stream),
+        format('  ✓ Compiled to ~w (java)~n', [FilePath])
+    ;   writeln('  ✗ FAIL - could not extract Java class name from generated code')
+    ).
 
 abolish_if_exists(Pred/Arity) :-
     (   current_predicate(Pred/Arity) ->

--- a/src/unifyweaver/core/advanced/mutual_recursion.pl
+++ b/src/unifyweaver/core/advanced/mutual_recursion.pl
@@ -695,8 +695,7 @@ test_mutual_recursion :-
         write_bash_file('output/advanced/even_odd.hs', Code1H),
         writeln('  ✓ Compiled to output/advanced/even_odd.hs (haskell)'),
         compile_mutual_recursion(Predicates1, [target(java)], Code1J),
-        write_bash_file('output/advanced/even_odd.java', Code1J),
-        writeln('  ✓ Compiled to output/advanced/even_odd.java (java)')
+        write_java_file('output/advanced', Code1J)
     ;   writeln('  ✗ FAIL - should detect mutual recursion')
     ),
 
@@ -723,3 +722,18 @@ write_bash_file(Path, Content) :-
     % Make executable
     atom_concat('chmod +x ', Path, ChmodCmd),
     shell(ChmodCmd).
+
+%% Write Java file using class name from generated code
+write_java_file(Dir, Code) :-
+    (   sub_string(Code, B, _, _, "public class "),
+        B1 is B + 13,
+        sub_string(Code, B1, _, _, Rest),
+        sub_string(Rest, SpacePos, 1, _, " "),
+        sub_string(Rest, 0, SpacePos, _, ClassName)
+    ->  atomic_list_concat([Dir, '/', ClassName, '.java'], FilePath),
+        open(FilePath, write, Stream),
+        write(Stream, Code),
+        close(Stream),
+        format('  ✓ Compiled to ~w (java)~n', [FilePath])
+    ;   writeln('  ✗ FAIL - could not extract Java class name from generated code')
+    ).

--- a/src/unifyweaver/core/advanced/tail_recursion.pl
+++ b/src/unifyweaver/core/advanced/tail_recursion.pl
@@ -262,8 +262,7 @@ test_tail_recursion :-
         write_bash_file('output/advanced/count_items.hs', Code1H),
         writeln('  ✓ Compiled to output/advanced/count_items.hs (haskell)'),
         compile_tail_recursion(count_items/3, [target(java)], Code1J),
-        write_bash_file('output/advanced/count_items.java', Code1J),
-        writeln('  ✓ Compiled to output/advanced/count_items.java (java)'),
+        write_java_file('output/advanced', Code1J),
         compile_tail_recursion(count_items/3, [target(elixir)], Code1E),
         write_bash_file('output/advanced/count_items.exs', Code1E),
         writeln('  ✓ Compiled to output/advanced/count_items.exs (elixir)'),
@@ -296,8 +295,7 @@ test_tail_recursion :-
         write_bash_file('output/advanced/sum_list.hs', Code2H),
         writeln('  ✓ Compiled to output/advanced/sum_list.hs (haskell)'),
         compile_tail_recursion(sum_list/3, [target(java)], Code2J),
-        write_bash_file('output/advanced/sum_list.java', Code2J),
-        writeln('  ✓ Compiled to output/advanced/sum_list.java (java)'),
+        write_java_file('output/advanced', Code2J),
         compile_tail_recursion(sum_list/3, [target(elixir)], Code2E),
         write_bash_file('output/advanced/sum_list.exs', Code2E),
         writeln('  ✓ Compiled to output/advanced/sum_list.exs (elixir)'),
@@ -317,3 +315,18 @@ write_bash_file(Path, Content) :-
     % Make executable
     atom_concat('chmod +x ', Path, ChmodCmd),
     shell(ChmodCmd).
+
+%% Write Java file using class name from generated code
+write_java_file(Dir, Code) :-
+    (   sub_string(Code, B, _, _, "public class "),
+        B1 is B + 13,
+        sub_string(Code, B1, _, _, Rest),
+        sub_string(Rest, SpacePos, 1, _, " "),
+        sub_string(Rest, 0, SpacePos, _, ClassName)
+    ->  atomic_list_concat([Dir, '/', ClassName, '.java'], FilePath),
+        open(FilePath, write, Stream),
+        write(Stream, Code),
+        close(Stream),
+        format('  ✓ Compiled to ~w (java)~n', [FilePath])
+    ;   writeln('  ✗ FAIL - could not extract Java class name from generated code')
+    ).

--- a/src/unifyweaver/core/advanced/tree_recursion.pl
+++ b/src/unifyweaver/core/advanced/tree_recursion.pl
@@ -376,8 +376,7 @@ test_tree_recursion :-
             write_bash_file('output/advanced/tree_fib.hs', FibCode1H),
             writeln('  ✓ Compiled to output/advanced/tree_fib.hs (haskell)'),
             compile_tree_recursion(test_tree_fib/2, [target(java)], FibCode1J),
-            write_bash_file('output/advanced/tree_fib.java', FibCode1J),
-            writeln('  ✓ Compiled to output/advanced/tree_fib.java (java)'),
+            write_java_file('output/advanced', FibCode1J),
             compile_tree_recursion(test_tree_fib/2, [target(elixir)], FibCode1E),
             write_bash_file('output/advanced/tree_fib.exs', FibCode1E),
             writeln('  ✓ Compiled to output/advanced/tree_fib.exs (elixir)'),
@@ -400,3 +399,18 @@ write_bash_file(Path, Code) :-
     % Make executable
     format(atom(ChmodCmd), 'chmod +x ~w', [Path]),
     shell(ChmodCmd).
+
+%% Write Java file using class name from generated code
+write_java_file(Dir, Code) :-
+    (   sub_string(Code, B, _, _, "public class "),
+        B1 is B + 13,
+        sub_string(Code, B1, _, _, Rest),
+        sub_string(Rest, SpacePos, 1, _, " "),
+        sub_string(Rest, 0, SpacePos, _, ClassName)
+    ->  atomic_list_concat([Dir, '/', ClassName, '.java'], FilePath),
+        open(FilePath, write, Stream),
+        write(Stream, Code),
+        close(Stream),
+        format('  ✓ Compiled to ~w (java)~n', [FilePath])
+    ;   writeln('  ✗ FAIL - could not extract Java class name from generated code')
+    ).

--- a/src/unifyweaver/targets/haskell_target.pl
+++ b/src/unifyweaver/targets/haskell_target.pl
@@ -782,7 +782,8 @@ multicall_linear_recursion:compile_multicall_pattern(haskell, PredStr, BaseClaus
         member(clause(BHead, _), BaseClauses),
         BHead =.. [_P, BInput, BOutput],
         format(string(BaseCaseCode), '~w ~w = ~w', [PredStr, BInput, BOutput])
-    ), BaseCaseCodes),
+    ), BaseCaseCodes0),
+    sort(BaseCaseCodes0, BaseCaseCodes),
     atomic_list_concat(BaseCaseCodes, '\n', BaseCaseStr),
     format(string(HsCode),
 '{-# LANGUAGE BangPatterns #-}
@@ -829,7 +830,8 @@ direct_multi_call_recursion:compile_direct_multicall_pattern(haskell, PredStr, B
         member(clause(BHead, _), BaseClauses),
         BHead =.. [_P, BInput, BOutput],
         format(string(BaseCaseCode), '~w ~w = ~w', [PredStr, BInput, BOutput])
-    ), BaseCaseCodes),
+    ), BaseCaseCodes0),
+    sort(BaseCaseCodes0, BaseCaseCodes),
     atomic_list_concat(BaseCaseCodes, '\n', BaseCaseStr),
     format(string(HsCode),
 '{-# LANGUAGE BangPatterns #-}


### PR DESCRIPTION
## Summary

- **Java**: Fix filename/classname mismatch — generated files used lowercase names (e.g. `factorial.java`) but PascalCase class names (e.g. `public class Factorial`), causing `javac` to reject them. Added `write_java_file/2` helper to all 6 core modules that extracts the class name from the generated code and writes to the correct filename (e.g. `Factorial.java`).
- **Haskell**: Fix duplicate base case warnings in multicall and direct multicall templates — `findall` collected duplicate base cases, causing GHC "Pattern match is redundant" warnings. Added `sort/2` dedup after `findall`, matching the fix already applied to Elixir templates.

## Files changed

- `src/unifyweaver/core/advanced/linear_recursion.pl` — `write_java_file/2` helper + updated 2 call sites
- `src/unifyweaver/core/advanced/tail_recursion.pl` — `write_java_file/2` helper + updated 2 call sites
- `src/unifyweaver/core/advanced/tree_recursion.pl` — `write_java_file/2` helper + updated 1 call site
- `src/unifyweaver/core/advanced/mutual_recursion.pl` — `write_java_file/2` helper + updated 1 call site
- `src/unifyweaver/core/advanced/multicall_linear_recursion.pl` — `write_java_file/2` helper + updated 1 call site
- `src/unifyweaver/core/advanced/direct_multi_call_recursion.pl` — `write_java_file/2` helper + updated 1 call site
- `src/unifyweaver/targets/haskell_target.pl` — `sort/2` dedup in multicall + direct multicall base case collection

## Test plan

- [x] Prolog test suite passes (`test_all_advanced`)
- [x] All 8 generated Java files now have filenames matching class names
- [x] `javac` + `java` succeeds directly without renaming (validated: Factorial, MutualGroup, TEST_FIB)
- [x] Haskell `fib_multicall.hs` compiles without "Pattern match is redundant" warnings
- [x] Haskell `fib_multicall` produces correct output (55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
