### PR TITLE
Keep native TypR direct-output alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ includes:
 - structured split-and-recombine chains where guarded derived values are later
   combined into a final native output
 - guarded disjunction-style alternative-assignment chains where each native
-  alternative binds the same later intermediate before later native steps
-  continue from the selected result
+  alternative binds either the same later intermediate or the final output
+  directly before later native steps continue from the selected result
 - supported literal-headed branch bodies built from those chains, with `let`
   used for new intermediate TypR locals
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -163,8 +163,8 @@ bring-up.
   - structured split-and-recombine chains where those guarded derived values
     later feed a combined output
   - guarded disjunction-style alternative-assignment chains where each
-    alternative binds the same later intermediate before later native steps
-    continue from the selected result
+    alternative binds either the same later intermediate or the final output
+    directly before later native steps continue from the selected result
   - supported literal-headed multi-clause branch bodies that keep those chains
     native by using `let` for new intermediate locals
   - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -335,8 +335,8 @@ Current TypR lowering policy is intentionally mixed:
 - structured split-and-recombine chains may also stay native when those guarded
   derived values later feed a combined output
 - guarded disjunction-style alternative-assignment chains may also stay native
-  when each alternative binds the same later intermediate and later native
-  steps continue from that selected result
+  when each alternative binds either the same later intermediate or the final
+  output directly and later native steps continue from that selected result
 - supported literal-headed branch bodies may also stay native when those chains
   fit inside a TypR `if` branch with `let`-introduced intermediate locals
 - supported dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -37,8 +37,8 @@ This document focuses on architecture and rollout choices specific to TypR.
    - structured split-and-recombine chains where those guarded derived values
      later feed a combined output
    - guarded disjunction-style alternative-assignment chains where each
-     alternative binds the same later intermediate before later native steps
-     continue from the selected result
+     alternative binds either the same later intermediate or the final output
+     directly before later native steps continue from the selected result
    - supported literal-headed branch bodies that keep those chains native by
      using `let` for newly introduced locals inside TypR branches
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
@@ -221,6 +221,9 @@ Completed:
 15. Extended the native generic path again so guarded semicolon alternatives
     can stay in TypR when each alternative binds the same later intermediate
     and later native steps continue from the selected result.
+16. Extended that guarded-alternative path further so those semicolon
+    alternatives may also bind the final output directly rather than only a
+    fresh later intermediate.
 
 R-family note:
 
@@ -251,10 +254,11 @@ Current implementation note:
   fan-out chains where one earlier value feeds multiple later outputs or
   conditions, structured split-and-recombine chains where guarded derived
   values later feed a combined output, guarded disjunction-style
