### PR TITLE
feat(agent-loop): wire 8 shared_logic methods into generation, replacing fragment code

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -74,7 +74,7 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 | `shared_logic/3` facts | 19 |
 | `logic_slot/3` facts | 40 (20 python + 20 rust) |
 | `expand_expr/3` facts | 26 (13 python + 13 rust) |
-| `resolve_type/3` facts | 22 (11 python + 11 rust incl. `optional/1`) |
+| `resolve_type/3` facts | 24 (12 python + 12 rust incl. `optional/1`, `owned_string`) |
 | `rust_data_table/5` specs | 9 |
 | `emit_config_section/3` clauses | 11 (python + prolog + rust) |
 | `compile_component/4` targets | 3 (python, prolog, rust) |
@@ -529,7 +529,20 @@ resolve_type(rust, optional(T), S) :-
 | `context` | `estimate_tokens`, `context_clear`, `context_len`, `context_is_empty` | `self_method`, `self_direct`, `len_of`, `is_empty_check`, `int_div` |
 | `mcp` | `next_request_id` | `self_inc`, `self_direct` |
 
-The compiled output is tested for parity against what py_fragment/rust_fragment already produce. The `~~` escape in templates emits literal `~` (for display strings like `~42 tokens`). `emit_shared_method/3` and `write_shared_block/3` provide ready-to-use Rust/Python method emission with proper signatures, type resolution, and syntax fixups (semicolons, `if/else` blocks, `&mut self` for mutating methods).
+The `~~` escape in templates emits literal `~` (for display strings like `~42 tokens`). `emit_shared_method/3` and `write_shared_block/3` provide ready-to-use Rust/Python method emission with proper signatures, type resolution, and syntax fixups (semicolons, `if/else` blocks, `&mut self` for mutating methods).
+
+**8 methods are actively wired** — emitted from `compile_logic` during generation, replacing former fragment code:
+
+| Method | Python | Rust | Notes |
+|--------|--------|------|-------|
+| `is_over_budget` | Wired | Wired | Removed from both fragments |
+| `budget_remaining` | Wired | Wired | Removed from both fragments |
+| `reset` | Wired | N/A | Removed from py_fragment; no Rust fragment existed |
+| `context_clear` | — | Wired | Python fragment has extra counter resets |
+| `context_len` | — | Wired | No Python method existed |
+| `context_is_empty` | — | Wired | No Python method existed |
+| `estimate_tokens` | — | Wired | Python has different function signature |
+| `format_summary` | — | Wired | Python fragment has extra cost logic |
 
 ### Hybrid generation example
 

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -2245,6 +2245,7 @@ resolve_type(python, void, "None").
 resolve_type(python, usize, "int").
 resolve_type(python, dict, "dict").
 resolve_type(python, set_of_string, "set[str]").
+resolve_type(python, owned_string, "str").
 resolve_type(python, list_of_dict, "list[dict]").
 resolve_type(python, optional(T), S) :-
     resolve_type(python, T, Inner),
@@ -2258,6 +2259,7 @@ resolve_type(rust, void, "()").
 resolve_type(rust, usize, "usize").
 resolve_type(rust, dict, "std::collections::HashMap<String, serde_json::Value>").
 resolve_type(rust, set_of_string, "std::collections::HashSet<String>").
+resolve_type(rust, owned_string, "String").
 resolve_type(rust, list_of_dict, "Vec<serde_json::Value>").
 resolve_type(rust, optional(T), S) :-
     resolve_type(rust, T, Inner),
@@ -2279,7 +2281,7 @@ shared_logic(streaming, on_token, [
 ]).
 
 shared_logic(streaming, format_summary, [
-    signature(format_summary, [], string),
+    signature(format_summary, [], owned_string),
     doc("Format a one-line summary of streaming stats."),
     container('StreamingTokenCounter'),
     body_template("~return_val(streaming_summary(self_direct(token_count), self_direct(char_count)))~")
@@ -2967,6 +2969,10 @@ generate_rust_costs :-
     %% Emit pricing table via component registry
     agent_loop_components:emit_rust_cost_facts(S, [target(rust)]),
     write_rust(S, costs_tracker),
+    %% Emit shared_logic methods (replacing former fragment methods)
+    emit_shared_method(S, rust, is_over_budget),
+    emit_shared_method(S, rust, budget_remaining),
+    write(S, '}\n'),
     close(S),
     format('  Generated rust/src/costs.rs~n', []).
 
@@ -3177,6 +3183,12 @@ generate_rust_context :-
     ]),
     write(S, 'use crate::types::*;\n\n'),
     write_rust(S, context_manager),
