### PR TITLE
Keep native TypR nested structural branch recombination

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ includes:
   `tree_sum_recursive_branch/2`, `weighted_tree_recursive_branch/3`,
   `tree_sum_nested_recursive_branch/2`,
   `weighted_tree_nested_recursive_branch/3`,
+  `tree_sum_nested_branch_recombine/2`,
+  `weighted_tree_nested_branch_recombine/3`,
   `weighted_tree_sum_subtree_scale/3`, `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
@@ -260,9 +262,10 @@ includes:
   calls, branch-local recursive-call aliases before the two subtree calls,
   guarded pre-recursive branching before the two subtree calls, recursive
   subtree calls inside supported branch bodies, nested recursive subtree
-  calls inside supported branch bodies, and asymmetric branch-local prework
-  that is reconciled later by a guarded result expression, instead of
-  wrapped-R fallback
+  calls inside supported branch bodies, nested branch-local post-recursive
+  recombination before a later shared result expression, and asymmetric
+  branch-local prework that is reconciled later by a guarded result
+  expression, instead of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive
   shapes, including multi-state branch-local recombination such as
   `power_if/3`, `count_occ/3`, `power_multistate/3`, and `count_weighted/3`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -207,8 +207,10 @@ bring-up.
     recursive-call aliases before the two subtree calls, guarded
     pre-recursive branching before the two subtree calls, recursive subtree
     calls inside supported branch bodies, nested recursive subtree calls
-    inside supported branch bodies, or asymmetric branch-local prework that
-    is reconciled later by a guarded result expression
+    inside supported branch bodies, nested branch-local post-recursive
+    recombination before a later shared result expression, or asymmetric
+    branch-local prework that is reconciled later by a guarded result
+    expression
   - guarded post-recursive recombination inside those same single-recursive-
     call numeric and list linear-recursive shapes when the later result and
     branch-local selected intermediate values are chosen by supported

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -385,15 +385,18 @@ Current TypR lowering policy is intentionally mixed:
   branch-local recursive-call aliases before those subtree calls, guarded
   pre-recursive branching before those subtree calls, recursive subtree
   calls inside supported branch bodies, nested recursive subtree calls
-  inside supported branch bodies, and a TypR-translatable result expression
-  that may also reconcile asymmetric branch-local prework, such as
-  `tree_sum/2`, `tree_height/2`,
+  inside supported branch bodies, nested branch-local post-recursive
+  recombination before a later shared result expression, and a
+  TypR-translatable result expression that may also reconcile asymmetric
+  branch-local prework, such as `tree_sum/2`, `tree_height/2`,
   `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,
   `weighted_tree_sum_scale_step/3`, `weighted_tree_sum_scale_branch/3`,
   `tree_sum_branch_calls/2`, `weighted_tree_branch_calls/3`,
   `tree_sum_recursive_branch/2`, `weighted_tree_recursive_branch/3`,
   `tree_sum_nested_recursive_branch/2`,
   `weighted_tree_nested_recursive_branch/3`,
