### PR TITLE
Keep native TypR nested structural recursive branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ includes:
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
   `tree_sum_branch_calls/2`, `weighted_tree_branch_calls/3`,
   `tree_sum_recursive_branch/2`, `weighted_tree_recursive_branch/3`,
+  `tree_sum_nested_recursive_branch/2`,
+  `weighted_tree_nested_recursive_branch/3`,
   `weighted_tree_sum_subtree_scale/3`, `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
@@ -257,9 +259,10 @@ includes:
   per-subtree invariant-context updates for the left and right recursive
   calls, branch-local recursive-call aliases before the two subtree calls,
   guarded pre-recursive branching before the two subtree calls, recursive
-  subtree calls inside supported branch bodies, and asymmetric branch-local
-  prework that is reconciled later by a guarded result expression, instead
-  of wrapped-R fallback
+  subtree calls inside supported branch bodies, nested recursive subtree
+  calls inside supported branch bodies, and asymmetric branch-local prework
+  that is reconciled later by a guarded result expression, instead of
+  wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive
   shapes, including multi-state branch-local recombination such as
   `power_if/3`, `count_occ/3`, `power_multistate/3`, and `count_weighted/3`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -206,8 +206,9 @@ bring-up.
     context updates for the left and right recursive calls, branch-local
     recursive-call aliases before the two subtree calls, guarded
     pre-recursive branching before the two subtree calls, recursive subtree
-    calls inside supported branch bodies, or asymmetric branch-local
-    prework that is reconciled later by a guarded result expression
+    calls inside supported branch bodies, nested recursive subtree calls
+    inside supported branch bodies, or asymmetric branch-local prework that
+    is reconciled later by a guarded result expression
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -384,13 +384,16 @@ Current TypR lowering policy is intentionally mixed:
   subtree invariant-context updates for the left and right recursive calls,
   branch-local recursive-call aliases before those subtree calls, guarded
   pre-recursive branching before those subtree calls, recursive subtree
-  calls inside supported branch bodies, and a TypR-translatable result
-  expression that may also reconcile asymmetric branch-local prework, such
-  as `tree_sum/2`, `tree_height/2`,
+  calls inside supported branch bodies, nested recursive subtree calls
+  inside supported branch bodies, and a TypR-translatable result expression
+  that may also reconcile asymmetric branch-local prework, such as
+  `tree_sum/2`, `tree_height/2`,
   `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
   `tree_sum_branch_calls/2`, `weighted_tree_branch_calls/3`,
   `tree_sum_recursive_branch/2`, `weighted_tree_recursive_branch/3`,
