### PR TITLE
Keep native TypR arity-2 mutual recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,18 +241,20 @@ includes:
 - conservative arity-2 numeric multi-call tree-recursive predicates such as
   `fib/2`, lowered to TypR functions that use raw-expression memoized helper
   bodies inside TypR instead of wrapped-R fallback
-- conservative arity-1 boolean mutual-recursive predicate groups such as
+- conservative boolean mutual-recursive predicate groups such as
   `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`,
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
-  including dual-subtree tree SCCs with alias-style prework or guarded
-  branch-local alias selection before the two recursive subtree calls, or
-  direct recursive subtree calls inside supported guarded branch bodies with
-  limited branch-local alias or guard state around those calls, including
-  one nested branch-local control point around those calls before the
-  shared boolean rejoin, one nested branch-local control point between the
-  two direct recursive subtree calls with limited alias or guard state
-  before the second call, and shared branch-local guard prework before a
-  nested mutual branch, lowered to TypR functions that use raw-expression
+  plus arity-2 tree-structural SCCs with one tree-driving argument and one
+  invariant context argument, including dual-subtree tree SCCs with
+  alias-style prework or guarded branch-local alias selection before the
+  two recursive subtree calls, or direct recursive subtree calls inside
+  supported guarded branch bodies with limited branch-local alias or guard
+  state around those calls, including one nested branch-local control point
+  around those calls before the shared boolean rejoin, one nested
+  branch-local control point between the two direct recursive subtree calls
+  with limited alias or guard state before the second call, and shared
+  branch-local guard prework before a nested mutual branch, lowered to TypR
+  functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -212,8 +212,10 @@ bring-up.
     calls, including one nested branch-local control point around those
     calls, one nested branch-local control point between the two direct
     recursive subtree calls with limited alias or guard state before the
-    second call, and shared branch-local guard prework before a nested
-    mutual branch
+    second call, shared branch-local guard prework before a nested mutual
+    branch, and conservative arity-2 tree-structural SCCs with one
+    invariant context argument threaded through the shared dual-subtree
+    calls
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -392,9 +392,11 @@ Current TypR lowering policy is intentionally mixed:
   including one nested branch-local control point around those calls, one
   nested branch-local control point between the two direct recursive
   subtree calls with limited alias or guard state before the second call,
-  and shared branch-local guard prework before a nested mutual branch,
-  using raw-expression memoized helper bodies inside TypR rather than
-  wrapped-R fallback
+  and shared branch-local guard prework before a nested mutual branch, and
+  conservative arity-2 tree-structural SCCs with one invariant context
+  argument threaded through the shared dual-subtree calls, using
+  raw-expression memoized helper bodies inside TypR rather than wrapped-R
+  fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -83,9 +83,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      including one nested branch-local control point around those calls,
      one nested branch-local control point between the two direct recursive
      subtree calls with limited alias or guard state before the second
-     call, and shared branch-local guard prework before a nested mutual
-     branch, and boolean return types, emitted as TypR functions with
-     raw-expression memoized helper bodies
+     call, shared branch-local guard prework before a nested mutual
+     branch, conservative arity-2 tree-structural SCCs with one invariant
+     context argument threaded through the shared dual-subtree calls, and
+     boolean return types, emitted as TypR functions with raw-expression
+     memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -81,6 +81,7 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
     (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_dual_context_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_branch_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_spec(Predicates), Predicates, Specs)
