### PR TITLE
fix(targets): fix escaped quotes in TC mustache templates, expand runtime tests to 83 , add ancest…

### DIFF
--- a/scripts/runtime_test.sh
+++ b/scripts/runtime_test.sh
@@ -144,6 +144,55 @@ go_test() {
     compile_and_test "Go" "$program" "$expected" go build -o "$TMPDIR/$bin" "$source" -- "$TMPDIR/$bin" "$@"
 }
 
+# pipe_test <lang> <program> <expected> <stdin_data> <command...>
+# Like run_test but pipes stdin_data into the command
+pipe_test() {
+    local lang="$1" program="$2" expected="$3" stdin_data="$4"
+    shift 4
+    local result
+    result=$(echo -e "$stdin_data" | "$@" 2>&1) || true
+    check_result "$lang" "$program" "$expected" "$result"
+}
+
+# pipe_compile_test <lang> <program> <expected> <stdin_data> <compile_cmd> -- <run_cmd>
+# Like compile_and_test but pipes stdin_data into the run command
+pipe_compile_test() {
+    local lang="$1" program="$2" expected="$3" stdin_data="$4"
+    shift 4
+    local compile_args=()
+    while [ "$1" != "--" ]; do compile_args+=("$1"); shift; done
+    shift  # skip --
+    if "${compile_args[@]}" 2>/dev/null; then
+        local result
+        result=$(echo -e "$stdin_data" | "$@" 2>&1) || true
+        check_result "$lang" "$program" "$expected" "$result"
+    else
+        check_result "$lang" "$program" "$expected" "compile_error"
+    fi
+}
+
+# java_pkg_test <program_label> <expected> <source_file> <stdin_data> <args...>
+# Like java_test but strips 'package ...' line and supports stdin piping
+java_pkg_test() {
+    local program="$1" expected="$2" source="$3" stdin_data="$4"
+    shift 4
+    local jclass
+    jclass=$(grep -o 'class [A-Za-z_]*' "$source" 2>/dev/null | head -1 | awk '{print $2}')
+    if [ -z "$jclass" ]; then
+        check_result "Java" "$program" "$expected" "no_class_found"
+        return
+    fi
+    # Strip package declaration for simple compilation
+    sed '/^package /d' "$source" > "$TMPDIR/${jclass}.java" 2>/dev/null || true
+    if javac "$TMPDIR/${jclass}.java" 2>/dev/null; then
+        local result
+        result=$(echo -e "$stdin_data" | java -cp "$TMPDIR" "$jclass" "$@" 2>&1) || true
+        check_result "Java" "$program" "$expected" "$result"
+    else
+        check_result "Java" "$program" "$expected" "compile_error"
+    fi
+}
+
 echo ""
 echo "╔════════════════════════════════════════════════════════╗"
 echo "║  RUNTIME TESTING — Compile & Execute                   ║"
@@ -376,6 +425,97 @@ if has_cmd go; then
 fi
 
 # ============================================================================
