### PR TITLE
docs(csharp-query): document cache smoke workflow

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -100,8 +100,37 @@ The core query runtime is intended to stay dependency-free (no LiteDB, ONNX, etc
 ## Smoke Testing (Runtime Execution)
 The Prolog test suite can generate per-plan C# console projects in codegen-only mode, and the PowerShell runner can then build/run them with dotnet and verify outputs.
 
-- Runner (recommended): `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1`
-  - Options: `-KeepArtifacts`, `-OutputDir tmp/csharp_query_smoke`, `-SkipCodegen`
+- Recommended runner (matches CI): `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1`
+  - Runs the stable cache smoke sequence in one shared output dir:
+    - `admission`
+    - `reuse -SkipCodegen`
+    - `lru -SkipCodegen`
+  - Common options:
+    - `-OutputDir tmp/csharp_query_smoke_ci`
+    - `-KeepArtifacts`
+    - `-SummaryPath tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md`
+- Lower-level runner (useful for ad hoc repro or a single slice): `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1`
+  - Common options:
+    - `-OutputDir tmp/csharp_query_smoke`
+    - `-KeepArtifacts`
+    - `-SkipCodegen`
+    - `-CacheSlice admission|reuse|lru`
+    - `-ProjectFilter <pattern>`
+- Typical local repro flow:
+  - Full CI-style cache smoke sequence:
+    - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/csharp_query_smoke_ci`
+  - Re-run a single slice against existing generated projects:
+    - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice reuse -SkipCodegen -KeepArtifacts`
+- CI behavior:
+  - Workflow job: `.github/workflows/test.yml` `csharp_query_runtime_smoke`
+  - Uses the cache smoke sequence wrapper rather than spelling slice commands inline
+  - Uploads `tmp/csharp_query_smoke_ci` as `csharp-query-smoke-artifacts` when the smoke job fails
+  - Appends a dynamic job summary with:
+    - overall result
+    - output dir
+    - project filter
+    - keep-artifacts setting
+    - per-slice status and duration
 - Environment variables (used by the test harness):
   - `SKIP_CSHARP_EXECUTION=1` (generate C# projects but do not execute via Prolog)
   - `CSHARP_QUERY_OUTPUT_DIR=...` (where generated projects are written)


### PR DESCRIPTION
  ## Summary
  Update the C# query runtime docs to describe the current cache smoke workflow, including the canonical wrapper script,
  the lower-level runner, and the current CI smoke behavior.

  ## What changed
  - Updated `docs/targets/csharp-query-runtime.md`
  - Documented the recommended cache smoke entrypoint:
    - `scripts/testing/run_csharp_query_cache_smoke_sequence.ps1`
  - Documented the lower-level runner for ad hoc repro:
    - `scripts/testing/run_csharp_query_runtime_smoke.ps1`
  - Added example local repro flows for:
    - full CI-style cache smoke sequence
    - rerunning a single cache slice with `-SkipCodegen`
  - Documented the current CI behavior:
    - stable cache slices
    - failure artifact upload
    - dynamic job summary

  ## Why
  The smoke workflow had evolved significantly:
  - stable cache slices
  - a CI/local shared wrapper
  - failure artifacts
  - dynamic summary output

  But the runtime docs still described the older single-runner workflow. This PR brings the docs back in sync with the
  actual tooling and CI flow.

  ## Validation
  - `SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt`
    - Passed (`222/222`)
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/
  csharp_query_smoke_docs_workflow -SummaryPath tmp/csharp_query_smoke_docs_workflow/cache_smoke_sequence_summary.md
  -KeepArtifacts`
    - Passed
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/
  csharp_query_smoke_docs_workflow -CacheSlice reuse -SkipCodegen -KeepArtifacts`
    - Passed