### PR TITLE
Keep native TypR nested subtree context branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,10 +263,12 @@ includes:
   `[]` / `[V, L, R]` trees, including limited native guards, local `is`
   steps, threaded invariant-context updates before the two subtree calls,
   per-subtree invariant-context updates for the left and right recursive
-  calls, branch-local recursive-call aliases before the two subtree calls,
-  guarded pre-recursive branching before the two subtree calls, recursive
-  subtree calls inside supported branch bodies, nested recursive subtree
-  calls inside supported branch bodies, shared pre-recursive local work
+  calls, nested branch-local subtree-context selection before shared
+  recursive subtree calls, branch-local recursive-call aliases before the
+  two subtree calls, guarded pre-recursive branching before the two subtree
+  calls, recursive subtree calls inside supported branch bodies, nested
+  recursive subtree calls inside supported branch bodies, shared
+  pre-recursive local work
   before nested recursive branch bodies, nested branch-local post-recursive
   recombination before a later shared result expression, multiple nested
   branch-local control points around the two subtree calls, and asymmetric

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -203,10 +203,12 @@ bring-up.
     the currently supported `[]` / `[V, L, R]` shape with invariant context
     args and limited native guards, local `is` steps, threaded invariant-
     context updates before the two subtree calls, per-subtree invariant-
-    context updates for the left and right recursive calls, branch-local
-    recursive-call aliases before the two subtree calls, guarded
-    pre-recursive branching before the two subtree calls, recursive subtree
-    calls inside supported branch bodies, nested recursive subtree calls
+    context updates for the left and right recursive calls, nested branch-
+    local subtree-context selection before shared recursive subtree calls,
+    branch-local recursive-call aliases before the two subtree calls,
+    guarded pre-recursive branching before the two subtree calls,
+    recursive subtree calls inside supported branch bodies, nested
+    recursive subtree calls
     inside supported branch bodies, shared pre-recursive local work before
     nested recursive branch bodies, nested branch-local post-recursive
     recombination before a later shared result expression, multiple nested

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -382,9 +382,11 @@ Current TypR lowering policy is intentionally mixed:
   two recursive subtree calls, limited native guards, local `is` steps,
   threaded invariant-context updates before those subtree calls, per-
   subtree invariant-context updates for the left and right recursive calls,
-  branch-local recursive-call aliases before those subtree calls, guarded
-  pre-recursive branching before those subtree calls, recursive subtree
-  calls inside supported branch bodies, nested recursive subtree calls
+  nested branch-local subtree-context selection before shared recursive
+  subtree calls, branch-local recursive-call aliases before those subtree
+  calls, guarded pre-recursive branching before those subtree calls,
+  recursive subtree calls inside supported branch bodies, nested recursive
+  subtree calls
   inside supported branch bodies, shared pre-recursive local work before
   nested recursive branch bodies, nested branch-local post-recursive
   recombination before a later shared result expression, multiple nested

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -73,10 +73,12 @@ This document focuses on architecture and rollout choices specific to TypR.
      argument, invariant context args, and limited native guards, local
      `is` steps, threaded invariant-context updates before the two subtree
      calls, per-subtree invariant-context updates for the left and right
-     recursive calls, branch-local recursive-call aliases before the two
-     subtree calls, guarded pre-recursive branching before the two subtree
-     calls, recursive subtree calls inside supported branch bodies, nested
-     recursive subtree calls inside supported branch bodies, shared
+     recursive calls, nested branch-local subtree-context selection before
+     shared recursive subtree calls, branch-local recursive-call aliases
+     before the two subtree calls, guarded pre-recursive branching before
+     the two subtree calls, recursive subtree calls inside supported branch
+     bodies, nested recursive subtree calls inside supported branch bodies,
+     shared
      pre-recursive local work before nested recursive branch bodies, nested
      branch-local post-recursive recombination before a later shared result
      expression, multiple nested branch-local control points around the two

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -695,7 +695,7 @@ structural_tree_branch_body_lines(
     OutputVar,
     Lines
 ) :-