+    %% Emit shared_logic methods (replacing former fragment methods)
+    emit_shared_method(S, rust, context_clear),
+    emit_shared_method(S, rust, context_len),
+    emit_shared_method(S, rust, context_is_empty),
+    emit_shared_method(S, rust, estimate_tokens),
+    write(S, '}\n'),
     close(S),
     format('  Generated rust/src/context.rs~n', []).
 
@@ -3481,6 +3493,9 @@ generate_rust_main :-
     nl(S),
     %% Streaming token counter struct
     write_rust(S, streaming_token_counter),
+    %% Emit shared_logic method for streaming (replacing former fragment method)
+    emit_shared_method(S, rust, format_summary),
+    write(S, '}\n\n'),
     %% Main loop (expects `config`, `matches`, `session_manager` to be defined)
     write_rust(S, main_loop),
     write(S, '}\n'),
@@ -4045,25 +4060,6 @@ py_fragment(cost_tracker_methods, '    def record_usage(self, model: str, input_
             f"Cost: {summary[\'cost_formatted\']}"
         )
 
-    def reset(self) -> None:
-        """Reset all tracking."""
-        self.records.clear()
-        self.total_input_tokens = 0
-        self.total_output_tokens = 0
-        self.total_cost = 0.0
-
-    def is_over_budget(self, budget: float) -> bool:
-        """Check if total cost exceeds budget. Budget of 0 means unlimited."""
-        if budget <= 0:
-            return False
-        return self.total_cost >= budget
-
-    def budget_remaining(self, budget: float) -> float:
-        """Return remaining budget in USD. Budget of 0 means unlimited (returns -1)."""
-        if budget <= 0:
-            return -1.0
-        return max(0.0, budget - self.total_cost)
-
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
         return {
@@ -4208,6 +4204,11 @@ generate_costs :-
     write_py(S, cost_usage_record),
     write_py(S, cost_tracker_class_def),
     write_py(S, cost_tracker_methods),
+    %% Emit shared_logic methods (replacing former fragment methods)
+    emit_shared_method(S, python, reset),
+    emit_shared_method(S, python, is_over_budget),
+    emit_shared_method(S, python, budget_remaining),
+    write(S, '\n'),
     write_py(S, cost_openrouter),
     close(S),
     format('  Generated costs.py~n', []).
@@ -5605,23 +5606,6 @@ impl CostTracker {
         )
     }
 
-    /// Check if total cost exceeds budget. Budget of 0.0 means unlimited.
-    pub fn is_over_budget(&self, budget: f64) -> bool {
-        if budget <= 0.0 {
-            return false;
-        }
-        self.total_cost() >= budget
-    }
-
-    /// Return remaining budget in USD. Budget of 0.0 returns -1.0 (unlimited).
-    pub fn budget_remaining(&self, budget: f64) -> f64 {
-        if budget <= 0.0 {
-            return -1.0;
-        }
-        (budget - self.total_cost()).max(0.0)
-    }
-}
-
 ').
 
 %% =============================================================================
@@ -6077,18 +6061,6 @@ impl ContextManager {
         &self.messages
     }
 
-    pub fn clear(&mut self) {
-        self.messages.clear();
-    }
-
-    pub fn len(&self) -> usize {
-        self.messages.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.messages.is_empty()
-    }
-
     /// Character count for a single message, including tool call estimates.
     fn message_char_count(m: &Message) -> usize {
         let mut n = m.content.len();
@@ -6113,11 +6085,6 @@ impl ContextManager {
         self.messages.iter()
             .map(|m| m.content.split_whitespace().count())
             .sum()
-    }
-
-    /// Estimated token count (chars / 4 heuristic).
-    pub fn estimate_tokens(&self) -> usize {
-        self.char_count() / 4
     }
 
     /// Trim messages to stay within all configured limits.
@@ -6256,7 +6223,6 @@ impl ContextManager {
         }
         out
     }
-}
 
 ').
 
@@ -8102,11 +8068,6 @@ impl StreamingTokenCounter {
         self.token_count = std::cmp::max(1, self.char_count / 4);
     }
 
-    /// Format a one-line summary of streaming stats.
-    pub fn format_summary(&self) -> String {
-        format!("~{} tokens, {} chars", self.token_count, self.char_count)
-    }
-}
 ').
 
 rust_fragment(config_loader_types, '

--- a/tools/agent-loop/generated/python/costs.py
+++ b/tools/agent-loop/generated/python/costs.py
@@ -101,25 +101,6 @@ class CostTracker:
             f"Cost: {summary['cost_formatted']}"
         )
 
