### PR TITLE
Keep Supported TypR Branch Bodies Native with Let-Bound Intermediates

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ includes:
 - guard-style command predicates such as `is_character/1`
 - multi-step native control-flow chains where an earlier output feeds a later
   guard and output
+- supported literal-headed branch bodies built from those chains, with `let`
+  used for new intermediate TypR locals
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
 
 More complex generic bodies still fall back to the wrapped R path.

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -156,6 +156,8 @@ bring-up.
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs
+  - supported literal-headed multi-clause branch bodies that keep those chains
+    native by using `let` for new intermediate locals
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
   - literal-guarded multi-clause branches built from those chains
 

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -328,6 +328,8 @@ Current TypR lowering policy is intentionally mixed:
   conditions
 - multi-step native TypR control-flow chains may keep later guards and outputs
   in native TypR when those guards depend on earlier bound values
+- supported literal-headed branch bodies may also stay native when those chains
+  fit inside a TypR `if` branch with `let`-introduced intermediate locals
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
   may lower directly to TypR raw-expression assignments
 - literal-guarded multi-clause predicates may lower to TypR `if` chains

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -30,6 +30,8 @@ This document focuses on architecture and rollout choices specific to TypR.
    - guard-style command predicates lowered into clause conditions
    - sequential native control-flow chains where earlier outputs feed later
      guards and outputs
+   - supported literal-headed branch bodies that keep those chains native by
+     using `let` for newly introduced locals inside TypR branches
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
      `group_by/3`
 7. The remaining gap is broader lowering for arbitrary generic rule bodies
@@ -192,7 +194,10 @@ Completed:
    `filter/3`, `sort_by/3`, and `group_by/3`.
 9. Extended the native generic path further so sequential guard/output control
    flow can stay in TypR when a later guard depends on an earlier bound value.
-10. Added structured diagnostics aggregation on the `r` side via
+10. Extended native multi-clause TypR lowering so supported branch bodies stay
+    native and introduce new branch-local intermediates with `let` rather than
+    raw `local({ ... })` wrappers.
+11. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
 
@@ -220,9 +225,10 @@ Current implementation note:
   inside nested scopes
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
-  predicates, sequential guard/output control-flow chains, dataframe helper
-  calls, and literal-guarded branch selection; more complex bodies still fall
-  back to wrapped R
+  predicates, sequential guard/output control-flow chains, native
+  literal-headed branch bodies built from those chains, dataframe helper calls,
+  and literal-guarded branch selection; more complex bodies still fall back to
+  wrapped R
 
 Follow-on work:
 

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -313,13 +313,14 @@ native_typr_clause_body(PredSpec, [Head-Body], Code) :-
     (   Condition == 'TRUE'
     ->  Code = ClauseCode
     ;   pred_spec_name(PredSpec, PredName),
-        raw_block_expression(ClauseCode, BranchExpr),
+        branch_safe_typr_code(ClauseCode, BranchClauseCode),
+        indent_text(BranchClauseCode, "\t", BranchCode),
         format(string(Code),
 'if (~w) {
-	~w
+~w
 } else {
 	stop("No matching clause for ~w")
-}', [Condition, BranchExpr, PredName])
+}', [Condition, BranchCode, PredName])
     ).
 native_typr_clause_body(PredSpec, Clauses, Code) :-
     maplist(native_typr_clause_pair, Clauses, Branches),
@@ -328,9 +329,9 @@ native_typr_clause_body(PredSpec, Clauses, Code) :-
     branches_to_typr_if_chain(Branches, IfChain),
     format(string(Code), '~w else {\n\tstop("No matching clause for ~w")\n}', [IfChain, PredName]).
 
-native_typr_clause_pair(Head-Body, branch(Condition, BranchExpr)) :-
+native_typr_clause_pair(Head-Body, branch(Condition, ClauseCode)) :-
     native_typr_clause(Head, Body, Condition, ClauseCode),
-    raw_block_expression(ClauseCode, BranchExpr).
+    !.
 
 native_typr_clause(Head, Body, Condition, ClauseCode) :-
     Head =.. [Pred|HeadArgs],
@@ -392,9 +393,9 @@ native_typr_guarded_tail_sequence(Goals, VarMap0, PredName, LastExpr, Code, VarM
 native_typr_guarded_tail_sequence([], VarMap, PredName, LastExpr, PendingGuards, [], FinalExpr, VarMap) :-
     guard_tail_final_expression(PendingGuards, PredName, LastExpr, FinalExpr).
 native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, _LastExpr0, PendingGuards, [Line|RestLines], FinalExpr, VarMapOut) :-
