### PR TITLE
Keep native TypR nested mutual tree call state

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ includes:
   direct recursive subtree calls inside supported guarded branch bodies with
   limited branch-local alias or guard state around those calls, including
   one nested branch-local control point around those calls before the
-  shared boolean rejoin and shared branch-local guard prework before a
+  shared boolean rejoin, one nested branch-local control point between the
+  two direct recursive subtree calls with limited alias or guard state
+  before the second call, and shared branch-local guard prework before a
   nested mutual branch, lowered to TypR functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -210,8 +210,10 @@ bring-up.
     bodies with limited branch-local alias or guard state around those
     calls before the shared boolean rejoin after the two recursive subtree
     calls, including one nested branch-local control point around those
-    calls and shared branch-local guard prework before a nested mutual
-    branch
+    calls, one nested branch-local control point between the two direct
+    recursive subtree calls with limited alias or guard state before the
+    second call, and shared branch-local guard prework before a nested
+    mutual branch
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -389,10 +389,12 @@ Current TypR lowering policy is intentionally mixed:
   recursive subtree calls inside supported guarded branch bodies with
   limited branch-local alias or guard state around those calls before
   those two recursive subtree calls rejoin via a shared boolean result,
-  including one nested branch-local control point around those calls and
-  shared branch-local guard prework before a nested mutual branch, using
-  raw-expression memoized helper bodies inside TypR rather than wrapped-R
-  fallback
+  including one nested branch-local control point around those calls, one
+  nested branch-local control point between the two direct recursive
+  subtree calls with limited alias or guard state before the second call,
+  and shared branch-local guard prework before a nested mutual branch,
+  using raw-expression memoized helper bodies inside TypR rather than
+  wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -80,10 +80,12 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursive subtree calls inside supported guarded branch bodies with
      limited branch-local alias or guard state around those calls before
      the shared boolean rejoin after the two recursive subtree calls,
-     including one nested branch-local control point around those calls and
-     shared branch-local guard prework before a nested mutual branch, and
-     boolean return types, emitted as TypR functions with raw-expression
-     memoized helper bodies
+     including one nested branch-local control point around those calls,
+     one nested branch-local control point between the two direct recursive
+     subtree calls with limited alias or guard state before the second
+     call, and shared branch-local guard prework before a nested mutual
+     branch, and boolean return types, emitted as TypR functions with
+     raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -524,6 +524,40 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
         Body
     ).
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+    append(PreGoals, [FirstGoal0, NestedIfGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
+    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, FirstGoal0, FirstGoalSpec),
+    typr_mutual_tree_branch_call(FirstGoalSpec, FirstCall),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_tail_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap,
+        ThenBody,
+        ThenGoalSpecs
+    ),
+    typr_mutual_tree_call_specs_cover_both_sides([FirstGoalSpec|ThenGoalSpecs]),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_tail_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap,
+        ElseBody,
+        ElseGoalSpecs
+    ),
+    typr_mutual_tree_call_specs_cover_both_sides([FirstGoalSpec|ElseGoalSpecs]),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr),
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_after_call(FirstCall, BranchConditionExpr, ThenBody, ElseBody),
+        Body
+    ).
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
@@ -567,6 +601,10 @@ typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasM
 typr_mutual_tree_branch_body_from_steps([step_call(Call1), step_call(Call2)], branch_calls([Call1, Call2])) :-
     !.
 typr_mutual_tree_branch_body_from_steps(Steps, branch_steps(Steps)).
