### PR TITLE
Keep native TypR recursive structural branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ includes:
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
   `tree_sum_branch_calls/2`, `weighted_tree_branch_calls/3`,
+  `tree_sum_recursive_branch/2`, `weighted_tree_recursive_branch/3`,
   `weighted_tree_sum_subtree_scale/3`, `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
@@ -255,9 +256,10 @@ includes:
   steps, threaded invariant-context updates before the two subtree calls,
   per-subtree invariant-context updates for the left and right recursive
   calls, branch-local recursive-call aliases before the two subtree calls,
-  guarded pre-recursive branching before the two subtree calls, and
-  asymmetric branch-local prework that is reconciled later by a guarded
-  result expression, instead of wrapped-R fallback
+  guarded pre-recursive branching before the two subtree calls, recursive
+  subtree calls inside supported branch bodies, and asymmetric branch-local
+  prework that is reconciled later by a guarded result expression, instead
+  of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive
   shapes, including multi-state branch-local recombination such as
   `power_if/3`, `count_occ/3`, `power_multistate/3`, and `count_weighted/3`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -205,9 +205,9 @@ bring-up.
     context updates before the two subtree calls, per-subtree invariant-
     context updates for the left and right recursive calls, branch-local
     recursive-call aliases before the two subtree calls, guarded
-    pre-recursive branching before the two subtree calls, or asymmetric
-    branch-local prework that is reconciled later by a guarded result
-    expression
+    pre-recursive branching before the two subtree calls, recursive subtree
+    calls inside supported branch bodies, or asymmetric branch-local
+    prework that is reconciled later by a guarded result expression
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -383,12 +383,14 @@ Current TypR lowering policy is intentionally mixed:
   threaded invariant-context updates before those subtree calls, per-
   subtree invariant-context updates for the left and right recursive calls,
   branch-local recursive-call aliases before those subtree calls, guarded
-  pre-recursive branching before those subtree calls, and a TypR-
-  translatable result expression that may also reconcile asymmetric
-  branch-local prework, such as `tree_sum/2`, `tree_height/2`,
+  pre-recursive branching before those subtree calls, recursive subtree
+  calls inside supported branch bodies, and a TypR-translatable result
+  expression that may also reconcile asymmetric branch-local prework, such
+  as `tree_sum/2`, `tree_height/2`,
   `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
   `tree_sum_branch_calls/2`, `weighted_tree_branch_calls/3`,
