### PR TITLE
Keep native TypR n-ary linear recursion loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,12 +230,14 @@ includes:
 - accumulator-style tail-recursive predicates such as `factorial_acc/3`,
   lowered to TypR functions that use raw-expression loop bodies instead of
   relabeled standalone R scripts
-- conservative arity-2 numeric linear-recursive predicates such as
-  `factorial_linear/2`, lowered to TypR functions that use raw-expression
-  fold/loop bodies instead of wrapped-R fallback
-- conservative arity-2 list linear-recursive predicates such as
-  `list_length/2`, lowered to TypR functions that use raw-expression
-  fold/loop bodies instead of wrapped-R fallback
+- conservative single-recursive-call numeric linear-recursive predicates with
+  one recursion-driving argument and invariant context args, such as
+  `factorial_linear/2` and `power/3`, lowered to TypR functions that use
+  raw-expression fold/loop bodies instead of wrapped-R fallback
+- conservative single-recursive-call list linear-recursive predicates with
+  one recursion-driving list argument and invariant context args, such as
+  `list_length/2` and `list_length_from/3`, lowered to TypR functions that
+  use raw-expression fold/loop bodies instead of wrapped-R fallback
 - two-level nested guarded alternatives inside supported semicolon branches,
   including nested multi-result selections, where each nested branch still
   selects the same later result set natively

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -187,12 +187,14 @@ bring-up.
   - accumulator-style tail-recursive predicates lowered to TypR-valid
     functions with raw-expression loop bodies for the currently supported
     tail-recursion shape
-  - conservative arity-2 numeric linear-recursive predicates lowered to
-    TypR-valid functions with raw-expression fold/loop bodies for the
-    currently supported single-base linear-recursion shape
-  - conservative arity-2 list linear-recursive predicates lowered to
-    TypR-valid functions with raw-expression fold/loop bodies for the
-    currently supported empty-list linear-recursion shape
+  - conservative single-recursive-call numeric linear-recursive predicates
+    lowered to TypR-valid functions with raw-expression fold/loop bodies for
+    the currently supported single-base shape with one recursion-driving
+    argument and invariant context args
+  - conservative single-recursive-call list linear-recursive predicates
+    lowered to TypR-valid functions with raw-expression fold/loop bodies for
+    the currently supported empty-list shape with one recursion-driving list
+    argument and invariant context args
   - two-level nested guarded alternatives inside supported semicolon branches
     where each nested branch still selects the same later result set,
     including nested multi-result selections

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -362,14 +362,16 @@ Current TypR lowering policy is intentionally mixed:
   functions when they match the conservative tail-recursion shape currently
   supported by the shared recursion compiler, using raw-expression loop bodies
   inside TypR rather than relabeled standalone R output
-- conservative arity-2 numeric linear-recursive predicates may also lower to
-  TypR-valid functions when they match the currently supported single-base,
-  single-recursive-clause fold shape, using raw-expression fold/loop bodies
+- conservative single-recursive-call numeric linear-recursive predicates may
+  also lower to TypR-valid functions when they match the currently supported
+  single-base, single-recursive-clause fold shape with one recursion-driving
+  argument and invariant context args, using raw-expression fold/loop bodies
   inside TypR rather than wrapped-R fallback
-- conservative arity-2 list linear-recursive predicates may also lower to
-  TypR-valid functions when they match the currently supported empty-list
-  base-case fold shape, using raw-expression fold/loop bodies inside TypR
-  rather than wrapped-R fallback
+- conservative single-recursive-call list linear-recursive predicates may
+  also lower to TypR-valid functions when they match the currently supported
+  empty-list base-case fold shape with one recursion-driving list argument
+  and invariant context args, using raw-expression fold/loop bodies inside
+  TypR rather than wrapped-R fallback
 - two-level nested guarded alternatives may also stay native when a supported
   semicolon branch contains another guarded alternative whose nested branch may
   itself contain one more guarded alternative, provided those branches select

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -57,12 +57,14 @@ This document focuses on architecture and rollout choices specific to TypR.
    - accumulator-style tail-recursive predicates that match the currently
      supported shared tail-recursion shape, emitted as TypR functions with
      raw-expression loop bodies
