### PR TITLE
ci(csharp-query): upload smoke artifacts on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,8 @@ jobs:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      CSHARP_QUERY_SMOKE_OUTPUT_DIR: tmp/csharp_query_smoke_ci
 
     steps:
       - name: Checkout code
@@ -117,12 +119,32 @@ jobs:
 
       - name: Run C# query cache smoke slice (admission)
         run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice admission -KeepArtifacts
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -CacheSlice admission -KeepArtifacts
 
       - name: Run C# query cache smoke slice (reuse)
         run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice reuse -SkipCodegen -KeepArtifacts
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -CacheSlice reuse -SkipCodegen -KeepArtifacts
 
       - name: Run C# query cache smoke slice (lru)
         run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice lru -SkipCodegen
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -CacheSlice lru -SkipCodegen
+
+      - name: Upload C# query smoke artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: csharp-query-smoke-artifacts
+          path: ${{ env.CSHARP_QUERY_SMOKE_OUTPUT_DIR }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Summarize C# query cache smoke slices
+        if: always()
+        run: |
+          {
+            echo "## C# Query Runtime Smoke"
+            echo ""
+            echo "- Cache slices: admission, reuse, lru"
+            echo "- Output dir: \`$CSHARP_QUERY_SMOKE_OUTPUT_DIR\`"
+            echo "- Failure artifacts: uploaded from \`$CSHARP_QUERY_SMOKE_OUTPUT_DIR\` when the smoke job fails"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
  ## Summary
  Improve the C# query runtime smoke workflow by uploading the generated smoke output as a workflow artifact when the
  job fails, and by adding a short job summary for the cache slices that ran.

  ## What changed
  - Added a job-level `CSHARP_QUERY_SMOKE_OUTPUT_DIR` env var in `.github/workflows/test.yml`
  - Reused that shared output dir across the existing cache smoke slices:
    - `admission`
    - `reuse`
    - `lru`
  - Added a failure-only artifact upload step:
    - uploads `tmp/csharp_query_smoke_ci`
    - artifact name: `csharp-query-smoke-artifacts`
  - Added an `if: always()` job summary step that records:
    - the cache slices that ran
    - the configured smoke output directory
    - the failure-artifact behavior

  ## Why
  The cache-slice workflow is now in CI, but a failing smoke job still required local reproduction to inspect generated
  projects and logs.

  This PR makes smoke failures easier to triage directly from GitHub Actions by preserving the generated smoke output
  when the job fails, while also making the executed cache slices visible in the job summary.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_artifacts_on_failure -CacheSlice admission -KeepArtifacts`
    - Passed