### PR TITLE
Keep native TypR nested tree mutual prework

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ includes:
   branch-local alias selection before the two recursive subtree calls, or
   direct recursive subtree calls inside supported guarded branch bodies,
   including one nested branch-local control point around those calls before
-  the shared boolean rejoin, lowered to TypR functions that use
-  raw-expression memoized helper bodies inside TypR instead of wrapped-R
-  fallback
+  the shared boolean rejoin and shared branch-local guard prework before a
+  nested mutual branch, lowered to TypR functions that use raw-expression
+  memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -209,7 +209,8 @@ bring-up.
     or direct recursive subtree calls inside supported guarded branch
     bodies before the shared boolean rejoin after the two recursive subtree
     calls, including one nested branch-local control point around those
-    calls
+    calls and shared branch-local guard prework before a nested mutual
+    branch
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -388,9 +388,10 @@ Current TypR lowering policy is intentionally mixed:
   alias-style prework, guarded branch-local alias selection, or direct
   recursive subtree calls inside supported guarded branch bodies before
   those two recursive subtree calls rejoin via a shared boolean result,
-  including one nested branch-local control point around those calls,
-  using raw-expression memoized helper bodies inside TypR rather than
-  wrapped-R fallback
+  including one nested branch-local control point around those calls and
+  shared branch-local guard prework before a nested mutual branch, using
+  raw-expression memoized helper bodies inside TypR rather than wrapped-R
+  fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -79,9 +79,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      alias-style prework, guarded branch-local alias selection, or direct
      recursive subtree calls inside supported guarded branch bodies before
      the shared boolean rejoin after the two recursive subtree calls,
-     including one nested branch-local control point around those calls,
-     and boolean return types, emitted as TypR functions with
-     raw-expression memoized helper bodies
+     including one nested branch-local control point around those calls and
+     shared branch-local guard prework before a nested mutual branch, and
+     boolean return types, emitted as TypR functions with raw-expression
+     memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -463,6 +463,26 @@ typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditi
     native_typr_if_condition(IfGoal, VarMap, BranchCondition0),
     typr_condition_expr_text(BranchCondition0, BranchConditionExpr).
 
+typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, AliasMap, none).
+typr_mutual_tree_branch_prework([Goal|Rest], ValueVar, AliasMap0, AliasMap, GuardExpr) :-
+    (   typr_mutual_tree_alias_goal(Goal)
+    ->  typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1),
+        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap1, AliasMap, GuardExpr)
+    ;   typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, VarMap),
+        native_typr_guard_goal(Goal, VarMap, GuardCondition),
+        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap0, AliasMap, RestGuardExpr),
+        typr_mutual_tree_guard_expr_join(GuardCondition, RestGuardExpr, GuardExpr)
+    ).
+
+typr_mutual_tree_guard_expr_join(GuardCondition, none, GuardCondition) :-
+    !.
+typr_mutual_tree_guard_expr_join(GuardCondition, RestGuardExpr, GuardExpr) :-
+    combine_typr_conditions([GuardCondition, RestGuardExpr], GuardExpr).
+
+typr_mutual_tree_guard_wrap(none, Body, Body) :-
+    !.
+typr_mutual_tree_guard_wrap(GuardExpr, Body, branch_guard(GuardExpr, Body)).
+
 typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap) :-
     findall(
         Var-Expr,
@@ -483,8 +503,7 @@ typr_mutual_tree_branch_call(call_spec(_Side, NextPred, StepExpr), branch_call(H
 
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
     append(PreGoals, [NestedIfGoal], Goals),
-    maplist(typr_mutual_tree_alias_goal, PreGoals),
-    typr_mutual_tree_alias_map(PreGoals, AliasMap0, AliasMap),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
@@ -493,14 +512,19 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
     typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ElseBody),
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr),
-    Body = branch_if(BranchConditionExpr, ThenBody, ElseBody).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, _ValueVar, AliasMap0, branch_calls(Calls)) :-
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_if(BranchConditionExpr, ThenBody, ElseBody),
+        Body
+    ).
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
-    typr_mutual_tree_alias_map(PreGoals, AliasMap0, AliasMap),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
     maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap), [GoalA, GoalB], GoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