+  `tree_sum_recursive_branch/2`, `weighted_tree_recursive_branch/3`,
   `weighted_tree_sum_subtree_scale/3`,
   `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -75,9 +75,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      calls, per-subtree invariant-context updates for the left and right
      recursive calls, branch-local recursive-call aliases before the two
      subtree calls, guarded pre-recursive branching before the two subtree
-     calls, or asymmetric branch-local prework that is reconciled later by
-     a guarded result expression, emitted as TypR functions with raw-
-     expression structural helper bodies
+     calls, recursive subtree calls inside supported branch bodies, or
+     asymmetric branch-local prework that is reconciled later by a guarded
+     result expression, emitted as TypR functions with raw-expression
+     structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported
@@ -369,8 +370,9 @@ Current implementation note:
   updates before the two subtree calls, per-subtree invariant-context
   updates for the left and right recursive calls, branch-local recursive-
   call aliases before the two subtree calls, guarded pre-recursive
-  branching before the two subtree calls, and asymmetric branch-local
-  prework that is reconciled later by a guarded result expression,
+  branching before the two subtree calls, recursive subtree calls inside
+  supported branch bodies, and asymmetric branch-local prework that is
+  reconciled later by a guarded result expression,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -413,6 +413,71 @@ structural_tree_recursive_spec(
     ),
     typr_goals_to_body(PostGoals, PostBody),
     linear_recursive_output_expr(PostBody, OutputVar, VarMap, ResultExpr).
+structural_tree_recursive_spec(
+    Pred,
+    Arity,
+    BaseClauses,
+    RecHead-RecBody,
+    structural_tree_spec{
+        base_output_expr: BaseOutputExpr,
+        guard_expr: 'TRUE',
+        step_lines: StepLines,
+        call_lines: [],
+        result_expr: "branch_result",
+        input_arg_name: _InputArgName,
+        output_arg_name: OutputArgName,
+        result_name: ResultName,
+        helper_name: HelperName,
+        helper_param_list: HelperParamList,
+        helper_call_arg_list: HelperCallArgList
+    }
+) :-
+    RecHead =.. [_PredName|RecHeadArgs],
+    typr_if_then_else_goal(RecBody, IfGoal, ThenGoal, ElseGoal),
+    normalize_typr_goals(ThenGoal, ThenGoals),
+    split_typr_multicall_goals(Pred, ThenGoals, _ThenPreGoals0, ThenRecCalls, _ThenPostGoals0),
+    structural_tree_arg_spec(
+        Arity,
+        BaseClauses,
+        RecHeadArgs,
+        ThenRecCalls,
+        BaseOutputExpr,
+        OutputVar,
+        DriverPos,
+        ValueVar,
+        LeftVar,
+        RightVar,
+        RecInvariantVarMap,
+        InputArgName,
+        OutputArgName,
+        ResultName
+    ),
+    PreVarMap0 = [ValueVar-"value", LeftVar-"left", RightVar-"right"|RecInvariantVarMap],
+    atom_string(Pred, PredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    structural_tree_helper_param_lists(
+        Arity,
+        DriverPos,
+        RecHeadArgs,
+        InputArgName,
+        PreVarMap0,
+        HelperParamList,
+        HelperCallArgList
+    ),
+    structural_tree_if_branch_step_lines(
+        Pred,
+        IfGoal,
+        ThenGoal,
+        ElseGoal,
+        PreVarMap0,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        OutputVar,
+        StepLines
+    ).
 
 structural_tree_arg_spec(
     Arity,
@@ -513,6 +578,22 @@ structural_tree_helper_call_plan(
         CallLines
     ).
 
+structural_tree_helper_param_lists(
+    Arity,
+    DriverPos,
+    RecHeadArgs,
+    InputArgName,
+    VarMap0,
+    HelperParamList,
+    HelperCallArgList
+) :-
+    linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
+    structural_tree_helper_invariant_names(RecHeadArgs, InvariantPositions, VarMap0, InvariantNames),
+    append(["current_tree"], InvariantNames, HelperParams),
+    atomic_list_concat(HelperParams, ', ', HelperParamList),
+    append([InputArgName], InvariantNames, HelperCallArgs),
+    atomic_list_concat(HelperCallArgs, ', ', HelperCallArgList).
+
 structural_tree_helper_invariant_names(_RecHeadArgs, [], _VarMap, []).
 structural_tree_helper_invariant_names(RecHeadArgs, [Pos|Rest], VarMap, [Name|RestNames]) :-
     nth1(Pos, RecHeadArgs, HeadArg),
@@ -557,6 +638,89 @@ structural_tree_call_invariant_exprs(CallArgs, [Pos|Rest], VarMap, [Expr|RestExp
     typr_translate_r_expr(CallArg, VarMap, Expr),
     structural_tree_call_invariant_exprs(CallArgs, Rest, VarMap, RestExprs).
 
+structural_tree_if_branch_step_lines(
+    Pred,
+    IfGoal,
+    ThenGoal,
+    ElseGoal,
+    VarMap0,
+    HelperName,
+    DriverPos,
+    Arity,
+    LeftVar,
+    RightVar,
+    OutputVar,
+    Lines
+) :-
+    native_typr_if_condition(IfGoal, VarMap0, IfCondition0),
+    typr_condition_expr_text(IfCondition0, IfCondition),
+    structural_tree_branch_body_lines(
+        Pred,
+        ThenGoal,
+        VarMap0,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        OutputVar,
+        ThenLines
+    ),
+    structural_tree_branch_body_lines(
+        Pred,
+        ElseGoal,
+        VarMap0,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        OutputVar,
+        ElseLines
+    ),
+    indent_lines(ThenLines, '    ', IndentedThenLines),
+    indent_lines(ElseLines, '    ', IndentedElseLines),
+    format(string(IfLine), '        if (~w) {', [IfCondition]),
+    append([IfLine|IndentedThenLines], ['        } else {'|IndentedElseLines], Lines0),
+    append(Lines0, ['        };'], Lines).
+
+structural_tree_branch_body_lines(
+    Pred,
+    BranchGoal,
+    VarMap0,
+    HelperName,
+    DriverPos,
+    Arity,
+    LeftVar,
+    RightVar,
+    OutputVar,
+    Lines
+) :-
+    OutputPos is Arity,
+    linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
+    normalize_typr_goals(BranchGoal, Goals),
+    split_typr_multicall_goals(Pred, Goals, PreGoals, RecCalls, PostGoals),
+    typr_goals_to_body(PreGoals, PreBody),
+    compile_tail_recursive_pre_goals(PreBody, VarMap0, PreVarMap, GuardConditions, StepLines),
+    tail_recursive_pre_branch_lines(GuardConditions, StepLines, BranchPreLines),
+    build_structural_tree_call_lines(
+        RecCalls,
+        HelperName,
+        DriverPos,
+        OutputPos,
+        LeftVar,
+        RightVar,
+        InvariantPositions,
+        PreVarMap,
+        VarMap,
+        CallLines
+    ),
+    typr_goals_to_body(PostGoals, PostBody),
+    linear_recursive_output_expr(PostBody, OutputVar, VarMap, BranchResultExpr),
+    format(string(ResultLine), '        branch_result = ~w;', [BranchResultExpr]),
+    append(BranchPreLines, CallLines, Lines0),
+    append(Lines0, [ResultLine], Lines).
+
 add_structural_tree_value_var(ValueVar, VarMap, [ValueVar-"value"|VarMap]) :-
     var(ValueVar),
     !.
@@ -588,16 +752,25 @@ contains_recursive_goal(Pred, [Goal|_]) :-
 contains_recursive_goal(Pred, [_|Rest]) :-
     contains_recursive_goal(Pred, Rest).
 
-goal_calls_predicate(Pred, _Module:Goal) :-
+goal_calls_predicate(Pred, Goal0) :-
+    nonvar(Goal0),
+    Goal0 = _Module:Goal,
     !,
     goal_calls_predicate(Pred, Goal).
 goal_calls_predicate(Pred, Goal) :-
+    nonvar(Goal),
     compound(Goal),
     functor(Goal, Pred, _).
 
 recursive_goal_count(Pred, Body, Count) :-
-    normalize_typr_goals(Body, Goals),
-    include(goal_calls_predicate(Pred), Goals, RecGoals),
+    findall(
+        Goal,
+        (
+            sub_term(Goal, Body),
+            goal_calls_predicate(Pred, Goal)
+        ),
+        RecGoals
+    ),
     length(RecGoals, Count).
 
 typr_goals_to_body([], true).
@@ -1408,7 +1581,9 @@ detect_transitive_closure(Module, Pred, 2, BasePred) :-
     transitive_closure_pattern(Pred, BaseBodies, RecursiveBodies, BasePred).
 
 calls_predicate(Pred, Arity, Goal) :-
-    contains_goal(Goal, SubGoal),
+    sub_term(SubGoal, Goal),
+    nonvar(SubGoal),
+    compound(SubGoal),
     functor(SubGoal, Pred, Arity).
 
 contains_goal((Left, _Right), Goal) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -59,6 +59,8 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_sum_scale_branch(_, _, _)),
     retractall(user:tree_sum_branch_calls(_, _)),
     retractall(user:weighted_tree_branch_calls(_, _, _)),
+    retractall(user:tree_sum_recursive_branch(_, _)),
+    retractall(user:weighted_tree_recursive_branch(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
@@ -476,6 +478,66 @@ test(recursive_compiler_supports_typr_weighted_structural_tree_branch_local_call
     once(sub_string(Code, _, _, _, "left_result = weighted_tree_branch_calls_impl(step_1, step_3);")),
     once(sub_string(Code, _, _, _, "right_result = weighted_tree_branch_calls_impl(step_2, arg2);")),
     once(sub_string(Code, _, _, _, "result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_recursive_branch_body_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_recursive_branch([], 0)),
+    assertz(user:(tree_sum_recursive_branch([V, L, R], Sum) :-
+        ( V > 0 ->
+            tree_sum_recursive_branch(L, LS),
+            tree_sum_recursive_branch(R, RS),
+            Sum is V + LS + RS
+        ;   tree_sum_recursive_branch(R, RS),
+            tree_sum_recursive_branch(L, LS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_recursive_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_recursive_branch <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "tree_sum_recursive_branch_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "} else {")),
+    once(sub_string(Code, _, _, _, "left_result = tree_sum_recursive_branch_impl(left);")),
+    once(sub_string(Code, _, _, _, "right_result = tree_sum_recursive_branch_impl(right);")),
+    \+ sub_string(Code, _, _, _, "left_result = tree_sum_recursive_branch_impl(right);"),
+    \+ sub_string(Code, _, _, _, "right_result = tree_sum_recursive_branch_impl(left);"),
+    once(sub_string(Code, _, _, _, "branch_result = ((value + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_weighted_structural_tree_recursive_branch_body_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_recursive_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_recursive_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            weighted_tree_recursive_branch(L, Scale, LS),
+            weighted_tree_recursive_branch(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        ;   weighted_tree_recursive_branch(R, Scale, RS),
+            weighted_tree_recursive_branch(L, Scale, LS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_recursive_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_recursive_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_recursive_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_recursive_branch_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "} else {")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_recursive_branch_impl(left, arg2);")),
+    once(sub_string(Code, _, _, _, "right_result = weighted_tree_recursive_branch_impl(right, arg2);")),
+    \+ sub_string(Code, _, _, _, "left_result = weighted_tree_recursive_branch_impl(right, arg2);"),
+    \+ sub_string(Code, _, _, _, "right_result = weighted_tree_recursive_branch_impl(left, arg2);"),
+    once(sub_string(Code, _, _, _, "branch_result = (((value * arg2) + left_result) + right_result);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -392,6 +392,63 @@ test(weighted_structural_tree_branch_local_calls_output_checks_with_typr, [condi
     ),
     retractall(user:weighted_tree_branch_calls(_, _, _)).
 
+test(structural_tree_recursive_branch_body_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_recursive_branch([], 0)),
+    assertz(user:(tree_sum_recursive_branch([V, L, R], Sum) :-
+        ( V > 0 ->
+            tree_sum_recursive_branch(L, LS),
+            tree_sum_recursive_branch(R, RS),
+            Sum is V + LS + RS
+        ;   tree_sum_recursive_branch(R, RS),
+            tree_sum_recursive_branch(L, LS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_recursive_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_recursive_branch(_, _)).
+
+test(weighted_structural_tree_recursive_branch_body_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_recursive_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_recursive_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            weighted_tree_recursive_branch(L, Scale, LS),
+            weighted_tree_recursive_branch(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        ;   weighted_tree_recursive_branch(R, Scale, RS),
+            weighted_tree_recursive_branch(L, Scale, LS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_recursive_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_recursive_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_recursive_branch(_, _, _)).
+
 test(nary_structural_tree_subtree_invariant_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR recursion path so structural tree-recursive predicates can stay native when the two recursive subtree calls appear inside a supported `if -> then ; else` branch body.

Before this change, structurally valid tree recursion worked when the two subtree calls appeared directly in the recursive clause body, but comparable branch-bodied shapes were not recognized cleanly by the TypR structural path.

This PR closes that gap for the supported structural subset.

## Why This PR Exists

Recent TypR recursion work already supported:

- accumulator-style tail recursion
- conservative linear recursion
- conservative structural tree recursion
- structural pre-recursive local work
- structural branch-local aliasing and invariant threading

That still left an adjacent structural gap:

- tree recursion worked when the recursive subtree calls were in the main clause body
- but similar shapes with the recursive subtree calls inside a supported branch body were not handled by the same native structural path

A representative shape is:

```prolog
tree_sum_recursive_branch([], 0).
tree_sum_recursive_branch([V, L, R], Sum) :-
    ( V > 0 ->
        tree_sum_recursive_branch(L, LS),
        tree_sum_recursive_branch(R, RS),
        Sum is V + LS + RS
    ;   tree_sum_recursive_branch(R, RS),
        tree_sum_recursive_branch(L, LS),
        Sum is V + LS + RS
    ).
