### PR TITLE
Keep native TypR recursive tree mutual branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,11 @@ includes:
   `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`,
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
   including dual-subtree tree SCCs with alias-style prework or guarded
-  branch-local alias selection before the two recursive subtree calls,
-  lowered to TypR functions that use raw-expression memoized helper bodies
-  inside TypR instead of wrapped-R fallback
+  branch-local alias selection before the two recursive subtree calls, or
+  direct recursive subtree calls inside supported guarded branch bodies
+  before the shared boolean rejoin, lowered to TypR functions that use
+  raw-expression memoized helper bodies inside TypR instead of wrapped-R
+  fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -205,8 +205,10 @@ bring-up.
     and `even_left_tree/1` / `odd_left_tree/1`-style tree-structural SCC
     shape with one-subtree recursive descent, plus `even_tree/1` /
     `odd_tree/1`-style tree-structural SCC shape with two-subtree boolean
-    descent and alias-style prework or guarded branch-local alias selection
-    before the two recursive subtree calls
+    descent and alias-style prework, guarded branch-local alias selection,
+    or direct recursive subtree calls inside supported guarded branch
+    bodies before the shared boolean rejoin after the two recursive subtree
+    calls
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -385,9 +385,11 @@ Current TypR lowering policy is intentionally mixed:
   with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
   or the `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
   `[]` / `[V, [], []]` base cases, two-subtree boolean descent, and
-  alias-style prework or guarded branch-local alias selection before those
-  two recursive subtree calls, using raw-expression memoized helper bodies
-  inside TypR rather than wrapped-R fallback
+  alias-style prework, guarded branch-local alias selection, or direct
+  recursive subtree calls inside supported guarded branch bodies before
+  those two recursive subtree calls rejoin via a shared boolean result,
+  using raw-expression memoized helper bodies inside TypR rather than
+  wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -76,9 +76,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
      or `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
      `[]` / `[V, [], []]` base cases, two-subtree boolean descent,
-     alias-style prework or guarded branch-local alias selection before the
-     two recursive subtree calls, and boolean return types, emitted as
-     TypR functions with raw-expression memoized helper bodies
+     alias-style prework, guarded branch-local alias selection, or direct
+     recursive subtree calls inside supported guarded branch bodies before
+     the shared boolean rejoin after the two recursive subtree calls, and
+     boolean return types, emitted as TypR functions with raw-expression
+     memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -262,6 +262,47 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     generic_typr_return_type(Pred/Arity, Clauses, "bool"),
     build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
     findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [BranchGoal],
+    typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_branch_goal_calls(GroupPredicates, ThenGoals, LeftVar, RightVar, ThenCalls),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_branch_goal_calls(GroupPredicates, ElseGoals, LeftVar, RightVar, ElseCalls),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, LeftVar, RightVar, BranchConditionExpr),
+    atom_string(Pred, PredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual_branch,
+        pred: Pred,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        branch_condition_expr: BranchConditionExpr,
+        then_calls: ThenCalls,
+        else_calls: ElseCalls
+    }.
+
+typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
     partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
     RecClauses = [clause(RecHead, RecBody)],
     BaseClauses \= [],
@@ -395,6 +436,15 @@ typr_mutual_tree_lookup_side(Var, [_|Rest], Side) :-
 typr_mutual_tree_side_step_expr(left, '.subset2(current_input, 2)').
 typr_mutual_tree_side_step_expr(right, '.subset2(current_input, 3)').
 
+typr_is_mutual_recursive_clause(GroupPredicates, clause(_Head, Body)) :-
+    sub_term(SubGoal0, Body),
+    nonvar(SubGoal0),
+    typr_strip_module_goal(SubGoal0, SubGoal),
+    compound(SubGoal),
+    functor(SubGoal, Pred, Arity),
+    memberchk(Pred/Arity, GroupPredicates),
+    !.
+
 typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, Goal0, call_spec(Side, NextPred, StepExpr)) :-
     typr_strip_module_goal(Goal0, Goal),
     Goal =.. [NextPred, RecArg],
@@ -421,6 +471,14 @@ typr_mutual_tree_condition_varmap(ValueVar, LeftVar, RightVar, VarMap) :-
 typr_mutual_tree_branch_call(call_spec(_Side, NextPred, StepExpr), branch_call(HelperName, StepExpr)) :-
     atom_string(NextPred, NextPredStr),
     format(string(HelperName), '~w_impl', [NextPredStr]).
+
+typr_mutual_tree_branch_goal_calls(GroupPredicates, Goals, LeftVar, RightVar, Calls) :-
+    typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
+    RecGoals = [GoalA, GoalB],
+    typr_mutual_tree_alias_map(PreGoals, LeftVar, RightVar, AliasMap),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap), [GoalA, GoalB], GoalSpecs),
+    typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
+    maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -59,6 +59,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_pre(_)),
     retractall(user:typr_mutual_even_tree_branch_pre(_)),
     retractall(user:typr_mutual_odd_tree_branch_pre(_)),
