### PR TITLE
Keep native TypR structural mutual recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ includes:
 - conservative arity-2 numeric multi-call tree-recursive predicates such as
   `fib/2`, lowered to TypR functions that use raw-expression memoized helper
   bodies inside TypR instead of wrapped-R fallback
-- conservative arity-1 boolean numeric mutual-recursive predicate groups
-  such as `is_even/1` and `is_odd/1`, lowered to TypR functions that use
-  raw-expression memoized helper bodies inside TypR instead of wrapped-R
-  fallback
+- conservative arity-1 boolean mutual-recursive predicate groups such as
+  `is_even/1` / `is_odd/1` and `even_list/1` / `odd_list/1`, lowered to
+  TypR functions that use raw-expression memoized helper bodies inside TypR
+  instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -198,10 +198,10 @@ bring-up.
   - conservative arity-2 numeric multi-call tree-recursive predicates
     lowered to TypR-valid functions with raw-expression memoized helper
     bodies for the currently supported `fib/2`-style shape
-  - conservative arity-1 boolean numeric mutual-recursive predicate groups
-    lowered to TypR-valid functions with raw-expression memoized helper
-    bodies for the currently supported `is_even/1` / `is_odd/1`-style SCC
-    shape
+  - conservative arity-1 boolean mutual-recursive predicate groups lowered
+    to TypR-valid functions with raw-expression memoized helper bodies for
+    the currently supported `is_even/1` / `is_odd/1`-style numeric SCC
+    shape and `even_list/1` / `odd_list/1`-style list-structural SCC shape
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -376,10 +376,11 @@ Current TypR lowering policy is intentionally mixed:
   lower to TypR-valid functions when they match the currently supported
   memoized helper shape for `fib/2`-style recursion, using raw-expression
   helper bodies inside TypR rather than wrapped-R fallback
-- conservative arity-1 boolean numeric mutual-recursive predicate groups may
-  also lower to TypR-valid functions when they match the currently supported
-  `is_even/1` / `is_odd/1`-style SCC shape with integer base cases, numeric
-  guard/step expressions, and boolean return types, using raw-expression
+- conservative arity-1 boolean mutual-recursive predicate groups may also
+  lower to TypR-valid functions when they match the currently supported
+  `is_even/1` / `is_odd/1`-style numeric SCC shape or the
+  `even_list/1` / `odd_list/1`-style list-structural SCC shape with `[]` /
+  `[_]` base cases and one-tail recursive descent, using raw-expression
   memoized helper bodies inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -68,9 +68,10 @@ This document focuses on architecture and rollout choices specific to TypR.
    - conservative arity-2 numeric multi-call tree-recursive predicates that
      match the currently supported memoized helper shape for `fib/2`-style
      recursion, emitted as TypR functions with raw-expression helper bodies
-   - conservative arity-1 boolean numeric mutual-recursive predicate groups
-     that match the currently supported `is_even/1` / `is_odd/1`-style SCC
-     shape with integer base cases, numeric guard/step expressions, and
+   - conservative arity-1 boolean mutual-recursive predicate groups that
+     match the currently supported `is_even/1` / `is_odd/1`-style numeric
+     SCC shape or `even_list/1` / `odd_list/1`-style list-structural SCC
+     shape with `[]` / `[_]` base cases, one-tail recursive descent, and
      boolean return types, emitted as TypR functions with raw-expression
      memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -79,7 +79,9 @@ mutual_recursion:compile_mutual_pattern(typr, Predicates, MemoEnabled, _MemoStra
 
 compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
-    maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs),
+    (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ),
     typr_mutual_group_code(Specs, MemoEnabled, Code).
 
 typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -105,6 +107,7 @@ typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
     format(string(HelperName), '~w_impl', [PredStr]),
     format(string(NextHelperName), '~w_impl', [NextPredStr]),
     Spec = mutual_spec{
+        kind: numeric,
         pred: Pred,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
@@ -116,10 +119,55 @@ typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
         step_expr: StepExpr
     }.
 
+typr_mutual_list_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_list_base_case_length, BaseClauses, BaseLengths0),
+    sort(BaseLengths0, BaseLengths),
+    RecHead =.. [_PredName, RecInputPattern],
+    RecInputPattern = [HeadVar|TailVar],
+    var(TailVar),
+    parse_recursive_body(RecBody, HeadVar, Conditions, Computations, RecCall),
+    Conditions == [],
+    Computations == [],
+    RecCall \= none,
+    RecCall =.. [NextPred, RecArg],
+    memberchk(NextPred/1, GroupPredicates),
+    RecArg == TailVar,
+    atom_string(Pred, PredStr),
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(NextHelperName), '~w_impl', [NextPredStr]),
+    Spec = mutual_spec{
+        kind: list,
+        pred: Pred,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        next_helper_name: NextHelperName,
+        base_lengths: BaseLengths,
+        guard_expr: 'length(current_input) > 0',
+        step_expr: 'tail(current_input, -1)'
+    }.
+
 typr_mutual_base_case_value(clause(Head, true), BaseExpr) :-
     Head =.. [_Pred, BaseValue],
     integer(BaseValue),
     typr_translate_r_expr(BaseValue, [], BaseExpr).
