### PR TITLE
Keep native TypR guarded tree mutual prework

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,10 @@ includes:
 - conservative arity-1 boolean mutual-recursive predicate groups such as
   `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`,
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
-  including dual-subtree tree SCCs with alias-style prework before the two
-  recursive subtree calls, lowered to TypR functions that use raw-expression
-  memoized helper bodies inside TypR instead of wrapped-R fallback
+  including dual-subtree tree SCCs with alias-style prework or guarded
+  branch-local alias selection before the two recursive subtree calls,
+  lowered to TypR functions that use raw-expression memoized helper bodies
+  inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -205,7 +205,8 @@ bring-up.
     and `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC
     shape with one-subtree recursive descent, plus `even_tree/1` /
     `odd_tree/1`-style tree-structural SCC shape with two-subtree boolean
-    descent and alias-style prework before the two recursive subtree calls
+    descent and alias-style prework or guarded branch-local alias selection
+    before the two recursive subtree calls
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -385,9 +385,9 @@ Current TypR lowering policy is intentionally mixed:
   with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
   or the `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
   `[]` / `[V, [], []]` base cases, two-subtree boolean descent, and
-  alias-style prework before those two recursive subtree calls, using
-  raw-expression memoized helper bodies inside TypR rather than wrapped-R
-  fallback
+  alias-style prework or guarded branch-local alias selection before those
+  two recursive subtree calls, using raw-expression memoized helper bodies
+  inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -76,9 +76,9 @@ This document focuses on architecture and rollout choices specific to TypR.
      with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
      or `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
      `[]` / `[V, [], []]` base cases, two-subtree boolean descent,
-     alias-style prework before the two recursive subtree calls, and
-     boolean return types, emitted as TypR functions with raw-expression
-     memoized helper bodies
+     alias-style prework or guarded branch-local alias selection before the
+     two recursive subtree calls, and boolean return types, emitted as
+     TypR functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -81,6 +81,7 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
     (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_dual_branch_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_spec(Predicates), Predicates, Specs)
     ),
@@ -254,6 +255,55 @@ typr_mutual_tree_dual_spec(GroupPredicates, Pred/Arity, Spec) :-
         guard_expr: 'length(current_input) == 3'
     }.
 
+typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [BranchGoal, GoalA, GoalB],
+    typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    maplist(typr_mutual_tree_alias_goal, ThenGoals),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    maplist(typr_mutual_tree_alias_goal, ElseGoals),
+    typr_mutual_tree_alias_map(ThenGoals, LeftVar, RightVar, ThenAliasMap),
+    typr_mutual_tree_alias_map(ElseGoals, LeftVar, RightVar, ElseAliasMap),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, ThenAliasMap), [GoalA, GoalB], ThenGoalSpecs),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, ElseAliasMap), [GoalA, GoalB], ElseGoalSpecs),
+    typr_mutual_tree_call_specs_cover_both_sides(ThenGoalSpecs),
+    typr_mutual_tree_call_specs_cover_both_sides(ElseGoalSpecs),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, LeftVar, RightVar, BranchConditionExpr),
+    maplist(typr_mutual_tree_branch_call, ThenGoalSpecs, ThenCalls),
+    maplist(typr_mutual_tree_branch_call, ElseGoalSpecs, ElseCalls),
+    atom_string(Pred, PredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual_branch,
+        pred: Pred,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        branch_condition_expr: BranchConditionExpr,
+        then_calls: ThenCalls,
+        else_calls: ElseCalls
+    }.
+
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 0') :-
     Head =.. [_Pred, []].
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0') :-
@@ -351,6 +401,26 @@ typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, Goal0, call_spec(Side
     memberchk(NextPred/1, GroupPredicates),
     typr_mutual_tree_lookup_side(RecArg, AliasMap, Side),
     typr_mutual_tree_side_step_expr(Side, StepExpr).
+
+typr_mutual_tree_call_specs_cover_both_sides(CallSpecs) :-
+    findall(Side, member(call_spec(Side, _NextPred, _StepExpr), CallSpecs), Sides0),
+    msort(Sides0, [left, right]).
+
+typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, LeftVar, RightVar, BranchConditionExpr) :-
+    typr_mutual_tree_condition_varmap(ValueVar, LeftVar, RightVar, VarMap),
+    native_typr_if_condition(IfGoal, VarMap, BranchCondition0),
+    typr_condition_expr_text(BranchCondition0, BranchConditionExpr).
+
+typr_mutual_tree_condition_varmap(ValueVar, LeftVar, RightVar, VarMap) :-
+    VarMap0 = [LeftVar-'.subset2(current_input, 2)', RightVar-'.subset2(current_input, 3)'],
+    (   var(ValueVar)
+    ->  VarMap = [ValueVar-'.subset2(current_input, 1)'|VarMap0]
+    ;   VarMap = VarMap0
+    ).
+
+typr_mutual_tree_branch_call(call_spec(_Side, NextPred, StepExpr), branch_call(HelperName, StepExpr)) :-
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (
@@ -487,6 +557,57 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     StepExpr = Spec.step_expr,
     typr_mutual_list_base_branch_lines_no_memo(BaseLengths, BaseLines),
     typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_branch,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    BranchConditionExpr = Spec.branch_condition_expr,
+    ThenCalls = Spec.then_calls,
+    ElseCalls = Spec.else_calls,
+    typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
+    typr_mutual_tree_dual_branch_recursive_branch_lines(
+        GroupName,
+        GuardExpr,
+        BranchConditionExpr,
+        ThenCalls,
+        ElseCalls,
+        RecursiveLines
+    ),
+    typr_mutual_false_lines(GroupName, FalseLines),
+    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, FalseLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_branch,
+    HelperName = Spec.helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    BranchConditionExpr = Spec.branch_condition_expr,
+    ThenCalls = Spec.then_calls,
+    ElseCalls = Spec.else_calls,
+    typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
+    typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
+        GuardExpr,
+        BranchConditionExpr,
+        ThenCalls,
+        ElseCalls,
+        RecursiveLines
+    ),
     format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
@@ -756,6 +877,58 @@ typr_mutual_tree_dual_recursive_branch_lines_no_memo(
         RightLine,
         '            left_result && right_result'
     ].
+
+typr_mutual_tree_dual_branch_recursive_branch_lines(
+    GroupName,
+    GuardExpr,
+    BranchConditionExpr,
+    ThenCalls,
+    ElseCalls,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    format(string(BranchIfLine), '            if (~w) {', [BranchConditionExpr]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    typr_mutual_tree_dual_branch_call_lines(ThenCalls, '                ', ThenLines),
+    typr_mutual_tree_dual_branch_call_lines(ElseCalls, '                ', ElseLines),
+    append([IfLine, BranchIfLine], ThenLines, Lines0),
+    append(Lines0, ['            } else {'], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, ['            }', AssignLine, '            result'], Lines).
+
+typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
+    GuardExpr,
+    BranchConditionExpr,
+    ThenCalls,
+    ElseCalls,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    format(string(BranchIfLine), '            if (~w) {', [BranchConditionExpr]),
+    typr_mutual_tree_dual_branch_call_lines_no_memo(ThenCalls, '                ', ThenLines),
+    typr_mutual_tree_dual_branch_call_lines_no_memo(ElseCalls, '                ', ElseLines),
+    append([IfLine, BranchIfLine], ThenLines, Lines0),
+    append(Lines0, ['            } else {'], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, ['            }'], Lines).
+
+typr_mutual_tree_dual_branch_call_lines(
+    [branch_call(FirstHelperName, FirstStepExpr), branch_call(SecondHelperName, SecondStepExpr)],
+    Prefix,
+    [FirstLine, SecondLine, ResultLine]
+) :-
+    format(string(FirstLine), '~wleft_result = ~w(~w);', [Prefix, FirstHelperName, FirstStepExpr]),
+    format(string(SecondLine), '~wright_result = ~w(~w);', [Prefix, SecondHelperName, SecondStepExpr]),
+    format(string(ResultLine), '~wresult = left_result && right_result;', [Prefix]).
+
+typr_mutual_tree_dual_branch_call_lines_no_memo(
+    [branch_call(FirstHelperName, FirstStepExpr), branch_call(SecondHelperName, SecondStepExpr)],
+    Prefix,
+    [FirstLine, SecondLine, ResultLine]
+) :-
+    format(string(FirstLine), '~wleft_result = ~w(~w);', [Prefix, FirstHelperName, FirstStepExpr]),
+    format(string(SecondLine), '~wright_result = ~w(~w);', [Prefix, SecondHelperName, SecondStepExpr]),
+    format(string(ResultLine), '~wleft_result && right_result', [Prefix]).
 
 typr_mutual_false_lines(GroupName, [
     '        } else {',

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -57,6 +57,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree(_)),
     retractall(user:typr_mutual_even_tree_pre(_)),
     retractall(user:typr_mutual_odd_tree_pre(_)),
+    retractall(user:typr_mutual_even_tree_branch_pre(_)),
+    retractall(user:typr_mutual_odd_tree_branch_pre(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -422,6 +424,52 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_prework_path) 
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_pre_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_pre_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_branch_prework_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_branch_pre([])),
+    assertz(user:(typr_mutual_even_tree_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_odd_tree_branch_pre(Left),
+        typr_mutual_odd_tree_branch_pre(Right)
+    )),
+    assertz(user:typr_mutual_odd_tree_branch_pre([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_even_tree_branch_pre(Left),
+        typr_mutual_even_tree_branch_pre(Right)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_branch_pre/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_branch_pre/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_branch_pre/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_branch_pre/1, typr_mutual_odd_tree_branch_pre/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_branch_pre <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_branch_pre <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_branch_pre_typr_mutual_odd_tree_branch_pre_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -291,6 +291,47 @@ test(structural_tree_dual_mutual_prework_output_checks_with_typr, [condition(typ
     retractall(user:typr_mutual_even_tree_pre(_)),
     retractall(user:typr_mutual_odd_tree_pre(_)).
 
+test(structural_tree_dual_mutual_branch_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_branch_pre([])),
+    assertz(user:(typr_mutual_even_tree_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_odd_tree_branch_pre(Left),
+        typr_mutual_odd_tree_branch_pre(Right)
+    )),
+    assertz(user:typr_mutual_odd_tree_branch_pre([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_even_tree_branch_pre(Left),
+        typr_mutual_even_tree_branch_pre(Right)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_branch_pre/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_branch_pre/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_branch_pre/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_branch_pre(_)),
+    retractall(user:typr_mutual_odd_tree_branch_pre(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens conservative native TypR mutual-recursion lowering for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when a guarded `if -> then ; else` chooses alias-style branch-local subtree inputs before the shared two recursive subtree calls.

A representative supported shape is:

```prolog
typr_mutual_even_tree_branch_pre([]).
typr_mutual_even_tree_branch_pre([V, L, R]) :-
    ( V > 0 ->
        Left = L,
        Right = R
    ;   Left = R,
        Right = L
    ),
    typr_mutual_odd_tree_branch_pre(Left),
    typr_mutual_odd_tree_branch_pre(Right).

