### PR TITLE
Keep native TypR arity-2 mutual tree branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,10 @@ includes:
   state around those calls, including one nested branch-local control point
   around those calls before the shared boolean rejoin, one nested
   branch-local control point between the two direct recursive subtree calls
-  with limited alias or guard state before the second call, and shared
-  branch-local guard prework before a nested mutual branch, lowered to TypR
+  with limited alias or guard state before the second call, shared
+  branch-local guard prework before a nested mutual branch, and the same
+  conservative guarded branch-body family with one invariant context
+  argument threaded through the subtree calls, lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -215,7 +215,7 @@ bring-up.
     second call, shared branch-local guard prework before a nested mutual
     branch, and conservative arity-2 tree-structural SCCs with one
     invariant context argument threaded through the shared dual-subtree
-    calls
+    calls and the same conservative guarded branch-body family
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -394,7 +394,8 @@ Current TypR lowering policy is intentionally mixed:
   subtree calls with limited alias or guard state before the second call,
   and shared branch-local guard prework before a nested mutual branch, and
   conservative arity-2 tree-structural SCCs with one invariant context
-  argument threaded through the shared dual-subtree calls, using
+  argument threaded through the shared dual-subtree calls and the same
+  conservative guarded branch-body family, using
   raw-expression memoized helper bodies inside TypR rather than wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -85,9 +85,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      subtree calls with limited alias or guard state before the second
      call, shared branch-local guard prework before a nested mutual
      branch, conservative arity-2 tree-structural SCCs with one invariant
-     context argument threaded through the shared dual-subtree calls, and
-     boolean return types, emitted as TypR functions with raw-expression
-     memoized helper bodies
+     context argument threaded through the shared dual-subtree calls and
+     the same conservative guarded branch-body family, and boolean return
+     types, emitted as TypR functions with raw-expression memoized helper
+     bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -321,6 +321,18 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
         guard_expr: GuardExpr
     }.
 
+typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr) :-
+    atom_string(Pred, PredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    ExtraArgMap = [ContextVar-"current_ctx"],
+    HelperParams = ["current_input", "current_ctx"],
+    WrapperCallArgs = ["arg1", "arg2"],
+    format(
+        string(MemoKeyExpr),
+        'paste0("~w:", paste(deparse(list(current_input, current_ctx)), collapse=""))',
+        [PredStr]
+    ).
+
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
     findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
@@ -408,6 +420,114 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
         typed_arg_list: TypedArgList,
         return_type: "bool",
         helper_name: HelperName,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        branch_condition_expr: BranchConditionExpr,
+        then_body: branch_calls(ThenCalls),
+        else_body: branch_calls(ElseCalls)
+    }.
+
+typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [BranchGoal],
+    typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap0, ExtraArgMap, ThenBody),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap0, ExtraArgMap, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, ExtraArgMap, BranchConditionExpr),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_branch,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        branch_condition_expr: BranchConditionExpr,
+        then_body: ThenBody,
+        else_body: ElseBody
+    }.
+
+typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [BranchGoal, GoalA, GoalB],
+    typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    maplist(typr_mutual_tree_alias_goal, ThenGoals),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    maplist(typr_mutual_tree_alias_goal, ElseGoals),
+    typr_mutual_tree_alias_map(ThenGoals, LeftVar, RightVar, ThenAliasMap),
+    typr_mutual_tree_alias_map(ElseGoals, LeftVar, RightVar, ElseAliasMap),
+    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    maplist(
+        typr_mutual_tree_recursive_goal(GroupPredicates, ThenAliasMap, ExtraArgMap),
+        [GoalA, GoalB],
+        ThenGoalSpecs
+    ),
+    maplist(
+        typr_mutual_tree_recursive_goal(GroupPredicates, ElseAliasMap, ExtraArgMap),
+        [GoalA, GoalB],
+        ElseGoalSpecs
+    ),
+    typr_mutual_tree_call_specs_cover_both_sides(ThenGoalSpecs),
+    typr_mutual_tree_call_specs_cover_both_sides(ElseGoalSpecs),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, ExtraArgMap, BranchConditionExpr),
+    maplist(typr_mutual_tree_branch_call, ThenGoalSpecs, ThenCalls),
+    maplist(typr_mutual_tree_branch_call, ElseGoalSpecs, ElseCalls),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_branch,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
         base_conditions: BaseConditions,
         guard_expr: 'length(current_input) == 3',
         branch_condition_expr: BranchConditionExpr,
