### PR TITLE
ci(csharp-query): surface cache smoke diff SHAs

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -232,6 +232,39 @@ jobs:
 
           & pwsh @diffArgs
 
+      - name: Annotate cache smoke diff JSON with resolved run metadata
+        if: always()
+        shell: pwsh
+        run: |
+          if (-not (Test-Path $env:CACHE_SMOKE_DIFF_JSON_PATH)) {
+            Write-Host "Cache smoke diff JSON was not produced; skipping run metadata annotation."
+            exit 0
+          }
+
+          $diff = Get-Content $env:CACHE_SMOKE_DIFF_JSON_PATH -Raw | ConvertFrom-Json
+
+          $diff | Add-Member -NotePropertyName baselineRun -NotePropertyValue ([pscustomobject]@{
+            runId = $env:BASELINE_RESOLVED_RUN_ID
+            resolutionSource = $env:BASELINE_RESOLUTION_SOURCE
+            requestedRef = $env:BASELINE_REQUESTED_REF
+            resolvedRef = $env:BASELINE_RESOLVED_REF
+            resolvedSha = $env:BASELINE_RESOLVED_SHA
+            runUrl = $env:BASELINE_RESOLVED_URL
+            artifactName = $env:BASELINE_ARTIFACT_NAME
+          }) -Force
+
+          $diff | Add-Member -NotePropertyName compareRun -NotePropertyValue ([pscustomobject]@{
+            runId = $env:COMPARE_RESOLVED_RUN_ID
+            resolutionSource = $env:COMPARE_RESOLUTION_SOURCE
+            requestedRef = $env:COMPARE_REQUESTED_REF
+            resolvedRef = $env:COMPARE_RESOLVED_REF
+            resolvedSha = $env:COMPARE_RESOLVED_SHA
+            runUrl = $env:COMPARE_RESOLVED_URL
+            artifactName = $env:COMPARE_ARTIFACT_NAME
+          }) -Force
+
+          $diff | ConvertTo-Json -Depth 10 | Set-Content -Path $env:CACHE_SMOKE_DIFF_JSON_PATH
+
       - name: Upload cache smoke diff JSON
         if: always()
         uses: actions/upload-artifact@v4
@@ -254,10 +287,12 @@ jobs:
               "",
               "- Baseline run ID: `"$($env:BASELINE_RESOLVED_RUN_ID)`"",
               "- Baseline resolution: `"$($env:BASELINE_RESOLUTION_SOURCE)`"` (requested ref: `"$($env:BASELINE_REQUESTED_REF)`"`, resolved ref: `"$($env:BASELINE_RESOLVED_REF)`"`)",
+              "- Baseline resolved SHA: `"$($env:BASELINE_RESOLVED_SHA)`"",
               "- Baseline run URL: `"$($env:BASELINE_RESOLVED_URL)`"",
               "- Baseline artifact: `"$($env:BASELINE_ARTIFACT_NAME)`"",
               "- Compare run ID: `"$($env:COMPARE_RESOLVED_RUN_ID)`"",
               "- Compare resolution: `"$($env:COMPARE_RESOLUTION_SOURCE)`"` (requested ref: `"$($env:COMPARE_REQUESTED_REF)`"`, resolved ref: `"$($env:COMPARE_RESOLVED_REF)`"`)",
+              "- Compare resolved SHA: `"$($env:COMPARE_RESOLVED_SHA)`"",
               "- Compare run URL: `"$($env:COMPARE_RESOLVED_URL)`"",
               "- Compare artifact: `"$($env:COMPARE_ARTIFACT_NAME)`"",
               "- Diff JSON artifact: `"$($env:CACHE_SMOKE_DIFF_ARTIFACT_NAME)`"",

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -211,6 +211,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - resolution source (`explicit` vs `latest-successful`)
         - requested refs
         - resolved refs
+        - resolved SHAs
         - resolved run URLs
         - artifact names
         - overall result delta
@@ -218,6 +219,9 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - threshold settings
         - threshold pass/fail result
         - threshold failure list when present
+      - diff JSON metadata with:
+        - `baselineRun.runId`, `baselineRun.resolutionSource`, `baselineRun.requestedRef`, `baselineRun.resolvedRef`, `baselineRun.resolvedSha`, `baselineRun.runUrl`, `baselineRun.artifactName`
+        - `compareRun.runId`, `compareRun.resolutionSource`, `compareRun.requestedRef`, `compareRun.resolvedRef`, `compareRun.resolvedSha`, `compareRun.runUrl`, `compareRun.artifactName`
 - Environment variables (used by the test harness):
   - `SKIP_CSHARP_EXECUTION=1` (generate C# projects but do not execute via Prolog)
   - `CSHARP_QUERY_OUTPUT_DIR=...` (where generated projects are written)


### PR DESCRIPTION
  ## Summary
  Expose exact commit SHA provenance in the manual cache smoke diff workflow so both the job summary and
  the diff JSON artifact show the precise revisions being compared.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Extended the job summary to include:
    - baseline resolved SHA
    - compare resolved SHA
  - Added a post-diff annotation step that enriches the uploaded diff JSON with run metadata for both
  sides:
    - `baselineRun.runId`
    - `baselineRun.resolutionSource`
    - `baselineRun.requestedRef`
    - `baselineRun.resolvedRef`
    - `baselineRun.resolvedSha`
    - `baselineRun.runUrl`
    - `baselineRun.artifactName`
    - matching `compareRun.*` fields
  - Updated `docs/targets/csharp-query-runtime.md` to document the new SHA fields in:
    - the manual compare workflow job summary
    - the diff JSON metadata

  ## Why
  The manual diff workflow already resolved baseline and compare SHAs internally, but it did not surface
  them anywhere. That left a provenance gap in both:
  - the human-readable job summary
  - the machine-readable diff artifact

  This PR closes that gap so it is clear exactly which commits were compared.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Replayed the workflow’s JSON-annotation logic locally against an existing
  `cache_smoke_sequence_diff.json`
  - Confirmed the rewritten JSON included:
    - `baselineRun.resolvedSha`
    - `compareRun.resolvedSha`
  - Sanity-checked the updated docs against:
    - `.github/workflows/csharp_query_cache_smoke_diff.yml`