### PR TITLE
Keep native TypR dual-subtree tree mutual recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ includes:
   `fib/2`, lowered to TypR functions that use raw-expression memoized helper
   bodies inside TypR instead of wrapped-R fallback
 - conservative arity-1 boolean mutual-recursive predicate groups such as
-  `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`, and
-  `even_left_tree/1` / `odd_left_tree/1`, lowered to TypR functions that
-  use raw-expression memoized helper bodies inside TypR instead of wrapped-R
-  fallback
+  `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`,
+  `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
+  lowered to TypR functions that use raw-expression memoized helper bodies
+  inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -203,7 +203,9 @@ bring-up.
     the currently supported `is_even/1` / `is_odd/1`-style numeric SCC
     shape, `even_list/1` / `odd_list/1`-style list-structural SCC shape,
     and `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC
-    shape with one-subtree recursive descent
+    shape with one-subtree recursive descent, plus `even_tree/1` /
+    `odd_tree/1`-style tree-structural SCC shape with two-subtree boolean
+    descent
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -383,8 +383,10 @@ Current TypR lowering policy is intentionally mixed:
   `[_]` base cases and one-tail recursive descent, or the
   `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC shape
   with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
-  using raw-expression memoized helper bodies inside TypR rather than
-  wrapped-R fallback
+  or the `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
+  `[]` / `[V, [], []]` base cases and two-subtree boolean descent, using
+  raw-expression memoized helper bodies inside TypR rather than wrapped-R
+  fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -73,8 +73,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      SCC shape, `even_list/1` / `odd_list/1`-style list-structural SCC
      shape with `[]` / `[_]` base cases and one-tail recursive descent, or
      `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC shape
-     with `[]` / `[V, [], []]` base cases, one-subtree recursive descent,
-     and boolean return types, emitted as TypR functions with raw-expression
+     with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
+     or `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
+     `[]` / `[V, [], []]` base cases, two-subtree boolean descent, and
+     boolean return types, emitted as TypR functions with raw-expression
      memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -81,6 +81,7 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
     (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_dual_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_spec(Predicates), Predicates, Specs)
     ),
     typr_mutual_group_code(Specs, MemoEnabled, Code).
@@ -212,6 +213,45 @@ typr_mutual_tree_spec(GroupPredicates, Pred/Arity, Spec) :-
         step_expr: StepExpr
     }.
 
+typr_mutual_tree_dual_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern],
+    RecInputPattern = [_ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [GoalA, GoalB],
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, LeftVar, RightVar), [GoalA, GoalB], GoalSpecs0),
+    select(call_spec(left, LeftNextPred, '.subset2(current_input, 2)'), GoalSpecs0, GoalSpecs1),
+    select(call_spec(right, RightNextPred, '.subset2(current_input, 3)'), GoalSpecs1, []),
+    atom_string(Pred, PredStr),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual,
+        pred: Pred,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        left_next_helper_name: LeftNextHelperName,
+        right_next_helper_name: RightNextHelperName,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3'
+    }.
+
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 0') :-
     Head =.. [_Pred, []].
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0') :-
@@ -242,6 +282,30 @@ typr_mutual_step_expr(_HeadVar, _Computations, RecArg, StepExpr) :-
     atomic(RecArg),
     !,
     typr_translate_r_expr(RecArg, [], StepExpr).