-    native_typr_output_expr(Goal, VarMap0, VarMap1, OutVar, OutputExpr),
+    native_typr_output_expr(Goal, VarMap0, VarMap1, OutVar, OutputExpr, IntroKind),
     guard_condition_expression(PendingGuards, GuardExpr),
-    conditional_output_line(GuardExpr, PredName, OutVar, OutputExpr, Line),
+    conditional_output_line(GuardExpr, PredName, IntroKind, OutVar, OutputExpr, Line),
     native_typr_guarded_tail_sequence(Rest, VarMap1, PredName, OutVar, [], RestLines, FinalExpr, VarMapOut).
 native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, LastExpr, PendingGuards0, Lines, FinalExpr, VarMapOut) :-
     native_typr_guard_goal(Goal, VarMap0, GuardCondition),
@@ -405,31 +406,31 @@ native_typr_output_goal(_Module:Goal, VarMap0, VarMap, Line, FinalExpr) :-
     !,
     native_typr_output_goal(Goal, VarMap0, VarMap, Line, FinalExpr).
 native_typr_output_goal(Goal, VarMap0, VarMap, Line, FinalExpr) :-
-    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr),
-    format(string(Line), '~w <- ~w;', [FinalExpr, OutputExpr]).
+    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind),
+    typr_assignment_line(IntroKind, FinalExpr, OutputExpr, Line).
 
-native_typr_output_expr(_Module:Goal, VarMap0, VarMap, FinalExpr, OutputExpr) :-
+native_typr_output_expr(_Module:Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
-    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr).
-native_typr_output_expr(filter(DF, Expr, Out), VarMap0, VarMap, FinalExpr, OutputExpr) :-
+    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind).
+native_typr_output_expr(filter(DF, Expr, Out), VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
-    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
+    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_translate_r_expr(Expr, VarMap0, RExpr),
     format(string(OutputExpr), '@{ subset(~w, ~w) }@', [RDF, RExpr]).
-native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr) :-
+native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
-    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
+    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_resolve_value(VarMap0, Col, RCol),
     format(string(OutputExpr), '@{ ~w[order(~w[[~w]]), ] }@', [RDF, RDF, RCol]).
-native_typr_output_expr(group_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr) :-
+native_typr_output_expr(group_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
-    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap),
+    ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_resolve_value(VarMap0, Col, RCol),
     format(string(OutputExpr), '@{ aggregate(. ~~ ~w, data=~w, FUN=list) }@', [RCol, RDF]).
-native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr) :-
+native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     functor(Goal, Pred, Arity),
     binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
     Outputs = [_],
@@ -440,7 +441,7 @@ native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr) :-
     append(InArgs, [OutArg], Args),
     maplist(typr_resolve_value(VarMap0), InArgs, ResolvedInArgs),
     atomic_list_concat(ResolvedInArgs, ', ', RArgsStr),
-    ensure_typr_var(VarMap0, OutArg, FinalExpr, VarMap),
+    ensure_typr_var(VarMap0, OutArg, FinalExpr, VarMap, IntroKind),
     format(string(OutputExpr), '@{ ~w(~w) }@', [TargetName, RArgsStr]).
 
 native_typr_guard_goal(_Module:Goal, VarMap, GuardCondition) :-
@@ -483,15 +484,23 @@ guard_condition_expression(Conditions, GuardExpr) :-
     Conditions \= [],
     atomic_list_concat(Conditions, ' && ', GuardExpr).
 
-conditional_output_line(none, _PredName, OutVar, OutputExpr, Line) :-
-    format(string(Line), '~w <- ~w;', [OutVar, OutputExpr]).
-conditional_output_line(GuardExpr, PredName, OutVar, OutputExpr, Line) :-
+typr_binding_prefix(existing, '').
+typr_binding_prefix(new, 'let ').
+
+typr_assignment_line(IntroKind, OutVar, OutputExpr, Line) :-
+    typr_binding_prefix(IntroKind, Prefix),
+    format(string(Line), '~w~w <- ~w;', [Prefix, OutVar, OutputExpr]).
+
+conditional_output_line(none, _PredName, IntroKind, OutVar, OutputExpr, Line) :-
+    typr_assignment_line(IntroKind, OutVar, OutputExpr, Line).
+conditional_output_line(GuardExpr, PredName, IntroKind, OutVar, OutputExpr, Line) :-
+    typr_binding_prefix(IntroKind, Prefix),
     format(string(Line),
-'~w <- if (~w) {
+'~w~w <- if (~w) {
 	~w
 } else {
 	stop("No matching clause for ~w")
-};', [OutVar, GuardExpr, OutputExpr, PredName]).
+};', [Prefix, OutVar, GuardExpr, OutputExpr, PredName]).
 
 guard_tail_final_expression([], _PredName, none, 'true').
 guard_tail_final_expression([], _PredName, LastExpr, LastExpr) :-
