### PR TITLE
Expand Native TypR Lowering for Guards and Dataframe Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,14 @@ compile_predicate_to_r(lower_name/2, [type_diagnostics_report(Report)], Code).
 
 TypR now uses the same shared return-type metadata and conservative inference
 layer. For simple binding-shaped predicates and literal-guarded multi-clause
-branches it lowers directly to native TypR syntax. More complex generic bodies
-still fall back to the wrapped R path.
+branches it lowers directly to native TypR syntax. That native subset now
+includes:
+
+- simple output-producing binding chains
+- guard-style command predicates such as `is_character/1`
+- dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
+
+More complex generic bodies still fall back to the wrapped R path.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -153,6 +153,8 @@ bring-up.
 - native TypR lowering for a conservative subset of generic non-recursive rule
   bodies:
   - simple output-producing binding chains
+  - guard-style command predicates lowered into clause conditions
+  - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
   - literal-guarded multi-clause branches built from those chains
 
 **Remaining scope after Phase 2.5:**

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -324,6 +324,10 @@ Current TypR lowering policy is intentionally mixed:
 
 - simple fact predicates lower directly to TypR
 - supported binding-shaped rule bodies lower directly to TypR
+- guard-style zero-output command bindings may be folded into TypR clause
+  conditions
+- supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
+  may lower directly to TypR raw-expression assignments
 - literal-guarded multi-clause predicates may lower to TypR `if` chains
 - more complex generic bodies may still fall back to wrapped R expressions
 

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -27,6 +27,9 @@ This document focuses on architecture and rollout choices specific to TypR.
    - transitive-closure generation
    - native lowering for a conservative subset of generic binding-shaped rule
      bodies
+   - guard-style command predicates lowered into clause conditions
+   - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
+     `group_by/3`
 7. The remaining gap is broader lowering for arbitrary generic rule bodies
    beyond that current subset.
 
@@ -182,7 +185,10 @@ Completed:
 7. Added conservative native TypR lowering for generic rule bodies when the
    body is a supported chain of simple R bindings, including literal-guarded
    multi-clause predicates compiled into TypR `if` / `else if` chains.
-8. Added structured diagnostics aggregation on the `r` side via
+8. Extended that native subset to include guard-style command predicates in
+   clause conditions and direct lowering for the dataframe helpers
+   `filter/3`, `sort_by/3`, and `group_by/3`.
+9. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
 
@@ -209,8 +215,9 @@ Current implementation note:
   current TypR surface language is too restrictive for the required BFS logic
   inside nested scopes
 - the native generic TypR path is intentionally conservative and currently
-  targets simple output-producing binding chains plus literal-guarded branch
-  selection; more complex bodies still fall back to wrapped R
+  targets simple output-producing binding chains, guard-style command
+  predicates, dataframe helper calls, and literal-guarded branch selection;
+  more complex bodies still fall back to wrapped R
 
 Follow-on work:
 

--- a/src/unifyweaver/targets/r_target.pl
+++ b/src/unifyweaver/targets/r_target.pl
@@ -346,6 +346,12 @@ infer_body_return_type(group_by(_, _, _), any) :-
     !.
 infer_body_return_type(sort_by(_, _, _), any) :-
     !.
+infer_body_return_type(Goal, boolean) :-
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    binding(r, Pred/Arity, _TargetName, _Inputs, [], Options),
+    member(pattern(command), Options),
+    !.
 infer_body_return_type(Goal, Type) :-
     compound(Goal),
     functor(Goal, Pred, Arity),

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -335,17 +335,32 @@ native_typr_clause_pair(Head-Body, branch(Condition, BranchExpr)) :-
 native_typr_clause(Head, Body, Condition, ClauseCode) :-
     Head =.. [_|HeadArgs],
     build_head_varmap(HeadArgs, 1, VarMap),
-    typr_head_condition(HeadArgs, 1, Conditions),
+    typr_head_condition(HeadArgs, 1, HeadConditions),
+    native_typr_goal_sequence(Body, VarMap, GoalConditions, ClauseCode),
+    append(HeadConditions, GoalConditions, Conditions),
     (   Conditions = []
     ->  Condition = 'TRUE'
     ;   atomic_list_concat(Conditions, ' && ', Condition)
-    ),
-    native_typr_goal_sequence(Body, VarMap, ClauseCode).
+    ).
 
-native_typr_goal_sequence(Body, VarMap, Code) :-
+native_typr_goal_sequence(Body, VarMap, Conditions, Code) :-
     normalize_typr_goals(Body, Goals),
     Goals \= [],