+    retractall(user:typr_mutual_even_tree_recursive_branch(_)),
+    retractall(user:typr_mutual_odd_tree_recursive_branch(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -470,6 +472,48 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_branch_prework
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_recursive_branch_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_recursive_branch([])),
+    assertz(user:(typr_mutual_even_tree_recursive_branch([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_recursive_branch(L),
+            typr_mutual_odd_tree_recursive_branch(R)
+        ;   typr_mutual_odd_tree_recursive_branch(R),
+            typr_mutual_odd_tree_recursive_branch(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_recursive_branch([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_recursive_branch([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_recursive_branch(L),
+            typr_mutual_even_tree_recursive_branch(R)
+        ;   typr_mutual_even_tree_recursive_branch(R),
+            typr_mutual_even_tree_recursive_branch(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_recursive_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_recursive_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_recursive_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_recursive_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_recursive_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_recursive_branch/1, typr_mutual_odd_tree_recursive_branch/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_recursive_branch <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_recursive_branch <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_recursive_branch_typr_mutual_odd_tree_recursive_branch_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_recursive_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_recursive_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_recursive_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_recursive_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -332,6 +332,43 @@ test(structural_tree_dual_mutual_branch_prework_output_checks_with_typr, [condit
     retractall(user:typr_mutual_even_tree_branch_pre(_)),
     retractall(user:typr_mutual_odd_tree_branch_pre(_)).
 
+test(structural_tree_dual_mutual_recursive_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_recursive_branch([])),
+    assertz(user:(typr_mutual_even_tree_recursive_branch([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_recursive_branch(L),
+            typr_mutual_odd_tree_recursive_branch(R)
+        ;   typr_mutual_odd_tree_recursive_branch(R),
+            typr_mutual_odd_tree_recursive_branch(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_recursive_branch([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_recursive_branch([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_recursive_branch(L),
+            typr_mutual_even_tree_recursive_branch(R)
+        ;   typr_mutual_even_tree_recursive_branch(R),
+            typr_mutual_even_tree_recursive_branch(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_recursive_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_recursive_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_recursive_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_recursive_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_recursive_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_recursive_branch(_)),
+    retractall(user:typr_mutual_odd_tree_recursive_branch(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion subset for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when a guarded branch body contains the recursive subtree calls directly, rather than only selecting aliases before a later shared call site.

A representative supported shape is:

```prolog
typr_mutual_even_tree_recursive_branch([]).
typr_mutual_even_tree_recursive_branch([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_odd_tree_recursive_branch(L),
        typr_mutual_odd_tree_recursive_branch(R)
    ;   typr_mutual_odd_tree_recursive_branch(R),
        typr_mutual_odd_tree_recursive_branch(L)
    ).

typr_mutual_odd_tree_recursive_branch([_, [], []]).
typr_mutual_odd_tree_recursive_branch([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_even_tree_recursive_branch(L),
        typr_mutual_even_tree_recursive_branch(R)
    ;   typr_mutual_even_tree_recursive_branch(R),
        typr_mutual_even_tree_recursive_branch(L)
    ).
```

Before this PR, that shape failed with `No mutual recursion support for target typr`. After this PR, it lowers natively and passes real `typr check` validation.

## Why This PR Exists

Recent TypR recursion work already established native support for conservative mutual-recursion shapes such as:

- numeric boolean SCCs like `is_even/1` / `is_odd/1`
- list-structural boolean SCCs like `even_list/1` / `odd_list/1`
- one-subtree tree SCCs like `even_left_tree/1` / `odd_left_tree/1`
- dual-subtree tree SCCs like `even_tree/1` / `odd_tree/1`
- dual-subtree tree SCCs with alias-style prework before the two recursive calls
- dual-subtree tree SCCs with guarded alias selection before the two recursive calls

That still left a real nearby gap.

If the guarded branch body itself contained the two mutual recursive subtree calls, the current TypR mutual-recursion matcher did not classify the clause as supported mutual recursion. The shape stayed conservative, but the nested branch-body recursive calls were not recognized by the TypR mutual path.

This PR closes that gap without widening TypR into general SCC lowering.

## Main Changes

### 1. TypR mutual recursion now recognizes direct recursive calls inside supported branch bodies

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-recursion backend now:

- detects recursive clauses even when the mutual recursive calls are nested under `if -> then ; else`
- matches conservative dual-subtree tree SCCs whose guarded branch bodies contain the two recursive calls directly
- preserves the existing TypR-native boolean rejoin shape with `left_result && right_result`

This keeps the TypR scope narrow:

- arity `1`
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- one recursive clause per predicate
- two recursive subtree calls in each recursive branch shape
- shared boolean rejoin after those calls

### 2. Added focused regression coverage for the new mutual tree branch-body shape

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level regression coverage verifies that:

- the guarded tree-mutual branch-body shape stays native in TypR
- both subtree helper calls are emitted in each branch
- branch-local call order is preserved
- the final rejoin remains `left_result && right_result`
- wrapped standalone-R fallback is not used
- generated TypR is still locally valid

### 3. Added real TypR toolchain validation for the same shape

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain test writes the generated TypR program to a smoke project and runs real `typr check`, so this support is validated against the actual TypR toolchain rather than only string-shape assertions.

### 4. Documentation now reflects the broader conservative mutual-recursion subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs where supported guarded branch bodies perform the recursive subtree calls directly before a shared boolean rejoin.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for guarded dual-subtree tree mutual recursion with direct recursive calls inside branch bodies
- continued TypR CLI validation for generated output

What it does not claim:

- broader branch-heavy SCC lowering
- non-boolean mutual-recursive tree groups
- arbitrary recursive-body native TypR lowering
- general recursive SCC lowering

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with guarded alias selection before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with direct recursive subtree calls inside supported guarded branch bodies before the shared boolean rejoin

The TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for direct recursive subtree calls inside supported guarded dual-subtree tree mutual-recursive branch bodies
- target-level regression coverage for that shape
- real `typr check` coverage for that shape
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- richer branch-local state around mutual subtree calls
- broader structural tree SCCs with more complex branch-local recombination
- non-boolean or multi-output mutual recursion
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes a real mutual-recursion gap without weakening the TypR backend’s conservative design boundary.

It gives the project:

- fewer false failures for obvious structural tree SCCs
- stronger native TypR coverage for guarded tree mutual recursion
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a precise, defensible way rather than jumping to general SCC lowering.
