### PR TITLE
Keep native TypR tree mutual prework

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ includes:
 - conservative arity-1 boolean mutual-recursive predicate groups such as
   `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`,
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
-  lowered to TypR functions that use raw-expression memoized helper bodies
-  inside TypR instead of wrapped-R fallback
+  including dual-subtree tree SCCs with alias-style prework before the two
+  recursive subtree calls, lowered to TypR functions that use raw-expression
+  memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -205,7 +205,7 @@ bring-up.
     and `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC
     shape with one-subtree recursive descent, plus `even_tree/1` /
     `odd_tree/1`-style tree-structural SCC shape with two-subtree boolean
-    descent
+    descent and alias-style prework before the two recursive subtree calls
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -384,7 +384,8 @@ Current TypR lowering policy is intentionally mixed:
   `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC shape
   with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
   or the `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
-  `[]` / `[V, [], []]` base cases and two-subtree boolean descent, using
+  `[]` / `[V, [], []]` base cases, two-subtree boolean descent, and
+  alias-style prework before those two recursive subtree calls, using
   raw-expression memoized helper bodies inside TypR rather than wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -75,7 +75,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC shape
      with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
      or `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
-     `[]` / `[V, [], []]` base cases, two-subtree boolean descent, and
+     `[]` / `[V, [], []]` base cases, two-subtree boolean descent,
+     alias-style prework before the two recursive subtree calls, and
      boolean return types, emitted as TypR functions with raw-expression
      memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -229,8 +229,10 @@ typr_mutual_tree_dual_spec(GroupPredicates, Pred/Arity, Spec) :-
     RecInputPattern = [_ValueVar, LeftVar, RightVar],
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
-    Goals = [GoalA, GoalB],
-    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, LeftVar, RightVar), [GoalA, GoalB], GoalSpecs0),
+    typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
+    RecGoals = [GoalA, GoalB],
+    typr_mutual_tree_alias_map(PreGoals, LeftVar, RightVar, AliasMap),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap), [GoalA, GoalB], GoalSpecs0),
     select(call_spec(left, LeftNextPred, '.subset2(current_input, 2)'), GoalSpecs0, GoalSpecs1),
     select(call_spec(right, RightNextPred, '.subset2(current_input, 3)'), GoalSpecs1, []),
     atom_string(Pred, PredStr),
@@ -295,17 +297,60 @@ typr_strip_module_goal(_Module:Goal, StrippedGoal) :-
     typr_strip_module_goal(Goal, StrippedGoal).
 typr_strip_module_goal(Goal, Goal).
 
-typr_mutual_tree_recursive_goal(GroupPredicates, LeftVar, RightVar, Goal0, call_spec(Side, NextPred, StepExpr)) :-
+typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals) :-
+    append(PreGoals, RecGoals, Goals),
+    RecGoals = [_, _],
+    maplist(typr_mutual_tree_alias_goal, PreGoals),
+    maplist(typr_mutual_recursive_group_goal(GroupPredicates), RecGoals).
+
+typr_mutual_recursive_group_goal(GroupPredicates, Goal0) :-
     typr_strip_module_goal(Goal0, Goal),
     Goal =.. [NextPred, RecArg],
     memberchk(NextPred/1, GroupPredicates),
-    (   RecArg == LeftVar ->
-        Side = left,
-        StepExpr = '.subset2(current_input, 2)'
-    ;   RecArg == RightVar ->
-        Side = right,
-        StepExpr = '.subset2(current_input, 3)'
+    var(RecArg).
+
+typr_mutual_tree_alias_goal(Goal) :-
+    Goal = (Left = Right),
+    var(Left),
+    var(Right).
+
+typr_mutual_tree_alias_map(PreGoals, LeftVar, RightVar, AliasMap) :-
+    typr_mutual_tree_alias_map(PreGoals, [LeftVar-left, RightVar-right], AliasMap).
+
+typr_mutual_tree_alias_map([], AliasMap, AliasMap).
+typr_mutual_tree_alias_map([Goal|Rest], AliasMap0, AliasMap) :-
+    typr_mutual_tree_alias_binding(Goal, AliasMap0, AliasMap1),
+    typr_mutual_tree_alias_map(Rest, AliasMap1, AliasMap).
+
+typr_mutual_tree_alias_binding(Left = Right, AliasMap0, AliasMap) :-
+    (   typr_mutual_tree_lookup_side(Left, AliasMap0, Side) ->
+        typr_mutual_tree_bind_var(Right, Side, AliasMap0, AliasMap)
+    ;   typr_mutual_tree_lookup_side(Right, AliasMap0, Side) ->
+        typr_mutual_tree_bind_var(Left, Side, AliasMap0, AliasMap)
     ).
+
+typr_mutual_tree_bind_var(Var, Side, AliasMap0, AliasMap) :-
+    (   typr_mutual_tree_lookup_side(Var, AliasMap0, ExistingSide) ->
+        ExistingSide == Side,
+        AliasMap = AliasMap0
+    ;   AliasMap = [Var-Side|AliasMap0]
+    ).
+
+typr_mutual_tree_lookup_side(Var, [KnownVar-Side|_], Side) :-
+    Var == KnownVar,
+    !.
+typr_mutual_tree_lookup_side(Var, [_|Rest], Side) :-
+    typr_mutual_tree_lookup_side(Var, Rest, Side).
+
+typr_mutual_tree_side_step_expr(left, '.subset2(current_input, 2)').
+typr_mutual_tree_side_step_expr(right, '.subset2(current_input, 3)').
+
+typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, Goal0, call_spec(Side, NextPred, StepExpr)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg],
+    memberchk(NextPred/1, GroupPredicates),
+    typr_mutual_tree_lookup_side(RecArg, AliasMap, Side),
+    typr_mutual_tree_side_step_expr(Side, StepExpr).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -55,6 +55,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_left_tree(_)),
     retractall(user:typr_mutual_even_tree(_)),
     retractall(user:typr_mutual_odd_tree(_)),
