### PR TITLE
ci(csharp-query): add smoke summary artifact links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,8 @@ jobs:
       CSHARP_QUERY_SMOKE_OUTPUT_DIR: tmp/csharp_query_smoke_ci
       CSHARP_QUERY_SMOKE_SUMMARY_PATH: tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md
       CSHARP_QUERY_SMOKE_JSON_SUMMARY_PATH: tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json
+      CSHARP_QUERY_SMOKE_FAILURE_ARTIFACT_NAME: csharp-query-smoke-artifacts
+      CSHARP_QUERY_SMOKE_JSON_ARTIFACT_NAME: csharp-query-smoke-summary-json
 
     steps:
       - name: Checkout code
@@ -127,7 +129,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: csharp-query-smoke-artifacts
+          name: ${{ env.CSHARP_QUERY_SMOKE_FAILURE_ARTIFACT_NAME }}
           path: ${{ env.CSHARP_QUERY_SMOKE_OUTPUT_DIR }}
           if-no-files-found: ignore
           retention-days: 7
@@ -136,7 +138,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: csharp-query-smoke-summary-json
+          name: ${{ env.CSHARP_QUERY_SMOKE_JSON_ARTIFACT_NAME }}
           path: ${{ env.CSHARP_QUERY_SMOKE_JSON_SUMMARY_PATH }}
           if-no-files-found: ignore
           retention-days: 7
@@ -154,3 +156,11 @@ jobs:
               "- Summary file not found at `"$($env:CSHARP_QUERY_SMOKE_SUMMARY_PATH)`""
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
+
+          @(
+            "",
+            "### Artifacts",
+            "",
+            "- JSON summary artifact: `"$($env:CSHARP_QUERY_SMOKE_JSON_ARTIFACT_NAME)`"` (uploaded on every run)",
+            "- Full smoke output artifact: `"$($env:CSHARP_QUERY_SMOKE_FAILURE_ARTIFACT_NAME)`"` (uploaded on failure only)"
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append


### PR DESCRIPTION
  ## Summary
  Add explicit artifact references to the C# query runtime smoke job summary so CI readers can
  immediately see which artifact to download for machine-readable results and which artifact appears only
  on failure.

  ## What changed
  - Updated `.github/workflows/test.yml`
  - Added stable env vars for smoke artifact names:
    - `CSHARP_QUERY_SMOKE_JSON_ARTIFACT_NAME`
    - `CSHARP_QUERY_SMOKE_FAILURE_ARTIFACT_NAME`
  - Switched the existing artifact upload steps to use those env vars
  - Extended the `csharp_query_runtime_smoke` job summary with an `Artifacts` footer that documents:
    - `csharp-query-smoke-summary-json` is uploaded on every run
    - `csharp-query-smoke-artifacts` is uploaded on failure only

  ## Why
  The smoke workflow already:
  - appends the markdown smoke summary to the job summary
  - uploads the JSON summary artifact on every run
  - uploads the full smoke output directory on failure

  But the job summary itself still did not tell readers which artifact names to look for. This PR closes
  that gap and makes CI triage more direct.

  ## Validation
  - Replayed the workflow summary-step logic locally against:
    - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md`
  - Confirmed the resulting summary now appends:
    - `JSON summary artifact: "csharp-query-smoke-summary-json" (uploaded on every run)`
    - `Full smoke output artifact: "csharp-query-smoke-artifacts" (uploaded on failure only)`