### PR TITLE
Document native TypR asymmetric linear recursion recombination

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ includes:
   where the recursive result and later selected intermediate values are
   recombined through native TypR `if` expressions instead of wrapped-R
   fallback
+- asymmetric post-recursive recombination in those same linear-recursive
+  shapes, such as `asym_rec_a/3` and `asym_rec_c/3`, where different
+  branch-local intermediates feed a shared later result expression and still
+  stay native in TypR
 - two-level nested guarded alternatives inside supported semicolon branches,
   including nested multi-result selections, where each nested branch still
   selects the same later result set natively

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -199,6 +199,10 @@ bring-up.
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported
     `if -> then ; else` choices over TypR-translatable expressions
+  - asymmetric post-recursive recombination inside those same single-
+    recursive-call numeric and list linear-recursive shapes when different
+    branch-local intermediates still feed a shared later TypR-translatable
+    result expression
   - two-level nested guarded alternatives inside supported semicolon branches
     where each nested branch still selects the same later result set,
     including nested multi-result selections

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -377,6 +377,10 @@ Current TypR lowering policy is intentionally mixed:
   the recursive result and later branch-local selected intermediate values
   are recombined through supported `if -> then ; else` choices over
   TypR-translatable expressions
+- asymmetric post-recursive recombination may also stay native inside those
+  same single-recursive-call numeric and list linear-recursive shapes when
+  different branch-local intermediates feed a shared later output expression
+  that can still be normalized into TypR-translatable branch results
 - two-level nested guarded alternatives may also stay native when a supported
   semicolon branch contains another guarded alternative whose nested branch may
   itself contain one more guarded alternative, provided those branches select

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -69,6 +69,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported
      `if -> then ; else` expressions over TypR-translatable branch results
+   - asymmetric post-recursive recombination inside those same single-
+     recursive-call numeric and list linear-recursive shapes when different
+     branch-local intermediates still feed a shared later TypR-translatable
+     result expression
    - multiple sequential branch/rejoin segments in the same native body,
      including repeated multi-result rejoin chains that feed later native
      steps after each rejoin
@@ -347,6 +351,8 @@ Current implementation note:
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,
+  asymmetric post-recursive recombination inside those same single-recursive-
+  call numeric and list linear-recursive shapes,
   native literal-headed branch bodies built from those chains,
   dataframe helper calls, and literal-guarded branch selection; more complex
   bodies still fall back to wrapped R

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -51,8 +51,10 @@ cleanup_typr_test :-
     retractall(user:power(_, _, _)),
     retractall(user:power_if(_, _, _)),
     retractall(user:power_multistate(_, _, _)),
+    retractall(user:asym_rec_a(_, _, _)),
     retractall(user:count_occ(_, _, _)),
     retractall(user:count_weighted(_, _, _)),
+    retractall(user:asym_rec_c(_, _, _)),
     retractall(user:list_length_from(_, _, _)),
     retractall(user:alternative_assign_chain(_, _)),
     retractall(user:alternative_assign_clause_chain(_, _)),
@@ -336,6 +338,56 @@ test(recursive_compiler_supports_typr_multistate_nary_list_linear_recursion_path
     once(sub_string(Code, _, _, _, "current_input = arg2;")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { (acc + 1) } else { acc }")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { ((acc + 1) + 1) } else { (acc + 2) }")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_asymmetric_nary_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:asym_rec_a(_Base, 0, 1)),
