### PR TITLE
Keep native TypR nested tree mutual branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ includes:
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
   including dual-subtree tree SCCs with alias-style prework or guarded
   branch-local alias selection before the two recursive subtree calls, or
-  direct recursive subtree calls inside supported guarded branch bodies
-  before the shared boolean rejoin, lowered to TypR functions that use
+  direct recursive subtree calls inside supported guarded branch bodies,
+  including one nested branch-local control point around those calls before
+  the shared boolean rejoin, lowered to TypR functions that use
   raw-expression memoized helper bodies inside TypR instead of wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates with one

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -208,6 +208,7 @@ bring-up.
     descent and alias-style prework, guarded branch-local alias selection,
     or direct recursive subtree calls inside supported guarded branch
     bodies before the shared boolean rejoin after the two recursive subtree
+    calls, including one nested branch-local control point around those
     calls
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -388,6 +388,7 @@ Current TypR lowering policy is intentionally mixed:
   alias-style prework, guarded branch-local alias selection, or direct
   recursive subtree calls inside supported guarded branch bodies before
   those two recursive subtree calls rejoin via a shared boolean result,
+  including one nested branch-local control point around those calls,
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -78,9 +78,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      `[]` / `[V, [], []]` base cases, two-subtree boolean descent,
      alias-style prework, guarded branch-local alias selection, or direct
      recursive subtree calls inside supported guarded branch bodies before
-     the shared boolean rejoin after the two recursive subtree calls, and
-     boolean return types, emitted as TypR functions with raw-expression
-     memoized helper bodies
+     the shared boolean rejoin after the two recursive subtree calls,
+     including one nested branch-local control point around those calls,
+     and boolean return types, emitted as TypR functions with
+     raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -269,17 +269,18 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     sort(BaseConds0, BaseConditions),
     RecHead =.. [_PredName, RecInputPattern],
     RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
     Goals = [BranchGoal],
     typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_branch_goal_calls(GroupPredicates, ThenGoals, LeftVar, RightVar, ThenCalls),
+    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap0, ThenBody),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_branch_goal_calls(GroupPredicates, ElseGoals, LeftVar, RightVar, ElseCalls),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, LeftVar, RightVar, BranchConditionExpr),
+    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap0, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, BranchConditionExpr),
     atom_string(Pred, PredStr),
     format(string(HelperName), '~w_impl', [PredStr]),
     Spec = mutual_spec{
@@ -292,8 +293,8 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
         base_conditions: BaseConditions,
         guard_expr: 'length(current_input) == 3',
         branch_condition_expr: BranchConditionExpr,
-        then_calls: ThenCalls,
-        else_calls: ElseCalls
+        then_body: ThenBody,
+        else_body: ElseBody
     }.
 
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -326,7 +327,8 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     maplist(typr_mutual_tree_recursive_goal(GroupPredicates, ElseAliasMap), [GoalA, GoalB], ElseGoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(ThenGoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(ElseGoalSpecs),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, LeftVar, RightVar, BranchConditionExpr),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, BranchConditionExpr),
     maplist(typr_mutual_tree_branch_call, ThenGoalSpecs, ThenCalls),
     maplist(typr_mutual_tree_branch_call, ElseGoalSpecs, ElseCalls),
     atom_string(Pred, PredStr),
@@ -341,8 +343,8 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
         base_conditions: BaseConditions,
         guard_expr: 'length(current_input) == 3',
         branch_condition_expr: BranchConditionExpr,
-        then_calls: ThenCalls,
-        else_calls: ElseCalls
+        then_body: branch_calls(ThenCalls),
+        else_body: branch_calls(ElseCalls)
     }.
 
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 0') :-
@@ -456,13 +458,20 @@ typr_mutual_tree_call_specs_cover_both_sides(CallSpecs) :-
     findall(Side, member(call_spec(Side, _NextPred, _StepExpr), CallSpecs), Sides0),
     msort(Sides0, [left, right]).
 
-typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, LeftVar, RightVar, BranchConditionExpr) :-
-    typr_mutual_tree_condition_varmap(ValueVar, LeftVar, RightVar, VarMap),
+typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr) :-
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap),
     native_typr_if_condition(IfGoal, VarMap, BranchCondition0),
     typr_condition_expr_text(BranchCondition0, BranchConditionExpr).
 
