### PR TITLE
Keep native TypR multistate linear recursion recombination

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,11 @@ includes:
   one recursion-driving list argument and invariant context args, such as
   `list_length/2` and `list_length_from/3`, lowered to TypR functions that
   use raw-expression fold/loop bodies instead of wrapped-R fallback
-- guarded post-recursive result selection in those same linear-recursive
-  shapes, such as `power_if/3` and `count_occ/3`, where the recursive result
-  is recombined through a native TypR `if` expression instead of wrapped-R
+- guarded post-recursive recombination in those same linear-recursive
+  shapes, including multi-state branch-local recombination such as
+  `power_if/3`, `count_occ/3`, `power_multistate/3`, and `count_weighted/3`,
+  where the recursive result and later selected intermediate values are
+  recombined through native TypR `if` expressions instead of wrapped-R
   fallback
 - two-level nested guarded alternatives inside supported semicolon branches,
   including nested multi-result selections, where each nested branch still

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -195,10 +195,10 @@ bring-up.
     lowered to TypR-valid functions with raw-expression fold/loop bodies for
     the currently supported empty-list shape with one recursion-driving list
     argument and invariant context args
-  - guarded post-recursive result selection inside those same single-recursive-
-    call numeric and list linear-recursive shapes when the later result is
-    chosen by a supported `if -> then ; else` over TypR-translatable
-    expressions
+  - guarded post-recursive recombination inside those same single-recursive-
+    call numeric and list linear-recursive shapes when the later result and
+    branch-local selected intermediate values are chosen by supported
+    `if -> then ; else` choices over TypR-translatable expressions
   - two-level nested guarded alternatives inside supported semicolon branches
     where each nested branch still selects the same later result set,
     including nested multi-result selections

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -372,10 +372,11 @@ Current TypR lowering policy is intentionally mixed:
   empty-list base-case fold shape with one recursion-driving list argument
   and invariant context args, using raw-expression fold/loop bodies inside
   TypR rather than wrapped-R fallback
-- guarded post-recursive result selection may also stay native inside those
+- guarded post-recursive recombination may also stay native inside those
   same single-recursive-call numeric and list linear-recursive shapes when
-  the recursive result is recombined through a supported `if -> then ; else`
-  choice over TypR-translatable expressions
+  the recursive result and later branch-local selected intermediate values
+  are recombined through supported `if -> then ; else` choices over
+  TypR-translatable expressions
 - two-level nested guarded alternatives may also stay native when a supported
   semicolon branch contains another guarded alternative whose nested branch may
   itself contain one more guarded alternative, provided those branches select

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -65,10 +65,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      that match the currently supported empty-list fold shape with one
      recursion-driving list argument and invariant context args, emitted as
      TypR functions with raw-expression fold/loop bodies
-   - guarded post-recursive result selection inside those same single-
-     recursive-call numeric and list linear-recursive shapes when the later
-     result is chosen by a supported `if -> then ; else` expression over
-     TypR-translatable branch results
+   - guarded post-recursive recombination inside those same single-recursive-
+     call numeric and list linear-recursive shapes when the later result and
+     branch-local selected intermediate values are chosen by supported
+     `if -> then ; else` expressions over TypR-translatable branch results
    - multiple sequential branch/rejoin segments in the same native body,
      including repeated multi-result rejoin chains that feed later native
      steps after each rejoin
@@ -344,8 +344,9 @@ Current implementation note:
   compiled to raw-expression fold/loop bodies inside TypR functions,
   conservative single-recursive-call list linear-recursive predicates
   compiled to raw-expression fold/loop bodies inside TypR functions,
-  guarded post-recursive result selection inside those same single-recursive-
-  call numeric and list linear-recursive shapes,
+  guarded post-recursive recombination inside those same single-recursive-
+  call numeric and list linear-recursive shapes, including multi-state
+  branch-local recombination after the recursive call,
   native literal-headed branch bodies built from those chains,
   dataframe helper calls, and literal-guarded branch selection; more complex
   bodies still fall back to wrapped R

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -345,10 +345,73 @@ linear_recursive_output_expr(PostGoals, OutputVar, VarMap, OutputExpr) :-
     linear_recursive_branch_output_expr(ElseGoal, OutputVar, VarMap, ElseExpr),
     native_typr_if_condition(IfGoal, VarMap, IfCondition),
     format(string(OutputExpr), 'if (~w) { ~w } else { ~w }', [IfCondition, ThenExpr, ElseExpr]).
