### PR TITLE
ci(csharp-query): upload cache smoke JSON summary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
     env:
       CSHARP_QUERY_SMOKE_OUTPUT_DIR: tmp/csharp_query_smoke_ci
       CSHARP_QUERY_SMOKE_SUMMARY_PATH: tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md
+      CSHARP_QUERY_SMOKE_JSON_SUMMARY_PATH: tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json
 
     steps:
       - name: Checkout code
@@ -128,6 +129,15 @@ jobs:
         with:
           name: csharp-query-smoke-artifacts
           path: ${{ env.CSHARP_QUERY_SMOKE_OUTPUT_DIR }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload C# query smoke JSON summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: csharp-query-smoke-summary-json
+          path: ${{ env.CSHARP_QUERY_SMOKE_JSON_SUMMARY_PATH }}
           if-no-files-found: ignore
           retention-days: 7
 


### PR DESCRIPTION
  ## Summary
  Upload the cache smoke JSON summary as a small always-available workflow artifact so
  CI consumers can inspect machine-readable smoke results without downloading the full
  smoke output directory.

  ## What changed
  - Updated `.github/workflows/test.yml`
  - Added `CSHARP_QUERY_SMOKE_JSON_SUMMARY_PATH` to the `csharp_query_runtime_smoke`
  job env
  - Added an `if: always()` artifact upload step for:
    - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json`
    - artifact name: `csharp-query-smoke-summary-json`
  - Kept the existing behavior unchanged for:
    - failure-only upload of the full smoke output directory
    - markdown job summary appended to `$GITHUB_STEP_SUMMARY`

  ## Why
  The cache smoke wrapper now emits both:
  - markdown summary
  - JSON summary

  CI was already using the markdown summary in the job summary, but the JSON result
  was still only available inside the workspace. This PR exposes that machine-readable
  summary directly as a lightweight workflow artifact, which makes future automation
  and triage simpler without forcing consumers to download the full failure artifact
  bundle.

  ## Validation
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
  -OutputDir tmp/csharp_query_smoke_json_artifact -NoSummaryOutput`
  - Confirmed the wrapper produced:
    - `tmp/csharp_query_smoke_json_artifact/cache_smoke_sequence_summary.json`
  - Confirmed the workflow upload path matches that generated JSON summary path