@@ -112,6 +113,7 @@ typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
     Spec = mutual_spec{
         kind: numeric,
         pred: Pred,
+        arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
@@ -151,6 +153,7 @@ typr_mutual_list_spec(GroupPredicates, Pred/Arity, Spec) :-
     Spec = mutual_spec{
         kind: list,
         pred: Pred,
+        arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
@@ -204,6 +207,7 @@ typr_mutual_tree_spec(GroupPredicates, Pred/Arity, Spec) :-
     Spec = mutual_spec{
         kind: tree,
         pred: Pred,
+        arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
@@ -234,8 +238,10 @@ typr_mutual_tree_dual_spec(GroupPredicates, Pred/Arity, Spec) :-
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_alias_map(PreGoals, LeftVar, RightVar, AliasMap),
     maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap), [GoalA, GoalB], GoalSpecs0),
-    select(call_spec(left, LeftNextPred, '.subset2(current_input, 2)'), GoalSpecs0, GoalSpecs1),
-    select(call_spec(right, RightNextPred, '.subset2(current_input, 3)'), GoalSpecs1, []),
+    select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
+    select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
+    LeftCallArgs = ['.subset2(current_input, 2)'],
+    RightCallArgs = ['.subset2(current_input, 3)'],
     atom_string(Pred, PredStr),
     atom_string(LeftNextPred, LeftNextPredStr),
     atom_string(RightNextPred, RightNextPredStr),
@@ -245,14 +251,74 @@ typr_mutual_tree_dual_spec(GroupPredicates, Pred/Arity, Spec) :-
     Spec = mutual_spec{
         kind: tree_dual,
         pred: Pred,
+        arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
         helper_name: HelperName,
-        left_next_helper_name: LeftNextHelperName,
-        right_next_helper_name: RightNextHelperName,
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
         base_conditions: BaseConditions,
         guard_expr: 'length(current_input) == 3'
+    }.
+
+typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    append(PreGoals, RecGoals, Goals),
+    RecGoals = [GoalA, GoalB],
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    ExtraArgMap = [ContextVar-"current_ctx"],
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, PreGuardExpr),
+    maplist(
+        typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap),
+        [GoalA, GoalB],
+        GoalSpecs0
+    ),
+    select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
+    select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
+    LeftCallArgs = ['.subset2(current_input, 2)', CurrentCtxExpr],
+    RightCallArgs = ['.subset2(current_input, 3)', CurrentCtxExpr],
+    atom_string(Pred, PredStr),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    typr_mutual_tree_top_guard_expr(PreGuardExpr, GuardExpr),
+    format(
+        string(MemoKeyExpr),
+        'paste0("~w:", paste(deparse(list(current_input, current_ctx)), collapse=""))',
+        [PredStr]
+    ),
+    Spec = mutual_spec{
+        kind: tree_dual,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: ["current_input", "current_ctx"],
+        wrapper_call_args: ["arg1", "arg2"],
+        memo_key_expr: MemoKeyExpr,
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        base_conditions: BaseConditions,
+        guard_expr: GuardExpr
     }.
 
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -286,6 +352,7 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Spec = mutual_spec{
         kind: tree_dual_branch,
         pred: Pred,
+        arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
@@ -336,6 +403,7 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Spec = mutual_spec{
         kind: tree_dual_branch,
         pred: Pred,
+        arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
@@ -348,9 +416,10 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     }.
 
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 0') :-
-    Head =.. [_Pred, []].
+    Head =.. [_Pred, FirstArg|_],
+    FirstArg == [].
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0') :-
-    Head =.. [_Pred, [Val, [], []]],
+    Head =.. [_Pred, [Val, [], []]|_],
     var(Val).
 
 typr_mutual_guard_expr(_HeadVar, [], 'TRUE') :-
@@ -447,30 +516,58 @@ typr_is_mutual_recursive_clause(GroupPredicates, clause(_Head, Body)) :-
     memberchk(Pred/Arity, GroupPredicates),
     !.
 
-typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, Goal0, call_spec(Side, NextPred, StepExpr)) :-
+typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, Goal0, CallSpec) :-
+    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, [], Goal0, CallSpec).
+
+typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, Goal0, call_spec(Side, NextPred, CallArgs)) :-
     typr_strip_module_goal(Goal0, Goal),
-    Goal =.. [NextPred, RecArg],
-    memberchk(NextPred/1, GroupPredicates),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
     typr_mutual_tree_lookup_side(RecArg, AliasMap, Side),