+# ANCESTOR: ancestor(tom, dave) = tom:dave (transitive closure)
+# ============================================================================
+echo ""
+echo -e "${BOLD}--- ancestor(tom,dave) = tom:dave [transitive] ---${NC}"
+
+ANCESTOR_FACTS="tom:bob\nbob:charlie\ncharlie:dave"
+
+has_cmd ruby    && pipe_test "Ruby"   "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" ruby "$DIR/ancestor.rb" tom dave        || true
+has_cmd perl    && pipe_test "Perl"   "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" perl "$DIR/ancestor.pl" tom dave        || true
+has_cmd lua     && pipe_test "Lua"    "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" lua "$DIR/ancestor.lua" tom dave        || true
+has_cmd python3 && pipe_test "Python" "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" python3 "$DIR/ancestor.jy.py" tom dave || true
+has_cmd Rscript && pipe_test "R"      "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" Rscript "$DIR/ancestor.R" tom dave     || true
+if has_cmd node; then
+    R=$(echo -e "$ANCESTOR_FACTS" | node "$DIR/ancestor.ts" tom dave 2>/dev/null) || true
+    check_result "Node" "ancestor(tom,dave)" "tom:dave" "$R"
+fi
+
+if has_cmd gcc; then
+    pipe_compile_test "C" "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" gcc -o "$TMPDIR/anc_c" "$DIR/ancestor.c" -lm -- "$TMPDIR/anc_c" tom dave
+fi
+
+if has_cmd g++; then
+    pipe_compile_test "C++" "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" g++ -o "$TMPDIR/anc_cpp" "$DIR/ancestor.cpp" -- "$TMPDIR/anc_cpp" tom dave
+fi
+
+if has_cmd javac; then
+    java_pkg_test "ancestor(tom,dave)" "tom:dave" "$DIR/ancestor.java" "$ANCESTOR_FACTS" tom dave
+fi
+
+if has_cmd kotlinc; then
+    # Strip package declaration for Kotlin ancestor
+    sed '/^package /d' "$DIR/ancestor.kt" > "$TMPDIR/ancestor_kt.kt" 2>/dev/null || true
+    if kotlinc "$TMPDIR/ancestor_kt.kt" -include-runtime -d "$TMPDIR/anc_kt.jar" 2>/dev/null; then
+        R=$(echo -e "$ANCESTOR_FACTS" | java -jar "$TMPDIR/anc_kt.jar" tom dave 2>&1) || true
+        check_result "Kotlin" "ancestor(tom,dave)" "tom:dave" "$R"
+    else
+        check_result "Kotlin" "ancestor(tom,dave)" "tom:dave" "compile_error"
+    fi
+fi
+
+if has_cmd scalac && [ -n "$SCALA_LIB" ] && [ -n "$SCALA3_LIB" ]; then
+    sed '/^package /d' "$DIR/ancestor.scala" > "$TMPDIR/ancestor_sc.scala" 2>/dev/null || true
+    mkdir -p "$TMPDIR/scala_anc"
+    if scalac "$TMPDIR/ancestor_sc.scala" -d "$TMPDIR/scala_anc" 2>/dev/null; then
+        R=$(echo -e "$ANCESTOR_FACTS" | java -cp "$TMPDIR/scala_anc:$SCALA_LIB:$SCALA3_LIB" ANCESTORQuery tom dave 2>&1) || true
+        check_result "Scala" "ancestor(tom,dave)" "tom:dave" "$R"
+    else
+        check_result "Scala" "ancestor(tom,dave)" "tom:dave" "compile_error"
+    fi
+fi
+
+if has_cmd rustc; then
+    pipe_compile_test "Rust" "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" rustc -o "$TMPDIR/anc_rs" "$DIR/ancestor.rs" -- "$TMPDIR/anc_rs" tom dave
+fi
+
+if has_cmd go; then
+    pipe_compile_test "Go" "ancestor(tom,dave)" "tom:dave" "$ANCESTOR_FACTS" go build -o "$TMPDIR/anc_go" "$DIR/ancestor.go" -- "$TMPDIR/anc_go" tom dave
+fi
+
+# ============================================================================
+# TREE_FIB(10) = 55 (tree recursion — advanced output, limited targets)
+# ============================================================================
+ADVDIR="output/advanced"
+if [ -d "$ADVDIR" ]; then
+    echo ""
+    echo -e "${BOLD}--- tree_fib(10) = 55 [tree recursion] ---${NC}"
+
+    has_cmd lua && [ -f "$ADVDIR/tree_fib.lua" ] && run_test "Lua" "tree_fib(10)" "55" lua "$ADVDIR/tree_fib.lua" 10 || true
+
+    if has_cmd gcc && [ -f "$ADVDIR/tree_fib.c" ]; then
+        compile_and_test "C" "tree_fib(10)" "55" gcc -o "$TMPDIR/tfib_c" "$ADVDIR/tree_fib.c" -lm -- "$TMPDIR/tfib_c" 10
+    fi
+
+    # R tree_fib is a tree-sum (different pattern), skip — no numeric CLI
+
+    # ============================================================================
+    # FIB_DIRECT(10) = 55 (direct multicall — advanced output, limited targets)
+    # ============================================================================
+    echo ""
+    echo -e "${BOLD}--- fib_direct(10) = 55 [direct multicall] ---${NC}"
+
+    has_cmd lua && [ -f "$ADVDIR/fib_direct.lua" ] && run_test "Lua" "fib_direct(10)" "55" lua "$ADVDIR/fib_direct.lua" 10 || true
+
+    if has_cmd gcc && [ -f "$ADVDIR/fib_direct.c" ]; then
+        compile_and_test "C" "fib_direct(10)" "55" gcc -o "$TMPDIR/dfib_c" "$ADVDIR/fib_direct.c" -lm -- "$TMPDIR/dfib_c" 10
+    fi
+
+    has_cmd Rscript && [ -f "$ADVDIR/fib_direct.R" ] && run_test "R" "fib_direct(10)" "55" Rscript "$ADVDIR/fib_direct.R" 10 || true
+fi
+
+# ============================================================================
 # PROOT DEBIAN TESTS (Termux only, optional)
 # ============================================================================
 USE_PROOT=false
