### PR TITLE
Generalize native TypR arity-2 mutual context threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,16 +246,17 @@ includes:
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
   plus arity-2 tree-structural SCCs with one tree-driving argument and one
   invariant context argument, including dual-subtree tree SCCs with
-  alias-style prework or guarded branch-local alias selection before the
-  two recursive subtree calls, or direct recursive subtree calls inside
-  supported guarded branch bodies with limited branch-local alias or guard
-  state around those calls, including one nested branch-local control point
-  around those calls before the shared boolean rejoin, one nested
-  branch-local control point between the two direct recursive subtree calls
-  with limited alias or guard state before the second call, shared
-  branch-local guard prework before a nested mutual branch, and the same
-  conservative guarded branch-body family with one invariant context
-  argument threaded through the subtree calls, lowered to TypR
+  alias-style prework, shared computed context updates, or guarded shared
+  context selection before the two recursive subtree calls, or direct
+  recursive subtree calls inside supported guarded branch bodies with
+  limited branch-local alias or guard state around those calls, including
+  one nested branch-local control point around those calls before the
+  shared boolean rejoin, one nested branch-local control point between the
+  two direct recursive subtree calls with limited alias or guard state
+  before the second call, shared branch-local guard prework before a nested
+  mutual branch, and the same conservative guarded branch-body family with
+  one invariant context argument threaded through the subtree calls,
+  lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates with one

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -215,7 +215,9 @@ bring-up.
     second call, shared branch-local guard prework before a nested mutual
     branch, and conservative arity-2 tree-structural SCCs with one
     invariant context argument threaded through the shared dual-subtree
-    calls and the same conservative guarded branch-body family
+    calls, shared computed context updates or guarded shared context
+    selection before those calls, and the same conservative guarded
+    branch-body family
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -394,8 +394,9 @@ Current TypR lowering policy is intentionally mixed:
   subtree calls with limited alias or guard state before the second call,
   and shared branch-local guard prework before a nested mutual branch, and
   conservative arity-2 tree-structural SCCs with one invariant context
-  argument threaded through the shared dual-subtree calls and the same
-  conservative guarded branch-body family, using
+  argument threaded through the shared dual-subtree calls, shared computed
+  context updates or guarded shared context selection before those calls,
+  and the same conservative guarded branch-body family, using
   raw-expression memoized helper bodies inside TypR rather than wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -76,19 +76,19 @@ This document focuses on architecture and rollout choices specific to TypR.
      with `[]` / `[V, [], []]` base cases and one-subtree recursive descent,
      or `even_tree/1` / `odd_tree/1`-style tree-structural SCC shape with
      `[]` / `[V, [], []]` base cases, two-subtree boolean descent,
-     alias-style prework, guarded branch-local alias selection, or direct
-     recursive subtree calls inside supported guarded branch bodies with
-     limited branch-local alias or guard state around those calls before
-     the shared boolean rejoin after the two recursive subtree calls,
-     including one nested branch-local control point around those calls,
-     one nested branch-local control point between the two direct recursive
-     subtree calls with limited alias or guard state before the second
-     call, shared branch-local guard prework before a nested mutual
-     branch, conservative arity-2 tree-structural SCCs with one invariant
-     context argument threaded through the shared dual-subtree calls and
-     the same conservative guarded branch-body family, and boolean return
-     types, emitted as TypR functions with raw-expression memoized helper
-     bodies
+     alias-style prework, shared computed context updates, guarded shared
+     context selection, or direct recursive subtree calls inside supported
+     guarded branch bodies with limited branch-local alias or guard state
+     around those calls before the shared boolean rejoin after the two
+     recursive subtree calls, including one nested branch-local control
+     point around those calls, one nested branch-local control point
+     between the two direct recursive subtree calls with limited alias or
+     guard state before the second call, shared branch-local guard prework
+     before a nested mutual branch, conservative arity-2 tree-structural
+     SCCs with one invariant context argument threaded through the shared
+     dual-subtree calls and the same computed-context and guarded
+     branch-body families, and boolean return types, emitted as TypR
+     functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving
      argument, invariant context args, and limited native guards, local

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -281,8 +281,8 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
     append(PreGoals, RecGoals, Goals),
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
-    ExtraArgMap = [ContextVar-"current_ctx"],
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, PreGuardExpr),
+    ExtraArgMap0 = [ContextVar-"current_ctx"],
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap, PreGuardExpr),
     maplist(
         typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap),
         [GoalA, GoalB],
