### PR TITLE
scripts(csharp-query): add cache smoke sequence wrapper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,17 +117,9 @@ jobs:
           dotnet --version
           pwsh -v
 
-      - name: Run C# query cache smoke slice (admission)
+      - name: Run C# query cache smoke sequence
         run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -CacheSlice admission -KeepArtifacts
-
-      - name: Run C# query cache smoke slice (reuse)
-        run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -CacheSlice reuse -SkipCodegen -KeepArtifacts
-
-      - name: Run C# query cache smoke slice (lru)
-        run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -CacheSlice lru -SkipCodegen
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR"
 
       - name: Upload C# query smoke artifacts on failure
         if: failure()

--- a/scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
+++ b/scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
@@ -1,0 +1,62 @@
+# Runs the canonical cache-focused C# query runtime smoke sequence used by CI.
+# It shares a single output directory so admission performs code generation,
+# reuse reuses the generated projects, and lru performs the final cleanup pass.
+#
+# Usage:
+#   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1
+#   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/csharp_query_smoke_ci
+#   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1 -KeepArtifacts
+#
+# Notes:
+# - Requires the same prerequisites as run_csharp_query_runtime_smoke.ps1.
+# - The final lru slice removes generated projects unless -KeepArtifacts is set.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$OutputDir = "tmp/csharp_query_smoke_ci",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ProjectFilter = "*",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = "Stop"
+
+$runnerPath = Join-Path $PSScriptRoot "run_csharp_query_runtime_smoke.ps1"
+
+function Invoke-CacheSmokeSlice {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Slice,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipCodegen,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$KeepArtifactsForSlice
+    )
+
+    $runnerArgs = @{
+        OutputDir = $OutputDir
+        ProjectFilter = $ProjectFilter
+        CacheSlice = $Slice
+    }
+
+    if ($SkipCodegen) {
+        $runnerArgs.SkipCodegen = $true
+    }
+
+    if ($KeepArtifactsForSlice) {
+        $runnerArgs.KeepArtifacts = $true
+    }
+
+    Write-Host "=== Running C# query cache smoke slice: $Slice ==="
+    & $runnerPath @runnerArgs
+}
+
+Invoke-CacheSmokeSlice -Slice "admission" -KeepArtifactsForSlice
+Invoke-CacheSmokeSlice -Slice "reuse" -SkipCodegen -KeepArtifactsForSlice
+Invoke-CacheSmokeSlice -Slice "lru" -SkipCodegen -KeepArtifactsForSlice:$KeepArtifacts


### PR DESCRIPTION
  ## Summary
  Add a single wrapper script for the canonical C# query cache smoke sequence and update CI to use it instead of
  spelling the three cache slices inline.

  ## What changed
  - Added `scripts/testing/run_csharp_query_cache_smoke_sequence.ps1`
  - The wrapper runs the stable cache smoke sequence against one shared output dir:
    - `admission`
    - `reuse -SkipCodegen`
    - `lru -SkipCodegen`
  - Preserved the existing artifact lifecycle:
    - admission keeps generated projects
    - reuse keeps generated projects
    - lru performs final cleanup unless `-KeepArtifacts` is set
  - Updated `.github/workflows/test.yml` to call the wrapper from the `csharp_query_runtime_smoke` job

  ## Why
  The cache-slice workflow was already in good shape, but the sequence itself was duplicated between CI and local repro.
  That creates an obvious drift point.

  This PR makes the cache smoke sequence a single maintained entrypoint for both:
  - CI execution
  - local reproduction of CI smoke behavior

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/
  csharp_query_smoke_sequence_workflow`
    - Passed