@@ -405,6 +545,19 @@ if $USE_PROOT; then
         check_result "Haskell" "is_even(4)" "True" "$R"
         R=$(proot_run "cd $PROOT_DIR && ghc -o count_hs count.hs -no-keep-hi-files -no-keep-o-files 2>/dev/null && ./count_hs 1,2,3,4,5")
         check_result "Haskell" "count(5 items)" "5" "$R"
+        R=$(proot_run "cd $PROOT_DIR && ghc -o anc_hs ancestor.hs -no-keep-hi-files -no-keep-o-files 2>/dev/null && echo -e 'tom:bob\nbob:charlie\ncharlie:dave' | ./anc_hs tom dave")
+        check_result "Haskell" "ancestor(tom,dave)" "tom:dave" "$R"
+
+        # Haskell advanced patterns (tree_fib, fib_direct)
+        PROOT_ADV="$(cd "$(dirname "$0")/.." && pwd)/output/advanced"
+        if [ -f "$PROOT_ADV/tree_fib.hs" ]; then
+            R=$(proot_run "cd $PROOT_ADV && ghc -o tfib_hs tree_fib.hs -no-keep-hi-files -no-keep-o-files 2>/dev/null && ./tfib_hs 10")
+            check_result "Haskell" "tree_fib(10)" "55" "$R"
+        fi
+        if [ -f "$PROOT_ADV/fib_direct.hs" ]; then
+            R=$(proot_run "cd $PROOT_ADV && ghc -o dfib_hs fib_direct.hs -no-keep-hi-files -no-keep-o-files 2>/dev/null && ./dfib_hs 10")
+            check_result "Haskell" "fib_direct(10)" "55" "$R"
+        fi
 
         # F# (dotnet fsi) — rewrite [<EntryPoint>] to fsi.CommandLineArgs for script mode
         echo ""
@@ -427,6 +580,23 @@ if $USE_PROOT; then
         check_result "F#" "is_even(4)" "true" "$R"
         R=$(fsi_run "$PROOT_DIR/list_sum.fs" 1,2,3,4,5)
         check_result "F#" "list_sum(5)" "15" "$R"
