### PR TITLE
ci(csharp-query): generate dynamic cache smoke summary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,13 +133,14 @@ jobs:
 
       - name: Summarize C# query cache smoke slices
         if: always()
+        shell: pwsh
         run: |
-          if (Test-Path "$CSHARP_QUERY_SMOKE_SUMMARY_PATH") {
-            Get-Content "$CSHARP_QUERY_SMOKE_SUMMARY_PATH" | Out-File -FilePath "$GITHUB_STEP_SUMMARY" -Encoding utf8 -Append
+          if (Test-Path $env:CSHARP_QUERY_SMOKE_SUMMARY_PATH) {
+            Get-Content $env:CSHARP_QUERY_SMOKE_SUMMARY_PATH | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           } else {
-            {
-              echo "## C# Query Runtime Smoke"
-              echo ""
-              echo "- Summary file not found at \`$CSHARP_QUERY_SMOKE_SUMMARY_PATH\`"
-            } >> "$GITHUB_STEP_SUMMARY"
+            @(
+              "## C# Query Runtime Smoke",
+              "",
+              "- Summary file not found at `"$($env:CSHARP_QUERY_SMOKE_SUMMARY_PATH)`""
+            ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
     timeout-minutes: 45
     env:
       CSHARP_QUERY_SMOKE_OUTPUT_DIR: tmp/csharp_query_smoke_ci
+      CSHARP_QUERY_SMOKE_SUMMARY_PATH: tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md
 
     steps:
       - name: Checkout code
@@ -119,7 +120,7 @@ jobs:
 
       - name: Run C# query cache smoke sequence
         run: |
-          pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR"
+          pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir "$CSHARP_QUERY_SMOKE_OUTPUT_DIR" -SummaryPath "$CSHARP_QUERY_SMOKE_SUMMARY_PATH"
 
       - name: Upload C# query smoke artifacts on failure
         if: failure()
@@ -133,10 +134,12 @@ jobs:
       - name: Summarize C# query cache smoke slices
         if: always()
         run: |
-          {
-            echo "## C# Query Runtime Smoke"
-            echo ""
-            echo "- Cache slices: admission, reuse, lru"
-            echo "- Output dir: \`$CSHARP_QUERY_SMOKE_OUTPUT_DIR\`"
-            echo "- Failure artifacts: uploaded from \`$CSHARP_QUERY_SMOKE_OUTPUT_DIR\` when the smoke job fails"
-          } >> "$GITHUB_STEP_SUMMARY"
+          if (Test-Path "$CSHARP_QUERY_SMOKE_SUMMARY_PATH") {
+            Get-Content "$CSHARP_QUERY_SMOKE_SUMMARY_PATH" | Out-File -FilePath "$GITHUB_STEP_SUMMARY" -Encoding utf8 -Append
+          } else {
+            {
+              echo "## C# Query Runtime Smoke"
+              echo ""
+              echo "- Summary file not found at \`$CSHARP_QUERY_SMOKE_SUMMARY_PATH\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }

--- a/scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
+++ b/scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
@@ -6,6 +6,7 @@
 #   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1
 #   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/csharp_query_smoke_ci
 #   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1 -KeepArtifacts
+#   pwsh -File .\scripts\testing\run_csharp_query_cache_smoke_sequence.ps1 -SummaryPath tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md
 #
 # Notes:
 # - Requires the same prerequisites as run_csharp_query_runtime_smoke.ps1.
@@ -20,12 +21,95 @@ param(
     [string]$ProjectFilter = "*",
 
     [Parameter(Mandatory = $false)]
+    [string]$SummaryPath,
+
+    [Parameter(Mandatory = $false)]
     [switch]$KeepArtifacts
 )
 
 $ErrorActionPreference = "Stop"
 
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 $runnerPath = Join-Path $PSScriptRoot "run_csharp_query_runtime_smoke.ps1"
+$resolvedOutputDir = if ([System.IO.Path]::IsPathRooted($OutputDir)) {
+    [System.IO.Path]::GetFullPath($OutputDir)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $projectRoot $OutputDir))
+}
+$displaySummaryPath = if ([string]::IsNullOrWhiteSpace($SummaryPath)) {
+    Join-Path $OutputDir "cache_smoke_sequence_summary.md"
+} else {
+    $SummaryPath
+}
+$resolvedSummaryPath = if ([System.IO.Path]::IsPathRooted($displaySummaryPath)) {
+    [System.IO.Path]::GetFullPath($displaySummaryPath)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $projectRoot $displaySummaryPath))
+}
+
+function Format-Duration {
+    param(
+        [Parameter(Mandatory = $true)]
+        [TimeSpan]$Duration
+    )
+
+    return ("{0:F1}s" -f $Duration.TotalSeconds)
+}
+
+function Write-CacheSmokeSummary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DisplayOutputDir,
+
+        [Parameter(Mandatory = $true)]
+        [string]$DisplaySummaryPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectFilterValue,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$KeepArtifactsAfterSequence,
+
+        [Parameter(Mandatory = $true)]
+        [object[]]$SliceResults,
+
+        [Parameter(Mandatory = $true)]
+        [bool]$HasFailure
+    )
+
+    $summaryDir = Split-Path -Parent $Path
+    if ($summaryDir) {
+        New-Item -ItemType Directory -Force -Path $summaryDir | Out-Null
+    }
+
+    $lines = @(
+        "## C# Query Runtime Smoke",
+        "",
+        "- Overall result: $(if ($HasFailure) { "FAIL" } else { "PASS" })",
+        "- Output dir: `"$DisplayOutputDir`"",
+        "- Summary path: `"$DisplaySummaryPath`"",
+        "- Project filter: `"$ProjectFilterValue`"",
+        "- Keep artifacts after sequence: $(if ($KeepArtifactsAfterSequence) { "true" } else { "false" })",
+        "",
+        "| Slice | Status | Duration |",
+        "| --- | --- | --- |"
+    )
+
+    foreach ($sliceResult in $SliceResults) {
+        $lines += "| $($sliceResult.Slice) | $($sliceResult.Status) | $(Format-Duration -Duration $sliceResult.Duration) |"
+    }
+
+    $failedSlice = $SliceResults | Where-Object { $_.Status -eq "FAIL" } | Select-Object -First 1
+    if ($failedSlice) {
+        $lines += ""
+        $lines += "Failure detail: `"$($failedSlice.Error)`""
+    }
+
+    Set-Content -Path $Path -Value $lines
+}
 
 function Invoke-CacheSmokeSlice {
     param(
@@ -40,7 +124,7 @@ function Invoke-CacheSmokeSlice {
     )
 
     $runnerArgs = @{
-        OutputDir = $OutputDir
+        OutputDir = $resolvedOutputDir
         ProjectFilter = $ProjectFilter
         CacheSlice = $Slice
     }
@@ -57,6 +141,65 @@ function Invoke-CacheSmokeSlice {
     & $runnerPath @runnerArgs
 }
 
-Invoke-CacheSmokeSlice -Slice "admission" -KeepArtifactsForSlice
-Invoke-CacheSmokeSlice -Slice "reuse" -SkipCodegen -KeepArtifactsForSlice
-Invoke-CacheSmokeSlice -Slice "lru" -SkipCodegen -KeepArtifactsForSlice:$KeepArtifacts
+New-Item -ItemType Directory -Force -Path $resolvedOutputDir | Out-Null
+
+$sliceSpecs = @(
+    @{
+        Slice = "admission"
+        SkipCodegen = $false
+        KeepArtifactsForSlice = $true
+    },
+    @{
+        Slice = "reuse"
+        SkipCodegen = $true
+        KeepArtifactsForSlice = $true
+    },
+    @{
+        Slice = "lru"
+        SkipCodegen = $true
+        KeepArtifactsForSlice = [bool]$KeepArtifacts
+    }
+)
+
+$sliceResults = @()
+$sequenceFailure = $null
+
+foreach ($sliceSpec in $sliceSpecs) {
+    $sliceStart = Get-Date
+    $sliceStatus = "PASS"
+    $sliceError = $null
+
+    try {
+        Invoke-CacheSmokeSlice -Slice $sliceSpec.Slice -SkipCodegen:$sliceSpec.SkipCodegen -KeepArtifactsForSlice:$sliceSpec.KeepArtifactsForSlice
+    } catch {
+        $sliceStatus = "FAIL"
+        $sliceError = $_.Exception.Message
+        $sequenceFailure = $_
+    } finally {
+        $sliceResults += [pscustomobject]@{
+            Slice = $sliceSpec.Slice
+            Status = $sliceStatus
+            Duration = ((Get-Date) - $sliceStart)
+            Error = $sliceError
+        }
+    }
+
+    if ($sequenceFailure) {
+        break
+    }
+}
+
+Write-CacheSmokeSummary `
+    -Path $resolvedSummaryPath `
+    -DisplayOutputDir $OutputDir `
+    -DisplaySummaryPath $displaySummaryPath `
+    -ProjectFilterValue $ProjectFilter `
+    -KeepArtifactsAfterSequence ([bool]$KeepArtifacts) `
+    -SliceResults $sliceResults `
+    -HasFailure ([bool]$sequenceFailure)
+
+Write-Host "Wrote cache smoke summary: $resolvedSummaryPath"
+
+if ($sequenceFailure) {
+    throw $sequenceFailure.Exception
+}


### PR DESCRIPTION
  ## Summary
  Generate the C# query cache smoke job summary from the cache-smoke wrapper itself, so CI reports real slice outcomes
  and timings instead of hard-coded text.

  ## What changed
  - Enhanced `scripts/testing/run_csharp_query_cache_smoke_sequence.ps1` to:
    - record per-slice status (`PASS` / `FAIL`)
    - record per-slice duration
    - write a markdown summary file for the full smoke sequence
    - still write that summary file when a slice fails
  - Updated `.github/workflows/test.yml` to:
    - define `CSHARP_QUERY_SMOKE_SUMMARY_PATH`
    - pass that summary path into the wrapper
    - append the generated summary file to `$GITHUB_STEP_SUMMARY`
    - fall back to a minimal “summary file not found” message if summary generation fails unexpectedly

  ## Why
  The cache smoke workflow already had:
  - stable cache slices
  - failure artifact upload
  - a summary step

  But the summary itself was static. That meant CI always reported the same text regardless of:
  - which slice failed
  - how long each slice took
  - whether the wrapper completed fully

  This PR makes the summary reflect the actual execution of:
  - `admission`
  - `reuse`
  - `lru`

  using the same wrapper logic that CI and local repro both run.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/
  csharp_query_smoke_dynamic_summary -SummaryPath tmp/csharp_query_smoke_dynamic_summary/
  cache_smoke_sequence_summary.md`
    - Passed

  ## Example summary output
  - overall result
  - output dir
  - summary path
  - project filter
  - keep-artifacts setting
  - per-slice table with:
    - `admission`
    - `reuse`
    - `lru`
    - status
    - duration