### PR TITLE
Keep native TypR double-nested structural calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ includes:
   `weighted_tree_nested_branch_recombine/3`,
   `tree_sum_nested_branch_prework/2`,
   `weighted_tree_nested_branch_prework/3`,
+  `tree_sum_double_nested_calls/2`,
+  `weighted_tree_double_nested_calls/3`,
   `weighted_tree_sum_subtree_scale/3`, `weighted_tree_sum_subtree_branch/3`,
   `tree_sum_prework/2`, `weighted_tree_sum_prework/3`,
   `tree_sum_branch/2`, `weighted_tree_sum_branch/3`,
@@ -266,7 +268,8 @@ includes:
   subtree calls inside supported branch bodies, nested recursive subtree
   calls inside supported branch bodies, shared pre-recursive local work
   before nested recursive branch bodies, nested branch-local post-recursive
-  recombination before a later shared result expression, and asymmetric
+  recombination before a later shared result expression, multiple nested
+  branch-local control points around the two subtree calls, and asymmetric
   branch-local prework that is reconciled later by a guarded result
   expression, instead of wrapped-R fallback
 - guarded post-recursive recombination in those same linear-recursive

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -209,7 +209,8 @@ bring-up.
     calls inside supported branch bodies, nested recursive subtree calls
     inside supported branch bodies, shared pre-recursive local work before
     nested recursive branch bodies, nested branch-local post-recursive
-    recombination before a later shared result expression, or asymmetric
+    recombination before a later shared result expression, multiple nested
+    branch-local control points around the two subtree calls, or asymmetric
     branch-local prework that is reconciled later by a guarded result
     expression
   - guarded post-recursive recombination inside those same single-recursive-

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -387,7 +387,8 @@ Current TypR lowering policy is intentionally mixed:
   calls inside supported branch bodies, nested recursive subtree calls
   inside supported branch bodies, shared pre-recursive local work before
   nested recursive branch bodies, nested branch-local post-recursive