@@ -493,29 +493,45 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    maplist(typr_mutual_tree_alias_goal, ThenGoals),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    maplist(typr_mutual_tree_alias_goal, ElseGoals),
-    typr_mutual_tree_alias_map(ThenGoals, LeftVar, RightVar, ThenAliasMap),
-    typr_mutual_tree_alias_map(ElseGoals, LeftVar, RightVar, ElseAliasMap),
-    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_branch_prework(
+        ThenGoals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        ThenAliasMap,
+        ThenExtraArgMap,
+        ThenGuardExpr
+    ),
+    typr_mutual_tree_branch_prework(
+        ElseGoals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        ElseAliasMap,
+        ElseExtraArgMap,
+        ElseGuardExpr
+    ),
     maplist(
-        typr_mutual_tree_recursive_goal(GroupPredicates, ThenAliasMap, ExtraArgMap),
+        typr_mutual_tree_recursive_goal(GroupPredicates, ThenAliasMap, ThenExtraArgMap),
         [GoalA, GoalB],
         ThenGoalSpecs
     ),
     maplist(
-        typr_mutual_tree_recursive_goal(GroupPredicates, ElseAliasMap, ExtraArgMap),
+        typr_mutual_tree_recursive_goal(GroupPredicates, ElseAliasMap, ElseExtraArgMap),
         [GoalA, GoalB],
         ElseGoalSpecs
     ),
     typr_mutual_tree_call_specs_cover_both_sides(ThenGoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(ElseGoalSpecs),
-    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, ExtraArgMap, BranchConditionExpr),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, ExtraArgMap0, BranchConditionExpr),
     maplist(typr_mutual_tree_branch_call, ThenGoalSpecs, ThenCalls),
     maplist(typr_mutual_tree_branch_call, ElseGoalSpecs, ElseCalls),
+    typr_mutual_tree_guard_wrap(ThenGuardExpr, branch_calls(ThenCalls), ThenBody),
+    typr_mutual_tree_guard_wrap(ElseGuardExpr, branch_calls(ElseCalls), ElseBody),
     atom_string(Pred, PredStr),
     Spec = mutual_spec{
         kind: tree_dual_branch,
@@ -531,8 +547,8 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
         base_conditions: BaseConditions,
         guard_expr: 'length(current_input) == 3',
         branch_condition_expr: BranchConditionExpr,
-        then_body: branch_calls(ThenCalls),
-        else_body: branch_calls(ElseCalls)
+        then_body: ThenBody,
+        else_body: ElseBody
     }.
 
 typr_mutual_tree_base_case_condition(clause(Head, true), 'length(current_input) == 0') :-
@@ -655,8 +671,8 @@ typr_mutual_extra_arg_expr(ExtraArgMap, Arg, Expr) :-
     member(StoredArg-Expr, ExtraArgMap),
     StoredArg == Arg,
     !.
-typr_mutual_extra_arg_expr(_ExtraArgMap, Arg, Expr) :-
-    typr_translate_r_expr(Arg, [], Expr).
+typr_mutual_extra_arg_expr(ExtraArgMap, Arg, Expr) :-
+    typr_translate_r_expr(Arg, ExtraArgMap, Expr).
 
 typr_mutual_tree_call_specs_cover_both_sides(CallSpecs) :-
     findall(Side, member(call_spec(Side, _NextPred, _StepExpr), CallSpecs), Sides0),
@@ -678,18 +694,35 @@ typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, 
 
 typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, AliasMap, none).
 typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, AliasMap, GuardExpr) :-
-    typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, [], AliasMap, GuardExpr).
+    typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, [], AliasMap, _ExtraArgMap, GuardExpr).
 
-typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, _ExtraArgMap, AliasMap, none).
-typr_mutual_tree_branch_prework([Goal|Rest], ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr) :-
+typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, GuardExpr) :-
+    typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, _ExtraArgMap, GuardExpr).
+
+typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, ExtraArgMap, AliasMap, ExtraArgMap, none).
+typr_mutual_tree_branch_prework([Goal|Rest], ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap, GuardExpr) :-
     (   typr_mutual_tree_alias_goal(Goal)
     ->  typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1),
