### PR TITLE
Keep native TypR guarded linear recursion recombination

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ includes:
   one recursion-driving list argument and invariant context args, such as
   `list_length/2` and `list_length_from/3`, lowered to TypR functions that
   use raw-expression fold/loop bodies instead of wrapped-R fallback
+- guarded post-recursive result selection in those same linear-recursive
+  shapes, such as `power_if/3` and `count_occ/3`, where the recursive result
+  is recombined through a native TypR `if` expression instead of wrapped-R
+  fallback
 - two-level nested guarded alternatives inside supported semicolon branches,
   including nested multi-result selections, where each nested branch still
   selects the same later result set natively

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -195,6 +195,10 @@ bring-up.
     lowered to TypR-valid functions with raw-expression fold/loop bodies for
     the currently supported empty-list shape with one recursion-driving list
     argument and invariant context args
+  - guarded post-recursive result selection inside those same single-recursive-
+    call numeric and list linear-recursive shapes when the later result is
+    chosen by a supported `if -> then ; else` over TypR-translatable
+    expressions
   - two-level nested guarded alternatives inside supported semicolon branches
     where each nested branch still selects the same later result set,
     including nested multi-result selections

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -372,6 +372,10 @@ Current TypR lowering policy is intentionally mixed:
   empty-list base-case fold shape with one recursion-driving list argument
   and invariant context args, using raw-expression fold/loop bodies inside
   TypR rather than wrapped-R fallback
+- guarded post-recursive result selection may also stay native inside those
+  same single-recursive-call numeric and list linear-recursive shapes when
+  the recursive result is recombined through a supported `if -> then ; else`
+  choice over TypR-translatable expressions
 - two-level nested guarded alternatives may also stay native when a supported
   semicolon branch contains another guarded alternative whose nested branch may
   itself contain one more guarded alternative, provided those branches select

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -65,6 +65,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      that match the currently supported empty-list fold shape with one
      recursion-driving list argument and invariant context args, emitted as
      TypR functions with raw-expression fold/loop bodies
+   - guarded post-recursive result selection inside those same single-
+     recursive-call numeric and list linear-recursive shapes when the later
+     result is chosen by a supported `if -> then ; else` expression over
+     TypR-translatable branch results
    - multiple sequential branch/rejoin segments in the same native body,
      including repeated multi-result rejoin chains that feed later native
      steps after each rejoin
@@ -340,6 +344,8 @@ Current implementation note:
   compiled to raw-expression fold/loop bodies inside TypR functions,
   conservative single-recursive-call list linear-recursive predicates
   compiled to raw-expression fold/loop bodies inside TypR functions,
+  guarded post-recursive result selection inside those same single-recursive-
+  call numeric and list linear-recursive shapes,
   native literal-headed branch bodies built from those chains,
   dataframe helper calls, and literal-guarded branch selection; more complex
   bodies still fall back to wrapped R

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -170,12 +170,11 @@ linear_recursive_numeric_spec(
     ),
     number(BaseInput),
     var(InputVar),
-    normalize_typr_goals(PostGoals, [OutputVar is FoldTerm]),
     extract_typr_linear_step_info(RecBody, DriverPos, RecCallArgs, InputVar, Step, Direction),
     append([InputVar-"current", RecResultVar-"acc"], RecInvariantVarMap, FoldVarMap),
     append([InputVar-"current_input"], RecInvariantVarMap, GuardVarMap),
     linear_recursive_guard_expr(PreGoals, GuardVarMap, RecursiveGuardExpr),
-    typr_translate_r_expr(FoldTerm, FoldVarMap, FoldExpr),
+    linear_recursive_output_expr(PostGoals, OutputVar, FoldVarMap, FoldExpr),
     typr_translate_r_expr(BaseOutput, BaseInvariantVarMap, BaseOutputExpr),
     r_literal(BaseInput, BaseInputLiteral),
     typr_linear_seq_expr(BaseInput, Step, Direction, SeqExpr).
