### PR TITLE
Keep native TypR structural tree mutual recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,9 +242,10 @@ includes:
   `fib/2`, lowered to TypR functions that use raw-expression memoized helper
   bodies inside TypR instead of wrapped-R fallback
 - conservative arity-1 boolean mutual-recursive predicate groups such as
-  `is_even/1` / `is_odd/1` and `even_list/1` / `odd_list/1`, lowered to
-  TypR functions that use raw-expression memoized helper bodies inside TypR
-  instead of wrapped-R fallback
+  `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`, and
+  `even_left_tree/1` / `odd_left_tree/1`, lowered to TypR functions that
+  use raw-expression memoized helper bodies inside TypR instead of wrapped-R
+  fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -201,7 +201,9 @@ bring-up.
   - conservative arity-1 boolean mutual-recursive predicate groups lowered
     to TypR-valid functions with raw-expression memoized helper bodies for
     the currently supported `is_even/1` / `is_odd/1`-style numeric SCC
-    shape and `even_list/1` / `odd_list/1`-style list-structural SCC shape
+    shape, `even_list/1` / `odd_list/1`-style list-structural SCC shape,
+    and `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC
+    shape with one-subtree recursive descent
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -378,10 +378,13 @@ Current TypR lowering policy is intentionally mixed:
   helper bodies inside TypR rather than wrapped-R fallback
 - conservative arity-1 boolean mutual-recursive predicate groups may also
   lower to TypR-valid functions when they match the currently supported
-  `is_even/1` / `is_odd/1`-style numeric SCC shape or the
+  `is_even/1` / `is_odd/1`-style numeric SCC shape, the
   `even_list/1` / `odd_list/1`-style list-structural SCC shape with `[]` /
-  `[_]` base cases and one-tail recursive descent, using raw-expression
-  memoized helper bodies inside TypR rather than wrapped-R fallback
+  `[_]` base cases and one-tail recursive descent, or the
+  `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC shape
+  with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
+  using raw-expression memoized helper bodies inside TypR rather than
+  wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -70,9 +70,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursion, emitted as TypR functions with raw-expression helper bodies
    - conservative arity-1 boolean mutual-recursive predicate groups that
      match the currently supported `is_even/1` / `is_odd/1`-style numeric
