### PR TITLE
feat(agent-loop): Rust Phase 15 — async/tokio, E2E mock tests, Python/Prolog test expansion, data-driven Prolog dispatch

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -62,7 +62,7 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 |--------|--------|--------|
 | Python | `generated/python/` (15+ modules) | Full agent loop |
 | Prolog | `generated/prolog/` (8 modules) | Full agent loop |
-| Rust | `generated/rust/` (17 files + integration tests) | Data + imperative + CLI + config loading + streaming (with token parsing) + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching + RuntimeState + session resume + env var expansion + multi-format export + retry with backoff + templates (16 built-in + persistence) + skills + multiline input + history edit/undo + spinner + rich display + proot sandbox + paste detection + config gen (paste_mode) + data-driven help + data-driven dispatch + plugin system (ToolHandler wiring) + WASM bindings (feature-gated) + 66 integration tests |
+| Rust | `generated/rust/` (17 files + integration tests) | Data + imperative + CLI + config loading + streaming (with token parsing) + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching + RuntimeState + session resume + env var expansion + multi-format export + retry with backoff + templates (16 built-in + persistence) + skills + multiline input + history edit/undo + spinner + rich display + proot sandbox + paste detection + config gen (paste_mode) + data-driven help + data-driven dispatch + plugin system (ToolHandler wiring) + WASM bindings (feature-gated) + async/tokio runtime + 76 integration tests |
 
 ### Declarative Infrastructure
 
@@ -70,12 +70,12 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 |--------|-------|
 | `py_fragment/2` facts | 85 |
 | `prolog_fragment/2` facts | 33 |
-| `rust_fragment/2` facts | 32 |
+| `rust_fragment/2` facts | 33 |
 | `rust_data_table/5` specs | 9 |
 | `emit_config_section/3` clauses | 11 (python + prolog + rust) |
 | `compile_component/4` targets | 3 (python, prolog, rust) |
 | `declare_binding` per target | 11 |
-| Total tests | 832 + 66 Rust integration (590+181 unit + 27 Prolog + 59 Python + 66 cargo test) |
+| Total tests | 854 + 76 Rust integration (590+181 unit + 27 Prolog + 59 Python + 76 cargo test) |
 
 ## Backends
 
@@ -727,11 +727,12 @@ python3 agent_loop.py -i 5 "prompt"  # Max 5 tool iterations
 | Config gen (paste_mode) | Y | Y | Complete (auto/bracketed/timing/off) |
 | Bracketed paste mode | Y | Y | Complete (optional, configurable) |
 | Data-driven /help | Y | Y | Complete (from slash_command/4 facts) |
-| Data-driven dispatch | Y | Y | Complete (py_command_body/2 + rust_command_body/2) |
+| Data-driven dispatch | Y | Y | Complete (py/rust/prolog_command_body + command_action) |
 | Plugin system | Y | Y | Complete (JSON manifests, tool schemas, ToolHandler wiring) |
 | Plugin system (Prolog) | N | N | Prolog-only (dynamic plugin_tool/3, JSON loading) |
 | WASM bindings | N | Y | Complete (feature-gated wasm-bindgen) |
-| Integration tests (cargo test) | N | Y (66 tests) | Rust-only |
+| Async/tokio runtime | N | Y | Complete (AsyncApiBackend, streaming, trait) |
+| Integration tests (cargo test) | N | Y (76 tests) | Rust-only (incl. E2E mock server tests) |
 
 ## License
 

--- a/tools/agent-loop/agent_loop_components.pl
+++ b/tools/agent-loop/agent_loop_components.pl
@@ -730,6 +730,11 @@ emit_command_facts(S, _Options) :-
         agent_loop_module:write_prolog_term(S, Cmds),
         write(S, ').\n')
     ), GroupPairs),
+    write(S, '\n'),
+    %% command_action — data-driven dispatch for commands without handlers
+    write(S, '%% command_action(+Command, +Action) — data-driven dispatch\n'),
+    findall(Cmd-Act, agent_loop_module:prolog_command_action(Cmd, Act), ActionPairs),
+    maplist([Cmd-Act]>>(format(S, 'command_action(~q, ~q).~n', [Cmd, Act])), ActionPairs),
     write(S, '\n').
 
 %% emit_backend_facts(+Stream, +Options)

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -858,6 +858,18 @@ py_command_body(multiline, [
 ]).
 
 %% =============================================================================
+%% Prolog command actions — used by data-driven dispatch generator
+%% prolog_command_action(Name, Action)
+%% Commands without a handler(H) property map to action atoms.
+%% =============================================================================
+
+prolog_command_action(exit, exit).
+prolog_command_action(clear, clear).
+prolog_command_action(help, help).
+prolog_command_action(status, status).
+prolog_command_action(multiline, multiline).
+
+%% =============================================================================
 %% Rust command bodies — used by data-driven dispatch generator
 %% rust_command_body(Name, RustCodeLines)
 %% Each line is emitted as-is inside the match arm.
@@ -1607,7 +1619,7 @@ generate_prolog_commands :-
     write_prolog_header(S, commands, 'Slash commands and aliases'),
     agent_loop_components:emit_prolog_module_skeleton(S, commands, [
         exports([slash_command/4, command_alias/2, slash_command_group/2,
-                 resolve_command/3, handle_slash_command/3]),
+                 command_action/2, resolve_command/3, handle_slash_command/3]),
         dependencies([module(commands)]),
         det([resolve_command/3, handle_slash_command/3])
     ]),
@@ -1769,7 +1781,9 @@ generate_rust_cargo_toml :-
     write(S, 'once_cell = "1"\n'),
     write(S, 'clap = { version = "4", features = ["derive"] }\n'),
     write(S, 'regex = "1"\n'),
-    write(S, 'reqwest = { version = "0.12", features = ["json", "blocking"] }\n'),
+    write(S, 'reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }\n'),
+    write(S, 'tokio = { version = "1", features = ["full"] }\n'),
+    write(S, 'futures = "0.3"\n'),
     write(S, 'rustyline = "14"\n'),
     write(S, 'serde_yaml = "0.9"\n'),
     write(S, 'wasm-bindgen = { version = "0.2", optional = true }\n\n'),
@@ -2026,6 +2040,7 @@ generate_rust_backends :-
     write_rust(S, backend_cli_impl),
     write_rust(S, streaming_handler),
     write_rust(S, backend_api_impl),
+    write_rust(S, async_backend),
     %% Data-driven backend factory
     generate_rust_backend_factory(S),
     close(S),
@@ -2242,7 +2257,8 @@ generate_rust_main :-
     nl(S),
     %% Data-driven command dispatch function (with session support)
     generate_rust_command_dispatch_with_sessions(S),
-    write(S, 'fn main() {\n'),
+    write(S, '#[tokio::main]\n'),
+    write(S, 'async fn main() {\n'),
     %% Clap argument parsing
     write(S, '    let matches = clap::Command::new("uwsal")\n'),
     write(S, '        .about("UnifyWeaver Agent Loop")\n'),
@@ -5123,7 +5139,7 @@ impl ApiBackend {
         messages
     }
 