+  `tree_sum_nested_branch_recombine/2`,
+  `weighted_tree_nested_branch_recombine/3`,
   `weighted_tree_sum_subtree_scale/3`,
   `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -76,10 +76,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursive calls, branch-local recursive-call aliases before the two
      subtree calls, guarded pre-recursive branching before the two subtree
      calls, recursive subtree calls inside supported branch bodies, nested
-     recursive subtree calls inside supported branch bodies, or asymmetric
-     branch-local prework that is reconciled later by a guarded result
-     expression, emitted as TypR functions with raw-expression structural
-     helper bodies
+     recursive subtree calls inside supported branch bodies, nested
+     branch-local post-recursive recombination before a later shared result
+     expression, or asymmetric branch-local prework that is reconciled
+     later by a guarded result expression, emitted as TypR functions with
+     raw-expression structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
      call numeric and list linear-recursive shapes when the later result and
      branch-local selected intermediate values are chosen by supported

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -803,7 +803,10 @@ structural_tree_recursive_prefix_lines(
     OutputPos is Arity,
     linear_recursive_invariant_positions(Arity, DriverPos, InvariantPositions),
     normalize_typr_goals(BranchGoal, Goals),
-    split_typr_multicall_goal_prefix(Pred, Goals, PreGoals, RecCalls),
+    (   split_typr_multicall_goals(Pred, Goals, PreGoals, RecCalls, PostGoals)
+    ;   split_typr_multicall_goal_prefix(Pred, Goals, PreGoals, RecCalls),
+        PostGoals = []
+    ),
     typr_goals_to_body(PreGoals, PreBody),
     compile_tail_recursive_pre_goals(PreBody, VarMap0, PreVarMap, GuardConditions, StepLines),
     tail_recursive_pre_branch_lines(GuardConditions, StepLines, BranchPreLines),
@@ -816,9 +819,10 @@ structural_tree_recursive_prefix_lines(
         RightVar,
         InvariantPositions,
         PreVarMap,
-        VarMap,
+        CallVarMap,
         CallLines
     ),
+    linear_recursive_post_goals_varmap(PostGoals, CallVarMap, VarMap),
     append(BranchPreLines, CallLines, Lines).
 
 add_structural_tree_value_var(ValueVar, VarMap, [ValueVar-"value"|VarMap]) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -63,6 +63,8 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_recursive_branch(_, _, _)),
     retractall(user:tree_sum_nested_recursive_branch(_, _)),
     retractall(user:weighted_tree_nested_recursive_branch(_, _, _)),
+    retractall(user:tree_sum_nested_branch_recombine(_, _)),
+    retractall(user:weighted_tree_nested_branch_recombine(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
@@ -603,6 +605,72 @@ test(recursive_compiler_supports_typr_weighted_nested_structural_tree_recursive_
     once(sub_string(Code, _, _, _, "if (value > 0) {")),
     once(sub_string(Code, _, _, _, "right_result = weighted_tree_nested_recursive_branch_impl(right, arg2);")),
     once(sub_string(Code, _, _, _, "left_result = weighted_tree_nested_recursive_branch_impl(left, arg2);")),
+    once(sub_string(Code, _, _, _, "branch_result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nested_structural_tree_branch_recombine_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_nested_branch_recombine([], 0)),
+    assertz(user:(tree_sum_nested_branch_recombine([V, L, R], Sum) :-
+        ( V > 0 ->
+            ( V > 1 ->
+                tree_sum_nested_branch_recombine(L, LS),
+                tree_sum_nested_branch_recombine(R, RS),
+                Part is V + LS + RS
+            ;   tree_sum_nested_branch_recombine(R, RS),
+                tree_sum_nested_branch_recombine(L, LS),
+                Part is V + LS + RS
+            ),
+            Sum is Part + 1
+        ;   tree_sum_nested_branch_recombine(L, LS),
+            tree_sum_nested_branch_recombine(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_recombine/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_recombine/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_nested_branch_recombine/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_nested_branch_recombine/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_nested_branch_recombine <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "tree_sum_nested_branch_recombine_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "if (value > 1) {")),
+    once(sub_string(Code, _, _, _, "branch_result = (((value + left_result) + right_result) + 1);")),
+    once(sub_string(Code, _, _, _, "branch_result = ((value + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_weighted_nested_structural_tree_branch_recombine_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_nested_branch_recombine([], _Scale, 0)),
+    assertz(user:(weighted_tree_nested_branch_recombine([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            ( V > 0 ->
+                weighted_tree_nested_branch_recombine(L, Scale, LS),
+                weighted_tree_nested_branch_recombine(R, Scale, RS),
+                Part is (V * Scale) + LS + RS
+            ;   weighted_tree_nested_branch_recombine(R, Scale, RS),
+                weighted_tree_nested_branch_recombine(L, Scale, LS),
+                Part is (V * Scale) + LS + RS
+            ),
+            Sum is Part + 1
+        ;   weighted_tree_nested_branch_recombine(L, Scale, LS),
+            weighted_tree_nested_branch_recombine(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_recombine/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_recombine/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_recombine/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_nested_branch_recombine/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_nested_branch_recombine/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_nested_branch_recombine <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_nested_branch_recombine_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "branch_result = ((((value * arg2) + left_result) + right_result) + 1);")),
     once(sub_string(Code, _, _, _, "branch_result = (((value * arg2) + left_result) + right_result);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -514,6 +514,75 @@ test(weighted_nested_structural_tree_recursive_branch_body_output_checks_with_ty
     ),
     retractall(user:weighted_tree_nested_recursive_branch(_, _, _)).
 
+test(nested_structural_tree_branch_recombine_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_nested_branch_recombine([], 0)),
+    assertz(user:(tree_sum_nested_branch_recombine([V, L, R], Sum) :-
+        ( V > 0 ->
+            ( V > 1 ->
+                tree_sum_nested_branch_recombine(L, LS),
+                tree_sum_nested_branch_recombine(R, RS),
+                Part is V + LS + RS
+            ;   tree_sum_nested_branch_recombine(R, RS),
+                tree_sum_nested_branch_recombine(L, LS),
+                Part is V + LS + RS
+            ),
+            Sum is Part + 1
+        ;   tree_sum_nested_branch_recombine(L, LS),
+            tree_sum_nested_branch_recombine(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_recombine/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_recombine/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_nested_branch_recombine/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_nested_branch_recombine/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_nested_branch_recombine(_, _)).
+
+test(weighted_nested_structural_tree_branch_recombine_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_nested_branch_recombine([], _Scale, 0)),
+    assertz(user:(weighted_tree_nested_branch_recombine([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            ( V > 0 ->
+                weighted_tree_nested_branch_recombine(L, Scale, LS),
+                weighted_tree_nested_branch_recombine(R, Scale, RS),
+                Part is (V * Scale) + LS + RS
+            ;   weighted_tree_nested_branch_recombine(R, Scale, RS),
+                weighted_tree_nested_branch_recombine(L, Scale, LS),
+                Part is (V * Scale) + LS + RS
+            ),
+            Sum is Part + 1
+        ;   weighted_tree_nested_branch_recombine(L, Scale, LS),
+            weighted_tree_nested_branch_recombine(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_recombine/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_recombine/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_recombine/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_nested_branch_recombine/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_nested_branch_recombine/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_nested_branch_recombine(_, _, _)).
+
 test(nary_structural_tree_subtree_invariant_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR structural recursion path so supported tree-recursive predicates can stay native when an inner branch performs its own post-recursive recombination before a later outer shared result.

Before this change, those shapes fell out of the structural TypR path and then failed in unsupported recursion fallback handling.

After this change, they lower natively and pass real `typr check`.

This is still a conservative recursion expansion, not arbitrary recursive-body lowering.

## Why This PR Exists

Recent TypR recursion work already supported:

- accumulator-style tail recursion
- conservative linear recursion
- `fib/2`-style helper recursion
- structural tree recursion over `[]` / `[V, L, R]` trees
- structural pre-recursive local work
- structural branching and asymmetric branch-local recombination
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies

That still left a nearby structural gap:

- an inner branch could perform the two recursive subtree calls
- that same inner branch could compute a local recombined value like `Part is ...`
- and the outer branch could continue later from that selected local result
- but that shape was still not accepted by the native structural TypR path

A representative shape is:

```prolog
tree_sum_nested_branch_recombine([], 0).
tree_sum_nested_branch_recombine([V, L, R], Sum) :-
    ( V > 0 ->
        ( V > 1 ->
            tree_sum_nested_branch_recombine(L, LS),
            tree_sum_nested_branch_recombine(R, RS),
            Part is V + LS + RS
        ;   tree_sum_nested_branch_recombine(R, RS),
            tree_sum_nested_branch_recombine(L, LS),
            Part is V + LS + RS
        ),
        Sum is Part + 1
    ;   tree_sum_nested_branch_recombine(L, LS),
        tree_sum_nested_branch_recombine(R, RS),
        Sum is V + LS + RS
    ).
