### PR TITLE
Keep native TypR arity-2 mutual nested second-call control

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ includes:
   dual-subtree calls, shared branch-local guard prework before a nested
   mutual branch, and the same conservative guarded branch-body family with
   one invariant context argument threaded through the subtree calls,
+  including branch bodies where one shared subtree call happens before
+  guarded control that contains the second subtree call plus nested
+  non-recursive post-call control,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -222,7 +222,9 @@ bring-up.
     invariant context argument threaded through the shared dual-subtree
     calls, shared computed context updates or guarded shared context
     selection before those calls, and the same conservative guarded
-    branch-body family
+    branch-body family, including branch bodies where one shared subtree
+    call happens before guarded control that contains the second subtree
+    call plus nested non-recursive post-call control
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -401,7 +401,10 @@ Current TypR lowering policy is intentionally mixed:
   SCCs with one invariant context
   argument threaded through the shared dual-subtree calls, shared computed
   context updates or guarded shared context selection before those calls,
-  and the same conservative guarded branch-body family, using
+  and the same conservative guarded branch-body family, including branch
+  bodies where one shared subtree call happens before guarded control that
+  contains the second subtree call plus nested non-recursive post-call
+  control, using
   raw-expression memoized helper bodies inside TypR rather than wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -92,7 +92,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      mutual branch, conservative arity-2 tree-structural SCCs with one invariant
      context argument threaded through the shared dual-subtree calls and
      the same computed-context and guarded
-     branch-body families, and boolean return types, emitted as TypR
+     branch-body families, including branch bodies where one shared
+     subtree call happens before guarded control that contains the second
+     subtree call plus nested non-recursive post-call control, and
+     boolean return types, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -767,6 +767,8 @@ typr_mutual_tree_goal_after_first_call(after_first_call, GroupPredicates, [Goal0
     ->  true
     ;   typr_mutual_tree_symbolic_extra_arg_goal(Goal, ValueVar, AliasMap0, ExtraArgMap0, _ExtraArgMap1)
     ->  true
+    ;   typr_mutual_tree_nested_goal(Goal)
+    ->  true
     ;   \+ typr_mutual_tree_nested_goal(Goal),
         typr_mutual_tree_condition_varmap(ValueVar, AliasMap0, ExtraArgMap0, VarMap),
         native_typr_guard_goal(Goal, VarMap, _GuardCondition)
@@ -1081,6 +1083,38 @@ typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body, Go
 
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, []) :-
     typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body).
+typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, [FirstGoalSpec]) :-
+    append(PreGoals, [FirstGoal0, NestedIfGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
+    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1, FirstGoal0, FirstGoalSpec),
+    typr_mutual_tree_branch_call(FirstGoalSpec, FirstCall),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_nonrecursive_tail_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        ThenBody
+    ),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_nonrecursive_tail_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        ElseBody
+    ),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_after_call(FirstCall, BranchConditionExpr, ThenBody, ElseBody),
+        Body
+    ).
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, GoalSpecs) :-
     typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
     typr_mutual_tree_branch_body_from_steps(Steps, Body).

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -85,6 +85,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_ctx_recursive_branch(_, _)),
     retractall(user:typr_mutual_even_tree_ctx_nested_branch(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_nested_branch(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_call_nested_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_call_nested_post(_, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -3029,6 +3031,49 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_nested
     once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 1) }@) {")),
     once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 2) }@) {")),
     once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 3) }@) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_branch_second_call_nested_postcall_control_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_call_nested_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_call_nested_post([V, L, R], T) :-
