### PR TITLE
Keep native TypR asymmetric structural tree branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,13 @@ includes:
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
-  `tree_sum_branch/2`, and `weighted_tree_sum_branch/3`, lowered to TypR
-  functions that use raw-expression structural helper bodies over `[]` /
-  `[V, L, R]` trees, including limited native guards, local `is` steps,
-  and guarded pre-recursive branching before the two subtree calls, instead
-  of wrapped-R fallback
+  `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
+  `tree_sum_asym_branch/2`, and `weighted_tree_sum_asym_branch/3`, lowered
+  to TypR functions that use raw-expression structural helper bodies over
+  `[]` / `[V, L, R]` trees, including limited native guards, local `is`
+  steps, guarded pre-recursive branching before the two subtree calls, and
+  asymmetric branch-local prework that is reconciled later by a guarded
+  result expression, instead of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive
   shapes, including multi-state branch-local recombination such as
   `power_if/3`, `count_occ/3`, `power_multistate/3`, and `count_weighted/3`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -201,8 +201,10 @@ bring-up.
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context
-    args and limited native guards, local `is` steps, or guarded
-    pre-recursive branching before the two subtree calls
+    args and limited native guards, local `is` steps, guarded
+    pre-recursive branching before the two subtree calls, or asymmetric
+    branch-local prework that is reconciled later by a guarded result
+    expression
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -379,12 +379,14 @@ Current TypR lowering policy is intentionally mixed:
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,
-  two recursive subtree calls, limited native guards, local `is` steps, and
+  two recursive subtree calls, limited native guards, local `is` steps,
   guarded pre-recursive branching before those subtree calls, and a
-  TypR-translatable result expression such as `tree_sum/2`, `tree_height/2`,
+  TypR-translatable result expression that may also reconcile asymmetric
+  branch-local prework, such as `tree_sum/2`, `tree_height/2`,
   `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
