### PR TITLE
Keep native TypR guarded alternative assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ includes:
   derived outputs or conditions
 - structured split-and-recombine chains where guarded derived values are later
   combined into a final native output
+- guarded disjunction-style alternative-assignment chains where each native
+  alternative binds the same later intermediate before later native steps
+  continue from the selected result
 - supported literal-headed branch bodies built from those chains, with `let`
   used for new intermediate TypR locals
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -162,6 +162,9 @@ bring-up.
     later derived outputs or conditions
   - structured split-and-recombine chains where those guarded derived values
     later feed a combined output
+  - guarded disjunction-style alternative-assignment chains where each
+    alternative binds the same later intermediate before later native steps
+    continue from the selected result
   - supported literal-headed multi-clause branch bodies that keep those chains
     native by using `let` for new intermediate locals
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -334,6 +334,9 @@ Current TypR lowering policy is intentionally mixed:
   feeds multiple later derived outputs or conditions
 - structured split-and-recombine chains may also stay native when those guarded
   derived values later feed a combined output
+- guarded disjunction-style alternative-assignment chains may also stay native
+  when each alternative binds the same later intermediate and later native
+  steps continue from that selected result
 - supported literal-headed branch bodies may also stay native when those chains
   fit inside a TypR `if` branch with `let`-introduced intermediate locals
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -36,6 +36,9 @@ This document focuses on architecture and rollout choices specific to TypR.
      later derived outputs or conditions
    - structured split-and-recombine chains where those guarded derived values
      later feed a combined output
+   - guarded disjunction-style alternative-assignment chains where each
+     alternative binds the same later intermediate before later native steps
+     continue from the selected result
    - supported literal-headed branch bodies that keep those chains native by
      using `let` for newly introduced locals inside TypR branches
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
@@ -215,6 +218,9 @@ Completed:
 14. Added structured diagnostics aggregation on the `r` side via
    `type_diagnostics_report(Report)`, which TypR can pass through on wrapped
    fallbacks and otherwise defaults to `[]` for native-lowered paths.
+15. Extended the native generic path again so guarded semicolon alternatives
+    can stay in TypR when each alternative binds the same later intermediate
+    and later native steps continue from the selected result.
 
 R-family note:
 
@@ -244,9 +250,11 @@ Current implementation note:
   and boolean guard expressions over already-bound intermediates, structured
   fan-out chains where one earlier value feeds multiple later outputs or
   conditions, structured split-and-recombine chains where guarded derived
-  values later feed a combined output, native literal-headed branch bodies
-  built from those chains, dataframe helper calls, and literal-guarded branch
-  selection; more complex bodies still fall back to wrapped R
+  values later feed a combined output, guarded disjunction-style
+  alternative-assignment chains where each alternative binds the same later
+  intermediate, native literal-headed branch bodies built from those chains,
+  dataframe helper calls, and literal-guarded branch selection; more complex
+  bodies still fall back to wrapped R
 
 Follow-on work:
 

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -377,7 +377,7 @@ native_typr_prefix_goals([], VarMap, _PredName, _SeenOutput, none, [], [], 'true
 native_typr_prefix_goals([], VarMap, _PredName, _SeenOutput, LastExpr, [], [], LastExpr, VarMap) :-
     LastExpr \== none.
 native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, _SeenOutput, _LastExpr0, Conditions, [Line|RestLines], TailCode, VarMapOut) :-
-    native_typr_output_goal(Goal, VarMap0, VarMap1, Line, OutExpr),
+    native_typr_output_goal(Goal, VarMap0, PredName, VarMap1, Line, OutExpr),
     native_typr_prefix_goals(Rest, VarMap1, PredName, true, OutExpr, Conditions, RestLines, TailCode, VarMapOut).
 native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, false, LastExpr, [GuardCondition|RestConditions], RestLines, TailCode, VarMapOut) :-
     native_typr_guard_goal(Goal, VarMap0, GuardCondition),
@@ -393,7 +393,7 @@ native_typr_guarded_tail_sequence(Goals, VarMap0, PredName, LastExpr, Code, VarM
 native_typr_guarded_tail_sequence([], VarMap, PredName, LastExpr, PendingGuards, [], FinalExpr, VarMap) :-
     guard_tail_final_expression(PendingGuards, PredName, LastExpr, FinalExpr).
 native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, _LastExpr0, PendingGuards, [Line|RestLines], FinalExpr, VarMapOut) :-
