### PR TITLE
Document native TypR split-and-recombine chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ includes:
   intermediates
 - structured fan-out chains where one earlier bound value feeds multiple later
   derived outputs or conditions
+- structured split-and-recombine chains where guarded derived values are later
+  combined into a final native output
 - supported literal-headed branch bodies built from those chains, with `let`
   used for new intermediate TypR locals
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -160,6 +160,8 @@ bring-up.
     intermediates in those chains
   - structured fan-out chains where one earlier bound value feeds multiple
     later derived outputs or conditions
+  - structured split-and-recombine chains where those guarded derived values
+    later feed a combined output
   - supported literal-headed multi-clause branch bodies that keep those chains
     native by using `let` for new intermediate locals
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -332,6 +332,8 @@ Current TypR lowering policy is intentionally mixed:
   intermediates may also stay native in those control-flow chains
 - structured fan-out chains may also stay native when one earlier bound value
   feeds multiple later derived outputs or conditions
+- structured split-and-recombine chains may also stay native when those guarded
+  derived values later feed a combined output
 - supported literal-headed branch bodies may also stay native when those chains
   fit inside a TypR `if` branch with `let`-introduced intermediate locals
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -34,6 +34,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      intermediates in those chains
    - structured fan-out chains where one earlier bound value feeds multiple
      later derived outputs or conditions
+   - structured split-and-recombine chains where those guarded derived values
+     later feed a combined output
    - supported literal-headed branch bodies that keep those chains native by
      using `let` for newly introduced locals inside TypR branches
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
@@ -207,7 +209,10 @@ Completed:
 12. Captured structured native fan-out chains as part of the supported TypR
     subset, where one earlier bound value feeds multiple later outputs or
     conditions without falling back to wrapped R.
-13. Added structured diagnostics aggregation on the `r` side via
+13. Captured structured native split-and-recombine chains as part of the
+    supported TypR subset, where guarded derived values later feed a combined
+    native output without falling back to wrapped R.
+14. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
 
@@ -238,9 +243,10 @@ Current implementation note:
   predicates, sequential guard/output control-flow chains, simple comparison
   and boolean guard expressions over already-bound intermediates, structured
   fan-out chains where one earlier value feeds multiple later outputs or
-  conditions, native literal-headed branch bodies built from those chains,
-  dataframe helper calls, and literal-guarded branch selection; more complex
-  bodies still fall back to wrapped R
+  conditions, structured split-and-recombine chains where guarded derived
+  values later feed a combined output, native literal-headed branch bodies
+  built from those chains, dataframe helper calls, and literal-guarded branch
+  selection; more complex bodies still fall back to wrapped R
 
 Follow-on work:
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -29,6 +29,8 @@ cleanup_typr_test :-
     retractall(user:comparison_clause_chain(_, _)),
     retractall(user:fanout_chain(_, _)),
     retractall(user:fanout_clause_chain(_, _)),