+        typr_mutual_odd_tree_ctx_call_nested_post(L, T),
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_call_nested_post(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_odd_tree_ctx_call_nested_post(R, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_call_nested_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_call_nested_post([V, L, R], T) :-
+        typr_mutual_even_tree_ctx_call_nested_post(L, T),
+        ( V > T ->
+            typr_mutual_even_tree_ctx_call_nested_post(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_even_tree_ctx_call_nested_post(R, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_call_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_call_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_call_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_call_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_call_nested_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_call_nested_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_call_nested_post/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_call_nested_post/2, typr_mutual_odd_tree_ctx_call_nested_post/2")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_call_nested_post_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_call_nested_post_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > (current_ctx + 10)) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= current_ctx }@) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 1) }@) {")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2003,6 +2003,51 @@ test(structural_tree_dual_mutual_context_nested_postcall_guard_output_checks_wit
     retractall(user:typr_mutual_even_tree_ctx_nested_post(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_nested_post(_, _)).
 
+test(structural_tree_dual_mutual_context_branch_second_call_nested_postcall_control_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_call_nested_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_call_nested_post([V, L, R], T) :-
+        typr_mutual_odd_tree_ctx_call_nested_post(L, T),
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_call_nested_post(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_odd_tree_ctx_call_nested_post(R, T)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_call_nested_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_call_nested_post([V, L, R], T) :-
+        typr_mutual_even_tree_ctx_call_nested_post(L, T),
+        ( V > T ->
+            typr_mutual_even_tree_ctx_call_nested_post(R, T),
+            ( V > T + 10 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   typr_mutual_even_tree_ctx_call_nested_post(R, T)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_call_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_call_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_call_nested_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_call_nested_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_call_nested_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_call_nested_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_call_nested_post/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_call_nested_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_call_nested_post(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR closes a real TypR SCC gap in the conservative arity-2 tree-mutual backend.

The supported arity-2 mutual-tree path already handled:

- one tree-driving argument plus one invariant context arg
- shared computed context updates before the two subtree calls
- guarded shared context selection before those calls
- direct recursive subtree calls inside supported guarded branch bodies
- nested control around those shared subtree calls
- shared post-call control after both subtree calls

It still failed on a nearby but distinct shape:

- the first subtree call happens
- control branches
- the second subtree call happens inside that branch
- nested non-recursive post-call control runs after that second call
- the shared boolean rejoin then continues natively

Representative example:

```prolog
typr_mutual_even_tree_ctx_call_nested_post([], _T0).
typr_mutual_even_tree_ctx_call_nested_post([V, L, R], T) :-
    typr_mutual_odd_tree_ctx_call_nested_post(L, T),
    ( V > T ->
        typr_mutual_odd_tree_ctx_call_nested_post(R, T),
        ( V > T + 10 ->
            V >= T
        ;   V >= T - 1
        )
    ;   typr_mutual_odd_tree_ctx_call_nested_post(R, T)
    ).
```

Before this PR, clean `main` still failed on that shape with:

- `Error: No mutual recursion support for target typr`

After this PR, it lowers natively to TypR, passes real `typr check`, and stays inside the existing memoized-helper TypR model.

## Why This PR Exists

The previous arity-2 SCC work had already generalized:

- helper signatures
- wrapper forwarding
- memo keys
- symbolic context threading
- shared branch-body lowering around the two subtree calls

That still left a gap in the ordered tail logic:

- once a branch had already consumed the first recursive call, TypR did not yet accept nested control that contained the second recursive call and then continued through nested non-recursive post-call control

This PR closes that gap by generalizing the existing matcher and tail-body lowering instead of adding a one-off branch-specific path.

## Main Changes

### 1. Generalized the arity-2 mutual-tree ordered-tail matcher

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

`typr_mutual_tree_goal_after_first_call/6` now treats nested control after the first recursive call as valid ordered tail structure.

That matters because the backend already had a native branch-body emitter for these bodies. The spec gate was the piece rejecting them.

### 2. Added reusable tail-body lowering for second-call-in-branch control

Also in [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl), the mutual-tree backend now has a tail-body path for:

- prework before a branch-local second call
- one recursive call inside that branch
- nested non-recursive control after that call
- native boolean continuation after the branch

This is broader than the single failing example and gives the arity-2 SCC path a real reusable form for “call, then nested control” tails.

### 3. Added focused regression coverage

Updated:

- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)

New coverage verifies:

- native TypR lowering for the first-call / branch / second-call / nested-post-control shape
- stable emitted helper/wrapper structure
- real `typr check` validation for the new SCC form

### 4. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly include arity-2 mutual tree branch bodies where:

- one shared subtree call happens before guarded control
- that guarded control contains the second subtree call
- nested non-recursive post-call control still stays native before the shared boolean rejoin

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- arbitrary recursive control-flow normalization
- broader `N`-ary mutual recursion beyond the current conservative tree subset

The next nearby frontier is still:

- richer arity-2 mutual branch-local state beyond this new second-call-inside-branch path
- or broader SCC lowering if the nearby conservative arity-2 cases are already clean
