### PR TITLE
feat(agent-loop): Phase 22 — tool approval UI, streaming retry, OutputParser wiring, MCP lifecycle

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -62,20 +62,20 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 |--------|--------|--------|
 | Python | `generated/python/` (15+ modules) | Full agent loop |
 | Prolog | `generated/prolog/` (8 modules) | Full agent loop |
-| Rust | `generated/rust/` (19 files + integration tests) | Data + imperative + CLI + config loading + streaming (with token parsing) + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching + RuntimeState + session resume + env var expansion + multi-format export + retry with backoff + templates (16 built-in + persistence) + skills + multiline input + history edit/undo + spinner + rich display + proot sandbox + paste detection + config gen (paste_mode) + data-driven help + data-driven dispatch + plugin system (ToolHandler wiring) + WASM bindings (feature-gated) + async/tokio runtime + async retry + streaming async + concurrent tool execution + plugin async + /init config command + binary packaging (Makefile, release profile, WASM targets) + config hot-reload (/reload) + tool approval UI (confirm_tool_execution) + streaming error recovery + context overflow notification + tool result caching + structured output parsing + MCP server support (stdio JSON-RPC) + cache/MCP wiring in ToolHandler + async API backend + 122 integration tests |
+| Rust | `generated/rust/` (19 files + integration tests) | Data + imperative + CLI + config loading + streaming (with token parsing) + security wiring + YAML + tool schemas + multi-format API (OpenAI/Anthropic) + context modes + gemini model validation + OnceLock caching + RuntimeState + session resume + env var expansion + multi-format export + retry with backoff + templates (16 built-in + persistence) + skills + multiline input + history edit/undo + spinner + rich display + proot sandbox + paste detection + config gen (paste_mode) + data-driven help + data-driven dispatch + plugin system (ToolHandler wiring) + WASM bindings (feature-gated) + async/tokio runtime + async retry + streaming async + concurrent tool execution + plugin async + /init config command + binary packaging (Makefile, release profile, WASM targets) + config hot-reload (/reload) + tool approval UI (confirm_tool_execution) + streaming error recovery + context overflow notification + tool result caching + structured output parsing + MCP server support (stdio JSON-RPC) + cache/MCP wiring in ToolHandler + async API backend + OutputParser wiring + MCP lifecycle + 130 integration tests |
 
 ### Declarative Infrastructure
 
 | Metric | Count |
 |--------|-------|
-| `py_fragment/2` facts | 93 |
+| `py_fragment/2` facts | 94 |
 | `prolog_fragment/2` facts | 33 |
 | `rust_fragment/2` facts | 37 |
 | `rust_data_table/5` specs | 9 |
 | `emit_config_section/3` clauses | 11 (python + prolog + rust) |
 | `compile_component/4` targets | 3 (python, prolog, rust) |
 | `declare_binding` per target | 11 |
-| Total tests | 982 + 122 Rust integration (653+181 unit + 36 Prolog integration + 108 Python + 122 cargo test) |
+| Total tests | 999 + 130 Rust integration + 128 Python (999 Prolog unit + 36 Prolog integration + 128 Python + 130 cargo test) |
 
 ## Backends
 
@@ -743,7 +743,11 @@ python3 agent_loop.py -i 5 "prompt"  # Max 5 tool iterations
 | Tool result caching | Y | Y | Complete (TTL-based, skips destructive tools, /clear-cache command) |
 | MCP server support | Y | Y | Complete (stdio JSON-RPC, tool discovery + dispatch, MCPManager) |
 | Cache/MCP wiring in ToolHandler | Y | Y | Complete (cache check/store + mcp: prefix dispatch) |
-| Integration tests (cargo test) | N | Y (122 tests) | Rust-only (incl. E2E mock, async retry, streaming, plugin async, WASM, cache, MCP) |
+| Tool approval UI | Y | Y | Complete (yolo/plan/auto_edit/default modes, interactive confirm) |
+| Streaming error recovery | Y | Y | Complete (retry with exponential backoff on connection/timeout errors) |
+| OutputParser wiring | Y | Y | Complete (JSON extraction from model responses, parse_response in loop) |
+| MCP server lifecycle | Y | Y | Complete (auto-connect on startup, disconnect on exit) |
+| Integration tests (cargo test) | N | Y (130 tests) | Rust-only (incl. E2E mock, async retry, streaming, plugin async, WASM, cache, MCP, approval, OutputParser) |
 
 ## License
 

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -2376,7 +2376,8 @@ generate_rust_main :-
     write(S, 'use agent_loop::tool_handler::*;\n'),
     write(S, 'use agent_loop::commands::*;\n'),
     write(S, 'use agent_loop::sessions::*;\n'),
-    write(S, 'use agent_loop::config_loader::*;\n\n'),
+    write(S, 'use agent_loop::config_loader::*;\n'),
+    write(S, 'use agent_loop::output_parser::*;\n\n'),
     %% Export conversation helper (module-level, before handle_command and main)
     write_rust(S, export_conversation),
     nl(S),
@@ -4251,6 +4252,9 @@ generate_agent_loop_main :-
     nl(S),
     %% 6b. _process_message (lines 617-779)
     write_py(S, agent_loop_process_message),
+    nl(S),
+    %% 6c. _send_streaming_with_retry
+    write_py(S, agent_loop_streaming_retry),
     %% Two blank line separators (lines 779-780)
     nl(S), nl(S),
     %% 7. build_system_prompt + _resolve_command (lines 781-835)
@@ -9861,6 +9865,75 @@ fn test_e2e_tool_handler_unknown_tool() {
     assert!(!result.success);
     assert!(result.output.contains("Unknown tool"));
 }