+
+typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body, GoalSpecs) :-
+    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, GoalSpecs, Steps),
+    typr_mutual_tree_branch_body_from_steps(Steps, Body).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (
@@ -1058,54 +1096,98 @@ typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
     append(Lines1, ElseLines, Lines2),
     append(Lines2, ['            }'], Lines).
 
-typr_mutual_tree_branch_body_lines(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Lines) :-
+typr_mutual_tree_branch_body_lines(Body, Prefix, Lines) :-
+    typr_mutual_tree_branch_body_lines_from(Body, Prefix, 1, Lines).
+
+typr_mutual_tree_branch_body_lines_from(branch_after_call(branch_call(HelperName, StepExpr), BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
+    atom_concat(Prefix, '    ', BranchPrefix),
+    format(string(BranchIfLine), '~wif (~w) {', [BranchPrefix, BranchConditionExpr]),
+    atom_concat(BranchPrefix, '    ', NestedPrefix),
+    NextIndex is Index + 1,
+    typr_mutual_tree_branch_body_lines_from(ThenBody, NestedPrefix, NextIndex, ThenLines),
+    format(string(BranchElseLine), '~w} else {', [BranchPrefix]),
+    typr_mutual_tree_branch_body_lines_from(ElseBody, NestedPrefix, NextIndex, ElseLines),
+    format(string(BranchEndLine), '~w}', [BranchPrefix]),
+    format(string(PrefixElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([CallLine, IfLine, BranchIfLine], ThenLines, Lines0),
+    append(Lines0, [BranchElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [BranchEndLine, PrefixElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_from(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    typr_mutual_tree_branch_body_lines(ThenBody, NestedPrefix, ThenLines),
-    typr_mutual_tree_branch_body_lines(ElseBody, NestedPrefix, ElseLines),
+    typr_mutual_tree_branch_body_lines_from(ThenBody, NestedPrefix, Index, ThenLines),
+    typr_mutual_tree_branch_body_lines_from(ElseBody, NestedPrefix, Index, ElseLines),
     append([IfLine], ThenLines, Lines0),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
-typr_mutual_tree_branch_body_lines(branch_guard(GuardExpr, Body), Prefix, Lines) :-
+typr_mutual_tree_branch_body_lines_from(branch_guard(GuardExpr, Body), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    typr_mutual_tree_branch_body_lines(Body, NestedPrefix, BodyLines),
+    typr_mutual_tree_branch_body_lines_from(Body, NestedPrefix, Index, BodyLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], BodyLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_body_lines(branch_steps(Steps), Prefix, Lines) :-
-    typr_mutual_tree_branch_steps_lines(Steps, Prefix, 1, Lines).
-typr_mutual_tree_branch_body_lines(branch_calls(Calls), Prefix, Lines) :-
+typr_mutual_tree_branch_body_lines_from(branch_steps(Steps), Prefix, Index, Lines) :-
+    typr_mutual_tree_branch_steps_lines(Steps, Prefix, Index, Lines).
+typr_mutual_tree_branch_body_lines_from(branch_calls(Calls), Prefix, 1, Lines) :-
     typr_mutual_tree_dual_branch_call_lines(Calls, Prefix, Lines).
 
-typr_mutual_tree_branch_body_lines_no_memo(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Lines) :-
+typr_mutual_tree_branch_body_lines_no_memo(Body, Prefix, Lines) :-
+    typr_mutual_tree_branch_body_lines_no_memo_from(Body, Prefix, 1, Lines).
+
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_after_call(branch_call(HelperName, StepExpr), BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
+    atom_concat(Prefix, '    ', BranchPrefix),
+    format(string(BranchIfLine), '~wif (~w) {', [BranchPrefix, BranchConditionExpr]),
+    atom_concat(BranchPrefix, '    ', NestedPrefix),
+    NextIndex is Index + 1,
+    typr_mutual_tree_branch_body_lines_no_memo_from(ThenBody, NestedPrefix, NextIndex, ThenLines),
+    format(string(BranchElseLine), '~w} else {', [BranchPrefix]),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ElseBody, NestedPrefix, NextIndex, ElseLines),
+    format(string(BranchEndLine), '~w}', [BranchPrefix]),
+    format(string(PrefixElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([CallLine, IfLine, BranchIfLine], ThenLines, Lines0),
+    append(Lines0, [BranchElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [BranchEndLine, PrefixElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    typr_mutual_tree_branch_body_lines_no_memo(ThenBody, NestedPrefix, ThenLines),
-    typr_mutual_tree_branch_body_lines_no_memo(ElseBody, NestedPrefix, ElseLines),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ThenBody, NestedPrefix, Index, ThenLines),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ElseBody, NestedPrefix, Index, ElseLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], ThenLines, Lines0),
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
-typr_mutual_tree_branch_body_lines_no_memo(branch_guard(GuardExpr, Body), Prefix, Lines) :-
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_guard(GuardExpr, Body), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    typr_mutual_tree_branch_body_lines_no_memo(Body, NestedPrefix, BodyLines),
+    typr_mutual_tree_branch_body_lines_no_memo_from(Body, NestedPrefix, Index, BodyLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    FALSE', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], BodyLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_body_lines_no_memo(branch_steps(Steps), Prefix, Lines) :-
-    typr_mutual_tree_branch_steps_lines_no_memo(Steps, Prefix, 1, Lines).
-typr_mutual_tree_branch_body_lines_no_memo(branch_calls(Calls), Prefix, Lines) :-
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_steps(Steps), Prefix, Index, Lines) :-
+    typr_mutual_tree_branch_steps_lines_no_memo(Steps, Prefix, Index, Lines).
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_calls(Calls), Prefix, 1, Lines) :-
     typr_mutual_tree_dual_branch_call_lines_no_memo(Calls, Prefix, Lines).
 
 typr_mutual_tree_branch_steps_lines([], Prefix, _Index, [ResultLine]) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -69,6 +69,10 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_call_guard(_)),
     retractall(user:typr_mutual_even_tree_call_alias(_)),
     retractall(user:typr_mutual_odd_tree_call_alias(_)),
+    retractall(user:typr_mutual_even_tree_nested_call_guard(_)),
+    retractall(user:typr_mutual_odd_tree_nested_call_guard(_)),
+    retractall(user:typr_mutual_even_tree_nested_call_alias(_)),
+    retractall(user:typr_mutual_odd_tree_nested_call_alias(_)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -711,6 +715,101 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_intercall_alia
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_call_alias_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = FALSE;")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_nested_intercall_guard_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_call_guard([])),
+    assertz(user:(typr_mutual_even_tree_nested_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_nested_call_guard(L),
+            ( V > 10 ->
+                V >= 0,
+                typr_mutual_odd_tree_nested_call_guard(R)
+            ;   typr_mutual_odd_tree_nested_call_guard(R)
+            )
+        ;   typr_mutual_odd_tree_nested_call_guard(R),
+            typr_mutual_odd_tree_nested_call_guard(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_call_guard([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_nested_call_guard(L),
+            ( V > 10 ->
+                V >= 0,
+                typr_mutual_even_tree_nested_call_guard(R)
+            ;   typr_mutual_even_tree_nested_call_guard(R)
+            )
+        ;   typr_mutual_even_tree_nested_call_guard(R),
+            typr_mutual_even_tree_nested_call_guard(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_call_guard/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_call_guard/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_call_guard/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_nested_call_guard/1, typr_mutual_odd_tree_nested_call_guard/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_nested_call_guard <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_nested_call_guard <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_nested_call_guard_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "if (left_result) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 10) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= 0 }@) {")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_nested_call_guard_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_call_guard_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_call_guard_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = FALSE;")),
+    once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_nested_intercall_alias_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_call_alias([])),
+    assertz(user:(typr_mutual_even_tree_nested_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_nested_call_alias(L),
+            ( V > 10 ->
+                Right = R,
+                typr_mutual_odd_tree_nested_call_alias(Right)
+            ;   typr_mutual_odd_tree_nested_call_alias(R)
+            )
+        ;   typr_mutual_odd_tree_nested_call_alias(R),
+            typr_mutual_odd_tree_nested_call_alias(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_call_alias([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_nested_call_alias(L),
+            ( V > 10 ->
+                Right = R,
+                typr_mutual_even_tree_nested_call_alias(Right)
+            ;   typr_mutual_even_tree_nested_call_alias(R)
+            )
+        ;   typr_mutual_even_tree_nested_call_alias(R),
+            typr_mutual_even_tree_nested_call_alias(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_call_alias/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_call_alias/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_call_alias/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_nested_call_alias/1, typr_mutual_odd_tree_nested_call_alias/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_nested_call_alias <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_nested_call_alias <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_nested_call_alias_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "if (left_result) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 10) {")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_nested_call_alias_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_nested_call_alias_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_nested_call_alias_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "result = FALSE;")),
     once(sub_string(Code, _, _, _, "result = left_result && right_result;")),
     \+ sub_string(Code, _, _, _, "(function("),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -539,6 +539,96 @@ test(structural_tree_dual_mutual_intercall_alias_output_checks_with_typr, [condi
     retractall(user:typr_mutual_even_tree_call_alias(_)),
     retractall(user:typr_mutual_odd_tree_call_alias(_)).
 
+test(structural_tree_dual_mutual_nested_intercall_guard_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_call_guard([])),
+    assertz(user:(typr_mutual_even_tree_nested_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_nested_call_guard(L),
+            ( V > 10 ->
+                V >= 0,
+                typr_mutual_odd_tree_nested_call_guard(R)
+            ;   typr_mutual_odd_tree_nested_call_guard(R)
+            )
+        ;   typr_mutual_odd_tree_nested_call_guard(R),
+            typr_mutual_odd_tree_nested_call_guard(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_call_guard([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_call_guard([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_nested_call_guard(L),
+            ( V > 10 ->
+                V >= 0,
+                typr_mutual_even_tree_nested_call_guard(R)
+            ;   typr_mutual_even_tree_nested_call_guard(R)
+            )
+        ;   typr_mutual_even_tree_nested_call_guard(R),
+            typr_mutual_even_tree_nested_call_guard(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_call_guard/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_call_guard/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_call_guard/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_call_guard/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_nested_call_guard(_)),
+    retractall(user:typr_mutual_odd_tree_nested_call_guard(_)).
+
+test(structural_tree_dual_mutual_nested_intercall_alias_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_nested_call_alias([])),
+    assertz(user:(typr_mutual_even_tree_nested_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_odd_tree_nested_call_alias(L),
+            ( V > 10 ->
+                Right = R,
+                typr_mutual_odd_tree_nested_call_alias(Right)
+            ;   typr_mutual_odd_tree_nested_call_alias(R)
+            )
+        ;   typr_mutual_odd_tree_nested_call_alias(R),
+            typr_mutual_odd_tree_nested_call_alias(L)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_nested_call_alias([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_nested_call_alias([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_nested_call_alias(L),
+            ( V > 10 ->
+                Right = R,
+                typr_mutual_even_tree_nested_call_alias(Right)
+            ;   typr_mutual_even_tree_nested_call_alias(R)
+            )
+        ;   typr_mutual_even_tree_nested_call_alias(R),
+            typr_mutual_even_tree_nested_call_alias(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_nested_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_nested_call_alias/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_nested_call_alias/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_nested_call_alias/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_nested_call_alias/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_nested_call_alias(_)),
+    retractall(user:typr_mutual_odd_tree_nested_call_alias(_)).
+
 test(structural_tree_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:tree_sum([], 0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion subset for structural tree SCCs.

Specifically, TypR now keeps dual-subtree tree mutual recursion native when a guarded branch body performs one direct recursive subtree call, then enters a nested branch-local control point that carries limited alias or guard state before the second direct recursive subtree call.

A representative supported shape is:

```prolog
typr_mutual_even_tree_nested_call_guard([]).
typr_mutual_even_tree_nested_call_guard([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_odd_tree_nested_call_guard(L),
        ( V > 10 ->
            V >= 0,
            typr_mutual_odd_tree_nested_call_guard(R)
        ;   typr_mutual_odd_tree_nested_call_guard(R)
        )
    ;   typr_mutual_odd_tree_nested_call_guard(R),
        typr_mutual_odd_tree_nested_call_guard(L)
    ).

typr_mutual_odd_tree_nested_call_guard([_, [], []]).
typr_mutual_odd_tree_nested_call_guard([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_even_tree_nested_call_guard(L),
        ( V > 10 ->
            V >= 0,
            typr_mutual_even_tree_nested_call_guard(R)
        ;   typr_mutual_even_tree_nested_call_guard(R)
        )
    ;   typr_mutual_even_tree_nested_call_guard(R),
        typr_mutual_even_tree_nested_call_guard(L)
    ).
```

Before this PR, that shape still failed with `No mutual recursion support for target typr`. After this PR, it lowers natively and passes real `typr check` validation.

## Why This PR Exists

Recent TypR mutual-recursion work already established native support for conservative structural tree SCCs such as:

- one-subtree tree mutual recursion
- dual-subtree tree mutual recursion
- alias-style prework before the two recursive calls
- guarded alias selection before the two recursive calls
- direct recursive subtree calls inside guarded branch bodies
- one nested branch-local control point around those calls
- shared branch-local guard prework before a nested mutual branch
- limited branch-local alias or guard state around direct recursive subtree calls

That still left a real nearby gap.

If a supported dual-subtree tree mutual-recursive branch body performed:

- the first direct recursive subtree call
- then a nested branch-local control point
- then limited alias or guard state before the second direct recursive subtree call

the current TypR mutual-recursion matcher still fell out of the native path.

The overall shape remained conservative:

- arity `1`
- boolean return type
- tree input encoded as `[]` or `[V, L, R]`
- exactly two mutual recursive subtree calls
- shared boolean rejoin via `left_result && right_result`

But the nested control point now sat between the two direct recursive calls, which was just beyond the previous matcher.

This PR closes that gap without widening TypR into general SCC lowering.

## Main Changes

### 1. TypR mutual tree branch lowering now supports nested branch-local state after the first direct recursive call

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-recursion backend now:

- recognizes supported mutual tree branch bodies where the first direct recursive call is followed by one nested `if -> then ; else`
- allows that nested branch to carry conservative alias or guard state before the second direct recursive call
- keeps the existing simpler mutual-tree paths intact
- preserves the final TypR-native boolean rejoin as `left_result && right_result`

Implementation-wise, the new path:

- matches a first direct recursive subtree call plus a nested tail branch
- compiles the nested tail branch with knowledge that `left_result` is already bound
- emits the nested tail body with indexed branch-body lowering so the second call binds `right_result`
- keeps failed branch-local guards native by resolving them to `FALSE`

### 2. Added focused regression coverage for nested inter-call mutual tree state

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level regression coverage verifies that:

- nested branch-local guard state between the two direct mutual recursive subtree calls stays native
- nested branch-local alias state between the two direct mutual recursive subtree calls stays native
- both subtree helper calls are still emitted
- the final boolean rejoin remains `left_result && right_result`
- failed branch-local guard paths stay native and resolve to `FALSE`
- wrapped-R fallback is not used
- generated TypR remains locally valid

### 3. Added real TypR toolchain validation for the same shapes

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new toolchain tests write the generated TypR program to a smoke project and run real `typr check`, so this support is validated against the actual TypR CLI rather than only target-level string assertions.

### 4. Documentation now reflects nested branch-local state between direct mutual subtree calls

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the conservative TypR mutual-recursion subset includes dual-subtree tree SCCs with one nested branch-local control point between the two direct recursive subtree calls, plus limited alias or guard state before the second call.

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

What this validation covers:

- shared type declaration behavior remaining intact
- existing R-target behavior remaining intact on the focused suite
- native TypR support for structural tree mutual recursion with one nested branch-local control point between the two direct recursive subtree calls
- continued TypR CLI validation for generated output

What it does not claim:

- general branch-heavy SCC lowering
- non-boolean mutual-recursive tree groups
- arbitrary recursive-body native TypR lowering
- general SCC lowering beyond the current conservative TypR subset

## Behavior Notes

After this PR, the documented native TypR mutual-recursion subset includes:

- numeric boolean SCCs
- list-structural boolean SCCs
- one-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs
- dual-subtree tree-structural boolean SCCs with alias-style prework before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with guarded alias selection before the two recursive subtree calls
- dual-subtree tree-structural boolean SCCs with direct recursive subtree calls inside supported guarded branch bodies before the shared boolean rejoin
- dual-subtree tree-structural boolean SCCs with one nested branch-local control point around those calls
- dual-subtree tree-structural boolean SCCs with shared guard prework before a nested mutual branch
- dual-subtree tree-structural boolean SCCs with limited branch-local alias or guard state around the direct recursive subtree calls
- dual-subtree tree-structural boolean SCCs with one nested branch-local control point between the two direct recursive subtree calls, plus limited alias or guard state before the second call

The TypR mutual-recursion path still remains conservative.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for one nested branch-local control point between the two direct dual-subtree tree mutual-recursive calls
- support for conservative alias or guard state in that nested tail position
- target-level regression coverage for those shapes
- real `typr check` coverage for those shapes
- docs updated so the supported mutual-recursion subset matches current behavior

Still not fully implemented:

- arity-2 mutual recursion with one invariant context argument
- broader structural tree SCCs with more complex branch-local recombination
- non-boolean or multi-output mutual recursion
- general SCC lowering beyond the current conservative TypR subset

## Why This PR Is Worth Merging

This PR closes another real mutual-recursion gap without weakening the TypR backend’s conservative design boundary.

It gives the project:

- fewer false failures for obvious structural tree SCCs
- stronger native TypR coverage for nested branch-heavy tree mutual recursion
- validation against the real TypR toolchain
- documentation that matches the actual supported subset

This is a good incremental PR because it expands TypR mutual recursion in a precise, defensible way rather than jumping to general SCC lowering.
