### PR TITLE
Keep native TypR comparison guard chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ includes:
 - guard-style command predicates such as `is_character/1`
 - multi-step native control-flow chains where an earlier output feeds a later
   guard and output
+- simple comparison and boolean guard expressions over already-bound
+  intermediates
 - supported literal-headed branch bodies built from those chains, with `let`
   used for new intermediate TypR locals
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -156,6 +156,8 @@ bring-up.
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs
+  - simple comparison and boolean guard expressions over already-bound
+    intermediates in those chains
   - supported literal-headed multi-clause branch bodies that keep those chains
     native by using `let` for new intermediate locals
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -328,6 +328,8 @@ Current TypR lowering policy is intentionally mixed:
   conditions
 - multi-step native TypR control-flow chains may keep later guards and outputs
   in native TypR when those guards depend on earlier bound values
+- simple comparison and boolean guard expressions over already-bound
+  intermediates may also stay native in those control-flow chains
 - supported literal-headed branch bodies may also stay native when those chains
   fit inside a TypR `if` branch with `let`-introduced intermediate locals
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -30,6 +30,8 @@ This document focuses on architecture and rollout choices specific to TypR.
    - guard-style command predicates lowered into clause conditions
    - sequential native control-flow chains where earlier outputs feed later
      guards and outputs
+   - simple comparison and boolean guard expressions over already-bound
+     intermediates in those chains
    - supported literal-headed branch bodies that keep those chains native by
      using `let` for newly introduced locals inside TypR branches
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
@@ -197,7 +199,10 @@ Completed:
 10. Extended native multi-clause TypR lowering so supported branch bodies stay
     native and introduce new branch-local intermediates with `let` rather than
     raw `local({ ... })` wrappers.
-11. Added structured diagnostics aggregation on the `r` side via
+11. Extended the native guard path again so simple comparison and boolean
+    expressions over already-bound intermediates can stay native in both
+    top-level control-flow chains and supported branch bodies.
+12. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
 
@@ -225,7 +230,8 @@ Current implementation note:
   inside nested scopes
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
-  predicates, sequential guard/output control-flow chains, native
+  predicates, sequential guard/output control-flow chains, simple comparison
+  and boolean guard expressions over already-bound intermediates, native
   literal-headed branch bodies built from those chains, dataframe helper calls,
   and literal-guarded branch selection; more complex bodies still fall back to
   wrapped R

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -448,6 +448,9 @@ native_typr_guard_goal(_Module:Goal, VarMap, GuardCondition) :-
     !,
     native_typr_guard_goal(Goal, VarMap, GuardCondition).
 native_typr_guard_goal(Goal, VarMap, GuardCondition) :-
+    typr_native_guard_expr(Goal, VarMap, GuardCondition),
+    !.
+native_typr_guard_goal(Goal, VarMap, GuardCondition) :-
     functor(Goal, Pred, Arity),
     binding(r, Pred/Arity, TargetName, Inputs, [], Options),
     member(pattern(command), Options),
@@ -458,6 +461,14 @@ native_typr_guard_goal(Goal, VarMap, GuardCondition) :-
     append(InArgs, [], Args),
     maplist(typr_resolve_value(VarMap), InArgs, ResolvedInArgs),
     typr_guard_expression(TargetName, ResolvedInArgs, GuardCondition).
+
+typr_native_guard_expr(Expr, VarMap, GuardCondition) :-
+    compound(Expr),
+    Expr =.. [Op, _Left, _Right],
+    r_expr_op_map(Op, _),
+    typr_translate_r_expr(Expr, VarMap, ResolvedExpr0),
+    typr_top_level_guard_expr(ResolvedExpr0, ResolvedExpr),
+    format(string(GuardCondition), '@{ ~w }@', [ResolvedExpr]).
 
 simple_r_binding_target(TargetName) :-
     atom(TargetName),
@@ -543,10 +554,18 @@ typr_translate_r_expr(Expr, VarMap, Resolved) :-
     r_expr_op_map(Op, ROp),
     format(string(Resolved), '(~w ~w ~w)', [LeftResolved, ROp, RightResolved]).
 
+typr_top_level_guard_expr(ResolvedExpr0, ResolvedExpr) :-
+    (   sub_string(ResolvedExpr0, 0, 1, _, "("),
+        sub_string(ResolvedExpr0, _, 1, 0, ")")
+    ->  sub_string(ResolvedExpr0, 1, _, 1, ResolvedExpr)
+    ;   ResolvedExpr = ResolvedExpr0
+    ).
+
 r_expr_op_map(>, '>').
 r_expr_op_map(<, '<').
 r_expr_op_map(>=, '>=').
 r_expr_op_map(=<, '<=').
+r_expr_op_map(=:=, '==').
 r_expr_op_map(==, '==').
 r_expr_op_map(\=, '!=').
 r_expr_op_map(and, '&').

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -25,6 +25,8 @@ cleanup_typr_test :-
     retractall(user:mid_guard(_, _)),
     retractall(user:multi_guard_chain(_, _)),
     retractall(user:multi_clause_chain(_, _)),