@@ -543,13 +552,15 @@ r_expr_op_map(\=, '!=').
 r_expr_op_map(and, '&').
 r_expr_op_map(or, '|').
 
-ensure_typr_var(VarMap, Var, Name, VarMap) :-
+ensure_typr_var(VarMap, Var, Name, VarMap, existing) :-
     lookup_typr_var(Var, VarMap, Name),
     !.
-ensure_typr_var(VarMap, Var, Name, [Var-Name|VarMap]) :-
+ensure_typr_var(VarMap, Var, Name, [Var-Name|VarMap], new) :-
     length(VarMap, ExistingCount),
     NextIndex is ExistingCount + 1,
     format(string(Name), 'v~w', [NextIndex]).
+ensure_typr_var(VarMap, Var, Name, VarMapOut) :-
+    ensure_typr_var(VarMap, Var, Name, VarMapOut, _).
 
 lookup_typr_var(Var, [StoredVar-Name|_], Name) :-
     Var == StoredVar,
@@ -579,10 +590,14 @@ typr_head_condition([HeadArg|Rest], Index, Conditions) :-
     typr_head_condition(Rest, NextIndex, RestConditions).
 
 branches_to_typr_if_chain([branch(Condition, Code)], IfChain) :-
-    format(string(IfChain), 'if (~w) {\n\t~w\n}', [Condition, Code]).
+    branch_safe_typr_code(Code, BranchCode),
+    indent_text(BranchCode, "\t", IndentedCode),
+    format(string(IfChain), 'if (~w) {\n~w\n}', [Condition, IndentedCode]).
 branches_to_typr_if_chain([branch(Condition, Code)|Rest], IfChain) :-
     branches_to_typr_if_chain(Rest, RestChain),
-    format(string(IfChain), 'if (~w) {\n\t~w\n} else ~w', [Condition, Code, RestChain]).
+    branch_safe_typr_code(Code, BranchCode),
+    indent_text(BranchCode, "\t", IndentedCode),
+    format(string(IfChain), 'if (~w) {\n~w\n} else ~w', [Condition, IndentedCode, RestChain]).
 
 pred_spec_name(_Module:Pred/_, PredName) :-
     !,
@@ -598,15 +613,26 @@ indent_text(Text, Prefix, Indented) :-
     ), IndentedLines),
     atomic_list_concat(IndentedLines, '\n', Indented).
 
+branch_safe_typr_code(Code, SafeCode) :-
+    split_string(Code, "\n", "", Lines),
+    maplist(branch_safe_typr_line, Lines, SafeLines),
+    atomic_list_concat(SafeLines, '\n', SafeCode).
+
+branch_safe_typr_line(Line, SafeLine) :-
+    (   sub_string(Line, 0, 4, _, "let ")
+    ->  SafeLine = Line
+    ;   sub_string(Line, _, _, _, " <- "),
+        sub_string(Line, _, 1, 0, ";")
+    ->  string_concat("let ", Line, SafeLine)
+    ;   SafeLine = Line
+    ).
+
 finalize_type_diagnostics_report(Options) :-
     (   memberchk(type_diagnostics_report(Report), Options),
         var(Report)
     ->  Report = []
     ;   true
     ).
-
-raw_block_expression(ClauseCode, RawExpr) :-
-    format(string(RawExpr), '@{ local({ ~w }) }@', [ClauseCode]).
 
 wrapped_r_body_expression(Module:Pred/Arity, Options, WrappedExpr) :-
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -23,6 +23,8 @@ cleanup_typr_test :-
     retractall(user:classify_name_guarded(_, _)),
     retractall(user:guarded_name(_, _)),
     retractall(user:mid_guard(_, _)),
