### PR TITLE
Keep native TypR arity-2 mutual post-call control

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ includes:
   limited branch-local alias or guard state around those calls, including
   one nested branch-local control point around those calls before the
   shared boolean rejoin, one nested branch-local control point between the
-  two direct recursive subtree calls with limited alias or guard state
+  two direct recursive subtree calls with limited alias or guard state,
+  and one nested post-call control point after the shared dual-subtree
+  calls before the shared boolean rejoin
   before the second call, shared branch-local guard prework before a nested
   mutual branch, and the same conservative guarded branch-body family with
   one invariant context argument threaded through the subtree calls,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -212,8 +212,10 @@ bring-up.
     calls, including one nested branch-local control point around those
     calls, one nested branch-local control point between the two direct
     recursive subtree calls with limited alias or guard state before the
-    second call, shared branch-local guard prework before a nested mutual
-    branch, and conservative arity-2 tree-structural SCCs with one
+    second call, one nested post-call control point after the shared
+    dual-subtree calls before the shared boolean rejoin, shared
+    branch-local guard prework before a nested mutual branch, and
+    conservative arity-2 tree-structural SCCs with one
     invariant context argument threaded through the shared dual-subtree
     calls, shared computed context updates or guarded shared context
     selection before those calls, and the same conservative guarded

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -392,8 +392,10 @@ Current TypR lowering policy is intentionally mixed:
   including one nested branch-local control point around those calls, one
   nested branch-local control point between the two direct recursive
   subtree calls with limited alias or guard state before the second call,
-  and shared branch-local guard prework before a nested mutual branch, and
-  conservative arity-2 tree-structural SCCs with one invariant context
+  one nested post-call control point after the shared dual-subtree calls
+  before the shared boolean rejoin, and shared branch-local guard prework
+  before a nested mutual branch, and conservative arity-2 tree-structural
+  SCCs with one invariant context
   argument threaded through the shared dual-subtree calls, shared computed
   context updates or guarded shared context selection before those calls,
   and the same conservative guarded branch-body family, using

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -83,10 +83,12 @@ This document focuses on architecture and rollout choices specific to TypR.
      recursive subtree calls, including one nested branch-local control
      point around those calls, one nested branch-local control point
      between the two direct recursive subtree calls with limited alias or