+        # F# ancestor: needs stdin piping — use direct fsi invocation
+        R=$(proot-distro login debian -- bash -c "
+            sed 's/\[<EntryPoint>\]//' '$PROOT_DIR/ancestor.fs' | \
+            sed 's/let main argv =/let argv = fsi.CommandLineArgs.[1..] in ignore (/' | \
+            sed 's/^    0$/    0)/' | \
+            sed 's/^        1$/        1)/' > /tmp/_fsi_anc.fsx && \
+            echo -e 'tom:bob\nbob:charlie\ncharlie:dave' | ~/.dotnet/dotnet fsi /tmp/_fsi_anc.fsx tom dave" 2>&1 | grep -v '^Warning:\|^>' | tail -1)
+        check_result "F#" "ancestor(tom,dave)" "tom:dave" "$R"
+        # F# advanced patterns
+        if [ -f "$PROOT_ADV/tree_fib.fs" ]; then
+            R=$(fsi_run "$PROOT_ADV/tree_fib.fs" 10)
+            check_result "F#" "tree_fib(10)" "55" "$R"
+        fi
+        if [ -f "$PROOT_ADV/fib_direct.fs" ]; then
+            R=$(fsi_run "$PROOT_ADV/fib_direct.fs" 10)
+            check_result "F#" "fib_direct(10)" "55" "$R"
+        fi
 
         # Clojure
         echo ""
@@ -446,6 +616,8 @@ if $USE_PROOT; then
         check_result "Clojure" "is_even(4)" "true" "$R"
         R=$(proot_run "cd $PROOT_DIR && java -cp '$CLJ_CP' clojure.main list_sum.clj 1,2,3,4,5")
         check_result "Clojure" "list_sum(5)" "15" "$R"
+        R=$(proot_run "cd $PROOT_DIR && echo -e 'tom:bob\nbob:charlie\ncharlie:dave' | java -cp '$CLJ_CP' clojure.main ancestor.clj tom dave")
+        check_result "Clojure" "ancestor(tom,dave)" "tom:dave" "$R"
 
         # Elixir (proot)
         echo ""
@@ -458,6 +630,17 @@ if $USE_PROOT; then
         check_result "Elixir/pr" "is_even(4)" "true" "$R"
         R=$(proot_run "cd $PROOT_DIR && elixir list_sum.ex 1,2,3,4,5")
         check_result "Elixir/pr" "list_sum(5)" "15" "$R"
+        R=$(proot_run "cd $PROOT_DIR && echo -e 'tom:bob\nbob:charlie\ncharlie:dave' | elixir ancestor.ex tom dave")
+        check_result "Elixir/pr" "ancestor(tom,dave)" "tom:dave" "$R"
+        # Elixir advanced patterns
+        if [ -f "$PROOT_ADV/tree_fib.exs" ]; then
+            R=$(proot_run "cd $PROOT_ADV && elixir tree_fib.exs 10")
+            check_result "Elixir/pr" "tree_fib(10)" "55" "$R"
+        fi
+        if [ -f "$PROOT_ADV/fib_direct.exs" ]; then
+            R=$(proot_run "cd $PROOT_ADV && elixir fib_direct.exs 10")
+            check_result "Elixir/pr" "fib_direct(10)" "55" "$R"
+        fi
     fi
 fi
 

--- a/templates/targets/clojure/transitive_closure.mustache
+++ b/templates/targets/clojure/transitive_closure.mustache
@@ -38,14 +38,14 @@
 (defn -main [& args]
   (doseq [line (line-seq (java.io.BufferedReader. *in*))]
     (when (seq line)
-      (let [[from to] (clojure.string/split line #\":\")]
+      (let [[from to] (clojure.string/split line #":")]
         (when (and from to)
           (add-fact (clojure.string/trim from) (clojure.string/trim to))))))
   (case (count args)
-    0 (do (binding [*out* *err*] (println \"Usage: clojure {{pred}}_query.clj <start> [target]\"))
+    0 (do (binding [*out* *err*] (println "Usage: clojure {{pred}}_query.clj <start> [target]"))
           (System/exit 1))
     1 (doseq [r (find-all (first args))]
-        (println (str (first args) \":\" r)))
+        (println (str (first args) ":" r)))
     (if (check-path (first args) (second args))
-      (println (str (first args) \":\" (second args)))
+      (println (str (first args) ":" (second args)))
       (System/exit 1))))

--- a/templates/targets/kotlin/transitive_closure.mustache
+++ b/templates/targets/kotlin/transitive_closure.mustache
@@ -56,12 +56,12 @@ object {{pred_cap}}Query {
 
 fun main(args: Array<String>) {
     generateSequence(::readLine).filter { it.isNotBlank() }.forEach { line ->
-        val parts = line.split(\":\")
+        val parts = line.split(":")
         if (parts.size >= 2) {{pred_cap}}Query.addFact(parts[0].trim(), parts[1].trim())
     }
     when {
-        args.isEmpty() -> { System.err.println(\"Usage: kotlin {{pred_cap}}QueryKt <start> [target]\"); kotlin.system.exitProcess(1) }
-        args.size == 1 -> {{pred_cap}}Query.findAll(args[0]).forEach { println(\"${args[0]}:$it\") }
-        else -> if ({{pred_cap}}Query.check(args[0], args[1])) println(\"${args[0]}:${args[1]}\") else kotlin.system.exitProcess(1)
+        args.isEmpty() -> { System.err.println("Usage: kotlin {{pred_cap}}QueryKt <start> [target]"); kotlin.system.exitProcess(1) }
+        args.size == 1 -> {{pred_cap}}Query.findAll(args[0]).forEach { println("${args[0]}:$it") }
+        else -> if ({{pred_cap}}Query.check(args[0], args[1])) println("${args[0]}:${args[1]}") else kotlin.system.exitProcess(1)
     }
 }

--- a/templates/targets/powershell/transitive_closure.mustache
+++ b/templates/targets/powershell/transitive_closure.mustache
@@ -60,20 +60,20 @@ $query = [{{pred}}Query]::new()
 # Read {{base}} facts from stdin (format: from:to)
 $input | ForEach-Object {
     $line = $_.Trim()
-    if ($line -match \"^([^:]+):(.+)$\") {
+    if ($line -match "^([^:]+):(.+)$") {
         $query.AddFact($Matches[1].Trim(), $Matches[2].Trim())
     }
 }
 
 if ($args.Count -eq 1) {
-    $query.FindAll($args[0]) | ForEach-Object { \"$($args[0]):$_\" }
+    $query.FindAll($args[0]) | ForEach-Object { "$($args[0]):$_" }
 } elseif ($args.Count -eq 2) {
     if ($query.Check($args[0], $args[1])) {
-        \"$($args[0]):$($args[1])\"
+        "$($args[0]):$($args[1])"
     } else {
         exit 1
     }
 } else {
-    Write-Error \"Usage: $($MyInvocation.MyCommand.Name) <start> [target]\"
+    Write-Error "Usage: $($MyInvocation.MyCommand.Name) <start> [target]"
     exit 1
 }

--- a/templates/targets/python/transitive_closure.mustache
+++ b/templates/targets/python/transitive_closure.mustache
@@ -43,25 +43,25 @@ class {{pred_cap}}Query:
         return False
 
 
-if __name__ == \"__main__\":
+if __name__ == "__main__":
     query = {{pred_cap}}Query()
 
     # Read {{base}} facts from stdin (format: from:to)
     for line in sys.stdin:
         line = line.strip()
-        if \":\" in line:
-            from_node, to_node = line.split(\":\", 1)
+        if ":" in line:
+            from_node, to_node = line.split(":", 1)
             query.add_fact(from_node.strip(), to_node.strip())
 
     args = sys.argv[1:]
     if len(args) == 1:
         for r in query.find_all(args[0]):
-            print(f\"{args[0]}:{r}\")
+            print(f"{args[0]}:{r}")
     elif len(args) == 2:
         if query.check(args[0], args[1]):
-            print(f\"{args[0]}:{args[1]}\")
+            print(f"{args[0]}:{args[1]}")
         else:
             sys.exit(1)
     else:
-        print(f\"Usage: {sys.argv[0]} <start> [target]\", file=sys.stderr)
+        print(f"Usage: {sys.argv[0]} <start> [target]", file=sys.stderr)
         sys.exit(1)

--- a/templates/targets/scala/transitive_closure.mustache
+++ b/templates/targets/scala/transitive_closure.mustache
@@ -26,7 +26,7 @@ object {{pred_cap}}Query {
 
     while (queue.nonEmpty) {
       val current = queue.dequeue()
-      baseRelation.getOrElse(current, Set()).foreach { next =>
+      baseRelation.getOrElse(current, Set.empty[String]).foreach { next =>
         if (!visited.contains(next)) {
           visited += next
           queue.enqueue(next)
@@ -45,7 +45,7 @@ object {{pred_cap}}Query {
     visited += start
     while (queue.nonEmpty) {
       val current = queue.dequeue()
-      baseRelation.getOrElse(current, Set()).foreach { next =>
+      baseRelation.getOrElse(current, Set.empty[String]).foreach { next =>
         if (next == target) return true
         if (!visited.contains(next)) {
           visited += next
@@ -58,13 +58,13 @@ object {{pred_cap}}Query {
 
   def main(args: Array[String]): Unit = {
     Iterator.continually(StdIn.readLine()).takeWhile(_ != null).filter(_.nonEmpty).foreach { line =>
-      val parts = line.split(\":\")
+      val parts = line.split(":")
       if (parts.length >= 2) addFact(parts(0).trim, parts(1).trim)
     }
     args.toList match {
-      case Nil => System.err.println(\"Usage: scala {{pred_cap}}Query <start> [target]\"); sys.exit(1)
-      case start :: Nil => findAll(start).foreach(r => println(s\"$start:$r\"))
-      case start :: target :: _ => if (check(start, target)) println(s\"$start:$target\") else sys.exit(1)
+      case Nil => System.err.println("Usage: scala {{pred_cap}}Query <start> [target]"); sys.exit(1)
+      case start :: Nil => findAll(start).foreach(r => println(s"$start:$r"))
+      case start :: target :: _ => if (check(start, target)) println(s"$start:$target") else sys.exit(1)
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Fix escaped quote bug in 5 transitive closure mustache templates** (Kotlin, Scala, Python, Clojure, PowerShell): templates contained Prolog-escaped `\"` instead of plain `"`, producing invalid source code that failed to compile. The Kotlin and Scala ancestor outputs were completely broken by this.
- **Fix Scala 3 type inference error** in transitive closure template: `getOrElse(current, Set())` inferred `String | Any` because `Set()` is `Set[Nothing]` in Scala 3. Changed to `Set.empty[String]` for correct type narrowing.
- **Add ancestor (transitive closure) runtime tests** for all 13 Termux-native languages (Ruby, Perl, Lua, Python, R, Node, C, C++, Java, Kotlin, Scala, Rust, Go) — tests pipe `from:to` facts via stdin and verify BFS reachability with `ancestor(tom, dave) = tom:dave`.
- **Add tree_fib and fib_direct runtime tests** from `output/advanced/` for Lua, C, and R (the languages with generated numeric-input CLI outputs).
- **Add pipe_test/pipe_compile_test/java_pkg_test helpers** to `runtime_test.sh` for tests requiring stdin piping and `package` line stripping (needed by ancestor's graph-query interface).
- **Expand proot tests** with ancestor, tree_fib, and fib_direct for Haskell, F#, Clojure, and Elixir.

## Changed files

| File | Change |
|------|--------|
| `templates/targets/kotlin/transitive_closure.mustache` | Fix `\"` → `"` |
| `templates/targets/scala/transitive_closure.mustache` | Fix `\"` → `"`, `Set()` → `Set.empty[String]` |
| `templates/targets/python/transitive_closure.mustache` | Fix `\"` → `"` |
| `templates/targets/clojure/transitive_closure.mustache` | Fix `\"` → `"` |
| `templates/targets/powershell/transitive_closure.mustache` | Fix `\"` → `"` |
| `scripts/runtime_test.sh` | Add ancestor/tree_fib/fib_direct sections, pipe helpers, proot expansion |

## Test results

```
83 passed, 0 failed, 1 skipped (Elixir — needs proot on Termux)
```

## Pattern coverage (7/7 patterns now tested)

| Pattern | Languages tested | Status |
|---------|-----------------|--------|
| factorial (linear/numeric) | 13 native + 4 proot | Existing |
| fib (multicall) | 13 native + 4 proot | Existing |
| is_even (mutual) | 13 native + 4 proot | Existing |
| count (tail/list) | 13 native + 4 proot | Existing |
| list_sum (linear/list) | 13 native + 4 proot | Existing |
| **ancestor (transitive)** | **13 native + 4 proot** | **New** |
| **tree_fib (tree recursion)** | **Lua, C + proot** | **New** |
| **fib_direct (direct multicall)** | **Lua, C, R + proot** | **New** |
