### PR TITLE
Document Native TypR Structural Tree Subtree-Context Recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,13 +245,15 @@ includes:
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
+  `weighted_tree_sum_subtree_scale/3`, `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
   `tree_sum_asym_branch/2`, and `weighted_tree_sum_asym_branch/3`, lowered
   to TypR functions that use raw-expression structural helper bodies over
   `[]` / `[V, L, R]` trees, including limited native guards, local `is`
   steps, threaded invariant-context updates before the two subtree calls,
-  guarded pre-recursive branching before the two subtree calls, and
+  per-subtree invariant-context updates for the left and right recursive
+  calls, guarded pre-recursive branching before the two subtree calls, and
   asymmetric branch-local prework that is reconciled later by a guarded
   result expression, instead of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -202,9 +202,11 @@ bring-up.
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context
     args and limited native guards, local `is` steps, threaded invariant-
-    context updates before the two subtree calls, guarded pre-recursive
-    branching before the two subtree calls, or asymmetric branch-local
-    prework that is reconciled later by a guarded result expression
+    context updates before the two subtree calls, per-subtree invariant-
+    context updates for the left and right recursive calls, guarded
+    pre-recursive branching before the two subtree calls, or asymmetric
+    branch-local prework that is reconciled later by a guarded result
+    expression
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -380,12 +380,15 @@ Current TypR lowering policy is intentionally mixed:
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,
   two recursive subtree calls, limited native guards, local `is` steps,
-  threaded invariant-context updates before those subtree calls, guarded
-  pre-recursive branching before those subtree calls, and a TypR-
+  threaded invariant-context updates before those subtree calls, per-
+  subtree invariant-context updates for the left and right recursive calls,
+  guarded pre-recursive branching before those subtree calls, and a TypR-
   translatable result expression that may also reconcile asymmetric
   branch-local prework, such as `tree_sum/2`, `tree_height/2`,
   `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