+linear_recursive_output_expr(PostGoals, OutputVar, VarMap, OutputExpr) :-
+    normalize_typr_goals(PostGoals, Goals),
+    linear_recursive_post_goals_varmap(Goals, VarMap, ResolvedVarMap),
+    lookup_typr_var(OutputVar, ResolvedVarMap, OutputExpr).
 
 linear_recursive_branch_output_expr(Goal, OutputVar, VarMap, OutputExpr) :-
     normalize_typr_goals(Goal, [OutputVar is FoldTerm]),
     typr_translate_r_expr(FoldTerm, VarMap, OutputExpr).
+
+linear_recursive_post_goals_varmap([], VarMap, VarMap).
+linear_recursive_post_goals_varmap([Goal|Rest], VarMap0, VarMap) :-
+    linear_recursive_post_goal_varmap(Goal, VarMap0, VarMap1),
+    linear_recursive_post_goals_varmap(Rest, VarMap1, VarMap).
+
+linear_recursive_post_goal_varmap(Goal, VarMap0, VarMap) :-
+    Goal = (Var is Expr),
+    !,
+    typr_translate_r_expr(Expr, VarMap0, ResolvedExpr),
+    update_typr_expr_varmap(VarMap0, Var, ResolvedExpr, VarMap).
+linear_recursive_post_goal_varmap(Goal, VarMap0, VarMap) :-
+    typr_if_then_else_goal(Goal, IfGoal, ThenGoal, ElseGoal),
+    !,
+    native_typr_if_condition(IfGoal, VarMap0, IfCondition),
+    normalize_typr_goals(ThenGoal, ThenGoals),
+    normalize_typr_goals(ElseGoal, ElseGoals),
+    linear_recursive_post_goals_varmap(ThenGoals, VarMap0, ThenVarMap),
+    linear_recursive_post_goals_varmap(ElseGoals, VarMap0, ElseVarMap),
+    varmap_changed_vars(VarMap0, ThenVarMap, ThenChangedVars0),
+    varmap_changed_vars(VarMap0, ElseVarMap, ElseChangedVars0),
+    unique_vars_by_identity(ThenChangedVars0, ThenChangedVars),
+    unique_vars_by_identity(ElseChangedVars0, ElseChangedVars),
+    include_vars_by_identity(ThenChangedVars, ElseChangedVars, SharedChangedVars),
+    SharedChangedVars \= [],
+    merge_linear_recursive_branch_vars(
+        SharedChangedVars,
+        IfCondition,
+        ThenVarMap,
+        ElseVarMap,
+        VarMap0,
+        VarMap
+    ).
+
+merge_linear_recursive_branch_vars([], _IfCondition, _ThenVarMap, _ElseVarMap, VarMap, VarMap).
+merge_linear_recursive_branch_vars([Var|Rest], IfCondition, ThenVarMap, ElseVarMap, VarMap0, VarMap) :-
+    lookup_typr_var(Var, ThenVarMap, ThenExpr),
+    lookup_typr_var(Var, ElseVarMap, ElseExpr),
+    format(string(MergedExpr), '(if (~w) { ~w } else { ~w })', [IfCondition, ThenExpr, ElseExpr]),
+    update_typr_expr_varmap(VarMap0, Var, MergedExpr, VarMap1),
+    merge_linear_recursive_branch_vars(Rest, IfCondition, ThenVarMap, ElseVarMap, VarMap1, VarMap).
+
+update_typr_expr_varmap(VarMap0, Var, Expr, [Var-Expr|FilteredVarMap]) :-
+    remove_var_mapping(Var, VarMap0, FilteredVarMap).
+
+varmap_changed_vars(VarMap0, VarMap1, ChangedVars) :-
+    varmap_changed_vars(VarMap0, VarMap1, [], RevChangedVars),
+    reverse(RevChangedVars, ChangedVars).
+
+varmap_changed_vars(_VarMap0, [], ChangedVars, ChangedVars).
+varmap_changed_vars(VarMap0, [Var-Expr1|Rest], ChangedVars0, ChangedVars) :-
+    (   lookup_typr_var(Var, VarMap0, Expr0)
+    ->  (   Expr0 \= Expr1
+        ->  ChangedVars1 = [Var|ChangedVars0]
+        ;   ChangedVars1 = ChangedVars0
+        )
+    ;   ChangedVars1 = [Var|ChangedVars0]
+    ),
+    varmap_changed_vars(VarMap0, Rest, ChangedVars1, ChangedVars).
 
 typr_linear_seq_expr(BaseInput, Step, down, SeqExpr) :-
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -50,7 +50,9 @@ cleanup_typr_test :-
     retractall(user:list_length(_, _)),
     retractall(user:power(_, _, _)),
     retractall(user:power_if(_, _, _)),
