### PR TITLE
test(csharp-query): add stable cache smoke slices

### DIFF
--- a/scripts/testing/run_csharp_query_runtime_smoke.ps1
+++ b/scripts/testing/run_csharp_query_runtime_smoke.ps1
@@ -7,6 +7,9 @@
 #   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1
 #   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1 -KeepArtifacts
 #   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke
+#   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1 -CacheSlice admission
+#   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1 -CacheSlice reuse
+#   pwsh -File .\scripts\testing\run_csharp_query_runtime_smoke.ps1 -CacheSlice lru
 #
 # Notes:
 # - Requires SWI-Prolog and dotnet (net9.0 SDK) on PATH (or in common SWI locations).
@@ -19,6 +22,10 @@ param(
 
     [Parameter(Mandatory = $false)]
     [string]$ProjectFilter = "*",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("admission", "reuse", "lru")]
+    [string]$CacheSlice,
 
     [Parameter(Mandatory = $false)]
     [switch]$KeepArtifacts,
@@ -66,6 +73,37 @@ function Get-GeneratedQueryProjects {
     return @(Get-ChildItem -Path $RootPath -Directory -Recurse -ErrorAction SilentlyContinue | Where-Object {
         $_.Name -like $NameFilter -and (Test-Path (Join-Path $_.FullName "expected_rows.txt"))
     } | Sort-Object -Property FullName -Unique)
+}
+
+function Test-ProjectMatchesCacheSlice {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.DirectoryInfo]$ProjectDir,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Slice
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Slice)) {
+        return $true
+    }
+
+    $expectedPath = Join-Path $ProjectDir.FullName "expected_rows.txt"
+    if (-not (Test-Path $expectedPath)) {
+        return $false
+    }
+
+    $expectedRows = Get-Content -Path $expectedPath
+    $hasAdmissions = @($expectedRows | Where-Object { $_ -match '^CACHE_ADMISSIONS:' }).Count -gt 0
+    $hasReuseHit = @($expectedRows | Where-Object { $_ -match '^CACHE_HIT:' }).Count -gt 0
+    $hasEvictions = @($expectedRows | Where-Object { $_ -match '^CACHE_EVICTIONS:' }).Count -gt 0
+
+    switch ($Slice) {
+        "admission" { return $hasAdmissions }
+        "reuse" { return $hasReuseHit }
+        "lru" { return $hasEvictions }
+        default { throw "Unknown cache slice '$Slice'." }
+    }
 }
 
 function Find-SwiplExe {
@@ -208,9 +246,14 @@ if (-not $SkipCodegen) {
 Assert-DotnetAvailable
 
 $projects = Get-GeneratedQueryProjects -RootPath $outputPath -NameFilter $ProjectFilter
+$projects = @($projects | Where-Object { Test-ProjectMatchesCacheSlice -ProjectDir $_ -Slice $CacheSlice })
 
 if (-not $projects) {
-    throw "No generated query projects found in '$outputPath' (expected directories containing expected_rows.txt)."
+    if ([string]::IsNullOrWhiteSpace($CacheSlice)) {
+        throw "No generated query projects found in '$outputPath' (expected directories containing expected_rows.txt)."
+    }
+
+    throw "No generated query projects found in '$outputPath' for cache slice '$CacheSlice' (project filter '$ProjectFilter')."
 }
 
 $failures = 0


### PR DESCRIPTION
  ## Summary
  Add explicit cache-focused smoke slices to the C# query runtime smoke runner so cache regressions can be exercised
  with stable filters instead of relying on truncated generated project names.

  ## What changed
  - Added `-CacheSlice` to `scripts/testing/run_csharp_query_runtime_smoke.ps1`
  - Supported cache slices:
    - `admission`
    - `reuse`
    - `lru`
  - Filtered generated projects by `expected_rows.txt` cache markers rather than directory-name prefixes
  - Improved the “no projects found” failure message to include the selected cache slice

  ## Why
  The previous smoke workflow depended on project-name filters like `cq_test_admissi*`, which were brittle because
  generated project names are truncated and not guaranteed to stay stable.

  This change makes cache-focused smoke runs deterministic and easier to use for:
  - admission regressions
  - cache reuse regressions
  - LRU / eviction regressions

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_cache_slices -CacheSlice admission`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_cache_slices -CacheSlice reuse -SkipCodegen -KeepArtifacts`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_cache_slices -CacheSlice lru -SkipCodegen -KeepArtifacts`
    - Passed