+    retractall(user:multi_guard_chain(_, _)),
+    retractall(user:multi_clause_chain(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -168,6 +170,34 @@ test(sequential_guards_after_output_lower_natively) :-
     once(sub_string(Code, _, _, _, "tolower(arg1)")),
     once(sub_string(Code, _, _, _, "is.character(v3)")),
     once(sub_string(Code, _, _, _, "nchar(v3)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(multi_decision_guard_chains_use_let_for_new_intermediates) :-
+    clear_type_declarations,
+    assertz(user:(multi_guard_chain(Name, Out) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Upper), is_character(Upper), string_concat(Upper, '!', Out))),
+    assertz(type_declarations:uw_type(multi_guard_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(multi_guard_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(multi_guard_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ tolower(arg1) }@;")),
+    once(sub_string(Code, _, _, _, "let v4 <- if (@{ is.character(v3) }@)")),
+    once(sub_string(Code, _, _, _, "let v5 <- if (@{ is.numeric(v4) }@)")),
+    once(sub_string(Code, _, _, _, "arg2 <- if (@{ is.character(v5) }@)")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(multi_clause_decision_chains_stay_native_in_branch_bodies) :-
+    clear_type_declarations,
+    assertz(user:(multi_clause_chain(short, Out) :- string_lower('HI', Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Out))),
+    assertz(user:(multi_clause_chain(long, Out) :- string_lower('BYE', Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Out))),
+    assertz(type_declarations:uw_type(multi_clause_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(multi_clause_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(multi_clause_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "else if")),
+    once(sub_string(Code, _, _, _, "let v2 <- @{ tolower(\"HI\") }@;")),
+    once(sub_string(Code, _, _, _, "let v3 <- if (@{ is.character(v2) }@)")),
+    \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 


### PR DESCRIPTION
## Summary

This PR expands the native TypR lowering path so supported multi-step predicates can remain native even inside literal-headed branch bodies.

The main improvement is that supported branch bodies no longer need to fall back to raw `local({ ... })` wrappers when they introduce new intermediate values. Instead, native TypR lowering now emits `let` for new branch-local intermediates and keeps the branch body in TypR.

This is still a conservative step, not full arbitrary-body native TypR lowering.

## Why This PR Exists

The previous TypR work already supported:

- native lowering for simple binding chains
- guard-style command predicates
- sequential guard/output chains where later guards depend on earlier bound values
- literal-headed multi-clause branching
- selected dataframe helpers

That still left an important gap:

- supported multi-step logic could stay native at top level
- but the same shape inside a branch body still tended to rely on raw wrapper-style lowering

This PR closes that gap for the supported native subset.

## Main Changes

### 1. Supported branch bodies now stay native in TypR

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

For supported literal-headed multi-clause predicates:

- branch bodies now emit native TypR code directly
- new branch-local intermediates are introduced with `let`
- the backend no longer relies on raw `local({ ... })` wrappers for these native cases

This keeps the generated code closer to real TypR structure and reduces dependence on wrapped-R-style lowering.

### 2. Native TypR lowering now distinguishes existing outputs from new locals

The TypR native path now tracks whether a target variable is:

- an existing output/head variable
- or a newly introduced intermediate

That lets the backend emit:

- ordinary assignment for existing output variables
- `let` bindings for newly introduced intermediates

This is the key change that makes native branch-body lowering valid in TypR.

### 3. Branch bodies are normalized for TypR-safe assignment form

Native branch-body emission now ensures supported assignment lines use TypR-safe forms inside branches.

In practice, that means supported native branch bodies can include:

- intermediate native outputs
- dependent guards
- later dependent outputs

without dropping into raw wrapper code.

### 4. Added regression coverage for multi-step dependent branch bodies

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl) to cover:

- multi-step native guard/output chains with more than one dependent decision
- supported literal-headed multi-clause branch bodies that stay native
- introduction of new intermediates with `let`
- continued absence of raw wrapper fallback in those supported cases
- continued real `typr check` validation

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the native TypR subset includes supported branch bodies built from the existing native control-flow chain model, with `let` used for new intermediate locals.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR subset includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- selected dataframe helpers
- supported literal-headed branch bodies built from those chains

More complex generic bodies still fall back to wrapped R.

## Scope and Remaining Gaps

Implemented now:

- native TypR branch-body lowering for supported multi-step control-flow cases
- `let`-binding for new intermediate locals inside native branches
- reduced dependence on raw wrapper blocks for supported native multi-clause paths

Still not fully implemented:

- full arbitrary-body native TypR lowering
- broader native lowering for more complex generic branch bodies
- complete elimination of wrapped-R fallback for unsupported TypR cases

## Why This PR Is Worth Merging

This PR improves actual TypR backend behavior, not just metadata or docs.

It gives the project:

- less wrapper-style code in supported TypR branches
- cleaner native TypR output
- better handling of intermediate values inside branch-local control flow
- stronger confidence through focused regression coverage and real TypR validation