+  `tree_sum_nested_recursive_branch/2`,
+  `weighted_tree_nested_recursive_branch/3`,
   `weighted_tree_sum_subtree_scale/3`,
   `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -75,10 +75,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      calls, per-subtree invariant-context updates for the left and right
      recursive calls, branch-local recursive-call aliases before the two
      subtree calls, guarded pre-recursive branching before the two subtree
-     calls, recursive subtree calls inside supported branch bodies, or
-     asymmetric branch-local prework that is reconciled later by a guarded
-     result expression, emitted as TypR functions with raw-expression
-     structural helper bodies
+     calls, recursive subtree calls inside supported branch bodies, nested
+     recursive subtree calls inside supported branch bodies, or asymmetric
+     branch-local prework that is reconciled later by a guarded result
+     expression, emitted as TypR functions with raw-expression structural
+     helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -434,8 +434,7 @@ structural_tree_recursive_spec(
 ) :-
     RecHead =.. [_PredName|RecHeadArgs],
     typr_if_then_else_goal(RecBody, IfGoal, ThenGoal, ElseGoal),
-    normalize_typr_goals(ThenGoal, ThenGoals),
-    split_typr_multicall_goals(Pred, ThenGoals, _ThenPreGoals0, ThenRecCalls, _ThenPostGoals0),
+    structural_tree_goal_rec_calls(Pred, ThenGoal, ThenRecCalls),
     structural_tree_arg_spec(
         Arity,
         BaseClauses,
@@ -696,6 +695,59 @@ structural_tree_branch_body_lines(
     OutputVar,
     Lines
 ) :-
+    normalize_typr_goals(BranchGoal, [NestedIfGoal|PostGoals]),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal, ElseGoal),
+    PostGoals \= [],
+    native_typr_if_condition(IfGoal, VarMap0, IfCondition0),
+    typr_condition_expr_text(IfCondition0, IfCondition),
+    structural_tree_recursive_prefix_lines(
+        Pred,
+        ThenGoal,
+        VarMap0,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        ThenVarMap,
+        ThenLines
+    ),
+    structural_tree_recursive_prefix_lines(
+        Pred,
+        ElseGoal,
+        VarMap0,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        ElseVarMap,
+        ElseLines
+    ),
+    typr_goals_to_body(PostGoals, PostBody),
+    linear_recursive_output_expr(PostBody, OutputVar, ThenVarMap, ThenBranchResultExpr),
+    linear_recursive_output_expr(PostBody, OutputVar, ElseVarMap, ElseBranchResultExpr),
+    format(string(ThenResultLine), '        branch_result = ~w;', [ThenBranchResultExpr]),
+    format(string(ElseResultLine), '        branch_result = ~w;', [ElseBranchResultExpr]),
+    append(ThenLines, [ThenResultLine], ThenLinesWithResult),
+    append(ElseLines, [ElseResultLine], ElseLinesWithResult),
+    indent_lines(ThenLinesWithResult, '    ', IndentedThenLines),
+    indent_lines(ElseLinesWithResult, '    ', IndentedElseLines),
+    format(string(IfLine), '        if (~w) {', [IfCondition]),
+    append([IfLine|IndentedThenLines], ['        } else {'|IndentedElseLines], Lines0),
+    append(Lines0, ['        };'], Lines).
+structural_tree_branch_body_lines(
+    Pred,
+    BranchGoal,
+    VarMap0,
+    HelperName,
+    DriverPos,
+    Arity,
+    LeftVar,
+    RightVar,
+    OutputVar,
+    Lines
+) :-
     OutputPos is Arity,
     linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
     normalize_typr_goals(BranchGoal, Goals),
@@ -721,6 +773,54 @@ structural_tree_branch_body_lines(
     append(BranchPreLines, CallLines, Lines0),
     append(Lines0, [ResultLine], Lines).
 
+structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
+    normalize_typr_goals(Goal, Goals),
+    (   split_typr_multicall_goals(Pred, Goals, _PreGoals, RecCalls, _PostGoals)
+    ;   split_typr_multicall_goal_prefix(Pred, Goals, _PreGoals, RecCalls)
+    ),
+    !.
+structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
+    typr_if_then_else_goal(Goal, _IfGoal, ThenGoal, _ElseGoal),
+    !,
+    structural_tree_goal_rec_calls(Pred, ThenGoal, RecCalls).
+structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
+    normalize_typr_goals(Goal, [NestedIfGoal|_PostGoals]),
+    typr_if_then_else_goal(NestedIfGoal, _IfGoal, ThenGoal, _ElseGoal),
+    structural_tree_goal_rec_calls(Pred, ThenGoal, RecCalls).
+
+structural_tree_recursive_prefix_lines(
+    Pred,
+    BranchGoal,
+    VarMap0,
+    HelperName,
+    DriverPos,
+    Arity,
+    LeftVar,
+    RightVar,
+    VarMap,
+    Lines
+) :-
+    OutputPos is Arity,
+    linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
+    normalize_typr_goals(BranchGoal, Goals),
+    split_typr_multicall_goal_prefix(Pred, Goals, PreGoals, RecCalls),
+    typr_goals_to_body(PreGoals, PreBody),
+    compile_tail_recursive_pre_goals(PreBody, VarMap0, PreVarMap, GuardConditions, StepLines),
+    tail_recursive_pre_branch_lines(GuardConditions, StepLines, BranchPreLines),
+    build_structural_tree_call_lines(
+        RecCalls,
+        HelperName,
+        DriverPos,
+        OutputPos,
+        LeftVar,
+        RightVar,
+        InvariantPositions,
+        PreVarMap,
+        VarMap,
+        CallLines
+    ),
+    append(BranchPreLines, CallLines, Lines).
+
 add_structural_tree_value_var(ValueVar, VarMap, [ValueVar-"value"|VarMap]) :-
     var(ValueVar),
     !.
@@ -732,6 +832,12 @@ split_typr_multicall_goals(Pred, Goals, PreGoals, RecCalls, PostGoals) :-
     RecCalls = [_|[_|_]],
     PostGoals \= [],
     \+ contains_recursive_goal(Pred, PostGoals).
+
+split_typr_multicall_goal_prefix(Pred, Goals, PreGoals, RecCalls) :-
+    split_non_recursive_prefix(Pred, Goals, PreGoals, RecAndPostGoals),
+    take_recursive_goal_prefix(Pred, RecAndPostGoals, RecCalls, PostGoals),
+    RecCalls = [_|[_|_]],
+    PostGoals == [].
 
 split_non_recursive_prefix(_Pred, [], [], []).
 split_non_recursive_prefix(Pred, [Goal|Rest], [], [Goal|Rest]) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -61,6 +61,8 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_branch_calls(_, _, _)),
     retractall(user:tree_sum_recursive_branch(_, _)),
     retractall(user:weighted_tree_recursive_branch(_, _, _)),
+    retractall(user:tree_sum_nested_recursive_branch(_, _)),
+    retractall(user:weighted_tree_nested_recursive_branch(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
@@ -537,6 +539,70 @@ test(recursive_compiler_supports_typr_weighted_structural_tree_recursive_branch_
     once(sub_string(Code, _, _, _, "right_result = weighted_tree_recursive_branch_impl(right, arg2);")),
     \+ sub_string(Code, _, _, _, "left_result = weighted_tree_recursive_branch_impl(right, arg2);"),
     \+ sub_string(Code, _, _, _, "right_result = weighted_tree_recursive_branch_impl(left, arg2);"),
+    once(sub_string(Code, _, _, _, "branch_result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nested_structural_tree_recursive_branch_body_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_nested_recursive_branch([], 0)),
+    assertz(user:(tree_sum_nested_recursive_branch([V, L, R], Sum) :-
+        ( V > 0 ->
+            ( V > 1 ->
+                tree_sum_nested_recursive_branch(L, LS),
+                tree_sum_nested_recursive_branch(R, RS)
+            ;   tree_sum_nested_recursive_branch(R, RS),
+                tree_sum_nested_recursive_branch(L, LS)
+            ),
+            Sum is V + LS + RS
+        ;   tree_sum_nested_recursive_branch(L, LS),
+            tree_sum_nested_recursive_branch(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_nested_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_nested_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_nested_recursive_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_nested_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_nested_recursive_branch <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "tree_sum_nested_recursive_branch_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "if (value > 1) {")),
+    once(sub_string(Code, _, _, _, "right_result = tree_sum_nested_recursive_branch_impl(right);")),
+    once(sub_string(Code, _, _, _, "left_result = tree_sum_nested_recursive_branch_impl(left);")),
+    once(sub_string(Code, _, _, _, "branch_result = ((value + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_weighted_nested_structural_tree_recursive_branch_body_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_nested_recursive_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_nested_recursive_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            ( V > 0 ->
+                weighted_tree_nested_recursive_branch(L, Scale, LS),
+                weighted_tree_nested_recursive_branch(R, Scale, RS)
+            ;   weighted_tree_nested_recursive_branch(R, Scale, RS),
+                weighted_tree_nested_recursive_branch(L, Scale, LS)
+            ),
+            Sum is (V * Scale) + LS + RS
+        ;   weighted_tree_nested_recursive_branch(L, Scale, LS),
+            weighted_tree_nested_recursive_branch(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_nested_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_nested_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_nested_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_nested_recursive_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_nested_recursive_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_nested_recursive_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_nested_recursive_branch_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "right_result = weighted_tree_nested_recursive_branch_impl(right, arg2);")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_nested_recursive_branch_impl(left, arg2);")),
     once(sub_string(Code, _, _, _, "branch_result = (((value * arg2) + left_result) + right_result);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -449,6 +449,71 @@ test(weighted_structural_tree_recursive_branch_body_output_checks_with_typr, [co
     ),
     retractall(user:weighted_tree_recursive_branch(_, _, _)).
 
+test(nested_structural_tree_recursive_branch_body_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_nested_recursive_branch([], 0)),
+    assertz(user:(tree_sum_nested_recursive_branch([V, L, R], Sum) :-
+        ( V > 0 ->
+            ( V > 1 ->
+                tree_sum_nested_recursive_branch(L, LS),
+                tree_sum_nested_recursive_branch(R, RS)
+            ;   tree_sum_nested_recursive_branch(R, RS),
+                tree_sum_nested_recursive_branch(L, LS)
+            ),
+            Sum is V + LS + RS
+        ;   tree_sum_nested_recursive_branch(L, LS),
+            tree_sum_nested_recursive_branch(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_nested_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_nested_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_nested_recursive_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_nested_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_nested_recursive_branch(_, _)).
+
+test(weighted_nested_structural_tree_recursive_branch_body_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_nested_recursive_branch([], _Scale, 0)),
+    assertz(user:(weighted_tree_nested_recursive_branch([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            ( V > 0 ->
+                weighted_tree_nested_recursive_branch(L, Scale, LS),
+                weighted_tree_nested_recursive_branch(R, Scale, RS)
+            ;   weighted_tree_nested_recursive_branch(R, Scale, RS),
+                weighted_tree_nested_recursive_branch(L, Scale, LS)
+            ),
+            Sum is (V * Scale) + LS + RS
+        ;   weighted_tree_nested_recursive_branch(L, Scale, LS),
+            weighted_tree_nested_recursive_branch(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_nested_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_nested_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_nested_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_nested_recursive_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_nested_recursive_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_nested_recursive_branch(_, _, _)).
+
 test(nary_structural_tree_subtree_invariant_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR structural recursion path so supported tree-recursive predicates can stay native when an outer branch contains an inner `if -> then ; else` that determines the subtree call order before a later shared recombination.

Before this change, those nested structural recursion shapes fell out of the TypR structural path and then failed in unsupported fallback recursion handling.

After this change, the same shapes lower natively and pass real `typr check`.

This is still a conservative recursion expansion, not arbitrary recursive-body lowering.

## Why This PR Exists

Recent TypR recursion work already supported:

- accumulator-style tail recursion
- conservative numeric and list linear recursion
- `fib/2`-style helper recursion
- structural tree recursion over `[]` / `[V, L, R]` trees
- structural pre-recursive local work
- structural branching and asymmetric branch-local recombination
- recursive subtree calls inside supported branch bodies

That still left a nearby structural gap:

- supported structural recursion worked when recursive subtree calls appeared directly in a supported branch body
- but it still failed when that branch body itself contained a nested `if -> then ; else` around the subtree calls

A representative shape is:

```prolog
tree_sum_nested_recursive_branch([], 0).
tree_sum_nested_recursive_branch([V, L, R], Sum) :-
    ( V > 0 ->
        ( V > 1 ->
            tree_sum_nested_recursive_branch(L, LS),
            tree_sum_nested_recursive_branch(R, RS)
        ;   tree_sum_nested_recursive_branch(R, RS),
            tree_sum_nested_recursive_branch(L, LS)
        ),
        Sum is V + LS + RS
    ;   tree_sum_nested_recursive_branch(L, LS),
        tree_sum_nested_recursive_branch(R, RS),
        Sum is V + LS + RS
    ).
