### PR TITLE
feat(agent-loop): close coverage gaps with 8 new shared_logic methods, 10 new slot types, 44/44/44/44 parity

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -164,31 +164,27 @@ compile_advanced(bash, Pred/Arity, FinalOptions, GeneratedCode) :-
         Pred/Arity, FinalOptions, GeneratedCode
     ).
 compile_advanced(java, Pred/Arity, FinalOptions, GeneratedCode) :-
-    java_target:compile_predicate_to_java(Pred/Arity, [generator_mode(true)|FinalOptions], GeneratedCode).
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(java)|FinalOptions], GeneratedCode).
 compile_advanced(kotlin, Pred/Arity, FinalOptions, GeneratedCode) :-
-    kotlin_target:compile_predicate_to_kotlin(Pred/Arity, [generator_mode(true)|FinalOptions], GeneratedCode).
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(kotlin)|FinalOptions], GeneratedCode).
 compile_advanced(scala, Pred/Arity, FinalOptions, GeneratedCode) :-
-    scala_target:compile_predicate_to_scala(Pred/Arity, [generator_mode(true)|FinalOptions], GeneratedCode).
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(scala)|FinalOptions], GeneratedCode).
 compile_advanced(clojure, Pred/Arity, FinalOptions, GeneratedCode) :-
-    clojure_target:compile_predicate_to_clojure(Pred/Arity, [generator_mode(true)|FinalOptions], GeneratedCode).
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(clojure)|FinalOptions], GeneratedCode).
 compile_advanced(jython, Pred/Arity, FinalOptions, GeneratedCode) :-
-    jython_target:compile_predicate_to_jython(Pred/Arity, [generator_mode(true)|FinalOptions], GeneratedCode).
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(jython)|FinalOptions], GeneratedCode).
 compile_advanced(elixir, Pred/Arity, FinalOptions, GeneratedCode) :-
-    elixir_target:compile_predicate_to_elixir(Pred/Arity, [generator_mode(true)|FinalOptions], GeneratedCode).
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(elixir)|FinalOptions], GeneratedCode).
 compile_advanced(r, Pred/Arity, FinalOptions, GeneratedCode) :-
     advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(r)|FinalOptions], GeneratedCode).
 compile_advanced(typr, Pred/Arity, FinalOptions, GeneratedCode) :-
     compile_recursive_predicate_to_typr(Pred/Arity, FinalOptions, GeneratedCode).
 compile_advanced(python, Pred/Arity, FinalOptions, GeneratedCode) :-
     advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(python)|FinalOptions], GeneratedCode).
-compile_advanced(go, Pred/Arity, _FinalOptions, _GeneratedCode) :-
-    format(user_error, 'Advanced recursive compilation for target go not yet implemented (~w).~n',
-           [Pred/Arity]),
-    fail.
-compile_advanced(rust, Pred/Arity, _FinalOptions, _GeneratedCode) :-
-    format(user_error, 'Advanced recursive compilation for target rust not yet implemented (~w).~n',
-           [Pred/Arity]),
-    fail.
+compile_advanced(go, Pred/Arity, FinalOptions, GeneratedCode) :-
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(go)|FinalOptions], GeneratedCode).
+compile_advanced(rust, Pred/Arity, FinalOptions, GeneratedCode) :-
+    advanced_recursive_compiler:compile_advanced_recursive(Pred/Arity, [target(rust)|FinalOptions], GeneratedCode).
 compile_advanced(Target, Pred/Arity, _FinalOptions, _GeneratedCode) :-
     format(user_error, 'Advanced recursive compilation for target ~w not implemented (~w).~n',
            [Target, Pred/Arity]),


### PR DESCRIPTION
## Summary

- Add **8 new shared_logic methods** closing all 3 documented PARITY_REPORT coverage gaps (context trimming, session I/O, tool dispatch):
  - `trim_excess_count` — compute how many oldest messages to drop for count limit
  - `tokens_over_budget` — check if estimated token count exceeds max budget
  - `message_token_estimate` — estimate tokens for a single message (chars/4 heuristic)
  - `session_list_filter` — check if filename ends with `.json`
  - `session_data_keys` — return metadata key list (`id`, `name`, `message_count`, `saved_at`)
  - `check_approval_block` — return true if tool is destructive and not in approved set
  - `is_mcp_tool` — check for `mcp:` prefix indicating MCP dispatch
  - `has_required_params` — verify all required parameter keys exist in args dict
- Add **10 new slot types** for all 4 targets (Python, Rust, Elixir, Prolog):
  - `not_expr` — boolean negation (`not` / `!()` / `\+`)
  - `gt` — greater-than comparison
  - `str_starts_with` — string prefix check
  - `str_ends_with` — string suffix check
  - `all_keys_present` — verify all keys exist in dict/map
  - `literal_list` — construct literal list/vec/array
  - `json_encode` — serialize to JSON string
  - `json_decode` — parse JSON string to dict/map
  - `file_read` — read file to string
  - `file_write` — write string to file
- Add **`list_of_string`** to `resolve_type/3` for all 4 targets
- **PARITY_REPORT coverage gaps table now empty** — all gaps addressed with shared helpers (orchestrating methods stay as target-specific fragments where error handling differs)
- Parity: **44/44/44/44** (Python/Rust/Elixir/Prolog)

## Test plan

- [x] All 1507 Prolog tests pass (1079 unit + 428 declarative, 0 failures)
- [x] All 44 shared_logic methods compile for all 4 targets
- [x] `generate_all` completes cleanly for all targets, no errors
- [x] PARITY_REPORT.md shows 44/44/44/44 with empty coverage gaps table
- [x] New slot types produce correct syntax per target (Python: `not`, Rust: `!()`, Elixir: `not`, Prolog: `\+`)
- [x] Declarative tests auto-generated for all 8 new methods (428 total, up from 388)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