-  alternative-assignment chains where each alternative binds the same later
-  intermediate, native literal-headed branch bodies built from those chains,
-  dataframe helper calls, and literal-guarded branch selection; more complex
-  bodies still fall back to wrapped R
+  alternative-assignment chains where each alternative binds either the same
+  later intermediate or the final output directly, native literal-headed
+  branch bodies built from those chains, dataframe helper calls, and
+  literal-guarded branch selection; more complex bodies still fall back to
+  wrapped R
 
 Follow-on work:
 

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -465,8 +465,15 @@ native_typr_disjunction_output_expr(Alternatives, VarMap0, PredName, VarMap, Fin
 typr_disjunction_shared_output_var([Alternative|Rest], VarMap, SharedVar) :-
     typr_alternative_output_var(Alternative, SharedVar),
     var(SharedVar),
-    \+ varmap_contains_var(VarMap, SharedVar),
+    typr_disjunction_output_var_allowed(VarMap, SharedVar),
     maplist(typr_alternative_output_var_matches(SharedVar), Rest).
+
+typr_disjunction_output_var_allowed(VarMap, SharedVar) :-
+    \+ varmap_contains_var(VarMap, SharedVar),
+    !.
+typr_disjunction_output_var_allowed(VarMap, SharedVar) :-
+    lookup_typr_var(SharedVar, VarMap, ArgName),
+    sub_string(ArgName, 0, 3, _, "arg").
 
 typr_alternative_output_var_matches(ExpectedVar, Alternative) :-
     typr_alternative_output_var(Alternative, ActualVar),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -33,6 +33,8 @@ cleanup_typr_test :-
     retractall(user:split_recombine_clause_chain(_, _)),
     retractall(user:alternative_assign_chain(_, _)),
     retractall(user:alternative_assign_clause_chain(_, _)),
+    retractall(user:direct_output_choice(_, _)),
+    retractall(user:direct_output_choice_clause(_, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -315,6 +317,36 @@ test(disjunction_alternative_assignments_stay_native_in_branch_bodies) :-
     once(sub_string(Code, _, _, _, "let v4 <- if (@{ v3 > 3 }@)")),
     once(sub_string(Code, _, _, _, "let v5 <- @{ paste0(v4, \"!\") }@;")),
     once(sub_string(Code, _, _, _, "let arg2 <- @{ paste0(v4, \"#\") }@;")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(disjunction_direct_output_selection_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(direct_output_choice(Name, Out) :- string_lower(Name, Lower), string_length(Lower, Len), ((>(Len, 3), string_upper(Lower, Upper), string_concat(Upper, '!', Out)); (=<(Len, 3), string_concat(Lower, '?', Out))))),
+    assertz(type_declarations:uw_type(direct_output_choice/2, 1, atom)),
+    assertz(type_declarations:uw_type(direct_output_choice/2, 2, atom)),
+    assertz(type_declarations:uw_return_type(direct_output_choice/2, atom)),
+    once(compile_predicate_to_typr(direct_output_choice/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let direct_output_choice <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "arg2 <- if (@{ v4 > 3 }@)")),
+    once(sub_string(Code, _, _, _, "let arg2 <- @{ paste0(v5, \"!\") }@;")),
+    once(sub_string(Code, _, _, _, "else if (@{ v4 <= 3 }@)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(disjunction_direct_output_selection_stays_native_in_branch_bodies) :-
+    clear_type_declarations,
+    assertz(user:(direct_output_choice_clause(short, Out) :- string_lower('Hello', Lower), string_length(Lower, Len), ((>(Len, 3), string_upper(Lower, Upper), string_concat(Upper, '!', Out)); (=<(Len, 3), string_concat(Lower, '?', Out))))),
+    assertz(user:(direct_output_choice_clause(tiny, Out) :- string_lower('Yo', Lower), string_length(Lower, Len), ((>(Len, 3), string_upper(Lower, Upper), string_concat(Upper, '!', Out)); (=<(Len, 3), string_concat(Lower, '?', Out))))),
+    assertz(type_declarations:uw_type(direct_output_choice_clause/2, 1, atom)),
+    assertz(type_declarations:uw_type(direct_output_choice_clause/2, 2, atom)),
+    assertz(type_declarations:uw_return_type(direct_output_choice_clause/2, atom)),
+    once(compile_predicate_to_typr(direct_output_choice_clause/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let direct_output_choice_clause <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "else if")),
+    once(sub_string(Code, _, _, _, "arg2 <- if (@{ v3 > 3 }@)")),
+    once(sub_string(Code, _, _, _, "let arg2 <- @{ paste0(v4, \"!\") }@;")),
     \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR disjunction-lowering path so guarded semicolon alternatives can bind the final output directly instead of forcing wrapped fallback behavior.

Before this change, the native TypR alternative-assignment path only handled cases where each alternative bound the same fresh later intermediate and later native steps continued from that selected result.

After this change, the same guarded-alternative path also supports:

- alternatives that bind the final head/output variable directly
- the same behavior inside supported literal-headed branch bodies

This is still a conservative expansion. It does not add general arbitrary-body disjunction lowering.

## Why This PR Exists

The previous TypR work already supported:

- simple binding chains
- guard-style command predicates
- sequential guard/output chains
- comparison-based native guard chains
- fan-out chains
- split-and-recombine chains
- guarded alternative-assignment chains that select a shared later intermediate

That still left an adjacent and practical gap:

- a guarded semicolon-disjunction could stay native if it selected a fresh intermediate
- but the same shape still fell back when the alternatives selected the final output directly

A representative shape is:

```prolog
direct_output_choice(Name, Out) :-
    string_lower(Name, Lower),
    string_length(Lower, Len),
    (
        >(Len, 3),
        string_upper(Lower, Upper),
        string_concat(Upper, '!', Out)
    ;
        =<(Len, 3),
        string_concat(Lower, '?', Out)
    ).
```

This PR closes that gap.

## Main Changes

### 1. Native TypR guarded alternatives now allow direct output selection

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The guarded disjunction path now accepts a shared selected variable when it is:

- a fresh later intermediate, or
- an existing head/output variable such as `arg2`

That means the native TypR path can now keep guarded alternatives native even when the selected result is the final output variable itself.

### 2. The implementation stays within the existing conservative model

This change does not introduce a new generic disjunction compiler.

It only broadens the existing native alternative path for cases where:

- there are semicolon-separated guarded alternatives
- each alternative binds the same selected variable
- the selected variable is structurally safe for the current TypR variable map

That keeps the scope disciplined while removing another real wrapped-R fallback case.

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New tests verify:

- top-level guarded alternatives that bind the final output directly
- supported literal-headed branch bodies that use the same direct-output shape
- continued absence of wrapped fallback in those supported native cases
- continued real `typr check` validation of generated output

### 4. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now describe guarded alternative-assignment support more accurately:

- alternatives may bind the same fresh later intermediate, or
- alternatives may bind the final output directly

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior
- existing R-target behavior remaining intact on the focused suite
- native TypR lowering for direct-output guarded alternatives
- continued TypR CLI validation of generated output

What it does not claim:

- full repo-wide regression coverage
- full arbitrary-body native TypR lowering
- full native support for unconstrained disjunction bodies

## Behavior Notes

After this PR, the conservative native TypR subset includes:

- fact predicates
- transitive closure
- simple binding chains
- guard-style command predicates
- sequential guard/output control-flow chains
- simple comparison and boolean guard expressions over already-bound intermediates
- structured fan-out chains
- structured split-and-recombine chains
- guarded alternative-assignment chains that select either:
  - a shared later intermediate, or
  - the final output directly
- supported literal-headed branch bodies built from those chains
- selected dataframe helpers

More complex generic bodies still fall back to wrapped R.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for guarded alternatives that bind the final output directly
- supported branch-body reuse of the same direct-output path
- docs updated so the supported TypR subset matches the broader implementation

Still not fully implemented:

- arbitrary-body disjunction lowering
- broader native lowering for more complex clause-local control flow
- complete elimination of wrapped-R fallback for unsupported TypR cases

## Why This PR Is Worth Merging

This PR removes another real TypR fallback boundary with a small, defensible change.

It gives the project:

- fewer wrapped fallback cases for practical guarded-choice predicates
- broader native TypR support for structured disjunction-driven output selection
- focused regression coverage backed by real TypR validation
- documentation that matches the actual supported native subset