-  recombination before a later shared result expression, and a
+  recombination before a later shared result expression, multiple nested
+  branch-local control points around those subtree calls, and a
   TypR-translatable result expression that may also reconcile asymmetric
   branch-local prework, such as `tree_sum/2`, `tree_height/2`,
   `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -79,7 +79,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursive subtree calls inside supported branch bodies, shared
      pre-recursive local work before nested recursive branch bodies, nested
      branch-local post-recursive recombination before a later shared result
-     expression, or asymmetric branch-local prework that is reconciled
+     expression, multiple nested branch-local control points around the two
+     subtree calls, or asymmetric branch-local prework that is reconciled
      later by a guarded result expression, emitted as TypR functions with
      raw-expression structural helper bodies
    - guarded post-recursive recombination inside those same single-recursive-
@@ -377,8 +378,9 @@ Current implementation note:
   supported branch bodies, nested recursive subtree calls inside supported
   branch bodies, shared pre-recursive local work before nested recursive
   branch bodies, nested branch-local post-recursive recombination before a
-  later shared result expression, and asymmetric branch-local prework that
-  is reconciled later by a guarded result expression,
+  later shared result expression, multiple nested branch-local control
+  points around the two subtree calls, and asymmetric branch-local prework
+  that is reconciled later by a guarded result expression,
   guarded post-recursive recombination inside those same single-recursive-
   call numeric and list linear-recursive shapes, including multi-state
   branch-local recombination after the recursive call,

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -787,7 +787,7 @@ structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
     !,
     structural_tree_goal_rec_calls(Pred, ThenGoal, RecCalls).
 structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
-    structural_tree_nested_if_goal(Goal, _PreGoals, NestedIfGoal, _PostGoals),
+    structural_tree_nested_if_goal_any(Goal, _PreGoals, NestedIfGoal, _PostGoals),
     typr_if_then_else_goal(NestedIfGoal, _IfGoal, ThenGoal, _ElseGoal),
     structural_tree_goal_rec_calls(Pred, ThenGoal, RecCalls).
 
@@ -798,6 +798,77 @@ structural_tree_nested_if_goal(Goal, PreGoals, NestedIfGoal, PostGoals) :-
     typr_if_then_else_goal(NestedIfGoal, _IfGoal, _ThenGoal, _ElseGoal),
     !.
 
+structural_tree_nested_if_goal_any(Goal, PreGoals, NestedIfGoal, PostGoals) :-
+    normalize_typr_goals(Goal, Goals),
+    append(PreGoals, [NestedIfGoal|PostGoals], Goals),
+    typr_if_then_else_goal(NestedIfGoal, _IfGoal, _ThenGoal, _ElseGoal),
+    !.
+
+structural_tree_recursive_prefix_lines(
+    Pred,
+    BranchGoal,
+    VarMap0,
+    HelperName,
+    DriverPos,
+    Arity,
+    LeftVar,
+    RightVar,
+    VarMap,
+    Lines
+) :-
+    structural_tree_nested_if_goal_any(BranchGoal, PreGoals, NestedIfGoal, PostGoals),
+    typr_goals_to_body(PreGoals, PreBody),
+    compile_tail_recursive_pre_goals(PreBody, VarMap0, PreVarMap, GuardConditions, StepLines),
+    tail_recursive_pre_branch_lines(GuardConditions, StepLines, BranchPreLines),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal, ElseGoal),
+    native_typr_if_condition(IfGoal, PreVarMap, IfCondition0),
+    typr_condition_expr_text(IfCondition0, IfCondition),
+    structural_tree_recursive_prefix_lines(
+        Pred,
+        ThenGoal,
+        PreVarMap,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        ThenVarMap0,
+        ThenLines
+    ),
+    structural_tree_recursive_prefix_lines(
+        Pred,
+        ElseGoal,
+        PreVarMap,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        ElseVarMap0,
+        ElseLines
+    ),
+    linear_recursive_post_goals_varmap(PostGoals, ThenVarMap0, ThenVarMap),
+    linear_recursive_post_goals_varmap(PostGoals, ElseVarMap0, ElseVarMap),
+    varmap_changed_vars(PreVarMap, ThenVarMap, ThenChangedVars0),
+    varmap_changed_vars(PreVarMap, ElseVarMap, ElseChangedVars0),
+    unique_vars_by_identity(ThenChangedVars0, ThenChangedVars),
+    unique_vars_by_identity(ElseChangedVars0, ElseChangedVars),
+    include_vars_by_identity(ThenChangedVars, ElseChangedVars, SharedChangedVars),
+    SharedChangedVars \= [],
+    merge_linear_recursive_branch_vars(
+        SharedChangedVars,
+        IfCondition,
+        ThenVarMap,
+        ElseVarMap,
+        PreVarMap,
+        VarMap
+    ),
+    indent_lines(ThenLines, '    ', IndentedThenLines),
+    indent_lines(ElseLines, '    ', IndentedElseLines),
+    format(string(IfLine), '        if (~w) {', [IfCondition]),
+    append(BranchPreLines, [IfLine|IndentedThenLines], Lines0),
+    append(Lines0, ['        } else {'|IndentedElseLines], Lines1),
+    append(Lines1, ['        };'], Lines).
 structural_tree_recursive_prefix_lines(
     Pred,
     BranchGoal,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -67,6 +67,8 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_nested_branch_recombine(_, _, _)),
     retractall(user:tree_sum_nested_branch_prework(_, _)),
     retractall(user:weighted_tree_nested_branch_prework(_, _, _)),
+    retractall(user:tree_sum_double_nested_calls(_, _)),
+    retractall(user:weighted_tree_double_nested_calls(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
@@ -738,6 +740,83 @@ test(recursive_compiler_supports_typr_weighted_nested_structural_tree_branch_pre
     once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
     once(sub_string(Code, _, _, _, "if (value > 0) {")),
     once(sub_string(Code, _, _, _, "branch_result = ((step_1 + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_double_nested_structural_tree_calls_path) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_double_nested_calls([], 0)),
+    assertz(user:(tree_sum_double_nested_calls([V, L, R], Sum) :-
+        ( V > 0 ->
+            Bias is V + 1,
+            ( V > 1 ->
+                ( V > 2 ->
+                    tree_sum_double_nested_calls(L, LS),
+                    tree_sum_double_nested_calls(R, RS)
+                ;   tree_sum_double_nested_calls(R, RS),
+                    tree_sum_double_nested_calls(L, LS)
+                ),
+                Part is Bias + LS + RS
+            ;   tree_sum_double_nested_calls(L, LS),
+                tree_sum_double_nested_calls(R, RS),
+                Part is V + LS + RS
+            ),
+            Sum is Part + 1
+        ;   tree_sum_double_nested_calls(L, LS),
+            tree_sum_double_nested_calls(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_double_nested_calls/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_double_nested_calls/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_double_nested_calls/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_double_nested_calls/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let tree_sum_double_nested_calls <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "tree_sum_double_nested_calls_impl <- function(current_tree)")),
+    once(sub_string(Code, _, _, _, "step_1 = (value + 1);")),
+    once(sub_string(Code, _, _, _, "if (value > 1) {")),
+    once(sub_string(Code, _, _, _, "if (value > 2) {")),
+    once(sub_string(Code, _, _, _, "branch_result = ((if (value > 2) { ((step_1 + left_result) + right_result) } else { ((step_1 + left_result) + right_result) }) + 1);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_weighted_double_nested_structural_tree_calls_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_double_nested_calls([], _Scale, 0)),
+    assertz(user:(weighted_tree_double_nested_calls([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            Bias is V * Scale,
+            ( V > 0 ->
+                ( Scale > 2 ->
+                    weighted_tree_double_nested_calls(L, Scale, LS),
+                    weighted_tree_double_nested_calls(R, Scale, RS)
+                ;   weighted_tree_double_nested_calls(R, Scale, RS),
+                    weighted_tree_double_nested_calls(L, Scale, LS)
+                ),
+                Part is Bias + LS + RS
+            ;   weighted_tree_double_nested_calls(L, Scale, LS),
+                weighted_tree_double_nested_calls(R, Scale, RS),
+                Part is (V * Scale) + LS + RS
+            ),
+            Sum is Part + 1
+        ;   weighted_tree_double_nested_calls(L, Scale, LS),
+            weighted_tree_double_nested_calls(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_calls/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_calls/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_calls/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_double_nested_calls/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_double_nested_calls/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_double_nested_calls <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_double_nested_calls_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 2) {")),
+    once(sub_string(Code, _, _, _, "branch_result = ((if (arg2 > 2) { ((step_1 + left_result) + right_result) } else { ((step_1 + left_result) + right_result) }) + 1);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -650,6 +650,85 @@ test(weighted_nested_structural_tree_branch_prework_output_checks_with_typr, [co
     ),
     retractall(user:weighted_tree_nested_branch_prework(_, _, _)).
 
+test(double_nested_structural_tree_calls_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:tree_sum_double_nested_calls([], 0)),
+    assertz(user:(tree_sum_double_nested_calls([V, L, R], Sum) :-
+        ( V > 0 ->
+            Bias is V + 1,
+            ( V > 1 ->
+                ( V > 2 ->
+                    tree_sum_double_nested_calls(L, LS),
+                    tree_sum_double_nested_calls(R, RS)
+                ;   tree_sum_double_nested_calls(R, RS),
+                    tree_sum_double_nested_calls(L, LS)
+                ),
+                Part is Bias + LS + RS
+            ;   tree_sum_double_nested_calls(L, LS),
+                tree_sum_double_nested_calls(R, RS),
+                Part is V + LS + RS
+            ),
+            Sum is Part + 1
+        ;   tree_sum_double_nested_calls(L, LS),
+            tree_sum_double_nested_calls(R, RS),
+            Sum is V + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(tree_sum_double_nested_calls/2, 1, list(any))),
+    assertz(type_declarations:uw_type(tree_sum_double_nested_calls/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(tree_sum_double_nested_calls/2, integer)),
+    once(recursive_compiler:compile_recursive(tree_sum_double_nested_calls/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:tree_sum_double_nested_calls(_, _)).
+
+test(weighted_double_nested_structural_tree_calls_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_double_nested_calls([], _Scale, 0)),
+    assertz(user:(weighted_tree_double_nested_calls([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            Bias is V * Scale,
+            ( V > 0 ->
+                ( Scale > 2 ->
+                    weighted_tree_double_nested_calls(L, Scale, LS),
+                    weighted_tree_double_nested_calls(R, Scale, RS)
+                ;   weighted_tree_double_nested_calls(R, Scale, RS),
+                    weighted_tree_double_nested_calls(L, Scale, LS)
+                ),
+                Part is Bias + LS + RS
+            ;   weighted_tree_double_nested_calls(L, Scale, LS),
+                weighted_tree_double_nested_calls(R, Scale, RS),
+                Part is (V * Scale) + LS + RS
+            ),
+            Sum is Part + 1
+        ;   weighted_tree_double_nested_calls(L, Scale, LS),
+            weighted_tree_double_nested_calls(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_calls/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_calls/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_calls/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_double_nested_calls/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_double_nested_calls/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_double_nested_calls(_, _, _)).
+
 test(nary_structural_tree_subtree_invariant_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_subtree_scale([], _Scale, 0)),


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR structural recursion path so supported tree-recursive predicates can stay native when a nested recursive branch contains another branch-local control point before the two subtree calls.

Before this change, those deeper structural multi-call shapes fell out of the structural TypR path and then failed in unsupported recursion fallback handling.

After this change, they lower natively and pass real `typr check`.

This is still a conservative recursion expansion, not arbitrary recursive-body lowering.

## Why This PR Exists

Recent TypR recursion work already supported:

- accumulator-style tail recursion
- conservative linear recursion
- `fib/2`-style helper recursion
- structural tree recursion over `[]` / `[V, L, R]` trees
- structural pre-recursive local work
- structural branching and asymmetric branch-local recombination
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies
- shared pre-recursive local work before nested recursive branch bodies
- nested branch-local post-recursive recombination before a later shared result

That still left a nearby structural gap:

- an outer branch could do shared prework
- an inner branch could choose among branch-local recursive call shapes
- but if that inner branch itself contained another branch-local control point before the two subtree calls, the structural TypR path still rejected it

A representative shape is:

```prolog
tree_sum_double_nested_calls([], 0).
tree_sum_double_nested_calls([V, L, R], Sum) :-
    ( V > 0 ->
        Bias is V + 1,
        ( V > 1 ->
            ( V > 2 ->
                tree_sum_double_nested_calls(L, LS),
                tree_sum_double_nested_calls(R, RS)
            ;   tree_sum_double_nested_calls(R, RS),
                tree_sum_double_nested_calls(L, LS)
            ),
            Part is Bias + LS + RS
        ;   tree_sum_double_nested_calls(L, LS),
            tree_sum_double_nested_calls(R, RS),
            Part is V + LS + RS
        ),
        Sum is Part + 1
    ;   tree_sum_double_nested_calls(L, LS),
        tree_sum_double_nested_calls(R, RS),
        Sum is V + LS + RS
    ).
