### PR TITLE
ci(csharp-query): add cache smoke compare URL

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -169,6 +169,7 @@ jobs:
             "COMPARE_RESOLVED_URL=$($compareRun.HtmlUrl)"
             "COMPARE_RESOLUTION_SOURCE=$($compareRun.Source)"
             "COMPARE_REQUESTED_REF=$($compareRun.RequestedRef)"
+            "CACHE_SMOKE_DIFF_COMPARE_URL=$($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/compare/$($baselineRun.Sha)...$($compareRun.Sha)"
           ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Download baseline cache smoke summary artifact
@@ -263,6 +264,8 @@ jobs:
             artifactName = $env:COMPARE_ARTIFACT_NAME
           }) -Force
 
+          $diff | Add-Member -NotePropertyName compareUrl -NotePropertyValue $env:CACHE_SMOKE_DIFF_COMPARE_URL -Force
+
           $diff | ConvertTo-Json -Depth 10 | Set-Content -Path $env:CACHE_SMOKE_DIFF_JSON_PATH
 
       - name: Upload cache smoke diff JSON
@@ -294,6 +297,7 @@ jobs:
               "- Compare resolution: `"$($env:COMPARE_RESOLUTION_SOURCE)`"` (requested ref: `"$($env:COMPARE_REQUESTED_REF)`"`, resolved ref: `"$($env:COMPARE_RESOLVED_REF)`"`)",
               "- Compare resolved SHA: `"$($env:COMPARE_RESOLVED_SHA)`"",
               "- Compare run URL: `"$($env:COMPARE_RESOLVED_URL)`"",
+              "- Compare URL: `"$($env:CACHE_SMOKE_DIFF_COMPARE_URL)`"",
               "- Compare artifact: `"$($env:COMPARE_ARTIFACT_NAME)`"",
               "- Diff JSON artifact: `"$($env:CACHE_SMOKE_DIFF_ARTIFACT_NAME)`"",
               "- Overall result delta: `"$($diff.overallResult.delta)`"",

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -213,6 +213,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - resolved refs
         - resolved SHAs
         - resolved run URLs
+        - GitHub compare URL derived from the resolved SHAs
         - artifact names
         - overall result delta
         - total duration delta
@@ -220,6 +221,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - threshold pass/fail result
         - threshold failure list when present
       - diff JSON metadata with:
+        - `compareUrl`
         - `baselineRun.runId`, `baselineRun.resolutionSource`, `baselineRun.requestedRef`, `baselineRun.resolvedRef`, `baselineRun.resolvedSha`, `baselineRun.runUrl`, `baselineRun.artifactName`
         - `compareRun.runId`, `compareRun.resolutionSource`, `compareRun.requestedRef`, `compareRun.resolvedRef`, `compareRun.resolvedSha`, `compareRun.runUrl`, `compareRun.artifactName`
 - Environment variables (used by the test harness):


### PR DESCRIPTION
  ## Summary
  Add a GitHub compare URL to the manual C# query cache-smoke diff workflow so both the job summary and
  the diff JSON artifact point directly at the exact commit comparison being analyzed.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Derived a compare URL from the resolved baseline and compare SHAs
  - Added that compare URL to:
    - the workflow job summary
    - the uploaded diff JSON metadata as `compareUrl`
  - Updated `docs/targets/csharp-query-runtime.md` to document the new compare-link output

  ## Why
  The manual cache-smoke diff workflow already surfaced:
  - resolved run IDs
  - refs
  - SHAs
  - run URLs

  But it still required readers to manually assemble the actual GitHub commit comparison. This change
  closes that gap and makes the diff output directly navigable.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Replayed the JSON-annotation logic locally and confirmed the diff JSON now includes:
    - `compareUrl`
    - matching baseline / compare SHAs used to build it