+  `weighted_tree_sum_subtree_scale/3`,
+  `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
   `tree_sum_asym_branch/2`, or `weighted_tree_sum_asym_branch/3`

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -72,10 +72,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local
      `is` steps, threaded invariant-context updates before the two subtree
-     calls, guarded pre-recursive branching before the two subtree calls,
-     or asymmetric branch-local prework that is reconciled later by a
-     guarded result expression, emitted as TypR functions with raw-
-     expression structural helper bodies
+     calls, per-subtree invariant-context updates for the left and right
+     recursive calls, guarded pre-recursive branching before the two
+     subtree calls, or asymmetric branch-local prework that is reconciled
+     later by a guarded result expression, emitted as TypR functions with
+     raw-expression structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported
@@ -364,9 +365,10 @@ Current implementation note:
   conservative `N`-ary structural tree-recursive predicates compiled to
   raw-expression structural helper bodies inside TypR functions, including
   limited native guards, local `is` steps, threaded invariant-context
-  updates before the two subtree calls, guarded pre-recursive branching
-  before the two subtree calls, and asymmetric branch-local prework that is
-  reconciled later by a guarded result expression,
+  updates before the two subtree calls, per-subtree invariant-context
+  updates for the left and right recursive calls, guarded pre-recursive
+  branching before the two subtree calls, and asymmetric branch-local
+  prework that is reconciled later by a guarded result expression,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -57,6 +57,8 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_affine_sum(_, _, _, _)),
     retractall(user:weighted_tree_sum_scale_step(_, _, _)),
     retractall(user:weighted_tree_sum_scale_branch(_, _, _)),
+    retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
+    retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
     retractall(user:weighted_tree_sum_branch(_, _, _)),
     retractall(user:weighted_tree_sum_asym_branch(_, _, _)),
@@ -416,6 +418,65 @@ test(recursive_compiler_supports_typr_nary_structural_tree_invariant_branch_path
     once(sub_string(Code, _, _, _, "left_result = weighted_tree_sum_scale_branch_impl(left, step_1);")),
     once(sub_string(Code, _, _, _, "right_result = weighted_tree_sum_scale_branch_impl(right, step_1);")),
     once(sub_string(Code, _, _, _, "result = (((value * step_1) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_structural_tree_subtree_invariant_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_subtree_scale([V, L, R], Scale, Sum) :-
+        ScaleL is Scale + 1,
+        ScaleR is Scale + 2,
+        weighted_tree_sum_subtree_scale(L, ScaleL, LS),
+        weighted_tree_sum_subtree_scale(R, ScaleR, RS),
+        Sum is (V * Scale) + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_scale/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_scale/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_scale/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_subtree_scale/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_subtree_scale/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_sum_subtree_scale <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_sum_subtree_scale_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "step_1 = (arg2 + 1);")),
+    once(sub_string(Code, _, _, _, "step_2 = (arg2 + 2);")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_sum_subtree_scale_impl(left, step_1);")),
+    once(sub_string(Code, _, _, _, "right_result = weighted_tree_sum_subtree_scale_impl(right, step_2);")),
+    once(sub_string(Code, _, _, _, "result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nary_structural_tree_subtree_branch_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_subtree_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_subtree_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            ScaleL is Scale + 1,
+            ScaleR is Scale + 2
+        ;   ScaleL is Scale + 3,
+            ScaleR is Scale + 4
+        ),
+        weighted_tree_sum_subtree_branch(L, ScaleL, LS),
+        weighted_tree_sum_subtree_branch(R, ScaleR, RS),
+        Sum is (V * ScaleL) + LS + RS + ScaleR
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_subtree_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_subtree_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_sum_subtree_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_sum_subtree_branch_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (arg2 + 1);")),
+    once(sub_string(Code, _, _, _, "step_2 = (arg2 + 2);")),
+    once(sub_string(Code, _, _, _, "step_1 = (arg2 + 3);")),
+    once(sub_string(Code, _, _, _, "step_2 = (arg2 + 4);")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_sum_subtree_branch_impl(left, step_1);")),
+    once(sub_string(Code, _, _, _, "right_result = weighted_tree_sum_subtree_branch_impl(right, step_2);")),
+    once(sub_string(Code, _, _, _, "result = ((((value * step_1) + left_result) + right_result) + step_2);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -342,6 +342,62 @@ test(nary_structural_tree_invariant_branch_output_checks_with_typr, [condition(t
     ),
     retractall(user:weighted_tree_sum_scale_branch(_, _, _)).
 
+test(nary_structural_tree_subtree_invariant_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_subtree_scale([V, L, R], Scale, Sum) :-
+        ScaleL is Scale + 1,
+        ScaleR is Scale + 2,
+        weighted_tree_sum_subtree_scale(L, ScaleL, LS),
+        weighted_tree_sum_subtree_scale(R, ScaleR, RS),
+        Sum is (V * Scale) + LS + RS
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_scale/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_scale/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_scale/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_subtree_scale/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_subtree_scale/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_sum_subtree_scale(_, _, _)).
+
+test(nary_structural_tree_subtree_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_sum_subtree_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_sum_subtree_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            ScaleL is Scale + 1,
+            ScaleR is Scale + 2
+        ;   ScaleL is Scale + 3,
+            ScaleR is Scale + 4
+        ),
+        weighted_tree_sum_subtree_branch(L, ScaleL, LS),
+        weighted_tree_sum_subtree_branch(R, ScaleR, RS),
+        Sum is (V * ScaleL) + LS + RS + ScaleR
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_sum_subtree_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_sum_subtree_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_sum_subtree_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_sum_subtree_branch(_, _, _)).
+
 test(nary_structural_tree_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_prework([], _Scale, 0)),


### PR DESCRIPTION
# Document Native TypR Structural Tree Subtree-Context Recursion

## Summary

This PR formalizes another supported part of the conservative native TypR recursion subset: structural tree-recursive predicates where the left and right subtree calls receive different computed context values.

The key point is that this shape already lowers correctly in the current native TypR emitter. This PR makes that support explicit by adding focused regression coverage and updating the docs to describe it as part of the supported contract.

This is intentionally a contract/coverage PR rather than a new lowering rewrite.

## Why This PR Exists

The recent TypR recursion work had already established native support for:

- accumulator-style tail recursion
- conservative single-call linear recursion
- guarded and multistate post-recursive recombination
- `fib/2`-style numeric multi-call recursion
- conservative structural tree recursion over `[]` / `[V, L, R]`
- structural tree prework and guarded pre-recursive branching
- threaded invariant-context updates shared across both subtree calls
- asymmetric branch-local prework reconciled later by a guarded result expression

That suggested the next nearby gap would be structural tree recursion where the left and right subtree calls do not share the same updated context value.

After probing that shape directly, it turned out the current emitter already handles it correctly for conservative cases such as:

```prolog
weighted_tree_sum_subtree_scale([V, L, R], Scale, Sum) :-
    ScaleL is Scale + 1,
    ScaleR is Scale + 2,
    weighted_tree_sum_subtree_scale(L, ScaleL, LS),
    weighted_tree_sum_subtree_scale(R, ScaleR, RS),
    Sum is (V * Scale) + LS + RS.
