### PR TITLE
Keep native TypR mutual tree call state

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,10 @@ includes:
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
   including dual-subtree tree SCCs with alias-style prework or guarded
   branch-local alias selection before the two recursive subtree calls, or
-  direct recursive subtree calls inside supported guarded branch bodies,
-  including one nested branch-local control point around those calls before
-  the shared boolean rejoin and shared branch-local guard prework before a
+  direct recursive subtree calls inside supported guarded branch bodies with
+  limited branch-local alias or guard state around those calls, including
+  one nested branch-local control point around those calls before the
+  shared boolean rejoin and shared branch-local guard prework before a
   nested mutual branch, lowered to TypR functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -207,7 +207,8 @@ bring-up.
     `odd_tree/1`-style tree-structural SCC shape with two-subtree boolean
     descent and alias-style prework, guarded branch-local alias selection,
     or direct recursive subtree calls inside supported guarded branch
-    bodies before the shared boolean rejoin after the two recursive subtree
+    bodies with limited branch-local alias or guard state around those
+    calls before the shared boolean rejoin after the two recursive subtree
     calls, including one nested branch-local control point around those
     calls and shared branch-local guard prework before a nested mutual
     branch

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -386,7 +386,8 @@ Current TypR lowering policy is intentionally mixed:
   or the `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
   `[]` / `[V, [], []]` base cases, two-subtree boolean descent, and
   alias-style prework, guarded branch-local alias selection, or direct
-  recursive subtree calls inside supported guarded branch bodies before
+  recursive subtree calls inside supported guarded branch bodies with
+  limited branch-local alias or guard state around those calls before
   those two recursive subtree calls rejoin via a shared boolean result,
   including one nested branch-local control point around those calls and
   shared branch-local guard prework before a nested mutual branch, using

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -77,7 +77,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      or `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
      `[]` / `[V, [], []]` base cases, two-subtree boolean descent,
      alias-style prework, guarded branch-local alias selection, or direct
-     recursive subtree calls inside supported guarded branch bodies before
+     recursive subtree calls inside supported guarded branch bodies with
+     limited branch-local alias or guard state around those calls before
      the shared boolean rejoin after the two recursive subtree calls,
      including one nested branch-local control point around those calls and
      shared branch-local guard prework before a nested mutual branch, and

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -483,6 +483,12 @@ typr_mutual_tree_guard_wrap(none, Body, Body) :-
     !.
 typr_mutual_tree_guard_wrap(GuardExpr, Body, branch_guard(GuardExpr, Body)).
 
+typr_mutual_tree_nested_goal(Goal) :-
+    typr_if_then_else_goal(Goal, _IfGoal, _ThenGoal, _ElseGoal),
+    !.
+typr_mutual_tree_nested_goal(Goal) :-
+    typr_if_then_goal(Goal, _IfGoal, _ThenGoal).
+
 typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap) :-
     findall(
         Var-Expr,
@@ -525,6 +531,42 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
     typr_mutual_tree_guard_wrap(GuardExpr, branch_calls(Calls), Body).
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, GoalSpecs, Steps),
+    typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
+    typr_mutual_tree_branch_body_from_steps(Steps, Body).
+
+typr_mutual_tree_branch_sequence(_GroupPredicates, [], _ValueVar, _AliasMap, [], []).
+typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, GoalSpecs, Steps) :-
+    typr_strip_module_goal(Goal0, Goal),
+    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, Goal, GoalSpec)
+    ->  typr_mutual_tree_branch_call(GoalSpec, Call),
+        GoalSpecs = [GoalSpec|RestGoalSpecs],
+        Steps = [step_call(Call)|RestSteps],
+        AliasMap1 = AliasMap0
+    ;   typr_mutual_tree_alias_goal(Goal)
+    ->  GoalSpecs = RestGoalSpecs,
+        Steps = RestSteps,
+        typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1)
+    ;   \+ typr_mutual_tree_nested_goal(Goal),
+        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, VarMap),
+        native_typr_guard_goal(Goal, VarMap, GuardCondition)
+    ->  GoalSpecs = RestGoalSpecs,
+        Steps = [step_guard(GuardCondition)|RestSteps],
+        AliasMap1 = AliasMap0
+    ),
+    typr_mutual_tree_branch_sequence(
+        GroupPredicates,
+        Rest,
+        ValueVar,
+        AliasMap1,
+        RestGoalSpecs,
+        RestSteps
+    ).
+
+typr_mutual_tree_branch_body_from_steps([step_call(Call1), step_call(Call2)], branch_calls([Call1, Call2])) :-
+    !.
+typr_mutual_tree_branch_body_from_steps(Steps, branch_steps(Steps)).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (
@@ -1036,6 +1078,8 @@ typr_mutual_tree_branch_body_lines(branch_guard(GuardExpr, Body), Prefix, Lines)
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], BodyLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines(branch_steps(Steps), Prefix, Lines) :-
+    typr_mutual_tree_branch_steps_lines(Steps, Prefix, 1, Lines).
 typr_mutual_tree_branch_body_lines(branch_calls(Calls), Prefix, Lines) :-
     typr_mutual_tree_dual_branch_call_lines(Calls, Prefix, Lines).
 