-    native_typr_output_expr(Goal, VarMap0, VarMap1, OutVar, OutputExpr, IntroKind),
+    native_typr_output_expr(Goal, VarMap0, PredName, VarMap1, OutVar, OutputExpr, IntroKind),
     guard_condition_expression(PendingGuards, GuardExpr),
     conditional_output_line(GuardExpr, PredName, IntroKind, OutVar, OutputExpr, Line),
     native_typr_guarded_tail_sequence(Rest, VarMap1, PredName, OutVar, [], RestLines, FinalExpr, VarMapOut).
@@ -402,35 +402,39 @@ native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, LastExpr, Pend
     append(PendingGuards0, [GuardCondition], PendingGuards),
     native_typr_guarded_tail_sequence(Rest, VarMap0, PredName, LastExpr, PendingGuards, Lines, FinalExpr, VarMapOut).
 
-native_typr_output_goal(_Module:Goal, VarMap0, VarMap, Line, FinalExpr) :-
+native_typr_output_goal(_Module:Goal, VarMap0, PredName, VarMap, Line, FinalExpr) :-
     !,
-    native_typr_output_goal(Goal, VarMap0, VarMap, Line, FinalExpr).
-native_typr_output_goal(Goal, VarMap0, VarMap, Line, FinalExpr) :-
-    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind),
+    native_typr_output_goal(Goal, VarMap0, PredName, VarMap, Line, FinalExpr).
+native_typr_output_goal(Goal, VarMap0, PredName, VarMap, Line, FinalExpr) :-
+    native_typr_output_expr(Goal, VarMap0, PredName, VarMap, FinalExpr, OutputExpr, IntroKind),
     typr_assignment_line(IntroKind, FinalExpr, OutputExpr, Line).
 
