### PR TITLE
fix(codegen): fix F# and Clojure ancestor transitive closure templates for proot

### DIFF
--- a/scripts/runtime_test.sh
+++ b/scripts/runtime_test.sh
@@ -606,7 +606,7 @@ if $USE_PROOT; then
         skip_test "proot" "proot-distro not found"
     else
         PROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)/output/validation"
-        proot_run() { proot-distro login debian -- bash -c "$1" 2>&1 | grep -v '^Warning:' | tail -1; }
+        proot_run() { proot-distro login debian -- bash -c "$1" 2>&1 | grep -v -e '^Warning:' -e '^proot warning:' -e $'\x1b' | tail -1; }
 
         # Haskell (ghc)
         echo ""

--- a/templates/targets/clojure/transitive_closure.mustache
+++ b/templates/targets/clojure/transitive_closure.mustache
@@ -35,17 +35,18 @@
             (into visited nexts)
             (into (rest queue) (remove visited nexts))))))))
 
-(defn -main [& args]
+(defn load-facts []
   (doseq [line (line-seq (java.io.BufferedReader. *in*))]
     (when (seq line)
       (let [[from to] (clojure.string/split line #":")]
         (when (and from to)
-          (add-fact (clojure.string/trim from) (clojure.string/trim to))))))
-  (case (count args)
-    0 (do (binding [*out* *err*] (println "Usage: clojure {{pred}}_query.clj <start> [target]"))
-          (System/exit 1))
-    1 (doseq [r (find-all (first args))]
-        (println (str (first args) ":" r)))
-    (if (check-path (first args) (second args))
-      (println (str (first args) ":" (second args)))
+          (add-fact (clojure.string/trim from) (clojure.string/trim to)))))))
+
+(when (seq *command-line-args*)
+  (load-facts)
+  (case (count *command-line-args*)
+    1 (doseq [r (find-all (first *command-line-args*))]
+        (println (str (first *command-line-args*) ":" r)))
+    (if (check-path (first *command-line-args*) (second *command-line-args*))
+      (println (str (first *command-line-args*) ":" (second *command-line-args*)))
       (System/exit 1))))

--- a/templates/targets/fsharp/transitive_closure.mustache
+++ b/templates/targets/fsharp/transitive_closure.mustache
@@ -32,9 +32,9 @@ let main argv =
     let rel = Dictionary<string, ResizeArray<string>>()
     let mutable line = Console.ReadLine()
     while line <> null do
-        let line = line.Trim()
-        if line.Contains(":") then
-            let parts = line.Split([|\':\' |], 2)
+        let trimmed = line.Trim()
+        if trimmed.Contains(":") then
+            let parts = trimmed.Split([|':' |], 2)
             addFact rel (parts.[0].Trim()) (parts.[1].Trim())
         line <- Console.ReadLine()
     match argv with


### PR DESCRIPTION
## Summary

- **F# ancestor template**: Fixed Prolog-escaped `\'` quotes leaking into generated F# code (`':'` instead of `\':\'`), and fixed mutable variable shadowing where `let line = line.Trim()` shadowed the outer mutable `line`, preventing `line <- Console.ReadLine()` from compiling — renamed to `let trimmed = line.Trim()`
- **Clojure ancestor template**: Replaced `(defn -main [& args] ...)` with top-level `(when (seq *command-line-args*) ...)` invocation — `clojure.main script.clj` evaluates the file but never calls `-main`, so the program produced no output; all other working Clojure templates use `*command-line-args*` directly
- **proot_run filter**: Improved grep filter to also catch `proot warning:` prefix lines and ANSI escape sequences that were polluting test output

## Test plan

- [x] F# ancestor proot test: `tom:dave` output verified
- [x] Clojure ancestor proot test: `tom:dave` output verified
- [x] Full runtime test suite: **134 passed, 0 failed, 1 skipped**
- [x] All proot targets pass (Haskell, F#, Clojure, Elixir, PowerShell)

## Files changed

| File | Change |
|------|--------|
| `templates/targets/fsharp/transitive_closure.mustache` | Fix escaped quotes + variable shadowing |
| `templates/targets/clojure/transitive_closure.mustache` | Replace `-main` with top-level `*command-line-args*` |
| `scripts/runtime_test.sh` | Improve `proot_run` warning filter |
