### PR TITLE
Generalize native TypR arity-2 mutual control

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,11 @@ includes:
   one nested branch-local control point around those calls before the
   shared boolean rejoin, one nested branch-local control point between the
   two direct recursive subtree calls with limited alias or guard state,
-  and one nested post-call control point after the shared dual-subtree
-  calls before the shared boolean rejoin
-  before the second call, shared branch-local guard prework before a nested
+  one nested post-call control point after the shared dual-subtree calls
+  before the shared boolean rejoin, inter-call symbolic context or alias
+  state before the second call combined with that shared post-call
+  control, nested non-recursive boolean post-call control after the shared
+  dual-subtree calls, shared branch-local guard prework before a nested
   mutual branch, and the same conservative guarded branch-body family with
   one invariant context argument threaded through the subtree calls,
   lowered to TypR

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -213,9 +213,12 @@ bring-up.
     calls, one nested branch-local control point between the two direct
     recursive subtree calls with limited alias or guard state before the
     second call, one nested post-call control point after the shared
-    dual-subtree calls before the shared boolean rejoin, shared
-    branch-local guard prework before a nested mutual branch, and
-    conservative arity-2 tree-structural SCCs with one
+    dual-subtree calls before the shared boolean rejoin, inter-call
+    symbolic context or alias state before the second call combined with
+    that shared post-call control, nested non-recursive boolean post-call
+    control after the shared dual-subtree calls, shared branch-local
+    guard prework before a nested mutual branch, and conservative arity-2
+    tree-structural SCCs with one
     invariant context argument threaded through the shared dual-subtree
     calls, shared computed context updates or guarded shared context
     selection before those calls, and the same conservative guarded

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -393,8 +393,11 @@ Current TypR lowering policy is intentionally mixed:
   nested branch-local control point between the two direct recursive
   subtree calls with limited alias or guard state before the second call,
   one nested post-call control point after the shared dual-subtree calls
-  before the shared boolean rejoin, and shared branch-local guard prework
-  before a nested mutual branch, and conservative arity-2 tree-structural
+  before the shared boolean rejoin, inter-call symbolic context or alias
+  state before the second call combined with that shared post-call
+  control, nested non-recursive boolean post-call control after the
+  shared dual-subtree calls, shared branch-local guard prework before a
+  nested mutual branch, and conservative arity-2 tree-structural
   SCCs with one invariant context
   argument threaded through the shared dual-subtree calls, shared computed
   context updates or guarded shared context selection before those calls,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -85,8 +85,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      between the two direct recursive subtree calls with limited alias or
      guard state before the second call, one nested post-call control
      point after the shared dual-subtree calls before the shared boolean
-     rejoin, shared branch-local guard prework before a nested mutual
-     branch, conservative arity-2 tree-structural SCCs with one invariant
+     rejoin, inter-call symbolic context or alias state before the second
+     call combined with that shared post-call control, nested
+     non-recursive boolean post-call control after the shared dual-
+     subtree calls, shared branch-local guard prework before a nested
+     mutual branch, conservative arity-2 tree-structural SCCs with one invariant
      context argument threaded through the shared dual-subtree calls and
      the same computed-context and guarded
      branch-body families, and boolean return types, emitted as TypR

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -278,6 +278,50 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
     RecInputPattern = [ValueVar, LeftVar, RightVar],
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    ExtraArgMap0 = [ContextVar-"current_ctx"],
+    typr_mutual_tree_ordered_dual_context_goals(
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        Body
+    ),
+    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, _ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
+    }.
+
+typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
     append(PreGoals, RecGoals, Goals),
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
@@ -692,6 +736,43 @@ typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap, 
     native_typr_if_condition(IfGoal, VarMap, BranchCondition0),
     typr_condition_expr_text(BranchCondition0, BranchConditionExpr).
 