-    fn build_request_body(&self, message: &str, context: &[Message]) -> serde_json::Value {
+    pub fn build_request_body(&self, message: &str, context: &[Message]) -> serde_json::Value {
         use crate::tools::tool_schemas_json;
         let messages = self.build_messages(message, context);
         let tools = tool_schemas_json();
@@ -5211,7 +5227,7 @@ impl ApiBackend {
     }
 
     /// Parse response JSON into AgentResponse (format-aware).
-    fn parse_response(&self, json: serde_json::Value) -> AgentResponse {
+    pub fn parse_response(&self, json: serde_json::Value) -> AgentResponse {
         if self.api_format == "anthropic" {
             let content = json["content"].as_array()
                 .and_then(|arr| arr.iter()
@@ -5293,6 +5309,174 @@ impl AgentBackend for ApiBackend {
     }
 
     fn name(&self) -> &str { &self.backend_name }
+    fn supports_streaming(&self) -> bool { true }
+}
+
+').
+
+rust_fragment(async_backend, '
+
+/// Async interface for agent backends (tokio-based).
+pub trait AsyncAgentBackend {
+    /// Send a message asynchronously and return the response.
+    fn send_message_async(&self, message: &str, context: &[Message])
+        -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentResponse> + Send + ''_>>;
+
+    /// Return the backend name.
+    fn name(&self) -> &str;
+
+    /// Whether this backend supports streaming.
+    fn supports_streaming(&self) -> bool { false }
+}
+
+/// Async wrapper around ApiBackend for non-blocking HTTP calls.
+pub struct AsyncApiBackend {
+    pub inner: ApiBackend,
+}
+
+impl AsyncApiBackend {
+    pub fn new(name: &str, endpoint: &str, api_key: Option<String>, model: &str, stream: bool, api_format: &str) -> Self {
+        Self {
+            inner: ApiBackend::new(name, endpoint, api_key, model, stream, api_format),
+        }
+    }
+
+    fn add_auth_header(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref key) = self.inner.api_key {
+            if self.inner.api_format == "anthropic" {
+                req.header("x-api-key", key)
+                   .header("anthropic-version", "2023-06-01")
+            } else {
+                req.header("Authorization", format!("Bearer {}", key))
+            }
+        } else {
+            req
+        }
+    }
+
+    /// Send a non-streaming async request.
+    pub async fn send_async(&self, message: &str, context: &[Message]) -> AgentResponse {
+        let client = reqwest::Client::new();
+        let body = self.inner.build_request_body(message, context);
+
+        let req = client.post(&self.inner.endpoint)
+            .header("Content-Type", "application/json");
+        let req = self.add_auth_header(req);
+
+        match req.json(&body).send().await {
+            Ok(resp) => {
+                match resp.json::<serde_json::Value>().await {
+                    Ok(json) => self.inner.parse_response(json),
+                    Err(e) => AgentResponse {
+                        content: format!("JSON parse error: {}", e),
+                        model: self.inner.model.clone(),
+                        ..Default::default()
+                    },
+                }
+            }
+            Err(e) => AgentResponse {
+                content: format!("HTTP error: {}", e),
+                model: self.inner.model.clone(),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Send a streaming async request, calling on_token for each chunk.
+    pub async fn send_streaming_async<F>(&self, message: &str, context: &[Message], mut on_token: F) -> AgentResponse
+    where F: FnMut(&str)
+    {
+        use futures::StreamExt;
+        let client = reqwest::Client::new();
+        let mut body = self.inner.build_request_body(message, context);
+        body["stream"] = serde_json::json!(true);
+        if self.inner.api_format != "anthropic" {
+            body["stream_options"] = serde_json::json!({"include_usage": true});
+        }
+
+        let req = client.post(&self.inner.endpoint)
+            .header("Content-Type", "application/json");
+        let req = self.add_auth_header(req);
+
+        match req.json(&body).send().await {
+            Ok(resp) => {
+                let mut full_content = String::new();
+                let mut input_tokens: u64 = 0;
+                let mut output_tokens: u64 = 0;
+                let mut stream = resp.bytes_stream();
+
+                let mut buffer = String::new();
+                while let Some(chunk) = stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            buffer.push_str(&String::from_utf8_lossy(&bytes));
+                            while let Some(line_end) = buffer.find(''\\n'') {
+                                let line = buffer[..line_end].to_string();
+                                buffer = buffer[line_end + 1..].to_string();
+                                if let Some(data) = line.strip_prefix("data: ") {
+                                    if data.trim() == "[DONE]" { continue; }
+                                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                                        // Extract token from delta
+                                        let token = if self.inner.api_format == "anthropic" {
+                                            json["delta"]["text"].as_str().unwrap_or("").to_string()
+                                        } else {
+                                            json["choices"][0]["delta"]["content"].as_str().unwrap_or("").to_string()
+                                        };
+                                        if !token.is_empty() {
+                                            on_token(&token);
+                                            full_content.push_str(&token);
+                                        }
+                                        // Extract usage if present
+                                        if let Some(usage) = json.get("usage") {
+                                            if let Some(it) = usage["input_tokens"].as_u64()
+                                                .or(usage["prompt_tokens"].as_u64()) {
+                                                input_tokens = it;
+                                            }
+                                            if let Some(ot) = usage["output_tokens"].as_u64()
+                                                .or(usage["completion_tokens"].as_u64()) {
+                                                output_tokens = ot;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            full_content.push_str(&format!("\n[Stream error: {}]", e));
+                            break;
+                        }
+                    }
+                }
+
+                AgentResponse {
+                    content: full_content,
+                    input_tokens,
+                    output_tokens,
+                    model: self.inner.model.clone(),
+                    ..Default::default()
+                }
+            }
+            Err(e) => AgentResponse {
+                content: format!("HTTP error: {}", e),
+                model: self.inner.model.clone(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl AsyncAgentBackend for AsyncApiBackend {
+    fn send_message_async(&self, message: &str, context: &[Message])
+        -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentResponse> + Send + ''_>>
+    {
+        let msg = message.to_string();
+        let ctx = context.to_vec();
+        Box::pin(async move {
+            self.send_async(&msg, &ctx).await
+        })
+    }
+
+    fn name(&self) -> &str { self.inner.name() }
     fn supports_streaming(&self) -> bool { true }
 }
 
@@ -7369,6 +7553,7 @@ use agent_loop::proot_sandbox::*;
 use agent_loop::plugin_manager::*;
 use agent_loop::wasm_bindings::*;
 use agent_loop::sessions::*;
+use agent_loop::backends::*;
 use std::collections::HashMap;
 
 // ============================================================================
@@ -8237,6 +8422,180 @@ fn test_cost_tracker_record_and_report() {
     let summary = tracker.format_summary();
     assert!(summary.contains("100") || summary.contains("150") || summary.len() > 0);
 }
+
+// ============================================================================
+// Async backend tests
+// ============================================================================
+
+#[test]
+fn test_async_api_backend_creation() {
+    let backend = AsyncApiBackend::new(
+        "test-async", "http://localhost:9999/v1/chat/completions",
+        Some("test-key".to_string()), "gpt-4", false, "openai"
+    );
+    assert_eq!(backend.inner.backend_name, "test-async");
+    assert_eq!(backend.inner.model, "gpt-4");
+    assert_eq!(backend.inner.api_format, "openai");
+    assert_eq!(backend.name(), "test-async");
+    assert!(backend.supports_streaming());
+}
+
+#[test]
+fn test_async_api_backend_anthropic_format() {
+    let backend = AsyncApiBackend::new(
+        "test-claude", "https://api.anthropic.com/v1/messages",
+        Some("sk-test".to_string()), "claude-3-opus", true, "anthropic"
+    );
+    assert_eq!(backend.inner.api_format, "anthropic");
+    assert_eq!(backend.inner.stream, true);
+}
+
+#[tokio::test]
+async fn test_async_backend_mock_server() {
+    use tokio::net::TcpListener;
+    use tokio::io::AsyncWriteExt;
+
+    // Start a mock HTTP server
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let endpoint = format!("http://{}/v1/chat/completions", addr);
+
+    // Spawn mock server that returns a valid OpenAI response
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        // Read the request (just consume it)
+        let mut buf = vec![0u8; 4096];
+        let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+        // Send response
+        let body = r#"{"choices":[{"message":{"content":"Hello from mock!","role":"assistant"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(), body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let backend = AsyncApiBackend::new(
+        "mock", &endpoint, None, "test-model", false, "openai"
+    );
+    let result = backend.send_async("test message", &[]).await;
+    assert_eq!(result.content, "Hello from mock!");
+    assert_eq!(result.input_tokens, 10);
+    assert_eq!(result.output_tokens, 5);
+}
+
+#[tokio::test]
+async fn test_async_backend_anthropic_mock() {
+    use tokio::net::TcpListener;
+    use tokio::io::AsyncWriteExt;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let endpoint = format!("http://{}/v1/messages", addr);
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+        let body = r#"{"content":[{"type":"text","text":"Bonjour from Anthropic mock!"}],"usage":{"input_tokens":8,"output_tokens":4}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(), body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let backend = AsyncApiBackend::new(
+        "mock-anthropic", &endpoint, Some("sk-test".to_string()),
+        "claude-3", false, "anthropic"
+    );
+    let result = backend.send_async("bonjour", &[]).await;
+    assert_eq!(result.content, "Bonjour from Anthropic mock!");
+    assert_eq!(result.input_tokens, 8);
+    assert_eq!(result.output_tokens, 4);
+}
+
+#[tokio::test]
+async fn test_async_backend_connection_refused() {
+    let backend = AsyncApiBackend::new(
+        "fail", "http://127.0.0.1:1/v1/chat", None, "test", false, "openai"
+    );
+    let result = backend.send_async("test", &[]).await;
+    assert!(result.content.contains("error") || result.content.contains("Error"));
+}
+
+#[test]
+fn test_async_backend_request_body_format() {
+    let backend = AsyncApiBackend::new(
+        "test", "http://localhost/v1", Some("key".to_string()),
+        "gpt-4", false, "openai"
+    );
+    let body = backend.inner.build_request_body("hello", &[]);
+    assert_eq!(body["model"], "gpt-4");
+    assert!(body["messages"].as_array().unwrap().len() > 0);
+}
+
+#[test]
+fn test_async_backend_anthropic_request_body() {
+    let backend = AsyncApiBackend::new(
+        "test", "http://localhost/v1", Some("key".to_string()),
+        "claude-3-opus", false, "anthropic"
+    );
+    let body = backend.inner.build_request_body("hello", &[]);
+    assert_eq!(body["model"], "claude-3-opus");
+    assert!(body.get("max_tokens").is_some());
+}
+
+#[test]
+fn test_tool_call_extraction_openai_format() {
+    let args_json = serde_json::json!({"command": "ls"}).to_string();
+    let json = serde_json::json!({
+        "choices": [{"message": {"content": "", "tool_calls": [
+            {"id": "call_1", "function": {"name": "bash", "arguments": args_json}}
+        ]}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+    });
+    let backend = ApiBackend::new("test", "", None, "gpt-4", false, "openai");
+    let response = backend.parse_response(json);
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].name, "bash");
+    assert_eq!(response.tool_calls[0].id, "call_1");
+}
+
+#[test]
+fn test_tool_call_extraction_anthropic_format() {
+    let json = serde_json::json!({
+        "content": [
+            {"type": "text", "text": "Let me check."},
+            {"type": "tool_use", "id": "toolu_1", "name": "read", "input": {"file_path": "test.txt"}}
+        ],
+        "usage": {"input_tokens": 20, "output_tokens": 10}
+    });
+    let backend = ApiBackend::new("test", "", None, "claude-3", false, "anthropic");
+    let response = backend.parse_response(json);
+    assert_eq!(response.content, "Let me check.");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].name, "read");
+    assert_eq!(response.tool_calls[0].arguments.get("file_path").unwrap(), "test.txt");
+}
+
+#[test]
+fn test_tool_call_multiple_calls() {
+    let args1 = serde_json::json!({"command": "ls"}).to_string();
+    let args2 = serde_json::json!({"file_path": "/tmp/test"}).to_string();
+    let json = serde_json::json!({
+        "choices": [{"message": {"content": "", "tool_calls": [
+            {"id": "call_1", "function": {"name": "bash", "arguments": args1}},
+            {"id": "call_2", "function": {"name": "read", "arguments": args2}}
+        ]}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+    });
+    let backend = ApiBackend::new("test", "", None, "gpt-4", false, "openai");
+    let response = backend.parse_response(json);
+    assert_eq!(response.tool_calls.len(), 2);
+    assert_eq!(response.tool_calls[0].name, "bash");
+    assert_eq!(response.tool_calls[1].name, "read");
+}
 ').
 
 rust_fragment(main_loop, '
@@ -8562,10 +8921,8 @@ handle_slash_command(RawCmd, Args, Action) :-
     (slash_command(CmdAtom, _Match, Opts, _Help) ->
         (member(handler(Handler), Opts) ->
             Action = call_handler(Handler, FinalArgs)
-        ; CmdAtom = exit -> Action = exit
-        ; CmdAtom = clear -> Action = clear
-        ; CmdAtom = help -> Action = help
-        ; CmdAtom = status -> Action = status
+        ; command_action(CmdAtom, DirectAction) ->
+            Action = DirectAction
         ; Action = unknown(CmdAtom))
     ; Action = not_a_command).
 ').
@@ -8619,17 +8976,31 @@ execute_plugin_tool(ToolName, Params, Result) :-
 render_plugin_template(Template, Args, PluginParams, Rendered) :-
     atom_string(Template, TStr),
     foldl([P, In, Out]>>(
-        (is_dict(P) -> get_dict(name, P, PName) ; PName = P),
-        atom_string(PName, PNameStr),
-        format(atom(Placeholder), "{~w}", [PNameStr]),
-        atom_string(Placeholder, PlaceholderStr),
-        (get_dict(PName, Args, Val) ->
+        (is_dict(P) -> get_dict(name, P, PName0) ; PName0 = P),
+        (atom(PName0) -> PNameAtom = PName0 ; atom_string(PNameAtom, PName0)),
+        atom_string(PNameAtom, PNameStr),
+        format(string(Placeholder), "{~w}", [PNameStr]),
+        (get_dict(PNameAtom, Args, Val) ->
             term_string(Val, ValStr),
-            split_string(In, PlaceholderStr, "", Parts),
-            atomics_to_string(Parts, ValStr, Out)
+            replace_all_in_string(In, Placeholder, ValStr, Out)
         ; Out = In)
     ), PluginParams, TStr, RenderedStr),
     atom_string(Rendered, RenderedStr).
+
+%% replace_all_in_string(+Input, +Search, +Replace, -Output)
+replace_all_in_string(Input, Search, Replace, Output) :-
+    string_length(Search, SLen),
+    (SLen =:= 0 -> Output = Input
+    ; replace_all_helper(Input, Search, SLen, Replace, Output)).
+replace_all_helper(Input, Search, SLen, Replace, Output) :-
+    (sub_string(Input, Before, SLen, _, Search) ->
+        sub_string(Input, 0, Before, _, Left),
+        AfterPos is Before + SLen,
+        sub_string(Input, AfterPos, _, 0, Right),
+        replace_all_helper(Right, Search, SLen, Replace, RestOutput),
+        string_concat(Left, Replace, Tmp),
+        string_concat(Tmp, RestOutput, Output)
+    ; Output = Input).
 
 atomics_to_string([], _, "").
 atomics_to_string([Part], _, Part).

--- a/tools/agent-loop/generated/prolog/commands.pl
+++ b/tools/agent-loop/generated/prolog/commands.pl
@@ -7,6 +7,7 @@
     slash_command/4,
     command_alias/2,
     slash_command_group/2,
+    command_action/2,
     resolve_command/3,
     handle_slash_command/3
 ]).
@@ -90,6 +91,13 @@ slash_command_group('Export & Costs', [export, cost, tokens]).
 slash_command_group('History', [history, delete, edit, replay, undo]).
 slash_command_group('Shortcuts', [aliases, templates]).
 
+%% command_action(+Command, +Action) — data-driven dispatch
+command_action(exit, exit).
+command_action(clear, clear).
+command_action(help, help).
+command_action(status, status).
+command_action(multiline, multiline).
+
 %% Resolve aliases — may return "command args" for compound aliases
 resolve_command(Input, Command, ExtraArgs) :-
     (command_alias(Input, Canonical) ->
@@ -117,9 +125,7 @@ handle_slash_command(RawCmd, Args, Action) :-
     (slash_command(CmdAtom, _Match, Opts, _Help) ->
         (member(handler(Handler), Opts) ->
             Action = call_handler(Handler, FinalArgs)
-        ; CmdAtom = exit -> Action = exit
-        ; CmdAtom = clear -> Action = clear
-        ; CmdAtom = help -> Action = help
-        ; CmdAtom = status -> Action = status
+        ; command_action(CmdAtom, DirectAction) ->
+            Action = DirectAction
         ; Action = unknown(CmdAtom))
     ; Action = not_a_command).

--- a/tools/agent-loop/generated/prolog/tools.pl
+++ b/tools/agent-loop/generated/prolog/tools.pl
@@ -118,17 +118,31 @@ execute_plugin_tool(ToolName, Params, Result) :-
 render_plugin_template(Template, Args, PluginParams, Rendered) :-
     atom_string(Template, TStr),
     foldl([P, In, Out]>>(
-        (is_dict(P) -> get_dict(name, P, PName) ; PName = P),
-        atom_string(PName, PNameStr),
-        format(atom(Placeholder), "{~w}", [PNameStr]),
-        atom_string(Placeholder, PlaceholderStr),
-        (get_dict(PName, Args, Val) ->
+        (is_dict(P) -> get_dict(name, P, PName0) ; PName0 = P),
+        (atom(PName0) -> PNameAtom = PName0 ; atom_string(PNameAtom, PName0)),
+        atom_string(PNameAtom, PNameStr),
+        format(string(Placeholder), "{~w}", [PNameStr]),
+        (get_dict(PNameAtom, Args, Val) ->
             term_string(Val, ValStr),
-            split_string(In, PlaceholderStr, "", Parts),
-            atomics_to_string(Parts, ValStr, Out)
+            replace_all_in_string(In, Placeholder, ValStr, Out)
         ; Out = In)
     ), PluginParams, TStr, RenderedStr),
     atom_string(Rendered, RenderedStr).
+
+%% replace_all_in_string(+Input, +Search, +Replace, -Output)
+replace_all_in_string(Input, Search, Replace, Output) :-
+    string_length(Search, SLen),
+    (SLen =:= 0 -> Output = Input
+    ; replace_all_helper(Input, Search, SLen, Replace, Output)).
+replace_all_helper(Input, Search, SLen, Replace, Output) :-
+    (sub_string(Input, Before, SLen, _, Search) ->
+        sub_string(Input, 0, Before, _, Left),
+        AfterPos is Before + SLen,
+        sub_string(Input, AfterPos, _, 0, Right),
+        replace_all_helper(Right, Search, SLen, Replace, RestOutput),
+        string_concat(Left, Replace, Tmp),
+        string_concat(Tmp, RestOutput, Output)
+    ; Output = Input).
 
 atomics_to_string([], _, "").
 atomics_to_string([Part], _, Part).

--- a/tools/agent-loop/generated/rust/Cargo.lock
+++ b/tools/agent-loop/generated/rust/Cargo.lock
@@ -7,6 +7,7 @@ name = "agent-loop"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "futures",
  "once_cell",
  "regex",
  "reqwest",
@@ -14,6 +15,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tokio",
  "wasm-bindgen",
 ]
 
@@ -323,6 +325,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,10 +356,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -362,8 +401,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -745,6 +786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +918,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,12 +1088,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -1119,6 +1203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1310,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1345,9 +1445,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1631,6 +1745,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/tools/agent-loop/generated/rust/Cargo.toml
+++ b/tools/agent-loop/generated/rust/Cargo.toml
@@ -14,7 +14,9 @@ serde_json = "1"
 once_cell = "1"
 clap = { version = "4", features = ["derive"] }
 regex = "1"
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
 rustyline = "14"
 serde_yaml = "0.9"
 wasm-bindgen = { version = "0.2", optional = true }

--- a/tools/agent-loop/generated/rust/src/backends.rs
+++ b/tools/agent-loop/generated/rust/src/backends.rs
@@ -279,7 +279,7 @@ impl ApiBackend {
         messages
     }
 
-    fn build_request_body(&self, message: &str, context: &[Message]) -> serde_json::Value {
+    pub fn build_request_body(&self, message: &str, context: &[Message]) -> serde_json::Value {
         use crate::tools::tool_schemas_json;
         let messages = self.build_messages(message, context);
         let tools = tool_schemas_json();
@@ -367,7 +367,7 @@ impl ApiBackend {
     }
 
     /// Parse response JSON into AgentResponse (format-aware).
-    fn parse_response(&self, json: serde_json::Value) -> AgentResponse {
+    pub fn parse_response(&self, json: serde_json::Value) -> AgentResponse {
         if self.api_format == "anthropic" {
             let content = json["content"].as_array()
                 .and_then(|arr| arr.iter()
@@ -449,6 +449,173 @@ impl AgentBackend for ApiBackend {
     }
 
     fn name(&self) -> &str { &self.backend_name }
+    fn supports_streaming(&self) -> bool { true }
+}
+
+
+
+/// Async interface for agent backends (tokio-based).
+pub trait AsyncAgentBackend {
+    /// Send a message asynchronously and return the response.
+    fn send_message_async(&self, message: &str, context: &[Message])
+        -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentResponse> + Send + '_>>;
+
+    /// Return the backend name.
+    fn name(&self) -> &str;
+
+    /// Whether this backend supports streaming.
+    fn supports_streaming(&self) -> bool { false }
+}
+
+/// Async wrapper around ApiBackend for non-blocking HTTP calls.
+pub struct AsyncApiBackend {
+    pub inner: ApiBackend,
+}
+
+impl AsyncApiBackend {
+    pub fn new(name: &str, endpoint: &str, api_key: Option<String>, model: &str, stream: bool, api_format: &str) -> Self {
+        Self {
+            inner: ApiBackend::new(name, endpoint, api_key, model, stream, api_format),
+        }
+    }
+
+    fn add_auth_header(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref key) = self.inner.api_key {
+            if self.inner.api_format == "anthropic" {
+                req.header("x-api-key", key)
+                   .header("anthropic-version", "2023-06-01")
+            } else {
+                req.header("Authorization", format!("Bearer {}", key))
+            }
+        } else {
+            req
+        }
+    }
+
+    /// Send a non-streaming async request.
+    pub async fn send_async(&self, message: &str, context: &[Message]) -> AgentResponse {
+        let client = reqwest::Client::new();
+        let body = self.inner.build_request_body(message, context);
+
+        let req = client.post(&self.inner.endpoint)
+            .header("Content-Type", "application/json");
+        let req = self.add_auth_header(req);
+
+        match req.json(&body).send().await {
+            Ok(resp) => {
+                match resp.json::<serde_json::Value>().await {
+                    Ok(json) => self.inner.parse_response(json),
+                    Err(e) => AgentResponse {
+                        content: format!("JSON parse error: {}", e),
+                        model: self.inner.model.clone(),
+                        ..Default::default()
+                    },
+                }
+            }
+            Err(e) => AgentResponse {
+                content: format!("HTTP error: {}", e),
+                model: self.inner.model.clone(),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Send a streaming async request, calling on_token for each chunk.
+    pub async fn send_streaming_async<F>(&self, message: &str, context: &[Message], mut on_token: F) -> AgentResponse
+    where F: FnMut(&str)
+    {
+        use futures::StreamExt;
+        let client = reqwest::Client::new();
+        let mut body = self.inner.build_request_body(message, context);
+        body["stream"] = serde_json::json!(true);
+        if self.inner.api_format != "anthropic" {
+            body["stream_options"] = serde_json::json!({"include_usage": true});
+        }
+
+        let req = client.post(&self.inner.endpoint)
+            .header("Content-Type", "application/json");
+        let req = self.add_auth_header(req);
+
+        match req.json(&body).send().await {
+            Ok(resp) => {
+                let mut full_content = String::new();
+                let mut input_tokens: u64 = 0;
+                let mut output_tokens: u64 = 0;
+                let mut stream = resp.bytes_stream();
+
+                let mut buffer = String::new();
+                while let Some(chunk) = stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            buffer.push_str(&String::from_utf8_lossy(&bytes));
+                            while let Some(line_end) = buffer.find('\n') {
+                                let line = buffer[..line_end].to_string();
+                                buffer = buffer[line_end + 1..].to_string();
+                                if let Some(data) = line.strip_prefix("data: ") {
+                                    if data.trim() == "[DONE]" { continue; }
+                                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+                                        // Extract token from delta
+                                        let token = if self.inner.api_format == "anthropic" {
+                                            json["delta"]["text"].as_str().unwrap_or("").to_string()
+                                        } else {
+                                            json["choices"][0]["delta"]["content"].as_str().unwrap_or("").to_string()
+                                        };
+                                        if !token.is_empty() {
+                                            on_token(&token);
+                                            full_content.push_str(&token);
+                                        }
+                                        // Extract usage if present
+                                        if let Some(usage) = json.get("usage") {
+                                            if let Some(it) = usage["input_tokens"].as_u64()
+                                                .or(usage["prompt_tokens"].as_u64()) {
+                                                input_tokens = it;
+                                            }
+                                            if let Some(ot) = usage["output_tokens"].as_u64()
+                                                .or(usage["completion_tokens"].as_u64()) {
+                                                output_tokens = ot;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            full_content.push_str(&format!("
+[Stream error: {}]", e));
+                            break;
+                        }
+                    }
+                }
+
+                AgentResponse {
+                    content: full_content,
+                    input_tokens,
+                    output_tokens,
+                    model: self.inner.model.clone(),
+                    ..Default::default()
+                }
+            }
+            Err(e) => AgentResponse {
+                content: format!("HTTP error: {}", e),
+                model: self.inner.model.clone(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl AsyncAgentBackend for AsyncApiBackend {
+    fn send_message_async(&self, message: &str, context: &[Message])
+        -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentResponse> + Send + '_>>
+    {
+        let msg = message.to_string();
+        let ctx = context.to_vec();
+        Box::pin(async move {
+            self.send_async(&msg, &ctx).await
+        })
+    }
+
+    fn name(&self) -> &str { self.inner.name() }
     fn supports_streaming(&self) -> bool { true }
 }
 

--- a/tools/agent-loop/generated/rust/src/main.rs
+++ b/tools/agent-loop/generated/rust/src/main.rs
@@ -876,7 +876,8 @@ fn handle_command(
     true
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let matches = clap::Command::new("uwsal")
         .about("UnifyWeaver Agent Loop")
         .version(env!("CARGO_PKG_VERSION"))

--- a/tools/agent-loop/generated/rust/tests/integration_tests.rs
+++ b/tools/agent-loop/generated/rust/tests/integration_tests.rs
@@ -13,6 +13,7 @@ use agent_loop::proot_sandbox::*;
 use agent_loop::plugin_manager::*;
 use agent_loop::wasm_bindings::*;
 use agent_loop::sessions::*;
+use agent_loop::backends::*;
 use std::collections::HashMap;
 
 // ============================================================================
@@ -880,4 +881,186 @@ fn test_cost_tracker_record_and_report() {
     tracker.record_usage("test-model", 100, 50);
     let summary = tracker.format_summary();
     assert!(summary.contains("100") || summary.contains("150") || summary.len() > 0);
+}
+
+// ============================================================================
+// Async backend tests
+// ============================================================================
+
+#[test]
+fn test_async_api_backend_creation() {
+    let backend = AsyncApiBackend::new(
+        "test-async", "http://localhost:9999/v1/chat/completions",
+        Some("test-key".to_string()), "gpt-4", false, "openai"
+    );
+    assert_eq!(backend.inner.backend_name, "test-async");
+    assert_eq!(backend.inner.model, "gpt-4");
+    assert_eq!(backend.inner.api_format, "openai");
+    assert_eq!(backend.name(), "test-async");
+    assert!(backend.supports_streaming());
+}
+
+#[test]
+fn test_async_api_backend_anthropic_format() {
+    let backend = AsyncApiBackend::new(
+        "test-claude", "https://api.anthropic.com/v1/messages",
+        Some("sk-test".to_string()), "claude-3-opus", true, "anthropic"
+    );
+    assert_eq!(backend.inner.api_format, "anthropic");
+    assert_eq!(backend.inner.stream, true);
+}
+
+#[tokio::test]
+async fn test_async_backend_mock_server() {
+    use tokio::net::TcpListener;
+    use tokio::io::AsyncWriteExt;
+
+    // Start a mock HTTP server
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let endpoint = format!("http://{}/v1/chat/completions", addr);
+
+    // Spawn mock server that returns a valid OpenAI response
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        // Read the request (just consume it)
+        let mut buf = vec![0u8; 4096];
+        let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+        // Send response
+        let body = r#"{"choices":[{"message":{"content":"Hello from mock!","role":"assistant"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: {}
+
+{}",
+            body.len(), body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let backend = AsyncApiBackend::new(
+        "mock", &endpoint, None, "test-model", false, "openai"
+    );
+    let result = backend.send_async("test message", &[]).await;
+    assert_eq!(result.content, "Hello from mock!");
+    assert_eq!(result.input_tokens, 10);
+    assert_eq!(result.output_tokens, 5);
+}
+
+#[tokio::test]
+async fn test_async_backend_anthropic_mock() {
+    use tokio::net::TcpListener;
+    use tokio::io::AsyncWriteExt;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let endpoint = format!("http://{}/v1/messages", addr);
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+        let body = r#"{"content":[{"type":"text","text":"Bonjour from Anthropic mock!"}],"usage":{"input_tokens":8,"output_tokens":4}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: {}
+
+{}",
+            body.len(), body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+
+    let backend = AsyncApiBackend::new(
+        "mock-anthropic", &endpoint, Some("sk-test".to_string()),
+        "claude-3", false, "anthropic"
+    );
+    let result = backend.send_async("bonjour", &[]).await;
+    assert_eq!(result.content, "Bonjour from Anthropic mock!");
+    assert_eq!(result.input_tokens, 8);
+    assert_eq!(result.output_tokens, 4);
+}
+
+#[tokio::test]
+async fn test_async_backend_connection_refused() {
+    let backend = AsyncApiBackend::new(
+        "fail", "http://127.0.0.1:1/v1/chat", None, "test", false, "openai"
+    );
+    let result = backend.send_async("test", &[]).await;
+    assert!(result.content.contains("error") || result.content.contains("Error"));
+}
+
+#[test]
+fn test_async_backend_request_body_format() {
+    let backend = AsyncApiBackend::new(
+        "test", "http://localhost/v1", Some("key".to_string()),
+        "gpt-4", false, "openai"
+    );
+    let body = backend.inner.build_request_body("hello", &[]);
+    assert_eq!(body["model"], "gpt-4");
+    assert!(body["messages"].as_array().unwrap().len() > 0);
+}
+
+#[test]
+fn test_async_backend_anthropic_request_body() {
+    let backend = AsyncApiBackend::new(
+        "test", "http://localhost/v1", Some("key".to_string()),
+        "claude-3-opus", false, "anthropic"
+    );
+    let body = backend.inner.build_request_body("hello", &[]);
+    assert_eq!(body["model"], "claude-3-opus");
+    assert!(body.get("max_tokens").is_some());
+}
+
+#[test]
+fn test_tool_call_extraction_openai_format() {
+    let args_json = serde_json::json!({"command": "ls"}).to_string();
+    let json = serde_json::json!({
+        "choices": [{"message": {"content": "", "tool_calls": [
+            {"id": "call_1", "function": {"name": "bash", "arguments": args_json}}
+        ]}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+    });
+    let backend = ApiBackend::new("test", "", None, "gpt-4", false, "openai");
+    let response = backend.parse_response(json);
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].name, "bash");
+    assert_eq!(response.tool_calls[0].id, "call_1");
+}
+
+#[test]
+fn test_tool_call_extraction_anthropic_format() {
+    let json = serde_json::json!({
+        "content": [
+            {"type": "text", "text": "Let me check."},
+            {"type": "tool_use", "id": "toolu_1", "name": "read", "input": {"file_path": "test.txt"}}
+        ],
+        "usage": {"input_tokens": 20, "output_tokens": 10}
+    });
+    let backend = ApiBackend::new("test", "", None, "claude-3", false, "anthropic");
+    let response = backend.parse_response(json);
+    assert_eq!(response.content, "Let me check.");
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].name, "read");
+    assert_eq!(response.tool_calls[0].arguments.get("file_path").unwrap(), "test.txt");
+}
+
+#[test]
+fn test_tool_call_multiple_calls() {
+    let args1 = serde_json::json!({"command": "ls"}).to_string();
+    let args2 = serde_json::json!({"file_path": "/tmp/test"}).to_string();
+    let json = serde_json::json!({
+        "choices": [{"message": {"content": "", "tool_calls": [
+            {"id": "call_1", "function": {"name": "bash", "arguments": args1}},
+            {"id": "call_2", "function": {"name": "read", "arguments": args2}}
+        ]}}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+    });
+    let backend = ApiBackend::new("test", "", None, "gpt-4", false, "openai");
+    let response = backend.parse_response(json);
+    assert_eq!(response.tool_calls.len(), 2);
+    assert_eq!(response.tool_calls[0].name, "bash");
+    assert_eq!(response.tool_calls[1].name, "read");
 }

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -258,6 +258,10 @@ run_tests :-
     test_py_command_body_dispatch,
     test_py_plugin_manager,
     test_prolog_plugin_loading,
+    %% Phase 15 — async backend, E2E tests, Prolog data-driven dispatch
+    test_rust_async_backend,
+    test_rust_e2e_integration_tests,
+    test_prolog_data_driven_dispatch,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -3065,7 +3069,7 @@ test_rust_fragments :-
     %% Count rust fragments
     findall(N, agent_loop_module:rust_fragment(N, _), RFs),
     length(RFs, RFCount),
-    assert_eq('Rust fragment count', RFCount, 32),
+    assert_eq('Rust fragment count', RFCount, 33),
     %% Check each fragment exists and has content
     assert_true('config_types has CliArgument', (
         agent_loop_module:rust_fragment(config_types, C1),
@@ -4895,4 +4899,102 @@ test_prolog_plugin_loading :-
     )),
     assert_true('render_plugin_template predicate exists', (
         sub_string(PlContent, _, _, _, "render_plugin_template")
+    )).
+
+%% ============================================================================
+%% Phase 15 — Async backend fragment
+%% ============================================================================
+
+test_rust_async_backend :-
+    format("~nRust async backend:~n"),
+    assert_true('async_backend fragment exists', (
+        agent_loop_module:rust_fragment(async_backend, _)
+    )),
+    agent_loop_module:rust_fragment(async_backend, AsyncContent),
+    assert_true('AsyncAgentBackend trait defined', (
+        sub_string(AsyncContent, _, _, _, "trait AsyncAgentBackend")
+    )),
+    assert_true('AsyncApiBackend struct defined', (
+        sub_string(AsyncContent, _, _, _, "struct AsyncApiBackend")
+    )),
+    assert_true('send_async method exists', (
+        sub_string(AsyncContent, _, _, _, "async fn send_async")
+    )),
+    assert_true('send_streaming_async method exists', (
+        sub_string(AsyncContent, _, _, _, "async fn send_streaming_async")
+    )),
+    assert_true('futures::StreamExt used', (
+        sub_string(AsyncContent, _, _, _, "futures::StreamExt")
+    )),
+    %% Verify tokio in Cargo.toml
+    agent_loop_module:output_path(rust, '', SrcDir),
+    atom_concat(SrcDir, '../Cargo.toml', CargoPath),
+    read_file_to_string(CargoPath, CargoContent, []),
+    assert_true('Cargo.toml has tokio dependency', (
+        sub_string(CargoContent, _, _, _, "tokio")
+    )),
+    assert_true('Cargo.toml has futures dependency', (
+        sub_string(CargoContent, _, _, _, "futures")
+    )).
+
+%% ============================================================================
+%% Phase 15 — E2E integration test assertions
+%% ============================================================================
+
+test_rust_e2e_integration_tests :-
+    format("~nRust E2E integration tests:~n"),
+    agent_loop_module:output_path(rust, '', SrcDir),
+    atom_concat(SrcDir, '../tests/integration_tests.rs', TestPath),
+    read_file_to_string(TestPath, TestContent, []),
+    assert_true('async mock server test exists', (
+        sub_string(TestContent, _, _, _, "test_async_backend_mock_server")
+    )),
+    assert_true('anthropic mock test exists', (
+        sub_string(TestContent, _, _, _, "test_async_backend_anthropic_mock")
+    )),
+    assert_true('connection refused test exists', (
+        sub_string(TestContent, _, _, _, "test_async_backend_connection_refused")
+    )),
+    assert_true('tool call extraction openai test exists', (
+        sub_string(TestContent, _, _, _, "test_tool_call_extraction_openai_format")
+    )),
+    assert_true('tool call extraction anthropic test exists', (
+        sub_string(TestContent, _, _, _, "test_tool_call_extraction_anthropic_format")
+    )),
+    assert_true('tool call multiple test exists', (
+        sub_string(TestContent, _, _, _, "test_tool_call_multiple_calls")
+    )),
+    assert_true('tokio::test attribute used', (
+        sub_string(TestContent, _, _, _, "tokio::test")
+    )).
+
+%% ============================================================================
+%% Phase 15 — Prolog data-driven dispatch
+%% ============================================================================
+
+test_prolog_data_driven_dispatch :-
+    format("~nProlog data-driven dispatch:~n"),
+    assert_true('prolog_command_action exit exists', (
+        agent_loop_module:prolog_command_action(exit, exit)
+    )),
+    assert_true('prolog_command_action clear exists', (
+        agent_loop_module:prolog_command_action(clear, clear)
+    )),
+    assert_true('prolog_command_action help exists', (
+        agent_loop_module:prolog_command_action(help, help)
+    )),
+    assert_true('prolog_command_action status exists', (
+        agent_loop_module:prolog_command_action(status, status)
+    )),
+    assert_true('prolog_command_action multiline exists', (
+        agent_loop_module:prolog_command_action(multiline, multiline)
+    )),
+    %% Verify generated commands.pl has command_action facts
+    agent_loop_module:output_path(prolog, 'commands.pl', CmdPath),
+    read_file_to_string(CmdPath, CmdContent, []),
+    assert_true('generated commands.pl has command_action facts', (
+        sub_string(CmdContent, _, _, _, "command_action(exit")
+    )),
+    assert_true('handle_slash_command uses command_action', (
+        sub_string(CmdContent, _, _, _, "command_action")
     )).

--- a/tools/agent-loop/test_integration.py
+++ b/tools/agent-loop/test_integration.py
@@ -503,3 +503,141 @@ class TestComponentDriven:
         assert "```mermaid" in content, "README should contain mermaid code block"
         assert "graph TD" in content, "README should contain graph TD directive"
         assert "agent_loop" in content, "README diagram should reference agent_loop module"
+
+
+# ============================================================================
+# TestPluginManager — Phase 14 Python plugin system
+# ============================================================================
+
+class TestPluginManager:
+    """Test the PluginManager class in generated tools.py."""
+
+    def test_plugin_manager_import(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        assert pm is not None
+
+    def test_plugin_manager_empty_state(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        assert pm.list_tools() == []
+        assert pm.get_tool_schemas() == []
+
+    def test_plugin_manager_load_nonexistent_dir(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        count = pm.load_dir("/nonexistent/path/to/plugins")
+        assert count == 0
+
+    def test_plugin_manager_load_file(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            import json
+            json.dump({
+                "name": "test-plugin",
+                "version": "1.0",
+                "tools": [{
+                    "name": "greet",
+                    "description": "Say hello",
+                    "parameters": [{"name": "name", "param_type": "string", "required": True}],
+                    "command_template": "echo Hello {name}!"
+                }]
+            }, f)
+            f.flush()
+            pm.load_file(f.name)
+        tools = pm.list_tools()
+        assert len(tools) == 1
+        assert tools[0]["name"] == "greet"
+        os.unlink(f.name)
+
+    def test_plugin_manager_execute(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            import json
+            json.dump({
+                "name": "test-plugin",
+                "version": "1.0",
+                "tools": [{
+                    "name": "greet",
+                    "description": "Say hello",
+                    "parameters": [{"name": "name", "param_type": "string", "required": True}],
+                    "command_template": "echo Hello {name}!"
+                }]
+            }, f)
+            f.flush()
+            pm.load_file(f.name)
+        result = pm.execute("greet", {"name": "World"})
+        assert result == "echo Hello World!"
+        os.unlink(f.name)
+
+    def test_plugin_manager_tool_schemas(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            import json
+            json.dump({
+                "name": "test-plugin",
+                "version": "1.0",
+                "tools": [{
+                    "name": "greet",
+                    "description": "Greet someone",
+                    "parameters": [{"name": "name", "param_type": "string", "required": True}],
+                    "command_template": "echo Hello {name}!"
+                }]
+            }, f)
+            f.flush()
+            pm.load_file(f.name)
+        schemas = pm.get_tool_schemas()
+        assert len(schemas) == 1
+        assert schemas[0]["type"] == "function"
+        assert schemas[0]["function"]["name"] == "greet"
+        os.unlink(f.name)
+
+    def test_plugin_execute_unknown_tool(self):
+        from tools import PluginManager
+        pm = PluginManager()
+        result = pm.execute("nonexistent", {})
+        assert result is None
+
+
+# ============================================================================
+# TestCommandDispatch — Phase 14 data-driven dispatch
+# ============================================================================
+
+class TestCommandDispatch:
+    """Test that data-driven command dispatch works in agent_loop.py."""
+
+    def test_agent_loop_module_importable(self):
+        """agent_loop module can be imported."""
+        import agent_loop
+        assert hasattr(agent_loop, 'AgentLoop')
+
+    def test_handle_command_exit(self):
+        """Exit command sets running=False."""
+        import agent_loop
+        loop = agent_loop.AgentLoop.__new__(agent_loop.AgentLoop)
+        loop.running = True
+        loop.config = {"model": "test", "max_context_tokens": 4096}
+        loop.context = type('MockCtx', (), {'clear': lambda self: None, 'token_count': lambda self: 0})()
+        loop.alias_manager = type('MockAlias', (), {'resolve': lambda self, x: x})()
+        # Mock other required attributes
+        loop.multiline_mode = False
+        result = loop._handle_command("exit")
+        assert result is True
+        assert loop.running is False
+
+    def test_handle_command_help(self):
+        """Help command returns True."""
+        import agent_loop
+        loop = agent_loop.AgentLoop.__new__(agent_loop.AgentLoop)
+        loop.running = True
+        loop.config = {"model": "test", "max_context_tokens": 4096}
+        loop.context = type('MockCtx', (), {'messages': []})()
+        loop.alias_manager = type('MockAlias', (), {'resolve': lambda self, x: x})()
+        loop.multiline_mode = False
+        # _print_help needs to exist
+        loop._print_help = lambda: None
+        result = loop._handle_command("help")
+        assert result is True

--- a/tools/agent-loop/test_prolog_integration.pl
+++ b/tools/agent-loop/test_prolog_integration.pl
@@ -17,6 +17,14 @@
 
 :- dynamic pl_test_passed/1, pl_test_failed/1.
 
+%% tmp_file_name(+Name, -Path) — get a writable temp file path
+tmp_file_name(Name, Path) :-
+    (getenv('TMPDIR', TmpDir) -> true
+    ; getenv('HOME', Home) -> atom_concat(Home, '/tmp', TmpDir)
+    ; TmpDir = '/tmp'),
+    (exists_directory(TmpDir) -> true ; make_directory_path(TmpDir)),
+    format(atom(Path), "~w/~w", [TmpDir, Name]).
+
 run_prolog_tests :-
     retractall(pl_test_passed(_)),
     retractall(pl_test_failed(_)),
@@ -28,6 +36,7 @@ run_prolog_tests :-
     test_backends_module,
     test_cost_tracker_runtime,
     test_config_runtime,
+    test_plugin_system,
     %% Report
     aggregate_all(count, pl_test_passed(_), Passed),
     aggregate_all(count, pl_test_failed(_), Failed),
@@ -203,4 +212,52 @@ test_config_runtime :-
     %% audit_profile_level lookup
     pl_assert_true('audit_profile_level paranoid is forensic', (
         config:audit_profile_level(paranoid, forensic)
+    )).
+
+%% ============================================================================
+%% Plugin loading and dispatch tests (Phase 15)
+%% ============================================================================
+
+test_plugin_system :-
+    format("~nplugin system:~n"),
+    %% Plugin tool loading from JSON fixture
+    tmp_file_name('uwsal_test_plugin.json', TmpFile),
+    PluginJson = '{"name":"test-plugin","version":"1.0","tools":[{"name":"greet","description":"Say hello","parameters":[{"name":"who","param_type":"string"}],"command_template":"echo Hello {who}!"}]}',
+    open(TmpFile, write, WS),
+    write(WS, PluginJson),
+    close(WS),
+    pl_assert_true('load_plugin_file succeeds', (
+        tools:load_plugin_file(TmpFile)
+    )),
+    pl_assert_true('plugin_tool registered', (
+        tools:plugin_tool(greet, _, _)
+    )),
+    pl_assert_true('execute_plugin_tool renders template', (
+        tools:execute_plugin_tool(greet, _{who: 'World'}, Result),
+        Result \= error(_)
+    )),
+    %% Cleanup
+    retractall(tools:plugin_tool(greet, _, _)),
+    (exists_file(TmpFile) -> delete_file(TmpFile) ; true),
+    %% command_action facts
+    pl_assert_true('command_action exit exists', (
+        commands:command_action(exit, exit)
+    )),
+    pl_assert_true('command_action clear exists', (
+        commands:command_action(clear, clear)
+    )),
+    pl_assert_true('command_action help exists', (
+        commands:command_action(help, help)
+    )),
+    pl_assert_true('command_action multiline exists', (
+        commands:command_action(multiline, multiline)
+    )),
+    %% handle_slash_command uses command_action
+    pl_assert_true('handle_slash_command exit returns exit action', (
+        commands:handle_slash_command(exit, "", Action),
+        Action == exit
+    )),
+    pl_assert_true('handle_slash_command help returns help action', (
+        commands:handle_slash_command(help, "", Action2),
+        Action2 == help
     )).


### PR DESCRIPTION
## Summary

Five features: async/tokio runtime for Rust, E2E integration tests with mock HTTP servers, expanded Python pytest suite, Prolog plugin integration tests with JSON fixtures, and data-driven Prolog command dispatch.

### 1. Async/tokio runtime (Rust)

| Component | Description |
|-----------|-------------|
| `AsyncAgentBackend` trait | Async interface with `send_message_async` returning pinned future |
| `AsyncApiBackend` struct | Wraps `ApiBackend` for non-blocking HTTP calls |
| `send_async()` | Async non-streaming request via `reqwest::Client` |
| `send_streaming_async(on_token)` | Async streaming with `futures::StreamExt` + SSE parsing |
| `#[tokio::main]` | Main function now async-ready |

**Dependencies added:** `tokio = { version = "1", features = ["full"] }`, `futures = "0.3"`, `reqwest` gains `"stream"` feature.

### 2. E2E integration tests (10 new cargo tests)

| Test | Category |
|------|----------|
| `test_async_api_backend_creation` | AsyncApiBackend construction |
| `test_async_api_backend_anthropic_format` | Anthropic format config |
| `test_async_backend_mock_server` | Full E2E: mock TCP server returns OpenAI response |
| `test_async_backend_anthropic_mock` | Full E2E: mock TCP server returns Anthropic response |
| `test_async_backend_connection_refused` | Error handling for unreachable server |
| `test_async_backend_request_body_format` | OpenAI request body structure |
| `test_async_backend_anthropic_request_body` | Anthropic request body structure |
| `test_tool_call_extraction_openai_format` | Parse OpenAI tool call responses |
| `test_tool_call_extraction_anthropic_format` | Parse Anthropic tool_use blocks |
| `test_tool_call_multiple_calls` | Parse multiple tool calls in one response |

Mock servers use `tokio::net::TcpListener` bound to `127.0.0.1:0` — no external network access needed.

### 3. Python test expansion (8 new pytest tests)

| Test | Category |
|------|----------|
| `test_plugin_manager_import` | Import and instantiation |
| `test_plugin_manager_empty_state` | Empty list_tools/get_tool_schemas |
| `test_plugin_manager_load_nonexistent_dir` | Graceful failure on missing dir |
| `test_plugin_manager_load_file` | Load JSON manifest, verify tool list |
| `test_plugin_manager_execute` | Template rendering with arguments |
| `test_plugin_manager_tool_schemas` | OpenAI-compatible schema generation |
| `test_plugin_execute_unknown_tool` | Returns None for unknown tool |
| `test_handle_command_exit` | Exit command sets running=False |

### 4. Prolog plugin integration tests (10 new tests)

| Test | Category |
|------|----------|
| `load_plugin_file succeeds` | JSON fixture loading |
| `plugin_tool registered` | Dynamic fact assertion |
| `execute_plugin_tool renders template` | Template rendering + bash execution |
| `command_action exit/clear/help/multiline exists` | Data-driven dispatch facts (4 tests) |
| `handle_slash_command exit/help returns action` | End-to-end dispatch (2 tests) |

**Bug fix:** `render_plugin_template/4` was using `split_string/4` which splits on individual characters, not substrings. Replaced with proper `replace_all_in_string/4` using `sub_string/5`.

### 5. Data-driven Prolog dispatch

Replaced hardcoded `CmdAtom = exit -> Action = exit` chain with data-driven lookup:

```prolog
%% Before (hardcoded):
; CmdAtom = exit -> Action = exit
; CmdAtom = clear -> Action = clear
; CmdAtom = help -> Action = help
; CmdAtom = status -> Action = status

%% After (data-driven):
; command_action(CmdAtom, DirectAction) -> Action = DirectAction
```

5 `prolog_command_action/2` facts define the mapping. Adding a new non-handler command = adding one fact.

## Test plan

- [x] 854 Prolog tests pass (+22 new), 1 pre-existing env-specific failure
- [x] 76 `cargo test` integration tests pass (+10 new, including 3 async E2E mock server tests)
- [x] `cargo check` — 0 errors, 0 warnings (1 pre-existing unused import)
- [x] All 3 targets generate clean (Python, Rust, Prolog)
- [x] Mock server tests use loopback only — no external network access
- [x] Plugin template rendering fixed and verified
- [x] Prolog command_action facts emitted in generated commands.pl

## Metrics

| Metric | Phase 14 | Phase 15 |
|--------|----------|----------|
| Prolog tests | 832 | 854 (+22) |
| Cargo tests | 66 | 76 (+10) |
| rust_fragment/2 facts | 32 | 33 (+async_backend) |
| prolog_command_action/2 facts | 0 | 5 (new) |
| Python pytest tests | 59 | 67 (+8) |
| Prolog integration tests | ~27 | ~37 (+10) |

## Files changed

| File | Changes |
|------|---------|
| `agent_loop_module.pl` | `async_backend` fragment; `prolog_command_action/2` facts; `#[tokio::main]`; tokio/futures deps; `pub` on parse_response/build_request_body; reqwest `stream` feature; fixed render_plugin_template; 10 new cargo tests in integration_tests fragment |
| `agent_loop_components.pl` | Emit `command_action/2` facts in `emit_command_facts` |
| `test_agent_loop.pl` | 3 new test predicates: `test_rust_async_backend` (8), `test_rust_e2e_integration_tests` (7), `test_prolog_data_driven_dispatch` (7); fragment count 32→33 |
| `test_integration.py` | 2 new test classes: `TestPluginManager` (7 tests), `TestCommandDispatch` (3 tests) |
| `test_prolog_integration.pl` | `test_plugin_system` with 10 assertions; `tmp_file_name` helper |
| `README.md` | Updated metrics (854+76 tests, 33 fragments), parity table (+async/tokio, data-driven Prolog dispatch) |
| Generated: `rust/Cargo.toml` | tokio, futures deps; reqwest stream feature |
| Generated: `rust/src/backends.rs` | AsyncAgentBackend trait + AsyncApiBackend impl |
| Generated: `rust/src/main.rs` | `#[tokio::main] async fn main()` |
| Generated: `rust/tests/integration_tests.rs` | 10 new tests (async E2E, tool call parsing) |
| Generated: `prolog/commands.pl` | `command_action/2` facts; updated handle_slash_command |
| Generated: `prolog/tools.pl` | Fixed render_plugin_template with replace_all_in_string |
