### PR TITLE
Document native TypR fan-out chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ includes:
   guard and output
 - simple comparison and boolean guard expressions over already-bound
   intermediates
+- structured fan-out chains where one earlier bound value feeds multiple later
+  derived outputs or conditions
 - supported literal-headed branch bodies built from those chains, with `let`
   used for new intermediate TypR locals
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -158,6 +158,8 @@ bring-up.
     guards and outputs
   - simple comparison and boolean guard expressions over already-bound
     intermediates in those chains
+  - structured fan-out chains where one earlier bound value feeds multiple
+    later derived outputs or conditions
   - supported literal-headed multi-clause branch bodies that keep those chains
     native by using `let` for new intermediate locals
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -330,6 +330,8 @@ Current TypR lowering policy is intentionally mixed:
   in native TypR when those guards depend on earlier bound values
 - simple comparison and boolean guard expressions over already-bound
   intermediates may also stay native in those control-flow chains
+- structured fan-out chains may also stay native when one earlier bound value
+  feeds multiple later derived outputs or conditions
 - supported literal-headed branch bodies may also stay native when those chains
   fit inside a TypR `if` branch with `let`-introduced intermediate locals
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -32,6 +32,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      guards and outputs
    - simple comparison and boolean guard expressions over already-bound
      intermediates in those chains
+   - structured fan-out chains where one earlier bound value feeds multiple
+     later derived outputs or conditions
    - supported literal-headed branch bodies that keep those chains native by
      using `let` for newly introduced locals inside TypR branches
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
@@ -202,7 +204,10 @@ Completed:
 11. Extended the native guard path again so simple comparison and boolean
     expressions over already-bound intermediates can stay native in both
     top-level control-flow chains and supported branch bodies.
-12. Added structured diagnostics aggregation on the `r` side via
+12. Captured structured native fan-out chains as part of the supported TypR
+    subset, where one earlier bound value feeds multiple later outputs or
+    conditions without falling back to wrapped R.
+13. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
 
@@ -231,10 +236,11 @@ Current implementation note:
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
   predicates, sequential guard/output control-flow chains, simple comparison
-  and boolean guard expressions over already-bound intermediates, native
-  literal-headed branch bodies built from those chains, dataframe helper calls,
-  and literal-guarded branch selection; more complex bodies still fall back to
-  wrapped R
+  and boolean guard expressions over already-bound intermediates, structured
+  fan-out chains where one earlier value feeds multiple later outputs or
+  conditions, native literal-headed branch bodies built from those chains,
+  dataframe helper calls, and literal-guarded branch selection; more complex
+  bodies still fall back to wrapped R
 
 Follow-on work:
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -27,6 +27,8 @@ cleanup_typr_test :-
     retractall(user:multi_clause_chain(_, _)),
     retractall(user:comparison_guard_chain(_, _)),
     retractall(user:comparison_clause_chain(_, _)),