+typr_mutual_tree_ordered_dual_context_goals(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+    typr_mutual_tree_goal_after_first_call(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0),
+    typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body).
+
+typr_mutual_tree_goal_after_first_call(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0) :-
+    typr_mutual_tree_goal_after_first_call(before_call, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0).
+
+typr_mutual_tree_goal_after_first_call(_State, _GroupPredicates, [], _ValueVar, _AliasMap, _ExtraArgMap) :-
+    fail.
+typr_mutual_tree_goal_after_first_call(before_call, GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap0) :-
+    typr_strip_module_goal(Goal0, Goal),
+    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, ExtraArgMap0, Goal, _GoalSpec)
+    ->  typr_mutual_tree_goal_after_first_call(after_first_call, GroupPredicates, Rest, ValueVar, AliasMap0, ExtraArgMap0)
+    ;   typr_mutual_tree_alias_goal(Goal)
+    ->  typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1),
+        typr_mutual_tree_goal_after_first_call(before_call, GroupPredicates, Rest, ValueVar, AliasMap1, ExtraArgMap0)
+    ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap0, ExtraArgMap1)
+    ->  typr_mutual_tree_goal_after_first_call(before_call, GroupPredicates, Rest, ValueVar, AliasMap0, ExtraArgMap1)
+    ;   \+ typr_mutual_tree_nested_goal(Goal),
+        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap0, VarMap),
+        native_typr_guard_goal(Goal, VarMap, _GuardCondition)
+    ->  typr_mutual_tree_goal_after_first_call(before_call, GroupPredicates, Rest, ValueVar, AliasMap0, ExtraArgMap0)
+    ).
+typr_mutual_tree_goal_after_first_call(after_first_call, GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap0) :-
+    typr_strip_module_goal(Goal0, Goal),
+    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, ExtraArgMap0, Goal, _GoalSpec)
+    ->  Rest \= []
+    ;   typr_mutual_tree_alias_goal(Goal)
+    ->  true
+    ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap0, _ExtraArgMap1)
+    ->  true
+    ;   \+ typr_mutual_tree_nested_goal(Goal),
+        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap0, VarMap),
+        native_typr_guard_goal(Goal, VarMap, _GuardCondition)
+    ->  true
+    ).
+
 typr_mutual_tree_branch_prework([], _ValueVar, AliasMap, AliasMap, none).
 typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, AliasMap, GuardExpr) :-
     typr_mutual_tree_branch_prework(Goals, ValueVar, AliasMap0, [], AliasMap, _ExtraArgMap, GuardExpr).
@@ -853,6 +934,48 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         branch_after_calls(Calls, BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
+typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+    append(PrefixGoals, [NestedIfGoal], Goals),
+    PrefixGoals \= [],
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_tree_branch_sequence_state(
+        GroupPredicates,
+        PrefixGoals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        GoalSpecs,
+        Steps,
+        AliasMap,
+        ExtraArgMap1
+    ),
+    typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_tail_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        ThenBody,
+        ThenGoalSpecs
+    ),
+    ThenGoalSpecs = [],
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_tail_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        ElseBody,
+        ElseGoalSpecs
+    ),
+    ElseGoalSpecs = [],
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    Body = branch_steps_if(Steps, BranchConditionExpr, ThenBody, ElseBody).
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
@@ -868,47 +991,96 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
 
 typr_mutual_tree_branch_sequence(_GroupPredicates, [], _ValueVar, _AliasMap, _ExtraArgMap, [], []).
 typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps) :-
+    typr_mutual_tree_branch_sequence_state(
+        GroupPredicates,
+        [Goal0|Rest],
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap,
+        GoalSpecs,
+        Steps,
+        _AliasMap,
+        _ExtraArgMap
+    ).
+
+typr_mutual_tree_branch_sequence_state(_GroupPredicates, [], _ValueVar, AliasMap, ExtraArgMap, [], [], AliasMap, ExtraArgMap).
+typr_mutual_tree_branch_sequence_state(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap0, GoalSpecs, Steps, AliasMap, ExtraArgMap) :-
     typr_strip_module_goal(Goal0, Goal),
-    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, ExtraArgMap, Goal, GoalSpec)
+    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, ExtraArgMap0, Goal, GoalSpec)
     ->  typr_mutual_tree_branch_call(GoalSpec, Call),
         GoalSpecs = [GoalSpec|RestGoalSpecs],
         Steps = [step_call(Call)|RestSteps],
         AliasMap1 = AliasMap0,