```

This PR closes that gap for the supported structural subset.

## Main Changes

### 1. Structural recursive-call extraction now recognizes nested branch prefixes

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR structural recursion path now accepts nested branch bodies where, after descending into the inner branch, the recursive portion is just the two subtree calls without extra trailing post-goals in that inner branch.

That was the first missing piece required for these predicates to stay on the structural TypR path at all.

### 2. Nested structural branch lowering now computes post-rejoin results per branch

For nested structural branch bodies, the compiler no longer assumes the later post-goal state must already be shared across both inner branches before recombination.

Instead, it now:

- compiles each inner branch’s recursive prefix with its own varmap
- computes the later shared result expression inside each inner branch
- emits the final nested TypR `if` structure directly

That matches the real control-flow shape and avoids the previous false failure in shared-post-state reconciliation.

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- `tree_sum_nested_recursive_branch/2`
- `weighted_tree_nested_recursive_branch/3`

The assertions focus on the supported emitted shape:

- native structural helper generation
- nested `if` presence
- subtree-result handling through native TypR

### 4. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new nested structural recursion shapes now also pass real `typr check`.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the supported structural tree-recursive TypR subset includes nested recursive subtree calls inside supported branch bodies.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR structural tree-recursive subset includes:

- direct two-subtree structural recursion
- threaded invariant-context updates
- per-subtree context updates
- branch-local recursive-call aliases
- supported pre-recursive branching
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies

Broader recursive patterns still remain out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural recursion for nested branch-local recursive subtree calls
- nested branch-body recursive-call extraction for the supported structural subset
- focused regression and toolchain coverage for those cases

Still not fully implemented:

- broader structural multi-call recursion beyond the current conservative subset
- mutual recursion
- generic arbitrary recursive body lowering

## Why This PR Is Worth Merging

This PR closes a real TypR recursion gap.

It gives the project:

- fewer unsupported structural recursion shapes
- stronger native TypR coverage for nested structural control flow
- better alignment between documented TypR support and actual compiler behavior
- real TypR validation for the new supported shapes