@@ -609,25 +729,28 @@ typr_mutual_tree_branch_call(call_spec(_Side, NextPred, CallArgs), branch_call(H
     format(string(HelperName), '~w_impl', [NextPredStr]).
 
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+    typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, [], Body).
+
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [NestedIfGoal], Goals),
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ThenBody),
+    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap, ThenBody),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ElseBody),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr),
+    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, BranchConditionExpr),
     typr_mutual_tree_guard_wrap(
         GuardExpr,
         branch_if(BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [FirstGoal0, NestedIfGoal], Goals),
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
-    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, FirstGoal0, FirstGoalSpec),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr),
+    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, FirstGoal0, FirstGoalSpec),
     typr_mutual_tree_branch_call(FirstGoalSpec, FirstCall),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
@@ -637,6 +760,7 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
         ThenGoals,
         ValueVar,
         AliasMap,
+        ExtraArgMap,
         ThenBody,
         ThenGoalSpecs
     ),
@@ -648,33 +772,34 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
         ElseGoals,
         ValueVar,
         AliasMap,
+        ExtraArgMap,
         ElseBody,
         ElseGoalSpecs
     ),
     typr_mutual_tree_call_specs_cover_both_sides([FirstGoalSpec|ElseGoalSpecs]),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, BranchConditionExpr),
     typr_mutual_tree_guard_wrap(
         GuardExpr,
         branch_after_call(FirstCall, BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
-    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap), [GoalA, GoalB], GoalSpecs),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap), [GoalA, GoalB], GoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
     typr_mutual_tree_guard_wrap(GuardExpr, branch_calls(Calls), Body).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
-    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, GoalSpecs, Steps),
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     typr_mutual_tree_branch_body_from_steps(Steps, Body).
 
-typr_mutual_tree_branch_sequence(_GroupPredicates, [], _ValueVar, _AliasMap, [], []).
-typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, GoalSpecs, Steps) :-
+typr_mutual_tree_branch_sequence(_GroupPredicates, [], _ValueVar, _AliasMap, _ExtraArgMap, [], []).
+typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps) :-
     typr_strip_module_goal(Goal0, Goal),
-    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, Goal, GoalSpec)
+    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, ExtraArgMap, Goal, GoalSpec)
     ->  typr_mutual_tree_branch_call(GoalSpec, Call),
         GoalSpecs = [GoalSpec|RestGoalSpecs],
         Steps = [step_call(Call)|RestSteps],
@@ -684,7 +809,7 @@ typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasM
         Steps = RestSteps,
         typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1)
     ;   \+ typr_mutual_tree_nested_goal(Goal),
-        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, VarMap),
+        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap, VarMap),
         native_typr_guard_goal(Goal, VarMap, GuardCondition)
     ->  GoalSpecs = RestGoalSpecs,
         Steps = [step_guard(GuardCondition)|RestSteps],
@@ -695,6 +820,7 @@ typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasM
         Rest,
         ValueVar,
         AliasMap1,
+        ExtraArgMap,
         RestGoalSpecs,
         RestSteps
     ).