@@ -221,9 +220,8 @@ linear_recursive_list_spec(
     var(TailVar),
     PreGoals == true,
     RecInputArg == TailVar,
-    normalize_typr_goals(PostGoals, [OutputVar is FoldTerm]),
     append([HeadVar-"current", RecResultVar-"acc"], RecInvariantVarMap, FoldVarMap),
-    typr_translate_r_expr(FoldTerm, FoldVarMap, FoldExpr),
+    linear_recursive_output_expr(PostGoals, OutputVar, FoldVarMap, FoldExpr),
     typr_translate_r_expr(BaseOutput, BaseInvariantVarMap, BaseOutputExpr).
 
 linear_recursive_arg_spec(
@@ -336,6 +334,21 @@ linear_recursive_step_goal(Goal) :-
 
 linear_recursive_guard_condition(VarMap, Goal, GuardCondition) :-
     native_typr_guard_goal(Goal, VarMap, GuardCondition).
+
+linear_recursive_output_expr(PostGoals, OutputVar, VarMap, OutputExpr) :-
+    normalize_typr_goals(PostGoals, [OutputVar is FoldTerm]),
+    !,
+    typr_translate_r_expr(FoldTerm, VarMap, OutputExpr).
+linear_recursive_output_expr(PostGoals, OutputVar, VarMap, OutputExpr) :-
+    typr_if_then_else_goal(PostGoals, IfGoal, ThenGoal, ElseGoal),
+    linear_recursive_branch_output_expr(ThenGoal, OutputVar, VarMap, ThenExpr),
+    linear_recursive_branch_output_expr(ElseGoal, OutputVar, VarMap, ElseExpr),
+    native_typr_if_condition(IfGoal, VarMap, IfCondition),
+    format(string(OutputExpr), 'if (~w) { ~w } else { ~w }', [IfCondition, ThenExpr, ElseExpr]).
+
+linear_recursive_branch_output_expr(Goal, OutputVar, VarMap, OutputExpr) :-
+    normalize_typr_goals(Goal, [OutputVar is FoldTerm]),
+    typr_translate_r_expr(FoldTerm, VarMap, OutputExpr).
 
 typr_linear_seq_expr(BaseInput, Step, down, SeqExpr) :-
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -49,6 +49,8 @@ cleanup_typr_test :-
     retractall(user:factorial_linear(_, _)),
     retractall(user:list_length(_, _)),
     retractall(user:power(_, _, _)),
+    retractall(user:power_if(_, _, _)),
+    retractall(user:count_occ(_, _, _)),
     retractall(user:list_length_from(_, _, _)),
     retractall(user:alternative_assign_chain(_, _)),
     retractall(user:alternative_assign_clause_chain(_, _)),
@@ -238,6 +240,46 @@ test(recursive_compiler_supports_typr_nary_list_linear_recursion_path) :-
     once(sub_string(Code, _, _, _, "current_input = arg2;")),
     once(sub_string(Code, _, _, _, "if (length(current_input) == 0)")),
     once(sub_string(Code, _, _, _, "acc = (acc + 1);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_guarded_nary_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:power_if(_Base, 0, 1)),
+    assertz(user:(power_if(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        power_if(Base, N1, Prev),
+        ( Base > 1 -> Result is Base * Prev ; Result is Prev )
+    )),
+    assertz(type_declarations:uw_type(power_if/3, 1, integer)),
+    assertz(type_declarations:uw_type(power_if/3, 2, integer)),
+    assertz(type_declarations:uw_type(power_if/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(power_if/3, integer)),
+    once(recursive_compiler:compile_recursive(power_if/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let power_if <- fn(arg1: int, arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "acc = if (@{ arg1 > 1 }@) { (arg1 * acc) } else { acc };")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_guarded_nary_list_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:count_occ(_, [], 0)),
+    assertz(user:(count_occ(X, [Y|T], N) :-
+        count_occ(X, T, N1),
+        ( X == Y -> N is N1 + 1 ; N is N1 )
+    )),
+    assertz(type_declarations:uw_type(count_occ/3, 1, integer)),
+    assertz(type_declarations:uw_type(count_occ/3, 2, list(integer))),
+    assertz(type_declarations:uw_type(count_occ/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(count_occ/3, integer)),
+    once(recursive_compiler:compile_recursive(count_occ/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let count_occ <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "acc = if (@{ arg1 == current }@) { (acc + 1) } else { acc };")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -165,6 +165,54 @@ test(nary_list_linear_recursive_output_checks_with_typr, [condition(typr_cli_ava
     ),
     retractall(user:list_length_from(_, _, _)).
 
+test(guarded_nary_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:power_if(_Base, 0, 1)),
+    assertz(user:(power_if(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        power_if(Base, N1, Prev),
+        ( Base > 1 -> Result is Base * Prev ; Result is Prev )
+    )),
+    assertz(type_declarations:uw_type(power_if/3, 1, integer)),
+    assertz(type_declarations:uw_type(power_if/3, 2, integer)),
+    assertz(type_declarations:uw_type(power_if/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(power_if/3, integer)),
+    once(recursive_compiler:compile_recursive(power_if/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:power_if(_, _, _)).
+
+test(guarded_nary_list_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:count_occ(_, [], 0)),
+    assertz(user:(count_occ(X, [Y|T], N) :-
+        count_occ(X, T, N1),
+        ( X == Y -> N is N1 + 1 ; N is N1 )
+    )),
+    assertz(type_declarations:uw_type(count_occ/3, 1, integer)),
+    assertz(type_declarations:uw_type(count_occ/3, 2, list(integer))),
+    assertz(type_declarations:uw_type(count_occ/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(count_occ/3, integer)),
+    once(recursive_compiler:compile_recursive(count_occ/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:count_occ(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR broadens the native TypR recursion path so conservative single-recursive-call linear recursion can remain native when the post-recursive result is selected through a guarded conditional expression.

Before this change, TypR linear recursion support handled direct post-recursive folds such as:

- `Result is Base * Prev`
- `N is N1 + 1`

But it still fell back once the recursive result had to pass through a guarded choice such as:

- `Base > 1 -> Result is Base * Prev ; Result is Prev`
- `X == Y -> N is N1 + 1 ; N is N1`

After this change, those guarded post-recursive recombination shapes stay in native TypR and continue to validate through the real TypR toolchain.

This is still a conservative recursion expansion, not full arbitrary recursive-body TypR lowering.

## Why This PR Exists

The previous TypR recursion work already established native support for:

- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion
- conservative `N`-ary single-recursive-call linear recursion

That still left an obvious next gap:

1. a predicate could recurse in a supported linear shape,
2. receive the recursive result into a later variable,
3. and then need a guarded selection over that result,
4. but the TypR backend only accepted a direct `Result is FoldTerm` post-step.

A representative shape is:

```prolog
power_if(_Base, 0, 1).
power_if(Base, N, Result) :-
    N > 0,
    N1 is N - 1,
    power_if(Base, N1, Prev),
    ( Base > 1 -> Result is Base * Prev ; Result is Prev ).
```

Another representative list shape is:

```prolog
count_occ(_, [], 0).
count_occ(X, [Y|T], N) :-
    count_occ(X, T, N1),
    ( X == Y -> N is N1 + 1 ; N is N1 ).
```

This PR closes that gap for the current conservative TypR recursion subset.

## Main Changes

### 1. Native TypR linear recursion now supports guarded post-recursive output selection

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR linear-recursion path no longer requires the post-recursive body tail to be only:

```prolog
Result is FoldTerm
```

It now also supports a guarded `if -> then ; else` recombination over TypR-translatable expressions, as long as the surrounding recursion shape still stays inside the conservative linear-recursion subset.

### 2. Guarded recombination is emitted as native TypR conditional expressions

The implementation now extracts guarded branch output expressions from the post-recursive tail and emits them as native TypR `if (...) { ... } else { ... }` expressions.

That means the recursive loop body can continue to update the accumulated result natively instead of falling back to wrapped R.

### 3. Both numeric and list linear recursion benefit from the new path

The new guarded recombination support applies to the current supported linear-recursion families, including:

- numeric single-recursive-call folds
- list single-recursive-call folds
- conservative `N`-ary variants of those shapes with one recursion-driving argument and invariant context arguments

### 4. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- guarded numeric post-recursive recombination such as `power_if/3`
- guarded list post-recursive recombination such as `count_occ/3`
- continued native TypR lowering rather than wrapped-R fallback
- continued real `typr check` validation for the new recursive shapes

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now state that the current TypR recursion subset includes guarded post-recursive result selection inside the supported single-recursive-call linear-recursion model.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR recursion subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion
- conservative `N`-ary single-recursive-call linear recursion
- guarded post-recursive result selection inside those same supported linear-recursive shapes

More complex recursive bodies still fall back or remain unsupported.

## Scope and Remaining Gaps

Implemented now:

- native TypR guarded post-recursive recombination for supported single-recursive-call linear recursion
- continued real TypR validation for those guarded recursive shapes
- documentation aligned with actual recursive TypR support

Still not fully implemented:

- broader branch-local or multi-state post-recursive recombination
- multi-call recursive bodies
- mutual recursion
- arbitrary recursive-body TypR lowering

## Why This PR Is Worth Merging

This PR expands real TypR recursion support in a useful and disciplined way.

It gives the project:

- fewer wrapped-fallback cases for practical recursive predicates
- broader native TypR coverage for post-recursive conditional logic
- behavior validated against the real TypR toolchain
- documentation that matches the actual supported recursion subset