-    structural_tree_nested_if_goal(BranchGoal, PreGoals, NestedIfGoal, PostGoals),
+    structural_tree_nested_if_goal_any(BranchGoal, PreGoals, NestedIfGoal, PostGoals),
     typr_goals_to_body(PreGoals, PreBody),
     compile_tail_recursive_pre_goals(PreBody, VarMap0, PreVarMap, GuardConditions, StepLines),
     tail_recursive_pre_branch_lines(GuardConditions, StepLines, BranchPreLines),
@@ -726,9 +726,8 @@ structural_tree_branch_body_lines(
         ElseVarMap,
         ElseLines
     ),
-    typr_goals_to_body(PostGoals, PostBody),
-    linear_recursive_output_expr(PostBody, OutputVar, ThenVarMap, ThenBranchResultExpr),
-    linear_recursive_output_expr(PostBody, OutputVar, ElseVarMap, ElseBranchResultExpr),
+    structural_tree_branch_result_expr(PostGoals, OutputVar, ThenVarMap, ThenBranchResultExpr),
+    structural_tree_branch_result_expr(PostGoals, OutputVar, ElseVarMap, ElseBranchResultExpr),
     format(string(ThenResultLine), '        branch_result = ~w;', [ThenBranchResultExpr]),
     format(string(ElseResultLine), '        branch_result = ~w;', [ElseBranchResultExpr]),
     append(ThenLines, [ThenResultLine], ThenLinesWithResult),