-    typr_mutual_tree_side_step_expr(Side, StepExpr).
+    typr_mutual_tree_side_step_expr(Side, StepExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [StepExpr|ExtraArgExprs].
+
+typr_mutual_extra_arg_expr(ExtraArgMap, Arg, Expr) :-
+    var(Arg),
+    member(StoredArg-Expr, ExtraArgMap),
+    StoredArg == Arg,
+    !.
+typr_mutual_extra_arg_expr(_ExtraArgMap, Arg, Expr) :-
+    typr_translate_r_expr(Arg, [], Expr).
 
 typr_mutual_tree_call_specs_cover_both_sides(CallSpecs) :-
     findall(Side, member(call_spec(Side, _NextPred, _StepExpr), CallSpecs), Sides0),
     msort(Sides0, [left, right]).
 
+typr_mutual_tree_top_guard_expr(none, 'length(current_input) == 3') :-
+    !.
+typr_mutual_tree_top_guard_expr(PreGuardExpr, GuardExpr) :-
+    combine_typr_conditions(['length(current_input) == 3', PreGuardExpr], CombinedGuard),
+    typr_condition_expr_text(CombinedGuard, GuardExpr).
+
 typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr) :-
-    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, [], BranchConditionExpr).
+
+typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, BranchConditionExpr) :-
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, VarMap),
     native_typr_if_condition(IfGoal, VarMap, BranchCondition0),
     typr_condition_expr_text(BranchCondition0, BranchConditionExpr).
 
 typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, AliasMap, none).
-typr_mutual_tree_branch_prework([Goal|Rest], ValueVar, AliasMap0, AliasMap, GuardExpr) :-
+typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, AliasMap, GuardExpr) :-
+    typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, [], AliasMap, GuardExpr).
+
+typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, _ExtraArgMap, AliasMap, none).
+typr_mutual_tree_branch_prework([Goal|Rest], ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr) :-
     (   typr_mutual_tree_alias_goal(Goal)
     ->  typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1),
-        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap1, AliasMap, GuardExpr)
-    ;   typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, VarMap),
+        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap1, ExtraArgMap, AliasMap, GuardExpr)
+    ;   typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap, VarMap),
         native_typr_guard_goal(Goal, VarMap, GuardCondition),
-        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap0, AliasMap, RestGuardExpr),
+        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap0, ExtraArgMap, AliasMap, RestGuardExpr),
         typr_mutual_tree_guard_expr_join(GuardCondition, RestGuardExpr, GuardExpr)
     ).
 
@@ -490,6 +587,9 @@ typr_mutual_tree_nested_goal(Goal) :-
     typr_if_then_goal(Goal, _IfGoal, _ThenGoal).
 
 typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap) :-
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, [], VarMap).
+
+typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, VarMap) :-
     findall(
         Var-Expr,
         (
@@ -498,12 +598,13 @@ typr_mutual_tree_condition_varmap(ValueVar, AliasMap, VarMap) :-
         ),
         VarMap0
     ),
+    append(ExtraArgMap, VarMap0, VarMap1),
     (   var(ValueVar)
-    ->  VarMap = [ValueVar-'.subset2(current_input, 1)'|VarMap0]
-    ;   VarMap = VarMap0
+    ->  VarMap = [ValueVar-'.subset2(current_input, 1)'|VarMap1]
+    ;   VarMap = VarMap1
     ).
 
-typr_mutual_tree_branch_call(call_spec(_Side, NextPred, StepExpr), branch_call(HelperName, StepExpr)) :-
+typr_mutual_tree_branch_call(call_spec(_Side, NextPred, CallArgs), branch_call(HelperName, CallArgs)) :-
     atom_string(NextPred, NextPredStr),
     format(string(HelperName), '~w_impl', [NextPredStr]).
 