-    native_typr_goals(Goals, VarMap, _VarMapOut, FinalExpr, Lines),
+    native_typr_goals(
+        Goals,
+        VarMap,
+        _VarMapOut,
+        Conditions,
+        HasOutput,
+        FinalKind,
+        FinalExpr,
+        Lines
+    ),
+    (   HasOutput == true,
+        FinalKind == guard
+    ->  fail
+    ;   true
+    ),
     append(Lines, [FinalExpr], BodyLines),
     atomic_list_concat(BodyLines, '\n', Code).
 
@@ -360,16 +375,57 @@ normalize_typr_goals(_Module:Goal, Goals) :-
     normalize_typr_goals(Goal, Goals).
 normalize_typr_goals(Goal, [Goal]).
 
-native_typr_goals([Goal], VarMap0, VarMap, FinalExpr, [Line]) :-
-    native_typr_goal(Goal, VarMap0, VarMap, Line, FinalExpr).
-native_typr_goals([Goal|Rest], VarMap0, VarMap, FinalExpr, [Line|RestLines]) :-
-    native_typr_goal(Goal, VarMap0, VarMap1, Line, _OutputExpr),
-    native_typr_goals(Rest, VarMap1, VarMap, FinalExpr, RestLines).
+native_typr_goals([], VarMap, VarMap, [], false, guard, 'true', []).
+native_typr_goals([Goal|Rest], VarMap0, VarMap, Conditions, HasOutput, FinalKind, FinalExpr, Lines) :-
+    native_typr_goal(Goal, VarMap0, VarMap1, GoalConditions, GoalLines, GoalKind, GoalExpr),
+    native_typr_goals(Rest, VarMap1, VarMap, RestConditions, RestHasOutput, RestFinalKind, RestFinalExpr, RestLines),
+    append(GoalConditions, RestConditions, Conditions),
+    append(GoalLines, RestLines, Lines),
+    (   GoalKind == output
+    ->  HasOutput = true
+    ;   HasOutput = RestHasOutput
+    ),
+    (   Rest == []
+    ->  FinalKind = GoalKind,
+        FinalExpr = GoalExpr
+    ;   FinalKind = RestFinalKind,
+        FinalExpr = RestFinalExpr
+    ).
 
-native_typr_goal(_Module:Goal, VarMap0, VarMap, Line, FinalExpr) :-
+native_typr_goal(_Module:Goal, VarMap0, VarMap, Conditions, Lines, GoalKind, FinalExpr) :-
     !,
