### PR TITLE
feat(agent-loop): wire 4 more shared_logic methods, add as_float expr, split tool_result_cache fragments

### DIFF
--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -73,7 +73,7 @@ The agent loop is generated from declarative Prolog facts into multiple targets:
 | `rust_fragment/2` facts | 38 |
 | `shared_logic/3` facts | 19 |
 | `logic_slot/3` facts | 40 (20 python + 20 rust) |
-| `expand_expr/3` facts | 26 (13 python + 13 rust) |
+| `expand_expr/3` facts | 28 (14 python + 14 rust) |
 | `resolve_type/3` facts | 24 (12 python + 12 rust incl. `optional/1`, `owned_string`) |
 | `rust_data_table/5` specs | 9 |
 | `emit_config_section/3` clauses | 11 (python + prolog + rust) |
@@ -531,7 +531,7 @@ resolve_type(rust, optional(T), S) :-
 
 The `~~` escape in templates emits literal `~` (for display strings like `~42 tokens`). `emit_shared_method/3` and `write_shared_block/3` provide ready-to-use Rust/Python method emission with proper signatures, type resolution, and syntax fixups (semicolons, `if/else` blocks, `&mut self` for mutating methods).
 
-**13 methods are actively wired** — emitted from `compile_logic` during generation, replacing former fragment code:
+**15 methods are actively wired** — emitted from `compile_logic` during generation, replacing former fragment code:
 
 | Method | Python | Rust | Notes |
 |--------|--------|------|-------|
