### PR TITLE
docs(csharp-query): document cache smoke JSON summary

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -105,10 +105,15 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
     - `admission`
     - `reuse -SkipCodegen`
     - `lru -SkipCodegen`
+  - Writes two summaries for the sequence:
+    - markdown: `cache_smoke_sequence_summary.md`
+    - JSON: `cache_smoke_sequence_summary.json`
   - Common options:
     - `-OutputDir tmp/csharp_query_smoke_ci`
     - `-KeepArtifacts`
     - `-SummaryPath tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md`
+      - The JSON companion summary uses the same path with a `.json` extension
+    - `-NoSummaryOutput`
 - Lower-level runner (useful for ad hoc repro or a single slice): `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1`
   - Common options:
     - `-OutputDir tmp/csharp_query_smoke`
@@ -119,13 +124,17 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
 - Typical local repro flow:
   - Full CI-style cache smoke sequence:
     - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/csharp_query_smoke_ci`
+    - Produces:
+      - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md`
+      - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json`
   - Re-run a single slice against existing generated projects:
     - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice reuse -SkipCodegen -KeepArtifacts`
 - CI behavior:
   - Workflow job: `.github/workflows/test.yml` `csharp_query_runtime_smoke`
   - Uses the cache smoke sequence wrapper rather than spelling slice commands inline
   - Uploads `tmp/csharp_query_smoke_ci` as `csharp-query-smoke-artifacts` when the smoke job fails
-  - Appends a dynamic job summary with:
+  - Uploads `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json` as `csharp-query-smoke-summary-json` on every run
+  - Appends the markdown summary to the job summary with:
     - overall result
     - output dir
     - project filter


### PR DESCRIPTION
  ## Summary
  Update the C# query runtime docs to describe the new JSON summary output from the cache smoke wrapper
  and the corresponding CI artifact flow.

  ## What changed
  - Updated `docs/targets/csharp-query-runtime.md`
  - Documented that `run_csharp_query_cache_smoke_sequence.ps1` now writes:
    - `cache_smoke_sequence_summary.md`
    - `cache_smoke_sequence_summary.json`
  - Documented that `-SummaryPath` controls the markdown summary path and the JSON companion uses the
  same basename with a `.json` extension
  - Added `-NoSummaryOutput` to the documented wrapper options
  - Updated the CI smoke section to describe:
    - failure-only full smoke artifact: `csharp-query-smoke-artifacts`
    - always-uploaded JSON summary artifact: `csharp-query-smoke-summary-json`
    - markdown summary appended to the GitHub job summary

  ## Why
  The smoke workflow and wrapper had already been updated to emit and publish a machine-readable JSON
  summary, but the runtime docs still only described the markdown summary flow. This PR brings the
  documentation back in sync with the current local and CI behavior.

  ## Validation
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/
  csharp_query_smoke_ci -NoSummaryOutput`
  - Confirmed the documented outputs were produced:
    - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md`
    - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json`