@@ -1059,8 +1103,61 @@ typr_mutual_tree_branch_body_lines_no_memo(branch_guard(GuardExpr, Body), Prefix
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], BodyLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo(branch_steps(Steps), Prefix, Lines) :-
+    typr_mutual_tree_branch_steps_lines_no_memo(Steps, Prefix, 1, Lines).
 typr_mutual_tree_branch_body_lines_no_memo(branch_calls(Calls), Prefix, Lines) :-
     typr_mutual_tree_dual_branch_call_lines_no_memo(Calls, Prefix, Lines).
+
+typr_mutual_tree_branch_steps_lines([], Prefix, _Index, [ResultLine]) :-
+    format(string(ResultLine), '~wresult = left_result && right_result;', [Prefix]).
+typr_mutual_tree_branch_steps_lines([step_guard(GuardExpr)|Rest], Prefix, Index, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_steps_lines(Rest, NestedPrefix, Index, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_steps_lines([step_call(branch_call(HelperName, StepExpr))|Rest], Prefix, Index, Lines) :-
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    NextIndex is Index + 1,
+    typr_mutual_tree_branch_steps_lines(Rest, NestedPrefix, NextIndex, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([CallLine, IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+
+typr_mutual_tree_branch_steps_lines_no_memo([], Prefix, _Index, [ResultLine]) :-
+    format(string(ResultLine), '~wresult', [Prefix]).
+typr_mutual_tree_branch_steps_lines_no_memo([step_guard(GuardExpr)|Rest], Prefix, Index, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, Index, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_steps_lines_no_memo([step_call(branch_call(HelperName, StepExpr))|Rest], Prefix, Index, Lines) :-
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    NextIndex is Index + 1,
+    typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, NextIndex, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([CallLine, IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+
+typr_mutual_tree_step_result_name(1, left_result).
+typr_mutual_tree_step_result_name(2, right_result).
 
 typr_mutual_tree_dual_branch_call_lines(
     [branch_call(FirstHelperName, FirstStepExpr), branch_call(SecondHelperName, SecondStepExpr)],

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -65,6 +65,10 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_nested_branch(_)),
     retractall(user:typr_mutual_even_tree_nested_branch_pre(_)),
     retractall(user:typr_mutual_odd_tree_nested_branch_pre(_)),
+    retractall(user:typr_mutual_even_tree_call_guard(_)),
+    retractall(user:typr_mutual_odd_tree_call_guard(_)),
+    retractall(user:typr_mutual_even_tree_call_alias(_)),
+    retractall(user:typr_mutual_odd_tree_call_alias(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -623,6 +627,90 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_nested_branch_
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_branch_pre_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = FALSE;")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_intercall_guard_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_call_guard([])),
+    assertz(user:(typr_mutual_even_tree_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_call_guard(L),
+            V >= 0,
+            typr_mutual_odd_tree_call_guard(R)
+        ;   typr_mutual_odd_tree_call_guard(R),
+            typr_mutual_odd_tree_call_guard(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_call_guard([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_call_guard(L),
+            V >= 0,
+            typr_mutual_even_tree_call_guard(R)
+        ;   typr_mutual_even_tree_call_guard(R),
+            typr_mutual_even_tree_call_guard(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_call_guard/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_call_guard/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_call_guard/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_call_guard/1, typr_mutual_odd_tree_call_guard/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_call_guard <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_call_guard <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_call_guard_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "if (left_result) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= 0 }@) {")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_call_guard_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_call_guard_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_call_guard_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = FALSE;")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_intercall_alias_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_call_alias([])),
+    assertz(user:(typr_mutual_even_tree_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_call_alias(L),
+            Right = R,
+            typr_mutual_odd_tree_call_alias(Right)
+        ;   typr_mutual_odd_tree_call_alias(R),
+            typr_mutual_odd_tree_call_alias(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_call_alias([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_call_alias(L),
+            Right = R,
+            typr_mutual_even_tree_call_alias(Right)
+        ;   typr_mutual_even_tree_call_alias(R),
+            typr_mutual_even_tree_call_alias(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_call_alias/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_call_alias/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_call_alias/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_call_alias/1, typr_mutual_odd_tree_call_alias/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_call_alias <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_call_alias <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_call_alias_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_call_alias_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_call_alias_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_call_alias_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "result = FALSE;")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -461,6 +461,84 @@ test(structural_tree_dual_mutual_nested_branch_prework_output_checks_with_typr, 
     retractall(user:typr_mutual_even_tree_nested_branch_pre(_)),
     retractall(user:typr_mutual_odd_tree_nested_branch_pre(_)).
 
+test(structural_tree_dual_mutual_intercall_guard_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_call_guard([])),
+    assertz(user:(typr_mutual_even_tree_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_call_guard(L),
+            V >= 0,
+            typr_mutual_odd_tree_call_guard(R)
+        ;   typr_mutual_odd_tree_call_guard(R),
+            typr_mutual_odd_tree_call_guard(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_call_guard([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_call_guard(L),
+            V >= 0,
+            typr_mutual_even_tree_call_guard(R)
+        ;   typr_mutual_even_tree_call_guard(R),
+            typr_mutual_even_tree_call_guard(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_call_guard/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_call_guard/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_call_guard/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_call_guard(_)),
+    retractall(user:typr_mutual_odd_tree_call_guard(_)).
+
+test(structural_tree_dual_mutual_intercall_alias_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_call_alias([])),
+    assertz(user:(typr_mutual_even_tree_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_call_alias(L),
+            Right = R,
+            typr_mutual_odd_tree_call_alias(Right)
+        ;   typr_mutual_odd_tree_call_alias(R),
+            typr_mutual_odd_tree_call_alias(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_call_alias([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_call_alias(L),
+            Right = R,
+            typr_mutual_even_tree_call_alias(Right)
+        ;   typr_mutual_even_tree_call_alias(R),
+            typr_mutual_even_tree_call_alias(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_call_alias/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_call_alias/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_call_alias/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_call_alias(_)),
+    retractall(user:typr_mutual_odd_tree_call_alias(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion subset for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when a guarded branch body carries limited branch-local alias or guard state around the two direct recursive subtree calls, rather than requiring the calls to be fully adjacent with no interleaved state.

A representative supported shape is:

```prolog
typr_mutual_even_tree_call_guard([]).
typr_mutual_even_tree_call_guard([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_odd_tree_call_guard(L),
        V >= 0,
        typr_mutual_odd_tree_call_guard(R)
    ;   typr_mutual_odd_tree_call_guard(R),
        typr_mutual_odd_tree_call_guard(L)
    ).

typr_mutual_odd_tree_call_guard([_, [], []]).
typr_mutual_odd_tree_call_guard([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_even_tree_call_guard(L),
        V >= 0,
        typr_mutual_even_tree_call_guard(R)
    ;   typr_mutual_even_tree_call_guard(R),
        typr_mutual_even_tree_call_guard(L)
    ).
```

Before this PR, that shape fell out of the TypR mutual-recursion path. After this PR, it stays native and passes real `typr check` validation.

## Why This PR Exists

Recent TypR mutual-recursion work already established native support for conservative structural tree SCCs such as:

- one-subtree tree mutual recursion
- dual-subtree tree mutual recursion
- alias-style prework before the two recursive calls
- guarded alias selection before the two recursive calls
- direct recursive subtree calls inside guarded branch bodies
- one nested branch-local control point around those calls
- shared branch-local guard prework before a nested mutual branch

That still left a nearby practical gap.

If a supported dual-subtree tree mutual-recursive branch body performed one recursive call, then did limited branch-local alias or guard work, then performed the second recursive call, the current TypR mutual-recursion matcher no longer recognized the shape as supported mutual recursion.

The overall pattern was still conservative:

- arity `1`
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- exactly two mutual recursive subtree calls
- boolean rejoin via `left_result && right_result`

But the recursive calls were no longer completely adjacent, so the backend dropped out of the native path.

This PR closes that gap without widening TypR into general SCC lowering.

## Main Changes

### 1. TypR mutual tree branch lowering now supports ordered branch-local state around direct recursive calls

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-recursion backend now:

- parses supported mutual tree branch bodies as an ordered sequence instead of only as a fixed pair of adjacent recursive calls
- accepts conservative alias goals and native guard goals around the two direct recursive subtree calls
- preserves the existing simple branch-body paths and only uses the broader sequence parser when needed
- keeps the final TypR-native boolean rejoin as `left_result && right_result`

Implementation-wise, the new path:

- walks the branch body in order
- classifies alias, guard, and recursive-call steps
- emits native TypR code for each supported step
- keeps failed branch-local guards native by resolving them to `FALSE`
- avoids wrapped standalone-R fallback for this supported SCC shape

### 2. Added focused regression coverage for inter-call mutual tree state

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level coverage verifies that:

- a branch-local guard between the two mutual recursive subtree calls stays native
- a branch-local alias between the two mutual recursive subtree calls stays native
- both subtree helper calls are still emitted
- the boolean rejoin remains `left_result && right_result`
- wrapped-R fallback is not used
- generated TypR remains locally valid

### 3. Added real TypR toolchain validation for the same shapes

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain tests write the generated TypR program to a smoke project and run real `typr check`, so this support is validated against the actual TypR CLI rather than only target-level string assertions.

### 4. Documentation now reflects branch-local state around direct mutual subtree calls

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs with limited branch-local alias or guard state around the direct recursive subtree calls.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for structural tree mutual recursion with limited branch-local alias or guard state around direct recursive subtree calls
- continued TypR CLI validation for generated output

What it does not claim:

- general branch-heavy SCC lowering
- non-boolean mutual-recursive tree groups
- arbitrary recursive-body native TypR lowering
- general SCC lowering beyond the current conservative TypR subset

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with guarded alias selection before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with direct recursive subtree calls inside supported guarded branch bodies before the shared boolean rejoin
- dual-subtree tree-structural boolean SCCs with one nested branch-local control point around those calls
- dual-subtree tree-structural boolean SCCs with shared guard prework before a nested mutual branch
- dual-subtree tree-structural boolean SCCs with limited branch-local alias or guard state around the direct recursive subtree calls

The TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative branch-local alias or guard state around direct dual-subtree tree mutual-recursive calls
- target-level regression coverage for that shape
- real `typr check` coverage for that shape
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- richer nested branch-local state around direct mutual recursive calls
- broader structural tree SCCs with more complex branch-local recombination
- non-boolean or multi-output mutual recursion
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes another real mutual-recursion gap without weakening the TypR backend’s conservative design boundary.

It gives the project:

- fewer false failures for obvious structural tree SCCs
- stronger native TypR coverage for branch-heavy tree mutual recursion
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a precise, defensible way rather than jumping to general SCC lowering.