+    retractall(user:fanout_chain(_, _)),
+    retractall(user:fanout_clause_chain(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -226,6 +228,34 @@ test(comparison_guard_branch_bodies_stay_native) :-
     once(sub_string(Code, _, _, _, "else if")),
     once(sub_string(Code, _, _, _, "let v3 <- @{ nchar(v2) }@;")),
     once(sub_string(Code, _, _, _, "if (@{ v3 > 1 }@)")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(fanout_chains_reuse_one_intermediate_across_multiple_later_outputs) :-
+    clear_type_declarations,
+    assertz(user:(fanout_chain(Name, Out) :- string_lower(Name, Lower), string_length(Lower, Len), >(Len, 1), string_upper(Lower, Upper), string_concat(Lower, '?', Tagged), string_length(Tagged, TaggedLen), <(TaggedLen, 20), string_concat(Upper, Tagged, Out))),
+    assertz(type_declarations:uw_type(fanout_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(fanout_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(fanout_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ tolower(arg1) }@;")),
+    once(sub_string(Code, _, _, _, "let v5 <- if (@{ v4 > 1 }@)")),
+    once(sub_string(Code, _, _, _, "let v6 <- @{ paste0(v3, \"?\") }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- if (@{ v7 < 20 }@)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(fanout_branch_bodies_stay_native) :-
+    clear_type_declarations,
+    assertz(user:(fanout_clause_chain(short, Out) :- string_lower('HI', Lower), string_length(Lower, Len), >(Len, 1), string_upper(Lower, Upper), string_concat(Lower, '?', Tagged), string_concat(Upper, Tagged, Out))),
+    assertz(user:(fanout_clause_chain(long, Out) :- string_lower('BYE', Lower), string_length(Lower, Len), >(Len, 2), string_upper(Lower, Upper), string_concat(Lower, '?', Tagged), string_concat(Upper, Tagged, Out))),
+    assertz(type_declarations:uw_type(fanout_clause_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(fanout_clause_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(fanout_clause_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "else if")),
+    once(sub_string(Code, _, _, _, "let v4 <- if (@{ v3 > 1 }@)")),
+    once(sub_string(Code, _, _, _, "let v5 <- @{ paste0(v2, \"?\") }@;")),
+    once(sub_string(Code, _, _, _, "let arg2 <- @{ paste0(v4, v5) }@;")),
     \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).


### PR DESCRIPTION
## Summary

This PR formalizes another part of the conservative native TypR subset: structured fan-out control-flow chains where one earlier bound value feeds multiple later outputs or conditions.

The key point is that this support already exists in the current native TypR lowering path. This PR makes that behavior explicit by adding focused regression coverage and updating the docs to describe it as part of the supported contract.

This is intentionally scoped as a contract/coverage PR rather than a broad new lowering rewrite.

## Why This PR Exists

The previous TypR work had already established native support for:

- simple binding chains
- guard-style command predicates
- sequential dependent guard/output chains
- comparison-guard chains over bound intermediates
- supported native branch bodies with `let`-bound locals

That suggested the next gap would be structured fan-out, where one earlier bound intermediate is reused across multiple later steps.

After probing that shape directly, it turned out the current native TypR emitter already handles it correctly for conservative cases such as:

```prolog
fanout_chain(Name, Out) :-
    string_lower(Name, Lower),
    string_length(Lower, Len),
    >(Len, 1),
    string_upper(Lower, Upper),
    string_concat(Lower, '?', Tagged),
    string_length(Tagged, TaggedLen),
    <(TaggedLen, 20),
    string_concat(Upper, Tagged, Out).
```

That meant the right next step was not more emitter churn. The right step was to lock the behavior in with tests and docs so this support becomes explicit rather than incidental.

## Main Changes

### 1. Added regression coverage for native fan-out control-flow chains

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New tests verify native TypR lowering for structured fan-out chains where:

- one earlier bound value is reused in multiple later derived outputs
- one of those later steps may still participate in a guard
- the overall predicate remains in native TypR
- wrapped-R fallback is not used
- generated code still passes real `typr check`

### 2. Added coverage for native fan-out inside supported branch bodies

The new tests also verify that supported literal-headed multi-clause predicates can keep the same fan-out structure natively inside branch bodies.

That matters because the earlier TypR work already established that native top-level lowering and native branch-body lowering do not always fail at the same boundary. This PR confirms that the fan-out shape works in both places for the current conservative subset.

### 3. Documentation now reflects native fan-out as part of the supported TypR subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly describe native fan-out support for conservative shapes where one earlier bound value feeds multiple later outputs or conditions.

### 4. Scope deliberately stayed narrow

This PR does **not** introduce a new generic lowering algorithm.

Instead, it:

- probes an already plausible native shape
- confirms the emitter already supports it
- adds tests so that support is preserved
- updates docs so the supported contract matches reality

That is the right tradeoff here because it raises confidence without inventing new complexity unnecessarily.

## Files Changed

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- existing shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for structured fan-out control-flow chains
- continued TypR CLI validation for generated output

What it does not claim:

- full repo-wide regression coverage
- arbitrary-body native TypR lowering
- elimination of wrapped-R fallback for unsupported generic TypR bodies

## Behavior Notes

After this PR, the explicitly documented native TypR subset includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- comparison and boolean guard expressions over already-bound intermediates
- structured fan-out chains where one earlier bound value feeds multiple later outputs or conditions
- supported literal-headed branch bodies built from those chains
- selected dataframe helpers

More complex generic bodies still fall back to wrapped R.

## Scope and Remaining Gaps

Implemented now:

- explicit regression coverage for native TypR fan-out chains
- explicit regression coverage for native fan-out inside supported branch bodies
- docs updated so the supported TypR subset matches actual emitter behavior

Still not fully implemented:

- full arbitrary-body native TypR lowering
- broader native lowering for more complex clause-local control flow
- complete elimination of wrapped-R fallback for unsupported TypR cases

## Why This PR Is Worth Merging

This PR strengthens the TypR backend contract in a disciplined way.

It gives the project:

- stronger confidence that existing native fan-out support will not regress
- clearer documentation of what the TypR backend actually supports today
- less ambiguity between “currently works” and “officially supported”
- focused tests backed by real TypR toolchain validation

In short, this is a good incremental PR because it converts already-working native behavior into explicit, defended backend coverage.
