### PR TITLE
Broaden native TypR control-flow lowering

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ includes:
 
 - simple output-producing binding chains
 - guard-style command predicates such as `is_character/1`
+- multi-step native control-flow chains where an earlier output feeds a later
+  guard and output
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
 
 More complex generic bodies still fall back to the wrapped R path.

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -154,6 +154,8 @@ bring-up.
   bodies:
   - simple output-producing binding chains
   - guard-style command predicates lowered into clause conditions
+  - sequential native control-flow chains where earlier outputs feed later
+    guards and outputs
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
   - literal-guarded multi-clause branches built from those chains
 

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -326,6 +326,8 @@ Current TypR lowering policy is intentionally mixed:
 - supported binding-shaped rule bodies lower directly to TypR
 - guard-style zero-output command bindings may be folded into TypR clause
   conditions
+- multi-step native TypR control-flow chains may keep later guards and outputs
+  in native TypR when those guards depend on earlier bound values
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
   may lower directly to TypR raw-expression assignments
 - literal-guarded multi-clause predicates may lower to TypR `if` chains

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -28,6 +28,8 @@ This document focuses on architecture and rollout choices specific to TypR.
    - native lowering for a conservative subset of generic binding-shaped rule
      bodies
    - guard-style command predicates lowered into clause conditions
+   - sequential native control-flow chains where earlier outputs feed later
+     guards and outputs
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
      `group_by/3`
 7. The remaining gap is broader lowering for arbitrary generic rule bodies
@@ -188,7 +190,9 @@ Completed:
 8. Extended that native subset to include guard-style command predicates in
    clause conditions and direct lowering for the dataframe helpers
    `filter/3`, `sort_by/3`, and `group_by/3`.
-9. Added structured diagnostics aggregation on the `r` side via
+9. Extended the native generic path further so sequential guard/output control
+   flow can stay in TypR when a later guard depends on an earlier bound value.
+10. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
 
@@ -216,8 +220,9 @@ Current implementation note:
   inside nested scopes
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
-  predicates, dataframe helper calls, and literal-guarded branch selection;
-  more complex bodies still fall back to wrapped R
+  predicates, sequential guard/output control-flow chains, dataframe helper
+  calls, and literal-guarded branch selection; more complex bodies still fall
+  back to wrapped R
 
 Follow-on work:
 

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -333,35 +333,32 @@ native_typr_clause_pair(Head-Body, branch(Condition, BranchExpr)) :-
     raw_block_expression(ClauseCode, BranchExpr).
 
 native_typr_clause(Head, Body, Condition, ClauseCode) :-
-    Head =.. [_|HeadArgs],
+    Head =.. [Pred|HeadArgs],
     build_head_varmap(HeadArgs, 1, VarMap),
     typr_head_condition(HeadArgs, 1, HeadConditions),
-    native_typr_goal_sequence(Body, VarMap, GoalConditions, ClauseCode),
+    atom_string(Pred, PredName),
+    native_typr_goal_sequence(Body, VarMap, PredName, GoalConditions, ClauseCode),
     append(HeadConditions, GoalConditions, Conditions),
     (   Conditions = []
     ->  Condition = 'TRUE'
     ;   atomic_list_concat(Conditions, ' && ', Condition)
     ).
 
-native_typr_goal_sequence(Body, VarMap, Conditions, Code) :-
+native_typr_goal_sequence(Body, VarMap, PredName, Conditions, Code) :-
     normalize_typr_goals(Body, Goals),
     Goals \= [],
