### PR TITLE
ci(csharp-query): summarize cache smoke diff generated-at

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -315,6 +315,78 @@ jobs:
               return $false
             }
 
+            function Format-SignedSecondsDelta {
+              param(
+                [Parameter(Mandatory = $false)]
+                $Seconds
+              )
+
+              if ($null -eq $Seconds) {
+                return $null
+              }
+
+              $numericSeconds = [double]$Seconds
+              $sign = if ($numericSeconds -ge 0) { '+' } else { '' }
+              return ("{0}{1:F1}s" -f $sign, $numericSeconds)
+            }
+
+            function Format-GeneratedAtUtc {
+              param(
+                [Parameter(Mandatory = $false)]
+                $Value
+              )
+
+              if ($null -eq $Value) {
+                return $null
+              }
+
+              if ($Value -is [DateTime]) {
+                return $Value.ToUniversalTime().ToString('o')
+              }
+
+              if ($Value -is [DateTimeOffset]) {
+                return $Value.ToUniversalTime().ToString('o')
+              }
+
+              $stringValue = [string]$Value
+              if ([string]::IsNullOrWhiteSpace($stringValue)) {
+                return $null
+              }
+
+              $parsedTimestamp = [DateTimeOffset]::MinValue
+              if ([DateTimeOffset]::TryParse($stringValue, [ref]$parsedTimestamp)) {
+                return $parsedTimestamp.ToUniversalTime().ToString('o')
+              }
+
+              return $stringValue
+            }
+
+            function Get-GeneratedAtDelta {
+              param(
+                [Parameter(Mandatory = $false)]
+                [string]$BaselineGeneratedAtUtc,
+
+                [Parameter(Mandatory = $false)]
+                [string]$CompareGeneratedAtUtc
+              )
+
+              if ([string]::IsNullOrWhiteSpace($BaselineGeneratedAtUtc) -or [string]::IsNullOrWhiteSpace($CompareGeneratedAtUtc)) {
+                return $null
+              }
+
+              $baselineTimestamp = [DateTimeOffset]::MinValue
+              $compareTimestamp = [DateTimeOffset]::MinValue
+              if (-not [DateTimeOffset]::TryParse($BaselineGeneratedAtUtc, [ref]$baselineTimestamp)) {
+                return $null
+              }
+
+              if (-not [DateTimeOffset]::TryParse($CompareGeneratedAtUtc, [ref]$compareTimestamp)) {
+                return $null
+              }
+
+              return Format-SignedSecondsDelta -Seconds (($compareTimestamp - $baselineTimestamp).TotalSeconds)
+            }
+
             $diff = Get-Content $env:CACHE_SMOKE_DIFF_JSON_PATH -Raw | ConvertFrom-Json
             $thresholds = $diff.thresholds
             $sliceMap = @{}
@@ -326,6 +398,9 @@ jobs:
             $remainingSliceNames = @($sliceMap.Keys | Where-Object { $_ -notin $orderedSliceNames } | Sort-Object)
             $sliceSummaryNames = @($orderedSliceNames + $remainingSliceNames | Select-Object -Unique)
             $regressionHighlights = @()