```

This PR closes that gap for the supported structural subset.

## Main Changes

### 1. Structural recursive-prefix lowering now supports another nested branch before the subtree calls

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The structural helper path no longer requires an inner recursive prefix to be only:

- shared pre-goals
- then the two recursive subtree calls
- then later shared recombination

It now also supports an additional nested `if -> then ; else` inside that prefix before the subtree calls.

That is the key change that makes double-nested structural recursive call selection stay native.

### 2. Branch-local symbolic state now merges back after the inner nested branch

The implementation now merges branch-local symbolic state from the inner nested branch back into a shared TypR varmap before later outer recombination continues.

That lets shapes like:

- shared outer prework
- inner nested call-order selection
- later `Part is ...`
- later `Sum is ...`

stay on the native structural TypR path.

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies native TypR lowering for:

- `tree_sum_double_nested_calls/2`
- `weighted_tree_double_nested_calls/3`

The tests lock in the supported emitted shape:

- native structural helper generation
- double-nested branch-local control flow around the two subtree calls
- continued native lowering after later shared recombination

### 4. Added real TypR toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new double-nested structural recursion shapes now also pass real `typr check`.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the supported structural tree-recursive TypR subset includes multiple nested branch-local control points around the two subtree calls.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR structural tree-recursive subset includes:

- direct two-subtree structural recursion
- threaded invariant-context updates
- per-subtree context updates
- branch-local recursive-call aliases
- supported pre-recursive branching
- recursive subtree calls inside supported branch bodies
- nested recursive subtree calls inside supported branch bodies
- shared pre-recursive local work before nested recursive branch bodies
- nested branch-local post-recursive recombination before a later shared result expression
- multiple nested branch-local control points around the two subtree calls

Broader recursive patterns still remain out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR structural recursion for double-nested branch-local control flow around the two subtree calls
- correct varmap merging after an inner nested recursive branch
- focused regression and toolchain coverage for those cases

Still not fully implemented:

- broader structural multi-call recursion beyond the current conservative subset
- mutual recursion
- generic arbitrary recursive body lowering

## Why This PR Is Worth Merging

This PR closes a real TypR recursion gap.

It gives the project:

- fewer unsupported deeper structural recursion shapes
- stronger native TypR coverage for double-nested structural recursive call selection
- better alignment between documented TypR support and actual compiler behavior
- real TypR validation for the new supported shapes