-        ExtraArgMap1 = ExtraArgMap
+        ExtraArgMap1 = ExtraArgMap0
     ;   typr_mutual_tree_alias_goal(Goal)
     ->  GoalSpecs = RestGoalSpecs,
         Steps = RestSteps,
         typr_mutual_tree_alias_map([Goal], AliasMap0, AliasMap1),
-        ExtraArgMap1 = ExtraArgMap
-    ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap, ExtraArgMap1)
+        ExtraArgMap1 = ExtraArgMap0
+    ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap0, ExtraArgMap1)
     ->  GoalSpecs = RestGoalSpecs,
         Steps = RestSteps,
         AliasMap1 = AliasMap0
     ;   \+ typr_mutual_tree_nested_goal(Goal),
-        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap, VarMap),
+        typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap0, VarMap),
         native_typr_guard_goal(Goal, VarMap, GuardCondition)
     ->  GoalSpecs = RestGoalSpecs,
         Steps = [step_guard(GuardCondition)|RestSteps],
         AliasMap1 = AliasMap0,
-        ExtraArgMap1 = ExtraArgMap
+        ExtraArgMap1 = ExtraArgMap0
     ),
-    typr_mutual_tree_branch_sequence(
+    typr_mutual_tree_branch_sequence_state(
         GroupPredicates,
         Rest,
         ValueVar,
         AliasMap1,
         ExtraArgMap1,
         RestGoalSpecs,
-        RestSteps
+        RestSteps,
+        AliasMap,
+        ExtraArgMap
     ).
 
 typr_mutual_tree_branch_body_from_steps([step_call(Call1), step_call(Call2)], branch_calls([Call1, Call2])) :-
     !.
 typr_mutual_tree_branch_body_from_steps(Steps, branch_steps(Steps)).
 
+typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+    append(PreGoals, [NestedIfGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap1, ThenBody),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap1, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_if(BranchConditionExpr, ThenBody, ElseBody),
+        Body
+    ).
+typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+    typr_mutual_tree_branch_sequence_state(
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        GoalSpecs,
+        Steps,
+        _AliasMap,
+        _ExtraArgMap
+    ),
+    GoalSpecs = [],
+    typr_mutual_tree_branch_body_from_steps(Steps, Body).
+
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body, GoalSpecs) :-
     typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, [], Body, GoalSpecs).
 
+typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, []) :-
+    typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body).
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, GoalSpecs) :-
     typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
     typr_mutual_tree_branch_body_from_steps(Steps, Body).
@@ -1131,6 +1303,49 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
         BranchConditionExpr,
         ThenBody,
         ElseBody,