-     SCC shape or `even_list/1` / `odd_list/1`-style list-structural SCC
-     shape with `[]` / `[_]` base cases, one-tail recursive descent, and
-     boolean return types, emitted as TypR functions with raw-expression
+     SCC shape, `even_list/1` / `odd_list/1`-style list-structural SCC
+     shape with `[]` / `[_]` base cases and one-tail recursive descent, or
+     `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC shape
+     with `[]` / `[V, [], []]` base cases, one-subtree recursive descent,
+     and boolean return types, emitted as TypR functions with raw-expression
      memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -81,6 +81,7 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
     (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_spec(Predicates), Predicates, Specs)
     ),
     typr_mutual_group_code(Specs, MemoEnabled, Code).
 
@@ -168,6 +169,54 @@ typr_mutual_list_base_case_length(clause(Head, true), 0) :-
 typr_mutual_list_base_case_length(clause(Head, true), 1) :-
     Head =.. [_Pred, [Elem]],
     var(Elem).
+
+typr_mutual_tree_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    parse_recursive_body(RecBody, ValueVar, Conditions, Computations, RecCall),
+    Conditions == [],
+    Computations == [],
+    RecCall \= none,
+    RecCall =.. [NextPred, RecArg],
+    memberchk(NextPred/1, GroupPredicates),
+    (   RecArg == LeftVar ->
+        StepExpr = '.subset2(current_input, 2)'
+    ;   RecArg == RightVar ->
+        StepExpr = '.subset2(current_input, 3)'
+    ),
+    atom_string(Pred, PredStr),
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(NextHelperName), '~w_impl', [NextPredStr]),
+    Spec = mutual_spec{
+        kind: tree,
+        pred: Pred,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        next_helper_name: NextHelperName,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        step_expr: StepExpr
+    }.
+
+typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 0') :-
+    Head =.. [_Pred, []].
+typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0') :-
+    Head =.. [_Pred, [Val, [], []]],
+    var(Val).
 
 typr_mutual_guard_expr(_HeadVar, [], 'TRUE') :-
     !.
@@ -334,6 +383,42 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     append(Lines0, RecursiveLines, Lines1),
     append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
     atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    NextHelperName = Spec.next_helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    StepExpr = Spec.step_expr,
+    typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
+    typr_mutual_recursive_branch_lines(GroupName, GuardExpr, NextHelperName, StepExpr, RecursiveLines),
+    typr_mutual_false_lines(GroupName, FalseLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    format_string_return('        key <- paste0(\"~w:\", paste(deparse(current_input), collapse=\"\"));', [PredStr], KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, FalseLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree,
+    HelperName = Spec.helper_name,
+    NextHelperName = Spec.next_helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    StepExpr = Spec.step_expr,
+    typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
+    typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
 
 format_string_return(Format, Args, String) :-
     format(string(String), Format, Args).
@@ -385,6 +470,30 @@ typr_mutual_list_base_branch_lines_no_memo_rest([], []).
 typr_mutual_list_base_branch_lines_no_memo_rest([BaseLength|Rest], [IfLine, '            TRUE'|RestLines]) :-
     format(string(IfLine), '        } else if (length(current_input) == ~w) {', [BaseLength]),
     typr_mutual_list_base_branch_lines_no_memo_rest(Rest, RestLines).
+
+typr_mutual_tree_base_branch_lines(GroupName, [BaseCondition|Rest], Lines) :-
+    format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [IfLine, '            result = TRUE;', AssignLine, '            result'|RestLines],
+    typr_mutual_tree_base_branch_lines_rest(GroupName, Rest, RestLines).
+
+typr_mutual_tree_base_branch_lines_rest(_GroupName, [], []).
+typr_mutual_tree_base_branch_lines_rest(GroupName, [BaseCondition|Rest], [
+    IfLine, '            result = TRUE;', AssignLine, '            result'|RestLines
+]) :-
+    format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    typr_mutual_tree_base_branch_lines_rest(GroupName, Rest, RestLines).
+
+typr_mutual_tree_base_branch_lines_no_memo([BaseCondition|Rest], Lines) :-
+    format(string(IfLine), '        if (~w) {', [BaseCondition]),
+    Lines = [IfLine, '            TRUE'|RestLines],
+    typr_mutual_tree_base_branch_lines_no_memo_rest(Rest, RestLines).
+
+typr_mutual_tree_base_branch_lines_no_memo_rest([], []).
+typr_mutual_tree_base_branch_lines_no_memo_rest([BaseCondition|Rest], [IfLine, '            TRUE'|RestLines]) :-
+    format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
+    typr_mutual_tree_base_branch_lines_no_memo_rest(Rest, RestLines).
 
 typr_mutual_recursive_branch_lines(GroupName, 'TRUE', NextHelperName, StepExpr, Lines) :-
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -51,6 +51,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd(_)),
     retractall(user:typr_mutual_even_list(_)),
     retractall(user:typr_mutual_odd_list(_)),
+    retractall(user:typr_mutual_even_left_tree(_)),
+    retractall(user:typr_mutual_odd_left_tree(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -319,6 +321,34 @@ test(recursive_compiler_supports_typr_structural_mutual_recursion_path) :-
     once(sub_string(Code, _, _, _, "length(current_input) == 1")),
     once(sub_string(Code, _, _, _, "result = typr_mutual_odd_list_impl(tail(current_input, -1));")),
     once(sub_string(Code, _, _, _, "result = typr_mutual_even_list_impl(tail(current_input, -1));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_mutual_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_left_tree([])),
+    assertz(user:(typr_mutual_even_left_tree([_, L, _]) :-
+        typr_mutual_odd_left_tree(L)
+    )),
+    assertz(user:typr_mutual_odd_left_tree([_, [], []])),
+    assertz(user:(typr_mutual_odd_left_tree([_, L, _]) :-
+        typr_mutual_even_left_tree(L)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_left_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_left_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_left_tree/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_left_tree/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_left_tree/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_left_tree/1, typr_mutual_odd_left_tree/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_left_tree <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_left_tree <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_left_tree_typr_mutual_odd_left_tree_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_left_tree:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_left_tree:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 0")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0")),
+    once(sub_string(Code, _, _, _, "result = typr_mutual_odd_left_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = typr_mutual_even_left_tree_impl(.subset2(current_input, 2));")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -202,6 +202,33 @@ test(structural_mutual_recursive_output_checks_with_typr, [condition(typr_cli_av
     retractall(user:typr_mutual_even_list(_)),
     retractall(user:typr_mutual_odd_list(_)).
 
+test(structural_tree_mutual_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_left_tree([])),
+    assertz(user:(typr_mutual_even_left_tree([_, L, _]) :-
+        typr_mutual_odd_left_tree(L)
+    )),
+    assertz(user:typr_mutual_odd_left_tree([_, [], []])),
+    assertz(user:(typr_mutual_odd_left_tree([_, L, _]) :-
+        typr_mutual_even_left_tree(L)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_left_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_left_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_left_tree/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_left_tree/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_left_tree/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_left_tree(_)),
+    retractall(user:typr_mutual_odd_left_tree(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion path from numeric and list-structural SCCs to the first structural tree mutual-recursion shape.

The supported shape is intentionally narrow:

- arity-1 predicates
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- `[]` or `[V, [], []]` fact-style base cases
- one recursive clause per predicate
- one recursive descent into another predicate in the same SCC through either the left or right subtree

A representative example is:

```prolog
even_left_tree([]).
even_left_tree([_, L, _]) :-
    odd_left_tree(L).

