### PR TITLE
docs(csharp-query): document cache smoke summary metadata

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -108,6 +108,10 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
   - Writes two summaries for the sequence:
     - markdown: `cache_smoke_sequence_summary.md`
     - JSON: `cache_smoke_sequence_summary.json`
+  - Both summaries include top-level run metadata:
+    - `generatedAtUtc`
+    - `totalDuration`
+    - `totalDurationSeconds` (JSON)
   - Common options:
     - `-OutputDir tmp/csharp_query_smoke_ci`
     - `-KeepArtifacts`
@@ -127,6 +131,9 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
     - Produces:
       - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.md`
       - `tmp/csharp_query_smoke_ci/cache_smoke_sequence_summary.json`
+    - Markdown summary now includes:
+      - `Generated at (UTC): ...`
+      - `Total duration: ...`
   - Re-run a single slice against existing generated projects:
     - `pwsh -NoProfile -File scripts/testing/run_csharp_query_runtime_smoke.ps1 -OutputDir tmp/csharp_query_smoke_ci -CacheSlice reuse -SkipCodegen -KeepArtifacts`
 - CI behavior:


### PR DESCRIPTION
  ## Summary
  Update the C# query runtime docs to describe the new run-level metadata now included in the cache smoke
  markdown and JSON summaries.

  ## What changed
  - Updated `docs/targets/csharp-query-runtime.md`
  - Documented that both cache smoke summaries now include:
    - `generatedAtUtc`
    - `totalDuration`
    - `totalDurationSeconds` (JSON)
  - Documented that the markdown summary now includes:
    - `Generated at (UTC): ...`
    - `Total duration: ...`

  ## Why
  The cache smoke wrapper now emits richer run-level metadata, but the runtime docs still described only
  the older per-slice summary content. This PR brings the documentation back in sync with the current
  wrapper output.

  ## Validation
  - Verified the updated doc text against the current generated outputs from:
    - `pwsh -NoProfile -File scripts/testing/run_csharp_query_cache_smoke_sequence.ps1 -OutputDir tmp/
  csharp_query_smoke_summary_metadata -NoSummaryOutput`
  - Confirmed the documented fields are present in:
    - `tmp/csharp_query_smoke_summary_metadata/cache_smoke_sequence_summary.md`
    - `tmp/csharp_query_smoke_summary_metadata/cache_smoke_sequence_summary.json`