### PR TITLE
Keep native TypR n-ary structural tree recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,10 @@ includes:
 - conservative arity-2 numeric multi-call tree-recursive predicates such as
   `fib/2`, lowered to TypR functions that use raw-expression memoized helper
   bodies inside TypR instead of wrapped-R fallback
-- conservative arity-2 structural tree-recursive predicates such as
-  `tree_sum/2` and `tree_height/2`, lowered to TypR functions that use
+- conservative `N`-ary structural tree-recursive predicates with one
+  tree-driving argument and invariant context args, such as `tree_sum/2`,
+  `tree_height/2`, `weighted_tree_sum/3`, and
+  `weighted_tree_affine_sum/4`, lowered to TypR functions that use
   raw-expression structural helper bodies over `[]` / `[V, L, R]` trees
   inside TypR instead of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -198,9 +198,10 @@ bring-up.
   - conservative arity-2 numeric multi-call tree-recursive predicates
     lowered to TypR-valid functions with raw-expression memoized helper
     bodies for the currently supported `fib/2`-style shape
-  - conservative arity-2 structural tree-recursive predicates lowered to
+  - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
-    the currently supported `[]` / `[V, L, R]` shape
+    the currently supported `[]` / `[V, L, R]` shape with invariant context
+    args
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -376,10 +376,12 @@ Current TypR lowering policy is intentionally mixed:
   lower to TypR-valid functions when they match the currently supported
   memoized helper shape for `fib/2`-style recursion, using raw-expression
   helper bodies inside TypR rather than wrapped-R fallback
-- conservative arity-2 structural tree-recursive predicates may also lower
+- conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
-  `[V, L, R]` shape with two recursive subtree calls and a TypR-translatable
-  result expression such as `tree_sum/2` or `tree_height/2`
+  `[V, L, R]` shape with one tree-driving argument, invariant context args,
+  two recursive subtree calls, and a TypR-translatable result expression
+  such as `tree_sum/2`, `tree_height/2`, `weighted_tree_sum/3`, or
+  `weighted_tree_affine_sum/4`
 - guarded post-recursive recombination may also stay native inside those
   same single-recursive-call numeric and list linear-recursive shapes when
   the recursive result and later branch-local selected intermediate values

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -68,9 +68,10 @@ This document focuses on architecture and rollout choices specific to TypR.
    - conservative arity-2 numeric multi-call tree-recursive predicates that
      match the currently supported memoized helper shape for `fib/2`-style
      recursion, emitted as TypR functions with raw-expression helper bodies
-   - conservative arity-2 structural tree-recursive predicates that match
-     the currently supported `[]` / `[V, L, R]` shape, emitted as TypR
-     functions with raw-expression structural helper bodies
+   - conservative `N`-ary structural tree-recursive predicates that match
+     the currently supported `[]` / `[V, L, R]` shape with one tree-driving
+     argument and invariant context args, emitted as TypR functions with
+     raw-expression structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported
@@ -356,7 +357,7 @@ Current implementation note:
   compiled to raw-expression fold/loop bodies inside TypR functions,
   conservative arity-2 numeric multi-call tree-recursive predicates
   compiled to raw-expression memoized helper bodies inside TypR functions,