+        RecursiveLines
+    ),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, ['        } else {', '            FALSE', '        }', '    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_body,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    Body = Spec.body,
+    typr_mutual_tree_base_branch_lines(GroupName, BaseConditions, BaseLines),
+    typr_mutual_tree_dual_body_recursive_branch_lines(
+        GroupName,
+        GuardExpr,
+        Body,
+        RecursiveLines
+    ),
+    typr_mutual_false_lines(GroupName, FalseLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, FalseLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_body,
+    HelperName = Spec.helper_name,
+    BaseConditions = Spec.base_conditions,
+    GuardExpr = Spec.guard_expr,
+    Body = Spec.body,
+    typr_mutual_tree_base_branch_lines_no_memo(BaseConditions, BaseLines),
+    typr_mutual_tree_dual_body_recursive_branch_lines_no_memo(
+        GuardExpr,
+        Body,
         RecursiveLines
     ),
     typr_mutual_helper_line(Spec, HelperName, HelperLine),
@@ -1445,6 +1660,46 @@ typr_mutual_tree_dual_branch_recursive_branch_lines_no_memo(
     append(Lines1, ElseLines, Lines2),
     append(Lines2, ['            }'], Lines).
 
+typr_mutual_tree_dual_body_recursive_branch_lines(
+    GroupName,
+    'TRUE',
+    Body,
+    Lines
+) :-
+    !,
+    typr_mutual_tree_branch_body_lines(Body, '            ', BodyLines),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    append(['        } else {'], BodyLines, Lines0),
+    append(Lines0, [AssignLine, '            result'], Lines).
+typr_mutual_tree_dual_body_recursive_branch_lines(
+    GroupName,
+    GuardExpr,
+    Body,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    typr_mutual_tree_branch_body_lines(Body, '            ', BodyLines),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    append([IfLine], BodyLines, Lines0),
+    append(Lines0, [AssignLine, '            result'], Lines).
+
+typr_mutual_tree_dual_body_recursive_branch_lines_no_memo(
+    'TRUE',
+    Body,
+    Lines
+) :-
+    !,
+    typr_mutual_tree_branch_body_lines_no_memo(Body, '            ', BodyLines),
+    append(['        } else {'], BodyLines, Lines).
+typr_mutual_tree_dual_body_recursive_branch_lines_no_memo(
+    GuardExpr,
+    Body,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    typr_mutual_tree_branch_body_lines_no_memo(Body, '            ', BodyLines),
+    append([IfLine], BodyLines, Lines).
+
 typr_mutual_tree_branch_body_lines(Body, Prefix, Lines) :-
     typr_mutual_tree_branch_body_lines_from(Body, Prefix, 1, Lines).
 
@@ -1480,6 +1735,8 @@ typr_mutual_tree_branch_body_lines_from(branch_after_calls(Calls, BranchConditio
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_body_lines_from(branch_steps_if(Steps, BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
+    typr_mutual_tree_branch_steps_if_lines(Steps, Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines).
 typr_mutual_tree_branch_body_lines_from(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
@@ -1540,6 +1797,8 @@ typr_mutual_tree_branch_body_lines_no_memo_from(branch_after_calls(Calls, Branch
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_steps_if(Steps, BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
+    typr_mutual_tree_branch_steps_if_lines_no_memo(Steps, Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines).
 typr_mutual_tree_branch_body_lines_no_memo_from(branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Index, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
@@ -1590,6 +1849,40 @@ typr_mutual_tree_branch_steps_lines([step_call(BranchCall)|Rest], Prefix, Index,
     append([CallLine, IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
 
+typr_mutual_tree_branch_steps_if_lines([], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines_from(ThenBody, NestedPrefix, Index, ThenLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    typr_mutual_tree_branch_body_lines_from(ElseBody, NestedPrefix, Index, ElseLines),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], ThenLines, Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_steps_if_lines([step_guard(GuardExpr)|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_steps_if_lines(Rest, NestedPrefix, Index, BranchConditionExpr, ThenBody, ElseBody, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_steps_if_lines([step_call(BranchCall)|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
+    format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    NextIndex is Index + 1,
+    typr_mutual_tree_branch_steps_if_lines(Rest, NestedPrefix, NextIndex, BranchConditionExpr, ThenBody, ElseBody, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([CallLine, IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+
 typr_mutual_tree_branch_steps_lines_no_memo([], Prefix, _Index, [ResultLine]) :-
     format(string(ResultLine), '~wresult', [Prefix]).
 typr_mutual_tree_branch_steps_lines_no_memo([step_guard(GuardExpr)|Rest], Prefix, Index, Lines) :-
@@ -1609,6 +1902,40 @@ typr_mutual_tree_branch_steps_lines_no_memo([step_call(BranchCall)|Rest], Prefix
     atom_concat(Prefix, '    ', NestedPrefix),
     NextIndex is Index + 1,
     typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, NextIndex, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([CallLine, IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+
+typr_mutual_tree_branch_steps_if_lines_no_memo([], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ThenBody, NestedPrefix, Index, ThenLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    typr_mutual_tree_branch_body_lines_no_memo_from(ElseBody, NestedPrefix, Index, ElseLines),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], ThenLines, Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
+typr_mutual_tree_branch_steps_if_lines_no_memo([step_guard(GuardExpr)|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_branch_steps_if_lines_no_memo(Rest, NestedPrefix, Index, BranchConditionExpr, ThenBody, ElseBody, StepLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], StepLines, Lines0),
+    append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_steps_if_lines_no_memo([step_call(BranchCall)|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
+    format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    NextIndex is Index + 1,
+    typr_mutual_tree_branch_steps_if_lines_no_memo(Rest, NestedPrefix, NextIndex, BranchConditionExpr, ThenBody, ElseBody, StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2948,4 +2948,88 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_postca
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_intercall_postcall_control_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_intercall_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_intercall_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_odd_tree_ctx_intercall_post(L, T1),
+        T2 is T1 + 1,
+        typr_mutual_odd_tree_ctx_intercall_post(R, T2),
+        ( V > T2 ->
+            V >= T
+        ;   V >= T - 1
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_intercall_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_intercall_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_even_tree_ctx_intercall_post(L, T1),
+        T2 is T1 + 1,
+        typr_mutual_even_tree_ctx_intercall_post(R, T2),
+        ( V > T2 ->
+            V >= T
+        ;   V >= T - 1
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_intercall_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_intercall_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_intercall_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_intercall_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_intercall_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_intercall_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_intercall_post/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_intercall_post/2, typr_mutual_odd_tree_ctx_intercall_post/2")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_intercall_post_impl(.subset2(current_input, 2), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_intercall_post_impl(.subset2(current_input, 3), ((current_ctx + 1) + 1));")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > ((current_ctx + 1) + 1)) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= current_ctx }@) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 1) }@) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_nested_postcall_guard_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_nested_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_nested_post([V, L, R], T) :-
+        typr_mutual_odd_tree_ctx_nested_post(L, T),
+        typr_mutual_odd_tree_ctx_nested_post(R, T),
+        ( V > T + 10 ->
+            ( V >= T ->
+                V >= T - 1
+            ;   V >= T - 2
+            )
+        ;   V >= T - 3
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_nested_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_nested_post([V, L, R], T) :-
+        typr_mutual_even_tree_ctx_nested_post(L, T),
+        typr_mutual_even_tree_ctx_nested_post(R, T),
+        ( V > T + 10 ->
+            ( V >= T ->
+                V >= T - 1
+            ;   V >= T - 2
+            )
+        ;   V >= T - 3
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_nested_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_nested_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_nested_post/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_nested_post/2, typr_mutual_odd_tree_ctx_nested_post/2")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_nested_post_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_nested_post_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > (current_ctx + 10)) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) >= current_ctx) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 1) }@) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 2) }@) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 3) }@) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -1915,6 +1915,94 @@ test(structural_tree_dual_mutual_context_postcall_guard_output_checks_with_typr,
     retractall(user:typr_mutual_even_tree_ctx_postcall_guard(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_postcall_guard(_, _)).
 
+test(structural_tree_dual_mutual_context_intercall_postcall_control_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_intercall_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_intercall_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_odd_tree_ctx_intercall_post(L, T1),
+        T2 is T1 + 1,
+        typr_mutual_odd_tree_ctx_intercall_post(R, T2),
+        ( V > T2 ->
+            V >= T
+        ;   V >= T - 1
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_intercall_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_intercall_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_even_tree_ctx_intercall_post(L, T1),
+        T2 is T1 + 1,
+        typr_mutual_even_tree_ctx_intercall_post(R, T2),
+        ( V > T2 ->
+            V >= T
+        ;   V >= T - 1
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_intercall_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_intercall_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_intercall_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_intercall_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_intercall_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_intercall_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_intercall_post/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_intercall_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_intercall_post(_, _)).
+
+test(structural_tree_dual_mutual_context_nested_postcall_guard_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_nested_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_nested_post([V, L, R], T) :-
+        typr_mutual_odd_tree_ctx_nested_post(L, T),
+        typr_mutual_odd_tree_ctx_nested_post(R, T),
+        ( V > T + 10 ->
+            ( V >= T ->
+                V >= T - 1
+            ;   V >= T - 2
+            )
+        ;   V >= T - 3
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_nested_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_nested_post([V, L, R], T) :-
+        typr_mutual_even_tree_ctx_nested_post(L, T),
+        typr_mutual_even_tree_ctx_nested_post(R, T),
+        ( V > T + 10 ->
+            ( V >= T ->
+                V >= T - 1
+            ;   V >= T - 2
+            )
+        ;   V >= T - 3
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_nested_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_nested_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_nested_post/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_nested_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_nested_post(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion backend for arity-2 tree-structural boolean SCCs.

The key change is that the arity-2 mutual-tree path no longer only handles:

- straight shared dual-subtree calls
- shared computed context updates before those calls
- one nested control point in a few fixed positions

It now supports a more general ordered shared-call sequence around those two subtree calls, including:

- inter-call alias state
- inter-call symbolic context updates
- shared post-call control after both subtree calls
- nested non-recursive boolean post-call control before the shared boolean rejoin

Representative examples:

```prolog
typr_mutual_even_tree_ctx_intercall_post([], _T0).
typr_mutual_even_tree_ctx_intercall_post([V, L, R], T) :-
    T1 is T + 1,
    typr_mutual_odd_tree_ctx_intercall_post(L, T1),
    T2 is T1 + 1,
    typr_mutual_odd_tree_ctx_intercall_post(R, T2),
    ( V > T2 ->
        V >= T
    ;   V >= T - 1
    ).

typr_mutual_even_tree_ctx_nested_post([], _T0).
typr_mutual_even_tree_ctx_nested_post([V, L, R], T) :-
    typr_mutual_odd_tree_ctx_nested_post(L, T),
    typr_mutual_odd_tree_ctx_nested_post(R, T),
    ( V > T + 10 ->
        ( V >= T ->
            V >= T - 1
        ;   V >= T - 2
        )
    ;   V >= T - 3
    ).
```

Before this PR, clean `main` still failed on these shapes with:

- `Error: No mutual recursion support for target typr`

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

The previous arity-2 SCC work already covered:

- one tree-driving argument plus one invariant context arg
- shared computed context updates before the two subtree calls
- guarded shared context selection before those calls
- some guarded branch-body families around the shared subtree calls
- one nested post-call control point in the simpler shared-call shape

That still left a real nearby gap:

- as soon as there was meaningful ordered state between the two shared subtree calls, or richer non-recursive control after those calls, the arity-2 TypR mutual path fell out of support

This PR closes that gap by generalizing the branch-body/control machinery instead of adding another one-off matcher.

## Main Changes

### 1. Generalized ordered arity-2 mutual-tree control

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The arity-2 mutual-tree backend now reuses the shared branch-body compiler when there is state after the first recursive call.

That generalized path carries:

- alias-map state
- symbolic extra-arg/context state
- guard state

through an ordered sequence around the two shared subtree calls.

### 2. Added non-recursive post-call tail lowering

The mutual-tree backend now has a reusable non-recursive tail-body path for boolean control after both subtree calls.

That is what makes these shapes work natively:

- inter-call context update followed by shared post-call control
- inter-call alias followed by shared post-call control
- nested boolean post-call control after the shared subtree calls

### 3. Tightened the audit with real TypR validation

This branch started by correcting the audit harness.

The earlier local audit had misreported some valid output as `invalid`.
I re-ran the audit against:

- clean `main`
- corrected `generated_typr_is_valid/2` usage
- direct `typr check`

That established the real failing slice before changing the emitter.

### 4. Added focused regression and toolchain coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for inter-call symbolic context updates plus shared post-call control
- native TypR lowering for nested non-recursive boolean post-call control
- stable arity-2 wrapper/helper shapes
- real `typr check` validation for the new SCC forms

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now state the broader supported generalization explicitly:

- arity-2 tree mutual SCCs can carry ordered alias/context state around the shared subtree calls
- they can also continue through nested non-recursive boolean post-call control before the shared boolean rejoin

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- arbitrary recursive control-flow normalization
- broader `N`-ary mutual recursion beyond the current conservative tree subset

The next confirmed frontier is narrower and more specific:

- nested post-call control after only the first subtree call, where the second recursive call happens inside that branch