-   - conservative arity-2 numeric linear-recursive predicates that match the
-     currently supported single-base fold shape, emitted as TypR functions
-     with raw-expression fold/loop bodies
-   - conservative arity-2 list linear-recursive predicates that match the
-     currently supported empty-list fold shape, emitted as TypR functions
-     with raw-expression fold/loop bodies
+   - conservative single-recursive-call numeric linear-recursive predicates
+     that match the currently supported single-base fold shape with one
+     recursion-driving argument and invariant context args, emitted as TypR
+     functions with raw-expression fold/loop bodies
+   - conservative single-recursive-call list linear-recursive predicates
+     that match the currently supported empty-list fold shape with one
+     recursion-driving list argument and invariant context args, emitted as
+     TypR functions with raw-expression fold/loop bodies
    - multiple sequential branch/rejoin segments in the same native body,
      including repeated multi-result rejoin chains that feed later native
      steps after each rejoin
@@ -334,10 +336,10 @@ Current implementation note:
   alternatives inside supported semicolon branches where each nested branch
   still selects the same later result set, accumulator-style tail-recursive
   predicates compiled to raw-expression loop bodies inside TypR functions,
-  conservative arity-2 numeric linear-recursive predicates compiled to
-  raw-expression fold/loop bodies inside TypR functions,
-  conservative arity-2 list linear-recursive predicates compiled to
-  raw-expression fold/loop bodies inside TypR functions,
+  conservative single-recursive-call numeric linear-recursive predicates
+  compiled to raw-expression fold/loop bodies inside TypR functions,
+  conservative single-recursive-call list linear-recursive predicates
+  compiled to raw-expression fold/loop bodies inside TypR functions,
   native literal-headed branch bodies built from those chains,
   dataframe helper calls, and literal-guarded branch selection; more complex
   bodies still fall back to wrapped R

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -96,9 +96,8 @@ single_linear_recursive_clause_pair(Pred, Arity, Clauses, BaseClause, RecClause)
     RecClauses = [RecClause].
 
 compile_typr_linear_recursive_numeric(_Module:Pred/Arity, TypedMode, Clauses, Code) :-
-    Arity =:= 2,
     single_linear_recursive_clause_pair(Pred, Arity, Clauses, BaseClause, RecClause),
-    linear_recursive_numeric_spec(Pred, BaseClause, RecClause, LoopSpec),
+    linear_recursive_numeric_spec(Pred, Arity, BaseClause, RecClause, LoopSpec),
     build_typed_arg_list(Pred/Arity, none, Arity, TypedMode, TypedArgList),
     generic_typr_return_type(Pred/Arity, Clauses, ReturnType),
     build_typr_linear_recursive_body(Pred, LoopSpec, Body),