```

This PR closes that gap for the supported structural subset.

## Main Changes

### 1. Structural branch prefixes now support post-recursive local recombination

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The structural tree-recursion helper path no longer requires inner branch prefixes to be only:

- pre-goals
- then the two recursive subtree calls

It now also supports:

- pre-goals
- the two recursive subtree calls
- then non-recursive post-goals that derive later branch-local state

That is the key change that makes nested branch-local recombination stay native.

### 2. Nested structural branches now preserve symbolic post-recursive state

After the recursive subtree calls, the compiler now resolves later inner-branch goals through the existing symbolic post-goal varmap machinery.

That lets shapes like:

- `Part is V + LS + RS`
- followed by `Sum is Part + 1`

continue in native TypR instead of dropping out of the structural path.

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- `tree_sum_nested_branch_recombine/2`
- `weighted_tree_nested_branch_recombine/3`

The tests lock in the supported emitted shape:

- native structural helper generation
- nested branch structure
- inner branch-local recombination staying native

### 4. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new nested structural recombination shapes now also pass real `typr check`.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the supported structural tree-recursive TypR subset includes nested branch-local post-recursive recombination before a later shared result expression.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR structural tree-recursive subset includes:

- direct two-subtree structural recursion
- threaded invariant-context updates
- per-subtree context updates
- branch-local recursive-call aliases
- supported pre-recursive branching
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies
- nested branch-local post-recursive recombination before a later shared result expression

Broader recursive patterns still remain out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural recursion for nested branch-local post-recursive recombination
- preservation of inner branch-local symbolic post-recursive state after subtree calls
- focused regression and toolchain coverage for those cases

Still not fully implemented:

- broader structural multi-call recursion beyond the current conservative subset
- mutual recursion
- generic arbitrary recursive body lowering

## Why This PR Is Worth Merging

This PR closes a real TypR recursion gap.

It gives the project:

- fewer unsupported nested structural recursion shapes
- stronger native TypR coverage for branch-local recursive recombination
- better alignment between documented TypR support and actual compiler behavior
- real TypR validation for the new supported shapes