@@ -610,7 +711,8 @@ typr_mutual_group_code(Specs, MemoEnabled, Code) :-
     findall(GroupLabel, (
         member(Spec, Specs),
         PredStr = Spec.pred_str,
-        format(string(GroupLabel), '~w/1', [PredStr])
+        Arity = Spec.arity,
+        format(string(GroupLabel), '~w/~w', [PredStr, Arity])
     ), GroupLabels),
     atomic_list_concat(GroupLabels, ', ', GroupText),
     findall(PredStr, (
@@ -630,11 +732,43 @@ typr_mutual_group_code(Specs, MemoEnabled, Code) :-
 ~w
 ', [GroupText, WrapperCodeText]).
 
+typr_mutual_spec_field_or_default(Spec, Field, Default, Value) :-
+    (   get_dict(Field, Spec, Value0)
+    ->  Value = Value0
+    ;   Value = Default
+    ).
+
+typr_mutual_helper_params(Spec, Params) :-
+    typr_mutual_spec_field_or_default(Spec, helper_params, ["current_input"], Params).
+
+typr_mutual_wrapper_call_args(Spec, CallArgs) :-
+    typr_mutual_spec_field_or_default(Spec, wrapper_call_args, ["arg1"], CallArgs).
+
+typr_mutual_call_expr(Name, CallArgs, Expr) :-
+    atomic_list_concat(CallArgs, ', ', CallArgsText),
+    format(string(Expr), '~w(~w)', [Name, CallArgsText]).
+
+typr_mutual_helper_line(Spec, HelperName, HelperLine) :-
+    typr_mutual_helper_params(Spec, HelperParams),
+    atomic_list_concat(HelperParams, ', ', HelperParamsText),
+    format_string_return('    ~w <- function(~w) {', [HelperName, HelperParamsText], HelperLine).
+
+typr_mutual_wrapper_helper_call_expr(Spec, HelperName, HelperCallExpr) :-
+    typr_mutual_wrapper_call_args(Spec, WrapperCallArgs),
+    typr_mutual_call_expr(HelperName, WrapperCallArgs, HelperCallExpr).
+
+typr_mutual_tree_key_line(Spec, PredStr, KeyLine) :-
+    (   get_dict(memo_key_expr, Spec, MemoKeyExpr)
+    ->  format_string_return('        key <- ~w;', [MemoKeyExpr], KeyLine)
+    ;   format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine)
+    ).
+
 typr_mutual_wrapper_code(GroupName, Specs, true, Spec, Code) :-
     PredStr = Spec.pred_str,
     TypedArgList = Spec.typed_arg_list,
     ReturnType = Spec.return_type,
     HelperName = Spec.helper_name,
+    typr_mutual_wrapper_helper_call_expr(Spec, HelperName, HelperCallExpr),
     findall(HelperCode, (
         member(HelperSpec, Specs),
         typr_mutual_helper_code(GroupName, true, HelperSpec, HelperCode)
@@ -647,16 +781,17 @@ typr_mutual_wrapper_code(GroupName, Specs, true, Spec, Code) :-
 \tlocal({
 \t    ~w_memo <- new.env(hash=TRUE, parent=emptyenv());
 ~w
-\t    ~w(arg1)
+\t    ~w
 \t})
 \t}@;
 \tresult
-};', [PredStr, TypedArgList, ReturnType, GroupName, IndentedHelpersText, HelperName]).
+};', [PredStr, TypedArgList, ReturnType, GroupName, IndentedHelpersText, HelperCallExpr]).
 typr_mutual_wrapper_code(GroupName, Specs, false, Spec, Code) :-
     PredStr = Spec.pred_str,
     TypedArgList = Spec.typed_arg_list,
     ReturnType = Spec.return_type,
     HelperName = Spec.helper_name,
+    typr_mutual_wrapper_helper_call_expr(Spec, HelperName, HelperCallExpr),
     findall(HelperCode, (
         member(HelperSpec, Specs),
         typr_mutual_helper_code(GroupName, false, HelperSpec, HelperCode)
@@ -668,11 +803,11 @@ typr_mutual_wrapper_code(GroupName, Specs, false, Spec, Code) :-
 \tresult <- @{
 \tlocal({
 ~w
-\t    ~w(arg1)
+\t    ~w
 \t})
 \t}@;
 \tresult
-};', [PredStr, TypedArgList, ReturnType, IndentedHelpersText, HelperName]).
+};', [PredStr, TypedArgList, ReturnType, IndentedHelpersText, HelperCallExpr]).
 
 typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     Kind = Spec.kind,
