### PR TITLE
Keep native TypR nested structural branch prework

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ includes:
   `weighted_tree_nested_recursive_branch/3`,
   `tree_sum_nested_branch_recombine/2`,
   `weighted_tree_nested_branch_recombine/3`,
+  `tree_sum_nested_branch_prework/2`,
+  `weighted_tree_nested_branch_prework/3`,
   `weighted_tree_sum_subtree_scale/3`, `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
@@ -262,7 +264,8 @@ includes:
   calls, branch-local recursive-call aliases before the two subtree calls,
   guarded pre-recursive branching before the two subtree calls, recursive
   subtree calls inside supported branch bodies, nested recursive subtree
-  calls inside supported branch bodies, nested branch-local post-recursive
+  calls inside supported branch bodies, shared pre-recursive local work
+  before nested recursive branch bodies, nested branch-local post-recursive
   recombination before a later shared result expression, and asymmetric
   branch-local prework that is reconciled later by a guarded result
   expression, instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -207,7 +207,8 @@ bring-up.
     recursive-call aliases before the two subtree calls, guarded
     pre-recursive branching before the two subtree calls, recursive subtree
     calls inside supported branch bodies, nested recursive subtree calls
-    inside supported branch bodies, nested branch-local post-recursive
+    inside supported branch bodies, shared pre-recursive local work before
+    nested recursive branch bodies, nested branch-local post-recursive
     recombination before a later shared result expression, or asymmetric
     branch-local prework that is reconciled later by a guarded result
     expression

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -385,7 +385,8 @@ Current TypR lowering policy is intentionally mixed:
   branch-local recursive-call aliases before those subtree calls, guarded
   pre-recursive branching before those subtree calls, recursive subtree
   calls inside supported branch bodies, nested recursive subtree calls
-  inside supported branch bodies, nested branch-local post-recursive
+  inside supported branch bodies, shared pre-recursive local work before
+  nested recursive branch bodies, nested branch-local post-recursive
   recombination before a later shared result expression, and a
   TypR-translatable result expression that may also reconcile asymmetric
   branch-local prework, such as `tree_sum/2`, `tree_height/2`,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -76,7 +76,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursive calls, branch-local recursive-call aliases before the two
      subtree calls, guarded pre-recursive branching before the two subtree
      calls, recursive subtree calls inside supported branch bodies, nested
-     recursive subtree calls inside supported branch bodies, nested
+     recursive subtree calls inside supported branch bodies, shared
+     pre-recursive local work before nested recursive branch bodies, nested
      branch-local post-recursive recombination before a later shared result
      expression, or asymmetric branch-local prework that is reconciled
      later by a guarded result expression, emitted as TypR functions with
@@ -373,8 +374,11 @@ Current implementation note:
   updates for the left and right recursive calls, branch-local recursive-
   call aliases before the two subtree calls, guarded pre-recursive
   branching before the two subtree calls, recursive subtree calls inside
-  supported branch bodies, and asymmetric branch-local prework that is
-  reconciled later by a guarded result expression,
+  supported branch bodies, nested recursive subtree calls inside supported
+  branch bodies, shared pre-recursive local work before nested recursive
+  branch bodies, nested branch-local post-recursive recombination before a
+  later shared result expression, and asymmetric branch-local prework that
+  is reconciled later by a guarded result expression,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -695,15 +695,17 @@ structural_tree_branch_body_lines(
     OutputVar,
     Lines
 ) :-
-    normalize_typr_goals(BranchGoal, [NestedIfGoal|PostGoals]),
+    structural_tree_nested_if_goal(BranchGoal, PreGoals, NestedIfGoal, PostGoals),
+    typr_goals_to_body(PreGoals, PreBody),
+    compile_tail_recursive_pre_goals(PreBody, VarMap0, PreVarMap, GuardConditions, StepLines),
+    tail_recursive_pre_branch_lines(GuardConditions, StepLines, BranchPreLines),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal, ElseGoal),
-    PostGoals \= [],
-    native_typr_if_condition(IfGoal, VarMap0, IfCondition0),
+    native_typr_if_condition(IfGoal, PreVarMap, IfCondition0),
     typr_condition_expr_text(IfCondition0, IfCondition),
     structural_tree_recursive_prefix_lines(
         Pred,
         ThenGoal,
-        VarMap0,
+        PreVarMap,
         HelperName,
         DriverPos,
         Arity,
@@ -715,7 +717,7 @@ structural_tree_branch_body_lines(
     structural_tree_recursive_prefix_lines(
         Pred,
         ElseGoal,
-        VarMap0,
+        PreVarMap,
         HelperName,
         DriverPos,
         Arity,
@@ -734,8 +736,9 @@ structural_tree_branch_body_lines(
     indent_lines(ThenLinesWithResult, '    ', IndentedThenLines),
     indent_lines(ElseLinesWithResult, '    ', IndentedElseLines),
     format(string(IfLine), '        if (~w) {', [IfCondition]),
-    append([IfLine|IndentedThenLines], ['        } else {'|IndentedElseLines], Lines0),
-    append(Lines0, ['        };'], Lines).
+    append(BranchPreLines, [IfLine|IndentedThenLines], Lines0),
+    append(Lines0, ['        } else {'|IndentedElseLines], Lines1),
+    append(Lines1, ['        };'], Lines).
 structural_tree_branch_body_lines(
     Pred,
     BranchGoal,
@@ -784,9 +787,16 @@ structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
     !,
     structural_tree_goal_rec_calls(Pred, ThenGoal, RecCalls).
 structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
-    normalize_typr_goals(Goal, [NestedIfGoal|_PostGoals]),
+    structural_tree_nested_if_goal(Goal, _PreGoals, NestedIfGoal, _PostGoals),
     typr_if_then_else_goal(NestedIfGoal, _IfGoal, ThenGoal, _ElseGoal),
     structural_tree_goal_rec_calls(Pred, ThenGoal, RecCalls).
+
+structural_tree_nested_if_goal(Goal, PreGoals, NestedIfGoal, PostGoals) :-
+    normalize_typr_goals(Goal, Goals),
+    append(PreGoals, [NestedIfGoal|PostGoals], Goals),
+    PostGoals \= [],
+    typr_if_then_else_goal(NestedIfGoal, _IfGoal, _ThenGoal, _ElseGoal),
+    !.
 
 structural_tree_recursive_prefix_lines(
     Pred,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -65,6 +65,8 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_nested_recursive_branch(_, _, _)),
     retractall(user:tree_sum_nested_branch_recombine(_, _)),
     retractall(user:weighted_tree_nested_branch_recombine(_, _, _)),
+    retractall(user:tree_sum_nested_branch_prework(_, _)),
+    retractall(user:weighted_tree_nested_branch_prework(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
@@ -672,6 +674,70 @@ test(recursive_compiler_supports_typr_weighted_nested_structural_tree_branch_rec
     once(sub_string(Code, _, _, _, "if (value > 0) {")),
     once(sub_string(Code, _, _, _, "branch_result = ((((value * arg2) + left_result) + right_result) + 1);")),
     once(sub_string(Code, _, _, _, "branch_result = (((value * arg2) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_nested_structural_tree_branch_prework_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_nested_branch_prework([], 0)),
+    assertz(user:(tree_sum_nested_branch_prework([V, L, R], Sum) :-
+        ( V > 0 ->
+            Bias is V + 1,
+            ( V > 1 ->
+                tree_sum_nested_branch_prework(L, LS),
+                tree_sum_nested_branch_prework(R, RS)
+            ;   tree_sum_nested_branch_prework(R, RS),
+                tree_sum_nested_branch_prework(L, LS)
+            ),
+            Sum is Bias + LS + RS
+        ;   tree_sum_nested_branch_prework(L, LS),
+            tree_sum_nested_branch_prework(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_prework/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_prework/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_nested_branch_prework/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_nested_branch_prework/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_nested_branch_prework <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "tree_sum_nested_branch_prework_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value + 1);")),
+    once(sub_string(Code, _, _, _, "if (value > 1) {")),
+    once(sub_string(Code, _, _, _, "branch_result = ((step_1 + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_weighted_nested_structural_tree_branch_prework_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_nested_branch_prework([], _Scale, 0)),
+    assertz(user:(weighted_tree_nested_branch_prework([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            Bias is V * Scale,
+            ( V > 0 ->
+                weighted_tree_nested_branch_prework(L, Scale, LS),
+                weighted_tree_nested_branch_prework(R, Scale, RS)
+            ;   weighted_tree_nested_branch_prework(R, Scale, RS),
+                weighted_tree_nested_branch_prework(L, Scale, LS)
+            ),
+            Sum is Bias + LS + RS
+        ;   weighted_tree_nested_branch_prework(L, Scale, LS),
+            weighted_tree_nested_branch_prework(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_prework/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_prework/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_prework/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_nested_branch_prework/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_nested_branch_prework/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_nested_branch_prework <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_nested_branch_prework_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "branch_result = ((step_1 + left_result) + right_result);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -583,6 +583,73 @@ test(weighted_nested_structural_tree_branch_recombine_output_checks_with_typr, [
     ),
     retractall(user:weighted_tree_nested_branch_recombine(_, _, _)).
 
+test(nested_structural_tree_branch_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_nested_branch_prework([], 0)),
+    assertz(user:(tree_sum_nested_branch_prework([V, L, R], Sum) :-
+        ( V > 0 ->
+            Bias is V + 1,
+            ( V > 1 ->
+                tree_sum_nested_branch_prework(L, LS),
+                tree_sum_nested_branch_prework(R, RS)
+            ;   tree_sum_nested_branch_prework(R, RS),
+                tree_sum_nested_branch_prework(L, LS)
+            ),
+            Sum is Bias + LS + RS
+        ;   tree_sum_nested_branch_prework(L, LS),
+            tree_sum_nested_branch_prework(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_prework/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_nested_branch_prework/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_nested_branch_prework/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_nested_branch_prework/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_nested_branch_prework(_, _)).
+
+test(weighted_nested_structural_tree_branch_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_nested_branch_prework([], _Scale, 0)),
+    assertz(user:(weighted_tree_nested_branch_prework([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            Bias is V * Scale,
+            ( V > 0 ->
+                weighted_tree_nested_branch_prework(L, Scale, LS),
+                weighted_tree_nested_branch_prework(R, Scale, RS)
+            ;   weighted_tree_nested_branch_prework(R, Scale, RS),
+                weighted_tree_nested_branch_prework(L, Scale, LS)
+            ),
+            Sum is Bias + LS + RS
+        ;   weighted_tree_nested_branch_prework(L, Scale, LS),
+            weighted_tree_nested_branch_prework(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_prework/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_prework/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_nested_branch_prework/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_nested_branch_prework/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_nested_branch_prework/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_nested_branch_prework(_, _, _)).
+
 test(nary_structural_tree_subtree_invariant_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR structural recursion path so supported tree-recursive predicates can stay native when a branch performs shared local work before entering an inner recursive `if -> then ; else` body.

Before this change, those shapes fell out of the structural TypR path and then failed in unsupported recursion fallback handling.

After this change, they lower natively and pass real `typr check`.

This is still a conservative recursion expansion, not arbitrary recursive-body lowering.

## Why This PR Exists

Recent TypR recursion work already supported:

- accumulator-style tail recursion
- conservative linear recursion
- `fib/2`-style helper recursion
- structural tree recursion over `[]` / `[V, L, R]` trees
- structural pre-recursive local work
- structural branching and asymmetric branch-local recombination
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies
- nested branch-local post-recursive recombination before a later shared result

That still left a nearby structural gap:

- an outer branch could do shared local work first
- then enter an inner branch that performed the two recursive subtree calls
- then continue from those recursive results natively
- but that shape was still not accepted by the structural TypR path

A representative shape is:

```prolog
tree_sum_nested_branch_prework([], 0).
tree_sum_nested_branch_prework([V, L, R], Sum) :-
    ( V > 0 ->
        Bias is V + 1,
        ( V > 1 ->
            tree_sum_nested_branch_prework(L, LS),
            tree_sum_nested_branch_prework(R, RS)
        ;   tree_sum_nested_branch_prework(R, RS),
            tree_sum_nested_branch_prework(L, LS)
        ),
        Sum is Bias + LS + RS
    ;   tree_sum_nested_branch_prework(L, LS),
        tree_sum_nested_branch_prework(R, RS),
        Sum is V + LS + RS
    ).