+
+// ============================================================================
+// Phase 22 — Tool approval UI, OutputParser wiring, MCP lifecycle
+// ============================================================================
+
+#[test]
+fn test_phase22_tool_approval_yolo() {
+    let handler = ToolHandler::new(true, "open".to_string(), "yolo".to_string());
+    assert!(handler.check_approval("bash"));
+    assert!(handler.check_approval("write"));
+    assert!(handler.check_approval("read"));
+}
+
+#[test]
+fn test_phase22_tool_approval_plan() {
+    let handler = ToolHandler::new(true, "open".to_string(), "plan".to_string());
+    assert!(handler.check_approval("read"));
+    assert!(!handler.check_approval("bash"));
+    assert!(!handler.check_approval("write"));
+}
+
+#[test]
+fn test_phase22_tool_approval_auto_edit() {
+    let handler = ToolHandler::new(true, "open".to_string(), "auto_edit".to_string());
+    assert!(handler.check_approval("read"));
+    assert!(handler.check_approval("edit"));
+    assert!(handler.check_approval("write"));
+    assert!(!handler.check_approval("bash"));
+}
+
+#[test]
+fn test_phase22_plan_mode_blocks_execute() {
+    let mut handler = ToolHandler::new(true, "open".to_string(), "plan".to_string());
+    let mut args = HashMap::new();
+    args.insert("command".to_string(), serde_json::json!("ls"));
+    let tc = ToolCall { name: "bash".to_string(), arguments: args, id: "plan_test".to_string() };
+    let result = handler.execute(&tc);
+    assert!(!result.success);
+    assert!(result.output.contains("blocked by approval mode"));
+}
+
+#[test]
+fn test_phase22_output_parser_in_main() {
+    let main_src = include_str!("../src/main.rs");
+    assert!(main_src.contains("use agent_loop::output_parser"), "main.rs should import output_parser");
+    assert!(main_src.contains("OutputParser::parse_response"), "main.rs should call OutputParser::parse_response");
+}
+
+#[test]
+fn test_phase22_mcp_lifecycle_init() {
+    let main_src = include_str!("../src/main.rs");
+    assert!(main_src.contains("set_mcp_servers"), "main.rs should init MCP servers");
+    assert!(main_src.contains("disconnect_all"), "main.rs should disconnect MCP on exit");
+}
+
+#[test]
+fn test_phase22_output_parser_extract_fenced() {
+    use agent_loop::output_parser::OutputParser;
+    let text = "Result:\n```json\n{}\n```\nEnd.";
+    let blocks = OutputParser::extract_json(text);
+    assert!(!blocks.is_empty(), "Should extract fenced JSON block");
+}
+
+#[test]
+fn test_phase22_output_parser_no_json() {
+    use agent_loop::output_parser::OutputParser;
+    let blocks = OutputParser::extract_json("No JSON here at all.");
+    assert!(blocks.is_empty());
+}
 ').
 
 rust_fragment(main_loop, '
@@ -9909,6 +9982,23 @@ rust_fragment(main_loop, '
     let plugin_count = tool_handler.load_default_plugins();
     if plugin_count > 0 {
         println!("[Loaded {} plugin(s)]", plugin_count);
+    }
+
+    // Initialize MCP servers from config
+    if !config.mcp_servers.is_empty() {
+        use agent_loop::mcp_client::McpServerConfig;
+        let mcp_configs: Vec<McpServerConfig> = config.mcp_servers.iter().filter_map(|s| {
+            serde_json::from_value(s.clone()).ok()
+        }).collect();
+        if !mcp_configs.is_empty() {
+            tool_handler.set_mcp_servers(&mcp_configs);
+            if let Some(ref mgr) = tool_handler.mcp_manager {
+                let tool_count = mgr.list_tools().len();
+                if tool_count > 0 {
+                    println!("[MCP: connected {} server(s), {} tool(s)]", mcp_configs.len(), tool_count);
+                }
+            }
+        }
     }
 
     let mut state = RuntimeState {
@@ -10094,6 +10184,11 @@ rust_fragment(main_loop, '
                     cost_tracker.record_usage(&response.model, response.input_tokens, response.output_tokens);
 
                     if response.tool_calls.is_empty() {
+                        // Parse structured output (JSON blocks) from response
+                        let parsed = OutputParser::parse_response(&response.content, None);
+                        if !parsed.json_blocks.is_empty() {
+                            eprintln!("  [parsed {} JSON block(s) from response]", parsed.json_blocks.len());
+                        }
                         context.add_message("assistant", &response.content);
                         break;
                     }
@@ -10173,6 +10268,11 @@ rust_fragment(main_loop, '
                 break;
             }
         }
+    }
+
+    // Disconnect MCP servers on exit
+    if let Some(ref mut mgr) = tool_handler.mcp_manager {
+        mgr.disconnect_all();
     }
 ').
 
@@ -13823,10 +13923,12 @@ py_fragment(tools_handler_class_header, 'class ToolHandler:
         confirm_destructive: bool = True,
         working_dir: str | None = None,
         security: SecurityConfig | None = None,
-        audit: AuditLogger | None = None
+        audit: AuditLogger | None = None,
+        approval_mode: str = "default"
     ):
         self.allowed_tools = allowed_tools or {{default_tools}}
         self.confirm_destructive = confirm_destructive
+        self.approval_mode = approval_mode
         self.working_dir = working_dir or os.getcwd()
         self.security = security or SecurityConfig()
         self.audit = audit or AuditLogger(level=\'disabled\')
@@ -13862,6 +13964,68 @@ py_fragment(tools_handler_class_header, 'class ToolHandler:
 ').
 
 py_fragment(tools_handler_class_methods, '
+    def check_approval(self, tool_name: str) -> bool:
+        """Check if a tool is approved to execute under the current approval mode.
+        Returns True if approved, False if blocked."""
+        mode = self.approval_mode
+        if mode == "yolo":
+            return True
+        if mode == "plan":
+            return tool_name == "read"
+        if mode == "auto_edit":
+            return tool_name in ("read", "edit", "write")
+        # default mode: read always approved, others go through confirm
+        if tool_name == "read":
+            return True
+        return True  # actual prompt happens in confirm_tool_execution
+
+    def confirm_tool_execution(self, tool_call: ToolCall) -> bool:
+        """Interactive confirmation for tool execution with argument preview.
+        Returns True if the user approves, False to skip."""
+        import sys
+        # Auto-approve in yolo mode
+        if self.approval_mode == "yolo" or not self.confirm_destructive:
+            return True
+        # Read is always safe
+        if tool_call.name == "read":
+            return True
+        # Plan mode blocks all non-read tools
+        if self.approval_mode == "plan":
+            print(f"  [plan mode] Blocked: {tool_call.name}", file=sys.stderr)
+            return False
+        # auto_edit mode: allow read/edit/write without prompt
+        if self.approval_mode == "auto_edit" and tool_call.name in ("edit", "write"):
+            return True
+
+        # Show tool details for confirmation
+        is_destructive = tool_call.name in ("bash", "write", "edit")
+        label = "DESTRUCTIVE" if is_destructive else "Tool"
+        print(f"  [{label}] {tool_call.name} tool:", file=sys.stderr)
+
+        # Show relevant arguments preview
+        if tool_call.name == "bash":
+            cmd = tool_call.arguments.get("command", "")
+            preview = cmd[:120] if len(cmd) > 120 else cmd
+            print(f"    command: {preview}", file=sys.stderr)
+        elif tool_call.name in ("write", "edit"):
+            path = tool_call.arguments.get("file_path", tool_call.arguments.get("path", ""))
+            print(f"    file: {path}", file=sys.stderr)
+        else:
+            # Show first argument for plugin/MCP tools
+            for key, val in tool_call.arguments.items():
+                preview = str(val)
+                preview = preview[:80] if len(preview) > 80 else preview
+                print(f"    {key}: {preview}", file=sys.stderr)
+                break
+
+        try:
+            sys.stderr.write("  Execute? [y/N] ")
+            sys.stderr.flush()
+            response = input().strip().lower()
+            return response in ("y", "yes")
+        except (EOFError, KeyboardInterrupt):
+            return False
+
     def _init_plugins(self):
         """Load plugins from default directory."""
         self.plugin_manager = PluginManager()
@@ -13890,6 +14054,22 @@ py_fragment(tools_handler_class_methods, '
 py_fragment(tools_handler_class_body, '
     def execute(self, tool_call: ToolCall) -> ToolResult:
         """Execute a tool call and return the result."""
+        # Check approval mode before executing
+        if not self.check_approval(tool_call.name):
+            return ToolResult(
+                success=False,
+                output=f"Tool \'{tool_call.name}\' blocked by approval mode \'{self.approval_mode}\'",
+                tool_name=tool_call.name
+            )
+
+        # Interactive confirmation (for default/auto_edit modes)
+        if not self.confirm_tool_execution(tool_call):
+            return ToolResult(
+                success=False,
+                output="User declined to execute tool",
+                tool_name=tool_call.name
+            )
+
         # Check cache first
         cached = self.cache.get(tool_call.name, tool_call.arguments)
         if cached is not None:
@@ -17460,14 +17640,14 @@ py_fragment(agent_loop_process_message, '    def _process_message(self, user_inp
             else:
                 print(f"  {status}")
 
-        # Get response from backend (with streaming if enabled)
+        # Get response from backend (with streaming + retry)
         try:
             if self.streaming and self.backend.supports_streaming() and hasattr(self.backend, \'send_message_streaming\'):
                 if spinner:
                     spinner.stop()
                     spinner = None
                 print("\\nAssistant: ", end="", flush=True)
-                response = self.backend.send_message_streaming(
+                response = self._send_streaming_with_retry(
                     user_input,
                     self.context.get_context(),
                     on_token=lambda t: print(t, end="", flush=True)
@@ -17580,6 +17760,15 @@ py_fragment(agent_loop_process_message, '    def _process_message(self, user_inp
         else:
             print()  # Just add spacing after streamed output
 
+        # Parse structured output (JSON blocks) from response
+        try:
+            from output_parser import OutputParser
+            parsed = OutputParser.parse_response(response.content)
+            if parsed.json_blocks:
+                self._last_parsed_output = parsed
+        except Exception:
+            pass  # OutputParser is optional
+
         # Add response to context
         output_tokens = response.tokens.get(\'output\', 0)
         input_tokens = response.tokens.get(\'input\', 0)
@@ -17600,6 +17789,34 @@ py_fragment(agent_loop_process_message, '    def _process_message(self, user_inp
             if self.cost_tracker:
                 cost_info = f" | Est. cost: {self.cost_tracker.get_summary()[\'cost_formatted\']}"
             print(f"  [Tokens: {token_info}{cost_info}]\\n")
+').
+
+py_fragment(agent_loop_streaming_retry, '    def _send_streaming_with_retry(self, message: str, context: list,
+                                    on_token=None, max_retries: int = 3) -> "AgentResponse":
+        """Send streaming message with retry on connection/timeout errors."""
+        import time as _retry_time
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                return self.backend.send_message_streaming(
+                    message, context, on_token=on_token
+                )
+            except (ConnectionError, TimeoutError, OSError) as e:
+                last_error = e
+                if attempt < max_retries - 1:
+                    delay = (2 ** attempt) * 0.5  # 0.5s, 1s, 2s
+                    print(f"\\n  [Retry {attempt + 1}/{max_retries} after {delay:.1f}s: {e}]", flush=True)
+                    _retry_time.sleep(delay)
+                    print("Assistant: ", end="", flush=True)
+            except Exception:
+                # Non-retryable errors — let the outer handler deal with them
+                raise
+        # All retries exhausted
+        from backends.base import AgentResponse
+        return AgentResponse(
+            content=f"[Streaming failed after {max_retries} retries: {last_error}]",
+            tokens={}
+        )
 ').
 
 py_fragment(agent_loop_helpers, 'def build_system_prompt(agent_config: AgentConfig, config_dir: str = "") -> str | None:
@@ -17807,14 +18024,30 @@ py_fragment(agent_loop_main_body_post_audit, '    audit_level = audit_levels.get
     audit_logger = AuditLogger(log_dir=audit_log_dir, level=audit_level)
 
     # Create tool handler
+    approval_mode = getattr(agent_config, "approval_mode", "default") or "default"
     tools = None
     if agent_config.tools:
         tools = ToolHandler(
             allowed_tools=agent_config.tools,
             confirm_destructive=not agent_config.auto_tools,
             security=security,
-            audit=audit_logger
+            audit=audit_logger,
+            approval_mode=approval_mode
         )
+
+    # Initialize MCP servers from config
+    mcp_manager = None
+    mcp_server_configs = getattr(agent_config, "mcp_servers", None) or []
+    if tools and mcp_server_configs:
+        try:
+            from mcp_client import MCPManager
+            mcp_manager = MCPManager(mcp_server_configs)
+            mcp_count = len(mcp_manager.tools)
+            if mcp_count > 0:
+                print(f"[MCP: connected {len(mcp_server_configs)} server(s), {mcp_count} tool(s)]")
+            tools.mcp_manager = mcp_manager
+        except Exception as e:
+            print(f"[MCP init warning: {e}]", file=sys.stderr)
 
     # Start audit session
     import uuid as _uuid
@@ -17873,6 +18106,12 @@ py_fragment(agent_loop_main_body_post_audit, '    audit_level = audit_levels.get
         # Interactive mode
         loop.run()
     finally:
+        # Disconnect MCP servers
+        if mcp_manager is not None:
+            try:
+                mcp_manager.disconnect_all()
+            except Exception:
+                pass
         audit_logger.end_session()
 
 

--- a/tools/agent-loop/generated/python/agent_loop.py
+++ b/tools/agent-loop/generated/python/agent_loop.py
@@ -712,14 +712,14 @@ Status:
             else:
                 print(f"  {status}")
 
-        # Get response from backend (with streaming if enabled)
+        # Get response from backend (with streaming + retry)
         try:
             if self.streaming and self.backend.supports_streaming() and hasattr(self.backend, 'send_message_streaming'):
                 if spinner:
                     spinner.stop()
                     spinner = None
                 print("\nAssistant: ", end="", flush=True)
-                response = self.backend.send_message_streaming(
+                response = self._send_streaming_with_retry(
                     user_input,
                     self.context.get_context(),
                     on_token=lambda t: print(t, end="", flush=True)
@@ -832,6 +832,15 @@ Status:
         else:
             print()  # Just add spacing after streamed output
 
+        # Parse structured output (JSON blocks) from response
+        try:
+            from output_parser import OutputParser
+            parsed = OutputParser.parse_response(response.content)
+            if parsed.json_blocks:
+                self._last_parsed_output = parsed
+        except Exception:
+            pass  # OutputParser is optional
+
         # Add response to context
         output_tokens = response.tokens.get('output', 0)
         input_tokens = response.tokens.get('input', 0)
@@ -852,6 +861,33 @@ Status:
             if self.cost_tracker:
                 cost_info = f" | Est. cost: {self.cost_tracker.get_summary()['cost_formatted']}"
             print(f"  [Tokens: {token_info}{cost_info}]\n")
+
+    def _send_streaming_with_retry(self, message: str, context: list,
+                                    on_token=None, max_retries: int = 3) -> "AgentResponse":
+        """Send streaming message with retry on connection/timeout errors."""
+        import time as _retry_time
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                return self.backend.send_message_streaming(
+                    message, context, on_token=on_token
+                )
+            except (ConnectionError, TimeoutError, OSError) as e:
+                last_error = e
+                if attempt < max_retries - 1:
+                    delay = (2 ** attempt) * 0.5  # 0.5s, 1s, 2s
+                    print(f"\n  [Retry {attempt + 1}/{max_retries} after {delay:.1f}s: {e}]", flush=True)
+                    _retry_time.sleep(delay)
+                    print("Assistant: ", end="", flush=True)
+            except Exception:
+                # Non-retryable errors — let the outer handler deal with them
+                raise
+        # All retries exhausted
+        from backends.base import AgentResponse
+        return AgentResponse(
+            content=f"[Streaming failed after {max_retries} retries: {last_error}]",
+            tokens={}
+        )
 
 
 def build_system_prompt(agent_config: AgentConfig, config_dir: str = "") -> str | None:
@@ -1465,14 +1501,30 @@ def main():
     audit_logger = AuditLogger(log_dir=audit_log_dir, level=audit_level)
 
     # Create tool handler
+    approval_mode = getattr(agent_config, "approval_mode", "default") or "default"
     tools = None
     if agent_config.tools:
         tools = ToolHandler(
             allowed_tools=agent_config.tools,
             confirm_destructive=not agent_config.auto_tools,
             security=security,
-            audit=audit_logger
+            audit=audit_logger,
+            approval_mode=approval_mode
         )
+
+    # Initialize MCP servers from config
+    mcp_manager = None
+    mcp_server_configs = getattr(agent_config, "mcp_servers", None) or []
+    if tools and mcp_server_configs:
+        try:
+            from mcp_client import MCPManager
+            mcp_manager = MCPManager(mcp_server_configs)
+            mcp_count = len(mcp_manager.tools)
+            if mcp_count > 0:
+                print(f"[MCP: connected {len(mcp_server_configs)} server(s), {mcp_count} tool(s)]")
+            tools.mcp_manager = mcp_manager
+        except Exception as e:
+            print(f"[MCP init warning: {e}]", file=sys.stderr)
 
     # Start audit session
     import uuid as _uuid
@@ -1531,6 +1583,12 @@ def main():
         # Interactive mode
         loop.run()
     finally:
+        # Disconnect MCP servers
+        if mcp_manager is not None:
+            try:
+                mcp_manager.disconnect_all()
+            except Exception:
+                pass
         audit_logger.end_session()
 
 

--- a/tools/agent-loop/generated/python/tools.py
+++ b/tools/agent-loop/generated/python/tools.py
@@ -324,10 +324,12 @@ class ToolHandler:
         confirm_destructive: bool = True,
         working_dir: str | None = None,
         security: SecurityConfig | None = None,
-        audit: AuditLogger | None = None
+        audit: AuditLogger | None = None,
+        approval_mode: str = "default"
     ):
         self.allowed_tools = allowed_tools or ['bash', 'read', 'write', 'edit']
         self.confirm_destructive = confirm_destructive
+        self.approval_mode = approval_mode
         self.working_dir = working_dir or os.getcwd()
         self.security = security or SecurityConfig()
         self.audit = audit or AuditLogger(level='disabled')
@@ -380,6 +382,68 @@ class ToolHandler:
         self._init_plugins()
 
 
+    def check_approval(self, tool_name: str) -> bool:
+        """Check if a tool is approved to execute under the current approval mode.
+        Returns True if approved, False if blocked."""
+        mode = self.approval_mode
+        if mode == "yolo":
+            return True
+        if mode == "plan":
+            return tool_name == "read"
+        if mode == "auto_edit":
+            return tool_name in ("read", "edit", "write")
+        # default mode: read always approved, others go through confirm
+        if tool_name == "read":
+            return True
+        return True  # actual prompt happens in confirm_tool_execution
+
+    def confirm_tool_execution(self, tool_call: ToolCall) -> bool:
+        """Interactive confirmation for tool execution with argument preview.
+        Returns True if the user approves, False to skip."""
+        import sys
+        # Auto-approve in yolo mode
+        if self.approval_mode == "yolo" or not self.confirm_destructive:
+            return True
+        # Read is always safe
+        if tool_call.name == "read":
+            return True
+        # Plan mode blocks all non-read tools
+        if self.approval_mode == "plan":
+            print(f"  [plan mode] Blocked: {tool_call.name}", file=sys.stderr)
+            return False
+        # auto_edit mode: allow read/edit/write without prompt
+        if self.approval_mode == "auto_edit" and tool_call.name in ("edit", "write"):
+            return True
+
+        # Show tool details for confirmation
+        is_destructive = tool_call.name in ("bash", "write", "edit")
+        label = "DESTRUCTIVE" if is_destructive else "Tool"
+        print(f"  [{label}] {tool_call.name} tool:", file=sys.stderr)
+
+        # Show relevant arguments preview
+        if tool_call.name == "bash":
+            cmd = tool_call.arguments.get("command", "")
+            preview = cmd[:120] if len(cmd) > 120 else cmd
+            print(f"    command: {preview}", file=sys.stderr)
+        elif tool_call.name in ("write", "edit"):
+            path = tool_call.arguments.get("file_path", tool_call.arguments.get("path", ""))
+            print(f"    file: {path}", file=sys.stderr)
+        else:
+            # Show first argument for plugin/MCP tools
+            for key, val in tool_call.arguments.items():
+                preview = str(val)
+                preview = preview[:80] if len(preview) > 80 else preview
+                print(f"    {key}: {preview}", file=sys.stderr)
+                break
+
+        try:
+            sys.stderr.write("  Execute? [y/N] ")
+            sys.stderr.flush()
+            response = input().strip().lower()
+            return response in ("y", "yes")
+        except (EOFError, KeyboardInterrupt):
+            return False
+
     def _init_plugins(self):
         """Load plugins from default directory."""
         self.plugin_manager = PluginManager()
@@ -406,6 +470,22 @@ class ToolHandler:
 
     def execute(self, tool_call: ToolCall) -> ToolResult:
         """Execute a tool call and return the result."""
+        # Check approval mode before executing
+        if not self.check_approval(tool_call.name):
+            return ToolResult(
+                success=False,
+                output=f"Tool '{tool_call.name}' blocked by approval mode '{self.approval_mode}'",
+                tool_name=tool_call.name
+            )
+
+        # Interactive confirmation (for default/auto_edit modes)
+        if not self.confirm_tool_execution(tool_call):
+            return ToolResult(
+                success=False,
+                output="User declined to execute tool",
+                tool_name=tool_call.name
+            )
+
         # Check cache first
         cached = self.cache.get(tool_call.name, tool_call.arguments)
         if cached is not None:

--- a/tools/agent-loop/generated/rust/src/main.rs
+++ b/tools/agent-loop/generated/rust/src/main.rs
@@ -10,6 +10,7 @@ use agent_loop::tool_handler::*;
 use agent_loop::commands::*;
 use agent_loop::sessions::*;
 use agent_loop::config_loader::*;
+use agent_loop::output_parser::*;
 
 
 /// Export conversation, auto-detecting format from file extension.
@@ -1252,6 +1253,23 @@ async fn main() {
         println!("[Loaded {} plugin(s)]", plugin_count);
     }
 
+    // Initialize MCP servers from config
+    if !config.mcp_servers.is_empty() {
+        use agent_loop::mcp_client::McpServerConfig;
+        let mcp_configs: Vec<McpServerConfig> = config.mcp_servers.iter().filter_map(|s| {
+            serde_json::from_value(s.clone()).ok()
+        }).collect();
+        if !mcp_configs.is_empty() {
+            tool_handler.set_mcp_servers(&mcp_configs);
+            if let Some(ref mgr) = tool_handler.mcp_manager {
+                let tool_count = mgr.list_tools().len();
+                if tool_count > 0 {
+                    println!("[MCP: connected {} server(s), {} tool(s)]", mcp_configs.len(), tool_count);
+                }
+            }
+        }
+    }
+
     let mut state = RuntimeState {
         max_iterations: config.max_iterations,
         stream: config.stream,
@@ -1435,6 +1453,11 @@ async fn main() {
                     cost_tracker.record_usage(&response.model, response.input_tokens, response.output_tokens);
 
                     if response.tool_calls.is_empty() {
+                        // Parse structured output (JSON blocks) from response
+                        let parsed = OutputParser::parse_response(&response.content, None);
+                        if !parsed.json_blocks.is_empty() {
+                            eprintln!("  [parsed {} JSON block(s) from response]", parsed.json_blocks.len());
+                        }
                         context.add_message("assistant", &response.content);
                         break;
                     }
@@ -1514,5 +1537,10 @@ async fn main() {
                 break;
             }
         }
+    }
+
+    // Disconnect MCP servers on exit
+    if let Some(ref mut mgr) = tool_handler.mcp_manager {
+        mgr.disconnect_all();
     }
 }

--- a/tools/agent-loop/generated/rust/tests/integration_tests.rs
+++ b/tools/agent-loop/generated/rust/tests/integration_tests.rs
@@ -1597,3 +1597,76 @@ fn test_e2e_tool_handler_unknown_tool() {
     assert!(!result.success);
     assert!(result.output.contains("Unknown tool"));
 }
+
+// ============================================================================
+// Phase 22 — Tool approval UI, OutputParser wiring, MCP lifecycle
+// ============================================================================
+
+#[test]
+fn test_phase22_tool_approval_yolo() {
+    let handler = ToolHandler::new(true, "open".to_string(), "yolo".to_string());
+    assert!(handler.check_approval("bash"));
+    assert!(handler.check_approval("write"));
+    assert!(handler.check_approval("read"));
+}
+
+#[test]
+fn test_phase22_tool_approval_plan() {
+    let handler = ToolHandler::new(true, "open".to_string(), "plan".to_string());
+    assert!(handler.check_approval("read"));
+    assert!(!handler.check_approval("bash"));
+    assert!(!handler.check_approval("write"));
+}
+
+#[test]
+fn test_phase22_tool_approval_auto_edit() {
+    let handler = ToolHandler::new(true, "open".to_string(), "auto_edit".to_string());
+    assert!(handler.check_approval("read"));
+    assert!(handler.check_approval("edit"));
+    assert!(handler.check_approval("write"));
+    assert!(!handler.check_approval("bash"));
+}
+
+#[test]
+fn test_phase22_plan_mode_blocks_execute() {
+    let mut handler = ToolHandler::new(true, "open".to_string(), "plan".to_string());
+    let mut args = HashMap::new();
+    args.insert("command".to_string(), serde_json::json!("ls"));
+    let tc = ToolCall { name: "bash".to_string(), arguments: args, id: "plan_test".to_string() };
+    let result = handler.execute(&tc);
+    assert!(!result.success);
+    assert!(result.output.contains("blocked by approval mode"));
+}
+
+#[test]
+fn test_phase22_output_parser_in_main() {
+    let main_src = include_str!("../src/main.rs");
+    assert!(main_src.contains("use agent_loop::output_parser"), "main.rs should import output_parser");
+    assert!(main_src.contains("OutputParser::parse_response"), "main.rs should call OutputParser::parse_response");
+}
+
+#[test]
+fn test_phase22_mcp_lifecycle_init() {
+    let main_src = include_str!("../src/main.rs");
+    assert!(main_src.contains("set_mcp_servers"), "main.rs should init MCP servers");
+    assert!(main_src.contains("disconnect_all"), "main.rs should disconnect MCP on exit");
+}
+
+#[test]
+fn test_phase22_output_parser_extract_fenced() {
+    use agent_loop::output_parser::OutputParser;
+    let text = "Result:
+```json
+{}
+```
+End.";
+    let blocks = OutputParser::extract_json(text);
+    assert!(!blocks.is_empty(), "Should extract fenced JSON block");
+}
+
+#[test]
+fn test_phase22_output_parser_no_json() {
+    use agent_loop::output_parser::OutputParser;
+    let blocks = OutputParser::extract_json("No JSON here at all.");
+    assert!(blocks.is_empty());
+}

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -294,6 +294,10 @@ run_tests :-
     test_phase21_async_backend,
     test_phase21_clear_cache_command,
     test_phase21_e2e_tests,
+    test_phase22_tool_approval_ui,
+    test_phase22_streaming_retry,
+    test_phase22_output_parser_wiring,
+    test_phase22_mcp_lifecycle,
     %% Report
     aggregate_all(count, test_passed(_), Passed),
     aggregate_all(count, test_failed(_), Failed),
@@ -5655,4 +5659,105 @@ test_phase21_e2e_tests :-
     assert_true('Rust has E2E unknown tool test', (
         agent_loop_module:rust_fragment(integration_tests, E3),
         sub_atom(E3, _, _, _, 'test_e2e_tool_handler_unknown_tool')
+    )).
+
+%% ============================================================================
+%% Phase 22 — Tool approval UI, streaming retry, OutputParser wiring, MCP lifecycle
+%% ============================================================================
+
+test_phase22_tool_approval_ui :-
+    format("~nPhase 22 — Tool approval UI (Python parity):~n"),
+    %% Python ToolHandler has approval_mode param
+    assert_true('Python ToolHandler has approval_mode param', (
+        agent_loop_module:py_fragment(tools_handler_class_header, H1),
+        sub_atom(H1, _, _, _, 'approval_mode')
+    )),
+    %% Python has check_approval method
+    assert_true('Python has check_approval method', (
+        agent_loop_module:py_fragment(tools_handler_class_methods, M1),
+        sub_atom(M1, _, _, _, 'def check_approval')
+    )),
+    %% Python has confirm_tool_execution method
+    assert_true('Python has confirm_tool_execution method', (
+        agent_loop_module:py_fragment(tools_handler_class_methods, M2),
+        sub_atom(M2, _, _, _, 'def confirm_tool_execution')
+    )),
+    %% Python execute() calls check_approval before cache
+    assert_true('Python execute checks approval before cache', (
+        agent_loop_module:py_fragment(tools_handler_class_body, B1),
+        sub_atom(B1, _, _, _, 'check_approval')
+    )),
+    %% Python execute() calls confirm_tool_execution
+    assert_true('Python execute calls confirm_tool_execution', (
+        agent_loop_module:py_fragment(tools_handler_class_body, B2),
+        sub_atom(B2, _, _, _, 'confirm_tool_execution')
+    )),
+    %% Main passes approval_mode to ToolHandler
+    assert_true('Main passes approval_mode to ToolHandler', (
+        agent_loop_module:py_fragment(agent_loop_main_body_post_audit, P1),
+        sub_atom(P1, _, _, _, 'approval_mode=approval_mode')
+    )).
+
+test_phase22_streaming_retry :-
+    format("~nPhase 22 — Streaming error recovery (Python):~n"),
+    %% Python has _send_streaming_with_retry method
+    assert_true('Python has _send_streaming_with_retry', (
+        agent_loop_module:py_fragment(agent_loop_streaming_retry, R1),
+        sub_atom(R1, _, _, _, '_send_streaming_with_retry')
+    )),
+    %% Retry method has exponential backoff
+    assert_true('Streaming retry has exponential backoff', (
+        agent_loop_module:py_fragment(agent_loop_streaming_retry, R2),
+        sub_atom(R2, _, _, _, '2 ** attempt')
+    )),
+    %% Retry method catches connection errors
+    assert_true('Streaming retry catches ConnectionError', (
+        agent_loop_module:py_fragment(agent_loop_streaming_retry, R3),
+        sub_atom(R3, _, _, _, 'ConnectionError')
+    )),
+    %% _process_message uses retry wrapper
+    assert_true('_process_message uses streaming retry wrapper', (
+        agent_loop_module:py_fragment(agent_loop_process_message, PM1),
+        sub_atom(PM1, _, _, _, '_send_streaming_with_retry')
+    )).
+
+test_phase22_output_parser_wiring :-
+    format("~nPhase 22 — OutputParser wiring:~n"),
+    %% Python _process_message imports OutputParser
+    assert_true('Python _process_message uses OutputParser', (
+        agent_loop_module:py_fragment(agent_loop_process_message, OP1),
+        sub_atom(OP1, _, _, _, 'OutputParser.parse_response')
+    )),
+    %% Rust main_loop uses OutputParser
+    assert_true('Rust main_loop uses OutputParser', (
+        agent_loop_module:rust_fragment(main_loop, RL1),
+        sub_atom(RL1, _, _, _, 'OutputParser::parse_response')
+    )),
+    %% Rust main imports output_parser
+    assert_true('Rust main imports output_parser', (
+        read_file_to_string('generated/rust/src/main.rs', MainSrc, []),
+        sub_atom(MainSrc, _, _, _, 'output_parser')
+    )).
+
+test_phase22_mcp_lifecycle :-
+    format("~nPhase 22 — MCP server lifecycle:~n"),
+    %% Python main initializes MCP from config
+    assert_true('Python main creates MCPManager', (
+        agent_loop_module:py_fragment(agent_loop_main_body_post_audit, MCP1),
+        sub_atom(MCP1, _, _, _, 'MCPManager')
+    )),
+    %% Python finally block disconnects MCP
+    assert_true('Python exit disconnects MCP', (
+        agent_loop_module:py_fragment(agent_loop_main_body_post_audit, MCP2),
+        sub_atom(MCP2, _, _, _, 'disconnect_all')
+    )),
+    %% Rust main initializes MCP
+    assert_true('Rust main initializes MCP', (
+        agent_loop_module:rust_fragment(main_loop, RM1),
+        sub_atom(RM1, _, _, _, 'set_mcp_servers')
+    )),
+    %% Rust exit disconnects MCP
+    assert_true('Rust exit disconnects MCP', (
+        agent_loop_module:rust_fragment(main_loop, RM2),
+        sub_atom(RM2, _, _, _, 'disconnect_all')
     )).

--- a/tools/agent-loop/test_integration.py
+++ b/tools/agent-loop/test_integration.py
@@ -971,3 +971,164 @@ class TestClearCacheCommand:
     def test_alias_count_updated(self):
         from aliases import DEFAULT_ALIASES
         assert DEFAULT_ALIASES.get("cc") == "clear-cache"
+
+
+# ============================================================================
+# TestToolApprovalUI — Phase 22 approval mode system
+# ============================================================================
+
+class TestToolApprovalUI:
+    """Test tool approval mode system in ToolHandler."""
+
+    def test_tool_handler_has_approval_mode(self):
+        from tools import ToolHandler
+        handler = ToolHandler()
+        assert hasattr(handler, 'approval_mode')
+        assert handler.approval_mode == "default"
+
+    def test_approval_mode_yolo(self):
+        from tools import ToolHandler
+        handler = ToolHandler(approval_mode="yolo")
+        assert handler.check_approval("bash") is True
+        assert handler.check_approval("write") is True
+
+    def test_approval_mode_plan(self):
+        from tools import ToolHandler
+        handler = ToolHandler(approval_mode="plan")
+        assert handler.check_approval("read") is True
+        assert handler.check_approval("bash") is False
+        assert handler.check_approval("write") is False
+
+    def test_approval_mode_auto_edit(self):
+        from tools import ToolHandler
+        handler = ToolHandler(approval_mode="auto_edit")
+        assert handler.check_approval("read") is True
+        assert handler.check_approval("edit") is True
+        assert handler.check_approval("write") is True
+        assert handler.check_approval("bash") is False
+
+    def test_approval_mode_default_read_approved(self):
+        from tools import ToolHandler
+        handler = ToolHandler(approval_mode="default")
+        assert handler.check_approval("read") is True
+
+    def test_confirm_tool_execution_yolo(self):
+        from tools import ToolHandler
+        from backends.base import ToolCall
+        handler = ToolHandler(approval_mode="yolo")
+        tc = ToolCall(name="bash", arguments={"command": "rm -rf /"})
+        assert handler.confirm_tool_execution(tc) is True
+
+    def test_confirm_tool_execution_plan_blocks(self):
+        from tools import ToolHandler
+        from backends.base import ToolCall
+        handler = ToolHandler(approval_mode="plan")
+        tc = ToolCall(name="bash", arguments={"command": "ls"})
+        assert handler.confirm_tool_execution(tc) is False
+
+    def test_execute_blocked_by_plan_mode(self):
+        from tools import ToolHandler
+        from backends.base import ToolCall
+        handler = ToolHandler(approval_mode="plan")
+        tc = ToolCall(name="bash", arguments={"command": "ls"})
+        result = handler.execute(tc)
+        assert not result.success
+        assert "blocked by approval mode" in result.output
+
+
+# ============================================================================
+# TestStreamingRetry — Phase 22 streaming error recovery
+# ============================================================================
+
+class TestStreamingRetry:
+    """Test streaming retry wrapper exists in generated code."""
+
+    def test_agent_loop_has_streaming_retry(self):
+        import importlib
+        agent_loop = importlib.import_module("agent_loop")
+        src = open(agent_loop.__file__).read()
+        assert "_send_streaming_with_retry" in src
+
+    def test_process_message_uses_retry(self):
+        import importlib
+        agent_loop = importlib.import_module("agent_loop")
+        src = open(agent_loop.__file__).read()
+        assert "_send_streaming_with_retry" in src
+
+
+# ============================================================================
+# TestOutputParserWiring — Phase 22 OutputParser in response processing
+# ============================================================================
+
+class TestOutputParserWiring:
+    """Test OutputParser is wired into response processing."""
+
+    def test_process_message_uses_output_parser(self):
+        import importlib
+        agent_loop = importlib.import_module("agent_loop")
+        src = open(agent_loop.__file__).read()
+        assert "OutputParser.parse_response" in src
+
+    def test_output_parser_importable(self):
+        from output_parser import OutputParser, ParsedOutput
+        assert hasattr(OutputParser, 'parse_response')
+        assert hasattr(OutputParser, 'extract_json')
+
+    def test_output_parser_extract_fenced(self):
+        from output_parser import OutputParser
+        text = 'Here is some JSON:\n```json\n{"key": "value"}\n```\nDone.'
+        blocks = OutputParser.extract_json(text)
+        assert len(blocks) == 1
+        assert blocks[0]["key"] == "value"
+
+    def test_output_parser_extract_bare(self):
+        from output_parser import OutputParser
+        text = 'The result is {"count": 42} and that is it.'
+        blocks = OutputParser.extract_json(text)
+        assert len(blocks) == 1
+        assert blocks[0]["count"] == 42
+
+    def test_output_parser_no_json(self):
+        from output_parser import OutputParser
+        blocks = OutputParser.extract_json("No JSON here at all")
+        assert len(blocks) == 0
+
+    def test_output_parser_key_validation(self):
+        from output_parser import OutputParser
+        text = '```json\n{"name": "test", "value": 1}\n```'
+        parsed = OutputParser.parse_response(text, expected_keys=["name"])
+        assert len(parsed.json_blocks) == 1
+        assert len(parsed.errors) == 0
+
+    def test_output_parser_key_validation_missing(self):
+        from output_parser import OutputParser
+        text = '```json\n{"name": "test"}\n```'
+        parsed = OutputParser.parse_response(text, expected_keys=["name", "missing_key"])
+        assert len(parsed.errors) > 0
+
+
+# ============================================================================
+# TestMCPLifecycle — Phase 22 MCP server lifecycle management
+# ============================================================================
+
+class TestMCPLifecycle:
+    """Test MCP lifecycle wiring in generated code."""
+
+    def test_main_has_mcp_init(self):
+        import importlib
+        agent_loop = importlib.import_module("agent_loop")
+        src = open(agent_loop.__file__).read()
+        assert "MCPManager" in src
+        assert "mcp_server_configs" in src
+
+    def test_main_has_mcp_disconnect(self):
+        import importlib
+        agent_loop = importlib.import_module("agent_loop")
+        src = open(agent_loop.__file__).read()
+        assert "disconnect_all" in src
+
+    def test_mcp_manager_importable(self):
+        from mcp_client import MCPManager
+        assert hasattr(MCPManager, 'disconnect_all')
+        assert hasattr(MCPManager, 'list_tools')
+        assert hasattr(MCPManager, 'dispatch')


### PR DESCRIPTION
## Summary

- Port **tool approval UI** from Rust to Python — full approval mode system (`yolo`/`plan`/`auto_edit`/`default`) with `check_approval()` and `confirm_tool_execution()` methods, interactive confirmation with `[DESTRUCTIVE]`/`[Tool]` labels and argument previews
- Add **streaming error recovery** to Python — `_send_streaming_with_retry()` wraps streaming calls with up to 3 retries and exponential backoff (0.5s, 1s, 2s) on `ConnectionError`/`TimeoutError`/`OSError`
- Wire **OutputParser** into response processing for both Python and Rust — extracts JSON blocks from model responses after each turn, stores parsed output for downstream use
- Wire **MCP server lifecycle** for both targets — auto-connect `MCPManager` on startup from `config.mcp_servers`, graceful `disconnect_all()` on exit

## Details

### Tool Approval UI (Python Parity)
- `ToolHandler.__init__` gains `approval_mode` parameter (default: `"default"`)
- `check_approval(tool_name)` — mode-based gate before any execution
  - `yolo`: approve all
  - `plan`: read-only
  - `auto_edit`: read/edit/write allowed, bash blocked
  - `default`: read auto-approved, others go to interactive confirm
- `confirm_tool_execution(tool_call)` — interactive prompt with tool-specific argument previews (command for bash, file path for write/edit, first arg for plugins)
- Wired into `execute()` before cache check; `main()` passes `approval_mode` from config

### Streaming Error Recovery (Python Parity)
- `_send_streaming_with_retry(message, context, on_token, max_retries=3)` on `AgentLoop`
- Catches `ConnectionError`, `TimeoutError`, `OSError` — retries with exponential backoff
- Non-retryable exceptions re-raised to outer handler
- Falls back to `AgentResponse` with error message after all retries exhausted
- `_process_message` now calls retry wrapper instead of direct streaming

### OutputParser Wiring (Both Targets)
- Python: after final response in `_process_message`, calls `OutputParser.parse_response()` and stores `_last_parsed_output` if JSON blocks found
- Rust: after response in interactive loop, calls `OutputParser::parse_response()` and logs block count to stderr
- `main.rs` gains `use agent_loop::output_parser::*;` import

### MCP Server Lifecycle (Both Targets)
- Python `main()`: after `ToolHandler` creation, if `agent_config.mcp_servers` is non-empty, creates `MCPManager`, connects all servers, sets on `tools.mcp_manager`; `finally` block calls `disconnect_all()`
- Rust `main_loop`: after plugin loading, parses `config.mcp_servers` as `McpServerConfig` via serde, calls `set_mcp_servers()`; after main loop exit, calls `disconnect_all()`

## Test Results

| Suite | Count | Failures |
|-------|-------|----------|
| Prolog | 999 | 0 |
| Rust (cargo test) | 130 | 0 |
| Python (pytest) | 128 | 0 |
| Prolog integration | 36 | 0 |

## Test plan

- [x] `swipl -l test_agent_loop.pl -g "run_tests, halt"` — 999 passed, 0 failed
- [x] `cd generated/rust && cargo test` — 130 passed, 0 failed
- [x] `PYTHONPATH=generated/python python3 -m pytest test_integration.py -v` — 128 passed, 0 failed
- [x] `swipl -l test_prolog_integration.pl -g "run_prolog_tests, halt"` — 36 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