+    retractall(user:typr_mutual_even_tree_pre(_)),
+    retractall(user:typr_mutual_odd_tree_pre(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -383,6 +385,43 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_recursion_path
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_prework_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_pre([])),
+    assertz(user:(typr_mutual_even_tree_pre([_, L, R]) :-
+        Left = L,
+        Right = R,
+        typr_mutual_odd_tree_pre(Left),
+        typr_mutual_odd_tree_pre(Right)
+    )),
+    assertz(user:typr_mutual_odd_tree_pre([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_pre([_, L, R]) :-
+        Left = L,
+        Right = R,
+        typr_mutual_even_tree_pre(Left),
+        typr_mutual_even_tree_pre(Right)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_pre/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_pre/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_pre/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_pre/1, typr_mutual_odd_tree_pre/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_pre <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_pre <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_pre_typr_mutual_odd_tree_pre_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_pre:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_tree_pre:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 0")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_pre_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -258,6 +258,39 @@ test(structural_tree_dual_mutual_recursive_output_checks_with_typr, [condition(t
     retractall(user:typr_mutual_even_tree(_)),
     retractall(user:typr_mutual_odd_tree(_)).
 
+test(structural_tree_dual_mutual_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_pre([])),
+    assertz(user:(typr_mutual_even_tree_pre([_, L, R]) :-
+        Left = L,
+        Right = R,
+        typr_mutual_odd_tree_pre(Left),
+        typr_mutual_odd_tree_pre(Right)
+    )),
+    assertz(user:typr_mutual_odd_tree_pre([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_pre([_, L, R]) :-
+        Left = L,
+        Right = R,
+        typr_mutual_even_tree_pre(Left),
+        typr_mutual_even_tree_pre(Right)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_pre/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_pre/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_pre/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_pre(_)),
+    retractall(user:typr_mutual_odd_tree_pre(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens conservative native TypR mutual-recursion lowering for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when the recursive clause includes alias-style prework before the two recursive subtree calls.

A representative supported shape is:

```prolog
typr_mutual_even_tree_pre([]).
typr_mutual_even_tree_pre([_, L, R]) :-
    Left = L,
    Right = R,
    typr_mutual_odd_tree_pre(Left),
    typr_mutual_odd_tree_pre(Right).

typr_mutual_odd_tree_pre([_, [], []]).
typr_mutual_odd_tree_pre([_, L, R]) :-
    Left = L,
    Right = R,
    typr_mutual_even_tree_pre(Left),
    typr_mutual_even_tree_pre(Right).
```

Before this PR, that shape fell out of the TypR structural mutual-recursion path. After this PR, it stays native and passes real `typr check` validation.

## Why This PR Exists

Recent TypR recursion work already established native support for:

- numeric boolean SCCs such as `is_even/1` / `is_odd/1`
- list-structural boolean SCCs such as `even_list/1` / `odd_list/1`
- one-subtree tree-structural SCCs such as `even_left_tree/1` / `odd_left_tree/1`
- dual-subtree tree-structural SCCs such as `even_tree/1` / `odd_tree/1`

That still left a practical nearby gap.

If a dual-subtree tree mutual-recursive clause introduced simple alias variables before the two recursive subtree calls, the current TypR mutual-recursion matcher no longer recognized the clause shape, even though the recursive structure was still conservative and obvious.

This PR closes that gap without widening the TypR mutual-recursion model into general branch-heavy SCC lowering.

## Main Changes

### 1. TypR mutual tree SCC matching now accepts alias-style prework

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The dual-subtree tree mutual-recursion path now:

- splits recursive clause bodies into pre-goals and the two recursive subtree calls
- accepts conservative alias-only pre-goals such as `Left = L` and `Right = R`
- tracks subtree identity through an alias map
- still emits the same native left/right helper-call structure once those aliases are resolved

This keeps the TypR path narrow and analyzable while covering a real practical shape.

### 2. Added focused regression coverage for structural tree mutual prework

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level regression coverage verifies that:

- a dual-subtree tree mutual-recursive SCC with alias-style prework stays native
- both subtree helper calls are still emitted
- the boolean rejoin remains `left_result && right_result`
- wrapped-R fallback is not used
- generated TypR still validates locally

### 3. Added real TypR toolchain validation for the new shape

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain test writes the generated TypR program to a smoke project and runs real `typr check`, so this support is validated against the actual TypR toolchain rather than only string-shape expectations.

### 4. Docs now reflect the broader mutual-recursion subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs with alias-style prework before the two recursive subtree calls.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for dual-subtree tree mutual recursion with alias-style prework
- continued TypR CLI validation for generated output

What it does not claim:

- broader guarded branch-local mutual recursion around subtree calls
- general SCC lowering for arbitrary mutual-recursive groups
- full arbitrary recursive-body native TypR lowering

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls

The current TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR support for alias-style prework before dual-subtree structural tree mutual-recursive calls
- target-level regression coverage for that shape
- real `typr check` coverage for that shape
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- guarded branch-local control around the two mutual subtree calls
- broader structural tree SCCs with richer branch-local logic
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes a real mutual-recursion gap without weakening the TypR backend’s conservative design boundary.

It gives the project:

- fewer false fallbacks for obvious structural tree SCCs
- stronger native TypR coverage for tree mutual recursion
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a precise, defensible way rather than jumping to general SCC lowering.