-    native_typr_goals(
+    native_typr_prefix_goals(
         Goals,
         VarMap,
-        _VarMapOut,
+        PredName,
+        false,
+        none,
         Conditions,
-        HasOutput,
-        FinalKind,
-        FinalExpr,
-        Lines
+        PrefixLines,
+        TailCode,
+        _VarMapOut
     ),
-    (   HasOutput == true,
-        FinalKind == guard
-    ->  fail
-    ;   true
-    ),
-    append(Lines, [FinalExpr], BodyLines),
+    append(PrefixLines, [TailCode], BodyLines),
     atomic_list_concat(BodyLines, '\n', Code).
 
 normalize_typr_goals(true, []) :- !.
@@ -375,57 +372,64 @@ normalize_typr_goals(_Module:Goal, Goals) :-
     normalize_typr_goals(Goal, Goals).
 normalize_typr_goals(Goal, [Goal]).
 
-native_typr_goals([], VarMap, VarMap, [], false, guard, 'true', []).
-native_typr_goals([Goal|Rest], VarMap0, VarMap, Conditions, HasOutput, FinalKind, FinalExpr, Lines) :-
-    native_typr_goal(Goal, VarMap0, VarMap1, GoalConditions, GoalLines, GoalKind, GoalExpr),
-    native_typr_goals(Rest, VarMap1, VarMap, RestConditions, RestHasOutput, RestFinalKind, RestFinalExpr, RestLines),
-    append(GoalConditions, RestConditions, Conditions),
-    append(GoalLines, RestLines, Lines),
-    (   GoalKind == output
-    ->  HasOutput = true
-    ;   HasOutput = RestHasOutput
-    ),
-    (   Rest == []
-    ->  FinalKind = GoalKind,
-        FinalExpr = GoalExpr
-    ;   FinalKind = RestFinalKind,
-        FinalExpr = RestFinalExpr
-    ).
+native_typr_prefix_goals([], VarMap, _PredName, _SeenOutput, none, [], [], 'true', VarMap).
+native_typr_prefix_goals([], VarMap, _PredName, _SeenOutput, LastExpr, [], [], LastExpr, VarMap) :-
+    LastExpr \== none.
+native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, _SeenOutput, _LastExpr0, Conditions, [Line|RestLines], TailCode, VarMapOut) :-
+    native_typr_output_goal(Goal, VarMap0, VarMap1, Line, OutExpr),
+    native_typr_prefix_goals(Rest, VarMap1, PredName, true, OutExpr, Conditions, RestLines, TailCode, VarMapOut).
+native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, false, LastExpr, [GuardCondition|RestConditions], RestLines, TailCode, VarMapOut) :-
+    native_typr_guard_goal(Goal, VarMap0, GuardCondition),
+    native_typr_prefix_goals(Rest, VarMap0, PredName, false, LastExpr, RestConditions, RestLines, TailCode, VarMapOut).
+native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, true, LastExpr, [], [], TailCode, VarMapOut) :-
+    native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, LastExpr, TailCode, VarMapOut).
 
-native_typr_goal(_Module:Goal, VarMap0, VarMap, Conditions, Lines, GoalKind, FinalExpr) :-
+native_typr_guarded_tail_sequence(Goals, VarMap0, PredName, LastExpr, Code, VarMapOut) :-
+    native_typr_guarded_tail_sequence(Goals, VarMap0, PredName, LastExpr, [], Lines, FinalExpr, VarMapOut),
+    append(Lines, [FinalExpr], BodyLines),
+    atomic_list_concat(BodyLines, '\n', Code).
+
+native_typr_guarded_tail_sequence([], VarMap, PredName, LastExpr, PendingGuards, [], FinalExpr, VarMap) :-
+    guard_tail_final_expression(PendingGuards, PredName, LastExpr, FinalExpr).
+native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, _LastExpr0, PendingGuards, [Line|RestLines], FinalExpr, VarMapOut) :-
+    native_typr_output_expr(Goal, VarMap0, VarMap1, OutVar, OutputExpr),
+    guard_condition_expression(PendingGuards, GuardExpr),
+    conditional_output_line(GuardExpr, PredName, OutVar, OutputExpr, Line),
+    native_typr_guarded_tail_sequence(Rest, VarMap1, PredName, OutVar, [], RestLines, FinalExpr, VarMapOut).
+native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, LastExpr, PendingGuards0, Lines, FinalExpr, VarMapOut) :-
+    native_typr_guard_goal(Goal, VarMap0, GuardCondition),
+    append(PendingGuards0, [GuardCondition], PendingGuards),
+    native_typr_guarded_tail_sequence(Rest, VarMap0, PredName, LastExpr, PendingGuards, Lines, FinalExpr, VarMapOut).
+
+native_typr_output_goal(_Module:Goal, VarMap0, VarMap, Line, FinalExpr) :-
     !,
