### PR TITLE
feat(core): extract shared clause body analysis module from TypR

### DIFF
--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -1,0 +1,571 @@
+:- encoding(utf8).
+% SPDX-License-Identifier: MIT OR Apache-2.0
+% Copyright (c) 2025 John William Creighton (@s243a)
+%
+% clause_body_analysis.pl — Target-independent clause body analysis
+%
+% Provides shared infrastructure for native clause body lowering across
+% all targets. Extracted from typr_target.pl (PRs #826–#898).
+%
+% This module handles the ANALYSIS side (structure detection, variable
+% tracking) while targets provide the CODE GENERATION side (syntax,
+% formatting, indentation).
+
+:- module(clause_body_analysis, [
+    % Goal normalization
+    normalize_goals/2,              % +Body, -GoalList
+
+    % Control flow pattern matching
+    if_then_else_goal/4,            % +Goal, -If, -Then, -Else
+    if_then_goal/3,                 % +Goal, -If, -Then
+    disjunction_alternatives/2,     % +Goal, -Alternatives
+
+    % Goal classification
+    classify_goal/3,                % +Goal, +VarMap, -Classification
+    is_guard_goal/2,                % +Goal, +VarMap
+    is_output_goal/2,               % +Goal, +VarMap
+    goal_output_var/2,              % +Goal, -OutputVar
+    goal_output_vars/2,             % +Goal, -OutputVars
+
+    % Shared output variable detection
+    shared_output_var/3,            % +Alternatives, +VarMap, -SharedVar
+    shared_output_vars/3,           % +Alternatives, +VarMap, -SharedVars
+    if_then_else_shared_output_var/4,   % +Then, +Else, +VarMap, -SharedVar
+    if_then_else_shared_output_vars/4,  % +Then, +Else, +VarMap, -SharedVars
+    if_then_output_var/3,           % +Then, +VarMap, -OutputVar
+    if_then_output_vars/3,          % +Then, +VarMap, -OutputVars
+
+    % VarMap management
+    build_head_varmap/3,            % +HeadArgs, +StartIndex, -VarMap
+    lookup_var/3,                   % +Var, +VarMap, -Name
+    ensure_var/5,                   % +VarMap, +Var, -Name, -VarMapOut, -IntroKind
+    ensure_var/4,                   % +VarMap, +Var, -Name, -VarMapOut
+    ensure_vars/4,                  % +Vars, +VarMap, -Pairs, -VarMapOut
+    varmap_contains_var/2,          % +VarMap, +Var
+    exclude_varmap_vars/3,          % +VarMap, +Vars, -Filtered
+    reserve_internal_var/5,         % +VarMap, -Token, -Name, -VarMapOut, -IntroKind
+    remove_var_mapping/3,           % +Var, +VarMap, -VarMapOut
+    next_var_index/2,               % +VarMap, -NextIndex
+
+    % Variable identity utilities
+    var_member_by_identity/2,       % +Var, +List
+    unique_vars_by_identity/2,      % +Vars, -Unique
+    intersect_output_vars/3,        % +Alternative, +Candidates, -Intersected
+
+    % Head condition analysis
+    head_conditions/3,              % +HeadArgs, +StartIndex, -Conditions
+    head_arg_is_var/1,              % +Arg — true if arg is unbound variable
+
+    % Expression analysis
+    expr_op/2,                      % +PrologOp, -StandardOp
+    translate_expr/3,               % +Expr, +VarMap, -TranslatedParts
+    literal_value/2,                % +PrologValue, -LiteralParts
+
+    % Clause structure analysis
+    analyze_clauses/2,              % +Clauses, -Analysis
+    clause_guard_output_split/4     % +Goals, +VarMap, -Guards, -Outputs
+]).
+
+:- use_module(library(lists)).
+
+% ============================================================================
+% GOAL NORMALIZATION
+% ============================================================================
+
+%% normalize_goals(+Body, -GoalList)
+%  Flatten a Prolog clause body (conjunction tree) into a list of goals.
+%  Strips module qualifications and handles true (empty body).
+normalize_goals(true, []) :- !.
+normalize_goals((Left, Right), Goals) :-
+    !,
+    normalize_goals(Left, LeftGoals),
+    normalize_goals(Right, RightGoals),
+    append(LeftGoals, RightGoals, Goals).
+normalize_goals(_Module:Goal, Goals) :-
+    !,
+    normalize_goals(Goal, Goals).
+normalize_goals(Goal, [Goal]).
+
+% ============================================================================
+% CONTROL FLOW PATTERN MATCHING
+% ============================================================================
+
+%% if_then_else_goal(+Goal, -IfGoal, -ThenGoal, -ElseGoal)
+%  Match Prolog's (If -> Then ; Else) pattern.
+%  SWI-Prolog may represent this as ;(->(If,Then), Else).
+if_then_else_goal((IfGoal -> ThenGoal ; ElseGoal), IfGoal, ThenGoal, ElseGoal) :- !.
+if_then_else_goal(;(->(IfGoal, ThenGoal), ElseGoal), IfGoal, ThenGoal, ElseGoal) :- !.
+
+%% if_then_goal(+Goal, -IfGoal, -ThenGoal)
+%  Match Prolog's (If -> Then) pattern (no else branch).
+if_then_goal((IfGoal -> ThenGoal), IfGoal, ThenGoal) :- !.
+if_then_goal(->(IfGoal, ThenGoal), IfGoal, ThenGoal) :- !.
+
+%% disjunction_alternatives(+Goal, -Alternatives)
+%  Flatten a Prolog disjunction (A ; B ; C) into a list [A, B, C].
+disjunction_alternatives((Left ; Right), Alternatives) :-
+    !,
+    disjunction_alternatives(Left, LeftAlts),
+    disjunction_alternatives(Right, RightAlts),
+    append(LeftAlts, RightAlts, Alternatives).
+disjunction_alternatives(Goal, [Goal]).
+
+% ============================================================================
+% GOAL CLASSIFICATION
+% ============================================================================
+
+%% classify_goal(+Goal, +VarMap, -Classification)
+%  Classify a goal as guard, output, multi_result_output, or control_flow.
+classify_goal(Goal, VarMap, control_flow) :-
+    (if_then_else_goal(Goal, _, _, _) ; if_then_goal(Goal, _, _)),
+    !,
+    (   is_output_goal(Goal, VarMap)
+    ->  true   % it's control_flow that produces output
+    ;   true   % it's control_flow that's a guard
+    ).
+classify_goal(Goal, _VarMap, output) :-
+    goal_output_var(Goal, _),
+    !.
+classify_goal(Goal, VarMap, guard) :-
+    is_guard_goal(Goal, VarMap),
+    !.
+classify_goal(_, _, unknown).
+
+%% is_guard_goal(+Goal, +VarMap)
+%  A goal is a guard if it's a comparison or type check that produces no
+%  new variable bindings (only tests existing values).
+is_guard_goal(_Module:Goal, VarMap) :-
+    !,
+    is_guard_goal(Goal, VarMap).
+is_guard_goal(Goal, _VarMap) :-
+    compound(Goal),
+    Goal =.. [Op, _, _],
+    comparison_op(Op),
+    !.
+is_guard_goal(Goal, _VarMap) :-
+    compound(Goal),
+    Goal =.. [TypeCheck, _],
+    type_check_pred(TypeCheck),
+    !.
+
+%% is_output_goal(+Goal, +VarMap)
+%  A goal is an output if it binds a variable not already in VarMap.
+is_output_goal(Goal, VarMap) :-
+    goal_output_var(Goal, Var),
+    var(Var),
+    \+ varmap_contains_var(VarMap, Var).
+
+%% comparison_op(+Op)
+%  Prolog comparison operators that act as guards.
+comparison_op(>).
+comparison_op(<).
+comparison_op(>=).
+comparison_op(=<).
+comparison_op(=:=).
+comparison_op(=\=).
+comparison_op(==).
+comparison_op(\==).
+comparison_op(\=).
+
+%% type_check_pred(+Pred)
+%  Prolog type check predicates that act as guards.
+type_check_pred(integer).
+type_check_pred(float).
+type_check_pred(number).
+type_check_pred(atom).
+type_check_pred(is_list).
+type_check_pred(compound).
+type_check_pred(var).
+type_check_pred(nonvar).
+
+% ============================================================================
+% OUTPUT VARIABLE DETECTION
+% ============================================================================
+
+%% goal_output_var(+Goal, -OutputVar)
+%  Extract the primary output variable from a goal.
+goal_output_var(_Module:Goal, OutputVar) :-
+    !,
+    goal_output_var(Goal, OutputVar).
+goal_output_var(Goal, OutputVar) :-
+    goal_output_vars(Goal, [OutputVar]),
+    !.
+goal_output_var(Goal, OutputVar) :-
+    goal_output_var_simple(Goal, OutputVar).
+
+%% goal_output_vars(+Goal, -OutputVars)
+%  Extract all output variables from a goal (handles nested control flow).
+goal_output_vars(_Module:Goal, OutputVars) :-
+    !,
+    goal_output_vars(Goal, OutputVars).
+goal_output_vars(Goal, OutputVars) :-
+    if_then_else_goal(Goal, _IfGoal, ThenGoal, ElseGoal),
+    if_then_else_goal_output_vars(ThenGoal, ElseGoal, OutputVars),
+    !.
+goal_output_vars(Goal, OutputVars) :-
+    if_then_goal(Goal, _IfGoal, ThenGoal),
+    if_then_goal_output_vars(ThenGoal, OutputVars),
+    !.
+goal_output_vars(Goal, OutputVars) :-
+    disjunction_alternatives(Goal, Alternatives),
+    Alternatives = [_|[_|_]],
+    disjunction_goal_output_vars(Alternatives, OutputVars),
+    !.
+goal_output_vars(Goal, [OutputVar]) :-
+    goal_output_var_simple(Goal, OutputVar).
+
+%% goal_output_var_simple(+Goal, -OutputVar)
+%  Extract output var from simple goals (Var is Expr, Var = Value).
+goal_output_var_simple(_Module:Goal, OutputVar) :-
+    !,
+    goal_output_var_simple(Goal, OutputVar).
+goal_output_var_simple(Var is _, Var) :- var(Var), !.
+goal_output_var_simple(Var = _, Var) :- var(Var), !.
+goal_output_var_simple(_ = Var, Var) :- var(Var), !.
+
+%% alternative_output_var(+Alternative, -OutputVar)
+%  Find the last output variable in an alternative branch.
+alternative_output_var(Alternative, OutputVar) :-
+    normalize_goals(Alternative, Goals),
+    reverse(Goals, ReversedGoals),
+    member(Goal, ReversedGoals),
+    goal_output_var(Goal, OutputVar),
+    !.
+
+%% alternative_output_vars(+Alternative, -OutputVars)
+%  Collect all output variables from an alternative branch.
+alternative_output_vars(Alternative, OutputVars) :-
+    normalize_goals(Alternative, Goals),
+    collect_goal_output_vars(Goals, OutputVars0),
+    unique_vars_by_identity(OutputVars0, OutputVars).
+
+collect_goal_output_vars([], []).
+collect_goal_output_vars([Goal|Rest], OutputVars) :-
+    (   goal_output_vars(Goal, GoalOutputVars)
+    ->  append(GoalOutputVars, RestOutputs, OutputVars)
+    ;   OutputVars = RestOutputs
+    ),
+    collect_goal_output_vars(Rest, RestOutputs).
+
+%% Nested output var helpers
+if_then_else_goal_output_vars(ThenGoal, ElseGoal, OutputVars) :-
+    alternative_output_vars(ThenGoal, ThenOutputVars),
+    intersect_output_vars(ElseGoal, ThenOutputVars, OutputVars),
+    OutputVars \= [].
+
+if_then_goal_output_vars(ThenGoal, OutputVars) :-
+    alternative_output_vars(ThenGoal, OutputVars),
+    OutputVars \= [].
+
+disjunction_goal_output_vars([Alternative|Rest], OutputVars) :-
+    alternative_output_vars(Alternative, FirstOutputVars),
+    foldl(intersect_output_vars, Rest, FirstOutputVars, OutputVars),
+    OutputVars \= [].
+
+% ============================================================================
+% SHARED OUTPUT VARIABLE DETECTION
+% ============================================================================
+
+%% shared_output_var(+Alternatives, +VarMap, -SharedVar)
+%  Find a single variable that all alternatives assign to.
+shared_output_var([Alternative|Rest], VarMap, SharedVar) :-
+    alternative_output_var(Alternative, SharedVar),
+    var(SharedVar),
+    output_var_allowed(VarMap, SharedVar),
+    maplist(alternative_output_var_matches(SharedVar), Rest).
+
+%% shared_output_vars(+Alternatives, +VarMap, -SharedVars)
+%  Find all variables that all alternatives assign to.
+shared_output_vars([Alternative|Rest], VarMap, SharedVars) :-
+    alternative_output_vars(Alternative, FirstOutputVars0),
+    exclude_varmap_vars(VarMap, FirstOutputVars0, FirstOutputVars),
+    foldl(intersect_output_vars, Rest, FirstOutputVars, SharedVars),
+    SharedVars \= [].
+
+%% if_then_else_shared_output_var(+Then, +Else, +VarMap, -SharedVar)
+if_then_else_shared_output_var(ThenGoal, ElseGoal, VarMap, SharedVar) :-
+    alternative_output_var(ThenGoal, SharedVar),
+    var(SharedVar),
+    output_var_allowed(VarMap, SharedVar),
+    alternative_output_var(ElseGoal, ElseVar),
+    ElseVar == SharedVar.
+
+%% if_then_else_shared_output_vars(+Then, +Else, +VarMap, -SharedVars)
+if_then_else_shared_output_vars(ThenGoal, ElseGoal, VarMap, SharedVars) :-
+    alternative_output_vars(ThenGoal, ThenOutputVars0),
+    exclude_varmap_vars(VarMap, ThenOutputVars0, ThenOutputVars),
+    intersect_output_vars(ElseGoal, ThenOutputVars, SharedVars),
+    SharedVars \= [].
+
+%% if_then_output_var(+Then, +VarMap, -OutputVar)
+if_then_output_var(ThenGoal, VarMap, OutputVar) :-
+    alternative_output_var(ThenGoal, OutputVar),
+    var(OutputVar),
+    output_var_allowed(VarMap, OutputVar).
+
+%% if_then_output_vars(+Then, +VarMap, -OutputVars)
+if_then_output_vars(ThenGoal, VarMap, OutputVars) :-
+    alternative_output_vars(ThenGoal, OutputVars0),
+    exclude_varmap_vars(VarMap, OutputVars0, OutputVars),
+    OutputVars \= [].
+
+%% output_var_allowed(+VarMap, +Var)
+%  A variable can be an output if it's not in VarMap, or if it's an arg.
+output_var_allowed(VarMap, Var) :-
+    \+ varmap_contains_var(VarMap, Var),
+    !.
+output_var_allowed(VarMap, Var) :-
+    lookup_var(Var, VarMap, ArgName),
+    sub_string(ArgName, 0, 3, _, "arg").
+
+alternative_output_var_matches(ExpectedVar, Alternative) :-
+    alternative_output_var(Alternative, ActualVar),
+    ActualVar == ExpectedVar.
+
+% ============================================================================
+% VARMAP MANAGEMENT
+% ============================================================================
+
+%% build_head_varmap(+HeadArgs, +StartIndex, -VarMap)
+%  Create initial VarMap from predicate head arguments.
+%  Variables become arg1, arg2, ...; non-variables are skipped.
+build_head_varmap([], _, []).
+build_head_varmap([Arg|Args], Index, [Arg-ArgName|Rest]) :-
+    var(Arg),
+    !,
+    format(string(ArgName), 'arg~w', [Index]),
+    NextIndex is Index + 1,
+    build_head_varmap(Args, NextIndex, Rest).
+build_head_varmap([_|Args], Index, Rest) :-
+    NextIndex is Index + 1,
+    build_head_varmap(Args, NextIndex, Rest).
+
+%% lookup_var(+Var, +VarMap, -Name)
+%  Find a variable's target name in VarMap using == identity.
+lookup_var(Var, [StoredVar-Name|_], Name) :-
+    Var == StoredVar,
+    !.
+lookup_var(Var, [_|Rest], Name) :-
+    lookup_var(Var, Rest, Name).
+
+%% ensure_var(+VarMap, +Var, -Name, -VarMapOut, -IntroKind)
+%  Look up or allocate a variable. IntroKind is 'existing' or 'new'.
+ensure_var(VarMap, Var, Name, VarMap, existing) :-
+    lookup_var(Var, VarMap, Name),
+    !.
+ensure_var(VarMap, Var, Name, [Var-Name|VarMap], new) :-
+    next_var_index(VarMap, NextIndex),
+    format(string(Name), 'v~w', [NextIndex]).
+
+%% ensure_var/4 — without IntroKind
+ensure_var(VarMap, Var, Name, VarMapOut) :-
+    ensure_var(VarMap, Var, Name, VarMapOut, _).
+
+%% ensure_vars(+Vars, +VarMap, -Pairs, -VarMapOut)
+%  Allocate multiple variables, returning Var-Name pairs.
+ensure_vars([], VarMap, [], VarMap).
+ensure_vars([Var|Rest], VarMap0, [Var-Name|RestPairs], VarMapOut) :-
+    ensure_var(VarMap0, Var, Name, VarMap1, _),
+    ensure_vars(Rest, VarMap1, RestPairs, VarMapOut).
+
+%% varmap_contains_var(+VarMap, +Var)
+varmap_contains_var([StoredVar-_|_], Var) :-
+    Var == StoredVar, !.
+varmap_contains_var([_|Rest], Var) :-
+    varmap_contains_var(Rest, Var).
+
+%% exclude_varmap_vars(+VarMap, +Vars, -Filtered)
+%  Remove vars that are already in VarMap.
+exclude_varmap_vars(_VarMap, [], []).
+exclude_varmap_vars(VarMap, [Var|Rest], Filtered) :-
+    (   varmap_contains_var(VarMap, Var)
+    ->  exclude_varmap_vars(VarMap, Rest, Filtered)
+    ;   Filtered = [Var|FilteredRest],
+        exclude_varmap_vars(VarMap, Rest, FilteredRest)
+    ).
+
+%% reserve_internal_var(+VarMap, -Token, -Name, -VarMapOut, -IntroKind)
+%  Allocate a temporary internal variable (for containers, etc.).
+reserve_internal_var(VarMap0, Token, Name, VarMap, IntroKind) :-
+    ensure_var(VarMap0, Token, Name, VarMap, IntroKind).
+
+%% remove_var_mapping(+Var, +VarMap, -VarMapOut)
+%  Remove a variable from VarMap (used after container extraction).
+remove_var_mapping(_Var, [], []).
+remove_var_mapping(Var, [StoredVar-Name|Rest], Filtered) :-
+    (   Var == StoredVar
+    ->  Filtered = FilteredRest
+    ;   Filtered = [StoredVar-Name|FilteredRest]
+    ),
+    remove_var_mapping(Var, Rest, FilteredRest).
+
+%% next_var_index(+VarMap, -NextIndex)
+%  Get the next available variable index (v1, v2, ...).
+next_var_index([], 1).
+next_var_index(VarMap, NextIndex) :-
+    findall(Index, (
+        member(_-Name, VarMap),
+        name_index(Name, Index)
+    ), Indices),
+    (   Indices = []
+    ->  NextIndex = 1
+    ;   max_list(Indices, MaxIndex),
+        NextIndex is MaxIndex + 1
+    ).
+
+%% name_index(+Name, -Index)
+%  Extract numeric index from a variable name like "arg3" or "v5".
+name_index(Name, Index) :-
+    string(Name),
+    (   sub_string(Name, 0, 3, _, "arg")
+    ->  sub_string(Name, 3, _, 0, Digits)
+    ;   sub_string(Name, 0, 1, _, "v"),
+        sub_string(Name, 1, _, 0, Digits)
+    ),
+    number_string(Index, Digits).
+
+% ============================================================================
+% VARIABLE IDENTITY UTILITIES
+% ============================================================================
+
+%% var_member_by_identity(+Var, +List)
+%  Check if Var is in List using == (not unification).
+var_member_by_identity(Var, [Candidate|_]) :-
+    Var == Candidate, !.
+var_member_by_identity(Var, [_|Rest]) :-
+    var_member_by_identity(Var, Rest).
+
+%% unique_vars_by_identity(+Vars, -Unique)
+%  Remove duplicates using == identity.
+unique_vars_by_identity([], []).
+unique_vars_by_identity([Var|Rest], Unique) :-
+    unique_vars_by_identity(Rest, RestUnique),
+    (   var_member_by_identity(Var, RestUnique)
+    ->  Unique = RestUnique
+    ;   Unique = [Var|RestUnique]
+    ).
+
+%% intersect_output_vars(+Alternative, +Candidates, -Intersected)
+%  Keep only candidates that also appear as outputs of Alternative.
+intersect_output_vars(Alternative, Candidates0, Candidates) :-
+    alternative_output_vars(Alternative, OutputVars),
+    include_vars_by_identity(Candidates0, OutputVars, Candidates).
+
+include_vars_by_identity([], _Allowed, []).
+include_vars_by_identity([Var|Rest], Allowed, Included) :-
+    (   var_member_by_identity(Var, Allowed)
+    ->  Included = [Var|IncludedRest]
+    ;   Included = IncludedRest
+    ),
+    include_vars_by_identity(Rest, Allowed, IncludedRest).
+
+% ============================================================================
+% HEAD CONDITION ANALYSIS
+% ============================================================================
+
+%% head_conditions(+HeadArgs, +StartIndex, -Conditions)
+%  Extract conditions from predicate head arguments.
+%  Variables produce no condition; constants produce equality checks.
+%  Returns a list of condition(ArgIndex, Value) terms.
+head_conditions([], _, []).
+head_conditions([HeadArg|Rest], Index, Conditions) :-
+    (   var(HeadArg)
+    ->  Conditions = RestConditions
+    ;   Conditions = [condition(Index, HeadArg)|RestConditions]
+    ),
+    NextIndex is Index + 1,
+    head_conditions(Rest, NextIndex, RestConditions).
+
+%% head_arg_is_var(+Arg) — true if arg is unbound variable
+head_arg_is_var(Arg) :- var(Arg).
+
+% ============================================================================
+% EXPRESSION ANALYSIS
+% ============================================================================
+
+%% expr_op(+PrologOp, -StandardOp)
+%  Map Prolog operators to standard operator names.
+%  Targets translate StandardOp to their own syntax.
+expr_op(>, '>').
+expr_op(<, '<').
+expr_op(>=, '>=').
+expr_op(=<, '<=').
+expr_op(=:=, '==').
+expr_op(==, '==').
+expr_op(\=, '!=').
+expr_op(\==, '!=').
+expr_op(+, '+').
+expr_op(-, '-').
+expr_op(*, '*').
+expr_op(/, '/').
+expr_op(mod, '%').
+expr_op(and, '&&').
+expr_op(or, '||').
+
+%% translate_expr(+Expr, +VarMap, -Parts)
+%  Decompose a Prolog expression into parts for target translation.
+%  Returns structured terms: var(Name), literal(Value), op(Op, Left, Right),
+%  call(Fn, Args), negation(Inner).
+translate_expr(Var, VarMap, var(Name)) :-
+    var(Var), !,
+    lookup_var(Var, VarMap, Name).
+translate_expr(Atom, _VarMap, literal(Atom)) :-
+    atom(Atom), !.
+translate_expr(Text, _VarMap, literal(Text)) :-
+    string(Text), !.
+translate_expr(Number, _VarMap, literal(Number)) :-
+    number(Number), !.
+translate_expr(-Expr, VarMap, negation(Inner)) :-
+    !,
+    translate_expr(Expr, VarMap, Inner).
+translate_expr(Expr, VarMap, op(Op, Left, Right)) :-
+    compound(Expr),
+    Expr =.. [PrologOp, LeftExpr, RightExpr],
+    expr_op(PrologOp, Op),
+    !,
+    translate_expr(LeftExpr, VarMap, Left),
+    translate_expr(RightExpr, VarMap, Right).
+translate_expr(Expr, VarMap, call(Fn, TranslatedArgs)) :-
+    compound(Expr),
+    Expr =.. [Fn|Args],
+    Args \= [],
+    maplist(translate_expr_arg(VarMap), Args, TranslatedArgs).
+
+translate_expr_arg(VarMap, Arg, Translated) :-
+    translate_expr(Arg, VarMap, Translated).
+
+%% literal_value(+PrologValue, -LiteralParts)
+%  Classify a Prolog value for target-specific literal rendering.
+%  Returns: null, bool(true/false), string(Text), number(N), atom(A), term(T).
+literal_value(Value, null) :- var(Value), !.
+literal_value(true, bool(true)) :- !.
+literal_value(false, bool(false)) :- !.
+literal_value(Value, string(Value)) :- string(Value), !.
+literal_value(Value, number(Value)) :- number(Value), !.
+literal_value(Value, atom(Value)) :- atom(Value), !.
+literal_value(Value, term(Value)).
+
+% ============================================================================
+% CLAUSE STRUCTURE ANALYSIS
+% ============================================================================
+
+%% analyze_clauses(+Clauses, -Analysis)
+%  Analyze a list of Head-Body clauses and return structured analysis.
+%  Analysis is a list of clause_info(Head, HeadArgs, HeadConditions, Goals).
+analyze_clauses([], []).
+analyze_clauses([Head-Body|Rest], [clause_info(Head, HeadArgs, HeadConditions, Goals)|RestAnalysis]) :-
+    Head =.. [_Pred|HeadArgs],
+    head_conditions(HeadArgs, 1, HeadConditions),
+    normalize_goals(Body, Goals),
+    analyze_clauses(Rest, RestAnalysis).
+
+%% clause_guard_output_split(+Goals, +VarMap, -Guards, -Outputs)
+%  Split a list of goals into leading guards and trailing outputs.
+%  Guards are comparison/type-check goals before any assignment.
+%  Once an assignment is seen, remaining goals are all outputs.
+clause_guard_output_split([], _VarMap, [], []).
+clause_guard_output_split([Goal|Rest], VarMap, [Goal|Guards], Outputs) :-
+    is_guard_goal(Goal, VarMap),
+    !,
+    clause_guard_output_split(Rest, VarMap, Guards, Outputs).
+clause_guard_output_split(Outputs, _VarMap, [], Outputs).


### PR DESCRIPTION
## Summary

- Phase 0 of native clause body lowering (per design doc in PR #902): extracts target-independent analysis predicates from `typr_target.pl` into `src/unifyweaver/core/clause_body_analysis.pl`
- Exports 29 predicates across 6 categories: goal normalization, control flow pattern matching, goal classification (guard vs output), shared output variable detection, VarMap management, and expression/clause structure analysis
- All predicates load cleanly and pass smoke tests — no existing code modified, purely additive
- Foundation for Phases 1-3: Python, Go, and Rust targets will import this module to implement native clause body lowering without duplicating TypR's analysis logic

## Test plan

- [x] Module loads without errors (`use_module` succeeds)
- [x] All 29 exported predicates resolve as defined
- [x] Smoke tests pass: `normalize_goals`, `if_then_else_goal`, `classify_goal`, `build_head_varmap`, `lookup_var`, `translate_expr`
- [x] No existing files modified — zero regression risk