-    def reset(self) -> None:
-        """Reset all tracking."""
-        self.records.clear()
-        self.total_input_tokens = 0
-        self.total_output_tokens = 0
-        self.total_cost = 0.0
-
-    def is_over_budget(self, budget: float) -> bool:
-        """Check if total cost exceeds budget. Budget of 0 means unlimited."""
-        if budget <= 0:
-            return False
-        return self.total_cost >= budget
-
-    def budget_remaining(self, budget: float) -> float:
-        """Return remaining budget in USD. Budget of 0 means unlimited (returns -1)."""
-        if budget <= 0:
-            return -1.0
-        return max(0.0, budget - self.total_cost)
-
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
         return {
@@ -178,6 +159,26 @@ class CostTracker:
             self.pricing[model] = pricing
             return True
         return False
+
+
+    def reset(self):
+        """Reset all cost tracking state."""
+        self.records.clear()
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        self.total_cost = 0.0
+
+    def is_over_budget(self, budget):
+        """Check if total cost exceeds budget. Budget of 0 means unlimited."""
+        if budget <= 0:
+            return False
+        return self.total_cost >= budget
+
+    def budget_remaining(self, budget):
+        """Return remaining budget in USD. Budget of 0 means unlimited (returns -1)."""
+        if budget <= 0:
+            return -1.0
+        return max(0.0, budget - self.total_cost)
 
 
 # --- OpenRouter pricing ---

--- a/tools/agent-loop/generated/rust/src/context.rs
+++ b/tools/agent-loop/generated/rust/src/context.rs
@@ -92,18 +92,6 @@ impl ContextManager {
         &self.messages
     }
 
-    pub fn clear(&mut self) {
-        self.messages.clear();
-    }
-
-    pub fn len(&self) -> usize {
-        self.messages.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.messages.is_empty()
-    }
-
     /// Character count for a single message, including tool call estimates.
     fn message_char_count(m: &Message) -> usize {
         let mut n = m.content.len();
@@ -128,11 +116,6 @@ impl ContextManager {
         self.messages.iter()
             .map(|m| m.content.split_whitespace().count())
             .sum()
-    }
-
-    /// Estimated token count (chars / 4 heuristic).
-    pub fn estimate_tokens(&self) -> usize {
-        self.char_count() / 4
     }
 
     /// Trim messages to stay within all configured limits.
@@ -271,5 +254,25 @@ impl ContextManager {
         }
         out
     }
-}
 
+    /// Clear all messages from context.
+    pub fn clear(&mut self) {
+        self.messages.clear();
+    }
+
+    /// Return number of messages in context.
+    pub fn len(&self) -> usize {
+        return self.messages.len();
+    }
+
+    /// Check if context has no messages.
+    pub fn is_empty(&self) -> bool {
+        return self.messages.is_empty();
+    }
+
+    /// Estimate token count using chars/4 heuristic.
+    pub fn estimate_tokens(&self) -> usize {
+        return self.char_count() / 4;
+    }
+
+}

--- a/tools/agent-loop/generated/rust/src/costs.rs
+++ b/tools/agent-loop/generated/rust/src/costs.rs
@@ -94,20 +94,20 @@ impl CostTracker {
         )
     }
 
-    /// Check if total cost exceeds budget. Budget of 0.0 means unlimited.
+    /// Check if total cost exceeds budget. Budget of 0 means unlimited.
     pub fn is_over_budget(&self, budget: f64) -> bool {
         if budget <= 0.0 {
             return false;
         }
-        self.total_cost() >= budget
+        return self.total_cost() >= budget;
     }
 
-    /// Return remaining budget in USD. Budget of 0.0 returns -1.0 (unlimited).
+    /// Return remaining budget in USD. Budget of 0 means unlimited (returns -1).
     pub fn budget_remaining(&self, budget: f64) -> f64 {
         if budget <= 0.0 {
             return -1.0;
         }
-        (budget - self.total_cost()).max(0.0)
+        return (budget - self.total_cost()).max(0.0);
     }
-}
 
+}

--- a/tools/agent-loop/generated/rust/src/main.rs
+++ b/tools/agent-loop/generated/rust/src/main.rs
@@ -1230,9 +1230,11 @@ impl StreamingTokenCounter {
 
     /// Format a one-line summary of streaming stats.
     pub fn format_summary(&self) -> String {
-        format!("~{} tokens, {} chars", self.token_count, self.char_count)
+        return format!("~{} tokens, {} chars", self.token_count, self.char_count);
     }
+
 }
+
 
     let backend = create_backend(&config);
     // Create async backend for API-type backends

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -5856,15 +5856,15 @@ test_phase23_token_budget :-
     assert_true('token_budget config field', (
         agent_loop_module:agent_config_field(token_budget, _, _, _)
     )),
