### PR TITLE
ci(csharp-query): highlight cache smoke regressions

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -287,6 +287,34 @@ jobs:
         shell: pwsh
         run: |
           if (Test-Path $env:CACHE_SMOKE_DIFF_JSON_PATH) {
+            function Test-IsStatusRegression {
+              param(
+                [Parameter(Mandatory = $true)]
+                [string]$BaselineStatus,
+
+                [Parameter(Mandatory = $true)]
+                [string]$CompareStatus
+              )
+
+              if ($BaselineStatus -eq $CompareStatus) {
+                return $false
+              }
+
+              if ($BaselineStatus -eq 'PASS' -and $CompareStatus -ne 'PASS') {
+                return $true
+              }
+
+              if ($BaselineStatus -eq 'MISSING' -and $CompareStatus -ne 'MISSING') {
+                return $false
+              }
+
+              if ($CompareStatus -eq 'MISSING') {
+                return $true
+              }
+
+              return $false
+            }
+
             $diff = Get-Content $env:CACHE_SMOKE_DIFF_JSON_PATH -Raw | ConvertFrom-Json
             $thresholds = $diff.thresholds
             $sliceMap = @{}
@@ -297,6 +325,26 @@ jobs:
             $orderedSliceNames = @('admission', 'reuse', 'lru')
             $remainingSliceNames = @($sliceMap.Keys | Where-Object { $_ -notin $orderedSliceNames } | Sort-Object)
             $sliceSummaryNames = @($orderedSliceNames + $remainingSliceNames | Select-Object -Unique)
+            $regressionHighlights = @()
+
+            if (Test-IsStatusRegression -BaselineStatus ([string]$diff.overallResult.baseline) -CompareStatus ([string]$diff.overallResult.compare)) {
+              $regressionHighlights += "Overall result regressed: `"$($diff.overallResult.baseline)`" -> `"$($diff.overallResult.compare)`"`"
+            }
+
+            foreach ($sliceName in $sliceSummaryNames) {
+              if (-not $sliceMap.ContainsKey($sliceName)) {
+                continue
+              }
+
+              $slice = $sliceMap[$sliceName]
+              if (Test-IsStatusRegression -BaselineStatus ([string]$slice.status.baseline) -CompareStatus ([string]$slice.status.compare)) {
+                $regressionHighlights += "Slice status regressed for `"$($slice.slice)`"`: `"$($slice.status.baseline)`" -> `"$($slice.status.compare)`"`"
+              }
+
+              if (($null -ne $slice.duration.deltaSeconds) -and ([double]$slice.duration.deltaSeconds -gt 0)) {
+                $regressionHighlights += "Slice duration increased for `"$($slice.slice)`"`: `"$($slice.duration.delta)`"`"
+              }
+            }
 
             @(
               "## C# Query Cache Smoke Diff",
@@ -320,6 +368,18 @@ jobs:
               "- Max slice duration delta seconds: $(if ($null -eq $thresholds.maxSliceDurationDeltaSeconds) { 'disabled' } else { $thresholds.maxSliceDurationDeltaSeconds })",
               "- Thresholds passed: $(if ($thresholds.passed) { 'true' } else { 'false' })"
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+            if ($regressionHighlights.Count -gt 0) {
+              @(
+                "",
+                "### Regression Highlights",
+                ""
+              ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+              foreach ($highlight in $regressionHighlights) {
+                "- $highlight" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+              }
+            }
 
             if ($sliceSummaryNames.Count -gt 0) {
               @(

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -208,6 +208,10 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
     - Outputs:
       - diff JSON artifact: `csharp-query-smoke-diff-json`
       - job summary with:
+        - compact `Regression Highlights` section when present
+        - overall result regressions
+        - per-slice status regressions
+        - positive per-slice duration deltas
         - baseline / compare run IDs
         - resolution source (`explicit` vs `latest-successful`)
         - requested refs


### PR DESCRIPTION
  ## Summary
  Add a compact regression-highlights block to the manual C# query cache-smoke diff workflow summary so
  the most important regressions are visible immediately without scanning the full summary or downloading
  the diff artifact.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Added a `Regression Highlights` section near the top of the job summary
  - The new highlight block reports:
    - overall result regressions
    - per-slice status regressions
    - positive per-slice duration deltas
  - Kept the existing detailed summary intact:
    - provenance
    - compare URL
    - thresholds
    - slice deltas
  - Updated `docs/targets/csharp-query-runtime.md` to document the new summary section

  ## Why
  The manual diff workflow already exposed the raw per-slice deltas, but it still required reading the
  whole summary to find the actual regressions. This change makes the summary easier to scan by surfacing
  the highest-signal issues first.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Replayed the regression-highlight logic against:
    - `tmp/csharp_query_smoke_summary_diff/cache_smoke_sequence_diff.json`
  - Confirmed it emitted the expected highlights for the sample diff:
    - `Slice duration increased for "reuse": "+141.1s"`
    - `Slice duration increased for "lru": "+60.2s"`