### PR TITLE
test(csharp-query): complete mixed pair-cache reuse symmetry

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -316,6 +316,7 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_key_order_insensitive_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_pair_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_by_target_cache_overlap_reuse_runtime,
@@ -333,6 +334,7 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_by_target_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_pair_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_pair_cache_overlap_reuse_runtime,
         verify_parameterized_reachability_seed_cache_eviction_runtime,
         verify_parameterized_reachability_by_target_seed_cache_eviction_runtime,
@@ -4199,6 +4201,27 @@ verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed
         ExecParams,
         HarnessSource).
 
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_pair_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_admission_group_mixed_lru_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z, red, cat1], [p, q, red, cat1]],
+    ExecParams = [[p, q, red, cat1], [a, z, red, cat1]],
+    harness_source_with_pair_cache_flag_warm_exec_normalized(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosurePairsSingleProbe',
+        4,
+        0,
+        0.1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z,red,cat1',
+         'p,q,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosurePairsSingleProbe=true'],
+        ExecParams,
+        HarnessSource).
+
 verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_by_target_cache_overlap_reuse_runtime :-
     csharp_query_target:build_query_plan(test_group_probe_dir_mixed_bytarget_reach/4, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -5383,6 +5406,28 @@ verify_parameterized_reachability_pairs_batched_single_probe_mixed_pair_cache_ke
     maybe_run_query_runtime_with_harness(Plan,
         ['a,z',
          'p,q',
+         'CACHE_HIT:TransitiveClosurePairsSingleProbe=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_pair_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_admission_mixed_lru_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, z], [p, q]],
+    ExecParams = [[a, z], [p, q], [p, r]],
+    harness_source_with_pair_cache_flag_warm_exec_normalized(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosurePairsSingleProbe',
+        4,
+        0,
+        0.1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['a,z',
+         'p,q',
+         'p,r',
          'CACHE_HIT:TransitiveClosurePairsSingleProbe=true'],
         ExecParams,
         HarnessSource).


### PR DESCRIPTION
  ## Summary
  Complete the remaining reuse-symmetry coverage for the mixed pair-probe cache paths in the C# query runtime tests.

  ## What changed
  - Added grouped mixed pair-cache `key_order_insensitive` coverage
  - Added non-grouped mixed pair-cache `overlap_reuse` coverage
  - Registered both new cases in `test_csharp_query_target/0`

  ## Why
  Before this PR, the mixed pair-cache reuse matrix was still missing the complementary pair of cases:

  - already covered:
    - non-grouped mixed pair-cache `cache_reuse`
    - non-grouped mixed pair-cache `key_order_insensitive`
    - grouped mixed pair-cache `cache_reuse`
    - grouped mixed pair-cache `overlap_reuse`

  - added here:
    - grouped mixed pair-cache `key_order_insensitive`
    - non-grouped mixed pair-cache `overlap_reuse`

  This closes the remaining reuse-symmetry gap for the normalized mixed pair-cache path.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`216/216`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_pair_cache_reuse_symmetry -ProjectFilter "cq_test_admissi*"`
    - Passed