-     guard state before the second call, shared branch-local guard prework
-     before a nested mutual branch, conservative arity-2 tree-structural
-     SCCs with one invariant context argument threaded through the shared
-     dual-subtree calls and the same computed-context and guarded
+     guard state before the second call, one nested post-call control
+     point after the shared dual-subtree calls before the shared boolean
+     rejoin, shared branch-local guard prework before a nested mutual
+     branch, conservative arity-2 tree-structural SCCs with one invariant
+     context argument threaded through the shared dual-subtree calls and
+     the same computed-context and guarded
      branch-body families, and boolean return types, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -817,6 +817,43 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         Body
     ).
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+    append(PreGoals, [GoalA0, GoalB0, NestedIfGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
+    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1), [GoalA0, GoalB0], GoalSpecs),
+    typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
+    maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_tail_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        ThenBody,
+        ThenGoalSpecs
+    ),
+    ThenGoalSpecs = [],
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_tail_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        ElseBody,
+        ElseGoalSpecs
+    ),
+    ElseGoalSpecs = [],
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_after_calls(Calls, BranchConditionExpr, ThenBody, ElseBody),
+        Body
+    ).
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
@@ -1431,6 +1468,18 @@ typr_mutual_tree_branch_body_lines_from(branch_after_call(BranchCall, BranchCond
     append(Lines0, [BranchElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [BranchEndLine, PrefixElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_from(branch_after_calls(Calls, BranchConditionExpr, ThenBody, ElseBody), Prefix, _Index, Lines) :-
+    typr_mutual_tree_dual_branch_call_prefix_lines(Calls, Prefix, CallLines),
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines_from(ThenBody, NestedPrefix, 3, ThenLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    typr_mutual_tree_branch_body_lines_from(ElseBody, NestedPrefix, 3, ElseLines),
+    format(string(EndLine), '~w}', [Prefix]),
+    append(CallLines, [IfLine|ThenLines], Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
 typr_mutual_tree_branch_body_lines_from(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
@@ -1479,6 +1528,18 @@ typr_mutual_tree_branch_body_lines_no_memo_from(branch_after_call(BranchCall, Br
     append(Lines0, [BranchElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [BranchEndLine, PrefixElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_after_calls(Calls, BranchConditionExpr, ThenBody, ElseBody), Prefix, _Index, Lines) :-
+    typr_mutual_tree_dual_branch_call_prefix_lines_no_memo(Calls, Prefix, CallLines),
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ThenBody, NestedPrefix, 3, ThenLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ElseBody, NestedPrefix, 3, ElseLines),
+    format(string(EndLine), '~w}', [Prefix]),
+    append(CallLines, [IfLine|ThenLines], Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
 typr_mutual_tree_branch_body_lines_no_memo_from(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
@@ -1572,6 +1633,16 @@ typr_mutual_tree_dual_branch_call_lines(
     format(string(SecondLine), '~wright_result = ~w;', [Prefix, SecondCallExpr]),
     format(string(ResultLine), '~wresult = left_result && right_result;', [Prefix]).
 
+typr_mutual_tree_dual_branch_call_prefix_lines(
+    [FirstCall, SecondCall],
+    Prefix,
+    [FirstLine, SecondLine]
+) :-
+    typr_mutual_tree_call_expr(FirstCall, FirstCallExpr),
+    typr_mutual_tree_call_expr(SecondCall, SecondCallExpr),
+    format(string(FirstLine), '~wleft_result = ~w;', [Prefix, FirstCallExpr]),
+    format(string(SecondLine), '~wright_result = ~w;', [Prefix, SecondCallExpr]).
+
 typr_mutual_tree_dual_branch_call_lines_no_memo(
     [FirstCall, SecondCall],
     Prefix,
@@ -1582,6 +1653,16 @@ typr_mutual_tree_dual_branch_call_lines_no_memo(
     format(string(FirstLine), '~wleft_result = ~w;', [Prefix, FirstCallExpr]),
     format(string(SecondLine), '~wright_result = ~w;', [Prefix, SecondCallExpr]),
     format(string(ResultLine), '~wleft_result && right_result', [Prefix]).
+
+typr_mutual_tree_dual_branch_call_prefix_lines_no_memo(
+    [FirstCall, SecondCall],
+    Prefix,
+    [FirstLine, SecondLine]
+) :-
+    typr_mutual_tree_call_expr(FirstCall, FirstCallExpr),
+    typr_mutual_tree_call_expr(SecondCall, SecondCallExpr),
+    format(string(FirstLine), '~wleft_result = ~w;', [Prefix, FirstCallExpr]),
+    format(string(SecondLine), '~wright_result = ~w;', [Prefix, SecondCallExpr]).
 
 typr_mutual_false_lines(GroupName, [
     '        } else {',

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2895,4 +2895,57 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_nested
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_postcall_guard_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_postcall_guard([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_postcall_guard([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_postcall_guard(L, T),
+            typr_mutual_odd_tree_ctx_postcall_guard(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_odd_tree_ctx_postcall_guard(L, T),
+            typr_mutual_odd_tree_ctx_postcall_guard(R, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_postcall_guard([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_postcall_guard([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_even_tree_ctx_postcall_guard(L, T),
+            typr_mutual_even_tree_ctx_postcall_guard(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_even_tree_ctx_postcall_guard(L, T),
+            typr_mutual_even_tree_ctx_postcall_guard(R, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_postcall_guard/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_postcall_guard/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_postcall_guard/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_postcall_guard/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_postcall_guard/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_postcall_guard/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_postcall_guard/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_postcall_guard/2, typr_mutual_odd_tree_ctx_postcall_guard/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx_postcall_guard <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_ctx_postcall_guard <- fn(arg1: [#N, Any], arg2: int): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_postcall_guard_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_postcall_guard_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx_postcall_guard:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx_postcall_guard_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "typr_mutual_odd_tree_ctx_postcall_guard_impl(arg1, arg2)")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_postcall_guard_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_postcall_guard_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > (current_ctx + 10)) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= current_ctx }@) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 1) }@) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_ctx_postcall_guard_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_ctx_postcall_guard_impl(.subset2(current_input, 3), current_ctx);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -1868,6 +1868,53 @@ test(structural_tree_dual_mutual_context_nested_branch_output_checks_with_typr, 
     retractall(user:typr_mutual_even_tree_ctx_nested_branch(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_nested_branch(_, _)).
 
+test(structural_tree_dual_mutual_context_postcall_guard_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_postcall_guard([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_postcall_guard([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_postcall_guard(L, T),
+            typr_mutual_odd_tree_ctx_postcall_guard(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_odd_tree_ctx_postcall_guard(L, T),
+            typr_mutual_odd_tree_ctx_postcall_guard(R, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_postcall_guard([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_postcall_guard([V, L, R], T) :-
+        ( V > T ->
+            typr_mutual_even_tree_ctx_postcall_guard(L, T),
+            typr_mutual_even_tree_ctx_postcall_guard(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_even_tree_ctx_postcall_guard(L, T),
+            typr_mutual_even_tree_ctx_postcall_guard(R, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_postcall_guard/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_postcall_guard/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_postcall_guard/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_postcall_guard/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_postcall_guard/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_postcall_guard/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_postcall_guard/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_postcall_guard(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_postcall_guard(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR closes a confirmed TypR SCC gap in the conservative arity-2 tree-mutual backend.

The newly supported shape is:

- arity-2 tree-structural boolean mutual recursion
- one tree-driving argument
- one threaded context argument
- two shared recursive subtree calls
- a nested branch-local control point after those two calls and before the shared boolean rejoin

Representative example:

```prolog
typr_mutual_even_tree_ctx_postcall_guard([], _T0).
typr_mutual_even_tree_ctx_postcall_guard([V, L, R], T) :-
    ( V > T ->
        typr_mutual_odd_tree_ctx_postcall_guard(L, T),
        typr_mutual_odd_tree_ctx_postcall_guard(R, T),
        ( V > T + 10 ->
            V >= T
        ;   V >= T - 1
        )
    ;   typr_mutual_odd_tree_ctx_postcall_guard(L, T),
        typr_mutual_odd_tree_ctx_postcall_guard(R, T)
    ).
```

Before this PR, that shape fell out of the TypR mutual-recursion path and failed with `No mutual recursion support for target typr`.

After this PR, it lowers natively to TypR, passes real `typr check`, and stays inside the existing memoized-helper TypR model.

## Why This PR Exists

Previous TypR SCC work already supported:

- arity-1 numeric/list/tree boolean SCCs
- conservative arity-2 tree-structural SCCs with one context argument
- guarded arity-2 tree mutual branch families around the shared subtree calls
- symbolic shared context threading before those calls

That still left a real nearby gap:

- branch-local control after both subtree calls, before the final boolean rejoin

This PR closes that gap by generalizing the mutual-tree branch-body model instead of adding another one-off matcher.

## Main Changes

### 1. Generalized post-call branch-body lowering for arity-2 mutual tree SCCs

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR mutual-tree backend now supports a reusable `post-call control` shape:

- emit the two shared subtree calls first
- continue with nested branch-local control that uses the already-bound subtree results
- then finish with the shared boolean rejoin

This is broader than the single failing example and gives the backend a cleaner internal shape for later arity-2 SCC work.

### 2. Added focused regression coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for arity-2 mutual tree post-call guarded control
- stable wrapper/helper signatures
- both shared subtree calls still emit before the nested post-call control
- real `typr check` validation for the generated TypR

### 3. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that conservative arity-2 tree mutual SCCs may use one nested post-call control point after the shared dual-subtree calls and before the shared boolean rejoin.

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- broader general SCC lowering
- arbitrary branch-local state across larger mutual-recursive bodies
- more general `N`-ary mutual recursion beyond the current conservative tree subset

The next high-signal follow-up is another arity-2 SCC audit around richer branch-local state between or after the two direct recursive calls.