-typr_mutual_tree_condition_varmap(ValueVar, LeftVar, RightVar, VarMap) :-
-    VarMap0 = [LeftVar-'.subset2(current_input, 2)', RightVar-'.subset2(current_input, 3)'],
+typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap) :-
+    findall(
+        Var-Expr,
+        (
+            member(Var-Side, AliasMap),
+            typr_mutual_tree_side_step_expr(Side, Expr)
+        ),
+        VarMap0
+    ),
     (   var(ValueVar)
     ->  VarMap = [ValueVar-'.subset2(current_input, 1)'|VarMap0]
     ;   VarMap = VarMap0
@@ -472,10 +481,23 @@ typr_mutual_tree_branch_call(call_spec(_Side, NextPred, StepExpr), branch_call(H
     atom_string(NextPred, NextPredStr),
     format(string(HelperName), '~w_impl', [NextPredStr]).
 
-typr_mutual_tree_branch_goal_calls(GroupPredicates, Goals, LeftVar, RightVar, Calls) :-
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+    append(PreGoals, [NestedIfGoal], Goals),
+    maplist(typr_mutual_tree_alias_goal, PreGoals),
+    typr_mutual_tree_alias_map(PreGoals, AliasMap0, AliasMap),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ThenBody),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr),
+    Body = branch_if(BranchConditionExpr, ThenBody, ElseBody).
+typr_mutual_tree_branch_body(GroupPredicates, Goals, _ValueVar, AliasMap0, branch_calls(Calls)) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
-    typr_mutual_tree_alias_map(PreGoals, LeftVar, RightVar, AliasMap),
+    typr_mutual_tree_alias_map(PreGoals, AliasMap0, AliasMap),
     maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap), [GoalA, GoalB], GoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls).
@@ -628,15 +650,15 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     BaseConditions = Spec.base_conditions,
     GuardExpr = Spec.guard_expr,
     BranchConditionExpr = Spec.branch_condition_expr,
-    ThenCalls = Spec.then_calls,
-    ElseCalls = Spec.else_calls,
+    ThenBody = Spec.then_body,
+    ElseBody = Spec.else_body,
     typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
     typr_mutual_tree_dual_branch_recursive_branch_lines(
         GroupName,
         GuardExpr,
         BranchConditionExpr,
-        ThenCalls,
-        ElseCalls,
+        ThenBody,
+        ElseBody,
         RecursiveLines
     ),
     typr_mutual_false_lines(GroupName, FalseLines),
@@ -656,14 +678,14 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     BaseConditions = Spec.base_conditions,
     GuardExpr = Spec.guard_expr,
     BranchConditionExpr = Spec.branch_condition_expr,
-    ThenCalls = Spec.then_calls,
-    ElseCalls = Spec.else_calls,
+    ThenBody = Spec.then_body,
+    ElseBody = Spec.else_body,
     typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
     typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
         GuardExpr,
         BranchConditionExpr,
-        ThenCalls,
-        ElseCalls,
+        ThenBody,
+        ElseBody,
         RecursiveLines
     ),
     format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
@@ -940,15 +962,15 @@ typr_mutual_tree_dual_branch_recursive_branch_lines(
     GroupName,
     GuardExpr,
     BranchConditionExpr,
-    ThenCalls,
-    ElseCalls,
+    ThenBody,
+    ElseBody,
     Lines
 ) :-
     format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
     format(string(BranchIfLine), '            if (~w) {', [BranchConditionExpr]),
     format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
-    typr_mutual_tree_dual_branch_call_lines(ThenCalls, '                ', ThenLines),
-    typr_mutual_tree_dual_branch_call_lines(ElseCalls, '                ', ElseLines),
+    typr_mutual_tree_branch_body_lines(ThenBody, '                ', ThenLines),
+    typr_mutual_tree_branch_body_lines(ElseBody, '                ', ElseLines),
     append([IfLine, BranchIfLine], ThenLines, Lines0),
     append(Lines0, ['            } else {'], Lines1),
     append(Lines1, ElseLines, Lines2),
@@ -957,18 +979,46 @@ typr_mutual_tree_dual_branch_recursive_branch_lines(
 typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
     GuardExpr,
     BranchConditionExpr,
-    ThenCalls,
-    ElseCalls,
+    ThenBody,
+    ElseBody,
     Lines
 ) :-
     format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
     format(string(BranchIfLine), '            if (~w) {', [BranchConditionExpr]),
-    typr_mutual_tree_dual_branch_call_lines_no_memo(ThenCalls, '                ', ThenLines),
-    typr_mutual_tree_dual_branch_call_lines_no_memo(ElseCalls, '                ', ElseLines),
+    typr_mutual_tree_branch_body_lines_no_memo(ThenBody, '                ', ThenLines),
+    typr_mutual_tree_branch_body_lines_no_memo(ElseBody, '                ', ElseLines),
     append([IfLine, BranchIfLine], ThenLines, Lines0),
     append(Lines0, ['            } else {'], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, ['            }'], Lines).
