### PR TITLE
docs(csharp-query): document latest cache smoke run resolution

### DIFF
--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -191,9 +191,13 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
     - per-slice status and duration
   - Manual compare workflow: `.github/workflows/csharp_query_cache_smoke_diff.yml`
     - Trigger: `workflow_dispatch`
-    - Required inputs:
+    - Optional explicit run-ID overrides:
       - `baseline_run_id`
       - `compare_run_id`
+    - Automatic latest-successful resolution inputs:
+      - `baseline_ref` (defaults to `main`)
+      - `compare_ref` (defaults to the workflow dispatch ref)
+    - Artifact inputs:
       - `baseline_artifact_name` (defaults to `csharp-query-smoke-summary-json`)
       - `compare_artifact_name` (defaults to `csharp-query-smoke-summary-json`)
     - Optional threshold inputs:
@@ -204,6 +208,10 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
       - diff JSON artifact: `csharp-query-smoke-diff-json`
       - job summary with:
         - baseline / compare run IDs
+        - resolution source (`explicit` vs `latest-successful`)
+        - requested refs
+        - resolved refs
+        - resolved run URLs
         - artifact names
         - overall result delta
         - total duration delta


### PR DESCRIPTION
  ## Summary
  Update the C# query runtime docs to describe the new ref-based automatic run resolution in the manual
  cache smoke diff workflow.

  ## What changed
  - Updated `docs/targets/csharp-query-runtime.md`
  - Documented that the manual compare workflow now supports:
    - optional explicit `baseline_run_id` / `compare_run_id`
    - automatic `baseline_ref` / `compare_ref` resolution
    - separate artifact-name inputs
  - Documented that the workflow job summary now includes:
    - resolution source (`explicit` vs `latest-successful`)
    - requested refs
    - resolved refs
    - resolved run URLs

  ## Why
  The manual cache smoke diff workflow no longer requires raw run IDs for the common case, but the
  runtime docs still described only the older manual-run-ID model. This PR brings the documentation back
  in sync with the current workflow behavior.

  ## Validation
  - Sanity-checked the documentation against:
    - `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Confirmed the documented input names and summary fields match the workflow:
    - `baseline_run_id`
    - `compare_run_id`
    - `baseline_ref`
    - `compare_ref`
    - `baseline_artifact_name`
    - `compare_artifact_name`
    - `fail_on_status_regression`
    - `max_total_duration_delta_seconds`
    - `max_slice_duration_delta_seconds`
    - resolved run URLs