+            $baselineGeneratedAtUtc = Format-GeneratedAtUtc -Value $diff.generatedAtUtc.baseline
+            $compareGeneratedAtUtc = Format-GeneratedAtUtc -Value $diff.generatedAtUtc.compare
+            $generatedAtDelta = Get-GeneratedAtDelta -BaselineGeneratedAtUtc $baselineGeneratedAtUtc -CompareGeneratedAtUtc $compareGeneratedAtUtc
 
             if (Test-IsStatusRegression -BaselineStatus ([string]$diff.overallResult.baseline) -CompareStatus ([string]$diff.overallResult.compare)) {
               $regressionHighlights += "Overall result regressed: `"$($diff.overallResult.baseline)`" -> `"$($diff.overallResult.compare)`"`"
@@ -353,11 +428,13 @@ jobs:
               "- Baseline resolution: `"$($env:BASELINE_RESOLUTION_SOURCE)`"` (requested ref: `"$($env:BASELINE_REQUESTED_REF)`"`, resolved ref: `"$($env:BASELINE_RESOLVED_REF)`"`)",
               "- Baseline resolved SHA: `"$($env:BASELINE_RESOLVED_SHA)`"",
               "- Baseline run URL: `"$($env:BASELINE_RESOLVED_URL)`"",
+              "- Baseline summary generated at (UTC): $(if ([string]::IsNullOrWhiteSpace($baselineGeneratedAtUtc)) { 'n/a' } else { '`"' + $baselineGeneratedAtUtc + '`"' })",
               "- Baseline artifact: `"$($env:BASELINE_ARTIFACT_NAME)`"",
               "- Compare run ID: `"$($env:COMPARE_RESOLVED_RUN_ID)`"",
               "- Compare resolution: `"$($env:COMPARE_RESOLUTION_SOURCE)`"` (requested ref: `"$($env:COMPARE_REQUESTED_REF)`"`, resolved ref: `"$($env:COMPARE_RESOLVED_REF)`"`)",
               "- Compare resolved SHA: `"$($env:COMPARE_RESOLVED_SHA)`"",
               "- Compare run URL: `"$($env:COMPARE_RESOLVED_URL)`"",
+              "- Compare summary generated at (UTC): $(if ([string]::IsNullOrWhiteSpace($compareGeneratedAtUtc)) { 'n/a' } else { '`"' + $compareGeneratedAtUtc + '`"' })",
               "- Compare URL: `"$($env:CACHE_SMOKE_DIFF_COMPARE_URL)`"",
               "- Compare artifact: `"$($env:COMPARE_ARTIFACT_NAME)`"",
               "- Diff JSON artifact: `"$($env:CACHE_SMOKE_DIFF_ARTIFACT_NAME)`"",
@@ -368,6 +445,10 @@ jobs:
               "- Max slice duration delta seconds: $(if ($null -eq $thresholds.maxSliceDurationDeltaSeconds) { 'disabled' } else { $thresholds.maxSliceDurationDeltaSeconds })",
               "- Thresholds passed: $(if ($thresholds.passed) { 'true' } else { 'false' })"
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+            if (-not [string]::IsNullOrWhiteSpace($generatedAtDelta)) {
+              "- Generated-at delta: `"$generatedAtDelta`"" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+            }
 
             if ($regressionHighlights.Count -gt 0) {
               @(

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -218,6 +218,9 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - resolved refs
         - resolved SHAs
         - resolved run URLs
+        - baseline `generatedAtUtc`
+        - compare `generatedAtUtc`
+        - generated-at delta when both timestamps are present
         - GitHub compare URL derived from the resolved SHAs
         - artifact names
         - overall result delta


### PR DESCRIPTION
  ## Summary
  Extend the manual C# query cache-smoke diff workflow summary so it includes the smoke-summary
  generation timestamps and their delta, making the compared runs easier to interpret in terms of
  recency.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Added the following fields to the manual diff job summary:
    - baseline summary `generatedAtUtc`
    - compare summary `generatedAtUtc`
    - generated-at delta when both timestamps are present
  - Normalized timestamp rendering to stable ISO UTC strings in the summary
  - Kept the existing summary structure intact:
    - regression highlights
    - provenance
    - compare URL
    - thresholds
    - slice deltas
  - Updated `docs/targets/csharp-query-runtime.md` to document the new generated-at fields

  ## Why
  The manual diff workflow already surfaced:
  - run IDs
  - refs
  - SHAs
  - compare URL
  - total duration deltas
  - slice deltas

  But it still lacked direct visibility into when each compared smoke summary was generated. This change
  adds that recency context without changing the underlying diff artifact or workflow behavior.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Replayed the timestamp formatting logic against:
    - `tmp/csharp_query_smoke_summary_diff/cache_smoke_sequence_diff.json`
  - Confirmed the real sample rendered:
    - baseline `generatedAtUtc`: `n/a`
    - compare `generatedAtUtc`: `2026-03-21T04:27:06.2647121Z`
    - generated-at delta: `n/a`
  - Confirmed a synthetic timestamp pair rendered:
    - generated-at delta: `+150.0s`