### PR TITLE
feat(agent-loop): Rust Phase 14 — plugin wiring, WASM config, Python dispatch, cross-target plugins

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -62,20 +62,20 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 |--------|--------|--------|
 | Python | `generated/python/` (15+ modules) | Full agent loop |
 | Prolog | `generated/prolog/` (8 modules) | Full agent loop |
-| Rust | `generated/rust/` (17 files + integration tests) | Data + imperative + CLI + config loading + streaming (with token parsing) + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching + RuntimeState + session resume + env var expansion + multi-format export + retry with backoff + templates (16 built-in + persistence) + skills + multiline input + history edit/undo + spinner + rich display + proot sandbox + paste detection + config gen (paste_mode) + data-driven help + data-driven dispatch + plugin system + WASM bindings + 66 integration tests |
+| Rust | `generated/rust/` (17 files + integration tests) | Data + imperative + CLI + config loading + streaming (with token parsing) + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching + RuntimeState + session resume + env var expansion + multi-format export + retry with backoff + templates (16 built-in + persistence) + skills + multiline input + history edit/undo + spinner + rich display + proot sandbox + paste detection + config gen (paste_mode) + data-driven help + data-driven dispatch + plugin system (ToolHandler wiring) + WASM bindings (feature-gated) + 66 integration tests |
 
 ### Declarative Infrastructure
 
 | Metric | Count |
 |--------|-------|
-| `py_fragment/2` facts | 82 |
+| `py_fragment/2` facts | 85 |
 | `prolog_fragment/2` facts | 33 |
 | `rust_fragment/2` facts | 32 |
 | `rust_data_table/5` specs | 9 |
 | `emit_config_section/3` clauses | 11 (python + prolog + rust) |
 | `compile_component/4` targets | 3 (python, prolog, rust) |
 | `declare_binding` per target | 11 |
-| Total tests | 809 + 66 Rust integration (590+181 unit + 27 Prolog + 59 Python + 66 cargo test) |
+| Total tests | 832 + 66 Rust integration (590+181 unit + 27 Prolog + 59 Python + 66 cargo test) |
 
 ## Backends
 
@@ -727,9 +727,10 @@ python3 agent_loop.py -i 5 "prompt"  # Max 5 tool iterations
 | Config gen (paste_mode) | Y | Y | Complete (auto/bracketed/timing/off) |
 | Bracketed paste mode | Y | Y | Complete (optional, configurable) |
 | Data-driven /help | Y | Y | Complete (from slash_command/4 facts) |
-| Data-driven dispatch | N | Y | Complete (from rust_command_body/2 facts) |
-| Plugin system | N | Y | Complete (JSON manifests, tool schemas) |
-| WASM bindings | N | Y | Complete (WasmAgentState + wasm_bindgen) |
+| Data-driven dispatch | Y | Y | Complete (py_command_body/2 + rust_command_body/2) |
+| Plugin system | Y | Y | Complete (JSON manifests, tool schemas, ToolHandler wiring) |
+| Plugin system (Prolog) | N | N | Prolog-only (dynamic plugin_tool/3, JSON loading) |
+| WASM bindings | N | Y | Complete (feature-gated wasm-bindgen) |
 | Integration tests (cargo test) | N | Y (66 tests) | Rust-only |
 
 ## License

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -773,6 +773,8 @@ slash_command(tokens, exact, [handler('_handle_tokens_command'),
     comment('/tokens - show context token estimate'),
     target(prolog)],
     'Show context token estimate and limit').
+slash_command(multiline, exact, [comment('Toggle multiline input mode')],
+    'Toggle multiline input mode').
 slash_command(aliases, exact, [handler('_handle_aliases_command'),
     comment('Aliases')],
     'List command aliases (e.g., /q -> /quit)').
@@ -823,6 +825,36 @@ slash_command_dispatch_order([
     aliases, templates,
     history, undo,
     delete, edit, replay
+]).
+
+%% =============================================================================
+%% Python command bodies — used by data-driven dispatch generator
+%% py_command_body(Name, PythonCodeLines)
+%% Each line is emitted inside the if/elif block (indented at 12 spaces).
+%% =============================================================================
+
+py_command_body(exit, [
+    '            self.running = False'
+]).
+
+py_command_body(clear, [
+    '            self.context.clear()',
+    '            self.history_manager = HistoryManager(self.context)',
+    '            print("[Context cleared]\\n")'
+]).
+
+py_command_body(help, [
+    '            self._print_help()'
+]).
+
+py_command_body(status, [
+    '            self._print_status()'
+]).
+
+py_command_body(multiline, [
+    '            self.multiline_mode = not getattr(self, "multiline_mode", False)',
+    '            state = "ON" if self.multiline_mode else "OFF"',
+    '            print(f"Multiline mode: {state}")'
 ]).
 
 %% =============================================================================
@@ -1740,6 +1772,12 @@ generate_rust_cargo_toml :-
     write(S, 'reqwest = { version = "0.12", features = ["json", "blocking"] }\n'),
     write(S, 'rustyline = "14"\n'),
     write(S, 'serde_yaml = "0.9"\n'),
+    write(S, 'wasm-bindgen = { version = "0.2", optional = true }\n\n'),
+    write(S, '[features]\n'),
+    write(S, 'default = []\n'),
+    write(S, 'wasm = ["wasm-bindgen"]\n\n'),
+    write(S, '[lib]\n'),
+    write(S, 'crate-type = ["cdylib", "rlib"]\n'),
     close(S),
     format('  Generated rust/Cargo.toml~n', []).
 
@@ -3276,6 +3314,9 @@ generate_tools_module :-
     %% SecurityConfig (imperative — has from_profile method)
     write_py(S, tools_security_config),
     write(S, '\n\n'),
+    %% PluginManager class
+    write_py(S, plugin_manager_class),
+    write(S, '\n\n'),
     %% ToolHandler class (header + generated dispatch + body)
     findall(T, tool_handler(T, _), DefaultTools),
     format_python_string_list(DefaultTools, DefaultToolsStr),
@@ -3416,34 +3457,15 @@ generate_command_dispatch_chain(S, [Cmd|Rest]) :-
     generate_command_dispatch_chain(S, Rest).
 
 %% Generate a single command dispatch entry
-%% Special cases: exit, clear, help, status are inline (no handler property)
-generate_single_dispatch(S, exit, exact, Props) :-
-    !,
+%% Commands with py_command_body/2 facts get inline bodies.
+%% Commands with handler property in slash_command/4 get method calls.
+generate_single_dispatch(S, Cmd, exact, Props) :-
+    py_command_body(Cmd, BodyLines), !,
     (member(aliases(Aliases), Props) -> true ; Aliases = []),
-    write(S, '        if cmd == \'exit\''),
+    format(S, '        if cmd == \'~w\'', [Cmd]),
     agent_loop_components:emit_alias_conditions(S, [aliases(Aliases), match_style(exact)]),
     write(S, ':\n'),