-    maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls).
+    maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
+    typr_mutual_tree_guard_wrap(GuardExpr, branch_calls(Calls), Body).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (
@@ -1003,6 +1027,15 @@ typr_mutual_tree_branch_body_lines(branch_if(BranchConditionExpr, ThenBody, Else
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_body_lines(branch_guard(GuardExpr, Body), Prefix, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines(Body, NestedPrefix, BodyLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], BodyLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
 typr_mutual_tree_branch_body_lines(branch_calls(Calls), Prefix, Lines) :-
     typr_mutual_tree_dual_branch_call_lines(Calls, Prefix, Lines).
 
@@ -1017,6 +1050,15 @@ typr_mutual_tree_branch_body_lines_no_memo(branch_if(BranchConditionExpr, ThenBo
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo(branch_guard(GuardExpr, Body), Prefix, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines_no_memo(Body, NestedPrefix, BodyLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    FALSE', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], BodyLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
 typr_mutual_tree_branch_body_lines_no_memo(branch_calls(Calls), Prefix, Lines) :-
     typr_mutual_tree_dual_branch_call_lines_no_memo(Calls, Prefix, Lines).
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -63,6 +63,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_recursive_branch(_)),
     retractall(user:typr_mutual_even_tree_nested_branch(_)),
     retractall(user:typr_mutual_odd_tree_nested_branch(_)),
+    retractall(user:typr_mutual_even_tree_nested_branch_pre(_)),
+    retractall(user:typr_mutual_odd_tree_nested_branch_pre(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -567,6 +569,61 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_nested_branch_
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_nested_branch_prework_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_branch_pre([])),
+    assertz(user:(typr_mutual_even_tree_nested_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            V >= 0,
+            ( V > 10 ->
+                typr_mutual_odd_tree_nested_branch_pre(L),
+                typr_mutual_odd_tree_nested_branch_pre(R)
+            ;   typr_mutual_odd_tree_nested_branch_pre(R),
+                typr_mutual_odd_tree_nested_branch_pre(L)
+            )
+        ;   typr_mutual_odd_tree_nested_branch_pre(L),
+            typr_mutual_odd_tree_nested_branch_pre(R)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_branch_pre([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            V >= 0,
+            ( V > 10 ->
+                typr_mutual_even_tree_nested_branch_pre(L),
+                typr_mutual_even_tree_nested_branch_pre(R)
+            ;   typr_mutual_even_tree_nested_branch_pre(R),
+                typr_mutual_even_tree_nested_branch_pre(L)
+            )
+        ;   typr_mutual_even_tree_nested_branch_pre(L),
+            typr_mutual_even_tree_nested_branch_pre(R)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_branch_pre/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_branch_pre/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_branch_pre/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_nested_branch_pre/1, typr_mutual_odd_tree_nested_branch_pre/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_nested_branch_pre <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_nested_branch_pre <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_nested_branch_pre_typr_mutual_odd_tree_nested_branch_pre_memo <- new.env(hash=TRUE, parent=emptyenv())")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= 0 }@) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 10) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_nested_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_nested_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_nested_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_nested_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = FALSE;")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -414,6 +414,53 @@ test(structural_tree_dual_mutual_nested_branch_output_checks_with_typr, [conditi
     retractall(user:typr_mutual_even_tree_nested_branch(_)),
     retractall(user:typr_mutual_odd_tree_nested_branch(_)).
 
+test(structural_tree_dual_mutual_nested_branch_prework_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_branch_pre([])),
+    assertz(user:(typr_mutual_even_tree_nested_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            V >= 0,
+            ( V > 10 ->
+                typr_mutual_odd_tree_nested_branch_pre(L),
+                typr_mutual_odd_tree_nested_branch_pre(R)
+            ;   typr_mutual_odd_tree_nested_branch_pre(R),
+                typr_mutual_odd_tree_nested_branch_pre(L)
+            )
+        ;   typr_mutual_odd_tree_nested_branch_pre(L),
+            typr_mutual_odd_tree_nested_branch_pre(R)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_branch_pre([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_branch_pre([V, L, R]) :-
+        ( V > 0 ->
+            V >= 0,
+            ( V > 10 ->
+                typr_mutual_even_tree_nested_branch_pre(L),
+                typr_mutual_even_tree_nested_branch_pre(R)
+            ;   typr_mutual_even_tree_nested_branch_pre(R),
+                typr_mutual_even_tree_nested_branch_pre(L)
+            )
+        ;   typr_mutual_even_tree_nested_branch_pre(L),
+            typr_mutual_even_tree_nested_branch_pre(R)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_branch_pre/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_branch_pre/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_branch_pre/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_branch_pre/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_nested_branch_pre(_)),
+    retractall(user:typr_mutual_odd_tree_nested_branch_pre(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion subset for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when a guarded mutual-recursive branch body performs shared guard prework before entering a nested branch that chooses the subtree-call order.

A representative supported shape is:

```prolog
typr_mutual_even_tree_nested_branch_pre([]).
typr_mutual_even_tree_nested_branch_pre([V, L, R]) :-
    ( V > 0 ->
        V >= 0,
        ( V > 10 ->
            typr_mutual_odd_tree_nested_branch_pre(L),
            typr_mutual_odd_tree_nested_branch_pre(R)
        ;   typr_mutual_odd_tree_nested_branch_pre(R),
            typr_mutual_odd_tree_nested_branch_pre(L)
        )
    ;   typr_mutual_odd_tree_nested_branch_pre(L),
        typr_mutual_odd_tree_nested_branch_pre(R)
    ).

typr_mutual_odd_tree_nested_branch_pre([_, [], []]).
typr_mutual_odd_tree_nested_branch_pre([V, L, R]) :-
    ( V > 0 ->
        V >= 0,
        ( V > 10 ->
            typr_mutual_even_tree_nested_branch_pre(L),
            typr_mutual_even_tree_nested_branch_pre(R)
        ;   typr_mutual_even_tree_nested_branch_pre(R),
            typr_mutual_even_tree_nested_branch_pre(L)
        )
    ;   typr_mutual_even_tree_nested_branch_pre(L),
        typr_mutual_even_tree_nested_branch_pre(R)
    ).
```

Before this PR, that shape failed with `No mutual recursion support for target typr`. After this PR, it lowers natively and passes real `typr check` validation.

## Why This PR Exists

Recent TypR recursion work already established native support for conservative mutual-recursion shapes such as:

- numeric boolean SCCs like `is_even/1` / `is_odd/1`
- list-structural boolean SCCs like `even_list/1` / `odd_list/1`
- one-subtree tree SCCs like `even_left_tree/1` / `odd_left_tree/1`
- dual-subtree tree SCCs like `even_tree/1` / `odd_tree/1`
- dual-subtree tree SCCs with alias-style prework before the two recursive calls
- dual-subtree tree SCCs with guarded alias selection before the two recursive calls
- dual-subtree tree SCCs with direct recursive subtree calls inside supported guarded branch bodies
- dual-subtree tree SCCs with one nested branch-local control point around those calls

That still left a real nearby gap.

If a guarded mutual-recursive branch body did shared guard prework before entering a nested branch that then selected the subtree-call order, the current TypR mutual-recursion path no longer recognized the clause as supported mutual recursion. The overall shape was still conservative, but the branch body contained both prework and nested control around the shared subtree-call rejoin.

This PR closes that gap without widening TypR into general SCC lowering.

## Main Changes

### 1. TypR mutual tree branches now support shared guard prework before a nested branch

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-recursion backend now:

- handles ordered branch prework for mutual tree branch bodies
- accepts both alias goals and native guard goals before a nested mutual branch or shared subtree calls
- keeps those guarded branch-local checks on the native TypR path instead of dropping to unsupported fallback
- emits branch-local guard wrappers that resolve to `FALSE` when the guard fails

This keeps the TypR scope narrow:

- arity `1`
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- one recursive clause per predicate
- two recursive subtree calls in the recursive branch shape
- one nested branch-local control point around those calls
- shared boolean rejoin after those calls
- shared guard prework before the nested mutual branch

### 2. Added focused regression coverage for nested mutual branch prework

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level regression coverage verifies that:

- the nested tree-mutual prework shape stays native in TypR
- the shared branch-local guard is emitted before the nested branch
- both subtree helper calls are still emitted in each nested branch arm
- the final rejoin remains `left_result && right_result`
- failed branch-local guard paths stay native and resolve to `FALSE`
- wrapped standalone-R fallback is not used
- generated TypR is still locally valid

### 3. Added real TypR toolchain validation for the same shape

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain test writes the generated TypR program to a smoke project and runs real `typr check`, so this support is validated against the actual TypR toolchain rather than only string-shape assertions.

### 4. Documentation now reflects the broader conservative mutual-recursion subset

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs where supported guarded branch bodies may perform shared guard prework before a nested mutual branch and a shared boolean rejoin.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for guarded dual-subtree tree mutual recursion with shared branch-local guard prework before a nested branch
- continued TypR CLI validation for generated output

What it does not claim:

- richer branch-local state beyond conservative guard/alias prework
- broader branch-heavy SCC lowering
- non-boolean mutual-recursive tree groups
- arbitrary recursive-body native TypR lowering
- general recursive SCC lowering

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with guarded alias selection before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with direct recursive subtree calls inside supported guarded branch bodies before the shared boolean rejoin
- dual-subtree tree-structural boolean SCCs with one nested branch-local control point around those calls before the shared boolean rejoin
- dual-subtree tree-structural boolean SCCs with shared guard prework before a nested mutual branch around those calls

The TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for shared guard prework before a nested branch inside supported dual-subtree tree mutual-recursive branch bodies
- target-level regression coverage for that shape
- real `typr check` coverage for that shape
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- richer branch-local state around direct mutual recursive calls
- broader structural tree SCCs with more complex branch-local recombination
- non-boolean or multi-output mutual recursion
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes a real mutual-recursion gap without weakening the TypR backend’s conservative design boundary.

It gives the project:

- fewer false failures for obvious structural tree SCCs
- stronger native TypR coverage for nested guarded tree mutual recursion
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a precise, defensible way rather than jumping to general SCC lowering.