@@ -776,6 +775,13 @@ structural_tree_branch_body_lines(
     append(BranchPreLines, CallLines, Lines0),
     append(Lines0, [ResultLine], Lines).
 
+structural_tree_branch_result_expr([], OutputVar, VarMap, ResultExpr) :-
+    !,
+    lookup_typr_var(OutputVar, VarMap, ResultExpr).
+structural_tree_branch_result_expr(PostGoals, OutputVar, VarMap, ResultExpr) :-
+    typr_goals_to_body(PostGoals, PostBody),
+    linear_recursive_output_expr(PostBody, OutputVar, VarMap, ResultExpr).
+
 structural_tree_goal_rec_calls(Pred, Goal, RecCalls) :-
     normalize_typr_goals(Goal, Goals),
     (   split_typr_multicall_goals(Pred, Goals, _PreGoals, RecCalls, _PostGoals)
@@ -802,6 +808,20 @@ structural_tree_nested_if_goal_any(Goal, PreGoals, NestedIfGoal, PostGoals) :-
     normalize_typr_goals(Goal, Goals),
     append(PreGoals, [NestedIfGoal|PostGoals], Goals),
     typr_if_then_else_goal(NestedIfGoal, _IfGoal, _ThenGoal, _ElseGoal),
+    !.
+
+structural_tree_recursive_prefix_lines(
+    _Pred,
+    true,
+    VarMap,
+    _HelperName,
+    _DriverPos,
+    _Arity,
+    _LeftVar,
+    _RightVar,
+    VarMap,
+    []
+) :-
     !.
 
 structural_tree_recursive_prefix_lines(
@@ -861,14 +881,28 @@ structural_tree_recursive_prefix_lines(
         ThenVarMap,
         ElseVarMap,
         PreVarMap,
-        VarMap
+        MergedVarMap
+    ),
+    typr_goals_to_body(PostGoals, PostBody),
+    structural_tree_recursive_prefix_lines(
+        Pred,
+        PostBody,
+        MergedVarMap,
+        HelperName,
+        DriverPos,
+        Arity,
+        LeftVar,
+        RightVar,
+        VarMap,
+        PostLines
     ),
     indent_lines(ThenLines, '    ', IndentedThenLines),
     indent_lines(ElseLines, '    ', IndentedElseLines),
     format(string(IfLine), '        if (~w) {', [IfCondition]),
     append(BranchPreLines, [IfLine|IndentedThenLines], Lines0),
     append(Lines0, ['        } else {'|IndentedElseLines], Lines1),
-    append(Lines1, ['        };'], Lines).
+    append(Lines1, ['        };'], Lines2),
+    append(Lines2, PostLines, Lines).
 structural_tree_recursive_prefix_lines(
     Pred,
     BranchGoal,
@@ -905,6 +939,21 @@ structural_tree_recursive_prefix_lines(
     ),
     linear_recursive_post_goals_varmap(PostGoals, CallVarMap, VarMap),
     append(BranchPreLines, CallLines, Lines).
+structural_tree_recursive_prefix_lines(
+    Pred,
+    BranchGoal,
+    VarMap0,
+    _HelperName,
+    _DriverPos,
+    _Arity,
+    _LeftVar,
+    _RightVar,
+    VarMap,
+    []
+) :-
+    normalize_typr_goals(BranchGoal, Goals),
+    \+ contains_recursive_goal(Pred, Goals),
+    linear_recursive_post_goals_varmap(Goals, VarMap0, VarMap).
 
 add_structural_tree_value_var(ValueVar, VarMap, [ValueVar-"value"|VarMap]) :-
     var(ValueVar),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -69,6 +69,7 @@ cleanup_typr_test :-
     retractall(user:weighted_tree_nested_branch_prework(_, _, _)),
     retractall(user:tree_sum_double_nested_calls(_, _)),
     retractall(user:weighted_tree_double_nested_calls(_, _, _)),
+    retractall(user:weighted_tree_double_nested_subtree_context_guard(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_scale(_, _, _)),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)),
     retractall(user:weighted_tree_sum_prework(_, _, _)),
@@ -777,7 +778,7 @@ test(recursive_compiler_supports_typr_double_nested_structural_tree_calls_path) 
     once(sub_string(Code, _, _, _, "step_1 = (value + 1);")),
     once(sub_string(Code, _, _, _, "if (value > 1) {")),
     once(sub_string(Code, _, _, _, "if (value > 2) {")),
-    once(sub_string(Code, _, _, _, "branch_result = ((if (value > 2) { ((step_1 + left_result) + right_result) } else { ((step_1 + left_result) + right_result) }) + 1);")),
+    once(sub_string(Code, _, _, _, "branch_result = (((step_1 + (if (value > 2) { left_result } else { left_result })) + (if (value > 2) { right_result } else { right_result })) + 1);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -816,7 +817,7 @@ test(recursive_compiler_supports_typr_weighted_double_nested_structural_tree_cal
     once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
     once(sub_string(Code, _, _, _, "if (value > 0) {")),
     once(sub_string(Code, _, _, _, "if (arg2 > 2) {")),
-    once(sub_string(Code, _, _, _, "branch_result = ((if (arg2 > 2) { ((step_1 + left_result) + right_result) } else { ((step_1 + left_result) + right_result) }) + 1);")),
+    once(sub_string(Code, _, _, _, "branch_result = (((step_1 + (if (arg2 > 2) { left_result } else { left_result })) + (if (arg2 > 2) { right_result } else { right_result })) + 1);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
@@ -876,6 +877,54 @@ test(recursive_compiler_supports_typr_nary_structural_tree_subtree_branch_path) 
     once(sub_string(Code, _, _, _, "left_result = weighted_tree_sum_subtree_branch_impl(left, step_1);")),
     once(sub_string(Code, _, _, _, "right_result = weighted_tree_sum_subtree_branch_impl(right, step_2);")),
     once(sub_string(Code, _, _, _, "result = ((((value * step_1) + left_result) + right_result) + step_2);")),
+    once(sub_string(Code, _, _, _, "arg3 <- v4;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_double_nested_structural_tree_subtree_context_guard_path) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_double_nested_subtree_context_guard([], _Scale, 0)),
+    assertz(user:(weighted_tree_double_nested_subtree_context_guard([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            Bias is V * Scale,
+            ( V > 0 ->
+                ( Scale > 2 ->
+                    ScaleL is Scale + 1,
+                    ScaleR is Scale + 2
+                ;   ScaleL is Scale + 3,
+                    ScaleR is Scale + 4
+                ),
+                weighted_tree_double_nested_subtree_context_guard(L, ScaleL, LS),
+                weighted_tree_double_nested_subtree_context_guard(R, ScaleR, RS),
+                Part is Bias + LS + RS + ScaleR
+            ;   weighted_tree_double_nested_subtree_context_guard(L, Scale, LS),
+                weighted_tree_double_nested_subtree_context_guard(R, Scale, RS),
+                Part is (V * Scale) + LS + RS
+            ),
+            Sum is Part + 1
+        ;   weighted_tree_double_nested_subtree_context_guard(L, Scale, LS),
+            weighted_tree_double_nested_subtree_context_guard(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_subtree_context_guard/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_subtree_context_guard/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_subtree_context_guard/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_double_nested_subtree_context_guard/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_double_nested_subtree_context_guard/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let weighted_tree_double_nested_subtree_context_guard <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "weighted_tree_double_nested_subtree_context_guard_impl <- function(current_tree, arg2)")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 1) {")),
+    once(sub_string(Code, _, _, _, "step_1 = (value * arg2);")),
+    once(sub_string(Code, _, _, _, "if (value > 0) {")),
+    once(sub_string(Code, _, _, _, "if (arg2 > 2) {")),
+    once(sub_string(Code, _, _, _, "step_2 = (arg2 + 1);")),
+    once(sub_string(Code, _, _, _, "step_3 = (arg2 + 2);")),
+    once(sub_string(Code, _, _, _, "step_2 = (arg2 + 3);")),
+    once(sub_string(Code, _, _, _, "step_3 = (arg2 + 4);")),
+    once(sub_string(Code, _, _, _, "left_result = weighted_tree_double_nested_subtree_context_guard_impl(left, step_2);")),
+    once(sub_string(Code, _, _, _, "right_result = weighted_tree_double_nested_subtree_context_guard_impl(right, step_3);")),
+    once(sub_string(Code, _, _, _, "branch_result = ((((step_1 + left_result) + right_result) + step_3) + 1);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -785,6 +785,48 @@ test(nary_structural_tree_subtree_branch_output_checks_with_typr, [condition(typ
     ),
     retractall(user:weighted_tree_sum_subtree_branch(_, _, _)).
 
+test(double_nested_structural_tree_subtree_context_guard_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:weighted_tree_double_nested_subtree_context_guard([], _Scale, 0)),
+    assertz(user:(weighted_tree_double_nested_subtree_context_guard([V, L, R], Scale, Sum) :-
+        ( Scale > 1 ->
+            Bias is V * Scale,
+            ( V > 0 ->
+                ( Scale > 2 ->
+                    ScaleL is Scale + 1,
+                    ScaleR is Scale + 2
+                ;   ScaleL is Scale + 3,
+                    ScaleR is Scale + 4
+                ),
+                weighted_tree_double_nested_subtree_context_guard(L, ScaleL, LS),
+                weighted_tree_double_nested_subtree_context_guard(R, ScaleR, RS),
+                Part is Bias + LS + RS + ScaleR
+            ;   weighted_tree_double_nested_subtree_context_guard(L, Scale, LS),
+                weighted_tree_double_nested_subtree_context_guard(R, Scale, RS),
+                Part is (V * Scale) + LS + RS
+            ),
+            Sum is Part + 1
+        ;   weighted_tree_double_nested_subtree_context_guard(L, Scale, LS),
+            weighted_tree_double_nested_subtree_context_guard(R, Scale, RS),
+            Sum is (V * Scale) + LS + RS
+        )
+    )),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_subtree_context_guard/3, 1, list(any))),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_subtree_context_guard/3, 2, integer)),
+    assertz(type_declarations:uw_type(weighted_tree_double_nested_subtree_context_guard/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(weighted_tree_double_nested_subtree_context_guard/3, integer)),
+    once(recursive_compiler:compile_recursive(weighted_tree_double_nested_subtree_context_guard/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:weighted_tree_double_nested_subtree_context_guard(_, _, _)).
+
 test(nary_structural_tree_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:weighted_tree_sum_prework([], _Scale, 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR structural-recursion path so nested branch-local control can choose per-subtree context values before shared recursive subtree calls, without falling back out of the native TypR lowering path.

The key supported shape is:

- structural tree recursion over `[]` / `[V, L, R]`
- nested `if -> then ; else` control before the recursive calls
- branch-local selection of left/right subtree context values
- shared recursive subtree calls after that selection
- TypR-translatable recombination after the recursive calls

This stays within the existing conservative structural recursion model. It is not general arbitrary recursive-body lowering.

## Why This PR Exists

Previous TypR recursion work already supported:

- tail recursion
- single-call linear recursion
- `fib/2`-style helper recursion
- structural tree recursion over `[]` / `[V, L, R]`
- invariant context threading before subtree calls
- per-subtree context threading for left/right recursive calls
- branch-local recursive-call aliases
- nested structural recursive branches
- nested structural branch-local recombination
- double-nested structural control around subtree calls

That still left a practical structural gap:

- nested branch-local control could already choose call order or local recombination
- subtree-specific context updates could already be threaded
- but the combined shape where nested control chooses the left/right recursive call context values before the shared recursive subtree calls was not staying on the native TypR path

A representative shape is:

```prolog
weighted_tree_double_nested_subtree_context_guard([V, L, R], Scale, Sum) :-
    ( Scale > 1 ->
        Bias is V * Scale,
        ( V > 0 ->
            ( Scale > 2 ->
                ScaleL is Scale + 1,
                ScaleR is Scale + 2
            ;   ScaleL is Scale + 3,
                ScaleR is Scale + 4
            ),
            weighted_tree_double_nested_subtree_context_guard(L, ScaleL, LS),
            weighted_tree_double_nested_subtree_context_guard(R, ScaleR, RS),
            Part is Bias + LS + RS + ScaleR
        ;   weighted_tree_double_nested_subtree_context_guard(L, Scale, LS),
            weighted_tree_double_nested_subtree_context_guard(R, Scale, RS),
            Part is (V * Scale) + LS + RS
        ),
        Sum is Part + 1
    ;   weighted_tree_double_nested_subtree_context_guard(L, Scale, LS),
        weighted_tree_double_nested_subtree_context_guard(R, Scale, RS),
        Sum is (V * Scale) + LS + RS
    ).
```

Before this PR, that shape fell out of the structural TypR path. This PR keeps it native.

## Main Changes

### 1. Nested structural branch lowering now accepts nested subtree-context selection

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

Structural branch handling now supports nested branch-local control that computes left/right subtree context values before the shared recursive subtree calls.

That means native structural TypR lowering now accepts:

- nested `if -> then ; else`
- shared recursive subtree calls after that inner branch
- shared later recombination after the recursive calls

### 2. Branch-local result computation now uses the branch-local TypR varmap

The structural branch path now computes branch result expressions through a dedicated branch-result helper, instead of assuming the post-branch result can always be derived from one shared post-body shape.

That matters for nested structural recursion because each inner branch may carry its own symbolic state before later shared recombination.

### 3. Structural recursive-prefix lowering can continue through nested post-goals

The recursive-prefix path now supports:

- nested branch-local recursive prefixes
- shared post-goals after those nested prefixes
- non-recursive symbolic state propagation through the resulting TypR variable map

This is what keeps the nested subtree-context case on the structural native path instead of dropping into unsupported generic recursion fallback.

### 4. Added focused regression coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- nested branch-local subtree-context selection before shared recursive subtree calls
- continued native TypR lowering for that shape
- real `typr check` validation for the generated output

The target-level suite also updates two older double-nested structural recursion assertions so they match the current valid emitted TypR shape instead of an older incidental string form.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly include:

- nested branch-local subtree-context selection before shared recursive subtree calls

as part of the supported conservative native TypR structural-recursion subset.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR structural-recursion subset includes:

- invariant context threading before subtree calls
- per-subtree context threading
- branch-local recursive-call aliases
- guarded structural prework
- nested structural recursive branches
- nested structural branch-local recombination
- double-nested structural control around subtree calls
- nested branch-local subtree-context selection before shared recursive subtree calls

More general recursive-body lowering is still out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for nested branch-local subtree-context selection before shared recursive subtree calls
- branch-local result computation for those nested structural branches
- regression coverage and real TypR validation for the new shape

Still not fully implemented:

- broader recursive patterns beyond the current conservative structural subset
- mutual recursion
- arbitrary generic-body recursive lowering

## Why This PR Is Worth Merging

This PR closes a real structural recursion gap in the TypR backend.

It gives the project:

- native TypR coverage for a useful combined structural recursion shape that previously fell out of the native path
- regression protection for that shape
- real `typr check` validation for the emitted code
- documentation that matches the actual supported TypR recursion subset

This is a good incremental PR because it closes a confirmed gap without widening the TypR recursion contract beyond what the current structural lowering model can defensibly support.
