### PR TITLE
Keep native TypR structural tree prework

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,11 @@ includes:
   bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
-  `tree_height/2`, `weighted_tree_sum/3`, and
-  `weighted_tree_affine_sum/4`, lowered to TypR functions that use
-  raw-expression structural helper bodies over `[]` / `[V, L, R]` trees
-  inside TypR instead of wrapped-R fallback
+  `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
+  `tree_sum_prework/2`, and `weighted_tree_sum_prework/3`, lowered to TypR
+  functions that use raw-expression structural helper bodies over `[]` /
+  `[V, L, R]` trees, including limited native guards and local `is` steps
+  before the two subtree calls, instead of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive
   shapes, including multi-state branch-local recombination such as
   `power_if/3`, `count_occ/3`, `power_multistate/3`, and `count_weighted/3`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -201,7 +201,8 @@ bring-up.
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context
-    args
+    args and limited native guards or local `is` steps before the two
+    subtree calls
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -379,9 +379,11 @@ Current TypR lowering policy is intentionally mixed:
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,
-  two recursive subtree calls, and a TypR-translatable result expression
-  such as `tree_sum/2`, `tree_height/2`, `weighted_tree_sum/3`, or
-  `weighted_tree_affine_sum/4`
+  two recursive subtree calls, limited native guards and local `is` steps
+  before those subtree calls, and a TypR-translatable result expression
+  such as `tree_sum/2`, `tree_height/2`, `weighted_tree_sum/3`,
+  `weighted_tree_affine_sum/4`, `tree_sum_prework/2`, or
+  `weighted_tree_sum_prework/3`
 - guarded post-recursive recombination may also stay native inside those
   same single-recursive-call numeric and list linear-recursive shapes when
   the recursive result and later branch-local selected intermediate values

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -70,8 +70,9 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursion, emitted as TypR functions with raw-expression helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
-     argument and invariant context args, emitted as TypR functions with
-     raw-expression structural helper bodies
+     argument, invariant context args, and limited native guards or local
+     `is` steps before the two subtree calls, emitted as TypR functions
+     with raw-expression structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported
@@ -358,7 +359,8 @@ Current implementation note:
   conservative arity-2 numeric multi-call tree-recursive predicates
   compiled to raw-expression memoized helper bodies inside TypR functions,
   conservative `N`-ary structural tree-recursive predicates compiled to
-  raw-expression structural helper bodies inside TypR functions,
+  raw-expression structural helper bodies inside TypR functions, including
+  limited native guards and local `is` steps before the two subtree calls,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -359,6 +359,8 @@ structural_tree_recursive_spec(
     RecHead-RecBody,
     structural_tree_spec{
         base_output_expr: BaseOutputExpr,
+        guard_expr: GuardExpr,
+        step_lines: StepLines,
         result_expr: ResultExpr,
         input_arg_name: InputArgName,
         output_arg_name: OutputArgName,
@@ -369,7 +371,6 @@ structural_tree_recursive_spec(
     RecHead =.. [_PredName|RecHeadArgs],
     normalize_typr_goals(RecBody, Goals),
     split_typr_multicall_goals(Pred, Goals, PreGoals, RecCalls, PostGoals),
-    PreGoals == [],
     structural_tree_arg_spec(
         Arity,
         BaseClauses,
@@ -386,6 +387,10 @@ structural_tree_recursive_spec(
         OutputArgName,
         ResultName
     ),
+    typr_goals_to_body(PreGoals, PreBody),
+    PreVarMap0 = [ValueVar-"value", LeftVar-"left", RightVar-"right"|RecInvariantVarMap],
+    compile_tail_recursive_pre_goals(PreBody, PreVarMap0, PreVarMap, GuardConditions, StepLines),
+    raw_guard_expr(GuardConditions, GuardExpr),
     structural_tree_call_varmap(
         Arity,
         DriverPos,
@@ -393,13 +398,12 @@ structural_tree_recursive_spec(
         RecCalls,
         LeftVar,
         RightVar,
-        RecInvariantVarMap,
+        PreVarMap,
         VarMap
     ),
-    add_structural_tree_value_var(ValueVar, VarMap, VarMap1),
     typr_goals_to_body(PostGoals, PostBody),
     normalize_typr_goals(PostBody, [OutputVar is AggExpr]),
-    typr_translate_r_expr(AggExpr, VarMap1, ResultExpr),
+    typr_translate_r_expr(AggExpr, VarMap, ResultExpr),
     atom_string(Pred, PredStr),
     format(string(HelperName), '~w_impl', [PredStr]).
 
@@ -895,6 +899,8 @@ build_typr_structural_tree_recursive_body(
     Pred,
     structural_tree_spec{
         base_output_expr: BaseOutputExpr,
+        guard_expr: GuardExpr,
+        step_lines: StepLines,
         result_expr: ResultExpr,
         input_arg_name: InputArgName,
         output_arg_name: OutputArgName,
@@ -907,7 +913,7 @@ build_typr_structural_tree_recursive_body(
     format(string(HelperLine), '    ~w <- function(current_tree) {', [HelperName]),
     format(string(HelperCallLine), '    ~w(~w)', [HelperName, InputArgName]),
     format(string(AssignResultLine), '~w <- ~w;', [OutputArgName, ResultName]),
-    structural_tree_dispatch_lines(Pred, HelperName, BaseOutputExpr, ResultExpr, DispatchLines),
+    structural_tree_dispatch_lines(Pred, HelperName, BaseOutputExpr, GuardExpr, StepLines, ResultExpr, DispatchLines),
     append(
         [
             ResultIntroLine,
@@ -931,19 +937,24 @@ build_typr_structural_tree_recursive_body(
     ),
     atomic_list_concat(RawLines, '\n', Body).
 
-structural_tree_dispatch_lines(Pred, HelperName, BaseOutputExpr, ResultExpr, Lines) :-
+structural_tree_dispatch_lines(Pred, HelperName, BaseOutputExpr, GuardExpr, StepLines, ResultExpr, Lines) :-
     format(string(BaseLine), '            ~w', [BaseOutputExpr]),
     format(string(ResultLine), '            result = ~w;', [ResultExpr]),
     format(string(StopLine), '            stop("No matching recursive clause for ~w")', [Pred]),
     format(string(LeftCallLine), '            left_result = ~w(left);', [HelperName]),
     format(string(RightCallLine), '            right_result = ~w(right);', [HelperName]),
-    Lines = [
+    structural_tree_guard_lines(GuardExpr, Pred, GuardLines),
+    indent_lines(StepLines, '    ', IndentedStepLines),
+    append([
         '        if (length(current_tree) == 0) {',
         BaseLine,
         '        } else if (length(current_tree) == 3) {',
         '            value = .subset2(current_tree, 1);',
         '            left = .subset2(current_tree, 2);',
-        '            right = .subset2(current_tree, 3);',
+        '            right = .subset2(current_tree, 3);'
+    ], GuardLines, Lines0),
+    append(Lines0, IndentedStepLines, Lines1),
+    append(Lines1, [
         LeftCallLine,
         RightCallLine,
         ResultLine,
@@ -951,7 +962,22 @@ structural_tree_dispatch_lines(Pred, HelperName, BaseOutputExpr, ResultExpr, Lin
         '        } else {',
         StopLine,
         '        }'
-    ].
+    ], Lines).
+
+structural_tree_guard_lines('TRUE', _PredName, []) :-
+    !.
+structural_tree_guard_lines(GuardExpr, PredName, [
+    IfLine,
+    StopLine,
+    '            };'
+]) :-
+    format_string('            if (!(~w)) {', [GuardExpr], IfLine),
+    format_string('                stop("No matching recursive clause for ~w")', [PredName], StopLine).
+
+indent_lines([], _Prefix, []).
+indent_lines([Line|Rest], Prefix, [IndentedLine|IndentedRest]) :-
+    string_concat(Prefix, Line, IndentedLine),
+    indent_lines(Rest, Prefix, IndentedRest).
 
 tree_recursive_dispatch_lines(BaseCases, GuardExpr, StepLines, CallLines, ResultExpr, MemoName, Lines) :-
     format(string(MemoCheckLine), '        if (exists(key, envir=~w, inherits=FALSE)) {', [MemoName]),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -50,8 +50,10 @@ cleanup_typr_test :-
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
+    retractall(user:tree_sum_prework(_, _)),
     retractall(user:weighted_tree_sum(_, _, _)),
     retractall(user:weighted_tree_affine_sum(_, _, _, _)),
+    retractall(user:weighted_tree_sum_prework(_, _, _)),
     retractall(user:list_length(_, _)),
     retractall(user:power(_, _, _)),
     retractall(user:power_if(_, _, _)),
@@ -273,6 +275,27 @@ test(recursive_compiler_supports_typr_structural_tree_height_path) :-
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_structural_tree_prework_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_prework([], 0)),
+    assertz(user:(tree_sum_prework([V, L, R], Sum) :-
+        V >= 0,
+        W is V + 1,
+        tree_sum_prework(L, LS),
+        tree_sum_prework(R, RS),
+        Sum is W + LS + RS
+    )),
+    assertz(type_declarations:uw_type(tree_sum_prework/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_prework/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_prework/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_prework/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_prework <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "if (!(value >= 0)) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value + 1);")),
+    once(sub_string(Code, _, _, _, "result = ((step_1 + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(recursive_compiler_supports_typr_nary_structural_tree_recursion_path) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum([], _Scale, 0)),
@@ -290,6 +313,29 @@ test(recursive_compiler_supports_typr_nary_structural_tree_recursion_path) :-
     once(sub_string(Code, _, _, _, "weighted_tree_sum_impl <- function(current_tree)")),
     once(sub_string(Code, _, _, _, "left_result = weighted_tree_sum_impl(left);")),
     once(sub_string(Code, _, _, _, "result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_structural_tree_prework_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_prework([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_prework([V, L, R], Scale, Sum) :-
+        Scale > 0,
+        W is V * Scale,
+        weighted_tree_sum_prework(L, Scale, LS),
+        weighted_tree_sum_prework(R, Scale, RS),
+        Sum is W + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_prework/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_prework/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_prework/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_prework/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_prework/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_sum_prework <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "if (!(arg2 > 0)) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
+    once(sub_string(Code, _, _, _, "result = ((step_1 + left_result) + right_result);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -190,6 +190,31 @@ test(structural_tree_height_output_checks_with_typr, [condition(typr_cli_availab
     ),
     retractall(user:tree_height(_, _)).
 
+test(structural_tree_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_prework([], 0)),
+    assertz(user:(tree_sum_prework([V, L, R], Sum) :-
+        V >= 0,
+        W is V + 1,
+        tree_sum_prework(L, LS),
+        tree_sum_prework(R, RS),
+        Sum is W + LS + RS
+    )),
+    assertz(type_declarations:uw_type(tree_sum_prework/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_prework/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_prework/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_prework/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_prework(_, _)).
+
 test(nary_structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum([], _Scale, 0)),
@@ -213,6 +238,32 @@ test(nary_structural_tree_recursive_output_checks_with_typr, [condition(typr_cli
         delete_directory_and_contents(ProjectDir)
     ),
     retractall(user:weighted_tree_sum(_, _, _)).
+
+test(nary_structural_tree_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_prework([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_prework([V, L, R], Scale, Sum) :-
+        Scale > 0,
+        W is V * Scale,
+        weighted_tree_sum_prework(L, Scale, LS),
+        weighted_tree_sum_prework(R, Scale, RS),
+        Sum is W + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_prework/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_prework/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_prework/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_prework/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_prework/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_sum_prework(_, _, _)).
 
 test(nary_structural_tree_recursive_nonleading_driver_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,


### PR DESCRIPTION
## Summary

This PR expands the native TypR structural tree-recursion path so supported tree-recursive predicates can remain native even when they perform limited local work before the two subtree calls.

The main addition is support for conservative `[]` / `[V, L, R]` tree-recursive shapes where a recursive clause may:

- run a native guard over already-available inputs or unpacked tree values
- compute one or more local `is`-based intermediate values
- then recurse on the left and right subtrees
- then combine those results in a TypR-translatable final expression

Before this change, those pre-recursive local-work shapes fell outside the current structural TypR subset and did not lower through the native structural-tree path.

After this change, that class of predicates stays in native TypR and continues to validate through the real TypR CLI.

This is still a conservative expansion, not full arbitrary recursive-body TypR lowering.

## Why This PR Exists

The previous TypR recursion work already supported:

- accumulator-style tail recursion
- conservative single-recursive-call numeric linear recursion
- conservative single-recursive-call list linear recursion
- guarded and multistate post-recursive recombination for those linear shapes
- `fib/2`-style numeric multi-call helper recursion
- conservative structural tree recursion over `[]` / `[V, L, R]` trees
- `N`-ary structural tree recursion with invariant context arguments

That still left a practical gap in the structural tree-recursive path:

- a clause could unpack a tree node
- perform a simple guard or local arithmetic step
- and then recurse over the two subtrees
- but the native structural-tree TypR lowering still rejected that pre-recursive prefix

Representative shapes are:

```prolog
tree_sum_prework([], 0).
tree_sum_prework([V, L, R], Sum) :-
    V >= 0,
    W is V + 1,
    tree_sum_prework(L, LS),
    tree_sum_prework(R, RS),
    Sum is W + LS + RS.
