### PR TITLE
test(csharp-query): add mixed pair-cache duplicate-heavy admission coverage

### DIFF
--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -365,6 +365,7 @@ test_csharp_query_target :-
         verify_parameterized_reachability_pairs_single_probe_cache_admission_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_admission_normalized_runtime,
         verify_parameterized_reachability_pairs_single_probe_cache_admission_duplicate_heavy_runtime,
+        verify_parameterized_reachability_pairs_batched_single_probe_mixed_pair_cache_admission_duplicate_heavy_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_seed_cache_admission_duplicate_heavy_runtime,
         verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_normalized_runtime,
@@ -381,6 +382,7 @@ test_csharp_query_target :-
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_normalized_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admission_duplicate_heavy_runtime,
+        verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_pair_cache_admission_duplicate_heavy_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_seed_cache_admission_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_seed_cache_admission_duplicate_heavy_runtime,
         verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_seed_cache_admission_selectivity_runtime,
@@ -4725,6 +4727,32 @@ verify_parameterized_reachability_pairs_single_probe_cache_admission_duplicate_h
         HotParams,
         HarnessSource).
 
+verify_parameterized_reachability_pairs_batched_single_probe_mixed_pair_cache_admission_duplicate_heavy_runtime :-
+    csharp_query_target:build_query_plan(test_admission_mixed_lru_reach/2, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [[a, z], [p, q], [a, z], [p, q], [a, z], [p, q]],
+    WarmColdParams = [[x, z], [x, z], [y, z], [y, z], [p, r], [p, r], [p, s], [p, s]],
+    HotParams = [[a, z], [p, q], [a, z], [p, q], [a, z], [p, q]],
+    ColdParams = [[x, z], [x, z], [y, z], [y, z], [p, r], [p, r], [p, s], [p, s]],
+    harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'TransitiveClosurePairsSingleProbe',
+        8,
+        0,
+        0.2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:TransitiveClosurePairsSingleProbe=true',
+         'CACHE_HIT_COLD:TransitiveClosurePairsSingleProbe=false',
+         'CACHE_ADMISSIONS:TransitiveClosurePairsSingleProbe=2',
+         'CACHE_ADMISSION_SKIPS:TransitiveClosurePairsSingleProbe=4'],
+        HotParams,
+        HarnessSource).
+
 verify_parameterized_reachability_pairs_batched_single_probe_mixed_cache_admission_runtime :-
     csharp_query_target:build_query_plan(test_probe_dir_mixed_reach/2, [target(csharp_query)], Plan),
     csharp_query_target:plan_module_name(Plan, ModuleClass),
@@ -5145,6 +5173,44 @@ verify_parameterized_grouped_transitive_closure_pairs_single_probe_cache_admissi
          'CACHE_HIT_COLD:GroupedTransitiveClosurePairsSingleProbe=false',
          'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=1',
          'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=1'],
+        HotParams,
+        HarnessSource).
+
+verify_parameterized_grouped_transitive_closure_pairs_batched_single_probe_mixed_pair_cache_admission_duplicate_heavy_runtime :-
+    csharp_query_target:build_query_plan(test_admission_group_mixed_lru_reach/4, [target(csharp_query)], Plan),
+    csharp_query_target:plan_module_name(Plan, ModuleClass),
+    WarmHotParams = [
+        [a, z, red, cat1], [p, q, red, cat1], [a, z, red, cat1], [p, q, red, cat1],
+        [a, z, red, cat1], [p, q, red, cat1]
+    ],
+    WarmColdParams = [
+        [x, z, red, cat1], [x, z, red, cat1], [y, z, red, cat1], [y, z, red, cat1],
+        [p, r, red, cat1], [p, r, red, cat1], [p, s, red, cat1], [p, s, red, cat1]
+    ],
+    HotParams = [
+        [a, z, red, cat1], [p, q, red, cat1], [a, z, red, cat1], [p, q, red, cat1],
+        [a, z, red, cat1], [p, q, red, cat1]
+    ],
+    ColdParams = [
+        [x, z, red, cat1], [x, z, red, cat1], [y, z, red, cat1], [y, z, red, cat1],
+        [p, r, red, cat1], [p, r, red, cat1], [p, s, red, cat1], [p, s, red, cat1]
+    ],
+    harness_source_with_pair_cache_admission_normalized_flag(
+        ModuleClass,
+        WarmHotParams,
+        WarmColdParams,
+        HotParams,
+        ColdParams,
+        'GroupedTransitiveClosurePairsSingleProbe',
+        8,
+        0,
+        0.2,
+        HarnessSource),
+    maybe_run_query_runtime_with_harness(Plan,
+        ['CACHE_HIT_HOT:GroupedTransitiveClosurePairsSingleProbe=true',
+         'CACHE_HIT_COLD:GroupedTransitiveClosurePairsSingleProbe=false',
+         'CACHE_ADMISSIONS:GroupedTransitiveClosurePairsSingleProbe=2',
+         'CACHE_ADMISSION_SKIPS:GroupedTransitiveClosurePairsSingleProbe=4'],
         HotParams,
         HarnessSource).
 


### PR DESCRIPTION
## Summary
  Add duplicate-heavy admission coverage for the mixed pair-probe cache paths in the C# query runtime tests.

  ## What changed
  - Added non-grouped mixed pair-cache duplicate-heavy admission coverage
  - Added grouped mixed pair-cache duplicate-heavy admission coverage
  - Registered both new cases in `test_csharp_query_target/0`

  ## Why
  The mixed pair-cache path already had:
  - normalized admission coverage
  - selectivity admission coverage
  - reuse symmetry coverage
  - eviction / LRU coverage

  What it was still missing was duplicate-heavy admission coverage, to match the plain single-probe pair-cache tests and
  ensure repeated copies of the same mixed pair requests do not regress admission behavior.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_mixed_pair_cache_admission_duplicate_heavy_rerun -ProjectFilter "cq_test_admissi*"`
    - Passed