+    retractall(user:power_multistate(_, _, _)),
     retractall(user:count_occ(_, _, _)),
+    retractall(user:count_weighted(_, _, _)),
     retractall(user:list_length_from(_, _, _)),
     retractall(user:alternative_assign_chain(_, _)),
     retractall(user:alternative_assign_clause_chain(_, _)),
@@ -280,6 +282,60 @@ test(recursive_compiler_supports_typr_guarded_nary_list_linear_recursion_path) :
     once(sub_string(Code, _, _, _, "let count_occ <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
     once(sub_string(Code, _, _, _, "current_input = arg2;")),
     once(sub_string(Code, _, _, _, "acc = if (@{ arg1 == current }@) { (acc + 1) } else { acc };")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_multistate_nary_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:power_multistate(_Base, 0, 1)),
+    assertz(user:(power_multistate(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        power_multistate(Base, N1, Prev),
+        ( Base > 1 ->
+            Step is Base * Prev,
+            Offset is Step + 1
+        ;   Step is Prev,
+            Offset is Step + 2
+        ),
+        Result is Offset + Step
+    )),
+    assertz(type_declarations:uw_type(power_multistate/3, 1, integer)),
+    assertz(type_declarations:uw_type(power_multistate/3, 2, integer)),
+    assertz(type_declarations:uw_type(power_multistate/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(power_multistate/3, integer)),
+    once(recursive_compiler:compile_recursive(power_multistate/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let power_multistate <- fn(arg1: int, arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "if (@{ arg1 > 1 }@) { (arg1 * acc) } else { acc }")),
+    once(sub_string(Code, _, _, _, "if (@{ arg1 > 1 }@) { ((arg1 * acc) + 1) } else { (acc + 2) }")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_multistate_nary_list_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:count_weighted(_, [], 0)),
+    assertz(user:(count_weighted(X, [Y|T], N) :-
+        count_weighted(X, T, N1),
+        ( X == Y ->
+            Delta is N1 + 1,
+            Adjust is Delta + 1
+        ;   Delta is N1,
+            Adjust is Delta + 2
+        ),
+        N is Adjust + Delta
+    )),
+    assertz(type_declarations:uw_type(count_weighted/3, 1, integer)),
+    assertz(type_declarations:uw_type(count_weighted/3, 2, list(integer))),
+    assertz(type_declarations:uw_type(count_weighted/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(count_weighted/3, integer)),
+    once(recursive_compiler:compile_recursive(count_weighted/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let count_weighted <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { (acc + 1) } else { acc }")),
+    once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { ((acc + 1) + 1) } else { (acc + 2) }")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -213,6 +213,66 @@ test(guarded_nary_list_linear_recursive_output_checks_with_typr, [condition(typr
     ),
     retractall(user:count_occ(_, _, _)).
 
+test(multistate_nary_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:power_multistate(_Base, 0, 1)),
+    assertz(user:(power_multistate(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        power_multistate(Base, N1, Prev),
+        ( Base > 1 ->
+            Step is Base * Prev,
+            Offset is Step + 1
+        ;   Step is Prev,
+            Offset is Step + 2
+        ),
+        Result is Offset + Step
+    )),
+    assertz(type_declarations:uw_type(power_multistate/3, 1, integer)),
+    assertz(type_declarations:uw_type(power_multistate/3, 2, integer)),
+    assertz(type_declarations:uw_type(power_multistate/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(power_multistate/3, integer)),
+    once(recursive_compiler:compile_recursive(power_multistate/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:power_multistate(_, _, _)).
+
+test(multistate_nary_list_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:count_weighted(_, [], 0)),
+    assertz(user:(count_weighted(X, [Y|T], N) :-
+        count_weighted(X, T, N1),
+        ( X == Y ->
+            Delta is N1 + 1,
+            Adjust is Delta + 1
+        ;   Delta is N1,
+            Adjust is Delta + 2
+        ),
+        N is Adjust + Delta
+    )),
+    assertz(type_declarations:uw_type(count_weighted/3, 1, integer)),
+    assertz(type_declarations:uw_type(count_weighted/3, 2, list(integer))),
+    assertz(type_declarations:uw_type(count_weighted/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(count_weighted/3, integer)),
+    once(recursive_compiler:compile_recursive(count_weighted/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:count_weighted(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR expands the native TypR recursion path so conservative single-recursive-call linear recursion can remain native when the post-recursive phase carries more than one branch-local intermediate before producing the final result.

Before this change, TypR linear recursion support already handled:

- direct post-recursive folds such as `Result is Base * Prev`
- guarded direct output selection such as `Base > 1 -> Result is Base * Prev ; Result is Prev`

But it still failed once the post-recursive phase introduced additional branch-local values before the final result.

After this change, those multistate post-recursive recombination shapes stay in native TypR and continue to validate through the real TypR toolchain.

This is still a conservative recursion expansion, not full arbitrary recursive-body TypR lowering.

## Why This PR Exists

The previous TypR recursion work had already established native support for:

- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion
- conservative `N`-ary single-recursive-call linear recursion
- guarded post-recursive result selection

That still left the next practical gap:

1. recurse in a supported single-call linear shape,
2. receive the recursive result into a later variable,
3. derive more than one branch-local intermediate from it,
4. then combine those intermediates into the final result,
5. but the TypR backend still rejected that shape and fell back.

A representative numeric shape is:

```prolog
power_multistate(_Base, 0, 1).
power_multistate(Base, N, Result) :-
    N > 0,
    N1 is N - 1,
    power_multistate(Base, N1, Prev),
    ( Base > 1 ->
        Step is Base * Prev,
        Offset is Step + 1
    ;   Step is Prev,
        Offset is Step + 2
    ),
    Result is Offset + Step.
```

A representative list shape is:

```prolog
count_weighted(_, [], 0).
count_weighted(X, [Y|T], N) :-
    count_weighted(X, T, N1),
    ( X == Y ->
        Delta is N1 + 1,
        Adjust is Delta + 1
    ;   Delta is N1,
        Adjust is Delta + 2
    ),
    N is Adjust + Delta.
```

This PR closes that gap for the current conservative TypR recursion subset.

## Main Changes

### 1. Native TypR linear recursion now supports multistate post-recursive recombination

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR linear-recursion path no longer requires the post-recursive tail to collapse immediately to a single final output assignment.

It now supports:

- post-recursive `is` chains after the recursive call
- guarded `if -> then ; else` post-recursive branches that bind more than one later intermediate
- final output expressions that continue from those branch-local values

### 2. Post-recursive symbolic evaluation now tracks branch-local intermediate values

The implementation now symbolically resolves post-recursive `is` goals into a TypR expression var map instead of insisting on a one-step final fold.

That lets the backend keep track of:

- recursive result values
- later branch-local derived values
- final output expressions that depend on both

while staying in the native TypR loop path.

### 3. Guarded branch-local recursive state is merged natively

The new path merges shared post-recursive branch-local variables across guarded alternatives using native TypR conditional expressions.

This allows shapes where both sides of an `if -> then ; else` derive matching later values, even if those values are not the final output themselves.

### 4. Fixed variable-identity tracking for post-recursive branch merges

The implementation also fixes shared-variable detection in the post-recursive merge path.

The previous changed-variable collection copied variables through `findall/3`, which broke identity-based comparison across branch-local recursive states.

That bug blocked the new recursive recombination slice and is now fixed.

### 5. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- multistate numeric post-recursive recombination such as `power_multistate/3`
- multistate list post-recursive recombination such as `count_weighted/3`
- continued native TypR lowering rather than wrapped fallback
- continued real `typr check` validation for the new recursive shapes

### 6. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now state that the current TypR recursion subset includes multistate guarded post-recursive recombination inside the supported single-recursive-call linear-recursion model.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR recursion subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion
- conservative `N`-ary single-recursive-call linear recursion
- guarded post-recursive result selection
- multistate post-recursive recombination inside those same supported linear-recursive shapes

More complex recursive bodies still fall back or remain unsupported.

## Scope and Remaining Gaps

Implemented now:

- native TypR multistate post-recursive recombination for supported single-recursive-call linear recursion
- guarded branch-local recursive-state merging through native TypR conditionals
- continued real TypR validation for those recursive shapes

Still not fully implemented:

- broader asymmetric branch-local post-recursive recombination
- multi-call recursive bodies
- mutual recursion
- arbitrary recursive-body TypR lowering

## Why This PR Is Worth Merging

This PR expands real TypR recursion support in a useful and disciplined way.

It gives the project:

- fewer wrapped-fallback cases for practical recursive predicates
- broader native TypR coverage for recursive branch-local state handling
- behavior validated against the real TypR toolchain
- documentation that matches the actual supported recursion subset