+
+typr_mutual_list_base_case_length(clause(Head, true), 0) :-
+    Head =.. [_Pred, []].
+typr_mutual_list_base_case_length(clause(Head, true), 1) :-
+    Head =.. [_Pred, [Elem]],
+    var(Elem).
 
 typr_mutual_guard_expr(_HeadVar, [], 'TRUE') :-
     !.
@@ -215,6 +263,8 @@ typr_mutual_wrapper_code(GroupName, Specs, false, Spec, Code) :-
 };', [PredStr, TypedArgList, ReturnType, IndentedHelpersText, HelperName]).
 
 typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == numeric,
     PredStr = Spec.pred_str,
     HelperName = Spec.helper_name,
     NextHelperName = Spec.next_helper_name,
@@ -234,12 +284,50 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     append(Lines2, ['    };'], Lines),
     atomic_list_concat(Lines, '\n', Code).
 typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == numeric,
     HelperName = Spec.helper_name,
     NextHelperName = Spec.next_helper_name,
     BaseValues = Spec.base_values,
     GuardExpr = Spec.guard_expr,
     StepExpr = Spec.step_expr,
     typr_mutual_base_branch_lines_no_memo(BaseValues, BaseLines),
+    typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == list,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    NextHelperName = Spec.next_helper_name,
+    BaseLengths = Spec.base_lengths,
+    GuardExpr = Spec.guard_expr,
+    StepExpr = Spec.step_expr,
+    typr_mutual_list_base_branch_lines(GroupName, BaseLengths, BaseLines),
+    typr_mutual_recursive_branch_lines(GroupName, GuardExpr, NextHelperName, StepExpr, RecursiveLines),
+    typr_mutual_false_lines(GroupName, FalseLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, FalseLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == list,
+    HelperName = Spec.helper_name,
+    NextHelperName = Spec.next_helper_name,
+    BaseLengths = Spec.base_lengths,
+    GuardExpr = Spec.guard_expr,
+    StepExpr = Spec.step_expr,
+    typr_mutual_list_base_branch_lines_no_memo(BaseLengths, BaseLines),
     typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
     format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
     append([HelperLine], BaseLines, Lines0),
@@ -273,6 +361,30 @@ typr_mutual_base_branch_lines_no_memo_rest([], []).
 typr_mutual_base_branch_lines_no_memo_rest([BaseValue|Rest], [IfLine, '            TRUE'|RestLines]) :-
     format(string(IfLine), '        } else if (identical(current_input, ~w)) {', [BaseValue]),
     typr_mutual_base_branch_lines_no_memo_rest(Rest, RestLines).
+
+typr_mutual_list_base_branch_lines(GroupName, [BaseLength|Rest], Lines) :-
+    format(string(IfLine), '        } else if (length(current_input) == ~w) {', [BaseLength]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [IfLine, '            result = TRUE;', AssignLine, '            result'|RestLines],
+    typr_mutual_list_base_branch_lines_rest(GroupName, Rest, RestLines).
+
+typr_mutual_list_base_branch_lines_rest(_GroupName, [], []).
+typr_mutual_list_base_branch_lines_rest(GroupName, [BaseLength|Rest], [
+    IfLine, '            result = TRUE;', AssignLine, '            result'|RestLines
+]) :-
+    format(string(IfLine), '        } else if (length(current_input) == ~w) {', [BaseLength]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    typr_mutual_list_base_branch_lines_rest(GroupName, Rest, RestLines).
+
+typr_mutual_list_base_branch_lines_no_memo([BaseLength|Rest], Lines) :-
+    format(string(IfLine), '        if (length(current_input) == ~w) {', [BaseLength]),
+    Lines = [IfLine, '            TRUE'|RestLines],
+    typr_mutual_list_base_branch_lines_no_memo_rest(Rest, RestLines).
+
+typr_mutual_list_base_branch_lines_no_memo_rest([], []).
+typr_mutual_list_base_branch_lines_no_memo_rest([BaseLength|Rest], [IfLine, '            TRUE'|RestLines]) :-
+    format(string(IfLine), '        } else if (length(current_input) == ~w) {', [BaseLength]),
+    typr_mutual_list_base_branch_lines_no_memo_rest(Rest, RestLines).
 
 typr_mutual_recursive_branch_lines(GroupName, 'TRUE', NextHelperName, StepExpr, Lines) :-
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -49,6 +49,8 @@ cleanup_typr_test :-
     retractall(user:factorial_linear(_, _)),
     retractall(user:typr_mutual_even(_)),
     retractall(user:typr_mutual_odd(_)),
+    retractall(user:typr_mutual_even_list(_)),
+    retractall(user:typr_mutual_odd_list(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -289,6 +291,34 @@ test(recursive_compiler_supports_typr_mutual_recursion_path) :-
     once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd:\", current_input);")),
     once(sub_string(Code, _, _, _, "result = typr_mutual_odd_impl((current_input + -1));")),
     once(sub_string(Code, _, _, _, "result = typr_mutual_even_impl((current_input + -1));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_mutual_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_list([])),
+    assertz(user:(typr_mutual_even_list([_|T]) :-
+        typr_mutual_odd_list(T)
+    )),
+    assertz(user:typr_mutual_odd_list([_])),
+    assertz(user:(typr_mutual_odd_list([_|T]) :-
+        typr_mutual_even_list(T)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_list/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_list/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_list/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_list/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_list/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_list/1, typr_mutual_odd_list/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_list <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_list <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_list_typr_mutual_odd_list_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_list:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_list:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 0")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 1")),
+    once(sub_string(Code, _, _, _, "result = typr_mutual_odd_list_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "result = typr_mutual_even_list_impl(tail(current_input, -1));")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -175,6 +175,33 @@ test(mutual_recursive_output_checks_with_typr, [condition(typr_cli_available)]) 
     retractall(user:typr_mutual_even(_)),
     retractall(user:typr_mutual_odd(_)).
 
+test(structural_mutual_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_list([])),
+    assertz(user:(typr_mutual_even_list([_|T]) :-
+        typr_mutual_odd_list(T)
+    )),
+    assertz(user:typr_mutual_odd_list([_])),
+    assertz(user:(typr_mutual_odd_list([_|T]) :-
+        typr_mutual_even_list(T)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_list/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_list/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_list/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_list/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_list/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_list(_)),
+    retractall(user:typr_mutual_odd_list(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion path from numeric `even/odd`-style SCCs to the first structural mutual-recursion shape: list-structural boolean SCCs.

The supported shape is intentionally narrow:

- arity-1 predicates
- boolean return type
- list input
- `[]` / `[_]` base cases
- one recursive clause per predicate
- one-tail recursive descent into another predicate in the same SCC

A representative example is:

```prolog
even_list([]).
even_list([_|T]) :-
    odd_list(T).

odd_list([_]).
odd_list([_|T]) :-
    even_list(T).
```

Before this PR, TypR mutual recursion only handled conservative numeric SCCs such as `is_even/1` / `is_odd/1`. Structural list mutual recursion still failed. This PR keeps that first structural SCC shape native in TypR.

## Why This PR Exists

Previous TypR recursion work already supported:

- transitive closure
- accumulator-style tail recursion
- single-call linear recursion
- `fib/2`-style helper recursion
- a broad conservative structural tree-recursion subset
- conservative numeric boolean mutual recursion groups such as `is_even/1` / `is_odd/1`

That still left a real mutual-recursion gap:

- TypR mutual recursion worked for numeric guard/step SCCs
- but the first obvious structural SCC shape over lists still fell out of the TypR path
- the recursion compiler correctly classified it as mutual recursion, but TypR had no structural mutual-recursion handler for that group shape

This PR closes that first structural mutual-recursion gap.

## Main Changes

### 1. TypR mutual recursion now recognizes conservative list-structural SCCs

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

After trying the existing numeric mutual-recursion path, TypR now also accepts conservative list-structural SCCs where each predicate has:

- arity `1`
- return type `bool`
- list input
- `[]` or `[_]` fact-style base clauses
- one recursive clause headed by `[_|T]`
- one recursive call into another predicate in the same SCC

This is still conservative mutual recursion, not general SCC lowering.

### 2. The new TypR path emits list-aware memoized helper bodies

The structural mutual-recursion emitter now generates TypR wrappers with raw-expression memoized helpers that:

- memoize by a list-derived key
- check the supported list base cases by `length(current_input)`
- recurse via `tail(current_input, -1)`

That keeps the emitted code inside the existing TypR wrapper model instead of falling back to unsupported recursion handling.

### 3. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for `even_list/1` / `odd_list/1`-style mutual recursion
- memoized helper emission inside TypR wrappers
- continued absence of wrapped standalone-R fallback
- real `typr check` validation for the generated output

### 4. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the conservative TypR mutual-recursion subset includes both:

- numeric boolean SCCs such as `is_even/1` / `is_odd/1`
- list-structural boolean SCCs such as `even_list/1` / `odd_list/1`

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR mutual-recursion subset includes:

- conservative arity-1 boolean numeric SCCs such as `is_even/1` / `is_odd/1`
- conservative arity-1 boolean list-structural SCCs such as `even_list/1` / `odd_list/1`

More general mutual recursion is still out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative list-structural boolean mutual-recursive groups
- memoized helper emission inside valid TypR wrappers for those groups
- regression coverage and real TypR validation for that shape

Still not fully implemented:

- structural mutual recursion beyond the one-tail list SCC shape
- broader structural mutual recursion over trees
- general recursive SCC lowering
- arbitrary recursive-body lowering

## Why This PR Is Worth Merging

This PR is the right next mutual-recursion increment.

It gives the project:

- the first TypR structural mutual-recursion path
- native support for a useful SCC shape adjacent to the already-supported numeric `even/odd` case
- real `typr check` validation for the emitted code
- documentation that matches the actual conservative mutual-recursion subset

This is a good incremental PR because it extends TypR mutual recursion to the next defensible structural shape without pretending TypR already supports general SCC lowering.