```

This PR closes that gap for the supported structural subset.

## Main Changes

### 1. Structural nested branch handling now supports shared prework before the inner recursive branch

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The structural tree-recursion branch path no longer requires the inner recursive `if -> then ; else` to be the first goal in the surrounding branch body.

It now supports:

- shared pre-goals in the surrounding branch
- then a nested recursive branch
- then later shared recombination

That is the key change that makes nested structural branch prework stay native.

### 2. Shared pre-goals now feed the inner recursive branch with the correct TypR varmap

The implementation now compiles the surrounding branch pre-goals before analyzing the nested inner branch.

That lets local values such as:

- `Bias is V + 1`
- `Bias is V * Scale`

remain available when the compiler lowers the inner recursive subtree calls and the later result expression.

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- `tree_sum_nested_branch_prework/2`
- `weighted_tree_nested_branch_prework/3`

The tests lock in the supported emitted shape:

- native structural helper generation
- shared prework before the nested recursive branch
- continued native lowering after the inner subtree calls

### 4. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new nested structural prework shapes now also pass real `typr check`.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the supported structural tree-recursive TypR subset includes shared pre-recursive local work before nested recursive branch bodies.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR structural tree-recursive subset includes:

- direct two-subtree structural recursion
- threaded invariant-context updates
- per-subtree context updates
- branch-local recursive-call aliases
- supported pre-recursive branching
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies
- shared pre-recursive local work before nested recursive branch bodies
- nested branch-local post-recursive recombination before a later shared result expression

Broader recursive patterns still remain out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural recursion for shared prework before nested recursive branch bodies
- correct TypR varmap flow from outer branch-local prework into inner recursive branch lowering
- focused regression and toolchain coverage for those cases

Still not fully implemented:

- broader structural multi-call recursion beyond the current conservative subset
- mutual recursion
- generic arbitrary recursive body lowering

## Why This PR Is Worth Merging

This PR closes a real TypR recursion gap.

It gives the project:

- fewer unsupported nested structural recursion shapes
- stronger native TypR coverage for branch-local prework before nested recursive calls
- better alignment between documented TypR support and actual compiler behavior
- real TypR validation for the new supported shapes