-    native_typr_goal(Goal, VarMap0, VarMap, Line, FinalExpr).
-native_typr_goal(Goal, VarMap0, VarMap, Line, FinalExpr) :-
+    native_typr_goal(Goal, VarMap0, VarMap, Conditions, Lines, GoalKind, FinalExpr).
+native_typr_goal(filter(DF, Expr, Out), VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    !,
+    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
+    typr_resolve_value(VarMap0, DF, RDF),
+    typr_translate_r_expr(Expr, VarMap0, RExpr),
+    format(string(Line), '~w <- @{ subset(~w, ~w) }@;', [FinalExpr, RDF, RExpr]).
+native_typr_goal(sort_by(DF, Col, Out), VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    !,
+    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
+    typr_resolve_value(VarMap0, DF, RDF),
+    typr_resolve_value(VarMap0, Col, RCol),
+    format(string(Line), '~w <- @{ ~w[order(~w[[~w]]), ] }@;', [FinalExpr, RDF, RDF, RCol]).
+native_typr_goal(group_by(DF, Col, Out), VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    !,
+    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
+    typr_resolve_value(VarMap0, DF, RDF),
+    typr_resolve_value(VarMap0, Col, RCol),
+    format(string(Line), '~w <- @{ aggregate(. ~~ ~w, data=~w, FUN=list) }@;', [FinalExpr, RCol, RDF]).
+native_typr_goal(Goal, VarMap0, VarMap, [GuardCondition], [], guard, 'true') :-
+    functor(Goal, Pred, Arity),
+    binding(r, Pred/Arity, TargetName, Inputs, [], Options),
+    member(pattern(command), Options),
+    simple_r_binding_target(TargetName),
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(InArgs, InCount),
+    append(InArgs, [], Args),
+    maplist(typr_resolve_value(VarMap0), InArgs, ResolvedInArgs),
+    typr_guard_expression(TargetName, ResolvedInArgs, GuardCondition),
+    VarMap = VarMap0.
+native_typr_goal(Goal, VarMap0, VarMap, [], [Line], output, FinalExpr) :-
     functor(Goal, Pred, Arity),
     binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
     Outputs = [_],
@@ -396,6 +452,45 @@ typr_resolve_value(VarMap, Var, Value) :-
     !.
 typr_resolve_value(_VarMap, Value, Literal) :-
     r_literal(Value, Literal).
+
+typr_guard_expression(TargetName, [], GuardCondition) :-
+    format(string(GuardCondition), '@{ ~w }@', [TargetName]).
+typr_guard_expression(TargetName, ResolvedInArgs, GuardCondition) :-
+    atomic_list_concat(ResolvedInArgs, ', ', RArgsStr),
+    format(string(GuardCondition), '@{ ~w(~w) }@', [TargetName, RArgsStr]).
+
+typr_translate_r_expr(Var, VarMap, Resolved) :-
+    var(Var),
+    lookup_typr_var(Var, VarMap, Resolved),
+    !.
+typr_translate_r_expr(Atom, _VarMap, Resolved) :-
+    atom(Atom),
+    !,
+    format(string(Resolved), '~w', [Atom]).
+typr_translate_r_expr(Text, _VarMap, Resolved) :-
+    string(Text),
+    !,
+    format(string(Resolved), '"~s"', [Text]).
+typr_translate_r_expr(Number, _VarMap, Resolved) :-
+    number(Number),
+    !,
+    format(string(Resolved), '~w', [Number]).
+typr_translate_r_expr(Expr, VarMap, Resolved) :-
+    compound(Expr),
+    Expr =.. [Op, Left, Right],
+    typr_translate_r_expr(Left, VarMap, LeftResolved),
+    typr_translate_r_expr(Right, VarMap, RightResolved),
+    r_expr_op_map(Op, ROp),
+    format(string(Resolved), '(~w ~w ~w)', [LeftResolved, ROp, RightResolved]).
+
+r_expr_op_map(>, '>').
+r_expr_op_map(<, '<').
+r_expr_op_map(>=, '>=').
+r_expr_op_map(=<, '<=').
+r_expr_op_map(==, '==').
+r_expr_op_map(\=, '!=').
+r_expr_op_map(and, '&').
+r_expr_op_map(or, '|').
 
 ensure_typr_var(VarMap, Var, Name, VarMap) :-
     lookup_typr_var(Var, VarMap, Name),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -20,7 +20,12 @@ cleanup_typr_test :-
     retractall(user:lower_name(_, _)),
     retractall(user:classify_name(_, _)),
     retractall(user:inferred_lower(_, _)),
-    retractall(user:classify_name_guarded(_, _)).
+    retractall(user:classify_name_guarded(_, _)),
+    retractall(user:guarded_name(_, _)),
+    retractall(user:sort_rows(_, _)),
+    retractall(user:filter_rows(_, _)),
+    retractall(user:group_rows(_, _)),
+    retractall(user:numeric_input(_)).
 
 :- begin_tests(typr_target, [
     setup(setup_typr_test),
@@ -141,6 +146,50 @@ test(type_diagnostics_report_defaults_to_empty_for_native_typr_lowering) :-
     assertz(type_declarations:uw_type(lower_name/2, 2, atom)),
     once(compile_predicate_to_typr(lower_name/2, [typed_mode(explicit), type_diagnostics_report(Report)], _Code)),
     assertion(Report == []).
+
+test(guard_bindings_expand_native_clause_conditions) :-
+    clear_type_declarations,
+    assertz(user:(guarded_name(Name, Lower) :- is_character(Name), string_lower(Name, Lower))),
+    assertz(type_declarations:uw_type(guarded_name/2, 1, atom)),
+    assertz(type_declarations:uw_type(guarded_name/2, 2, atom)),
+    once(compile_predicate_to_typr(guarded_name/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "is.character(arg1)")),
+    once(sub_string(Code, _, _, _, "tolower(arg1)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(guard_only_predicates_infer_boolean_return_type) :-
+    clear_type_declarations,
+    assertz(user:(numeric_input(Value) :- is_numeric(Value))),
+    once(compile_predicate_to_typr(numeric_input/1, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let numeric_input <- fn(arg1): bool")),
+    once(sub_string(Code, _, _, _, "is.numeric(arg1)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(dataframe_sort_predicates_lower_natively) :-
+    clear_type_declarations,
+    assertz(user:(sort_rows(Input, Output) :- sort_by(Input, name, Output))),
+    once(compile_predicate_to_typr(sort_rows/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "order(arg1[[\"name\"]])")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(dataframe_filter_predicates_lower_natively) :-
+    clear_type_declarations,
+    assertz(user:(filter_rows(Input, Output) :- filter(Input, score > 10, Output))),
+    once(compile_predicate_to_typr(filter_rows/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "subset(arg1, (score > 10))")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(dataframe_group_predicates_lower_natively) :-
+    clear_type_declarations,
+    assertz(user:(group_rows(Input, Output) :- group_by(Input, category, Output))),
+    once(compile_predicate_to_typr(group_rows/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "aggregate(. ~ \"category\", data=arg1, FUN=list)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
 
 test(transitive_closure_template_is_valid_typr) :-
     clear_type_declarations,


### PR DESCRIPTION
## Summary

This PR extends the native TypR lowering work so more generic predicates no longer need to fall back to wrapped R.

The main additions are:

- native TypR lowering for guard-style zero-output command predicates
- native TypR lowering for dataframe helpers:
  - `filter/3`
  - `sort_by/3`
  - `group_by/3`
- shallow return-type inference updated so guard-style command predicates infer `boolean`
- tests and docs updated to reflect the broader native TypR subset

This keeps the same overall design intact:

- standard `r` remains usable without type metadata
- TypR still uses conservative native lowering rather than trying to lower all arbitrary rule bodies at once
- unsupported generic bodies still fall back to wrapped R

## Why This PR Exists

The previous TypR native-lowering work established a useful baseline:

- simple binding chains could lower directly to TypR
- literal-guarded multi-clause predicates could lower to TypR `if` / `else if`
- more complex cases still used the wrapped-R fallback

That left an obvious next gap:

1. Guard-style predicates such as `is_character/1` and `is_numeric/1` still behaved like fallback cases rather than native TypR conditions.
2. Common dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3` were still outside the native TypR subset.
3. Guard-only predicates did not contribute a clean boolean return inference path for TypR signatures.

This PR closes those gaps without trying to solve full arbitrary-body native lowering.

## Main Changes

### 1. Native TypR lowering for guard-style command predicates

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

TypR now treats supported zero-output R command bindings as clause conditions instead of forcing those predicates through wrapped R.

Examples include predicates such as:

- `is_character/1`
- `is_numeric/1`
- other supported `pattern(command)` R bindings

This means predicates like:

```prolog
guarded_name(Name, Lower) :-
    is_character(Name),
    string_lower(Name, Lower).
```

can now compile into TypR with a native condition plus native body lowering, rather than dropping back to wrapped R.

### 2. Native TypR lowering for dataframe helper bindings

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The native TypR subset now also handles:

- `filter/3`
- `sort_by/3`
- `group_by/3`

These compile to TypR assignments containing raw R expressions, which is consistent with the existing pragmatic TypR strategy: use valid TypR syntax around embedded R where that is the safest way to preserve real semantics.

This expands the useful native subset without pretending TypR is now a full native dataframe compiler.

### 3. Better boolean inference for guard-only predicates

Updated [src/unifyweaver/targets/r_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/r_target.pl).

Shallow return-type inference now treats zero-output command bindings marked with `pattern(command)` as boolean-producing.

That improves both semantics and TypR signatures for predicates such as:

```prolog
numeric_input(Value) :-
    is_numeric(Value).
```

Without this change, these cases were weaker than they should have been in the shared inference layer.

### 4. Expanded TypR test coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage includes:

- native guard-condition lowering
- guard-only boolean return inference
- native lowering for `filter/3`
- native lowering for `sort_by/3`
- native lowering for `group_by/3`

The tests also continue to assert that supported native cases do not fall back to wrapped R.

### 5. Documentation updates

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now describe the current native TypR subset more accurately:

- simple binding chains
- guard-style command predicates
- dataframe helpers
- literal-guarded branch chains

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)
- [src/unifyweaver/targets/r_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/r_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Tests Added / Updated

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl) to cover:

- guard-style predicates lowering into native TypR clause conditions
- guard-only predicates inferring boolean return types
- native TypR lowering for `filter/3`
- native TypR lowering for `sort_by/3`
- native TypR lowering for `group_by/3`

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior
- R-side shallow inference compatibility
- expanded native TypR lowering
- continued TypR CLI validation of generated output

What it does not claim:

- full repo-wide regression coverage
- full arbitrary-body native TypR lowering
- elimination of wrapped-R fallback for all remaining generic TypR predicates

## Behavior Notes

### TypR behavior after this PR

TypR’s native subset now includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- literal-guarded multi-clause branches
- dataframe helpers `filter/3`, `sort_by/3`, and `group_by/3`

Unsupported generic bodies still fall back to wrapped R.

### R behavior after this PR

This PR does not change the overall R-target contract.

The relevant shared improvement is that guard-style command predicates now infer boolean return types more accurately in the shared inference layer.

## Scope and Remaining Gaps

Implemented now:

- native TypR clause-condition lowering for guard bindings
- native TypR lowering for core dataframe helper predicates
- boolean inference for guard-only predicates
- updated docs and tests for the broader native subset

Still not fully implemented:

- broader native TypR lowering for more complex generic rule bodies
- richer control-flow lowering beyond the current conservative subset
- complete removal of wrapped-R fallback for generic TypR compilation

## Why This PR Is Worth Merging

This PR improves real TypR backend behavior in a contained way.

It gives the project:

- fewer wrapped-R fallbacks in common predicate shapes
- better boolean inference for guard-style predicates
- broader native TypR coverage in practical cases
- documentation that matches the actual implemented subset

In short, this is a good incremental PR because it expands native TypR coverage where the payoff is real and the risk stays controlled.
