### PR TITLE
ci(csharp-query): run stable cache smoke slices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
     name: C# Query Runtime Smoke
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
@@ -115,6 +115,14 @@ jobs:
           dotnet --version
           pwsh -v
 
-      - name: Run C# query runtime smoke runner
+      - name: Run C# query cache smoke slice (admission)
         run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice admission -KeepArtifacts
+
+      - name: Run C# query cache smoke slice (reuse)
+        run: |
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice reuse -SkipCodegen -KeepArtifacts
+
+      - name: Run C# query cache smoke slice (lru)
+        run: |
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice lru -SkipCodegen


### PR DESCRIPTION
  ## Summary
  Update the C# query runtime smoke workflow to use the new stable cache slices instead of one monolithic smoke
  invocation.

  ## What changed
  - Replaced the single smoke step in `.github/workflows/test.yml` with three explicit cache-focused slices:
    - `admission`
    - `reuse`
    - `lru`
  - Kept a shared output directory so:
    - the admission pass performs code generation
    - the reuse and lru passes reuse the same generated projects with `-SkipCodegen`
  - Increased the `csharp_query_runtime_smoke` job timeout from `25` to `45` minutes to match the measured runtime of
  the three-slice sequence

  ## Why
  We recently added stable cache slicing to `run_csharp_query_runtime_smoke.ps1`, but CI was still running a single
  unsliced smoke command.

  This PR makes the workflow align with the new smoke model and gives us clearer, more targeted cache regression
  coverage for:
  - admission
  - cache reuse
  - LRU / eviction

  It also removes dependence on brittle project-name filtering in future cache-focused smoke runs.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_ci_cache_slices_workflow -CacheSlice admission -KeepArtifacts`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_ci_cache_slices_workflow -CacheSlice reuse -SkipCodegen -KeepArtifacts`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_ci_cache_slices_workflow -CacheSlice lru -SkipCodegen`
    - Passed