@@ -114,9 +113,8 @@ let ~w <- fn(~w): ~w {
 ', [PredStr, Arity, PredStr, TypedArgList, ReturnType, IndentedBody]).
 
 compile_typr_linear_recursive_list(_Module:Pred/Arity, TypedMode, Clauses, Code) :-
-    Arity =:= 2,
     single_linear_recursive_clause_pair(Pred, Arity, Clauses, BaseClause, RecClause),
-    linear_recursive_list_spec(Pred, BaseClause, RecClause, LoopSpec),
+    linear_recursive_list_spec(Pred, Arity, BaseClause, RecClause, LoopSpec),
     build_typed_arg_list(Pred/Arity, none, Arity, TypedMode, TypedArgList),
     generic_typr_return_type(Pred/Arity, Clauses, ReturnType),
     build_typr_linear_recursive_list_body(LoopSpec, Body),
@@ -133,64 +131,204 @@ let ~w <- fn(~w): ~w {
 
 linear_recursive_numeric_spec(
     Pred,
+    Arity,
     BaseHead-BaseBody,
     RecHead-RecBody,
     linear_loop_spec{
         base_input_literal: BaseInputLiteral,
-        base_output_literal: BaseOutputLiteral,
+        base_output_expr: BaseOutputExpr,
         recursive_guard_expr: RecursiveGuardExpr,
         seq_expr: SeqExpr,
-        fold_expr: FoldExpr
+        fold_expr: FoldExpr,
+        input_arg_name: InputArgName,
+        output_arg_name: OutputArgName,
+        result_name: ResultName
     }
 ) :-
     BaseBody == true,
-    BaseHead =.. [_BasePredName, BaseInput, BaseOutput],
-    number(BaseInput),
-    number(BaseOutput),
-    RecHead =.. [_RecPredName, InputVar, OutputVar],
-    var(InputVar),
-    var(OutputVar),
+    BaseHead =.. [_BasePredName|BaseArgs],
+    RecHead =.. [_RecPredName|RecHeadArgs],
     split_body_at_recursive_call(RecBody, Pred, PreGoals, RecCall, PostGoals),
-    RecCall =.. [_PredName, _NextInput, RecResultVar],
+    RecCall =.. [_PredName|RecCallArgs],
+    linear_recursive_arg_spec(
+        Arity,
+        BaseArgs,
+        RecHeadArgs,
+        RecCallArgs,
+        BaseOutput,
+        OutputVar,
+        RecResultVar,
+        DriverPos,
+        BaseInput,
+        InputVar,
+        _RecInputArg,
+        BaseInvariantVarMap,
+        RecInvariantVarMap,
+        InputArgName,
+        OutputArgName,
+        ResultName
+    ),
+    number(BaseInput),
+    var(InputVar),
     normalize_typr_goals(PostGoals, [OutputVar is FoldTerm]),
-    extract_step_info([clause(RecHead, RecBody)], InputVar, Step, Direction),
-    linear_recursive_guard_expr(PreGoals, InputVar, RecursiveGuardExpr),
-    typr_translate_r_expr(FoldTerm, [InputVar-"current", RecResultVar-"acc"], FoldExpr),
+    extract_typr_linear_step_info(RecBody, DriverPos, RecCallArgs, InputVar, Step, Direction),
+    append([InputVar-"current", RecResultVar-"acc"], RecInvariantVarMap, FoldVarMap),
+    append([InputVar-"current_input"], RecInvariantVarMap, GuardVarMap),
+    linear_recursive_guard_expr(PreGoals, GuardVarMap, RecursiveGuardExpr),
+    typr_translate_r_expr(FoldTerm, FoldVarMap, FoldExpr),
+    typr_translate_r_expr(BaseOutput, BaseInvariantVarMap, BaseOutputExpr),
     r_literal(BaseInput, BaseInputLiteral),
-    r_literal(BaseOutput, BaseOutputLiteral),
     typr_linear_seq_expr(BaseInput, Step, Direction, SeqExpr).
 
 linear_recursive_list_spec(
     Pred,
+    Arity,
     BaseHead-BaseBody,
     RecHead-RecBody,
     list_loop_spec{
-        base_output_literal: BaseOutputLiteral,
-        fold_expr: FoldExpr
+        base_output_expr: BaseOutputExpr,
+        fold_expr: FoldExpr,
+        input_arg_name: InputArgName,
+        output_arg_name: OutputArgName,
+        result_name: ResultName
     }
 ) :-
     BaseBody == true,
-    BaseHead =.. [_BasePredName, BaseInput, BaseOutput],
+    BaseHead =.. [_BasePredName|BaseArgs],
+    RecHead =.. [_RecPredName|RecHeadArgs],
+    split_body_at_recursive_call(RecBody, Pred, PreGoals, RecCall, PostGoals),
+    RecCall =.. [_PredName|RecCallArgs],
+    linear_recursive_arg_spec(
+        Arity,
+        BaseArgs,
+        RecHeadArgs,
+        RecCallArgs,
+        BaseOutput,
+        OutputVar,
+        RecResultVar,
+        _DriverPos,
+        BaseInput,
+        InputPattern,
+        RecInputArg,
+        BaseInvariantVarMap,
+        RecInvariantVarMap,
+        InputArgName,
+        OutputArgName,
+        ResultName
+    ),
     BaseInput == [],
-    number(BaseOutput),
-    RecHead =.. [_RecPredName, InputPattern, OutputVar],
     InputPattern = [HeadVar|TailVar],
     var(TailVar),
-    var(OutputVar),
-    split_body_at_recursive_call(RecBody, Pred, PreGoals, RecCall, PostGoals),
     PreGoals == true,
-    RecCall =.. [_PredName, RecInputArg, RecResultVar],
     RecInputArg == TailVar,
     normalize_typr_goals(PostGoals, [OutputVar is FoldTerm]),
-    typr_translate_r_expr(FoldTerm, [HeadVar-"current", RecResultVar-"acc"], FoldExpr),
-    r_literal(BaseOutput, BaseOutputLiteral).
+    append([HeadVar-"current", RecResultVar-"acc"], RecInvariantVarMap, FoldVarMap),
+    typr_translate_r_expr(FoldTerm, FoldVarMap, FoldExpr),
+    typr_translate_r_expr(BaseOutput, BaseInvariantVarMap, BaseOutputExpr).
 
-linear_recursive_guard_expr(true, _InputVar, 'TRUE') :-
+linear_recursive_arg_spec(
+    Arity,
+    BaseArgs,
+    RecHeadArgs,
+    RecCallArgs,
+    BaseOutput,
+    OutputVar,
+    RecResultVar,
+    DriverPos,
+    BaseInput,
+    DriverHeadArg,
+    DriverRecArg,
+    BaseInvariantVarMap,
+    RecInvariantVarMap,
+    InputArgName,
+    OutputArgName,
+    ResultName
+) :-
+    Arity >= 2,
+    OutputPos is Arity,
+    nth1(OutputPos, BaseArgs, BaseOutput),
+    nth1(OutputPos, RecHeadArgs, OutputVar),
+    var(OutputVar),
+    nth1(OutputPos, RecCallArgs, RecResultVar),
+    var(RecResultVar),
+    single_linear_recursive_driver_pos(Arity, RecHeadArgs, RecCallArgs, DriverPos),
+    nth1(DriverPos, BaseArgs, BaseInput),
+    nth1(DriverPos, RecHeadArgs, DriverHeadArg),
+    nth1(DriverPos, RecCallArgs, DriverRecArg),
+    linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
+    base_linear_invariants_ok(BaseArgs, RecHeadArgs, InvariantPositions),
+    build_linear_recursive_varmap(BaseArgs, InvariantPositions, BaseInvariantVarMap),
+    build_linear_recursive_varmap(RecHeadArgs, InvariantPositions, RecInvariantVarMap),
+    format(string(InputArgName), 'arg~w', [DriverPos]),
+    format(string(OutputArgName), 'arg~w', [OutputPos]),
+    linear_recursive_result_name(Arity, ResultName).
+
+single_linear_recursive_driver_pos(Arity, RecHeadArgs, RecCallArgs, DriverPos) :-
+    InputLast is Arity - 1,
+    findall(Pos, (
+        between(1, InputLast, Pos),
+        linear_recursive_changed_arg(RecHeadArgs, RecCallArgs, Pos)
+    ), DriverPositions),
+    DriverPositions = [DriverPos].
+
+linear_recursive_changed_arg(HeadArgs, CallArgs, Pos) :-
+    nth1(Pos, HeadArgs, HeadArg),
+    nth1(Pos, CallArgs, CallArg),
+    \+ linear_recursive_same_arg(HeadArg, CallArg).
+
+linear_recursive_same_arg(Left, Right) :-
+    Left == Right,
     !.
-linear_recursive_guard_expr(PreGoals, InputVar, GuardExpr) :-
+linear_recursive_same_arg(Left, Right) :-
+    nonvar(Left),
+    nonvar(Right),
+    Left =@= Right.
+
+linear_recursive_invariant_positions(Arity, DriverPos, Positions) :-
+    InputLast is Arity - 1,
+    findall(Pos, (
+        between(1, InputLast, Pos),
+        Pos =\= DriverPos
+    ), Positions).
+
+base_linear_invariants_ok(_BaseArgs, _RecHeadArgs, []).
+base_linear_invariants_ok(BaseArgs, RecHeadArgs, [Pos|Rest]) :-
+    nth1(Pos, BaseArgs, BaseArg),
+    nth1(Pos, RecHeadArgs, RecArg),
+    linear_recursive_base_invariant_ok(BaseArg, RecArg),
+    base_linear_invariants_ok(BaseArgs, RecHeadArgs, Rest).
+
+linear_recursive_base_invariant_ok(BaseArg, _RecArg) :-
+    var(BaseArg),
+    !.
+linear_recursive_base_invariant_ok(BaseArg, RecArg) :-
+    nonvar(RecArg),
+    BaseArg =@= RecArg.
+
+build_linear_recursive_varmap(Args, Positions, VarMap) :-
+    build_linear_recursive_varmap(Args, Positions, [], RevVarMap),
+    reverse(RevVarMap, VarMap).
+
+build_linear_recursive_varmap(_Args, [], VarMap, VarMap).
+build_linear_recursive_varmap(Args, [Pos|Rest], VarMap0, VarMap) :-
+    nth1(Pos, Args, Var),
+    (   var(Var)
+    ->  format(string(ArgName), 'arg~w', [Pos]),
+        VarMap1 = [Var-ArgName|VarMap0]
+    ;   VarMap1 = VarMap0
+    ),
+    build_linear_recursive_varmap(Args, Rest, VarMap1, VarMap).
+
+linear_recursive_result_name(Arity, ResultName) :-
+    ResultIndex is Arity + 1,
+    format(string(ResultName), 'v~w', [ResultIndex]).
+
+linear_recursive_guard_expr(true, _VarMap, 'TRUE') :-
+    !.
+linear_recursive_guard_expr(PreGoals, VarMap, GuardExpr) :-
     normalize_typr_goals(PreGoals, Goals0),
     exclude(linear_recursive_step_goal, Goals0, GuardGoals),
-    maplist(linear_recursive_guard_condition([InputVar-"current_input"]), GuardGoals, GuardConditions),
+    maplist(linear_recursive_guard_condition(VarMap), GuardGoals, GuardConditions),
     combine_typr_conditions(GuardConditions, GuardExpr).
 
 linear_recursive_step_goal(Goal) :-
@@ -218,24 +356,30 @@ build_typr_linear_recursive_body(
     Pred,
     linear_loop_spec{
         base_input_literal: BaseInputLiteral,
-        base_output_literal: BaseOutputLiteral,
+        base_output_expr: BaseOutputExpr,
         recursive_guard_expr: RecursiveGuardExpr,
         seq_expr: SeqExpr,
-        fold_expr: FoldExpr
+        fold_expr: FoldExpr,
+        input_arg_name: InputArgName,
+        output_arg_name: OutputArgName,
+        result_name: ResultName
     },
     Body
 ) :-
     linear_recursive_guard_lines(RecursiveGuardExpr, Pred, GuardLines),
-    format(string(BaseLine), '        ~w', [BaseOutputLiteral]),
-    format(string(AccInitLine), '        acc = ~w;', [BaseOutputLiteral]),
+    format(string(BaseLine), '        ~w', [BaseOutputExpr]),
+    format(string(AccInitLine), '        acc = ~w;', [BaseOutputExpr]),
     format(string(LoopLine), '        for (current in ~w) {', [SeqExpr]),
     format(string(AccStepLine), '            acc = ~w;', [FoldExpr]),
     format(string(BaseCaseIfLine), '    if (identical(current_input, ~w)) {', [BaseInputLiteral]),
+    format(string(ResultIntroLine), 'let ~w <- @{', [ResultName]),
+    format(string(CurrentInputLine), '    current_input = ~w;', [InputArgName]),
+    format(string(AssignResultLine), '~w <- ~w;', [OutputArgName, ResultName]),
     atomic_list_concat(
         [
-            'let v3 <- @{',
+            ResultIntroLine,
             'local({',
-            '    current_input = arg1;',
+            CurrentInputLine,
             BaseCaseIfLine,
             BaseLine,
             '    } else {'
@@ -261,8 +405,8 @@ build_typr_linear_recursive_body(
             '    }',
             '})',
             '}@;',
-            'arg2 <- v3;',
-            'arg2'
+            AssignResultLine,
+            OutputArgName
         ],
         RawLines
     ),
@@ -270,19 +414,25 @@ build_typr_linear_recursive_body(
 
 build_typr_linear_recursive_list_body(
     list_loop_spec{
-        base_output_literal: BaseOutputLiteral,
-        fold_expr: FoldExpr
+        base_output_expr: BaseOutputExpr,
+        fold_expr: FoldExpr,
+        input_arg_name: InputArgName,
+        output_arg_name: OutputArgName,
+        result_name: ResultName
     },
     Body
 ) :-
-    format(string(BaseLine), '        ~w', [BaseOutputLiteral]),
-    format(string(AccInitLine), '        acc = ~w;', [BaseOutputLiteral]),
+    format(string(BaseLine), '        ~w', [BaseOutputExpr]),
+    format(string(AccInitLine), '        acc = ~w;', [BaseOutputExpr]),
     format(string(AccStepLine), '            acc = ~w;', [FoldExpr]),
+    format(string(ResultIntroLine), 'let ~w <- @{', [ResultName]),
+    format(string(CurrentInputLine), '    current_input = ~w;', [InputArgName]),
+    format(string(AssignResultLine), '~w <- ~w;', [OutputArgName, ResultName]),
     atomic_list_concat(
         [
-            'let v3 <- @{',
+            ResultIntroLine,
             'local({',
-            '    current_input = arg1;',
+            CurrentInputLine,
             '    if (length(current_input) == 0) {',
             BaseLine,
             '    } else {',
@@ -294,12 +444,38 @@ build_typr_linear_recursive_list_body(
             '    }',
             '})',
             '}@;',
-            'arg2 <- v3;',
-            'arg2'
+            AssignResultLine,
+            OutputArgName
         ],
         '\n',
         Body
     ).
+
+extract_typr_linear_step_info(RecBody, DriverPos, RecCallArgs, InputVar, Step, Direction) :-
+    nth1(DriverPos, RecCallArgs, RecInputVar),
+    normalize_typr_goals(RecBody, Goals),
+    member(RecInputVar is StepExpr, Goals),
+    extract_typr_linear_step_from_expr(StepExpr, InputVar, Step, Direction),
+    !.
+
+extract_typr_linear_step_from_expr(A - B, InputVar, Step, down) :-
+    A == InputVar,
+    integer(B),
+    B > 0,
+    !,
+    Step = B.
+extract_typr_linear_step_from_expr(A + B, InputVar, Step, up) :-
+    A == InputVar,
+    integer(B),
+    B > 0,
+    !,
+    Step = B.
+extract_typr_linear_step_from_expr(A + B, InputVar, Step, down) :-
+    A == InputVar,
+    integer(B),
+    B < 0,
+    !,
+    Step is abs(B).
 
 linear_recursive_guard_lines('TRUE', _Pred, []) :-
     !.
@@ -1486,8 +1662,8 @@ guard_tail_final_expression(PendingGuards, PredName, LastExpr, FinalExpr) :-
 
 typr_translate_r_expr(Var, VarMap, Resolved) :-
     var(Var),
-    lookup_typr_var(Var, VarMap, Resolved),
-    !.
+    !,
+    lookup_typr_var(Var, VarMap, Resolved).
 typr_translate_r_expr(Atom, _VarMap, Resolved) :-
     atom(Atom),
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -48,6 +48,8 @@ cleanup_typr_test :-
     retractall(user:factorial_acc(_, _, _)),
     retractall(user:factorial_linear(_, _)),
     retractall(user:list_length(_, _)),
+    retractall(user:power(_, _, _)),
+    retractall(user:list_length_from(_, _, _)),
     retractall(user:alternative_assign_chain(_, _)),
     retractall(user:alternative_assign_clause_chain(_, _)),
     retractall(user:direct_output_choice(_, _)),
@@ -195,6 +197,48 @@ test(recursive_compiler_supports_typr_list_linear_recursion_path) :-
     once(sub_string(Code, _, _, _, "if (length(current_input) == 0)")),
     once(sub_string(Code, _, _, _, "for (current in rev(current_input))")),
     once(sub_string(Code, _, _, _, "acc = (acc + 1);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:power(_Base, 0, 1)),
+    assertz(user:(power(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        power(Base, N1, Prev),
+        Result is Base * Prev
+    )),
+    assertz(type_declarations:uw_type(power/3, 1, integer)),
+    assertz(type_declarations:uw_type(power/3, 2, integer)),
+    assertz(type_declarations:uw_type(power/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(power/3, integer)),
+    once(recursive_compiler:compile_recursive(power/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let power <- fn(arg1: int, arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "for (current in seq(current_input, 1))")),
+    once(sub_string(Code, _, _, _, "acc = (arg1 * acc);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_list_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:list_length_from(Base, [], Base)),
+    assertz(user:(list_length_from(Base, [_|T], N) :-
+        list_length_from(Base, T, N1),
+        N is N1 + 1
+    )),
+    assertz(type_declarations:uw_type(list_length_from/3, 1, integer)),
+    assertz(type_declarations:uw_type(list_length_from/3, 2, list(any))),
+    assertz(type_declarations:uw_type(list_length_from/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(list_length_from/3, integer)),
+    once(recursive_compiler:compile_recursive(list_length_from/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let list_length_from <- fn(arg1: int, arg2: [#N, Any], arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "if (length(current_input) == 0)")),
+    once(sub_string(Code, _, _, _, "acc = (acc + 1);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -117,6 +117,54 @@ test(list_linear_recursive_output_checks_with_typr, [condition(typr_cli_availabl
     ),
     retractall(user:list_length(_, _)).
 
+test(nary_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:power(_Base, 0, 1)),
+    assertz(user:(power(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        power(Base, N1, Prev),
+        Result is Base * Prev
+    )),
+    assertz(type_declarations:uw_type(power/3, 1, integer)),
+    assertz(type_declarations:uw_type(power/3, 2, integer)),
+    assertz(type_declarations:uw_type(power/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(power/3, integer)),
+    once(recursive_compiler:compile_recursive(power/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:power(_, _, _)).
+
+test(nary_list_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:list_length_from(Base, [], Base)),
+    assertz(user:(list_length_from(Base, [_|T], N) :-
+        list_length_from(Base, T, N1),
+        N is N1 + 1
+    )),
+    assertz(type_declarations:uw_type(list_length_from/3, 1, integer)),
+    assertz(type_declarations:uw_type(list_length_from/3, 2, list(any))),
+    assertz(type_declarations:uw_type(list_length_from/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(list_length_from/3, integer)),
+    once(recursive_compiler:compile_recursive(list_length_from/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:list_length_from(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR broadens native TypR recursion support from the current arity-2 linear-recursion subset to a conservative `N`-ary single-recursive-call linear-recursion subset.

The main addition is support for recursive predicates with:

- one recursion-driving argument
- one recursive call
- one final output/result argument
- zero or more invariant context arguments
- a simple post-recursive recombination step

That lets shapes such as `power/3` and `list_length_from/3` stay in native TypR instead of classifying as linear recursion and then failing recursive compilation for the TypR target.

This is still a conservative expansion, not arbitrary recursive-body lowering.

## Why This PR Exists

The previous TypR recursion work already supported:

- transitive closure
- accumulator-style tail recursion
- conservative arity-2 numeric linear recursion
- conservative arity-2 list linear recursion

That still left a practical recursion gap:

- linear recursion with one driver argument and one output argument worked
- but the same shape with additional invariant context arguments still failed for TypR

Representative examples are:

```prolog
power(_Base, 0, 1).
power(Base, N, Result) :-
    N > 0,
    N1 is N - 1,
    power(Base, N1, Prev),
    Result is Base * Prev.
```

and:

```prolog
list_length_from(Base, [], Base).
list_length_from(Base, [_|T], N) :-
    list_length_from(Base, T, N1),
    N is N1 + 1.
```

Before this change, those predicates classified as linear recursion but still fell through to:

- `Advanced recursive compilation for target typr not implemented`
- then memoized recursion fallback, which is also not implemented for TypR

This PR closes that gap for a narrow, analyzable subset.

## Main Changes

### 1. Generalized native TypR linear-recursion analysis

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR target no longer assumes every linear-recursive shape must be arity-2.

Instead, the native TypR recursion path now recognizes conservative `N`-ary shapes where:

- the last argument is the selected result/output
- exactly one non-output argument is the recursion-driving argument
- all other non-output arguments stay invariant across the recursive call

That shared analysis is now used by both the numeric and list-linear TypR recursion paths.

### 2. Numeric linear recursion now supports invariant context args

The existing numeric linear-recursion lowering was generalized so a predicate such as `power/3` can stay native in TypR.

That means post-recursive fold expressions can now reference:

- the current recursion-driving value
- the recursive result accumulator
- invariant context args such as `Base`

instead of only the original arity-2 case.

### 3. List linear recursion now supports invariant context args

The same conservative generalization now applies to list-based linear recursion.

That means predicates such as `list_length_from/3` can stay native in TypR when they:

- recurse on one list-driving argument
- keep other context args invariant
- use a single simple post-recursive fold step

### 4. Added driver-local step extraction for non-arity-2 shapes

The native TypR recursion path now extracts the recursive step from the actual recursion-driving argument position rather than relying on the old arity-2 assumption.

That was necessary to keep `N`-ary numeric linear recursion valid when the driver is not `arg1`.

### 5. Fixed a TypR expression-translation bug found by the new audit

While widening the recursion path, the branch exposed a bug in TypR expression translation:

- an unmapped variable could fall through and recursively match the unary-minus translator
- that caused stack overflow instead of clean failure

This PR fixes that by making unresolved variables fail cleanly in `typr_translate_r_expr/3`.

That bug mattered because it would have made the broader recursion work brittle even where the higher-level analysis was otherwise correct.

### 6. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies native TypR lowering and real `typr check` for:

- `power/3`-style numeric `N`-ary linear recursion
- `list_length_from/3`-style list `N`-ary linear recursion

### 7. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the conservative TypR recursion subset includes `N`-ary single-recursive-call linear recursion with invariant context args, not just the earlier arity-2 cases.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR lowering for conservative `N`-ary linear-recursive predicates
- continued real TypR CLI validation for generated recursive output

What it does not claim:

- arbitrary recursive-body TypR lowering
- mutual recursion
- multi-recursive-call recursion
- arbitrary context-arg mutation across the recursive call
- elimination of fallback for all remaining TypR recursion shapes

## Behavior Notes

After this PR, the conservative TypR recursion subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative single-recursive-call numeric linear recursion with invariant context args
- conservative single-recursive-call list linear recursion with invariant context args

More complex recursion shapes still remain outside the supported native TypR subset.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative `N`-ary numeric linear recursion
- native TypR lowering for conservative `N`-ary list linear recursion
- correct handling of invariant context args in those recursive folds
- focused TypR regression and toolchain validation for the broader recursion subset

Still not fully implemented:

- broader post-recursive recombination shapes
- mutation of more than one recursive state slot
- mutual recursion
- tree recursion / multi-call recursion
- arbitrary recursive generic-body lowering

## Why This PR Is Worth Merging

This PR improves TypR recursion support in a meaningful way:

- it removes an obvious practical limitation in the current linear-recursion path
- it broadens support without pretending to solve arbitrary recursion
- it keeps the output TypR-valid instead of relabeling raw R
- it adds real `typr check` coverage for the new recursive shapes

In short, this is a good incremental recursion PR because it extends native TypR recursion from arity-2 folds to a broader but still defensible `N`-ary linear-recursion subset.