-  conservative arity-2 structural tree-recursive predicates compiled to
+  conservative `N`-ary structural tree-recursive predicates compiled to
   raw-expression structural helper bodies inside TypR functions,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -140,9 +140,9 @@ let ~w <- fn(~w): ~w {
 ', [PredStr, Arity, PredStr, TypedArgList, ReturnType, IndentedBody]).
 
 compile_typr_tree_recursive_structural(_Module:Pred/Arity, TypedMode, Clauses, Code) :-
-    Arity =:= 2,
+    Arity >= 2,
     single_tree_recursive_clause_set(Pred, Arity, Clauses, BaseClauses, RecClause),
-    structural_tree_recursive_spec(Pred, BaseClauses, RecClause, TreeSpec),
+    structural_tree_recursive_spec(Pred, Arity, BaseClauses, RecClause, TreeSpec),
     build_typed_arg_list(Pred/Arity, none, Arity, TypedMode, TypedArgList),
     generic_typr_return_type(Pred/Arity, Clauses, ReturnType),
     build_typr_structural_tree_recursive_body(Pred, TreeSpec, Body),
@@ -354,6 +354,7 @@ tree_recursive_base_case_spec(Head-Body, base_case(InputLiteral, OutputExpr)) :-
 
 structural_tree_recursive_spec(
     Pred,
+    Arity,
     BaseClauses,
     RecHead-RecBody,
     structural_tree_spec{
@@ -365,48 +366,153 @@ structural_tree_recursive_spec(
         helper_name: HelperName
     }
 ) :-
-    structural_tree_base_case_spec(BaseClauses, BaseOutputExpr),
-    RecHead =.. [_PredName, TreeArg, OutputVar],
-    TreeArg = [ValueVar, LeftVar, RightVar],
-    var(OutputVar),
+    RecHead =.. [_PredName|RecHeadArgs],
     normalize_typr_goals(RecBody, Goals),
     split_typr_multicall_goals(Pred, Goals, PreGoals, RecCalls, PostGoals),
     PreGoals == [],
-    structural_tree_call_varmap(RecCalls, LeftVar, RightVar, VarMap),
+    structural_tree_arg_spec(
+        Arity,
+        BaseClauses,
+        RecHeadArgs,
+        RecCalls,
+        BaseOutputExpr,
+        OutputVar,
+        DriverPos,
+        ValueVar,
+        LeftVar,
+        RightVar,
+        RecInvariantVarMap,
+        InputArgName,
+        OutputArgName,
+        ResultName
+    ),
+    structural_tree_call_varmap(
+        Arity,
+        DriverPos,
+        RecHeadArgs,
+        RecCalls,
+        LeftVar,
+        RightVar,
+        RecInvariantVarMap,
+        VarMap
+    ),
     add_structural_tree_value_var(ValueVar, VarMap, VarMap1),
     typr_goals_to_body(PostGoals, PostBody),
     normalize_typr_goals(PostBody, [OutputVar is AggExpr]),
     typr_translate_r_expr(AggExpr, VarMap1, ResultExpr),
-    InputArgName = "arg1",
-    OutputArgName = "arg2",
-    linear_recursive_result_name(2, ResultName),
     atom_string(Pred, PredStr),
     format(string(HelperName), '~w_impl', [PredStr]).
 
-structural_tree_base_case_spec([Head-Body], BaseOutputExpr) :-
+structural_tree_arg_spec(
+    Arity,
+    BaseClauses,
+    RecHeadArgs,
+    RecCalls,
+    BaseOutputExpr,
+    OutputVar,
+    DriverPos,
+    ValueVar,
+    LeftVar,
+    RightVar,
+    RecInvariantVarMap,
+    InputArgName,
+    OutputArgName,
+    ResultName
+) :-
+    OutputPos is Arity,
+    nth1(OutputPos, RecHeadArgs, OutputVar),
+    var(OutputVar),
+    structural_tree_driver_pos(Arity, RecHeadArgs, RecCalls, DriverPos, ValueVar, LeftVar, RightVar),
+    linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
+    structural_tree_base_case_spec(
+        BaseClauses,
+        DriverPos,
+        OutputPos,
+        InvariantPositions,
+        RecHeadArgs,
+        BaseOutputExpr
+    ),
+    build_linear_recursive_varmap(RecHeadArgs, InvariantPositions, RecInvariantVarMap),
+    format(string(InputArgName), 'arg~w', [DriverPos]),
+    format(string(OutputArgName), 'arg~w', [OutputPos]),
+    linear_recursive_result_name(Arity, ResultName).
+
+structural_tree_driver_pos(Arity, RecHeadArgs, RecCalls, DriverPos, ValueVar, LeftVar, RightVar) :-
+    InputLast is Arity - 1,
+    structural_tree_driver_pos(1, InputLast, RecHeadArgs, RecCalls, DriverPos, ValueVar, LeftVar, RightVar).
+
+structural_tree_driver_pos(Pos, InputLast, RecHeadArgs, RecCalls, DriverPos, ValueVar, LeftVar, RightVar) :-
+    Pos =< InputLast,
+    nth1(Pos, RecHeadArgs, TreeArg),
+    TreeArg = [ValueVar, LeftVar, RightVar],
+    var(LeftVar),
+    var(RightVar),
+    structural_tree_recursive_inputs(RecCalls, Pos, LeftVar, RightVar),
+    !,
+    DriverPos = Pos.
+structural_tree_driver_pos(Pos, InputLast, RecHeadArgs, RecCalls, DriverPos, ValueVar, LeftVar, RightVar) :-
+    Pos < InputLast,
+    NextPos is Pos + 1,
+    structural_tree_driver_pos(NextPos, InputLast, RecHeadArgs, RecCalls, DriverPos, ValueVar, LeftVar, RightVar).
+
+structural_tree_recursive_inputs([FirstCall, SecondCall], DriverPos, LeftVar, RightVar) :-
+    FirstCall =.. [_PredName|FirstArgs],
+    SecondCall =.. [_PredName2|SecondArgs],
+    nth1(DriverPos, FirstArgs, FirstInput),
+    nth1(DriverPos, SecondArgs, SecondInput),
+    (   FirstInput == LeftVar,
+        SecondInput == RightVar
+    ;   FirstInput == RightVar,
+        SecondInput == LeftVar
+    ).
+
+structural_tree_base_case_spec(BaseClauses, DriverPos, OutputPos, InvariantPositions, RecHeadArgs, BaseOutputExpr) :-
+    BaseClauses = [Head-Body],
     Body == true,
-    Head =.. [_PredName, BaseTree, BaseOutput],
+    Head =.. [_PredName|BaseArgs],
+    nth1(DriverPos, BaseArgs, BaseTree),
     BaseTree == [],
-    r_literal(BaseOutput, BaseOutputExpr).
+    base_linear_invariants_ok(BaseArgs, RecHeadArgs, InvariantPositions),
+    build_linear_recursive_varmap(BaseArgs, InvariantPositions, BaseInvariantVarMap),
+    nth1(OutputPos, BaseArgs, BaseOutput),
+    typr_translate_r_expr(BaseOutput, BaseInvariantVarMap, BaseOutputExpr).
 
-structural_tree_call_varmap(RecCalls, LeftVar, RightVar, VarMap) :-
+structural_tree_call_varmap(Arity, DriverPos, RecHeadArgs, RecCalls, LeftVar, RightVar, RecInvariantVarMap, VarMap) :-
+    OutputPos is Arity,
+    linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
     RecCalls = [FirstCall, SecondCall],
-    structural_tree_call_pair(FirstCall, LeftVar, left_result, SecondCall, RightVar, right_result, VarMap),
-    !.
-structural_tree_call_varmap(RecCalls, LeftVar, RightVar, VarMap) :-
-    RecCalls = [FirstCall, SecondCall],
-    structural_tree_call_pair(FirstCall, RightVar, right_result, SecondCall, LeftVar, left_result, VarMap).
-
-structural_tree_call_pair(FirstCall, FirstInput, FirstName, SecondCall, SecondInput, SecondName, VarMap) :-
-    FirstCall =.. [_PredName, FirstInputArg, FirstOutputVar],
-    SecondCall =.. [_PredName2, SecondInputArg, SecondOutputVar],
-    FirstInputArg == FirstInput,
-    SecondInputArg == SecondInput,
+    FirstCall =.. [_PredName|FirstArgs],
+    SecondCall =.. [_PredName2|SecondArgs],
+    structural_tree_call_invariants_ok(RecHeadArgs, FirstArgs, SecondArgs, InvariantPositions),
+    nth1(OutputPos, FirstArgs, FirstOutputVar),
+    nth1(OutputPos, SecondArgs, SecondOutputVar),
     var(FirstOutputVar),
     var(SecondOutputVar),
-    format(string(FirstResolvedName), '~w', [FirstName]),
-    format(string(SecondResolvedName), '~w', [SecondName]),
-    VarMap = [FirstOutputVar-FirstResolvedName, SecondOutputVar-SecondResolvedName].
+    nth1(DriverPos, FirstArgs, FirstInput),
+    nth1(DriverPos, SecondArgs, SecondInput),
+    (   FirstInput == LeftVar,
+        SecondInput == RightVar
+    ->  FirstResolvedName = "left_result",
+        SecondResolvedName = "right_result"
+    ;   FirstInput == RightVar,
+        SecondInput == LeftVar
+    ->  FirstResolvedName = "right_result",
+        SecondResolvedName = "left_result"
+    ),
+    VarMap = [
+        FirstOutputVar-FirstResolvedName,
+        SecondOutputVar-SecondResolvedName
+        | RecInvariantVarMap
+    ].
+
+structural_tree_call_invariants_ok(_RecHeadArgs, _FirstArgs, _SecondArgs, []).
+structural_tree_call_invariants_ok(RecHeadArgs, FirstArgs, SecondArgs, [Pos|Rest]) :-
+    nth1(Pos, RecHeadArgs, HeadArg),
+    nth1(Pos, FirstArgs, FirstArg),
+    nth1(Pos, SecondArgs, SecondArg),
+    linear_recursive_same_arg(HeadArg, FirstArg),
+    linear_recursive_same_arg(HeadArg, SecondArg),
+    structural_tree_call_invariants_ok(RecHeadArgs, FirstArgs, SecondArgs, Rest).
 
 add_structural_tree_value_var(ValueVar, VarMap, [ValueVar-"value"|VarMap]) :-
     var(ValueVar),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -50,6 +50,8 @@ cleanup_typr_test :-
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
+    retractall(user:weighted_tree_sum(_, _, _)),
+    retractall(user:weighted_tree_affine_sum(_, _, _, _)),
     retractall(user:list_length(_, _)),
     retractall(user:power(_, _, _)),
     retractall(user:power_if(_, _, _)),
@@ -268,6 +270,50 @@ test(recursive_compiler_supports_typr_structural_tree_height_path) :-
     once(sub_string(Code, _, _, _, "let tree_height <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "tree_height_impl <- function(current_tree)")),
     once(sub_string(Code, _, _, _, "result = (1 + max(left_result, right_result));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_structural_tree_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum([V, L, R], Scale, Sum) :-
+        weighted_tree_sum(L, Scale, LS),
+        weighted_tree_sum(R, Scale, RS),
+        Sum is (V * Scale) + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_sum <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_sum_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_sum_impl(left);")),
+    once(sub_string(Code, _, _, _, "result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_structural_tree_recursion_nonleading_driver_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_affine_sum(_Scale, _Offset, [], 0)),
+    assertz(user:(weighted_tree_affine_sum(Scale, Offset, [V, L, R], Sum) :-
+        weighted_tree_affine_sum(Scale, Offset, L, LS),
+        weighted_tree_affine_sum(Scale, Offset, R, RS),
+        Sum is ((V * Scale) + Offset) + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 1, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 3, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 4, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_affine_sum/4, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_affine_sum/4, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_affine_sum <- fn(arg1: int, arg2: int, arg3: [#N, Any], arg4: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_affine_sum_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_affine_sum_impl(left);")),
+    once(sub_string(Code, _, _, _, "result = ((((value * arg1) + arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "weighted_tree_affine_sum_impl(arg3)")),
+    once(sub_string(Code, _, _, _, "arg4 <- v5;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -190,6 +190,55 @@ test(structural_tree_height_output_checks_with_typr, [condition(typr_cli_availab
     ),
     retractall(user:tree_height(_, _)).
 
+test(nary_structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum([V, L, R], Scale, Sum) :-
+        weighted_tree_sum(L, Scale, LS),
+        weighted_tree_sum(R, Scale, RS),
+        Sum is (V * Scale) + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_sum(_, _, _)).
+
+test(nary_structural_tree_recursive_nonleading_driver_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_affine_sum(_Scale, _Offset, [], 0)),
+    assertz(user:(weighted_tree_affine_sum(Scale, Offset, [V, L, R], Sum) :-
+        weighted_tree_affine_sum(Scale, Offset, L, LS),
+        weighted_tree_affine_sum(Scale, Offset, R, RS),
+        Sum is ((V * Scale) + Offset) + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 1, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 3, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_affine_sum/4, 4, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_affine_sum/4, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_affine_sum/4, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_affine_sum(_, _, _, _)).
+
 test(nary_linear_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:power(_Base, 0, 1)),


### PR DESCRIPTION
## Summary

This PR expands native TypR structural tree recursion from arity-2-only predicates to a conservative `N`-ary subset with invariant context arguments.

The main addition is support for recursive predicates where:

- one argument is the tree-driving input
- zero or more earlier arguments are invariant context inputs
- the recursive clause still matches `[V, L, R]`
- there are exactly two recursive subtree calls
- the final result is computed from the current node value, the recursive subtree results, and the invariant context args

Representative supported shapes now include:

```prolog
weighted_tree_sum([], _Scale, 0).
weighted_tree_sum([V, L, R], Scale, Sum) :-
    weighted_tree_sum(L, Scale, LS),
    weighted_tree_sum(R, Scale, RS),
    Sum is (V * Scale) + LS + RS.
```

and:

```prolog
weighted_tree_affine_sum(_Scale, _Offset, [], 0).
weighted_tree_affine_sum(Scale, Offset, [V, L, R], Sum) :-
    weighted_tree_affine_sum(Scale, Offset, L, LS),
    weighted_tree_affine_sum(Scale, Offset, R, RS),
    Sum is ((V * Scale) + Offset) + LS + RS.
```

Before this change, the TypR target only handled the arity-2 structural tree-recursion subset such as `tree_sum/2` and `tree_height/2`.

After this change, those same structural recursion rules can carry invariant context arguments and still remain in native TypR.

This is still a conservative expansion, not arbitrary structural recursion or arbitrary multi-call recursion.

## Why This PR Exists

The previous TypR recursion work already supported:

- accumulator-style tail recursion
- conservative single-recursive-call linear recursion
- conservative `N`-ary linear recursion
- conservative numeric multi-call recursion such as `fib/2`
- conservative arity-2 structural tree recursion

That still left a practical gap:

- structural tree recursion worked only when the predicate arity was exactly `2`
- the same recursion shape with invariant context arguments still fell through to `unknown_recursion`

That meant useful predicates like weighted tree folds could not stay in the native TypR path even though their structure remained just as regular as the already supported arity-2 cases.

This PR closes that gap.

## Main Changes

### 1. Generalized structural tree recursion from arity-2 to conservative `N`-ary shapes

Updated `src/unifyweaver/targets/typr_target.pl`.

The TypR structural tree-recursion path no longer requires `Arity =:= 2`.

Supported shape now allows:

- one tree-driving argument
- one output argument
- zero or more invariant context args
- exactly two recursive subtree calls
- a final `Out is Expr` recombination step

### 2. Added tree-driver and invariant-context analysis

The structural recursion compiler now identifies:

- which argument is the tree driver
- which arguments are invariant across recursive calls
- how the left and right subtree calls map back to the shared recursive result vars

That is the key change that makes `N`-ary structural recursion possible without changing the helper-emission model.

### 3. Preserved variable identity during structural driver discovery

The implementation replaces the earlier copying-style structural driver search with a non-copying recursive search.

That mattered because the copied-variable approach broke identity between:

- the tree pattern in the recursive head
- the subtree inputs in the recursive calls
- the variables referenced in the final result expression

Without fixing that, even the earlier arity-2 structural tree cases regressed.

### 4. Added focused regression and toolchain coverage

Updated:

- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`

New coverage verifies:

- native TypR lowering for `weighted_tree_sum/3`
- native TypR lowering for `weighted_tree_affine_sum/4`
- support for a non-leading tree-driving argument
- continued real `typr check` validation

### 5. Documentation updated

Updated:

- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

The docs now describe the structural tree-recursion subset as conservative `N`-ary recursion with one tree-driving argument and invariant context args, rather than as an arity-2-only feature.

## Files Changed

### Implementation

- `src/unifyweaver/targets/typr_target.pl`

### Tests

- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`

### Documentation

- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the TypR recursion subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative single-recursive-call linear recursion
- conservative `N`-ary linear recursion
- conservative numeric multi-call recursion such as `fib/2`
- conservative structural tree recursion with one tree-driving argument and invariant context args

More complex recursive bodies still fall back or remain unsupported.

## Scope and Remaining Gaps

Implemented now:

- native TypR `N`-ary structural tree recursion with invariant context args
- support for non-leading tree-driving arguments
- regression and toolchain coverage for the broader structural subset

Still not fully implemented:

- structural tree recursion with pre-recursive local work before the subtree calls
- broader structural recursion beyond the current `[]` / `[V, L, R]` subset
- arbitrary multi-call recursion
- mutual recursion
- arbitrary recursive-body lowering

## Why This PR Is Worth Merging

This PR extends real TypR recursion coverage in a useful way without widening the compiler model irresponsibly.

It gives the project:

- broader structural tree recursion support
- support for weighted and context-sensitive tree folds
- continued real TypR validation
- docs that match the actual supported recursion boundary