odd_left_tree([_, [], []]).
odd_left_tree([_, L, _]) :-
    even_left_tree(L).
```

Before this PR, TypR mutual recursion only handled conservative numeric `is_even/1` / `is_odd/1`-style SCCs and list-structural `even_list/1` / `odd_list/1`-style SCCs. Structural tree mutual recursion still failed. This PR keeps that first tree-structural SCC shape native in TypR.

## Why This PR Exists

Previous TypR recursion work already supported:

- transitive closure
- accumulator-style tail recursion
- single-call linear recursion
- `fib/2`-style helper recursion
- a broad conservative structural tree-recursion subset
- conservative numeric boolean mutual recursion groups such as `is_even/1` / `is_odd/1`
- conservative list-structural boolean mutual recursion groups such as `even_list/1` / `odd_list/1`

That still left a real mutual-recursion gap:

- TypR mutual recursion worked for numeric SCCs and one-tail list SCCs
- but the first obvious structural tree SCC shape over `[]` / `[V, L, R]` still fell out of the TypR path
- the recursion compiler correctly classified it as mutual recursion, but TypR had no structural tree mutual-recursion handler for that group shape

This PR closes that next structural mutual-recursion gap.

## Main Changes

### 1. TypR mutual recursion now recognizes conservative tree-structural SCCs

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

After trying the existing numeric and list mutual-recursion paths, TypR now also accepts conservative tree-structural SCCs where each predicate has:

- arity `1`
- return type `bool`
- tree input encoded as `[]` or `[V, L, R]`
- `[]` or `[V, [], []]` fact-style base clauses
- one recursive clause
- one recursive call into another predicate in the same SCC
- one-subtree recursive descent through either `.subset2(current_input, 2)` or `.subset2(current_input, 3)`

This is still conservative mutual recursion, not general SCC lowering.

### 2. The new TypR path emits tree-aware memoized helper bodies

The structural tree mutual-recursion emitter now generates TypR wrappers with raw-expression memoized helpers that:

- memoize by a tree-derived key
- check supported tree base cases by `length(current_input)` and subtree emptiness
- recurse into the selected subtree using `.subset2(...)`

That keeps the emitted code inside the existing TypR wrapper model instead of falling back to unsupported recursion handling.

### 3. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for `even_left_tree/1` / `odd_left_tree/1`-style mutual recursion
- memoized helper emission inside TypR wrappers
- continued absence of wrapped standalone-R fallback
- real `typr check` validation for the generated output

### 4. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the conservative TypR mutual-recursion subset includes:

- numeric boolean SCCs such as `is_even/1` / `is_odd/1`
- list-structural boolean SCCs such as `even_list/1` / `odd_list/1`
- tree-structural boolean SCCs such as `even_left_tree/1` / `odd_left_tree/1`

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR mutual-recursion subset includes:

- conservative arity-1 boolean numeric SCCs such as `is_even/1` / `is_odd/1`
- conservative arity-1 boolean list-structural SCCs such as `even_list/1` / `odd_list/1`
- conservative arity-1 boolean tree-structural SCCs such as `even_left_tree/1` / `odd_left_tree/1`

More general mutual recursion is still out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative tree-structural boolean mutual-recursive groups
- memoized helper emission inside valid TypR wrappers for those groups
- regression coverage and real TypR validation for that shape

Still not fully implemented:

- broader structural tree mutual recursion beyond the one-subtree SCC shape
- multi-output or non-boolean mutual-recursive tree groups
- general recursive SCC lowering
- arbitrary recursive-body lowering

## Why This PR Is Worth Merging

This PR is the right next mutual-recursion increment.

It gives the project:

- the first TypR structural tree mutual-recursion path
- native support for a useful SCC shape adjacent to the already-supported numeric and list structural cases
- real `typr check` validation for the emitted code
- documentation that matches the actual conservative mutual-recursion subset

This is a good incremental PR because it extends TypR mutual recursion to the next defensible structural shape without pretending TypR already supports general SCC lowering.