+    retractall(user:comparison_guard_chain(_, _)),
+    retractall(user:comparison_clause_chain(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -197,6 +199,33 @@ test(multi_clause_decision_chains_stay_native_in_branch_bodies) :-
     once(sub_string(Code, _, _, _, "else if")),
     once(sub_string(Code, _, _, _, "let v2 <- @{ tolower(\"HI\") }@;")),
     once(sub_string(Code, _, _, _, "let v3 <- if (@{ is.character(v2) }@)")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(comparison_guard_chains_lower_natively) :-
+    clear_type_declarations,
+    assertz(user:(comparison_guard_chain(Name, Out) :- string_lower(Name, Lower), string_length(Lower, Len), >(Len, 1), string_upper(Lower, Upper), string_length(Upper, UpperLen), <(UpperLen, 10), string_concat(Upper, '!', Out))),
+    assertz(type_declarations:uw_type(comparison_guard_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(comparison_guard_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(comparison_guard_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let v4 <- @{ nchar(v3) }@;")),
+    once(sub_string(Code, _, _, _, "if (@{ v4 > 1 }@)")),
+    once(sub_string(Code, _, _, _, "let v6 <- @{ nchar(v5) }@;")),
+    once(sub_string(Code, _, _, _, "if (@{ v6 < 10 }@)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(comparison_guard_branch_bodies_stay_native) :-
+    clear_type_declarations,
+    assertz(user:(comparison_clause_chain(short, Out) :- string_lower('HI', Lower), string_length(Lower, Len), >(Len, 1), string_upper(Lower, Out))),
+    assertz(user:(comparison_clause_chain(long, Out) :- string_lower('BYE', Lower), string_length(Lower, Len), >(Len, 2), string_upper(Lower, Out))),
+    assertz(type_declarations:uw_type(comparison_clause_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(comparison_clause_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(comparison_clause_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "else if")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ nchar(v2) }@;")),
+    once(sub_string(Code, _, _, _, "if (@{ v3 > 1 }@)")),
     \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR lowering path so simple comparison and boolean guard expressions over already-bound intermediate values can stay native instead of forcing wrapped fallback behavior.

The main addition is support for multi-step control-flow chains such as:

- bind an intermediate value
- derive another intermediate from it
- guard on a simple comparison over that derived value
- continue producing later outputs natively

This also applies inside supported literal-headed branch bodies, so those cases can remain native TypR as well.

This is still a conservative expansion, not arbitrary-body native TypR lowering.

## Why This PR Exists

The previous TypR work already supported:

- simple binding chains
- guard-style command predicates
- sequential dependent guard/output chains
- supported native branch bodies with `let`-bound intermediates

That still left a practical gap:

- guard predicates like `is_character/1` could stay native
- but simple comparison-style guards over already-bound intermediates were still a weak point

A representative shape is:

```prolog
comparison_guard_chain(Name, Out) :-
    string_lower(Name, Lower),
    string_length(Lower, Len),
    >(Len, 1),
    string_upper(Lower, Upper),
    string_length(Upper, UpperLen),
    <(UpperLen, 10),
    string_concat(Upper, '!', Out).
```

This PR closes that gap for the supported native TypR subset.

## Main Changes

### 1. Native TypR now accepts simple comparison guards over bound intermediates

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The native guard path now recognizes simple comparison and boolean expressions whose operands are already available in the current TypR variable map.

Supported forms are based on the existing shared R-expression translation logic, including operators such as:

- `>`
- `<`
- `>=`
- `=<`
- `=:=`
- `==`
- `\\=`
- `and`
- `or`

That means these guards can remain in native TypR control-flow chains instead of pushing the predicate toward wrapped fallback.

### 2. Guard expressions are normalized into TypR-safe raw expressions

The implementation now normalizes top-level translated guard expressions into TypR-safe raw-expression form.

For example, the emitter now prefers:

```typr
@{ v4 > 1 }@
```

instead of wrapping the full comparison in an extra outer pair of parentheses that the real `typr check` parser rejects in this position.

This was necessary to keep the new comparison-guard cases valid under the real TypR toolchain rather than only looking plausible in emitted text.

### 3. Supported branch bodies benefit from the same native comparison-guard path

The same conservative native comparison-guard handling now applies inside supported literal-headed branch bodies.

That means branch bodies such as:

```prolog
comparison_clause_chain(short, Out) :-
    string_lower('HI', Lower),
    string_length(Lower, Len),
    >(Len, 1),
    string_upper(Lower, Out).
```

can stay native instead of regressing toward wrapper-style lowering.

### 4. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies:

- multi-step native comparison-guard chains
- comparison guards over derived intermediate values
- supported branch-body lowering with comparison guards
- continued absence of wrapped fallback in those native cases
- continued real `typr check` validation

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the conservative native TypR subset includes simple comparison and boolean guard expressions over already-bound intermediates.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR subset includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- simple comparison and boolean guard expressions over already-bound intermediates
- supported literal-headed branch bodies built from those chains
- selected dataframe helpers

More complex generic bodies still fall back to wrapped R.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for comparison-guard chains over bound intermediates
- TypR-safe normalization of top-level raw comparison guards
- supported branch-body reuse of the same native comparison-guard path

Still not fully implemented:

- full arbitrary-body native TypR lowering
- broader native lowering for more complex generic branch bodies
- complete elimination of wrapped-R fallback for unsupported TypR cases

## Why This PR Is Worth Merging

This PR improves real TypR backend behavior in another concrete area.

It gives the project:

- fewer wrapped fallback cases for practical control-flow-heavy predicates
- stronger native TypR coverage for comparison-driven logic
- behavior validated against the real TypR toolchain, not just string-shape expectations
- documentation that matches the current conservative native subset