-        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap1, ExtraArgMap, AliasMap, GuardExpr)
-    ;   typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap, VarMap),
+        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap1, ExtraArgMap0, AliasMap, ExtraArgMap, GuardExpr)
+    ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap0, ExtraArgMap1)
+    ->  typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap0, ExtraArgMap1, AliasMap, ExtraArgMap, GuardExpr)
+    ;   typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap0, VarMap),
         native_typr_guard_goal(Goal, VarMap, GuardCondition),
-        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap0, ExtraArgMap, AliasMap, RestGuardExpr),
+        typr_mutual_tree_branch_prework(Rest, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap, RestGuardExpr),
         typr_mutual_tree_guard_expr_join(GuardCondition, RestGuardExpr, GuardExpr)
     ).
+
+typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap, ExtraArgMap0, ExtraArgMap) :-
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap0, VarMap0),
+    linear_recursive_post_goal_varmap(Goal, VarMap0, VarMap1),
+    varmap_changed_vars(VarMap0, VarMap1, ChangedVars0),
+    unique_vars_by_identity(ChangedVars0, ChangedVars),
+    ChangedVars \= [],
+    foldl(typr_mutual_tree_store_symbolic_expr(VarMap1), ChangedVars, ExtraArgMap0, ExtraArgMap).
+
+typr_mutual_tree_store_symbolic_expr(VarMap, Var, ExtraArgMap0, ExtraArgMap) :-
+    lookup_typr_var(Var, VarMap, Expr),
+    update_typr_expr_varmap(ExtraArgMap0, Var, Expr, ExtraArgMap).
 
 typr_mutual_tree_guard_expr_join(GuardCondition, none, GuardCondition) :-
     !.
@@ -733,15 +766,15 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
 
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [NestedIfGoal], Goals),
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap, ThenBody),
+    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap1, ThenBody),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap, ElseBody),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, BranchConditionExpr),
+    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap1, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     typr_mutual_tree_guard_wrap(
         GuardExpr,
         branch_if(BranchConditionExpr, ThenBody, ElseBody),
@@ -749,8 +782,8 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
     ).
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [FirstGoal0, NestedIfGoal], Goals),
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr),
-    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, FirstGoal0, FirstGoalSpec),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
+    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1, FirstGoal0, FirstGoalSpec),
     typr_mutual_tree_branch_call(FirstGoalSpec, FirstCall),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
@@ -760,7 +793,7 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         ThenGoals,
         ValueVar,
         AliasMap,
-        ExtraArgMap,
+        ExtraArgMap1,
         ThenBody,
         ThenGoalSpecs
     ),
@@ -772,12 +805,12 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         ElseGoals,
         ValueVar,
         AliasMap,
-        ExtraArgMap,
+        ExtraArgMap1,
         ElseBody,
         ElseGoalSpecs
     ),
     typr_mutual_tree_call_specs_cover_both_sides([FirstGoalSpec|ElseGoalSpecs]),
-    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, BranchConditionExpr),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     typr_mutual_tree_guard_wrap(
         GuardExpr,
         branch_after_call(FirstCall, BranchConditionExpr, ThenBody, ElseBody),
@@ -786,8 +819,8 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
-    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, GuardExpr),
-    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap), [GoalA, GoalB], GoalSpecs),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1), [GoalA, GoalB], GoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
     typr_mutual_tree_guard_wrap(GuardExpr, branch_calls(Calls), Body).
@@ -803,24 +836,31 @@ typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasM
     ->  typr_mutual_tree_branch_call(GoalSpec, Call),
         GoalSpecs = [GoalSpec|RestGoalSpecs],
         Steps = [step_call(Call)|RestSteps],
-        AliasMap1 = AliasMap0
+        AliasMap1 = AliasMap0,
+        ExtraArgMap1 = ExtraArgMap
     ;   typr_mutual_tree_alias_goal(Goal)
     ->  GoalSpecs = RestGoalSpecs,
         Steps = RestSteps,
-        typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1)
+        typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1),
+        ExtraArgMap1 = ExtraArgMap
+    ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap, ExtraArgMap1)
+    ->  GoalSpecs = RestGoalSpecs,
+        Steps = RestSteps,
+        AliasMap1 = AliasMap0
     ;   \+ typr_mutual_tree_nested_goal(Goal),
         typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap, VarMap),
         native_typr_guard_goal(Goal, VarMap, GuardCondition)
     ->  GoalSpecs = RestGoalSpecs,
         Steps = [step_guard(GuardCondition)|RestSteps],