typr_mutual_odd_tree_branch_pre([_, [], []]).
typr_mutual_odd_tree_branch_pre([V, L, R]) :-
    ( V > 0 ->
        Left = L,
        Right = R
    ;   Left = R,
        Right = L
    ),
    typr_mutual_even_tree_branch_pre(Left),
    typr_mutual_even_tree_branch_pre(Right).
```

Before this PR, that shape still failed with `No mutual recursion support for target typr`. After this PR, it stays native and passes real `typr check` validation.

## Why This PR Exists

Recent TypR mutual-recursion work already supported:

- numeric boolean SCCs such as `is_even/1` / `is_odd/1`
- list-structural boolean SCCs such as `even_list/1` / `odd_list/1`
- one-subtree tree-structural SCCs such as `even_left_tree/1` / `odd_left_tree/1`
- dual-subtree tree-structural SCCs such as `even_tree/1` / `odd_tree/1`
- dual-subtree tree-structural SCCs with simple alias-style prework before the two recursive subtree calls

That still left a nearby practical gap.

If a conservative dual-subtree tree mutual-recursive clause used guarded branch-local alias selection before the shared recursive calls, TypR still failed to recognize the SCC shape even though the overall lowering target was still narrow and structurally obvious.

This PR closes that gap without attempting general mutual-recursive branch-body lowering.

## Main Changes

### 1. TypR now supports guarded alias selection before shared dual mutual subtree calls

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-recursion backend now recognizes a conservative tree SCC shape where:

- the recursive clause is still arity `1`
- the return type is still boolean
- the tree input is still `[]` / `[V, L, R]`
- a guarded `if -> then ; else` performs alias-only branch-local selection
- the two recursive subtree calls remain shared after that branch
- the final rejoin remains a TypR-translatable boolean conjunction

Implementation-wise, the new path:

- adds a dedicated dual-subtree tree mutual-branch matcher
- resolves branch-local alias maps separately for the `then` and `else` branches
- emits native TypR helper code with branch-specific subtree helper calls
- preserves wrapped-R avoidance for this supported SCC shape

### 2. Added focused regression coverage for guarded tree mutual prework

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level coverage verifies that:

- guarded branch-local alias selection before shared dual subtree calls stays native
- both branch-specific subtree call orders are preserved in emitted TypR
- the boolean rejoin remains `left_result && right_result`
- wrapped-R fallback is not used
- generated TypR remains locally valid

### 3. Added real TypR toolchain validation for the same shape

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain test writes the generated TypR program to a smoke project and runs real `typr check`, so this support is validated against the actual TypR CLI rather than only target-level text expectations.

### 4. Docs now reflect guarded branch-local tree mutual prework

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs with guarded branch-local alias selection before the two recursive subtree calls.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for guarded branch-local alias selection before shared dual tree mutual-recursive calls
- continued TypR CLI validation for generated output

What it does not claim:

- direct recursive calls inside mutual branch bodies
- broader branch-heavy structural tree SCC lowering
- general SCC lowering for arbitrary mutual-recursive groups

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with guarded branch-local alias selection before the two recursive subtree calls

The TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR support for guarded branch-local alias selection before shared dual-subtree tree mutual-recursive calls
- target-level regression coverage for that shape
- real `typr check` coverage for that shape
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- direct recursive calls inside mutual branch bodies
- broader structural tree SCCs with richer branch-local logic
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes another real mutual-recursion gap without widening the TypR backend into general SCC lowering.

It gives the project:

- fewer false fallbacks for conservative tree-structural SCCs
- stronger native TypR coverage for mutual recursion over tree inputs
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a narrow, defensible way and leaves the next broader SCC step clearly bounded.