```

This PR makes that shape part of the supported native TypR recursion subset.

## Main Changes

### 1. Structural tree recursion now handles supported branch-bodied recursive calls

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR structural recursion path now recognizes top-level `if -> then ; else` recursive bodies where:

- one argument is the tree-driving input
- each branch contains the two recursive subtree calls
- the final branch result is still TypR-translatable

Those shapes now emit native TypR helper code instead of dropping out of the structural path.

### 2. Recursive-goal discovery now sees branch-body recursive calls

The implementation also tightens recursive-goal analysis so nested recursive calls inside branch bodies are counted and classified correctly.

That was required for these structural branch-bodied predicates to reach the intended TypR recursion path at all.

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- `tree_sum_recursive_branch/2`
- `weighted_tree_recursive_branch/3`

The tests also lock in the actual emitter contract:

- recursive result names remain tied to subtree identity
- they are not required to mirror branch-local call order

### 4. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new recursive branch-body shapes now also pass real `typr check` validation.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the supported structural tree-recursive subset includes recursive subtree calls inside supported branch bodies.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR structural tree-recursive subset includes:

- direct two-subtree structural recursion
- threaded invariant-context updates
- per-subtree context updates
- branch-local recursive-call aliases
- supported pre-recursive branching
- recursive subtree calls inside supported branch bodies

Broader recursive patterns still remain out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural recursion for supported branch-bodied recursive subtree calls
- better recursive-goal discovery for branch-local recursive bodies
- focused regression and toolchain coverage for those cases

Still not fully implemented:

- broader structural multi-call recursion beyond the current conservative subset
- mutual recursion
- generic arbitrary recursive body lowering

## Why This PR Is Worth Merging

This PR improves real TypR recursion behavior in a nearby high-value case.

It gives the project:

- fewer unsupported structural recursion shapes
- stronger coverage for branch-bodied recursive tree predicates
- better alignment between documented TypR support and actual compiler behavior
- real TypR validation for the new supported shapes