+    assertz(user:(asym_rec_a(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        asym_rec_a(Base, N1, Prev),
+        ( Base > 1 ->
+            Step is Base * Prev,
+            Result is Step + 1
+        ;   Temp is Prev + 2,
+            Result is Temp + Prev
+        )
+    )),
+    assertz(type_declarations:uw_type(asym_rec_a/3, 1, integer)),
+    assertz(type_declarations:uw_type(asym_rec_a/3, 2, integer)),
+    assertz(type_declarations:uw_type(asym_rec_a/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(asym_rec_a/3, integer)),
+    once(recursive_compiler:compile_recursive(asym_rec_a/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let asym_rec_a <- fn(arg1: int, arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "if (@{ arg1 > 1 }@) { ((arg1 * acc) + 1) } else { ((acc + 2) + acc) }")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_asymmetric_nary_list_linear_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:asym_rec_c(_, [], 0)),
+    assertz(user:(asym_rec_c(X, [Y|T], N) :-
+        asym_rec_c(X, T, N1),
+        ( X == Y ->
+            Delta is N1 + 1,
+            N is Delta + 1
+        ;   Extra is N1 + 2,
+            N is Extra + N1
+        )
+    )),
+    assertz(type_declarations:uw_type(asym_rec_c/3, 1, integer)),
+    assertz(type_declarations:uw_type(asym_rec_c/3, 2, list(integer))),
+    assertz(type_declarations:uw_type(asym_rec_c/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(asym_rec_c/3, integer)),
+    once(recursive_compiler:compile_recursive(asym_rec_c/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let asym_rec_c <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
+    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { ((acc + 1) + 1) } else { ((acc + 2) + acc) }")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -273,6 +273,64 @@ test(multistate_nary_list_linear_recursive_output_checks_with_typr, [condition(t
     ),
     retractall(user:count_weighted(_, _, _)).
 
+test(asymmetric_nary_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:asym_rec_a(_Base, 0, 1)),
+    assertz(user:(asym_rec_a(Base, N, Result) :-
+        N > 0,
+        N1 is N - 1,
+        asym_rec_a(Base, N1, Prev),
+        ( Base > 1 ->
+            Step is Base * Prev,
+            Result is Step + 1
+        ;   Temp is Prev + 2,
+            Result is Temp + Prev
+        )
+    )),
+    assertz(type_declarations:uw_type(asym_rec_a/3, 1, integer)),
+    assertz(type_declarations:uw_type(asym_rec_a/3, 2, integer)),
+    assertz(type_declarations:uw_type(asym_rec_a/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(asym_rec_a/3, integer)),
+    once(recursive_compiler:compile_recursive(asym_rec_a/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:asym_rec_a(_, _, _)).
+
+test(asymmetric_nary_list_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:asym_rec_c(_, [], 0)),
+    assertz(user:(asym_rec_c(X, [Y|T], N) :-
+        asym_rec_c(X, T, N1),
+        ( X == Y ->
+            Delta is N1 + 1,
+            N is Delta + 1
+        ;   Extra is N1 + 2,
+            N is Extra + N1
+        )
+    )),
+    assertz(type_declarations:uw_type(asym_rec_c/3, 1, integer)),
+    assertz(type_declarations:uw_type(asym_rec_c/3, 2, list(integer))),
+    assertz(type_declarations:uw_type(asym_rec_c/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(asym_rec_c/3, integer)),
+    once(recursive_compiler:compile_recursive(asym_rec_c/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:asym_rec_c(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR formalizes another part of the conservative native TypR recursion subset: asymmetric post-recursive recombination inside supported single-recursive-call linear recursion.

The key point is that this support already exists in the current TypR recursion lowering path. This PR makes that behavior explicit by adding focused regression coverage and updating the docs to describe it as part of the supported contract.

This is intentionally a contract/coverage PR, not a new recursion-lowering rewrite.

## Why This PR Exists

The previous TypR recursion work had already established native support for:

- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion
- conservative `N`-ary single-recursive-call linear recursion
- guarded post-recursive result selection
- multistate post-recursive recombination

That suggested the next likely gap would be asymmetric post-recursive recombination, where the two post-recursive branches do not derive the same intermediate structure before the final result.

After probing that shape directly, it turned out the current TypR emitter already handles conservative cases such as:

```prolog
asym_rec_a(_Base, 0, 1).
asym_rec_a(Base, N, Result) :-
    N > 0,
    N1 is N - 1,
    asym_rec_a(Base, N1, Prev),
    ( Base > 1 ->
        Step is Base * Prev,
        Result is Step + 1
    ;   Temp is Prev + 2,
        Result is Temp + Prev
    ).
```

and:

```prolog
asym_rec_c(_, [], 0).
asym_rec_c(X, [Y|T], N) :-
    asym_rec_c(X, T, N1),
    ( X == Y ->
        Delta is N1 + 1,
        N is Delta + 1
    ;   Extra is N1 + 2,
        N is Extra + N1
    ).
```

That meant the right next step was not more emitter churn. The right step was to lock the behavior in with tests and docs so this support becomes explicit rather than incidental.

## Main Changes

### 1. Added regression coverage for asymmetric linear-recursive recombination

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New tests verify native TypR lowering for conservative asymmetric single-recursive-call linear recursion where:

- one recursive call stays in the supported linear-recursive subset
- post-recursive branches derive different local intermediate shapes
- those branches still feed a shared later output expression
- the overall predicate remains native TypR
- wrapped-R fallback is not used
- generated code remains valid TypR

### 2. Added real TypR toolchain coverage

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain tests verify that those asymmetric recursion shapes do not just look plausible in emitted text. They also pass real `typr check`.

### 3. Documentation now reflects asymmetric recursive recombination as part of the supported TypR subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly describe asymmetric post-recursive recombination as supported inside the current conservative single-recursive-call TypR recursion subset.

### 4. Scope deliberately stayed narrow

This PR does **not** introduce a new recursion-lowering algorithm.

Instead, it:

- probes an already plausible recursive TypR shape
- confirms the emitter already supports it
- adds regression coverage so that support is preserved
- updates docs so the supported contract matches reality

That is the right tradeoff here because it raises confidence without inventing unnecessary recursion complexity.

## Files Changed

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- existing shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for asymmetric single-recursive-call recombination shapes
- continued TypR CLI validation for generated recursive output

What it does not claim:

- full repo-wide regression coverage
- arbitrary recursive-body TypR lowering
- multi-call recursion
- mutual recursion
- tree recursion

## Behavior Notes

After this PR, the explicitly documented TypR recursion subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion
- conservative `N`-ary single-recursive-call linear recursion
- guarded post-recursive result selection
- multistate post-recursive recombination
- asymmetric post-recursive recombination where different branch-local intermediates still feed a shared later result expression

More complex recursive bodies still remain unsupported or fall back.

## Scope and Remaining Gaps

Implemented now:

- explicit regression coverage for asymmetric TypR linear-recursive recombination
- explicit `typr check` coverage for those shapes
- docs updated so the supported recursive TypR subset matches actual emitter behavior

Still not fully implemented:

- broader multi-call recursion
- mutual recursion
- tree recursion
- arbitrary recursive-body TypR lowering

## Why This PR Is Worth Merging

This PR strengthens the TypR recursion contract in a disciplined way.

It gives the project:

- stronger confidence that existing asymmetric recursive support will not regress
- clearer documentation of what the TypR backend actually supports today
- less ambiguity between “currently works” and “officially supported”
- focused tests backed by real TypR toolchain validation

In short, this is a good incremental PR because it converts already-working recursive behavior into explicit, defended backend coverage.