@@ -686,7 +821,7 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     typr_mutual_base_branch_lines(GroupName, BaseValues, BaseLines),
     typr_mutual_recursive_branch_lines(GroupName, GuardExpr, NextHelperName, StepExpr, RecursiveLines),
     typr_mutual_false_lines(GroupName, FalseLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     format_string_return('        key <- paste0("~w:", current_input);', [PredStr], KeyLine),
     format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
     format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
@@ -705,7 +840,7 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     StepExpr = Spec.step_expr,
     typr_mutual_base_branch_lines_no_memo(BaseValues, BaseLines),
     typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
     append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
@@ -722,7 +857,7 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     typr_mutual_list_base_branch_lines(GroupName, BaseLengths, BaseLines),
     typr_mutual_recursive_branch_lines(GroupName, GuardExpr, NextHelperName, StepExpr, RecursiveLines),
     typr_mutual_false_lines(GroupName, FalseLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine),
     format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
     format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
@@ -741,7 +876,7 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     StepExpr = Spec.step_expr,
     typr_mutual_list_base_branch_lines_no_memo(BaseLengths, BaseLines),
     typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
     append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
@@ -766,8 +901,8 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
         RecursiveLines
     ),
     typr_mutual_false_lines(GroupName, FalseLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
-    format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
     format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
     format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
     append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
@@ -792,7 +927,7 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
         ElseBody,
         RecursiveLines
     ),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
     append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
@@ -802,21 +937,21 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     Kind == tree_dual,
     PredStr = Spec.pred_str,
     HelperName = Spec.helper_name,
