### PR TITLE
docs(csharp-query): document manual cache smoke diff workflow

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -189,6 +189,27 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
     - project filter
     - keep-artifacts setting
     - per-slice status and duration
+  - Manual compare workflow: `.github/workflows/csharp_query_cache_smoke_diff.yml`
+    - Trigger: `workflow_dispatch`
+    - Required inputs:
+      - `baseline_run_id`
+      - `compare_run_id`
+      - `baseline_artifact_name` (defaults to `csharp-query-smoke-summary-json`)
+      - `compare_artifact_name` (defaults to `csharp-query-smoke-summary-json`)
+    - Optional threshold inputs:
+      - `fail_on_status_regression`
+      - `max_total_duration_delta_seconds`
+      - `max_slice_duration_delta_seconds`
+    - Outputs:
+      - diff JSON artifact: `csharp-query-smoke-diff-json`
+      - job summary with:
+        - baseline / compare run IDs
+        - artifact names
+        - overall result delta
+        - total duration delta
+        - threshold settings
+        - threshold pass/fail result
+        - threshold failure list when present
 - Environment variables (used by the test harness):
   - `SKIP_CSHARP_EXECUTION=1` (generate C# projects but do not execute via Prolog)
   - `CSHARP_QUERY_OUTPUT_DIR=...` (where generated projects are written)


### PR DESCRIPTION
  ## Summary
  Update the C# query runtime docs to describe the new manual GitHub Actions workflow for comparing two
  cache smoke summary JSON artifacts.

  ## What changed
  - Updated `docs/targets/csharp-query-runtime.md`
  - Documented the manual compare workflow:
    - `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Documented the required workflow inputs:
    - `baseline_run_id`
    - `compare_run_id`
    - `baseline_artifact_name`
    - `compare_artifact_name`
  - Documented the optional threshold inputs:
    - `fail_on_status_regression`
    - `max_total_duration_delta_seconds`
    - `max_slice_duration_delta_seconds`
  - Documented the workflow outputs:
    - diff JSON artifact `csharp-query-smoke-diff-json`
    - job summary with threshold settings, pass/fail result, and failures

  ## Why
  The manual cache smoke diff workflow now exists in CI, but the runtime docs still only described the
  local diff-helper usage. This PR closes that gap and makes the manual compare flow discoverable
  alongside the rest of the cache smoke tooling.

  ## Validation
  - Sanity-checked the documentation against:
    - `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Confirmed the documented input names and artifact name match the workflow:
    - `baseline_run_id`
    - `compare_run_id`
    - `baseline_artifact_name`
    - `compare_artifact_name`
    - `fail_on_status_regression`
    - `max_total_duration_delta_seconds`
    - `max_slice_duration_delta_seconds`
    - `csharp-query-smoke-diff-json`