### PR TITLE
perf(csharp-query): reuse pair cache for one-sided batched probes

### DIFF
--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -7262,10 +7262,14 @@ namespace UnifyWeaver.QueryRuntime
                         out var forwardTargetsBySource,
                         out var backwardSourcesByTarget))
                 {
+                    var canReuseBatchedPairProbeCache =
+                        _pairProbeCacheMaxEntries > 0 &&
+                        _pairProbeCacheAdmissionMinCostPerProbe > 0d;
+
                     if (forwardTargetsBySource.Count > 0 && backwardSourcesByTarget.Count > 0)
                     {
                         trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBatchedSingleProbeMixed");
-                        if (_pairProbeCacheMaxEntries > 0 && _pairProbeCacheAdmissionMinCostPerProbe > 0d)
+                        if (canReuseBatchedPairProbeCache)
                         {
                             return ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
                                 closure,
@@ -7286,6 +7290,16 @@ namespace UnifyWeaver.QueryRuntime
                     if (forwardTargetsBySource.Count > 0)
                     {
                         trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBatchedSingleProbeForward");
+                        if (canReuseBatchedPairProbeCache)
+                        {
+                            return ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                                closure,
+                                inputPositions,
+                                forwardTargetsBySource,
+                                backwardSourcesByTarget,
+                                context);
+                        }
+
                         if (_cacheContext is not null && forwardTargetsBySource.Count <= MaxMemoizedGroupedPairSeeds)
                         {
                             trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
@@ -7304,6 +7318,16 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsBatchedSingleProbeBackward");
+                    if (canReuseBatchedPairProbeCache)
+                    {
+                        return ExecuteSeededGroupedTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                            closure,
+                            inputPositions,
+                            forwardTargetsBySource,
+                            backwardSourcesByTarget,
+                            context);
+                    }
+
                     if (_cacheContext is not null && backwardSourcesByTarget.Count <= MaxMemoizedGroupedPairSeeds)
                     {
                         trace?.RecordStrategy(closure, "GroupedTransitiveClosurePairsMemoized");
@@ -10454,10 +10478,14 @@ namespace UnifyWeaver.QueryRuntime
                         out var forwardBySource,
                         out var backwardByTarget))
                 {
+                    var canReuseBatchedPairProbeCache =
+                        _pairProbeCacheMaxEntries > 0 &&
+                        _pairProbeCacheAdmissionMinCostPerProbe > 0d;
+
                     if (forwardBySource.Count > 0 && backwardByTarget.Count > 0)
                     {
                         trace?.RecordStrategy(closure, "TransitiveClosurePairsBatchedSingleProbeMixed");
-                        if (_pairProbeCacheMaxEntries > 0 && _pairProbeCacheAdmissionMinCostPerProbe > 0d)
+                        if (canReuseBatchedPairProbeCache)
                         {
                             return ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
                                 closure,
@@ -10476,6 +10504,15 @@ namespace UnifyWeaver.QueryRuntime
                     if (forwardBySource.Count > 0)
                     {
                         trace?.RecordStrategy(closure, "TransitiveClosurePairsBatchedSingleProbeForward");
+                        if (canReuseBatchedPairProbeCache)
+                        {
+                            return ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                                closure,
+                                forwardBySource,
+                                backwardByTarget,
+                                context);
+                        }
+
                         if (_cacheContext is not null && forwardBySource.Count <= MaxMemoizedPairSeeds)
                         {
                             trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");
@@ -10487,6 +10524,15 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     trace?.RecordStrategy(closure, "TransitiveClosurePairsBatchedSingleProbeBackward");
+                    if (canReuseBatchedPairProbeCache)
+                    {
+                        return ExecuteSeededTransitiveClosurePairsMixedDirectionWithPairProbeCache(
+                            closure,
+                            forwardBySource,
+                            backwardByTarget,
+                            context);
+                    }
+
                     if (_cacheContext is not null && backwardByTarget.Count <= MaxMemoizedPairSeeds)
                     {
                         trace?.RecordStrategy(closure, "TransitiveClosurePairsMemoized");

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -311,6 +311,10 @@ test_csharp_query_target :-
         verify_parameterized_reachability_by_target_single_strategy_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_reuse_runtime,
+        verify_parameterized_reachability_pairs_single_probe_cache_key_order_insensitive_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_key_order_insensitive_runtime,
+        verify_parameterized_reachability_pairs_single_probe_cache_overlap_reuse_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_overlap_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_cache_reuse_runtime,
         verify_parameterized_grouped_transitive_closure_seed_cache_key_order_insensitive_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_cache_key_order_insensitive_runtime,
@@ -3778,6 +3782,92 @@ verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_reuse_r
         ['a,c,red,cat1',
          'CACHE_HIT:GroupedTransitiveClosurePairsSingleProbe=true'],
         Params,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_single_probe_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param_both/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[alice, bob], [bob, charlie]],
+    ExecParams = [[bob, charlie], [alice, bob]],
+    harness_source_with_pair_cache_flag_warm_exec_normalized(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosurePairsSingleProbe',
+        4,
+        0,
+        0.1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['bob,charlie',
+         'alice,bob',
+         'CACHE_HIT:TransitiveClosurePairsSingleProbe=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_key_order_insensitive_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param_both/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, b, red, cat1], [b, c, red, cat1]],
+    ExecParams = [[b, c, red, cat1], [a, b, red, cat1]],
+    harness_source_with_pair_cache_flag_warm_exec_normalized(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosurePairsSingleProbe',
+        4,
+        0,
+        0.1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['b,c,red,cat1',
+         'a,b,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosurePairsSingleProbe=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_reachability_pairs_single_probe_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_reachable_param_both/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[alice, bob], [bob, charlie]],
+    ExecParams = [[bob, charlie], [alice, bob], [alice, charlie]],
+    harness_source_with_pair_cache_flag_warm_exec_normalized(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'TransitiveClosurePairsSingleProbe',
+        4,
+        0,
+        0.1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['bob,charlie',
+         'alice,charlie',
+         'alice,bob',
+         'CACHE_HIT:TransitiveClosurePairsSingleProbe=true'],
+        ExecParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_overlap_reuse_runtime :-
+    csharp_query_target:build_query_plan(test_label_cat_reach_param_both/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmParams = [[a, b, red, cat1], [b, c, red, cat1]],
+    ExecParams = [[b, c, red, cat1], [a, b, red, cat1], [a, c, red, cat1]],
+    harness_source_with_pair_cache_flag_warm_exec_normalized(
+        ModuleClass,
+        WarmParams,
+        ExecParams,
+        'GroupedTransitiveClosurePairsSingleProbe',
+        4,
+        0,
+        0.1,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['b,c,red,cat1',
+         'a,b,red,cat1',
+         'a,c,red,cat1',
+         'CACHE_HIT:GroupedTransitiveClosurePairsSingleProbe=true'],
+        ExecParams,
         HarnessSource).
 
 verify_parameterized_reachability_pairs_single_probe_cache_eviction_runtime :-


### PR DESCRIPTION
  ## Summary
  Enable plain batched single-probe pair queries to reuse the pair cache even when the batch is entirely forward-only or
  entirely backward-only, and add the missing reuse-symmetry coverage for those paths.

  ## What changed
  - Updated the C# query runtime so one-sided batched pair requests can route through the existing pair-cache reuse
  path:
    - forward-only `TransitiveClosurePairsSingleProbe`
    - backward-only `TransitiveClosurePairsSingleProbe`
    - forward-only `GroupedTransitiveClosurePairsSingleProbe`
    - backward-only `GroupedTransitiveClosurePairsSingleProbe`
  - Added the four missing plain pair-cache reuse-symmetry tests:
    - non-grouped `key_order_insensitive`
    - non-grouped `overlap_reuse`
    - grouped `key_order_insensitive`
    - grouped `overlap_reuse`

  ## Why
  The test gap exposed a runtime limitation: plain batched pair-cache reuse only worked for mixed-direction batches.
  Forward-only and backward-only batched requests still fell back to non-reuse paths, which made the missing reuse-
  symmetry cases fail.

  This change makes reuse behavior consistent across batched pair requests and completes the plain pair-cache reuse
  matrix.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`220/220`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_pair_cache_reuse_symmetry_reachab_ready -ProjectFilter "cq_test_reachab*"`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_pair_cache_reuse_symmetry_label_ready -ProjectFilter "cq_test_label_c*"`
    - Passed