-    %% Python CostTracker has is_over_budget
+    %% Python CostTracker has is_over_budget (via shared_logic)
     assert_true('Python CostTracker has is_over_budget', (
-        agent_loop_module:py_fragment(cost_tracker_methods, CT1),
-        sub_atom(CT1, _, _, _, 'is_over_budget')
+        agent_loop_module:compile_logic(python, is_over_budget, Code1),
+        sub_atom(Code1, _, _, _, 'total_cost')
     )),
-    %% Python CostTracker has budget_remaining
+    %% Python CostTracker has budget_remaining (via shared_logic)
     assert_true('Python CostTracker has budget_remaining', (
-        agent_loop_module:py_fragment(cost_tracker_methods, CT2),
-        sub_atom(CT2, _, _, _, 'budget_remaining')
+        agent_loop_module:compile_logic(python, budget_remaining, Code2),
+        sub_atom(Code2, _, _, _, 'budget')
     )),
     %% Python _process_message checks budget
     assert_true('Python checks budget in loop', (
@@ -5919,10 +5919,10 @@ test_phase24_streaming_token_counter :-
         agent_loop_module:rust_fragment(streaming_token_counter, RS2),
         sub_atom(RS2, _, _, _, 'fn on_token')
     )),
-    %% Rust has format_summary method
+    %% Rust has format_summary method (via shared_logic)
     assert_true('Rust has format_summary', (
-        agent_loop_module:rust_fragment(streaming_token_counter, RS3),
-        sub_atom(RS3, _, _, _, 'fn format_summary')
+        agent_loop_module:compile_logic(rust, format_summary, Code3),
+        sub_atom(Code3, _, _, _, 'token_count')
     )),
     %% Rust main_loop uses StreamingTokenCounter
     assert_true('Rust main_loop uses counter', (


### PR DESCRIPTION
## Summary

- Wire 8 `shared_logic` methods into active code generation via `emit_shared_method/3`, replacing hardcoded `py_fragment`/`rust_fragment` code
- Remove 114 lines of duplicated fragment code; methods now emitted from `compile_logic` at generation time
- Add `owned_string` type to `resolve_type/3` (`String` in Rust, `str` in Python) for methods returning owned strings
- Generated output is functionally identical to previous fragment-based output
- All test suites pass: 1322 Prolog, 148 Python, 139 Rust

## Wired Methods

| Method | Python | Rust | Fragment Removed From |
|--------|--------|------|-----------------------|
| `is_over_budget` | Wired | Wired | `py_fragment(cost_tracker_methods)`, `rust_fragment(costs_tracker)` |
| `budget_remaining` | Wired | Wired | `py_fragment(cost_tracker_methods)`, `rust_fragment(costs_tracker)` |
| `reset` | Wired | N/A | `py_fragment(cost_tracker_methods)` |
| `context_clear` | — | Wired | `rust_fragment(context_manager)` |
| `context_len` | — | Wired | `rust_fragment(context_manager)` |
| `context_is_empty` | — | Wired | `rust_fragment(context_manager)` |
| `estimate_tokens` | — | Wired | `rust_fragment(context_manager)` |
| `format_summary` | — | Wired | `rust_fragment(streaming_token_counter)` |

## How It Works

Before (hardcoded in fragment string):
```prolog
rust_fragment(costs_tracker, '
    ...
    pub fn is_over_budget(&self, budget: f64) -> bool {
        if budget <= 0.0 { return false; }
        self.total_cost() >= budget
    }
    ...
').
```

After (emitted from shared_logic at generation time):
```prolog
generate_rust_costs :-
    ...
    write_rust(S, costs_tracker),
    emit_shared_method(S, rust, is_over_budget),
    emit_shared_method(S, rust, budget_remaining),
    write(S, '}\n'),
    ...
```

The `emit_shared_method/3` call compiles the `body_template` via `compile_logic/3`, resolves argument types via `resolve_type/3`, applies `rust_fixup_body/2` for Rust syntax, and emits a complete method with doc comment and signature.

## Not Yet Wired

These methods compile correctly but need emitter enhancements before wiring:

| Method | Blocker |
|--------|---------|
| `on_token` (Rust) | Fragment includes `use std::io::Write;` import not in template |
| `extract_json_dispatch` (Python) | Uses `@classmethod` decorator; emitter only supports `self` methods |
| `is_retryable_status`, `compute_delay` | Standalone functions, not struct methods; emitter always adds `&self` |
| `cache_clear`, `cache_len`, etc. | Field naming differs (`self._cache` vs `self.cache`) |

## Test Results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit + declarative | 1322 | All pass |
| Python (pytest) | 148 | All pass |
| Rust (cargo test) | 139 | All pass (3 pre-existing fs sandbox skips) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