-    write(S, '            self.running = False\n'),
-    write(S, '            return True\n').
-
-generate_single_dispatch(S, clear, exact, _) :-
-    !,
-    write(S, '        if cmd == \'clear\':\n'),
-    write(S, '            self.context.clear()\n'),
-    write(S, '            self.history_manager = HistoryManager(self.context)\n'),
-    write(S, '            print("[Context cleared]\\n")\n'),
-    write(S, '            return True\n').
-
-generate_single_dispatch(S, help, exact, _) :-
-    !,
-    write(S, '        if cmd == \'help\':\n'),
-    write(S, '            self._print_help()\n'),
-    write(S, '            return True\n').
-
-generate_single_dispatch(S, status, exact, _) :-
-    !,
-    write(S, '        if cmd == \'status\':\n'),
-    write(S, '            self._print_status()\n'),
+    maplist([Line]>>(format(S, '~w~n', [Line])), BodyLines),
     write(S, '            return True\n').
 
 %% Generic exact-match command with handler
@@ -5279,6 +5301,7 @@ impl AgentBackend for ApiBackend {
 rust_fragment(tool_handler_struct, '
 use crate::security::SecurityProfileSpec;
 use crate::proot_sandbox::{ProotSandbox, ProotConfig};
+use crate::plugin_manager::PluginManager;
 
 /// Handles tool execution with security validation.
 pub struct ToolHandler {
@@ -5286,11 +5309,12 @@ pub struct ToolHandler {
     pub security_profile: String,
     pub approval_mode: String,
     pub proot: Option<ProotSandbox>,
+    pub plugins: Option<PluginManager>,
 }
 
 impl ToolHandler {
     pub fn new(auto_approve: bool, security_profile: String, approval_mode: String) -> Self {
-        Self { auto_approve, security_profile, approval_mode, proot: None }
+        Self { auto_approve, security_profile, approval_mode, proot: None, plugins: None }
     }
 
     /// Enable proot sandbox with the given allowed dirs.
@@ -5305,6 +5329,35 @@ impl ToolHandler {
         } else {
             eprintln!("[Warning] proot sandbox requested but proot not found. Install with: pkg install proot");
         }
+    }
+
+    /// Load plugins from a directory. Returns number of plugins loaded.
+    pub fn load_plugins(&mut self, dir: &str) -> usize {
+        let mut pm = PluginManager::new();
+        let count = pm.load_dir(dir);
+        if count > 0 {
+            self.plugins = Some(pm);
+        }
+        count
+    }
+
+    /// Load plugins from the default directory (~/.agent-loop/plugins/).
+    pub fn load_default_plugins(&mut self) -> usize {
+        let dir = PluginManager::default_dir();
+        if dir.exists() {
+            self.load_plugins(dir.to_str().unwrap_or(""))
+        } else {
+            0
+        }
+    }
+
+    /// Get all tool schemas (built-in + plugins) for API tool_use format.
+    pub fn get_all_tool_schemas(&self) -> Vec<serde_json::Value> {
+        let mut schemas = crate::tools::tool_schemas_json().clone();
+        if let Some(ref pm) = self.plugins {
+            schemas.extend(pm.get_tool_schemas());
+        }
+        schemas
     }
 
     /// Look up the SecurityProfileSpec for the current profile.
@@ -5465,10 +5518,23 @@ impl ToolHandler {
             "read" => self.handle_read(&tool_call.arguments),
             "write" => self.handle_write(&tool_call.arguments),
             "edit" => self.handle_edit(&tool_call.arguments),
-            _ => ToolResult {
-                success: false,
-                output: format!("Unknown tool: {}", tool_call.name),
-                tool_name: tool_call.name.clone(),
+            _ => {
+                // Check plugin tools
+                if let Some(ref pm) = self.plugins {
+                    if let Some(cmd) = pm.execute(&tool_call.name, &tool_call.arguments) {
+                        // Execute plugin command via bash
+                        let mut plugin_args = std::collections::HashMap::new();
+                        plugin_args.insert("command".to_string(), serde_json::json!(cmd));
+                        let mut result = self.handle_bash(&plugin_args);
+                        result.tool_name = tool_call.name.clone();
+                        return result;
+                    }
+                }
+                ToolResult {
+                    success: false,
+                    output: format!("Unknown tool: {}", tool_call.name),
+                    tool_name: tool_call.name.clone(),
+                }
             },
         }
     }
@@ -5839,7 +5905,7 @@ rust_fragment(wasm_bindings, '
 //! Build with: `cargo build --target wasm32-unknown-unknown --features wasm`
 //! Or with wasm-pack: `wasm-pack build --target web`
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 use wasm_bindgen::prelude::*;
 
 use crate::types::*;
@@ -5980,13 +6046,13 @@ impl WasmAgentState {
 }
 
 /// WASM-exported functions (only compiled for wasm32 targets).
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 #[wasm_bindgen]
 pub struct WasmAgent {
     inner: WasmAgentState,
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 #[wasm_bindgen]
 impl WasmAgent {
     #[wasm_bindgen(constructor)]
@@ -8116,7 +8182,7 @@ fn test_wasm_agent_state_parse_tool_calls_anthropic() {
 #[test]
 fn test_session_manager_empty_list() {
     let tmp_dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    let test_dir = format!("{}/uwsal_test_sessions_{}", tmp_dir, std::process::id());
+    let test_dir = format!("{}/uwsal_test_sessions_empty_{}", tmp_dir, std::process::id());
     let sm = SessionManager::new(Some(&test_dir));
     let sessions = sm.list();
     assert!(sessions.is_empty());
@@ -8126,7 +8192,7 @@ fn test_session_manager_empty_list() {
 #[test]
 fn test_session_manager_save_and_load() {
     let tmp_dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    let test_dir = format!("{}/uwsal_test_sessions_{}", tmp_dir, std::process::id());
+    let test_dir = format!("{}/uwsal_test_sessions_saveload_{}", tmp_dir, std::process::id());
     let sm = SessionManager::new(Some(&test_dir));
 
     let messages = vec![
@@ -8192,6 +8258,12 @@ rust_fragment(main_loop, '
             .unwrap_or_default();
         let cwd = std::env::current_dir().unwrap_or_default();
         tool_handler.enable_proot(&cwd.to_string_lossy(), proot_dirs);
+    }
+
+    // Load plugins from default directory
+    let plugin_count = tool_handler.load_default_plugins();
+    if plugin_count > 0 {
+        println!("[Loaded {} plugin(s)]", plugin_count);
     }
 
     let mut state = RuntimeState {
@@ -8502,10 +8574,70 @@ handle_slash_command(RawCmd, Args, Action) :-
 
 prolog_fragment(tools_execute_dispatch, '%% Execute a tool by name
 execute_tool(ToolName, Params, Result) :-
-    (tool_handler(ToolName, _) -> true
+    (tool_handler(ToolName, _) ->
+        execute_tool_impl(ToolName, Params, Result)
+    ; execute_plugin_tool(ToolName, Params, Result) ->
+        true
     ; format(atom(Err), "Unknown tool: ~w", [ToolName]),
-      Result = error(Err), !),
-    execute_tool_impl(ToolName, Params, Result).
+      Result = error(Err)
+    ).
+
+%% Plugin tool execution — loads from ~/.agent-loop/plugins/
+:- dynamic plugin_tool/3.  %% plugin_tool(Name, Template, Params)
+
+load_plugins :-
+    retractall(plugin_tool(_, _, _)),
+    (getenv(''HOME'', Home) -> true ; Home = "."),
+    format(atom(PluginDir), "~w/.agent-loop/plugins", [Home]),
+    (exists_directory(PluginDir) ->
+        directory_files(PluginDir, Files),
+        include([F]>>(atom_concat(_, ''.json'', F)), Files, JsonFiles),
+        maplist([JF]>>(
+            format(atom(FullPath), "~w/~w", [PluginDir, JF]),
+            catch(load_plugin_file(FullPath), _, true)
+        ), JsonFiles)
+    ; true).
+
+load_plugin_file(Path) :-
+    read_file_to_string(Path, Content, []),
+    atom_json_dict(Content, Manifest, []),
+    (get_dict(tools, Manifest, Tools) ->
+        maplist([Tool]>>(
+            get_dict(name, Tool, Name),
+            (get_dict(command_template, Tool, Template) -> true ; Template = ""),
+            (get_dict(parameters, Tool, Params) -> true ; Params = []),
+            atom_string(NameAtom, Name),
+            assertz(plugin_tool(NameAtom, Template, Params))
+        ), Tools)
+    ; true).
+
+execute_plugin_tool(ToolName, Params, Result) :-
+    plugin_tool(ToolName, Template, PluginParams),
+    render_plugin_template(Template, Params, PluginParams, Command),
+    execute_tool_impl(bash, _{command: Command}, Result).
+
+render_plugin_template(Template, Args, PluginParams, Rendered) :-
+    atom_string(Template, TStr),
+    foldl([P, In, Out]>>(
+        (is_dict(P) -> get_dict(name, P, PName) ; PName = P),
+        atom_string(PName, PNameStr),
+        format(atom(Placeholder), "{~w}", [PNameStr]),
+        atom_string(Placeholder, PlaceholderStr),
+        (get_dict(PName, Args, Val) ->
+            term_string(Val, ValStr),
+            split_string(In, PlaceholderStr, "", Parts),
+            atomics_to_string(Parts, ValStr, Out)
+        ; Out = In)
+    ), PluginParams, TStr, RenderedStr),
+    atom_string(Rendered, RenderedStr).
+
+atomics_to_string([], _, "").
+atomics_to_string([Part], _, Part).
+atomics_to_string([Part|Rest], Sep, Result) :-
+    Rest \\= [],
+    atomics_to_string(Rest, Sep, RestStr),
+    string_concat(Part, Sep, WithSep),
+    string_concat(WithSep, RestStr, Result).
 
 execute_tool_impl(bash, Params, Result) :-
     get_dict(command, Params, Cmd),
@@ -11386,6 +11518,104 @@ class SecurityConfig:
         )
 ').
 
+py_fragment(plugin_manager_class, '
+class PluginManager:
+    """Manages loading and executing plugin-defined tools from JSON files."""
+
+    DEFAULT_DIR = os.path.join(os.path.expanduser("~"), ".agent-loop", "plugins")
+
+    def __init__(self):
+        self.plugins: list[dict] = []
+        self.tool_map: dict[str, tuple[int, int]] = {}  # name -> (plugin_idx, tool_idx)
+
+    def load_dir(self, directory: str) -> int:
+        """Load all .json plugin manifests from a directory. Returns count."""
+        if not os.path.isdir(directory):
+            return 0
+        count = 0
+        for fname in sorted(os.listdir(directory)):
+            if fname.endswith(".json"):
+                path = os.path.join(directory, fname)
+                if self.load_file(path):
+                    count += 1
+        return count
+
+    def load_file(self, path: str) -> bool:
+        """Load a single plugin manifest."""
+        try:
+            with open(path, "r") as f:
+                manifest = json.load(f)
+            plugin_idx = len(self.plugins)
+            for tool_idx, tool in enumerate(manifest.get("tools", [])):
+                self.tool_map[tool["name"]] = (plugin_idx, tool_idx)
+            self.plugins.append(manifest)
+            return True
+        except (json.JSONDecodeError, IOError, KeyError):
+            return False
+
+    def has_tool(self, name: str) -> bool:
+        return name in self.tool_map
+
+    def get_tool(self, name: str) -> dict | None:
+        if name not in self.tool_map:
+            return None
+        pi, ti = self.tool_map[name]
+        return self.plugins[pi]["tools"][ti]
+
+    def execute(self, name: str, args: dict) -> str | None:
+        """Render command template with arguments. Returns command string."""
+        tool = self.get_tool(name)
+        if tool is None:
+            return None
+        cmd = tool.get("command_template", "")
+        for param in tool.get("parameters", []):
+            placeholder = "{" + param["name"] + "}"
+            if param["name"] in args:
+                val = args[param["name"]]
+                cmd = cmd.replace(placeholder, str(val))
+            elif param.get("required", False):
+                return None
+        return cmd
+
+    def list_tools(self) -> list[dict]:
+        tools = []
+        for plugin in self.plugins:
+            tools.extend(plugin.get("tools", []))
+        return tools
+
+    def get_tool_schemas(self) -> list[dict]:
+        """Get tool schemas in OpenAI-compatible format."""
+        schemas = []
+        for tool in self.list_tools():
+            params = tool.get("parameters", [])
+            properties = {}
+            required = []
+            for p in params:
+                properties[p["name"]] = {
+                    "type": p.get("param_type", "string"),
+                    "description": p.get("description", "")
+                }
+                if p.get("required", False):
+                    required.append(p["name"])
+            schemas.append({
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": required
+                    }
+                }
+            })
+        return schemas
+
+    def load_default(self) -> int:
+        """Load plugins from the default directory."""
+        return self.load_dir(self.DEFAULT_DIR)
+').
+
 py_fragment(tools_handler_class_header, 'class ToolHandler:
     """Handles execution of tool calls from agent responses."""
 
@@ -11431,6 +11661,30 @@ py_fragment(tools_handler_class_header, 'class ToolHandler:
                 print("[Warning] proot sandbox requested but proot not "
                       "found. Install with: pkg install proot",
                       file=sys.stderr)
+
+        # Load plugins
+        self.plugin_manager = PluginManager()
+        plugin_count = self.plugin_manager.load_default()
+        if plugin_count > 0:
+            # Register plugin tools as allowed and add dispatchers
+            for tool in self.plugin_manager.list_tools():
+                name = tool["name"]
+                self.allowed_tools.append(name)
+                self.tools[name] = self._make_plugin_handler(name)
+            print(f"[Loaded {plugin_count} plugin(s)]")
+
+    def _make_plugin_handler(self, tool_name: str):
+        """Create a handler function for a plugin tool."""
+        def handler(args):
+            cmd = self.plugin_manager.execute(tool_name, args)
+            if cmd is None:
+                return ToolResult(
+                    success=False,
+                    output=f"Missing required parameters for {tool_name}",
+                    tool_name=tool_name
+                )
+            return self._execute_bash({"command": cmd})
+        return handler
 ').
 
 py_fragment(tools_handler_class_body, '
@@ -14628,6 +14882,25 @@ py_fragment(handler_stream_command, '    def _handle_stream_command(self) -> boo
         self.streaming = not self.streaming
         status = "enabled" if self.streaming else "disabled"
         print(f"[Streaming {status}]\\n")
+        return True').
+
+py_fragment(handler_model_command, '    def _handle_model_command(self, text: str) -> bool:
+        """Handle /model [name] command."""
+        parts = text.split(maxsplit=1)
+        if len(parts) > 1:
+            new_model = parts[1].strip()
+            self.config["model"] = new_model
+            print(f"Model switched to: {new_model}")
+        else:
+            print(f"Current model: {self.config.get(\"model\", \"unknown\")}")
+        return True').
+
+py_fragment(handler_tokens_command, '    def _handle_tokens_command(self) -> bool:
+        """Handle /tokens command."""
+        count = self.context.token_count()
+        limit = self.config.get("max_context_tokens", 128000)
+        pct = (count / limit * 100) if limit > 0 else 0
+        print(f"Context: ~{count} tokens ({pct:.1f}% of {limit})")
         return True').
 
 py_fragment(handler_aliases_command, '    def _handle_aliases_command(self) -> bool:

--- a/tools/agent-loop/generated/prolog/commands.pl
+++ b/tools/agent-loop/generated/prolog/commands.pl
@@ -21,7 +21,7 @@
 %%   - command_alias/2: first-argument string hash-indexed, all distinct
 
 %% Indexing hints (SWI-Prolog auto-indexes first argument):
-%%   slash_command/4: first-argument indexed (23 clauses)
+%%   slash_command/4: first-argument indexed (24 clauses)
 %%   command_alias/2: first-argument indexed (30 clauses)
 
 %% slash_command(+Name, +MatchType, +Options, +HelpText)
@@ -41,8 +41,9 @@ slash_command(search, prefix, [handler('_handle_search_command'), comment('/sear
 slash_command(stream, exact, [aliases([streaming]), handler('_handle_stream_command'), comment('/stream - toggle streaming mode')], 'Toggle streaming mode for API backends').
 slash_command(model, prefix_sp, [handler('_handle_model_command'), comment('/model [name] - show or switch model'), help_display('/model [name]'), target(prolog)], 'Show or switch model at runtime').
 slash_command(tokens, exact, [handler('_handle_tokens_command'), comment('/tokens - show context token estimate'), target(prolog)], 'Show context token estimate and limit').
+slash_command(multiline, exact, [comment('Toggle multiline input mode')], 'Toggle multiline input mode').
 slash_command(aliases, exact, [handler('_handle_aliases_command'), comment('Aliases')], 'List command aliases (e.g., /q -> /quit)').
-slash_command(templates, exact, [handler('_handle_templates_command'), comment('Templates')], 'List prompt templates').
+slash_command(templates, exact, [aliases([template]), handler('_handle_templates_command'), comment('Templates')], 'List prompt templates').
 slash_command(history, exact_or_prefix_sp, [handler('_handle_history_command'), comment('History'), help_display('/history [n]')], 'Show last n messages (default 10)').
 slash_command(undo, exact, [handler('_handle_undo_command'), comment('Undo')], 'Undo last history change').
 slash_command(delete, prefix_sp, [aliases([del]), handler('_handle_delete_command'), comment('Delete message(s)'), help_lines(['/delete <idx>      - Delete message at index','/delete <s>-<e>    - Delete messages from s to e','/delete last [n]   - Delete last n messages'])], 'Delete message(s) at index or range').

--- a/tools/agent-loop/generated/prolog/tools.pl
+++ b/tools/agent-loop/generated/prolog/tools.pl
@@ -73,10 +73,70 @@ tool_description(openrouter_api, bash, $, command, truncate(72)).
 
 %% Execute a tool by name
 execute_tool(ToolName, Params, Result) :-
-    (tool_handler(ToolName, _) -> true
+    (tool_handler(ToolName, _) ->
+        execute_tool_impl(ToolName, Params, Result)
+    ; execute_plugin_tool(ToolName, Params, Result) ->
+        true
     ; format(atom(Err), "Unknown tool: ~w", [ToolName]),
-      Result = error(Err), !),
-    execute_tool_impl(ToolName, Params, Result).
+      Result = error(Err)
+    ).
+
+%% Plugin tool execution — loads from ~/.agent-loop/plugins/
+:- dynamic plugin_tool/3.  %% plugin_tool(Name, Template, Params)
+
+load_plugins :-
+    retractall(plugin_tool(_, _, _)),
+    (getenv('HOME', Home) -> true ; Home = "."),
+    format(atom(PluginDir), "~w/.agent-loop/plugins", [Home]),
+    (exists_directory(PluginDir) ->
+        directory_files(PluginDir, Files),
+        include([F]>>(atom_concat(_, '.json', F)), Files, JsonFiles),
+        maplist([JF]>>(
+            format(atom(FullPath), "~w/~w", [PluginDir, JF]),
+            catch(load_plugin_file(FullPath), _, true)
+        ), JsonFiles)
+    ; true).
+
+load_plugin_file(Path) :-
+    read_file_to_string(Path, Content, []),
+    atom_json_dict(Content, Manifest, []),
+    (get_dict(tools, Manifest, Tools) ->
+        maplist([Tool]>>(
+            get_dict(name, Tool, Name),
+            (get_dict(command_template, Tool, Template) -> true ; Template = ""),
+            (get_dict(parameters, Tool, Params) -> true ; Params = []),
+            atom_string(NameAtom, Name),
+            assertz(plugin_tool(NameAtom, Template, Params))
+        ), Tools)
+    ; true).
+
+execute_plugin_tool(ToolName, Params, Result) :-
+    plugin_tool(ToolName, Template, PluginParams),
+    render_plugin_template(Template, Params, PluginParams, Command),
+    execute_tool_impl(bash, _{command: Command}, Result).
+
+render_plugin_template(Template, Args, PluginParams, Rendered) :-
+    atom_string(Template, TStr),
+    foldl([P, In, Out]>>(
+        (is_dict(P) -> get_dict(name, P, PName) ; PName = P),
+        atom_string(PName, PNameStr),
+        format(atom(Placeholder), "{~w}", [PNameStr]),
+        atom_string(Placeholder, PlaceholderStr),
+        (get_dict(PName, Args, Val) ->
+            term_string(Val, ValStr),
+            split_string(In, PlaceholderStr, "", Parts),
+            atomics_to_string(Parts, ValStr, Out)
+        ; Out = In)
+    ), PluginParams, TStr, RenderedStr),
+    atom_string(Rendered, RenderedStr).
+
+atomics_to_string([], _, "").
+atomics_to_string([Part], _, Part).
+atomics_to_string([Part|Rest], Sep, Result) :-
+    Rest \= [],
+    atomics_to_string(Rest, Sep, RestStr),
+    string_concat(Part, Sep, WithSep),
+    string_concat(WithSep, RestStr, Result).
 
 execute_tool_impl(bash, Params, Result) :-
     get_dict(command, Params, Cmd),

--- a/tools/agent-loop/generated/python/agent_loop.py
+++ b/tools/agent-loop/generated/python/agent_loop.py
@@ -204,12 +204,26 @@ class AgentLoop:
         if cmd == 'stream' or cmd == 'streaming':
             return self._handle_stream_command()
 
+        # /model [name] - show or switch model
+        if cmd.startswith('model '):
+            return self._handle_model_command(text)
+
+        # /tokens - show context token estimate
+        if cmd == 'tokens':
+            return self._handle_tokens_command()
+
+        if cmd == 'multiline':
+            self.multiline_mode = not getattr(self, "multiline_mode", False)
+            state = "ON" if self.multiline_mode else "OFF"
+            print(f"Multiline mode: {state}")
+            return True
+
         # Aliases
         if cmd == 'aliases':
             return self._handle_aliases_command()
 
         # Templates
-        if cmd == 'templates':
+        if cmd == 'templates' or cmd == 'template':
             return self._handle_templates_command()
 
         # History
@@ -424,6 +438,25 @@ Cost Summary:
         self.streaming = not self.streaming
         status = "enabled" if self.streaming else "disabled"
         print(f"[Streaming {status}]\n")
+        return True
+
+    def _handle_model_command(self, text: str) -> bool:
+        """Handle /model [name] command."""
+        parts = text.split(maxsplit=1)
+        if len(parts) > 1:
+            new_model = parts[1].strip()
+            self.config["model"] = new_model
+            print(f"Model switched to: {new_model}")
+        else:
+            print(f"Current model: {self.config.get("model", "unknown")}")
+        return True
+
+    def _handle_tokens_command(self) -> bool:
+        """Handle /tokens command."""
+        count = self.context.token_count()
+        limit = self.config.get("max_context_tokens", 128000)
+        pct = (count / limit * 100) if limit > 0 else 0
+        print(f"Context: ~{count} tokens ({pct:.1f}% of {limit})")
         return True
 
     def _handle_aliases_command(self) -> bool:

--- a/tools/agent-loop/generated/python/test_metadata.json
+++ b/tools/agent-loop/generated/python/test_metadata.json
@@ -3,7 +3,7 @@
   "tools": {"count": 4, "names": ["bash", "read", "write", "edit"]},
   "security": {"count": 4, "profiles": ["open", "cautious", "guarded", "paranoid"]},
   "backends": {"count": 8, "names": ["coro", "claude-code", "gemini", "claude", "openai", "openrouter", "ollama-api", "ollama-cli"]},
-  "commands": {"count": 23, "names": ["exit", "clear", "help", "status", "iterations", "backend", "save", "load", "sessions", "format", "export", "cost", "search", "stream", "model", "tokens", "aliases", "templates", "history", "undo", "delete", "edit", "replay"]},
+  "commands": {"count": 24, "names": ["exit", "clear", "help", "status", "iterations", "backend", "save", "load", "sessions", "format", "export", "cost", "search", "stream", "model", "tokens", "multiline", "aliases", "templates", "history", "undo", "delete", "edit", "replay"]},
   "destructive_tools": ["bash", "write", "edit"],
   "module_dependencies": {"agent_loop": ["config", "tools", "backends", "commands", "security", "costs"], "backends": ["costs", "config"], "config": ["backends"], "security": ["config"], "tools": ["security"]}
 }

--- a/tools/agent-loop/generated/python/tools.py
+++ b/tools/agent-loop/generated/python/tools.py
@@ -174,6 +174,104 @@ class SecurityConfig:
         )
 
 
+
+class PluginManager:
+    """Manages loading and executing plugin-defined tools from JSON files."""
+
+    DEFAULT_DIR = os.path.join(os.path.expanduser("~"), ".agent-loop", "plugins")
+
+    def __init__(self):
+        self.plugins: list[dict] = []
+        self.tool_map: dict[str, tuple[int, int]] = {}  # name -> (plugin_idx, tool_idx)
+
+    def load_dir(self, directory: str) -> int:
+        """Load all .json plugin manifests from a directory. Returns count."""
+        if not os.path.isdir(directory):
+            return 0
+        count = 0
+        for fname in sorted(os.listdir(directory)):
+            if fname.endswith(".json"):
+                path = os.path.join(directory, fname)
+                if self.load_file(path):
+                    count += 1
+        return count
+
+    def load_file(self, path: str) -> bool:
+        """Load a single plugin manifest."""
+        try:
+            with open(path, "r") as f:
+                manifest = json.load(f)
+            plugin_idx = len(self.plugins)
+            for tool_idx, tool in enumerate(manifest.get("tools", [])):
+                self.tool_map[tool["name"]] = (plugin_idx, tool_idx)
+            self.plugins.append(manifest)
+            return True
+        except (json.JSONDecodeError, IOError, KeyError):
+            return False
+
+    def has_tool(self, name: str) -> bool:
+        return name in self.tool_map
+
+    def get_tool(self, name: str) -> dict | None:
+        if name not in self.tool_map:
+            return None
+        pi, ti = self.tool_map[name]
+        return self.plugins[pi]["tools"][ti]
+
+    def execute(self, name: str, args: dict) -> str | None:
+        """Render command template with arguments. Returns command string."""
+        tool = self.get_tool(name)
+        if tool is None:
+            return None
+        cmd = tool.get("command_template", "")
+        for param in tool.get("parameters", []):
+            placeholder = "{" + param["name"] + "}"
+            if param["name"] in args:
+                val = args[param["name"]]
+                cmd = cmd.replace(placeholder, str(val))
+            elif param.get("required", False):
+                return None
+        return cmd
+
+    def list_tools(self) -> list[dict]:
+        tools = []
+        for plugin in self.plugins:
+            tools.extend(plugin.get("tools", []))
+        return tools
+
+    def get_tool_schemas(self) -> list[dict]:
+        """Get tool schemas in OpenAI-compatible format."""
+        schemas = []
+        for tool in self.list_tools():
+            params = tool.get("parameters", [])
+            properties = {}
+            required = []
+            for p in params:
+                properties[p["name"]] = {
+                    "type": p.get("param_type", "string"),
+                    "description": p.get("description", "")
+                }
+                if p.get("required", False):
+                    required.append(p["name"])
+            schemas.append({
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": {
+                        "type": "object",
+                        "properties": properties,
+                        "required": required
+                    }
+                }
+            })
+        return schemas
+
+    def load_default(self) -> int:
+        """Load plugins from the default directory."""
+        return self.load_dir(self.DEFAULT_DIR)
+
+
 class ToolHandler:
     """Handles execution of tool calls from agent responses."""
 
@@ -219,6 +317,30 @@ class ToolHandler:
                 print("[Warning] proot sandbox requested but proot not "
                       "found. Install with: pkg install proot",
                       file=sys.stderr)
+
+        # Load plugins
+        self.plugin_manager = PluginManager()
+        plugin_count = self.plugin_manager.load_default()
+        if plugin_count > 0:
+            # Register plugin tools as allowed and add dispatchers
+            for tool in self.plugin_manager.list_tools():
+                name = tool["name"]
+                self.allowed_tools.append(name)
+                self.tools[name] = self._make_plugin_handler(name)
+            print(f"[Loaded {plugin_count} plugin(s)]")
+
+    def _make_plugin_handler(self, tool_name: str):
+        """Create a handler function for a plugin tool."""
+        def handler(args):
+            cmd = self.plugin_manager.execute(tool_name, args)
+            if cmd is None:
+                return ToolResult(
+                    success=False,
+                    output=f"Missing required parameters for {tool_name}",
+                    tool_name=tool_name
+                )
+            return self._execute_bash({"command": cmd})
+        return handler
 
         self.tools = {
             'bash': self._execute_bash,

--- a/tools/agent-loop/generated/rust/Cargo.lock
+++ b/tools/agent-loop/generated/rust/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/tools/agent-loop/generated/rust/Cargo.toml
+++ b/tools/agent-loop/generated/rust/Cargo.toml
@@ -17,3 +17,11 @@ regex = "1"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 rustyline = "14"
 serde_yaml = "0.9"
+wasm-bindgen = { version = "0.2", optional = true }
+
+[features]
+default = []
+wasm = ["wasm-bindgen"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/tools/agent-loop/generated/rust/src/commands.rs
+++ b/tools/agent-loop/generated/rust/src/commands.rs
@@ -31,6 +31,7 @@ pub static SLASH_COMMANDS: &[(&str, CommandSpec)] = &[
     ("stream", CommandSpec { match_type: "exact", help: "Toggle streaming mode for API backends" }),
     ("model", CommandSpec { match_type: "prefix_sp", help: "Show or switch model at runtime" }),
     ("tokens", CommandSpec { match_type: "exact", help: "Show context token estimate and limit" }),
+    ("multiline", CommandSpec { match_type: "exact", help: "Toggle multiline input mode" }),
     ("aliases", CommandSpec { match_type: "exact", help: "List command aliases (e.g., /q -> /quit)" }),
     ("templates", CommandSpec { match_type: "exact", help: "List prompt templates" }),
     ("history", CommandSpec { match_type: "exact_or_prefix_sp", help: "Show last n messages (default 10)" }),

--- a/tools/agent-loop/generated/rust/src/main.rs
+++ b/tools/agent-loop/generated/rust/src/main.rs
@@ -1125,6 +1125,12 @@ fn main() {
         tool_handler.enable_proot(&cwd.to_string_lossy(), proot_dirs);
     }
 
+    // Load plugins from default directory
+    let plugin_count = tool_handler.load_default_plugins();
+    if plugin_count > 0 {
+        println!("[Loaded {} plugin(s)]", plugin_count);
+    }
+
     let mut state = RuntimeState {
         max_iterations: config.max_iterations,
         stream: config.stream,

--- a/tools/agent-loop/generated/rust/src/tool_handler.rs
+++ b/tools/agent-loop/generated/rust/src/tool_handler.rs
@@ -8,6 +8,7 @@ use crate::types::*;
 
 use crate::security::SecurityProfileSpec;
 use crate::proot_sandbox::{ProotSandbox, ProotConfig};
+use crate::plugin_manager::PluginManager;
 
 /// Handles tool execution with security validation.
 pub struct ToolHandler {
@@ -15,11 +16,12 @@ pub struct ToolHandler {
     pub security_profile: String,
     pub approval_mode: String,
     pub proot: Option<ProotSandbox>,
+    pub plugins: Option<PluginManager>,
 }
 
 impl ToolHandler {
     pub fn new(auto_approve: bool, security_profile: String, approval_mode: String) -> Self {
-        Self { auto_approve, security_profile, approval_mode, proot: None }
+        Self { auto_approve, security_profile, approval_mode, proot: None, plugins: None }
     }
 
     /// Enable proot sandbox with the given allowed dirs.
@@ -34,6 +36,35 @@ impl ToolHandler {
         } else {
             eprintln!("[Warning] proot sandbox requested but proot not found. Install with: pkg install proot");
         }
+    }
+
+    /// Load plugins from a directory. Returns number of plugins loaded.
+    pub fn load_plugins(&mut self, dir: &str) -> usize {
+        let mut pm = PluginManager::new();
+        let count = pm.load_dir(dir);
+        if count > 0 {
+            self.plugins = Some(pm);
+        }
+        count
+    }
+
+    /// Load plugins from the default directory (~/.agent-loop/plugins/).
+    pub fn load_default_plugins(&mut self) -> usize {
+        let dir = PluginManager::default_dir();
+        if dir.exists() {
+            self.load_plugins(dir.to_str().unwrap_or(""))
+        } else {
+            0
+        }
+    }
+
+    /// Get all tool schemas (built-in + plugins) for API tool_use format.
+    pub fn get_all_tool_schemas(&self) -> Vec<serde_json::Value> {
+        let mut schemas = crate::tools::tool_schemas_json().clone();
+        if let Some(ref pm) = self.plugins {
+            schemas.extend(pm.get_tool_schemas());
+        }
+        schemas
     }
 
     /// Look up the SecurityProfileSpec for the current profile.
@@ -190,10 +221,23 @@ impl ToolHandler {
             "read" => self.handle_read(&tool_call.arguments),
             "write" => self.handle_write(&tool_call.arguments),
             "edit" => self.handle_edit(&tool_call.arguments),
-            _ => ToolResult {
-                success: false,
-                output: format!("Unknown tool: {}", tool_call.name),
-                tool_name: tool_call.name.clone(),
+            _ => {
+                // Check plugin tools
+                if let Some(ref pm) = self.plugins {
+                    if let Some(cmd) = pm.execute(&tool_call.name, &tool_call.arguments) {
+                        // Execute plugin command via bash
+                        let mut plugin_args = std::collections::HashMap::new();
+                        plugin_args.insert("command".to_string(), serde_json::json!(cmd));
+                        let mut result = self.handle_bash(&plugin_args);
+                        result.tool_name = tool_call.name.clone();
+                        return result;
+                    }
+                }
+                ToolResult {
+                    success: false,
+                    output: format!("Unknown tool: {}", tool_call.name),
+                    tool_name: tool_call.name.clone(),
+                }
             },
         }
     }

--- a/tools/agent-loop/generated/rust/src/wasm_bindings.rs
+++ b/tools/agent-loop/generated/rust/src/wasm_bindings.rs
@@ -11,7 +11,7 @@
 //! Build with: `cargo build --target wasm32-unknown-unknown --features wasm`
 //! Or with wasm-pack: `wasm-pack build --target web`
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 use wasm_bindgen::prelude::*;
 
 use crate::types::*;
@@ -152,13 +152,13 @@ impl WasmAgentState {
 }
 
 /// WASM-exported functions (only compiled for wasm32 targets).
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 #[wasm_bindgen]
 pub struct WasmAgent {
     inner: WasmAgentState,
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 #[wasm_bindgen]
 impl WasmAgent {
     #[wasm_bindgen(constructor)]

--- a/tools/agent-loop/generated/rust/tests/integration_tests.rs
+++ b/tools/agent-loop/generated/rust/tests/integration_tests.rs
@@ -826,7 +826,7 @@ fn test_wasm_agent_state_parse_tool_calls_anthropic() {
 #[test]
 fn test_session_manager_empty_list() {
     let tmp_dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    let test_dir = format!("{}/uwsal_test_sessions_{}", tmp_dir, std::process::id());
+    let test_dir = format!("{}/uwsal_test_sessions_empty_{}", tmp_dir, std::process::id());
     let sm = SessionManager::new(Some(&test_dir));
     let sessions = sm.list();
     assert!(sessions.is_empty());
@@ -836,7 +836,7 @@ fn test_session_manager_empty_list() {
 #[test]
 fn test_session_manager_save_and_load() {
     let tmp_dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
-    let test_dir = format!("{}/uwsal_test_sessions_{}", tmp_dir, std::process::id());
+    let test_dir = format!("{}/uwsal_test_sessions_saveload_{}", tmp_dir, std::process::id());
     let sm = SessionManager::new(Some(&test_dir));
 
     let messages = vec![

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -252,6 +252,12 @@ run_tests :-
     test_rust_wasm_bindings,
     test_rust_data_driven_dispatch,
     test_rust_phase13_integration_tests,
+    %% Phase 14 — plugin wiring, WASM config, Python dispatch, Python/Prolog plugins
+    test_rust_plugin_wiring,
+    test_rust_wasm_cargo_config,
+    test_py_command_body_dispatch,
+    test_py_plugin_manager,
+    test_prolog_plugin_loading,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -307,7 +313,7 @@ test_component_registration :-
     length(Commands, NC),
     length(Backends, NB),
     assert_eq('Tool count', NT, 4),
-    assert_eq('Command count', NC, 23),
+    assert_eq('Command count', NC, 24),
     assert_eq('Backend count', NB, 8).
 
 %% ============================================================================
@@ -381,7 +387,7 @@ test_handler_fragment_count :-
         sub_atom(Name, 0, _, _, handler_)
     ), Handlers),
     length(Handlers, Count),
-    assert_eq('Handler fragment count', Count, 17).
+    assert_eq('Handler fragment count', Count, 19).
 
 %% ============================================================================
 %% Test 7: CLI Override Facts
@@ -1237,7 +1243,7 @@ test_emit_command_optimization_hints :-
             current_output(S2),
             agent_loop_components:emit_command_facts(S2, [target(prolog)])
         )),
-        sub_atom(Output2, _, _, _, 'slash_command/4: first-argument indexed (23 clauses)')
+        sub_atom(Output2, _, _, _, 'slash_command/4: first-argument indexed (24 clauses)')
     )),
     assert_true('emit_command_facts includes command_alias clause count', (
         with_output_to(atom(Output3), (
@@ -4682,7 +4688,7 @@ test_rust_wasm_bindings :-
         sub_string(WasmContent, _, _, _, "fn parse_tool_calls")
     )),
     assert_true('cfg wasm32 conditional', (
-        sub_string(WasmContent, _, _, _, "cfg(target_arch")
+        sub_string(WasmContent, _, _, _, "target_arch = \"wasm32\"")
     )),
     assert_true('wasm_bindgen import', (
         sub_string(WasmContent, _, _, _, "wasm_bindgen")
@@ -4766,4 +4772,127 @@ test_rust_phase13_integration_tests :-
     %% Cost tracker tests
     assert_true('cost tracker record test exists', (
         sub_string(TestContent, _, _, _, "test_cost_tracker_record_and_report")
+    )).
+
+%% ============================================================================
+%% Phase 14 — Plugin wiring into ToolHandler
+%% ============================================================================
+
+test_rust_plugin_wiring :-
+    format("~nRust plugin wiring:~n"),
+    agent_loop_module:rust_fragment(tool_handler_struct, Content),
+    %% ToolHandler has plugins field
+    assert_true('ToolHandler has plugins field', (
+        sub_string(Content, _, _, _, "plugins: Option<PluginManager>")
+    )),
+    %% load_plugins method exists
+    assert_true('load_plugins method exists', (
+        sub_string(Content, _, _, _, "fn load_plugins")
+    )),
+    %% load_default_plugins method exists
+    assert_true('load_default_plugins method exists', (
+        sub_string(Content, _, _, _, "fn load_default_plugins")
+    )),
+    %% get_all_tool_schemas method exists
+    assert_true('get_all_tool_schemas method exists', (
+        sub_string(Content, _, _, _, "fn get_all_tool_schemas")
+    )),
+    %% Plugin fallback in dispatch
+    agent_loop_module:rust_fragment(tool_handler_dispatch, DispatchContent),
+    assert_true('execute has plugin fallback', (
+        sub_string(DispatchContent, _, _, _, "pm.execute")
+    )).
+
+%% ============================================================================
+%% Phase 14 — WASM Cargo.toml configuration
+%% ============================================================================
+
+test_rust_wasm_cargo_config :-
+    format("~nRust WASM Cargo config:~n"),
+    %% Read generated Cargo.toml
+    agent_loop_module:output_path(rust, '', SrcDir),
+    atom_concat(SrcDir, '../Cargo.toml', CargoPath),
+    read_file_to_string(CargoPath, CargoContent, []),
+    assert_true('Cargo.toml has wasm-bindgen dependency', (
+        sub_string(CargoContent, _, _, _, "wasm-bindgen")
+    )),
+    assert_true('Cargo.toml has wasm feature', (
+        sub_string(CargoContent, _, _, _, "[features]")
+    )),
+    assert_true('Cargo.toml has cdylib crate-type', (
+        sub_string(CargoContent, _, _, _, "cdylib")
+    )).
+
+%% ============================================================================
+%% Phase 14 — Python data-driven command dispatch
+%% ============================================================================
+
+test_py_command_body_dispatch :-
+    format("~nPython data-driven dispatch:~n"),
+    %% py_command_body facts exist
+    assert_true('py_command_body for exit exists', (
+        agent_loop_module:py_command_body(exit, _)
+    )),
+    assert_true('py_command_body for clear exists', (
+        agent_loop_module:py_command_body(clear, _)
+    )),
+    assert_true('py_command_body for help exists', (
+        agent_loop_module:py_command_body(help, _)
+    )),
+    assert_true('py_command_body for status exists', (
+        agent_loop_module:py_command_body(status, _)
+    )),
+    assert_true('py_command_body for multiline exists', (
+        agent_loop_module:py_command_body(multiline, _)
+    )),
+    %% Verify dispatch generation uses py_command_body
+    with_output_to(string(DispatchOutput), (
+        current_output(S),
+        agent_loop_module:generate_single_dispatch(S, exit, exact, [])
+    )),
+    assert_true('exit dispatch uses inline body', (
+        sub_string(DispatchOutput, _, _, _, "self.running = False")
+    )).
+
+%% ============================================================================
+%% Phase 14 — Python plugin manager
+%% ============================================================================
+
+test_py_plugin_manager :-
+    format("~nPython plugin manager:~n"),
+    assert_true('py_fragment plugin_manager_class exists', (
+        agent_loop_module:py_fragment(plugin_manager_class, _)
+    )),
+    agent_loop_module:py_fragment(plugin_manager_class, PyPluginContent),
+    assert_true('PluginManager class defined', (
+        sub_string(PyPluginContent, _, _, _, "class PluginManager")
+    )),
+    assert_true('load_dir method exists', (
+        sub_string(PyPluginContent, _, _, _, "def load_dir")
+    )),
+    assert_true('execute method exists', (
+        sub_string(PyPluginContent, _, _, _, "def execute")
+    )),
+    assert_true('get_tool_schemas method exists', (
+        sub_string(PyPluginContent, _, _, _, "def get_tool_schemas")
+    )).
+
+%% ============================================================================
+%% Phase 14 — Prolog plugin loading
+%% ============================================================================
+
+test_prolog_plugin_loading :-
+    format("~nProlog plugin loading:~n"),
+    agent_loop_module:prolog_fragment(tools_execute_dispatch, PlContent),
+    assert_true('execute_plugin_tool predicate exists', (
+        sub_string(PlContent, _, _, _, "execute_plugin_tool")
+    )),
+    assert_true('load_plugin_file predicate exists', (
+        sub_string(PlContent, _, _, _, "load_plugin_file")
+    )),
+    assert_true('plugin_tool dynamic declaration', (
+        sub_string(PlContent, _, _, _, "dynamic plugin_tool")
+    )),
+    assert_true('render_plugin_template predicate exists', (
+        sub_string(PlContent, _, _, _, "render_plugin_template")
     )).

--- a/tools/agent-loop/test_prolog_integration.pl
+++ b/tools/agent-loop/test_prolog_integration.pl
@@ -97,7 +97,7 @@ test_commands_module :-
     format("~ncommands.pl:~n"),
     findall(N, commands:slash_command(N, _, _, _), Cmds),
     length(Cmds, CmdCount),
-    pl_assert_eq('slash_command count', CmdCount, 23),
+    pl_assert_eq('slash_command count', CmdCount, 24),
     findall(A, commands:command_alias(A, _), Aliases),
     length(Aliases, ACount),
     pl_assert_eq('command_alias count', ACount, 30),


### PR DESCRIPTION
## Summary

Four features: plugin system wiring into Rust ToolHandler, WASM build configuration with feature gates, data-driven Python command dispatch, and cross-target plugin systems for Python and Prolog.

### 1. Plugin wiring into ToolHandler (Rust)

| Component | Description |
|-----------|-------------|
| `plugins: Option<PluginManager>` | Optional plugin manager field on ToolHandler |
| `load_plugins(dir)` | Load plugins from a specified directory |
| `load_default_plugins()` | Load from `~/.agent-loop/plugins/` |
| `get_all_tool_schemas()` | Merge built-in + plugin tool schemas |
| Execute fallback | Unknown tools check plugins before returning error |

Plugin loading wired into main loop — prints `[Loaded N plugin(s)]` on startup.

### 2. WASM build configuration

| Component | Description |
|-----------|-------------|
| `wasm-bindgen` optional dep | Only pulled when `wasm` feature enabled |
| `[features] wasm = ["wasm-bindgen"]` | Feature flag for WASM target |
| `crate-type = ["cdylib", "rlib"]` | Dual library output for wasm-pack |
| `#[cfg(all(target_arch = "wasm32", feature = "wasm"))]` | Feature-gated WASM bindings |

Build: `cargo build --features wasm --target wasm32-unknown-unknown`

### 3. Data-driven Python command dispatch

Replaced hardcoded exit/clear/help/status handlers with `py_command_body/2` facts:

```prolog
py_command_body(exit, ['            self.running = False']).
py_command_body(clear, ['            self.context.clear()', ...]).
py_command_body(help, ['            self._print_help()']).
py_command_body(status, ['            self._print_status()']).
py_command_body(multiline, ['            self.multiline_mode = not getattr(self, "multiline_mode", False)', ...]).
```

`generate_single_dispatch/4` now checks `py_command_body/2` first, emitting inline code instead of method calls. Adding a new inline command = adding one fact.

Also added:
- `slash_command(multiline, ...)` fact (was in dispatch order but undeclared)
- `handler_model_command` and `handler_tokens_command` py_fragments

### 4. Cross-target plugin systems

**Python PluginManager class:**
- `load_dir(path)` / `load_file(path)` — load JSON plugin manifests
- `execute(name, args)` — render command template with argument substitution
- `get_tool_schemas()` — generate OpenAI-compatible tool schemas
- `load_default()` — load from `~/.agent-loop/plugins/`
- Wired into ToolHandler `__init__` — plugin tools auto-registered

**Prolog plugin loading:**
- `:- dynamic plugin_tool/3` — runtime plugin registration
- `load_plugin_file/1` — read JSON manifest, assert `plugin_tool/3` facts
- `execute_plugin_tool/3` — render template, delegate to bash
- `render_plugin_template/4` — `{var}` substitution in command templates
- `execute_tool/3` falls back to plugins before returning "Unknown tool"

## Test plan

- [x] 832 Prolog tests pass (+23 new), 1 pre-existing env-specific failure
- [x] 66 `cargo test` integration tests pass (session test isolation fixed)
- [x] `cargo check` — 0 errors, 0 warnings (1 pre-existing unused import)
- [x] All 3 targets generate clean (Python, Rust, Prolog)
- [x] Plugin wiring: ToolHandler field, load, execute fallback verified
- [x] WASM: feature-gated cfg, Cargo.toml features, cdylib verified
- [x] Python dispatch: py_command_body facts generate correct if/elif chains
- [x] Python plugin: PluginManager class with all methods verified
- [x] Prolog plugin: dynamic loading, template rendering verified

## Metrics

| Metric | Phase 13 | Phase 14 |
|--------|----------|----------|
| Prolog tests | 809 | 832 (+23) |
| Cargo tests | 66 | 66 |
| py_fragment/2 facts | 82 | 85 (+3: handler_model_command, handler_tokens_command, plugin_manager_class) |
| py_command_body/2 facts | 0 | 5 (new) |
| slash_command/4 facts | 23 | 24 (+multiline) |
| Handler fragments | 17 | 19 (+model, tokens) |

## Files changed

| File | Changes |
|------|---------|
| `agent_loop_module.pl` | `py_command_body/2` facts (5); `slash_command(multiline)` fact; `handler_model_command` + `handler_tokens_command` py_fragments; `plugin_manager_class` py_fragment; ToolHandler plugin wiring (rust_fragment edits); WASM cfg gates; Cargo.toml features; Prolog plugin predicates; session test isolation |
| `test_agent_loop.pl` | 5 new test predicates: `test_rust_plugin_wiring` (5), `test_rust_wasm_cargo_config` (3), `test_py_command_body_dispatch` (6), `test_py_plugin_manager` (4), `test_prolog_plugin_loading` (4); count assertions updated (23→24, 17→19) |
| `test_prolog_integration.pl` | slash_command count 23→24 |
| `README.md` | Updated metrics (832 tests, 85 py_fragments), parity table (plugin + dispatch now cross-target) |
| Generated: `rust/Cargo.toml` | wasm-bindgen optional dep, features, crate-type |
| Generated: `rust/src/tool_handler.rs` | plugins field, load methods, execute fallback |
| Generated: `rust/src/main.rs` | Plugin loading on startup |
| Generated: `rust/src/wasm_bindings.rs` | Feature-gated cfg attributes |
| Generated: `rust/tests/integration_tests.rs` | Session test isolation (unique temp dirs) |
| Generated: `python/agent_loop.py` | Multiline command dispatch, model/tokens handlers |
| Generated: `python/tools.py` | PluginManager class, plugin wiring in ToolHandler |
| Generated: `prolog/commands.pl` | multiline slash_command fact |
| Generated: `prolog/tools.pl` | Plugin loading predicates |