-    native_typr_goal(Goal, VarMap0, VarMap, Conditions, Lines, GoalKind, FinalExpr).
-native_typr_goal(filter(DF, Expr, Out), VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    native_typr_output_goal(Goal, VarMap0, VarMap, Line, FinalExpr).
+native_typr_output_goal(Goal, VarMap0, VarMap, Line, FinalExpr) :-
+    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr),
+    format(string(Line), '~w <- ~w;', [FinalExpr, OutputExpr]).
+
+native_typr_output_expr(_Module:Goal, VarMap0, VarMap, FinalExpr, OutputExpr) :-
+    !,
+    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr).
+native_typr_output_expr(filter(DF, Expr, Out), VarMap0, VarMap, FinalExpr, OutputExpr) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_translate_r_expr(Expr, VarMap0, RExpr),
-    format(string(Line), '~w <- @{ subset(~w, ~w) }@;', [FinalExpr, RDF, RExpr]).
-native_typr_goal(sort_by(DF, Col, Out), VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    format(string(OutputExpr), '@{ subset(~w, ~w) }@', [RDF, RExpr]).
+native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_resolve_value(VarMap0, Col, RCol),
-    format(string(Line), '~w <- @{ ~w[order(~w[[~w]]), ] }@;', [FinalExpr, RDF, RDF, RCol]).
-native_typr_goal(group_by(DF, Col, Out), VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    format(string(OutputExpr), '@{ ~w[order(~w[[~w]]), ] }@', [RDF, RDF, RCol]).
+native_typr_output_expr(group_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_resolve_value(VarMap0, Col, RCol),
-    format(string(Line), '~w <- @{ aggregate(. ~~ ~w, data=~w, FUN=list) }@;', [FinalExpr, RCol, RDF]).
-native_typr_goal(Goal, VarMap0, VarMap, [GuardCondition], [], guard, 'true') :-
-    functor(Goal, Pred, Arity),
-    binding(r, Pred/Arity, TargetName, Inputs, [], Options),
-    member(pattern(command), Options),
-    simple_r_binding_target(TargetName),
-    Goal =.. [_|Args],
-    length(Inputs, InCount),
-    length(InArgs, InCount),
-    append(InArgs, [], Args),
-    maplist(typr_resolve_value(VarMap0), InArgs, ResolvedInArgs),
-    typr_guard_expression(TargetName, ResolvedInArgs, GuardCondition),
-    VarMap = VarMap0.
-native_typr_goal(Goal, VarMap0, VarMap, [], [Line], output, FinalExpr) :-
+    format(string(OutputExpr), '@{ aggregate(. ~~ ~w, data=~w, FUN=list) }@', [RCol, RDF]).
+native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr) :-
     functor(Goal, Pred, Arity),
     binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
     Outputs = [_],
@@ -437,7 +441,22 @@ native_typr_goal(Goal, VarMap0, VarMap, [], [Line], output, FinalExpr) :-
     maplist(typr_resolve_value(VarMap0), InArgs, ResolvedInArgs),
     atomic_list_concat(ResolvedInArgs, ', ', RArgsStr),
     ensure_typr_var(VarMap0, OutArg, FinalExpr, VarMap),
-    format(string(Line), '~w <- @{ ~w(~w) }@;', [FinalExpr, TargetName, RArgsStr]).
+    format(string(OutputExpr), '@{ ~w(~w) }@', [TargetName, RArgsStr]).
+
+native_typr_guard_goal(_Module:Goal, VarMap, GuardCondition) :-
+    !,
+    native_typr_guard_goal(Goal, VarMap, GuardCondition).
+native_typr_guard_goal(Goal, VarMap, GuardCondition) :-
+    functor(Goal, Pred, Arity),
+    binding(r, Pred/Arity, TargetName, Inputs, [], Options),
+    member(pattern(command), Options),
+    simple_r_binding_target(TargetName),
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(InArgs, InCount),
+    append(InArgs, [], Args),
+    maplist(typr_resolve_value(VarMap), InArgs, ResolvedInArgs),
+    typr_guard_expression(TargetName, ResolvedInArgs, GuardCondition).
 
 simple_r_binding_target(TargetName) :-
     atom(TargetName),
@@ -458,6 +477,38 @@ typr_guard_expression(TargetName, [], GuardCondition) :-
 typr_guard_expression(TargetName, ResolvedInArgs, GuardCondition) :-
     atomic_list_concat(ResolvedInArgs, ', ', RArgsStr),
     format(string(GuardCondition), '@{ ~w(~w) }@', [TargetName, RArgsStr]).
+
+guard_condition_expression([], none).
+guard_condition_expression(Conditions, GuardExpr) :-
+    Conditions \= [],
+    atomic_list_concat(Conditions, ' && ', GuardExpr).
+
+conditional_output_line(none, _PredName, OutVar, OutputExpr, Line) :-
+    format(string(Line), '~w <- ~w;', [OutVar, OutputExpr]).
+conditional_output_line(GuardExpr, PredName, OutVar, OutputExpr, Line) :-
+    format(string(Line),
+'~w <- if (~w) {
+	~w
+} else {
+	stop("No matching clause for ~w")
+};', [OutVar, GuardExpr, OutputExpr, PredName]).
+
+guard_tail_final_expression([], _PredName, none, 'true').
+guard_tail_final_expression([], _PredName, LastExpr, LastExpr) :-
+    LastExpr \== none.
+guard_tail_final_expression(PendingGuards, PredName, LastExpr, FinalExpr) :-
+    PendingGuards \= [],
+    guard_condition_expression(PendingGuards, GuardExpr),
+    (   LastExpr == none
+    ->  BaseExpr = 'true'
+    ;   BaseExpr = LastExpr
+    ),
+    format(string(FinalExpr),
+'if (~w) {
+	~w
+} else {
+	stop("No matching clause for ~w")
+}', [GuardExpr, BaseExpr, PredName]).
 
 typr_translate_r_expr(Var, VarMap, Resolved) :-
     var(Var),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -22,6 +22,7 @@ cleanup_typr_test :-
     retractall(user:inferred_lower(_, _)),
     retractall(user:classify_name_guarded(_, _)),
     retractall(user:guarded_name(_, _)),
+    retractall(user:mid_guard(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -155,6 +156,18 @@ test(guard_bindings_expand_native_clause_conditions) :-
     once(compile_predicate_to_typr(guarded_name/2, [typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "is.character(arg1)")),
     once(sub_string(Code, _, _, _, "tolower(arg1)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(sequential_guards_after_output_lower_natively) :-
+    clear_type_declarations,
+    assertz(user:(mid_guard(Name, Len) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len))),
+    assertz(type_declarations:uw_type(mid_guard/2, 1, atom)),
+    assertz(type_declarations:uw_type(mid_guard/2, 2, integer)),
+    once(compile_predicate_to_typr(mid_guard/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "tolower(arg1)")),
+    once(sub_string(Code, _, _, _, "is.character(v3)")),
+    once(sub_string(Code, _, _, _, "nchar(v3)")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 


### PR DESCRIPTION
## Summary

This PR expands the native TypR lowering path so more control-flow-heavy generic predicates can stay in native TypR instead of falling back to wrapped R.

The main addition is support for sequential guard/output chains where:

- an earlier output binding produces an intermediate value
- a later guard depends on that intermediate value
- a later output depends on the same intermediate value

Before this change, those shapes crossed the boundary of the current native TypR subset and either failed to lower cleanly or forced the backend toward wrapped-R-style behavior.

After this change, that class of predicates can stay in the native TypR path and continue to validate through the real TypR CLI.

This is still a conservative expansion, not full arbitrary-body TypR lowering.

## Why This PR Exists

The previous native TypR work had already established support for:

- simple output-producing binding chains
- guard-style zero-output command predicates
- literal-guarded multi-clause predicates
- selected dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

That left an obvious next gap:

1. a body could start in the native TypR path,
2. bind an intermediate value,
3. then hit a guard that depends on that intermediate value,
4. and then produce another output,
5. but the backend did not yet have a clean native representation for that sequence.

A representative shape is:

```prolog
mid_guard(Name, Len) :-
    string_lower(Name, Lower),
    is_character(Lower),
    string_length(Lower, Len).
```

The key issue is that `is_character/1` depends on `Lower`, which is only available after the first binding step. That makes it different from the earlier “front-loaded clause condition” cases.

This PR closes that gap.

## Main Changes

### 1. Native TypR lowering now supports sequential guard/output control flow

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR target no longer treats every guard as something that must be hoisted into top-level clause conditions.

Instead, native lowering now distinguishes between:

- guards that occur before any output has been produced
- guards that occur after one or more output-producing steps

Behavior after this change:

- pre-output guards still fold into clause conditions when appropriate
- post-output guards can remain in native TypR as conditional expressions/assignments
- subsequent output steps can continue in the native TypR path after those guards

This allows the backend to express multi-step control flow without dropping into the wrapped R fallback just because a later guard depends on an earlier bound value.

### 2. Refactored native TypR clause-body lowering

The internal native TypR lowering path was restructured to support staged body compilation instead of a simple “collect conditions first” model.

That refactor now separates:

- prefix handling for early guards and outputs
- output expression generation
- guarded tail handling for later guard/output chains

The result is that the backend can keep more body shapes in TypR while still preserving the existing conservative boundaries.

### 3. Added regression coverage for intermediate-value control flow

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

This PR adds coverage for the previously unsupported shape where:

- a first output produces an intermediate variable
- a later guard references that intermediate variable
- a later output also references that intermediate variable

The new regression test verifies that this case:

- lowers natively to TypR
- does not fall back to wrapped R
- passes real `typr check`

### 4. Documentation updated to reflect the broader native TypR subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the current native TypR subset includes sequential control-flow chains where earlier outputs feed later guards and later outputs.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Tests Added / Updated

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl) to cover:

- sequential guard/output native lowering
- use of an intermediate bound value inside a later guard
- use of the same intermediate bound value inside a later output
- continued absence of wrapped-R fallback for supported native cases
- continued real TypR toolchain validation for the new shape

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior
- existing R-target behavior remaining intact on the focused suite
- expanded native TypR control-flow lowering
- continued TypR CLI validation of generated output

What it does not claim:

- full repo-wide regression coverage
- full arbitrary-body native TypR lowering
- elimination of wrapped-R fallback for all remaining generic TypR predicates

## Behavior Notes

### TypR behavior after this PR

TypR’s native subset now includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- literal-guarded multi-clause branches
- dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

Unsupported generic bodies still fall back to wrapped R.

### R behavior after this PR

This PR does not materially change the R-target contract.

The change is on the TypR side: it allows more generic predicates to avoid the wrapped-R fallback path by staying in native TypR lowering longer.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for sequential guard/output chains
- support for guards that depend on earlier bound values
- continued native TypR output for later dependent outputs in the same chain
- regression coverage and docs for the broader control-flow subset

Still not fully implemented:

- broader native TypR lowering for arbitrary generic rule bodies
- richer control-flow lowering beyond the current conservative staged subset
- complete removal of wrapped-R fallback for remaining unsupported TypR cases

## Why This PR Is Worth Merging

This PR closes a real backend gap rather than just extending documentation or inference metadata.

It improves TypR in a practical way:

- fewer fallback cases for realistic multi-step predicates
- better native TypR coverage for dependent intermediate-value flows
- stronger confidence through real toolchain validation
- documentation that matches the actual implemented subset

In short, this is a good incremental PR because it broadens native TypR lowering in a controlled way and removes another meaningful class of wrapped-R fallback.
