### PR TITLE
ci(csharp-query): summarize cache smoke diff slices

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -289,6 +289,14 @@ jobs:
           if (Test-Path $env:CACHE_SMOKE_DIFF_JSON_PATH) {
             $diff = Get-Content $env:CACHE_SMOKE_DIFF_JSON_PATH -Raw | ConvertFrom-Json
             $thresholds = $diff.thresholds
+            $sliceMap = @{}
+            foreach ($sliceEntry in @($diff.slices)) {
+              $sliceMap[[string]$sliceEntry.slice] = $sliceEntry
+            }
+
+            $orderedSliceNames = @('admission', 'reuse', 'lru')
+            $remainingSliceNames = @($sliceMap.Keys | Where-Object { $_ -notin $orderedSliceNames } | Sort-Object)
+            $sliceSummaryNames = @($orderedSliceNames + $remainingSliceNames | Select-Object -Unique)
 
             @(
               "## C# Query Cache Smoke Diff",
@@ -312,6 +320,25 @@ jobs:
               "- Max slice duration delta seconds: $(if ($null -eq $thresholds.maxSliceDurationDeltaSeconds) { 'disabled' } else { $thresholds.maxSliceDurationDeltaSeconds })",
               "- Thresholds passed: $(if ($thresholds.passed) { 'true' } else { 'false' })"
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+            if ($sliceSummaryNames.Count -gt 0) {
+              @(
+                "",
+                "### Slice Deltas",
+                ""
+              ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+              foreach ($sliceName in $sliceSummaryNames) {
+                if (-not $sliceMap.ContainsKey($sliceName)) {
+                  continue
+                }
+
+                $slice = $sliceMap[$sliceName]
+                @(
+                  "- $($slice.slice): status delta = `"$($slice.status.delta)`"`, duration delta = `"$($slice.duration.delta)`"`"
+                ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+              }
+            }
 
             if ($thresholds.failures.Count -gt 0) {
               @(

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -218,6 +218,8 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - artifact names
         - overall result delta
         - total duration delta
+        - per-slice `admission` / `reuse` / `lru` status deltas
+        - per-slice `admission` / `reuse` / `lru` duration deltas
         - threshold settings
         - threshold pass/fail result
         - threshold failure list when present


### PR DESCRIPTION
  ## Summary
  Extend the manual C# query cache-smoke diff workflow summary so it shows per-slice deltas directly in
  the GitHub job summary, instead of leaving that detail only in the diff JSON artifact.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Added a `Slice Deltas` section to the manual diff job summary
  - Rendered the standard cache slices in stable order:
    - `admission`
    - `reuse`
    - `lru`
  - Included both for each slice:
    - status delta
    - duration delta
  - Kept fallback rendering for any unexpected additional slices
  - Updated `docs/targets/csharp-query-runtime.md` to document the richer summary output

  ## Why
  The manual diff workflow already surfaced:
  - run provenance
  - SHAs
  - compare URL
  - threshold settings
  - overall result delta
  - total duration delta

  But the most actionable performance detail was still buried in the JSON diff artifact. This change puts
  the per-slice status and timing changes directly in the job summary, which makes the workflow more
  useful without downloading artifacts.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Replayed the slice-summary logic against:
    - `tmp/csharp_query_smoke_summary_diff/cache_smoke_sequence_diff.json`
  - Confirmed it renders:
    - `admission`
    - `reuse`
    - `lru`
    in that order, with the expected status and duration deltas