-native_typr_output_expr(_Module:Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+native_typr_output_expr(_Module:Goal, VarMap0, PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
-    native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind).
-native_typr_output_expr(filter(DF, Expr, Out), VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+    native_typr_output_expr(Goal, VarMap0, PredName, VarMap, FinalExpr, OutputExpr, IntroKind).
+native_typr_output_expr(Goal, VarMap0, PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+    typr_disjunction_alternatives(Goal, Alternatives),
+    native_typr_disjunction_output_expr(Alternatives, VarMap0, PredName, VarMap, FinalExpr, OutputExpr, IntroKind),
+    !.
+native_typr_output_expr(filter(DF, Expr, Out), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_translate_r_expr(Expr, VarMap0, RExpr),
     format(string(OutputExpr), '@{ subset(~w, ~w) }@', [RDF, RExpr]).
-native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_resolve_value(VarMap0, Col, RCol),
     format(string(OutputExpr), '@{ ~w[order(~w[[~w]]), ] }@', [RDF, RDF, RCol]).
-native_typr_output_expr(group_by(DF, Col, Out), VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+native_typr_output_expr(group_by(DF, Col, Out), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
     typr_resolve_value(VarMap0, DF, RDF),
     typr_resolve_value(VarMap0, Col, RCol),
     format(string(OutputExpr), '@{ aggregate(. ~~ ~w, data=~w, FUN=list) }@', [RCol, RDF]).
-native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+native_typr_output_expr(Goal, VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     functor(Goal, Pred, Arity),
     binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
     Outputs = [_],
@@ -443,6 +447,70 @@ native_typr_output_expr(Goal, VarMap0, VarMap, FinalExpr, OutputExpr, IntroKind)
     atomic_list_concat(ResolvedInArgs, ', ', RArgsStr),
     ensure_typr_var(VarMap0, OutArg, FinalExpr, VarMap, IntroKind),
     format(string(OutputExpr), '@{ ~w(~w) }@', [TargetName, RArgsStr]).
+
+typr_disjunction_alternatives((Left ; Right), Alternatives) :-
+    !,
+    typr_disjunction_alternatives(Left, LeftAlternatives),
+    typr_disjunction_alternatives(Right, RightAlternatives),
+    append(LeftAlternatives, RightAlternatives, Alternatives).
+typr_disjunction_alternatives(Goal, [Goal]).
+
+native_typr_disjunction_output_expr(Alternatives, VarMap0, PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+    Alternatives = [_|[_|_]],
+    typr_disjunction_shared_output_var(Alternatives, VarMap0, SharedVar),
+    ensure_typr_var(VarMap0, SharedVar, FinalExpr, VarMap, IntroKind),
+    maplist(native_typr_alternative_branch(VarMap0, PredName, SharedVar), Alternatives, Branches),
+    branches_to_typr_output_if_chain(Branches, PredName, OutputExpr).
+
+typr_disjunction_shared_output_var([Alternative|Rest], VarMap, SharedVar) :-
+    typr_alternative_output_var(Alternative, SharedVar),
+    var(SharedVar),
+    \+ varmap_contains_var(VarMap, SharedVar),
+    maplist(typr_alternative_output_var_matches(SharedVar), Rest).
+
+typr_alternative_output_var_matches(ExpectedVar, Alternative) :-
+    typr_alternative_output_var(Alternative, ActualVar),
+    ActualVar == ExpectedVar.
+
+typr_alternative_output_var(Alternative, OutputVar) :-
+    normalize_typr_goals(Alternative, Goals),
+    reverse(Goals, ReversedGoals),
+    member(Goal, ReversedGoals),
+    typr_goal_output_var(Goal, OutputVar),
+    !.
+
+typr_goal_output_var(_Module:Goal, OutputVar) :-
+    !,
+    typr_goal_output_var(Goal, OutputVar).
+typr_goal_output_var(filter(_, _, OutputVar), OutputVar).
+typr_goal_output_var(sort_by(_, _, OutputVar), OutputVar).
+typr_goal_output_var(group_by(_, _, OutputVar), OutputVar).
+typr_goal_output_var(Goal, OutputVar) :-
+    functor(Goal, Pred, Arity),
+    binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
+    Outputs = [_],
+    simple_r_binding_target(TargetName),
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(Outputs, OutCount),
+    length(InArgs, InCount),
+    length(OutArgs, OutCount),
+    append(InArgs, OutArgs, Args),
+    OutArgs = [OutputVar].
+
+native_typr_alternative_branch(VarMap0, PredName, SharedVar, Alternative, branch(Condition, BranchCode)) :-
+    typr_alternative_output_var_matches(SharedVar, Alternative),
+    native_typr_goal_sequence(Alternative, VarMap0, PredName, Conditions, BranchCode),
+    (   Conditions = []
+    ->  Condition = 'TRUE'
+    ;   atomic_list_concat(Conditions, ' && ', Condition)
+    ).
+
+varmap_contains_var([StoredVar-_|_], Var) :-
+    Var == StoredVar,
+    !.
+varmap_contains_var([_|Rest], Var) :-
+    varmap_contains_var(Rest, Var).
 
 native_typr_guard_goal(_Module:Goal, VarMap, GuardCondition) :-
     !,
@@ -618,6 +686,22 @@ branches_to_typr_if_chain([branch(Condition, Code)|Rest], IfChain) :-
     indent_text(BranchCode, "\t", IndentedCode),
     format(string(IfChain), 'if (~w) {\n~w\n} else ~w', [Condition, IndentedCode, RestChain]).
 
+branches_to_typr_output_if_chain([branch(Condition, Code)], PredName, OutputExpr) :-
+    branch_safe_typr_code(Code, BranchCode),
+    indent_text(BranchCode, "\t", IndentedCode),
+    format(string(OutputExpr),
+'if (~w) {
+~w
+} else {
+	stop("No matching clause for ~w")
+}', [Condition, IndentedCode, PredName]).
+branches_to_typr_output_if_chain([branch(Condition, Code)|Rest], PredName, OutputExpr) :-
+    Rest \= [],
+    branch_safe_typr_code(Code, BranchCode),
+    indent_text(BranchCode, "\t", IndentedCode),
+    branches_to_typr_output_if_chain(Rest, PredName, RestChain),
+    format(string(OutputExpr), 'if (~w) {\n~w\n} else ~w', [Condition, IndentedCode, RestChain]).
+
 pred_spec_name(_Module:Pred/_, PredName) :-
     !,
     atom_string(Pred, PredName).
@@ -638,13 +722,26 @@ branch_safe_typr_code(Code, SafeCode) :-
     atomic_list_concat(SafeLines, '\n', SafeCode).
 
 branch_safe_typr_line(Line, SafeLine) :-
-    (   sub_string(Line, 0, 4, _, "let ")
+    leading_layout(Line, Layout, Content),
+    (   sub_string(Content, 0, 4, _, "let ")
     ->  SafeLine = Line
-    ;   sub_string(Line, _, _, _, " <- "),
-        sub_string(Line, _, 1, 0, ";")
-    ->  string_concat("let ", Line, SafeLine)
+    ;   sub_string(Content, _, _, _, " <- "),
+        sub_string(Content, _, 1, 0, ";")
+    ->  format(string(SafeLine), '~wlet ~w', [Layout, Content])
     ;   SafeLine = Line
     ).
+
+leading_layout(Line, Layout, Content) :-
+    string_codes(Line, Codes),
+    take_layout_codes(Codes, LayoutCodes, ContentCodes),
+    string_codes(Layout, LayoutCodes),
+    string_codes(Content, ContentCodes).
+
+take_layout_codes([Code|Rest], [Code|LayoutCodes], ContentCodes) :-
+    code_type(Code, space),
+    !,
+    take_layout_codes(Rest, LayoutCodes, ContentCodes).
+take_layout_codes(ContentCodes, [], ContentCodes).
 
 finalize_type_diagnostics_report(Options) :-
     (   memberchk(type_diagnostics_report(Report), Options),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -31,6 +31,8 @@ cleanup_typr_test :-
     retractall(user:fanout_clause_chain(_, _)),
     retractall(user:split_recombine_chain(_, _)),
     retractall(user:split_recombine_clause_chain(_, _)),
+    retractall(user:alternative_assign_chain(_, _)),
+    retractall(user:alternative_assign_clause_chain(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -285,6 +287,34 @@ test(split_recombine_branch_bodies_stay_native) :-
     once(sub_string(Code, _, _, _, "let v4 <- if (@{ v3 > 1 }@)")),
     once(sub_string(Code, _, _, _, "let v6 <- if (@{ v5 < 10 }@)")),
     once(sub_string(Code, _, _, _, "arg2 <- if (@{ v7 < 20 }@)")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(disjunction_alternative_assignments_lower_natively) :-
+    clear_type_declarations,
+    assertz(user:(alternative_assign_chain(Name, Out) :- string_lower(Name, Lower), string_length(Lower, Len), ((>(Len, 3), string_upper(Lower, Upper), string_concat(Upper, '!', Mid)); (=<(Len, 3), string_concat(Lower, '?', Mid))), string_concat(Mid, '#', Out))),
+    assertz(type_declarations:uw_type(alternative_assign_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(alternative_assign_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(alternative_assign_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let v5 <- if (@{ v4 > 3 }@)")),
+    once(sub_string(Code, _, _, _, "let v6 <- @{ paste0(v5, \"!\") }@;")),
+    once(sub_string(Code, _, _, _, "else if (@{ v4 <= 3 }@)")),
+    once(sub_string(Code, _, _, _, "arg2 <- @{ paste0(v5, \"#\") }@;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(disjunction_alternative_assignments_stay_native_in_branch_bodies) :-
+    clear_type_declarations,
+    assertz(user:(alternative_assign_clause_chain(short, Out) :- string_lower('Hello', Lower), string_length(Lower, Len), ((>(Len, 3), string_upper(Lower, Upper), string_concat(Upper, '!', Mid)); (=<(Len, 3), string_concat(Lower, '?', Mid))), string_concat(Mid, '#', Out))),
+    assertz(user:(alternative_assign_clause_chain(tiny, Out) :- string_lower('Yo', Lower), string_length(Lower, Len), ((>(Len, 3), string_upper(Lower, Upper), string_concat(Upper, '!', Mid)); (=<(Len, 3), string_concat(Lower, '?', Mid))), string_concat(Mid, '#', Out))),
+    assertz(type_declarations:uw_type(alternative_assign_clause_chain/2, 1, atom)),
+    assertz(type_declarations:uw_type(alternative_assign_clause_chain/2, 2, atom)),
+    once(compile_predicate_to_typr(alternative_assign_clause_chain/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "else if")),
+    once(sub_string(Code, _, _, _, "let v4 <- if (@{ v3 > 3 }@)")),
+    once(sub_string(Code, _, _, _, "let v5 <- @{ paste0(v4, \"!\") }@;")),
+    once(sub_string(Code, _, _, _, "let arg2 <- @{ paste0(v4, \"#\") }@;")),
     \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).


### PR DESCRIPTION
## Summary

This PR expands the conservative native TypR lowering path so a constrained class of body disjunctions can stay native instead of falling back to wrapped R.

The newly supported shape is:

- an earlier native binding produces one or more intermediates
- a guarded semicolon-disjunction chooses between alternative native derivations
- each alternative binds the same later intermediate
- later native steps continue from that selected result

This support also works inside supported literal-headed branch bodies.

The scope is intentionally narrow. This is not general arbitrary-body disjunction lowering.

## Why This PR Exists

The recent TypR work already supported:

- simple binding chains
- guard-style command predicates
- sequential dependent guard/output chains
- comparison-driven native guards
- fan-out chains
- split-and-recombine chains
- supported native branch bodies with `let`-bound locals

That still left a practical gap:

- native TypR could keep several structured control-flow shapes
- but a clause with guarded semicolon alternatives for producing one later intermediate still fell back to wrapped R

A representative shape is:

```prolog
alternative_assign_chain(Name, Out) :-
    string_lower(Name, Lower),
    string_length(Lower, Len),
    (
        >(Len, 3),
        string_upper(Lower, Upper),
        string_concat(Upper, '!', Mid)
    ;
        =<(Len, 3),
        string_concat(Lower, '?', Mid)
    ),
    string_concat(Mid, '#', Out).
```

Before this change, that shape dropped out of the native TypR path. After this change, it stays native as long as the alternatives remain within the conservative supported model.

## Main Changes

### 1. Native TypR lowering now supports guarded alternative assignments

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The native TypR emitter now recognizes semicolon-disjunction alternatives when:

- there are multiple alternatives
- each alternative binds the same output/intermediate variable
- that variable is not already bound in the incoming TypR variable map

When those conditions hold, TypR lowering emits native `if` / `else if` structure rather than wrapped fallback.

### 2. Alternative branches compile into native TypR output expressions

Each supported alternative is compiled using the existing native clause-body machinery, then combined into a TypR output expression chain.

That means alternative branches can still contain supported native steps such as:

- guards
- intermediate native outputs
- later dependent native outputs inside the branch

without forcing the whole clause back into wrapped R.

### 3. Fixed branch-local `let` rewriting for nested native branches

While implementing this shape, the existing branch-safety rewrite logic needed tightening.

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl) so branch-local assignment rewriting now respects leading indentation before deciding whether to prefix `let`.

That prevents malformed nested lines such as duplicated `let` prefixes inside native branch bodies.

### 4. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New tests verify:

- top-level guarded alternative-assignment chains lower natively
- supported literal-headed branch bodies keep the same shape native
- wrapped-R fallback is not used for those supported cases
- generated TypR still passes real `typr check`

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now describe guarded disjunction-style alternative-assignment chains as part of the supported conservative native TypR subset.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior
- existing R-target behavior remaining intact on the focused suite
- native TypR lowering for guarded alternative-assignment chains
- continued TypR CLI validation of generated output

What it does not claim:

- full repo-wide regression coverage
- full arbitrary-body native TypR lowering
- full native support for unconstrained body disjunctions

## Behavior Notes

After this PR, the conservative native TypR subset includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- simple comparison and boolean guard expressions over already-bound intermediates
- structured fan-out chains
- structured split-and-recombine chains
- guarded disjunction-style alternative-assignment chains where each alternative binds the same later intermediate
- supported literal-headed branch bodies built from those chains
- selected dataframe helpers

More complex generic bodies still fall back to wrapped R.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for constrained guarded semicolon alternatives
- reuse of the selected intermediate in later native clause steps
- supported branch-body reuse of the same native alternative-assignment path
- tighter branch-local `let` rewriting for nested native branch code

Still not fully implemented:

- arbitrary-body disjunction lowering
- broader native lowering for more complex clause-local control flow
- complete elimination of wrapped-R fallback for unsupported TypR cases

## Why This PR Is Worth Merging

This PR closes a real native-lowering gap rather than just documenting existing behavior.

It gives the project:

- fewer wrapped fallback cases for practical guarded-choice predicates
- broader native TypR coverage for structured clause-local control flow
- safer branch-local code generation in nested native TypR branches
- focused regression coverage backed by real TypR validation