+
+typr_mutual_goal_list((A, B), Goals) :-
+    !,
+    typr_mutual_goal_list(A, GoalsA),
+    typr_mutual_goal_list(B, GoalsB),
+    append(GoalsA, GoalsB, Goals).
+typr_mutual_goal_list(Goal, [Goal]).
+
+typr_strip_module_goal(_Module:Goal, StrippedGoal) :-
+    !,
+    typr_strip_module_goal(Goal, StrippedGoal).
+typr_strip_module_goal(Goal, Goal).
+
+typr_mutual_tree_recursive_goal(GroupPredicates, LeftVar, RightVar, Goal0, call_spec(Side, NextPred, StepExpr)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg],
+    memberchk(NextPred/1, GroupPredicates),
+    (   RecArg == LeftVar ->
+        Side = left,
+        StepExpr = '.subset2(current_input, 2)'
+    ;   RecArg == RightVar ->
+        Side = right,
+        StepExpr = '.subset2(current_input, 3)'
+    ).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (
@@ -378,6 +442,53 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     StepExpr = Spec.step_expr,
     typr_mutual_list_base_branch_lines_no_memo(BaseLengths, BaseLines),
     typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    LeftNextHelperName = Spec.left_next_helper_name,
+    RightNextHelperName = Spec.right_next_helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
+    typr_mutual_tree_dual_recursive_branch_lines(
+        GroupName,
+        GuardExpr,
+        LeftNextHelperName,
+        RightNextHelperName,
+        RecursiveLines
+    ),
+    typr_mutual_false_lines(GroupName, FalseLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, FalseLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual,
+    HelperName = Spec.helper_name,
+    LeftNextHelperName = Spec.left_next_helper_name,
+    RightNextHelperName = Spec.right_next_helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
+    typr_mutual_tree_dual_recursive_branch_lines_no_memo(
+        GuardExpr,
+        LeftNextHelperName,
+        RightNextHelperName,
+        RecursiveLines
+    ),
     format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
@@ -529,6 +640,76 @@ typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, 
     Lines = [
         IfLine,
         ResultLine
+    ].
+
+typr_mutual_tree_dual_recursive_branch_lines(
+    GroupName,
+    'TRUE',
+    LeftNextHelperName,
+    RightNextHelperName,
+    Lines
+) :-
+    !,
+    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
+    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [
+        '        } else {',
+        LeftLine,
+        RightLine,
+        '            result = left_result && right_result;',
+        AssignLine,
+        '            result'
+    ].
+typr_mutual_tree_dual_recursive_branch_lines(
+    GroupName,
+    GuardExpr,
+    LeftNextHelperName,
+    RightNextHelperName,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
+    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [
+        IfLine,
+        LeftLine,
+        RightLine,
+        '            result = left_result && right_result;',
+        AssignLine,
+        '            result'
+    ].
+
+typr_mutual_tree_dual_recursive_branch_lines_no_memo(
+    'TRUE',
+    LeftNextHelperName,
+    RightNextHelperName,
+    Lines
+) :-
+    !,
+    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
+    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    Lines = [
+        '        } else {',
+        LeftLine,
+        RightLine,
+        '            left_result && right_result'
+    ].
+typr_mutual_tree_dual_recursive_branch_lines_no_memo(
+    GuardExpr,
+    LeftNextHelperName,
+    RightNextHelperName,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
+    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    Lines = [
+        IfLine,
+        LeftLine,
+        RightLine,
+        '            left_result && right_result'
     ].
 
 typr_mutual_false_lines(GroupName, [

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -53,6 +53,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_list(_)),
     retractall(user:typr_mutual_even_left_tree(_)),
     retractall(user:typr_mutual_odd_left_tree(_)),
+    retractall(user:typr_mutual_even_tree(_)),
+    retractall(user:typr_mutual_odd_tree(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -349,6 +351,39 @@ test(recursive_compiler_supports_typr_structural_tree_mutual_recursion_path) :-
     once(sub_string(Code, _, _, _, "length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0")),
     once(sub_string(Code, _, _, _, "result = typr_mutual_odd_left_tree_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "result = typr_mutual_even_left_tree_impl(.subset2(current_input, 2));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_recursion_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree([])),
+    assertz(user:(typr_mutual_even_tree([_, L, R]) :-
+        typr_mutual_odd_tree(L),
+        typr_mutual_odd_tree(R)
+    )),
+    assertz(user:typr_mutual_odd_tree([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree([_, L, R]) :-
+        typr_mutual_even_tree(L),
+        typr_mutual_even_tree(R)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree/1, typr_mutual_odd_tree/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_typr_mutual_odd_tree_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_tree:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 0")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -229,6 +229,35 @@ test(structural_tree_mutual_recursive_output_checks_with_typr, [condition(typr_c
     retractall(user:typr_mutual_even_left_tree(_)),
     retractall(user:typr_mutual_odd_left_tree(_)).
 
+test(structural_tree_dual_mutual_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree([])),
+    assertz(user:(typr_mutual_even_tree([_, L, R]) :-
+        typr_mutual_odd_tree(L),
+        typr_mutual_odd_tree(R)
+    )),
+    assertz(user:typr_mutual_odd_tree([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree([_, L, R]) :-
+        typr_mutual_even_tree(L),
+        typr_mutual_even_tree(R)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree(_)),
+    retractall(user:typr_mutual_odd_tree(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion path from one-subtree structural tree SCCs to the next real tree-mutual shape: dual-subtree boolean descent.

The supported shape is intentionally narrow:

- arity-1 predicates
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- `[]` or `[V, [], []]` fact-style base cases
- one recursive clause per predicate
- two recursive calls in the recursive clause
- boolean rejoin of both subtree results

A representative example is:

```prolog
even_tree([]).
even_tree([_, L, R]) :-
    odd_tree(L),
    odd_tree(R).

odd_tree([_, [], []]).
odd_tree([_, L, R]) :-
    even_tree(L),
    even_tree(R).
```

Before this PR, TypR accepted that shape as mutual recursion, but the emitted TypR helper silently dropped the second recursive subtree call. This PR fixes that bug and keeps the full dual-subtree tree-mutual shape native in TypR.

## Why This PR Exists

Previous TypR recursion work already supported:

- transitive closure
- accumulator-style tail recursion
- single-call linear recursion
- `fib/2`-style helper recursion
- a broad conservative structural tree-recursion subset
- conservative numeric boolean mutual recursion groups such as `is_even/1` / `is_odd/1`
- conservative list-structural boolean mutual recursion groups such as `even_list/1` / `odd_list/1`
- conservative one-subtree tree-structural boolean mutual recursion groups such as `even_left_tree/1` / `odd_left_tree/1`

That still left a real mutual-recursion gap:

- the next obvious tree-SCC shape with two recursive subtree calls did reach the TypR mutual-recursion path
- but the generated TypR only emitted one subtree call
- that meant the output looked native while implementing the wrong recursion semantics

This PR closes that gap by making TypR emit both subtree calls and the boolean rejoin they require.

## Main Changes

### 1. TypR mutual recursion now recognizes conservative dual-subtree tree SCCs

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

After the existing numeric, list-structural, and one-subtree tree-structural mutual-recursion paths, TypR now also accepts conservative dual-subtree tree SCCs where each predicate has:

- arity `1`
- return type `bool`
- tree input encoded as `[]` or `[V, L, R]`
- `[]` or `[V, [], []]` fact-style base clauses
- one recursive clause
- exactly two recursive calls into predicates in the same SCC
- left descent through `.subset2(current_input, 2)`
- right descent through `.subset2(current_input, 3)`
- boolean rejoin of both recursive results

This is still conservative mutual recursion, not general SCC lowering.

### 2. The TypR emitter now preserves both recursive subtree calls

The new TypR path emits memoized helper bodies that:

- memoize by a tree-derived key
- check supported tree base cases
- recurse on the left subtree
- recurse on the right subtree
- rejoin both results with:

```r
result = left_result && right_result;
```

This fixes the previous bug where only one subtree call was emitted for the dual-subtree mutual-recursion shape.

### 3. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for `even_tree/1` / `odd_tree/1`-style dual-subtree mutual recursion
- presence of both left and right recursive helper calls
- boolean rejoin of both subtree results
- continued absence of wrapped standalone-R fallback
- real `typr check` validation for the generated output

### 4. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now reflect that the conservative TypR mutual-recursion subset includes:

- numeric boolean SCCs such as `is_even/1` / `is_odd/1`
- list-structural boolean SCCs such as `even_list/1` / `odd_list/1`
- one-subtree tree-structural boolean SCCs such as `even_left_tree/1` / `odd_left_tree/1`
- dual-subtree tree-structural boolean SCCs such as `even_tree/1` / `odd_tree/1`

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR mutual-recursion subset includes:

- conservative arity-1 boolean numeric SCCs such as `is_even/1` / `is_odd/1`
- conservative arity-1 boolean list-structural SCCs such as `even_list/1` / `odd_list/1`
- conservative arity-1 boolean one-subtree tree-structural SCCs such as `even_left_tree/1` / `odd_left_tree/1`
- conservative arity-1 boolean dual-subtree tree-structural SCCs such as `even_tree/1` / `odd_tree/1`

More general mutual recursion is still out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative dual-subtree tree-structural boolean mutual-recursive groups
- preservation of both subtree calls and their boolean rejoin inside valid TypR wrappers
- regression coverage and real TypR validation for that shape

Still not fully implemented:

- broader structural tree mutual recursion beyond the current boolean dual-subtree SCC shape
- richer result recombination beyond straightforward boolean conjunction
- multi-output or non-boolean mutual-recursive tree groups
- general recursive SCC lowering
- arbitrary recursive-body lowering

## Why This PR Is Worth Merging

This PR fixes a real TypR recursion correctness gap.

It gives the project:

- correct native support for the next conservative structural tree mutual-recursion shape
- elimination of a silent codegen bug where one subtree call was dropped
- real `typr check` validation for the emitted code
- documentation that matches the actual conservative mutual-recursion subset

This is a good incremental PR because it fixes semantics and extends TypR mutual recursion to the next defensible structural tree shape without pretending TypR already supports general SCC lowering.