@@ -704,7 +830,10 @@ typr_mutual_tree_branch_body_from_steps([step_call(Call1), step_call(Call2)], br
 typr_mutual_tree_branch_body_from_steps(Steps, branch_steps(Steps)).
 
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body, GoalSpecs) :-
-    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, GoalSpecs, Steps),
+    typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, [], Body, GoalSpecs).
+
+typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, GoalSpecs) :-
+    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
     typr_mutual_tree_branch_body_from_steps(Steps, Body).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2654,4 +2654,152 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_path) 
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_branch_pre_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_branch_pre([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_branch_pre([V, L, R], T) :-
+        ( V > T ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_odd_tree_ctx_branch_pre(Left, T),
+        typr_mutual_odd_tree_ctx_branch_pre(Right, T)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_branch_pre([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_branch_pre([V, L, R], T) :-
+        ( V > T ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_even_tree_ctx_branch_pre(Left, T),
+        typr_mutual_even_tree_ctx_branch_pre(Right, T)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_pre/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_pre/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_pre/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_pre/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_branch_pre/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_branch_pre/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_branch_pre/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_branch_pre/2, typr_mutual_odd_tree_ctx_branch_pre/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx_branch_pre <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx_branch_pre <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_branch_pre_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_branch_pre_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx_branch_pre:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_branch_pre_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_branch_pre_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_branch_pre_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_branch_pre_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_branch_pre_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_branch_pre_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_branch_pre_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_branch_pre_impl(.subset2(current_input, 3), current_ctx);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_recursive_branch_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_recursive_branch([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_recursive_branch([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_recursive_branch(L, T),
+            typr_mutual_odd_tree_ctx_recursive_branch(R, T)
+        ;   typr_mutual_odd_tree_ctx_recursive_branch(R, T),
+            typr_mutual_odd_tree_ctx_recursive_branch(L, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_recursive_branch([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_recursive_branch([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_even_tree_ctx_recursive_branch(L, T),
+            typr_mutual_even_tree_ctx_recursive_branch(R, T)
+        ;   typr_mutual_even_tree_ctx_recursive_branch(R, T),
+            typr_mutual_even_tree_ctx_recursive_branch(L, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_recursive_branch/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_recursive_branch/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_recursive_branch/2, typr_mutual_odd_tree_ctx_recursive_branch/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx_recursive_branch <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx_recursive_branch <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_recursive_branch_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_recursive_branch_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx_recursive_branch:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_recursive_branch_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_recursive_branch_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_recursive_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_recursive_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_recursive_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_recursive_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_recursive_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_recursive_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_nested_branch_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_nested_branch([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_nested_branch([V, L, R], T) :-
+        ( V > T ->
+            ( V > T + 10 ->
+                typr_mutual_odd_tree_ctx_nested_branch(L, T),
+                typr_mutual_odd_tree_ctx_nested_branch(R, T)
+            ;   typr_mutual_odd_tree_ctx_nested_branch(R, T),
+                typr_mutual_odd_tree_ctx_nested_branch(L, T)
+            )
+        ;   typr_mutual_odd_tree_ctx_nested_branch(L, T),
+            typr_mutual_odd_tree_ctx_nested_branch(R, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_nested_branch([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_nested_branch([V, L, R], T) :-
+        ( V > T ->
+            ( V > T + 10 ->
+                typr_mutual_even_tree_ctx_nested_branch(L, T),
+                typr_mutual_even_tree_ctx_nested_branch(R, T)
+            ;   typr_mutual_even_tree_ctx_nested_branch(R, T),
+                typr_mutual_even_tree_ctx_nested_branch(L, T)
+            )
+        ;   typr_mutual_even_tree_ctx_nested_branch(L, T),
+            typr_mutual_even_tree_ctx_nested_branch(R, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_nested_branch/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_nested_branch/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_nested_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_nested_branch/2, typr_mutual_odd_tree_ctx_nested_branch/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx_nested_branch <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx_nested_branch <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_nested_branch_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_nested_branch_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx_nested_branch:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_nested_branch_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_nested_branch_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > (current_ctx + 10)) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_nested_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_nested_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_nested_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_nested_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_nested_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_nested_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -1665,6 +1665,135 @@ test(structural_tree_dual_mutual_context_output_checks_with_typr, [condition(typ
     retractall(user:typr_mutual_even_tree_ctx(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx(_, _)).
 
+test(structural_tree_dual_mutual_context_branch_pre_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_branch_pre([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_branch_pre([V, L, R], T) :-
+        ( V > T ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_odd_tree_ctx_branch_pre(Left, T),
+        typr_mutual_odd_tree_ctx_branch_pre(Right, T)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_branch_pre([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_branch_pre([V, L, R], T) :-
+        ( V > T ->
+            Left = L,
+            Right = R
+        ;   Left = R,
+            Right = L
+        ),
+        typr_mutual_even_tree_ctx_branch_pre(Left, T),
+        typr_mutual_even_tree_ctx_branch_pre(Right, T)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_pre/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_pre/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_pre/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_pre/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_branch_pre/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_branch_pre/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_branch_pre/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_branch_pre(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_branch_pre(_, _)).
+
+test(structural_tree_dual_mutual_context_recursive_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_recursive_branch([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_recursive_branch([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_recursive_branch(L, T),
+            typr_mutual_odd_tree_ctx_recursive_branch(R, T)
+        ;   typr_mutual_odd_tree_ctx_recursive_branch(R, T),
+            typr_mutual_odd_tree_ctx_recursive_branch(L, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_recursive_branch([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_recursive_branch([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_even_tree_ctx_recursive_branch(L, T),
+            typr_mutual_even_tree_ctx_recursive_branch(R, T)
+        ;   typr_mutual_even_tree_ctx_recursive_branch(R, T),
+            typr_mutual_even_tree_ctx_recursive_branch(L, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_recursive_branch/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_recursive_branch/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_recursive_branch(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_recursive_branch(_, _)).
+
+test(structural_tree_dual_mutual_context_nested_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_nested_branch([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_nested_branch([V, L, R], T) :-
+        ( V > T ->
+            ( V > T + 10 ->
+                typr_mutual_odd_tree_ctx_nested_branch(L, T),
+                typr_mutual_odd_tree_ctx_nested_branch(R, T)
+            ;   typr_mutual_odd_tree_ctx_nested_branch(R, T),
+                typr_mutual_odd_tree_ctx_nested_branch(L, T)
+            )
+        ;   typr_mutual_odd_tree_ctx_nested_branch(L, T),
+            typr_mutual_odd_tree_ctx_nested_branch(R, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_nested_branch([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_nested_branch([V, L, R], T) :-
+        ( V > T ->
+            ( V > T + 10 ->
+                typr_mutual_even_tree_ctx_nested_branch(L, T),
+                typr_mutual_even_tree_ctx_nested_branch(R, T)
+            ;   typr_mutual_even_tree_ctx_nested_branch(R, T),
+                typr_mutual_even_tree_ctx_nested_branch(L, T)
+            )
+        ;   typr_mutual_even_tree_ctx_nested_branch(L, T),
+            typr_mutual_even_tree_ctx_nested_branch(R, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_nested_branch/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_nested_branch/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_nested_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_nested_branch(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_nested_branch(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR mutual-recursion path for arity-2 tree-structural boolean SCCs.

The newly supported shapes are still intentionally narrow:

- arity-2 predicates
- boolean return type
- one tree-driving argument
- one invariant context argument
- fact-style tree base cases
- one recursive clause per predicate
- two subtree calls into the other predicate in the same SCC
- TypR-translatable boolean rejoin

What is new is that the arity-2 path now supports the same guarded branch-body family that the arity-1 tree mutual path already handled:

- guarded alias selection before shared subtree calls
- direct recursive subtree calls inside guarded branch bodies
- one nested branch-local control point around those subtree calls

Representative examples:

```prolog
typr_mutual_even_tree_ctx_branch_pre([], _T).
typr_mutual_even_tree_ctx_branch_pre([V, L, R], T) :-
    ( V > T ->
        Left = L,
        Right = R
    ;   Left = R,
        Right = L
    ),
    typr_mutual_odd_tree_ctx_branch_pre(Left, T),
    typr_mutual_odd_tree_ctx_branch_pre(Right, T).

typr_mutual_odd_tree_ctx_recursive_branch([_, [], []], _T).
typr_mutual_odd_tree_ctx_recursive_branch([V, L, R], T) :-
    ( V > T ->
        typr_mutual_even_tree_ctx_recursive_branch(L, T),
        typr_mutual_even_tree_ctx_recursive_branch(R, T)
    ;   typr_mutual_even_tree_ctx_recursive_branch(R, T),
        typr_mutual_even_tree_ctx_recursive_branch(L, T)
    ).
```

Before this PR, those conservative arity-2 SCC shapes still failed with `No mutual recursion support for target typr`.

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

Previous TypR mutual-recursion work already supported:

- arity-1 numeric boolean SCCs
- arity-1 list-structural boolean SCCs
- arity-1 tree-structural boolean SCCs with increasingly rich guarded branch bodies
- arity-2 tree-structural boolean SCCs with one invariant context argument only for the straight shared-call case

That left a confirmed SCC gap:

- the multi-argument helper plumbing existed
- but the richer guarded tree mutual branch-body path still assumed the arity-1 shape
- so conservative arity-2 mutual tree branches kept falling out of the TypR mutual backend

This PR closes that gap by generalizing the branch-body path instead of adding another one-off matcher.

## Main Changes

### 1. Generalized mutual tree helper plumbing

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual tree backend now uses reusable helper metadata for:

- helper parameter lists
- wrapper-to-helper forwarding
- multi-argument recursive call emission
- memo key construction

That generalization is the main compiler step in this PR. The new supported SCC shapes sit on top of it.

### 2. Added conservative arity-2 mutual tree branch-body lowering

TypR now recognizes conservative arity-2 tree mutual SCCs where the shared context argument is threaded through:

- guarded alias-selection branches before shared subtree calls
- guarded branch bodies that directly perform the subtree calls
- one nested branch-local control point around those subtree calls

This is still conservative SCC lowering, not general mutual recursion.

### 3. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for arity-2 guarded mutual tree branch prework
- native TypR lowering for arity-2 guarded mutual direct-call branch bodies
- native TypR lowering for arity-2 nested mutual tree branches
- arity-2 wrapper signatures
- multi-argument helper signatures
- shared context threading through subtree calls
- real `typr check` validation for the generated output

### 4. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now make the real supported generalization explicit:

- conservative arity-2 tree-structural boolean SCCs may use the same conservative guarded branch-body family as the current arity-1 tree mutual path, while threading one invariant context argument through the subtree calls

## Files Changed

### Implementation

- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All of the above passed.

## Behavior Notes

After this PR, the supported native TypR mutual-recursion subset includes:

- conservative arity-1 numeric boolean SCCs
- conservative arity-1 list-structural boolean SCCs
- conservative arity-1 tree-structural boolean SCCs
- conservative arity-2 tree-structural boolean SCCs with one invariant context argument
- the same conservative guarded branch-body family for that arity-2 tree path

More general SCC lowering is still out of scope.

## Scope and Remaining Gaps

Implemented now:

- native TypR lowering for conservative arity-2 tree mutual recursion with one invariant context argument across richer guarded branch bodies
- reusable multi-argument mutual tree helper metadata and call emission
- regression coverage and real TypR validation for those shapes

Still not fully implemented:

- richer branch-local state between the two direct recursive calls in arity-2 mutual tree SCCs
- broader arity-2 mutual recursion beyond one invariant threaded argument
- general SCC lowering
- arbitrary recursive-body lowering

## Why This PR Is Worth Merging

This PR closes a confirmed failing SCC slice and does it by improving the compiler boundary rather than adding another fragile special case.

It gives the project:

- the first guarded arity-2 mutual tree branch-body path in native TypR
- a reusable generalization for multi-argument mutual tree helpers
- real `typr check` validation for the richer arity-2 SCC family
- docs that match the actual supported TypR SCC subset

This is the right incremental SCC PR because it expands the TypR mutual-recursion boundary in a defensible way without pretending TypR already supports general SCC lowering.