@@ -546,8 +546,12 @@ The `~~` escape in templates emits literal `~` (for display strings like `~42 to
 | `format_summary` | — | Wired | Python fragment has extra cost logic |
 | `extract_json_dispatch` | Wired | — | Python uses `classmethod` property |
 | `is_retryable_status` | — | Wired | Rust standalone function via `container(none)` |
+| `cache_clear` | Wired | Wired | Uses `field_map` for both targets, `mutable` for Rust |
+| `cache_len` | — | Wired | Python uses `size()` name (stays as fragment) |
+| `cost_compute` | Wired | Wired | Standalone function via `container(none)`, uses `as_float` |
+| `compute_delay` | — | Wired | Rust standalone; Python logic embedded in retry decorator |
 
-The emitter supports: `container(none)` for standalone functions, `classmethod` for Python `@classmethod`, `rust_use(Items)` for Rust `use` imports, `field_map(Target, Map)` for target-specific field rewrites, and `py_extra_body(Code)` for Python-specific body extensions.
+The emitter supports: `container(none)` for standalone functions, `classmethod` for Python `@classmethod`, `rust_use(Items)` for Rust `use` imports, `field_map(Target, Map)` for target-specific field rewrites, `py_extra_body(Code)` for Python-specific body extensions, and `as_float` for cross-type arithmetic.
 
 ### Hybrid generation example
 

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -1936,15 +1936,18 @@ shared_logic(tool_cache, cache_clear, [
     signature(clear, [], void),
     doc("Clear all cached tool results."),
     container('ToolResultCache'),
+    mutable,
     field_map(python, ['self.cache'-'self._cache']),
+    field_map(rust, ['self.cache()'-'self.cache']),
     body_template("~self_field(cache)~.clear()")
 ]).
 
 shared_logic(tool_cache, cache_len, [
-    signature(len, [], int),
+    signature(len, [], usize),
     doc("Return number of cached entries."),
     container('ToolResultCache'),
     field_map(python, ['self.cache'-'self._cache']),
+    field_map(rust, ['self.cache()'-'self.cache']),
     body_template("~return_val(len_of(self_field(cache)))~")
 ]).
 
@@ -2435,7 +2438,7 @@ shared_logic(costs, cost_compute, [
     arg_types([int, float]),
     doc("Compute cost from token count and price per 1M tokens."),
     container(none),
-    body_template("~return_val(div_float(mul(tokens, price_per_million), 1000000.0))~")
+    body_template("~return_val(div_float(mul(as_float(tokens), price_per_million), 1000000.0))~")
 ]).
 
 %% --- Context manager methods ---
@@ -2590,7 +2593,7 @@ logic_slot(rust, call_method(Method, Args), S) :-
 logic_slot(python, canonical_json(X), S) :-
     format(atom(S), "_json.dumps(~w, sort_keys=True, default=str)", [X]).
 logic_slot(rust, canonical_json(X), S) :-
-    format(atom(S), "serde_json::to_string(&~w).unwrap_or_default()", [X]).
+    format(atom(S), "serde_json::to_string(~w).unwrap_or_default()", [X]).
 
 %% --- Method call on self (getter-style) ---
 logic_slot(python, self_method(M), S) :- format(atom(S), "self.~w()", [M]).
@@ -2670,6 +2673,13 @@ expand_expr(rust, sub(A, B), S) :-
     expand_expr(rust, B, BStr),
     format(atom(S), "(~w - ~w)", [AStr, BStr]).
 
+expand_expr(python, as_float(X), S) :-
+    expand_expr(python, X, Inner),
+    format(atom(S), "float(~w)", [Inner]).
+expand_expr(rust, as_float(X), S) :-
+    expand_expr(rust, X, Inner),
+    format(atom(S), "(~w as f64)", [Inner]).
+
 expand_expr(python, div_float(A, B), S) :-
     expand_expr(python, A, AStr),
     expand_expr(python, B, BStr),
@@ -2677,7 +2687,7 @@ expand_expr(python, div_float(A, B), S) :-
 expand_expr(rust, div_float(A, B), S) :-
     expand_expr(rust, A, AStr),
     expand_expr(rust, B, BStr),
-    format(atom(S), "(~w as f64 / ~w)", [AStr, BStr]).
+    format(atom(S), "((~w) as f64 / ~w)", [AStr, BStr]).
 
 expand_expr(_, N, S) :- number(N), number_codes(N, Codes), atom_codes(S, Codes).
 
@@ -3082,7 +3092,8 @@ generate_rust_costs :-
     %% Emit shared_logic methods (replacing former fragment methods)
     emit_shared_method(S, rust, is_over_budget),
     emit_shared_method(S, rust, budget_remaining),
-    write(S, '}\n'),
+    write(S, '}\n\n'),
+    emit_shared_method(S, rust, cost_compute),
     close(S),
     format('  Generated rust/src/costs.rs~n', []).
 
@@ -3399,6 +3410,9 @@ generate_rust_tool_handler :-
     write_rust(S, tool_handler_validation),
     write_rust(S, tool_handler_dispatch),
     write_rust(S, tool_result_cache),
+    emit_shared_method(S, rust, cache_clear),
+    emit_shared_method(S, rust, cache_len),
+    write_rust(S, tool_result_cache_tail),
     close(S),
     format('  Generated rust/src/tool_handler.rs~n', []).
 
@@ -3522,6 +3536,7 @@ generate_rust_main :-
     write_rust(S, retry_logic),
     %% Emit shared_logic standalone function (replacing former fragment code)
     emit_shared_method(S, rust, is_retryable_status),
+    emit_shared_method(S, rust, compute_delay),
     nl(S),
     %% Templates and skills
     write_rust(S, template_manager),
@@ -4328,6 +4343,8 @@ generate_costs :-
     emit_shared_method(S, python, reset),
     emit_shared_method(S, python, is_over_budget),
     emit_shared_method(S, python, budget_remaining),
+    write(S, '\n\n'),
+    emit_shared_method(S, python, cost_compute),
     write(S, '\n'),
     write_py(S, cost_openrouter),
     close(S),
@@ -4680,6 +4697,8 @@ generate_tools_module :-
     write(S, '\n\n'),
     %% ToolResultCache class
     write_py(S, tool_result_cache),
+    emit_shared_method(S, python, cache_clear),
+    write_py(S, tool_result_cache_tail),
     write(S, '\n\n'),
     %% PluginManager class
     write_py(S, plugin_manager_class),
@@ -8618,9 +8637,10 @@ impl ToolResultCache {
         let key = Self::make_key(tool_name, args);
         self.cache.insert(key, (Instant::now(), result));
     }
+').
 
-    pub fn clear(&mut self) { self.cache.clear(); }
-    pub fn len(&self) -> usize { self.cache.len() }
+%% Rust tool_result_cache tail — closing brace after shared_logic methods
+rust_fragment(tool_result_cache_tail, '
 }
 ').
 
@@ -13338,10 +13358,10 @@ class ToolResultCache:
             return
         key = self._make_key(tool_name, args)
         self._cache[key] = (_time.monotonic(), result)
+').
 
-    def clear(self) -> None:
-        self._cache.clear()
-
+%% Python tool_result_cache tail — size method (not shared_logic, uses 'size' not 'len')
+py_fragment(tool_result_cache_tail, '
     def size(self) -> int:
         return len(self._cache)
 ').

--- a/tools/agent-loop/generated/prolog/test_declarative.pl
+++ b/tools/agent-loop/generated/prolog/test_declarative.pl
@@ -342,9 +342,9 @@ test_decl_counts :-
     findall(N, agent_loop_module:slash_command(N, _, _, _), Ss), length(Ss, SC),
     decl_assert_eq('slash_command count', SC, 27),
     findall(N, agent_loop_module:py_fragment(N, _), PFs), length(PFs, PFC),
-    decl_assert_eq('py_fragment count', PFC, 95),
+    decl_assert_eq('py_fragment count', PFC, 98),
     findall(N, agent_loop_module:rust_fragment(N, _), RFs), length(RFs, RFC),
-    decl_assert_eq('rust_fragment count', RFC, 38),
+    decl_assert_eq('rust_fragment count', RFC, 39),
     true.
 
 %% =============================================================================

--- a/tools/agent-loop/generated/python/costs.py
+++ b/tools/agent-loop/generated/python/costs.py
@@ -181,6 +181,12 @@ class CostTracker:
         return max(0.0, budget - self.total_cost)
 
 
+
+def cost_compute(tokens, price_per_million):
+    """Compute cost from token count and price per 1M tokens."""
+    return (float(tokens) * price_per_million / 1.0e+06)
+
+
 # --- OpenRouter pricing ---
 
 _OPENROUTER_CACHE_DIR = Path(os.environ.get(

--- a/tools/agent-loop/generated/python/tools.py
+++ b/tools/agent-loop/generated/python/tools.py
@@ -209,9 +209,10 @@ class ToolResultCache:
             return
         key = self._make_key(tool_name, args)
         self._cache[key] = (_time.monotonic(), result)
-
-    def clear(self) -> None:
+    def clear(self):
+        """Clear all cached tool results."""
         self._cache.clear()
+
 
     def size(self) -> int:
         return len(self._cache)

--- a/tools/agent-loop/generated/rust/src/costs.rs
+++ b/tools/agent-loop/generated/rust/src/costs.rs
@@ -111,3 +111,9 @@ impl CostTracker {
     }
 
 }
+
+    /// Compute cost from token count and price per 1M tokens.
+pub fn cost_compute(tokens: i64, price_per_million: f64) -> f64 {
+    return (((tokens as f64) * price_per_million) as f64 / 1.0e+06);
+}
+

--- a/tools/agent-loop/generated/rust/src/main.rs
+++ b/tools/agent-loop/generated/rust/src/main.rs
@@ -233,6 +233,11 @@ pub fn is_retryable_status(status: i64) -> bool {
     return matches!(status, 408 | 429 | 500 | 502 | 503 | 504);
 }
 
+    /// Calculate exponential backoff delay, capped at max_delay.
+pub fn compute_delay(base_delay: f64, exponential_base: f64, attempt: i64, max_delay: f64) -> f64 {
+    return (base_delay * exponential_base.powi((attempt - 1) as i32)).min(max_delay);
+}
+
 
 
 use std::collections::HashMap;

--- a/tools/agent-loop/generated/rust/src/tool_handler.rs
+++ b/tools/agent-loop/generated/rust/src/tool_handler.rs
@@ -609,7 +609,15 @@ impl ToolResultCache {
         let key = Self::make_key(tool_name, args);
         self.cache.insert(key, (Instant::now(), result));
     }
+    /// Clear all cached tool results.
+    pub fn clear(&mut self) {
+        self.cache.clear();
+    }
 
-    pub fn clear(&mut self) { self.cache.clear(); }
-    pub fn len(&self) -> usize { self.cache.len() }
+    /// Return number of cached entries.
+    pub fn len(&self) -> usize {
+        return self.cache.len();
+    }
+
+
 }

--- a/tools/agent-loop/test_agent_loop.pl
+++ b/tools/agent-loop/test_agent_loop.pl
@@ -3143,7 +3143,7 @@ test_rust_fragments :-
     %% Count rust fragments
     findall(N, agent_loop_module:rust_fragment(N, _), RFs),
     length(RFs, RFCount),
-    assert_eq('Rust fragment count', RFCount, 38),
+    assert_eq('Rust fragment count', RFCount, 39),
     %% Check each fragment exists and has content
     assert_true('config_types has CliArgument', (
         agent_loop_module:rust_fragment(config_types, C1),


### PR DESCRIPTION
## Summary

- Wire 4 more `shared_logic` methods into active generation, bringing total to **15 methods emitted from `compile_logic`**
- Split `tool_result_cache` py_fragment and rust_fragment for clean shared_logic insertion points
- Add `as_float` expression type for cross-type arithmetic (`i64` → `f64` in Rust, `float()` in Python)
- Fix `div_float` Rust parenthesization for correct operator precedence
- All test suites pass: 1322 Prolog, 139 Rust (3 pre-existing fs sandbox skips)

## Newly Wired Methods (this PR)

| Method | Python | Rust | Emitter Feature Used |
|--------|--------|------|----------------------|
| `cache_clear` | Wired | Wired | `field_map` for both targets, `mutable` for Rust `&mut self` |
| `cache_len` | — | Wired | `usize` return type; Python keeps `size()` name in fragment |
| `cost_compute` | Wired | Wired | `container(none)` standalone + `as_float` for type casting |
| `compute_delay` | — | Wired | `container(none)` standalone exponential backoff |

## All 15 Actively Wired Methods

| Method | Python | Rust | Notes |
|--------|--------|------|-------|
| `is_over_budget` | Wired | Wired | |
| `budget_remaining` | Wired | Wired | |
| `reset` | Wired | — | |
| `context_clear` | Wired | Wired | Python uses `py_extra_body` for counter resets |
| `context_len` | — | Wired | |
| `context_is_empty` | — | Wired | |
| `estimate_tokens` | — | Wired | |
| `on_token` | Wired | Wired | Rust uses `rust_use` for `std::io::Write` |
| `format_summary` | — | Wired | |
| `extract_json_dispatch` | Wired | — | Python `@classmethod` |
| `is_retryable_status` | — | Wired | Standalone via `container(none)` |
| `cache_clear` | Wired | Wired | `field_map` + `mutable` |
| `cache_len` | — | Wired | `usize` return type |
| `cost_compute` | Wired | Wired | `as_float` for cross-type math |
| `compute_delay` | — | Wired | Standalone exponential backoff |

## New Infrastructure

| Feature | Target | Description |
|---------|--------|-------------|
| `as_float` expr | Both | Casts int to float — `float(x)` in Python, `(x as f64)` in Rust |
| `div_float` fix | Rust | Parenthesizes numerator: `((expr) as f64 / divisor)` to avoid precedence bugs |
| `canonical_json` fix | Rust | Removed unnecessary `&` reference (`serde_json::to_string(x)` not `&x`) |
| Fragment splits | Both | `tool_result_cache` → head + tail for both Python and Rust |

## Fragment Splits

Two fragments were split to create insertion points for shared_logic methods:

- **Python** `tool_result_cache` → `tool_result_cache` (through `put`) + `tool_result_cache_tail` (`size` method)
- **Rust** `tool_result_cache` → `tool_result_cache` (through `put`) + `tool_result_cache_tail` (closing brace)

## Remaining Unwired (4 methods)

| Method | Blocker |
|--------|---------|
| `make_key` | Associated function pattern — needs `static_method` emitter feature |
| `cache_get_guard`, `cache_put_guard` | Guard logic embedded in `get`/`put` method bodies, not standalone |
| `compute_delay` (Python) | Delay calculation inline in retry decorator closure |

## Test Results

| Suite | Count | Status |
|-------|-------|--------|
| Prolog unit + declarative | 1322 | All pass |
| Rust (cargo test) | 139 | All pass (3 pre-existing fs sandbox skips) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