-  `tree_sum_branch/2`, or `weighted_tree_sum_branch/3`
+  `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
+  `tree_sum_asym_branch/2`, or `weighted_tree_sum_asym_branch/3`
 - guarded post-recursive recombination may also stay native inside those
   same single-recursive-call numeric and list linear-recursive shapes when
   the recursive result and later branch-local selected intermediate values

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -71,9 +71,10 @@ This document focuses on architecture and rollout choices specific to TypR.
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local
-     `is` steps, or guarded pre-recursive branching before the two subtree
-     calls, emitted as TypR functions with raw-expression structural helper
-     bodies
+     `is` steps, guarded pre-recursive branching before the two subtree
+     calls, or asymmetric branch-local prework that is reconciled later by
+     a guarded result expression, emitted as TypR functions with
+     raw-expression structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported
@@ -361,8 +362,9 @@ Current implementation note:
   compiled to raw-expression memoized helper bodies inside TypR functions,
   conservative `N`-ary structural tree-recursive predicates compiled to
   raw-expression structural helper bodies inside TypR functions, including
-  limited native guards, local `is` steps, and guarded pre-recursive
-  branching before the two subtree calls,
+  limited native guards, local `is` steps, guarded pre-recursive branching
+  before the two subtree calls, and asymmetric branch-local prework that is
+  reconciled later by a guarded result expression,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -402,8 +402,7 @@ structural_tree_recursive_spec(
         VarMap
     ),
     typr_goals_to_body(PostGoals, PostBody),
-    normalize_typr_goals(PostBody, [OutputVar is AggExpr]),
-    typr_translate_r_expr(AggExpr, VarMap, ResultExpr),
+    linear_recursive_output_expr(PostBody, OutputVar, VarMap, ResultExpr),
     atom_string(Pred, PredStr),
     format(string(HelperName), '~w_impl', [PredStr]).
 
@@ -1144,10 +1143,10 @@ compile_tail_recursive_pre_if_then_else_goal(
 ) :-
     native_typr_if_condition(IfGoal, VarMap0, IfCondition0),
     typr_condition_expr_text(IfCondition0, IfCondition),
-    tail_recursive_pre_if_then_else_shared_output_var(ThenGoal, ElseGoal, SharedVar),
-    ensure_tail_temp_var(VarMap0, SharedVar, _SharedName, VarMap),
-    compile_tail_recursive_pre_branch_body(ThenGoal, SharedVar, VarMap, ThenLines),
-    compile_tail_recursive_pre_branch_body(ElseGoal, SharedVar, VarMap, ElseLines),
+    compile_tail_recursive_pre_goals(ThenGoal, VarMap0, VarMap1, ThenGuardConditions, ThenStepLines),
+    compile_tail_recursive_pre_goals(ElseGoal, VarMap1, VarMap, ElseGuardConditions, ElseStepLines),
+    tail_recursive_pre_branch_lines(ThenGuardConditions, ThenStepLines, ThenLines),
+    tail_recursive_pre_branch_lines(ElseGuardConditions, ElseStepLines, ElseLines),
     indent_lines(ThenLines, '    ', IndentedThenLines),
     indent_lines(ElseLines, '    ', IndentedElseLines),
     format(string(IfLine), '        if (~w) {', [IfCondition]),
@@ -1158,37 +1157,10 @@ compile_tail_recursive_pre_if_then_else_goal(
     ),
     append(Lines0, ['        };'], Lines).
 
-tail_recursive_pre_if_then_else_shared_output_var(ThenGoal, ElseGoal, SharedVar) :-
-    tail_recursive_pre_branch_output_var(ThenGoal, SharedVar),
-    var(SharedVar),
-    tail_recursive_pre_branch_output_var(ElseGoal, ElseVar),
-    SharedVar == ElseVar.
-
-tail_recursive_pre_branch_output_var(Body, OutputVar) :-
-    normalize_typr_goals(Body, Goals),
-    append(_, [LastGoal], Goals),
-    tail_recursive_pre_final_output_var(LastGoal, OutputVar).
-
-tail_recursive_pre_final_output_var(_Module:Goal, OutputVar) :-
-    !,
-    tail_recursive_pre_final_output_var(Goal, OutputVar).
-tail_recursive_pre_final_output_var(Var is _Expr, Var) :-
-    var(Var),
-    !.
-tail_recursive_pre_final_output_var(Goal, OutputVar) :-
-    typr_goal_output_var_simple(Goal, OutputVar).
-
-compile_tail_recursive_pre_branch_body(Body, SharedVar, VarMap0, Lines) :-
-    normalize_typr_goals(Body, Goals),
-    Goals \= [],
-    append(PrefixGoals, [LastGoal], Goals),
-    typr_goals_to_body(PrefixGoals, PrefixBody),
-    compile_tail_recursive_pre_goals(PrefixBody, VarMap0, VarMap1, GuardConditions, PrefixLines),
+tail_recursive_pre_branch_lines(GuardConditions, StepLines, Lines) :-
     raw_guard_expr(GuardConditions, GuardExpr),
     tail_recursive_pre_branch_guard_lines(GuardExpr, GuardLines),
-    tail_recursive_pre_branch_output_lines(LastGoal, SharedVar, VarMap1, OutputLines),
-    append(GuardLines, PrefixLines, Lines0),
-    append(Lines0, OutputLines, Lines).
+    append(GuardLines, StepLines, Lines).
 
 tail_recursive_pre_branch_guard_lines('TRUE', []) :-
     !.
@@ -1199,33 +1171,6 @@ tail_recursive_pre_branch_guard_lines(GuardExpr, [
 ]) :-
     format_string('        if (!(~w)) {', [GuardExpr], IfLine),
     StopLine = '            stop("No matching recursive branch")'.
-
-tail_recursive_pre_branch_output_lines(_Module:Goal, SharedVar, VarMap, Lines) :-
-    !,
-    tail_recursive_pre_branch_output_lines(Goal, SharedVar, VarMap, Lines).
-tail_recursive_pre_branch_output_lines(SharedVar is Expr, SharedVar, VarMap, [Line]) :-
-    !,
-    lookup_typr_var(SharedVar, VarMap, SharedName),
-    typr_translate_r_expr(Expr, VarMap, ResolvedExpr),
-    format(string(Line), '        ~w = ~w;', [SharedName, ResolvedExpr]).
-tail_recursive_pre_branch_output_lines(Goal, SharedVar, VarMap, [Line]) :-
-    tail_recursive_pre_branch_binding_expr(Goal, SharedVar, VarMap, OutputExpr),
-    lookup_typr_var(SharedVar, VarMap, SharedName),
-    format(string(Line), '        ~w = ~w;', [SharedName, OutputExpr]).
-
-tail_recursive_pre_branch_binding_expr(Goal, SharedVar, VarMap, OutputExpr) :-
-    functor(Goal, Pred, Arity),
-    binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
-    Outputs = [_],
-    simple_r_binding_target(TargetName),
-    Goal =.. [_|Args],
-    length(Inputs, InCount),
-    length(InArgs, InCount),
-    append(InArgs, [OutArg], Args),
-    OutArg == SharedVar,
-    maplist(typr_resolve_value(VarMap), InArgs, ResolvedInArgs),
-    atomic_list_concat(ResolvedInArgs, ', ', RArgsStr),
-    format(string(OutputExpr), '~w(~w)', [TargetName, RArgsStr]).
 
 ensure_tail_temp_var(VarMap, Var, Name, VarMap, existing) :-
     lookup_typr_var(Var, VarMap, Name),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -52,10 +52,12 @@ cleanup_typr_test :-
     retractall(user:tree_height(_, _)),
     retractall(user:tree_sum_prework(_, _)),
     retractall(user:tree_sum_branch(_, _)),
+    retractall(user:tree_sum_asym_branch(_, _)),
     retractall(user:weighted_tree_sum(_, _, _)),
     retractall(user:weighted_tree_affine_sum(_, _, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
     retractall(user:weighted_tree_sum_branch(_, _, _)),
+    retractall(user:weighted_tree_sum_asym_branch(_, _, _)),
     retractall(user:list_length(_, _)),
     retractall(user:power(_, _, _)),
     retractall(user:power_if(_, _, _)),
@@ -318,9 +320,30 @@ test(recursive_compiler_supports_typr_structural_tree_branching_path) :-
     once(recursive_compiler:compile_recursive(tree_sum_branch/2, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let tree_sum_branch <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "if (value > 0) {")),
-    once(sub_string(Code, _, _, _, "step_2 = (value + 1);")),
-    once(sub_string(Code, _, _, _, "step_1 = (step_2 + 1);")),
-    once(sub_string(Code, _, _, _, "result = ((step_1 + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "step_1 = (value + 1);")),
+    once(sub_string(Code, _, _, _, "step_2 = (step_1 + 1);")),
+    once(sub_string(Code, _, _, _, "result = ((step_2 + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_asymmetric_branching_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_asym_branch([], 0)),
+    assertz(user:(tree_sum_asym_branch([V, L, R], Sum) :-
+        ( V > 0 -> A is V + 1 ; B is V + 2 ),
+        tree_sum_asym_branch(L, LS),
+        tree_sum_asym_branch(R, RS),
+        ( V > 0 -> Sum is A + LS + RS ; Sum is B + LS + RS )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_asym_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_asym_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_asym_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_asym_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_asym_branch <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value + 1);")),
+    once(sub_string(Code, _, _, _, "step_2 = (value + 2);")),
+    once(sub_string(Code, _, _, _, "result = if (@{ value > 0 }@) { ((step_1 + left_result) + right_result) } else { ((step_2 + left_result) + right_result) };")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -389,9 +412,32 @@ test(recursive_compiler_supports_typr_nary_structural_tree_branching_path) :-
     once(recursive_compiler:compile_recursive(weighted_tree_sum_branch/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let weighted_tree_sum_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
     once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
-    once(sub_string(Code, _, _, _, "step_2 = (value * arg2);")),
-    once(sub_string(Code, _, _, _, "step_1 = (step_2 + 1);")),
-    once(sub_string(Code, _, _, _, "result = ((step_1 + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
+    once(sub_string(Code, _, _, _, "step_2 = (step_1 + 1);")),
+    once(sub_string(Code, _, _, _, "result = ((step_2 + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_structural_tree_asymmetric_branching_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_asym_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_asym_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 -> A is V * Scale ; B is V + Scale ),
+        weighted_tree_sum_asym_branch(L, Scale, LS),
+        weighted_tree_sum_asym_branch(R, Scale, RS),
+        ( Scale > 1 -> Sum is A + LS + RS ; Sum is B + LS + RS )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_asym_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_asym_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_asym_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_asym_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_asym_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_sum_asym_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
+    once(sub_string(Code, _, _, _, "step_2 = (value + arg2);")),
+    once(sub_string(Code, _, _, _, "result = if (@{ arg2 > 1 }@) { ((step_1 + left_result) + right_result) } else { ((step_2 + left_result) + right_result) };")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -244,6 +244,30 @@ test(structural_tree_branching_output_checks_with_typr, [condition(typr_cli_avai
     ),
     retractall(user:tree_sum_branch(_, _)).
 
+test(structural_tree_asymmetric_branching_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_asym_branch([], 0)),
+    assertz(user:(tree_sum_asym_branch([V, L, R], Sum) :-
+        ( V > 0 -> A is V + 1 ; B is V + 2 ),
+        tree_sum_asym_branch(L, LS),
+        tree_sum_asym_branch(R, RS),
+        ( V > 0 -> Sum is A + LS + RS ; Sum is B + LS + RS )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_asym_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_asym_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_asym_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_asym_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_asym_branch(_, _)).
+
 test(nary_structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum([], _Scale, 0)),
@@ -323,6 +347,31 @@ test(nary_structural_tree_branching_output_checks_with_typr, [condition(typr_cli
         delete_directory_and_contents(ProjectDir)
     ),
     retractall(user:weighted_tree_sum_branch(_, _, _)).
+
+test(nary_structural_tree_asymmetric_branching_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_asym_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_asym_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 -> A is V * Scale ; B is V + Scale ),
+        weighted_tree_sum_asym_branch(L, Scale, LS),
+        weighted_tree_sum_asym_branch(R, Scale, RS),
+        ( Scale > 1 -> Sum is A + LS + RS ; Sum is B + LS + RS )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_asym_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_asym_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_asym_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_asym_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_asym_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_sum_asym_branch(_, _, _)).
 
 test(nary_structural_tree_recursive_nonleading_driver_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,


### PR DESCRIPTION
## Summary

This PR expands the native TypR structural tree-recursion path so supported tree-recursive predicates can remain native even when pre-recursive branching introduces different branch-local intermediates before the two subtree calls.

The main addition is support for conservative `[]` / `[V, L, R]` tree-recursive shapes where a recursive clause may:

- choose a branch with `if -> then ; else`
- compute different branch-local intermediates in each branch
- recurse on the left and right subtrees
- and then reconcile those branch-local values through a guarded final result expression

Before this change, those asymmetric pre-recursive branching shapes fell outside the current structural TypR subset.

After this change, that class of predicates stays in native TypR and continues to validate through the real TypR CLI.

This is still a conservative expansion, not full arbitrary recursive-body TypR lowering.

## Why This PR Exists

The previous TypR recursion work already supported:

- accumulator-style tail recursion
- conservative numeric and list linear recursion
- guarded and multistate post-recursive recombination for those single-call shapes
- `fib/2`-style helper-based multi-call recursion
- structural tree recursion over `[]` / `[V, L, R]` trees
- `N`-ary structural tree recursion with invariant context args
- limited pre-recursive native guards and local `is` steps before the two subtree calls
- guarded pre-recursive branching when both branches converged directly on the same later local result

That still left an adjacent structural-tree gap:

- a recursive clause could perform guarded pre-recursive branching
- but if the two branches produced different local intermediates
- and only reconciled them later in the final guarded result expression
- the native structural path did not yet support that shape

Representative shapes are:

```prolog
tree_sum_asym_branch([], 0).
tree_sum_asym_branch([V, L, R], Sum) :-
    ( V > 0 -> A is V + 1 ; B is V + 2 ),
    tree_sum_asym_branch(L, LS),
    tree_sum_asym_branch(R, RS),
    ( V > 0 -> Sum is A + LS + RS ; Sum is B + LS + RS ).
