### PR TITLE
scripts(csharp-query): add cache smoke summary metadata

### DIFF
--- a/scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
+++ b/scripts/testing/run_csharp_query_cache_smoke_sequence.ps1
@@ -85,6 +85,12 @@ function New-CacheSmokeSummaryData {
         [object[]]$SliceResults,
 
         [Parameter(Mandatory = $true)]
+        [TimeSpan]$TotalDuration,
+
+        [Parameter(Mandatory = $true)]
+        [string]$GeneratedAtUtc,
+
+        [Parameter(Mandatory = $true)]
         [bool]$HasFailure
     )
 
@@ -103,6 +109,9 @@ function New-CacheSmokeSummaryData {
 
     return [pscustomobject][ordered]@{
         overallResult = if ($HasFailure) { "FAIL" } else { "PASS" }
+        generatedAtUtc = $GeneratedAtUtc
+        totalDuration = (Format-Duration -Duration $TotalDuration)
+        totalDurationSeconds = [Math]::Round($TotalDuration.TotalSeconds, 1)
         outputDir = $DisplayOutputDir
         summaryPath = $DisplaySummaryPath
         jsonSummaryPath = $DisplayJsonSummaryPath
@@ -131,6 +140,8 @@ function Write-CacheSmokeSummary {
         "## C# Query Runtime Smoke",
         "",
         "- Overall result: $($SummaryData.overallResult)",
+        "- Generated at (UTC): `"$($SummaryData.generatedAtUtc)`"",
+        "- Total duration: $($SummaryData.totalDuration)",
         "- Output dir: `"$($SummaryData.outputDir)`"",
         "- Summary path: `"$($SummaryData.summaryPath)`"",
         "- JSON summary path: `"$($SummaryData.jsonSummaryPath)`"",
@@ -222,6 +233,7 @@ $sliceSpecs = @(
 
 $sliceResults = @()
 $sequenceFailure = $null
+$sequenceStart = Get-Date
 
 foreach ($sliceSpec in $sliceSpecs) {
     $sliceStart = Get-Date
@@ -248,6 +260,7 @@ foreach ($sliceSpec in $sliceSpecs) {
     }
 }
 
+$sequenceEnd = Get-Date
 $summaryData = New-CacheSmokeSummaryData `
     -DisplayOutputDir $OutputDir `
     -DisplaySummaryPath $displaySummaryPath `
@@ -255,6 +268,8 @@ $summaryData = New-CacheSmokeSummaryData `
     -ProjectFilterValue $ProjectFilter `
     -KeepArtifactsAfterSequence ([bool]$KeepArtifacts) `
     -SliceResults $sliceResults `
+    -TotalDuration ($sequenceEnd - $sequenceStart) `
+    -GeneratedAtUtc ($sequenceEnd.ToUniversalTime().ToString("o")) `
     -HasFailure ([bool]$sequenceFailure)
 
 Write-CacheSmokeSummary `


### PR DESCRIPTION
  ## Summary
  Add top-level timing metadata to the cache smoke sequence summaries so both the markdown and JSON
  outputs carry a complete run-level summary, not just per-slice timings.

  ## What changed
  - Updated `scripts/testing/run_csharp_query_cache_smoke_sequence.ps1`
  - Added top-level summary fields:
    - `generatedAtUtc`
    - `totalDuration`
    - `totalDurationSeconds`
  - Added the matching markdown summary lines:
    - `Generated at (UTC)`
    - `Total duration`
  - Kept both summary formats sourced from the same shared summary payload

  ## Why
  The cache smoke summaries already reported per-slice durations, but they did not include:
  - when the sequence finished
  - the total end-to-end runtime

  Adding that metadata makes the summaries more self-contained for:
  - CI triage
  - artifact inspection
  - future automation that wants run-level timing without recomputing it from slice data

  ## Validation
  - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/
  csharp_query_smoke_summary_metadata -NoSummaryOutput`
  - Confirmed markdown summary includes:
    - `Generated at (UTC): "..."`
    - `Total duration: ...`
  - Confirmed JSON summary includes:
    - `"generatedAtUtc"`
    - `"totalDuration"`
    - `"totalDurationSeconds"`