```

and guarded variants such as:

```prolog
weighted_tree_sum_subtree_branch([V, L, R], Scale, Sum) :-
    ( Scale > 1 ->
        ScaleL is Scale + 1,
        ScaleR is Scale + 2
    ;   ScaleL is Scale + 3,
        ScaleR is Scale + 4
    ),
    weighted_tree_sum_subtree_branch(L, ScaleL, LS),
    weighted_tree_sum_subtree_branch(R, ScaleR, RS),
    Sum is (V * ScaleL) + LS + RS + ScaleR.
```

That meant the right next step was to lock the behavior in with tests and docs, not churn `typr_target.pl` unnecessarily.

## Main Changes

### 1. Added regression coverage for subtree-specific context updates

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New tests verify native TypR lowering for structural tree recursion where:

- one tree-driving argument still controls the recursion
- the left subtree call receives one computed context value
- the right subtree call receives a different computed context value
- the final result still recombines natively in TypR
- wrapped-R fallback is not used
- generated code remains valid under real TypR validation

### 2. Added coverage for guarded subtree-context divergence

The new tests also cover guarded variants where left and right subtree contexts are selected through pre-recursive branching before the subtree calls.

That matters because it confirms the current supported structural recursion subset is broader than just:

- shared invariant context
- or one common updated context threaded into both recursive calls

The supported contract now explicitly includes per-subtree context divergence for conservative shapes.

### 3. Added real `typr check` toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain tests verify that these subtree-context recursion shapes are not just plausible emitted strings. They continue to validate through the real TypR CLI.

### 4. Documentation now reflects subtree-context support

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly describe native TypR support for structural tree-recursive predicates where left and right recursive subtree calls may receive different computed invariant-context values.

### 5. Scope deliberately stayed narrow

This PR does **not** introduce a new structural recursion algorithm.

Instead, it:

- probes a plausible nearby recursive shape
- confirms the emitter already supports it
- adds tests so that support is preserved
- updates docs so the supported contract matches reality

That is the correct tradeoff here because it raises confidence without inventing unnecessary compiler churn.

## Files Changed

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- existing shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for structural tree recursion with per-subtree context divergence
- continued TypR CLI validation for generated output

What it does not claim:

- full arbitrary recursive-body TypR lowering
- mutual recursion support
- elimination of wrapped-R fallback for unsupported recursive patterns

## Behavior Notes

After this PR, the explicitly documented native TypR recursion subset includes:

- accumulator-style tail recursion
- conservative single-call linear recursion
- guarded and multistate linear post-recursive recombination
- conservative `fib/2`-style numeric multi-call recursion
- conservative structural tree recursion over `[]` / `[V, L, R]`
- structural pre-recursive local work
- shared invariant-context updates before subtree calls
- subtree-specific invariant-context updates for left and right recursive calls
- guarded pre-recursive branching before subtree calls
- asymmetric branch-local structural prework reconciled later by a guarded result expression

Broader recursive patterns still remain outside the current conservative TypR subset.

## Scope and Remaining Gaps

Implemented now:

- explicit regression coverage for structural tree recursion with different left/right subtree context values
- explicit regression coverage for guarded subtree-context divergence
- docs updated so the supported TypR recursion subset matches actual emitter behavior

Still not fully implemented:

- broader structural multi-call recursion beyond the current conservative shape
- mutual recursion
- full arbitrary recursive-body native TypR lowering

## Why This PR Is Worth Merging

This PR strengthens the TypR recursion contract in a disciplined way.

It gives the project:

- stronger confidence that already-working subtree-context recursion support will not regress
- clearer documentation of what the TypR recursion backend actually supports today
- less ambiguity between “currently works” and “officially supported”
- focused tests backed by real TypR toolchain validation

In short, this is a good incremental PR because it converts already-working structural recursion behavior into explicit, defended backend coverage.