```

and:

```prolog
weighted_tree_sum_asym_branch([], _Scale, 0).
weighted_tree_sum_asym_branch([V, L, R], Scale, Sum) :-
    ( Scale > 1 -> A is V * Scale ; B is V + Scale ),
    weighted_tree_sum_asym_branch(L, Scale, LS),
    weighted_tree_sum_asym_branch(R, Scale, RS),
    ( Scale > 1 -> Sum is A + LS + RS ; Sum is B + LS + RS ).
```

This PR closes that gap for the supported structural tree-recursive subset.

## Main Changes

### 1. Native structural tree recursion now supports asymmetric pre-recursive branching

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The structural tree-recursive TypR path no longer requires pre-recursive guarded branching to converge immediately on the same local result variable before the subtree calls.

Instead, supported structural recursion may now include:

- branch-local `is` intermediates that differ between the two pre-recursive branches
- subtree recursion that proceeds after those branch-local assignments
- guarded final recombination that selects the appropriate branch-local value later

That keeps these structural-tree predicates in native TypR instead of dropping them out of the supported recursion subset.

### 2. Structural post-recursive result handling now reuses guarded recombination

The structural tree-recursive path now reuses the existing guarded output-expression machinery already used by linear recursion.

That means the final structural result expression may now be:

- a direct TypR-translatable arithmetic expression
- or a supported guarded `if -> then ; else` result selection over branch-local values and recursive results

This is the key change that makes asymmetric branch-local prework valid in the structural tree-recursive path.

### 3. Pre-recursive branch compilation was generalized

The pre-recursive native goal compiler was generalized so a supported `if -> then ; else` prefix can emit valid helper-body code even when the two branches do not bind the same immediate local variable.

In practice, that means the helper body can now contain:

- branch-local assignments in the `then` branch
- different branch-local assignments in the `else` branch
- later recursive subtree calls
- and later guarded result selection that refers to those branch-local names

### 4. Added focused regression coverage for asymmetric structural branching

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- arity-2 structural tree recursion with asymmetric pre-recursive branch-local state
- `N`-ary structural tree recursion with invariant context args and the same asymmetric branching shape
- continued absence of wrapped-R fallback in those supported cases
- continued TypR-valid generated output

### 5. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

New toolchain tests verify that the generated output for the new asymmetric structural-branching shapes passes real `typr check`.

### 6. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now state that the current native TypR structural tree-recursion subset includes asymmetric branch-local prework before the two subtree calls, so long as later guarded recombination remains TypR-translatable.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

Additional note:

- full validation exposed two brittle older target tests that depended on incidental temporary-variable numbering in the symmetric structural-branching output
- those tests were updated to assert the valid generated shape instead of the old numbering detail

## Behavior Notes

After this PR, the supported native TypR recursive subset includes:

- transitive closure
- accumulator-style tail recursion
- conservative numeric and list linear recursion
- guarded and multistate post-recursive recombination for those single-call shapes
- conservative arity-2 numeric multi-call helper recursion such as `fib/2`
- conservative `N`-ary structural tree recursion over `[]` / `[V, L, R]` trees
- limited pre-recursive native guards and local `is` steps in those structural shapes
- guarded pre-recursive branching that converges on the same later local result before the two subtree calls
- asymmetric pre-recursive branching with different branch-local intermediates that are reconciled later by a guarded result expression

More complex recursive bodies still fall back or remain unsupported.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural tree recursion with asymmetric pre-recursive branch-local state
- guarded structural result recombination over those branch-local values after the subtree calls
- focused regression and toolchain coverage for the broader structural tree-recursive subset

Still not fully implemented:

- broader structural tree recursion with less constrained branch-local state flow
- broader recursive-body normalization beyond the current conservative structural subset
- mutual recursion and more general recursive IR support

## Why This PR Is Worth Merging

This PR closes a real TypR recursion gap rather than only extending docs.

It gives the project:

- fewer unsupported cases in practical structural tree recursion
- better native TypR coverage for tree-processing predicates with asymmetric local setup
- stronger confidence through focused regression coverage and real TypR validation
- documentation that matches the actual supported structural recursion subset