```

and:

```prolog
weighted_tree_sum_prework([], _Scale, 0).
weighted_tree_sum_prework([V, L, R], Scale, Sum) :-
    Scale > 0,
    W is V * Scale,
    weighted_tree_sum_prework(L, Scale, LS),
    weighted_tree_sum_prework(R, Scale, RS),
    Sum is W + LS + RS.
```

This PR closes that gap for the supported structural tree-recursive subset.

## Main Changes

### 1. Native structural tree recursion now accepts limited pre-recursive local work

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The structural tree-recursive TypR path no longer requires the recursive clause prefix before the two subtree calls to be empty.

Instead, supported structural recursion may now include:

- native guard conditions over unpacked node values or invariant inputs
- local `is`-based intermediate assignments that can be normalized into TypR-safe step lines

Those steps are compiled into the native structural helper body before the recursive subtree calls.

### 2. Structural helper emission now threads pre-recursive guards and step lines

The generated TypR structural helper body now emits, in order:

- node unpacking for `value`, `left`, and `right`
- any supported guard checks
- any supported local step assignments
- left and right recursive calls
- final result recombination

That preserves the existing conservative structural recursion model while broadening the kinds of recursive clauses that can stay native.

### 3. Added focused regression coverage for structural-tree prework

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- arity-2 structural tree recursion with pre-recursive guard and local-step work
- `N`-ary structural tree recursion with invariant context arguments and the same pre-recursive local-work shape
- continued absence of wrapped-R fallback in those supported cases
- continued TypR-valid generated output

### 4. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

New toolchain tests verify that the generated output for the new structural-tree-prework shapes passes real `typr check`.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now state that the current native TypR structural tree-recursion subset includes limited pre-recursive native guards and local `is` steps before the two subtree calls.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR recursive subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative single-recursive-call numeric linear recursion
- conservative single-recursive-call list linear recursion
- guarded and multistate post-recursive recombination for those linear shapes
- conservative arity-2 numeric multi-call helper recursion such as `fib/2`
- conservative `N`-ary structural tree recursion over `[]` / `[V, L, R]` trees
- limited pre-recursive native guards and local `is` steps inside those supported structural tree-recursive shapes

More complex recursive bodies still fall back or remain unsupported.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural tree recursion with limited pre-recursive guards
- native TypR structural tree recursion with limited local `is`-based prework before subtree calls
- focused regression and toolchain coverage for the broader structural-tree subset

Still not fully implemented:

- broader arbitrary pre-recursive local work in structural multi-call recursion
- broader recursive-body normalization beyond the current conservative structural subset
- mutual recursion and more general recursive IR support

## Why This PR Is Worth Merging

This PR closes a real TypR recursion gap rather than only expanding documentation.

It gives the project:

- fewer fallback or unsupported cases in supported structural tree recursion
- better native TypR coverage for realistic recursive tree-processing predicates
- stronger confidence through focused regression coverage and real TypR validation
- documentation that matches the actual supported structural recursion subset