-    LeftNextHelperName = Spec.left_next_helper_name,
-    RightNextHelperName = Spec.right_next_helper_name,
+    LeftCall = Spec.left_call,
+    RightCall = Spec.right_call,
     BaseConditions = Spec.base_conditions,
     GuardExpr = Spec.guard_expr,
     typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
     typr_mutual_tree_dual_recursive_branch_lines(
         GroupName,
         GuardExpr,
-        LeftNextHelperName,
-        RightNextHelperName,
+        LeftCall,
+        RightCall,
         RecursiveLines
     ),
     typr_mutual_false_lines(GroupName, FalseLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
-    format_string_return('        key <- paste0("~w:", paste(deparse(current_input), collapse=""));', [PredStr], KeyLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
     format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
     format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
     append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
@@ -828,18 +963,18 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     Kind = Spec.kind,
     Kind == tree_dual,
     HelperName = Spec.helper_name,
-    LeftNextHelperName = Spec.left_next_helper_name,
-    RightNextHelperName = Spec.right_next_helper_name,
+    LeftCall = Spec.left_call,
+    RightCall = Spec.right_call,
     BaseConditions = Spec.base_conditions,
     GuardExpr = Spec.guard_expr,
     typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
     typr_mutual_tree_dual_recursive_branch_lines_no_memo(
         GuardExpr,
-        LeftNextHelperName,
-        RightNextHelperName,
+        LeftCall,
+        RightCall,
         RecursiveLines
     ),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
     append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
@@ -856,8 +991,8 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
     typr_mutual_recursive_branch_lines(GroupName, GuardExpr, NextHelperName, StepExpr, RecursiveLines),
     typr_mutual_false_lines(GroupName, FalseLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
-    format_string_return('        key <- paste0(\"~w:\", paste(deparse(current_input), collapse=\"\"));', [PredStr], KeyLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
     format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
     format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
     append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
@@ -875,7 +1010,7 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     StepExpr = Spec.step_expr,
     typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
     typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, RecursiveLines),
-    format_string_return('    ~w <- function(current_input) {', [HelperName], HelperLine),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
     append([HelperLine], BaseLines, Lines0),
     append(Lines0, RecursiveLines, Lines1),
     append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
@@ -995,13 +1130,15 @@ typr_mutual_recursive_branch_lines_no_memo(GuardExpr, NextHelperName, StepExpr, 
 typr_mutual_tree_dual_recursive_branch_lines(
     GroupName,
     'TRUE',
-    LeftNextHelperName,
-    RightNextHelperName,
+    LeftCall,
+    RightCall,
     Lines
 ) :-
     !,
-    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
-    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
     format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
     Lines = [
         '        } else {',
@@ -1014,13 +1151,15 @@ typr_mutual_tree_dual_recursive_branch_lines(
 typr_mutual_tree_dual_recursive_branch_lines(
     GroupName,
     GuardExpr,
-    LeftNextHelperName,
-    RightNextHelperName,
+    LeftCall,
+    RightCall,
     Lines
 ) :-
     format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
-    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
-    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
     format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
     Lines = [
         IfLine,
@@ -1033,13 +1172,15 @@ typr_mutual_tree_dual_recursive_branch_lines(
 
 typr_mutual_tree_dual_recursive_branch_lines_no_memo(
     'TRUE',
-    LeftNextHelperName,
-    RightNextHelperName,
+    LeftCall,
+    RightCall,
     Lines
 ) :-
     !,
-    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
-    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
     Lines = [
         '        } else {',
         LeftLine,
@@ -1048,13 +1189,15 @@ typr_mutual_tree_dual_recursive_branch_lines_no_memo(
     ].
 typr_mutual_tree_dual_recursive_branch_lines_no_memo(
     GuardExpr,
-    LeftNextHelperName,
-    RightNextHelperName,
+    LeftCall,
+    RightCall,
     Lines
 ) :-
     format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
-    format(string(LeftLine), '            left_result = ~w(.subset2(current_input, 2));', [LeftNextHelperName]),
-    format(string(RightLine), '            right_result = ~w(.subset2(current_input, 3));', [RightNextHelperName]),
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
     Lines = [
         IfLine,
         LeftLine,
@@ -1099,9 +1242,10 @@ typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
 typr_mutual_tree_branch_body_lines(Body, Prefix, Lines) :-
     typr_mutual_tree_branch_body_lines_from(Body, Prefix, 1, Lines).
 
-typr_mutual_tree_branch_body_lines_from(branch_after_call(branch_call(HelperName, StepExpr), BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
+typr_mutual_tree_branch_body_lines_from(branch_after_call(BranchCall, BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     typr_mutual_tree_step_result_name(Index, ResultName),
-    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', BranchPrefix),
     format(string(BranchIfLine), '~wif (~w) {', [BranchPrefix, BranchConditionExpr]),
@@ -1146,9 +1290,10 @@ typr_mutual_tree_branch_body_lines_from(branch_calls(Calls), Prefix, 1, Lines) :
 typr_mutual_tree_branch_body_lines_no_memo(Body, Prefix, Lines) :-
     typr_mutual_tree_branch_body_lines_no_memo_from(Body, Prefix, 1, Lines).
 
-typr_mutual_tree_branch_body_lines_no_memo_from(branch_after_call(branch_call(HelperName, StepExpr), BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_after_call(BranchCall, BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     typr_mutual_tree_step_result_name(Index, ResultName),
-    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', BranchPrefix),
     format(string(BranchIfLine), '~wif (~w) {', [BranchPrefix, BranchConditionExpr]),
@@ -1201,9 +1346,10 @@ typr_mutual_tree_branch_steps_lines([step_guard(GuardExpr)|Rest], Prefix, Index,
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_steps_lines([step_call(branch_call(HelperName, StepExpr))|Rest], Prefix, Index, Lines) :-
+typr_mutual_tree_branch_steps_lines([step_call(BranchCall)|Rest], Prefix, Index, Lines) :-
     typr_mutual_tree_step_result_name(Index, ResultName),
-    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', NestedPrefix),
     NextIndex is Index + 1,
@@ -1225,9 +1371,10 @@ typr_mutual_tree_branch_steps_lines_no_memo([step_guard(GuardExpr)|Rest], Prefix
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_steps_lines_no_memo([step_call(branch_call(HelperName, StepExpr))|Rest], Prefix, Index, Lines) :-
+typr_mutual_tree_branch_steps_lines_no_memo([step_call(BranchCall)|Rest], Prefix, Index, Lines) :-
     typr_mutual_tree_step_result_name(Index, ResultName),
-    format(string(CallLine), '~w~w = ~w(~w);', [Prefix, ResultName, HelperName, StepExpr]),
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', NestedPrefix),
     NextIndex is Index + 1,
@@ -1241,22 +1388,30 @@ typr_mutual_tree_branch_steps_lines_no_memo([step_call(branch_call(HelperName, S
 typr_mutual_tree_step_result_name(1, left_result).
 typr_mutual_tree_step_result_name(2, right_result).
 
+typr_mutual_tree_call_expr(branch_call(HelperName, CallArgs), CallExpr) :-
+    atomic_list_concat(CallArgs, ', ', CallArgsText),
+    format(string(CallExpr), '~w(~w)', [HelperName, CallArgsText]).
+
 typr_mutual_tree_dual_branch_call_lines(
-    [branch_call(FirstHelperName, FirstStepExpr), branch_call(SecondHelperName, SecondStepExpr)],
+    [FirstCall, SecondCall],
     Prefix,
     [FirstLine, SecondLine, ResultLine]
 ) :-
-    format(string(FirstLine), '~wleft_result = ~w(~w);', [Prefix, FirstHelperName, FirstStepExpr]),
-    format(string(SecondLine), '~wright_result = ~w(~w);', [Prefix, SecondHelperName, SecondStepExpr]),
+    typr_mutual_tree_call_expr(FirstCall, FirstCallExpr),
+    typr_mutual_tree_call_expr(SecondCall, SecondCallExpr),
+    format(string(FirstLine), '~wleft_result = ~w;', [Prefix, FirstCallExpr]),
+    format(string(SecondLine), '~wright_result = ~w;', [Prefix, SecondCallExpr]),
     format(string(ResultLine), '~wresult = left_result && right_result;', [Prefix]).
 
 typr_mutual_tree_dual_branch_call_lines_no_memo(
-    [branch_call(FirstHelperName, FirstStepExpr), branch_call(SecondHelperName, SecondStepExpr)],
+    [FirstCall, SecondCall],
     Prefix,
     [FirstLine, SecondLine, ResultLine]
 ) :-
-    format(string(FirstLine), '~wleft_result = ~w(~w);', [Prefix, FirstHelperName, FirstStepExpr]),
-    format(string(SecondLine), '~wright_result = ~w(~w);', [Prefix, SecondHelperName, SecondStepExpr]),
+    typr_mutual_tree_call_expr(FirstCall, FirstCallExpr),
+    typr_mutual_tree_call_expr(SecondCall, SecondCallExpr),
+    format(string(FirstLine), '~wleft_result = ~w;', [Prefix, FirstCallExpr]),
+    format(string(SecondLine), '~wright_result = ~w;', [Prefix, SecondCallExpr]),
     format(string(ResultLine), '~wleft_result && right_result', [Prefix]).
 
 typr_mutual_false_lines(GroupName, [

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2618,4 +2618,40 @@ test(transitive_closure_seeds_known_base_facts) :-
     once(sub_string(Code, _, _, _, "_seed_edge_1 <- add_edge(\"a\", \"b\");")),
     once(sub_string(Code, _, _, _, "_seed_edge_2 <- add_edge(\"b\", \"c\");")).
 
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx([V, L, R], T) :-
+        V >= T,
+        typr_mutual_odd_tree_ctx(L, T),
+        typr_mutual_odd_tree_ctx(R, T)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx([V, L, R], T) :-
+        V >= T,
+        typr_mutual_even_tree_ctx(L, T),
+        typr_mutual_even_tree_ctx(R, T)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx/2, typr_mutual_odd_tree_ctx/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_impl(.subset2(current_input, 3), current_ctx);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -1632,6 +1632,39 @@ test(asymmetric_nary_list_linear_recursive_output_checks_with_typr, [condition(t
     ),
     retractall(user:asym_rec_c(_, _, _)).
 
+test(structural_tree_dual_mutual_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx([V, L, R], T) :-
+        V >= T,
+        typr_mutual_odd_tree_ctx(L, T),
+        typr_mutual_odd_tree_ctx(R, T)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx([V, L, R], T) :-
+        V >= T,
+        typr_mutual_even_tree_ctx(L, T),
+        typr_mutual_even_tree_ctx(R, T)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion path from arity-1 boolean SCCs to a first arity-2 structural SCC shape.

The newly supported shape is intentionally narrow:

- arity-2 predicates
- boolean return type
- one tree-driving argument
- one invariant context argument
- fact-style tree base cases
- one recursive clause per predicate
- two shared subtree calls into the other predicate in the same SCC
- TypR-translatable boolean rejoin

A representative example is:

```prolog
typr_mutual_even_tree_ctx([], _T).
typr_mutual_even_tree_ctx([V, L, R], T) :-
    V >= T,
    typr_mutual_odd_tree_ctx(L, T),
    typr_mutual_odd_tree_ctx(R, T).

typr_mutual_odd_tree_ctx([_, [], []], _T).
typr_mutual_odd_tree_ctx([V, L, R], T) :-
    V >= T,
    typr_mutual_even_tree_ctx(L, T),
    typr_mutual_even_tree_ctx(R, T).
```

Before this PR, the SCC compiler correctly classified that shape as mutual recursion, but TypR still failed with `No mutual recursion support for target typr`.

After this PR, that conservative arity-2 shape lowers natively to TypR, passes real `typr check`, and stays inside the existing memoized-helper TypR model.

## Why This PR Exists

Previous TypR recursion work already supported:

- transitive closure
- accumulator-style tail recursion
- single-call linear recursion
- `fib/2`-style helper recursion
- a broad conservative structural tree-recursion subset
- conservative mutual recursion for:
  - arity-1 numeric boolean SCCs
  - arity-1 list-structural boolean SCCs
  - arity-1 tree-structural boolean SCCs

That still left a confirmed SCC gap:

- mutual recursion over tree structure with one extra invariant context argument
- native TypR had no way to carry that extra argument through helper signatures, wrapper calls, memo keys, and subtree recursive calls as one consistent path

This PR closes that first arity-2 mutual-recursion gap.

## Main Changes

### 1. Generalized mutual tree helper emission to support full call-argument lists

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual tree backend no longer assumes every helper only takes `current_input`.

It now has reusable support for:

- helper parameter lists
- wrapper-to-helper call forwarding
- multi-argument helper call expression generation
- memo key generation for multi-argument tree helpers

That generalization is the real compiler step in this PR. The arity-2 SCC support sits on top of it.

### 2. Added conservative arity-2 tree mutual-recursion matching

TypR now recognizes a conservative SCC shape where each predicate has:

- arity `2`
- a tree input in arg `1`
- an invariant context value in arg `2`
- boolean return type
- one recursive clause
- two shared subtree calls passing the same context value through

This is still conservative SCC lowering, not general mutual recursion.

### 3. Generalized tree mutual base-case matching

Tree mutual base-case recognition no longer assumes arity `1` heads.

That means supported tree mutual-recursion shapes can ignore trailing invariant arguments when checking base cases, instead of failing SCC recognition outright.

### 4. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for `typr_mutual_even_tree_ctx/2` / `typr_mutual_odd_tree_ctx/2`
- arity-2 wrapper signatures
- multi-argument helper signatures
- multi-argument recursive subtree calls
- real `typr check` validation for the generated output

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now make the real supported generalization explicit:

- conservative tree-structural boolean SCCs may include one invariant context argument threaded through the shared subtree calls

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR mutual-recursion subset includes:

- conservative arity-1 numeric boolean SCCs
- conservative arity-1 list-structural boolean SCCs
- conservative arity-1 tree-structural boolean SCCs
- conservative arity-2 tree-structural boolean SCCs with one invariant context argument

More general SCC lowering is still out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative arity-2 tree mutual recursion with one invariant context argument
- reusable multi-argument mutual tree helper emission infrastructure
- regression coverage and real TypR validation for that shape

Still not fully implemented:

- broader arity-2 mutual recursion with guarded branch-local control around the direct recursive calls
- richer SCCs with more than one invariant threaded argument
- general SCC lowering
- arbitrary recursive-body lowering

## Why This PR Is Worth Merging

This PR is the right next SCC increment because it closes a confirmed failing slice and leaves the backend cleaner than before.

It gives the project:

- the first native TypR arity-2 mutual-recursion path
- a real generalization of mutual tree helper plumbing instead of another one-off special case
- real `typr check` validation for the new shape
- docs that match the actual supported TypR SCC subset

This is a good incremental PR because it expands the TypR mutual-recursion boundary in a defensible way without pretending TypR already supports general SCC lowering.