+
+typr_mutual_tree_branch_body_lines(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines(ThenBody, NestedPrefix, ThenLines),
+    typr_mutual_tree_branch_body_lines(ElseBody, NestedPrefix, ElseLines),
+    append([IfLine], ThenLines, Lines0),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_body_lines(branch_calls(Calls), Prefix, Lines) :-
+    typr_mutual_tree_dual_branch_call_lines(Calls, Prefix, Lines).
+
+typr_mutual_tree_branch_body_lines_no_memo(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines_no_memo(ThenBody, NestedPrefix, ThenLines),
+    typr_mutual_tree_branch_body_lines_no_memo(ElseBody, NestedPrefix, ElseLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], ThenLines, Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo(branch_calls(Calls), Prefix, Lines) :-
+    typr_mutual_tree_dual_branch_call_lines_no_memo(Calls, Prefix, Lines).
 
 typr_mutual_tree_dual_branch_call_lines(
     [branch_call(FirstHelperName, FirstStepExpr), branch_call(SecondHelperName, SecondStepExpr)],

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -61,6 +61,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_branch_pre(_)),
     retractall(user:typr_mutual_even_tree_recursive_branch(_)),
     retractall(user:typr_mutual_odd_tree_recursive_branch(_)),
+    retractall(user:typr_mutual_even_tree_nested_branch(_)),
+    retractall(user:typr_mutual_odd_tree_nested_branch(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -514,6 +516,57 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_recursive_bran
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_recursive_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_nested_branch_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_branch([])),
+    assertz(user:(typr_mutual_even_tree_nested_branch([V, L, R]) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_odd_tree_nested_branch(L),
+                typr_mutual_odd_tree_nested_branch(R)
+            ;   typr_mutual_odd_tree_nested_branch(R),
+                typr_mutual_odd_tree_nested_branch(L)
+            )
+        ;   typr_mutual_odd_tree_nested_branch(L),
+            typr_mutual_odd_tree_nested_branch(R)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_branch([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_branch([V, L, R]) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_even_tree_nested_branch(L),
+                typr_mutual_even_tree_nested_branch(R)
+            ;   typr_mutual_even_tree_nested_branch(R),
+                typr_mutual_even_tree_nested_branch(L)
+            )
+        ;   typr_mutual_even_tree_nested_branch(L),
+            typr_mutual_even_tree_nested_branch(R)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_nested_branch/1, typr_mutual_odd_tree_nested_branch/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_nested_branch <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_nested_branch <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_nested_branch_typr_mutual_odd_tree_nested_branch_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 10) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_nested_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_nested_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_nested_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_nested_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -369,6 +369,51 @@ test(structural_tree_dual_mutual_recursive_branch_output_checks_with_typr, [cond
     retractall(user:typr_mutual_even_tree_recursive_branch(_)),
     retractall(user:typr_mutual_odd_tree_recursive_branch(_)).
 
+test(structural_tree_dual_mutual_nested_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_branch([])),
+    assertz(user:(typr_mutual_even_tree_nested_branch([V, L, R]) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_odd_tree_nested_branch(L),
+                typr_mutual_odd_tree_nested_branch(R)
+            ;   typr_mutual_odd_tree_nested_branch(R),
+                typr_mutual_odd_tree_nested_branch(L)
+            )
+        ;   typr_mutual_odd_tree_nested_branch(L),
+            typr_mutual_odd_tree_nested_branch(R)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_branch([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_branch([V, L, R]) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_even_tree_nested_branch(L),
+                typr_mutual_even_tree_nested_branch(R)
+            ;   typr_mutual_even_tree_nested_branch(R),
+                typr_mutual_even_tree_nested_branch(L)
+            )
+        ;   typr_mutual_even_tree_nested_branch(L),
+            typr_mutual_even_tree_nested_branch(R)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_nested_branch(_)),
+    retractall(user:typr_mutual_odd_tree_nested_branch(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion subset for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when a guarded mutual-recursive branch body contains one nested branch-local control point before the shared two subtree calls.

A representative supported shape is:

```prolog
typr_mutual_even_tree_nested_branch([]).
typr_mutual_even_tree_nested_branch([V, L, R]) :-
    ( V > 0 ->
        ( V > 10 ->
            typr_mutual_odd_tree_nested_branch(L),
            typr_mutual_odd_tree_nested_branch(R)
        ;   typr_mutual_odd_tree_nested_branch(R),
            typr_mutual_odd_tree_nested_branch(L)
        )
    ;   typr_mutual_odd_tree_nested_branch(L),
        typr_mutual_odd_tree_nested_branch(R)
    ).

typr_mutual_odd_tree_nested_branch([_, [], []]).
typr_mutual_odd_tree_nested_branch([V, L, R]) :-
    ( V > 0 ->
        ( V > 10 ->
            typr_mutual_even_tree_nested_branch(L),
            typr_mutual_even_tree_nested_branch(R)
        ;   typr_mutual_even_tree_nested_branch(R),
            typr_mutual_even_tree_nested_branch(L)
        )
    ;   typr_mutual_even_tree_nested_branch(L),
        typr_mutual_even_tree_nested_branch(R)
    ).
```

Before this PR, that shape failed with `No mutual recursion support for target typr`. After this PR, it lowers natively and passes real `typr check` validation.

## Why This PR Exists

Recent TypR recursion work already established native support for conservative mutual-recursion shapes such as:

- numeric boolean SCCs like `is_even/1` / `is_odd/1`
- list-structural boolean SCCs like `even_list/1` / `odd_list/1`
- one-subtree tree SCCs like `even_left_tree/1` / `odd_left_tree/1`
- dual-subtree tree SCCs like `even_tree/1` / `odd_tree/1`
- dual-subtree tree SCCs with alias-style prework before the two recursive calls
- dual-subtree tree SCCs with guarded alias selection before the two recursive calls
- dual-subtree tree SCCs with direct recursive subtree calls inside supported guarded branch bodies

That still left a real nearby gap.

If a guarded mutual-recursive branch body contained another nested `if -> then ; else` before the two subtree calls, the current TypR mutual-recursion matcher no longer recognized the clause as supported mutual recursion. The overall shape was still conservative, but the branch-local recursion structure was one level deeper than the existing TypR mutual path handled.

This PR closes that gap without widening TypR into general SCC lowering.

## Main Changes

### 1. TypR mutual recursion now recognizes one nested branch-local control point before shared subtree calls

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-recursion backend now:

- detects supported dual-subtree tree SCCs whose guarded branch bodies contain another nested `if -> then ; else`
- recursively lowers those nested mutual branch bodies instead of requiring a flat branch body with only one control point
- preserves the existing TypR-native boolean rejoin shape with `left_result && right_result`

This keeps the TypR scope narrow:

- arity `1`
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- one recursive clause per predicate
- two recursive subtree calls in the recursive branch shape
- one nested branch-local control point around those calls
- shared boolean rejoin after those calls

### 2. Added focused regression coverage for nested structural tree mutual branches

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level regression coverage verifies that:

- the nested tree-mutual branch-body shape stays native in TypR
- both subtree helper calls are still emitted in each nested branch
- branch-local call order is preserved across the inner branch
- the final rejoin remains `left_result && right_result`
- wrapped standalone-R fallback is not used
- generated TypR is still locally valid

### 3. Added real TypR toolchain validation for the same shape

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain test writes the generated TypR program to a smoke project and runs real `typr check`, so this support is validated against the actual TypR toolchain rather than only string-shape assertions.

### 4. Documentation now reflects the broader conservative mutual-recursion subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs where supported guarded branch bodies may contain one nested branch-local control point before the shared boolean rejoin.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for guarded dual-subtree tree mutual recursion with one nested branch-local control point before the shared boolean rejoin
- continued TypR CLI validation for generated output

What it does not claim:

- nested branch-local prework around those mutual subtree calls
- broader branch-heavy SCC lowering
- non-boolean mutual-recursive tree groups
- arbitrary recursive-body native TypR lowering
- general recursive SCC lowering

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with guarded alias selection before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with direct recursive subtree calls inside supported guarded branch bodies before the shared boolean rejoin
- dual-subtree tree-structural boolean SCCs with one nested branch-local control point around those calls before the shared boolean rejoin

The TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for one nested branch-local control point inside supported guarded dual-subtree tree mutual-recursive branch bodies
- target-level regression coverage for that shape
- real `typr check` coverage for that shape
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- nested branch-local prework around those mutual subtree calls
- richer branch-local state around mutual subtree calls
- broader structural tree SCCs with more complex branch-local recombination
- non-boolean or multi-output mutual recursion
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes a real mutual-recursion gap without weakening the TypR backend’s conservative design boundary.

It gives the project:

- fewer false failures for obvious structural tree SCCs
- stronger native TypR coverage for nested guarded tree mutual recursion
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a precise, defensible way rather than jumping to general SCC lowering.