+    retractall(user:split_recombine_chain(_, _)),
+    retractall(user:split_recombine_clause_chain(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -256,6 +258,33 @@ test(fanout_branch_bodies_stay_native) :-
     once(sub_string(Code, _, _, _, "let v4 <- if (@{ v3 > 1 }@)")),
     once(sub_string(Code, _, _, _, "let v5 <- @{ paste0(v2, \"?\") }@;")),
     once(sub_string(Code, _, _, _, "let arg2 <- @{ paste0(v4, v5) }@;")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(split_recombine_chains_stay_native) :-
+    clear_type_declarations,
+    assertz(user:(split_recombine_chain(Name, Out) :- string_lower(Name, Lower), string_length(Lower, LowerLen), >(LowerLen, 1), string_upper(Lower, Upper), string_length(Upper, UpperLen), <(UpperLen, 10), string_concat(Lower, '?', Tagged), string_length(Tagged, TaggedLen), <(TaggedLen, 20), string_concat(Upper, Tagged, Out))),
+    assertz(type_declarations:uw_type(split_recombine_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(split_recombine_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(split_recombine_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let v5 <- if (@{ v4 > 1 }@)")),
+    once(sub_string(Code, _, _, _, "let v7 <- if (@{ v6 < 10 }@)")),
+    once(sub_string(Code, _, _, _, "arg2 <- if (@{ v8 < 20 }@)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(split_recombine_branch_bodies_stay_native) :-
+    clear_type_declarations,
+    assertz(user:(split_recombine_clause_chain(short, Out) :- string_lower('HI', Lower), string_length(Lower, LowerLen), >(LowerLen, 1), string_upper(Lower, Upper), string_length(Upper, UpperLen), <(UpperLen, 10), string_concat(Lower, '?', Tagged), string_length(Tagged, TaggedLen), <(TaggedLen, 20), string_concat(Upper, Tagged, Out))),
+    assertz(user:(split_recombine_clause_chain(long, Out) :- string_lower('BYE', Lower), string_length(Lower, LowerLen), >(LowerLen, 2), string_upper(Lower, Upper), string_length(Upper, UpperLen), <(UpperLen, 10), string_concat(Lower, '?', Tagged), string_length(Tagged, TaggedLen), <(TaggedLen, 20), string_concat(Upper, Tagged, Out))),
+    assertz(type_declarations:uw_type(split_recombine_clause_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(split_recombine_clause_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(split_recombine_clause_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "else if")),
+    once(sub_string(Code, _, _, _, "let v4 <- if (@{ v3 > 1 }@)")),
+    once(sub_string(Code, _, _, _, "let v6 <- if (@{ v5 < 10 }@)")),
+    once(sub_string(Code, _, _, _, "arg2 <- if (@{ v7 < 20 }@)")),
     \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).


### PR DESCRIPTION
## Summary

This PR formalizes another part of the conservative native TypR subset: structured split-and-recombine control-flow chains where guarded derived values are later combined into a final native output.

The key point is the same as the recent fan-out work: this support already exists in the current native TypR lowering path. This PR makes that behavior explicit by adding focused regression coverage and updating the docs to describe it as part of the supported contract.

This is intentionally a contract/coverage PR, not a broad new lowering rewrite.

## Why This PR Exists

The previous TypR work had already established native support for:

- simple binding chains
- guard-style command predicates
- sequential dependent guard/output chains
- comparison-guard chains over bound intermediates
- structured fan-out chains
- supported native branch bodies with `let`-bound locals

That suggested the next likely gap would be split-and-recombine control flow, where:

- one earlier bound value feeds multiple guarded derived values
- those derived values are then recombined into a later output

After probing that shape directly, it turned out the current native TypR emitter already handles it correctly for conservative cases such as:

```prolog
split_recombine_chain(Name, Out) :-
    string_lower(Name, Lower),
    string_length(Lower, LowerLen),
    >(LowerLen, 1),
    string_upper(Lower, Upper),
    string_length(Upper, UpperLen),
    <(UpperLen, 10),
    string_concat(Lower, '?', Tagged),
    string_length(Tagged, TaggedLen),
    <(TaggedLen, 20),
    string_concat(Upper, Tagged, Out).
```

That meant the right next step was not to rewrite the emitter. The right next step was to add regression coverage and update the docs so this support becomes explicit rather than accidental.

## Main Changes

### 1. Added regression coverage for native split-and-recombine chains

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New tests verify native TypR lowering for structured split-and-recombine chains where:

- an earlier bound value feeds one guarded derived value
- that derived value feeds another guarded derived value
- the resulting values are later recombined into a final output
- the overall predicate remains in native TypR
- wrapped-R fallback is not used
- generated code still passes real `typr check`

### 2. Added coverage for split-and-recombine inside supported branch bodies

The new tests also verify that supported literal-headed multi-clause predicates can keep the same split-and-recombine structure natively inside branch bodies.

That matters because top-level native lowering and branch-body native lowering do not always share the same practical boundary. This PR confirms that the current conservative split-and-recombine shape works in both places.

### 3. Documentation now reflects split-and-recombine as part of the supported TypR subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly describe native split-and-recombine support for conservative shapes where guarded derived values later feed a combined output.

### 4. Scope deliberately stayed narrow

This PR does **not** introduce a new generic lowering algorithm.

Instead, it:

- probes an already plausible native shape
- confirms the emitter already supports it
- adds tests so that support is preserved
- updates docs so the supported contract matches reality

That is the right tradeoff here because it increases confidence without broadening implementation complexity unnecessarily.

## Files Changed

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- existing shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for structured split-and-recombine chains
- continued TypR CLI validation for generated output

What it does not claim:

- full repo-wide regression coverage
- arbitrary-body native TypR lowering
- elimination of wrapped-R fallback for unsupported generic TypR bodies

## Behavior Notes

After this PR, the explicitly documented native TypR subset includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- comparison and boolean guard expressions over already-bound intermediates
- structured fan-out chains where one earlier bound value feeds multiple later outputs or conditions
- structured split-and-recombine chains where guarded derived values later feed a combined output
- supported literal-headed branch bodies built from those chains
- selected dataframe helpers

More complex generic bodies still fall back to wrapped R.

## Scope and Remaining Gaps

Implemented now:

- explicit regression coverage for native TypR split-and-recombine chains
- explicit regression coverage for native split-and-recombine inside supported branch bodies
- docs updated so the supported TypR subset matches actual emitter behavior

Still not fully implemented:

- full arbitrary-body native TypR lowering
- broader native lowering for more complex clause-local control flow
- complete elimination of wrapped-R fallback for unsupported TypR cases

## Why This PR Is Worth Merging

This PR strengthens the TypR backend contract in another concrete area.

It gives the project:

- stronger confidence that existing native split-and-recombine support will not regress
- clearer documentation of what the TypR backend actually supports today
- less ambiguity between “currently works” and “officially supported”
- focused tests backed by real TypR toolchain validation

In short, this is a good incremental PR because it converts already-working native behavior into explicit, defended backend coverage.