-        AliasMap1 = AliasMap0
+        AliasMap1 = AliasMap0,
+        ExtraArgMap1 = ExtraArgMap
     ),
     typr_mutual_tree_branch_sequence(
         GroupPredicates,
         Rest,
         ValueVar,
         AliasMap1,
-        ExtraArgMap,
+        ExtraArgMap1,
         RestGoalSpecs,
         RestSteps
     ).

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -73,6 +73,18 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_nested_call_guard(_)),
     retractall(user:typr_mutual_even_tree_nested_call_alias(_)),
     retractall(user:typr_mutual_odd_tree_nested_call_alias(_)),
+    retractall(user:typr_mutual_even_tree_ctx(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_step(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_step(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_branch_step(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_branch_step(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_branch_pre(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_branch_pre(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_recursive_branch(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_recursive_branch(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_nested_branch(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_nested_branch(_, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -2651,6 +2663,87 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_path) 
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_impl(.subset2(current_input, 3), current_ctx);")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_impl(.subset2(current_input, 2), current_ctx);")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_impl(.subset2(current_input, 3), current_ctx);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_step_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_step([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_step([V, L, R], T) :-
+        V >= T,
+        T1 is T + 1,
+        typr_mutual_odd_tree_ctx_step(L, T1),
+        typr_mutual_odd_tree_ctx_step(R, T1)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_step([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_step([V, L, R], T) :-
+        V >= T,
+        T1 is T + 1,
+        typr_mutual_even_tree_ctx_step(L, T1),
+        typr_mutual_even_tree_ctx_step(R, T1)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_step/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_step/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_step/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_step/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_step/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_step/2, typr_mutual_odd_tree_ctx_step/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx_step <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx_step <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_step_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_step_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx_step:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_step_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_step_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_step_impl(.subset2(current_input, 2), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_step_impl(.subset2(current_input, 3), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_step_impl(.subset2(current_input, 2), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_step_impl(.subset2(current_input, 3), (current_ctx + 1));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_branch_step_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_branch_step([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_branch_step([V, L, R], T) :-
+        ( V > T ->
+            T1 is T + 1
+        ;   T1 is T + 2
+        ),
+        typr_mutual_odd_tree_ctx_branch_step(L, T1),
+        typr_mutual_odd_tree_ctx_branch_step(R, T1)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_branch_step([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_branch_step([V, L, R], T) :-
+        ( V > T ->
+            T1 is T + 1
+        ;   T1 is T + 2
+        ),
+        typr_mutual_even_tree_ctx_branch_step(L, T1),
+        typr_mutual_even_tree_ctx_branch_step(R, T1)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_branch_step/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_branch_step/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_branch_step/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_branch_step/2, typr_mutual_odd_tree_ctx_branch_step/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx_branch_step <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx_branch_step <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_branch_step_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_branch_step_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx_branch_step:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_branch_step_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_branch_step_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) > current_ctx }@) { (current_ctx + 1) } else { (current_ctx + 2) }")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_branch_step_impl(.subset2(current_input, 2), (if (@{ .subset2(current_input, 1) > current_ctx }@) { (current_ctx + 1) } else { (current_ctx + 2) }));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_branch_step_impl(.subset2(current_input, 3), (if (@{ .subset2(current_input, 1) > current_ctx }@) { (current_ctx + 1) } else { (current_ctx + 2) }));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_branch_step_impl(.subset2(current_input, 2), (if (@{ .subset2(current_input, 1) > current_ctx }@) { (current_ctx + 1) } else { (current_ctx + 2) }));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_branch_step_impl(.subset2(current_input, 3), (if (@{ .subset2(current_input, 1) > current_ctx }@) { (current_ctx + 1) } else { (current_ctx + 2) }));")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -1665,6 +1665,80 @@ test(structural_tree_dual_mutual_context_output_checks_with_typr, [condition(typ
     retractall(user:typr_mutual_even_tree_ctx(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx(_, _)).
 
+test(structural_tree_dual_mutual_context_step_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_step([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_step([V, L, R], T) :-
+        V >= T,
+        T1 is T + 1,
+        typr_mutual_odd_tree_ctx_step(L, T1),
+        typr_mutual_odd_tree_ctx_step(R, T1)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_step([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_step([V, L, R], T) :-
+        V >= T,
+        T1 is T + 1,
+        typr_mutual_even_tree_ctx_step(L, T1),
+        typr_mutual_even_tree_ctx_step(R, T1)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_step/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_step/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_step/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_step/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_step/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_step(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_step(_, _)).
+
+test(structural_tree_dual_mutual_context_branch_step_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_branch_step([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_branch_step([V, L, R], T) :-
+        ( V > T ->
+            T1 is T + 1
+        ;   T1 is T + 2
+        ),
+        typr_mutual_odd_tree_ctx_branch_step(L, T1),
+        typr_mutual_odd_tree_ctx_branch_step(R, T1)
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_branch_step([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_branch_step([V, L, R], T) :-
+        ( V > T ->
+            T1 is T + 1
+        ;   T1 is T + 2
+        ),
+        typr_mutual_even_tree_ctx_branch_step(L, T1),
+        typr_mutual_even_tree_ctx_branch_step(R, T1)
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_branch_step/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_branch_step/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_branch_step/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_branch_step(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_branch_step(_, _)).
+
 test(structural_tree_dual_mutual_context_branch_pre_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:typr_mutual_even_tree_ctx_branch_pre([], _T0)),


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion path for arity-2 tree-structural boolean SCCs.

The key change is that the arity-2 mutual-tree backend no longer only forwards an unchanged invariant context argument through the shared dual-subtree calls.

It now supports:

- shared computed context updates before the two recursive subtree calls
- guarded shared context selection before those calls
- the same symbolic extra-arg threading through guarded mutual-tree branch bodies and branch sequences

Representative examples:

```prolog
typr_mutual_even_tree_ctx_step([], _T0).
typr_mutual_even_tree_ctx_step([V, L, R], T) :-
    V >= T,
    T1 is T + 1,
    typr_mutual_odd_tree_ctx_step(L, T1),
    typr_mutual_odd_tree_ctx_step(R, T1).

typr_mutual_even_tree_ctx_branch_step([], _T0).
typr_mutual_even_tree_ctx_branch_step([V, L, R], T) :-
    ( V > T ->
        T1 is T + 1
    ;   T1 is T + 2
    ),
    typr_mutual_odd_tree_ctx_branch_step(L, T1),
    typr_mutual_odd_tree_ctx_branch_step(R, T1).
```

Before this PR, those shapes still fell out of the TypR mutual-recursion path and failed with `No mutual recursion support for target typr`.

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

Previous TypR mutual-recursion work already supported:

- arity-1 numeric boolean SCCs
- arity-1 list-structural boolean SCCs
- arity-1 tree-structural boolean SCCs
- conservative arity-2 tree-structural boolean SCCs with one invariant context argument
- guarded arity-2 tree mutual branch families that still only forwarded that unchanged context

That left a confirmed gap:

- the multi-argument helper plumbing existed
- but branch prework only understood aliases and guards for arity-2 mutual tree SCCs
- symbolic `is` updates to the context argument were not being threaded through the shared subtree calls

This PR closes that gap by generalizing the extra-arg state tracking instead of adding a one-off matcher for `T1 is T + 1`.

## Main Changes

### 1. Generalized symbolic extra-arg threading for mutual tree SCCs

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-tree backend now carries symbolic extra-arg state through:

- straight prework before shared subtree calls
- guarded branch-local prework before shared subtree calls
- mutual-tree branch bodies
- mutual-tree branch sequences

This reuses the existing symbolic varmap machinery instead of inventing another parallel expression tracker.

### 2. Generalized arity-2 guarded shared-call lowering

The arity-2 branch-spec path no longer assumes branch bodies are alias-only.

It now supports branch-local prework that computes a shared next context before the two recursive subtree calls, while keeping:

- one tree-driving argument
- one invariant context argument
- boolean return type
- shared boolean rejoin

### 3. Generalized extra-arg expression translation

Recursive subtree call argument translation now resolves expressions against the current extra-arg map instead of treating extra args as raw standalone expressions.

That is the reusable part that makes later arity-2 and eventually broader `N`-ary SCC work more plausible.

### 4. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for shared context-step threading
- native TypR lowering for guarded shared context selection
- arity-2 wrapper signatures
- multi-argument helper signatures
- shared subtree calls using the computed context expression
- real `typr check` validation for both new shapes

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now make the real supported generalization explicit:

- arity-2 mutual tree SCCs can thread a shared computed context through the shared dual-subtree calls
- guarded branch-local selection of that shared computed context is also supported

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- arbitrary branch-local state across broader mutual-recursive bodies
- broader `N`-ary mutual recursion beyond the current conservative tree-structural subset

The next high-signal follow-up is another arity-2 SCC audit around richer branch-local state between or around the direct recursive subtree calls.
