### PR TITLE
Document Native TypR Richer Arity-2 Mutual Tree Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ includes:
   one invariant context argument threaded through the subtree calls,
   including branch bodies where one shared subtree call happens before
   guarded control that contains the second subtree call plus nested
-  non-recursive post-call control,
+  non-recursive post-call control, shared context updates before that
+  first subtree call, or branch-local context updates before the second
+  subtree call,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -224,7 +224,9 @@ bring-up.
     selection before those calls, and the same conservative guarded
     branch-body family, including branch bodies where one shared subtree
     call happens before guarded control that contains the second subtree
-    call plus nested non-recursive post-call control
+    call plus nested non-recursive post-call control, shared context
+    updates before that first subtree call, or branch-local context
+    updates before the second subtree call
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -404,7 +404,8 @@ Current TypR lowering policy is intentionally mixed:
   and the same conservative guarded branch-body family, including branch
   bodies where one shared subtree call happens before guarded control that
   contains the second subtree call plus nested non-recursive post-call
-  control, using
+  control, shared context updates before that first subtree call, or
+  branch-local context updates before the second subtree call, using
   raw-expression memoized helper bodies inside TypR rather than wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -94,7 +94,9 @@ This document focuses on architecture and rollout choices specific to TypR.
      the same computed-context and guarded
      branch-body families, including branch bodies where one shared
      subtree call happens before guarded control that contains the second
-     subtree call plus nested non-recursive post-call control, and
+     subtree call plus nested non-recursive post-call control, shared
+     context updates before that first subtree call, or branch-local
+     context updates before the second subtree call, and
      boolean return types, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -87,6 +87,10 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_ctx_nested_branch(_, _)),
     retractall(user:typr_mutual_even_tree_ctx_call_nested_post(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_call_nested_post(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_pre_branch_call_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_pre_branch_call_post(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx_branch_step_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_branch_step_post(_, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -3074,6 +3078,104 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_branch
     once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > (current_ctx + 10)) {")),
     once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= current_ctx }@) {")),
     once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx - 1) }@) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_prework_plus_branch_second_call_post_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_pre_branch_call_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_pre_branch_call_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_odd_tree_ctx_pre_branch_call_post(L, T1),
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_pre_branch_call_post(R, T1),
+            ( V > T1 + 10 ->
+                V >= T1
+            ;   V >= T1 - 1
+            )
+        ;   typr_mutual_odd_tree_ctx_pre_branch_call_post(R, T1)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_pre_branch_call_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_pre_branch_call_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_even_tree_ctx_pre_branch_call_post(L, T1),
+        ( V > T ->
+            typr_mutual_even_tree_ctx_pre_branch_call_post(R, T1),
+            ( V > T1 + 10 ->
+                V >= T1
+            ;   V >= T1 - 1
+            )
+        ;   typr_mutual_even_tree_ctx_pre_branch_call_post(R, T1)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_pre_branch_call_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_pre_branch_call_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_pre_branch_call_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_pre_branch_call_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_pre_branch_call_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_pre_branch_call_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_pre_branch_call_post/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_pre_branch_call_post/2, typr_mutual_odd_tree_ctx_pre_branch_call_post/2")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_pre_branch_call_post_impl(.subset2(current_input, 2), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_pre_branch_call_post_impl(.subset2(current_input, 3), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > ((current_ctx + 1) + 10)) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= (current_ctx + 1) }@) {")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= ((current_ctx + 1) - 1) }@) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_branch_step_second_call_post_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_branch_step_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_branch_step_post([V, L, R], T) :-
+        typr_mutual_odd_tree_ctx_branch_step_post(L, T),
+        ( V > T ->
+            T1 is T + 1,
+            typr_mutual_odd_tree_ctx_branch_step_post(R, T1),
+            ( V >= T1 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   T2 is T + 2,
+            typr_mutual_odd_tree_ctx_branch_step_post(R, T2),
+            ( V >= T2 ->
+                V >= T
+            ;   V >= T - 2
+            )
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_branch_step_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_branch_step_post([V, L, R], T) :-
+        typr_mutual_even_tree_ctx_branch_step_post(L, T),
+        ( V > T ->
+            T1 is T + 1,
+            typr_mutual_even_tree_ctx_branch_step_post(R, T1),
+            ( V >= T1 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   T2 is T + 2,
+            typr_mutual_even_tree_ctx_branch_step_post(R, T2),
+            ( V >= T2 ->
+                V >= T
+            ;   V >= T - 2
+            )
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_branch_step_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_branch_step_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_branch_step_post/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx_branch_step_post/2, typr_mutual_odd_tree_ctx_branch_step_post/2")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx_branch_step_post_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_branch_step_post_impl(.subset2(current_input, 3), (current_ctx + 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_branch_step_post_impl(.subset2(current_input, 3), (current_ctx + 2));")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) >= (current_ctx + 1)) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) >= (current_ctx + 2)) {")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2048,6 +2048,110 @@ test(structural_tree_dual_mutual_context_branch_second_call_nested_postcall_cont
     retractall(user:typr_mutual_even_tree_ctx_call_nested_post(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_call_nested_post(_, _)).
 
+test(structural_tree_dual_mutual_context_prework_plus_branch_second_call_post_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_pre_branch_call_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_pre_branch_call_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_odd_tree_ctx_pre_branch_call_post(L, T1),
+        ( V > T ->
+            typr_mutual_odd_tree_ctx_pre_branch_call_post(R, T1),
+            ( V > T1 + 10 ->
+                V >= T1
+            ;   V >= T1 - 1
+            )
+        ;   typr_mutual_odd_tree_ctx_pre_branch_call_post(R, T1)
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_pre_branch_call_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_pre_branch_call_post([V, L, R], T) :-
+        T1 is T + 1,
+        typr_mutual_even_tree_ctx_pre_branch_call_post(L, T1),
+        ( V > T ->
+            typr_mutual_even_tree_ctx_pre_branch_call_post(R, T1),
+            ( V > T1 + 10 ->
+                V >= T1
+            ;   V >= T1 - 1
+            )
+        ;   typr_mutual_even_tree_ctx_pre_branch_call_post(R, T1)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_pre_branch_call_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_pre_branch_call_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_pre_branch_call_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_pre_branch_call_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_pre_branch_call_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_pre_branch_call_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_pre_branch_call_post/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_pre_branch_call_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_pre_branch_call_post(_, _)).
+
+test(structural_tree_dual_mutual_context_branch_step_second_call_post_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx_branch_step_post([], _T0)),
+    assertz(user:(typr_mutual_even_tree_ctx_branch_step_post([V, L, R], T) :-
+        typr_mutual_odd_tree_ctx_branch_step_post(L, T),
+        ( V > T ->
+            T1 is T + 1,
+            typr_mutual_odd_tree_ctx_branch_step_post(R, T1),
+            ( V >= T1 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   T2 is T + 2,
+            typr_mutual_odd_tree_ctx_branch_step_post(R, T2),
+            ( V >= T2 ->
+                V >= T
+            ;   V >= T - 2
+            )
+        )
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx_branch_step_post([_, [], []], _T1)),
+    assertz(user:(typr_mutual_odd_tree_ctx_branch_step_post([V, L, R], T) :-
+        typr_mutual_even_tree_ctx_branch_step_post(L, T),
+        ( V > T ->
+            T1 is T + 1,
+            typr_mutual_even_tree_ctx_branch_step_post(R, T1),
+            ( V >= T1 ->
+                V >= T
+            ;   V >= T - 1
+            )
+        ;   T2 is T + 2,
+            typr_mutual_even_tree_ctx_branch_step_post(R, T2),
+            ( V >= T2 ->
+                V >= T
+            ;   V >= T - 2
+            )
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx_branch_step_post/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step_post/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx_branch_step_post/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx_branch_step_post/2, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx_branch_step_post/2, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx_branch_step_post/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx_branch_step_post(_, _)),
+    retractall(user:typr_mutual_odd_tree_ctx_branch_step_post(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR formalizes a broader conservative TypR mutual-recursion subset for arity-2 tree-structural boolean SCCs.

The branch started as a gap audit for richer arity-2 mutual-tree control around the two shared subtree calls.
That audit found that clean `main` already lowered these shapes natively and passed real TypR validation.

So this PR does the correct thing:

- adds focused regression coverage
- adds real `typr check` coverage
- updates the docs to make the supported subset explicit
- fixes one incorrect target-level golden-string assertion so the tests match the valid emitted TypR

Representative shapes now covered explicitly include:

```prolog
typr_mutual_even_tree_ctx_pre_branch_call_post([], _T0).
typr_mutual_even_tree_ctx_pre_branch_call_post([V, L, R], T) :-
    T1 is T + 1,
    typr_mutual_odd_tree_ctx_pre_branch_call_post(L, T1),
    ( V > T ->
        typr_mutual_odd_tree_ctx_pre_branch_call_post(R, T1),
        ( V > T1 + 10 ->
            V >= T1
        ;   V >= T1 - 1
        )
    ;   typr_mutual_odd_tree_ctx_pre_branch_call_post(R, T1)
    ).

typr_mutual_even_tree_ctx_branch_step_post([], _T0).
typr_mutual_even_tree_ctx_branch_step_post([V, L, R], T) :-
    typr_mutual_odd_tree_ctx_branch_step_post(L, T),
    ( V > T ->
        T1 is T + 1,
        typr_mutual_odd_tree_ctx_branch_step_post(R, T1),
        ( V >= T1 ->
            V >= T
        ;   V >= T - 1
        )
    ;   T2 is T + 2,
        typr_mutual_odd_tree_ctx_branch_step_post(R, T2),
        ( V >= T2 ->
            V >= T
        ;   V >= T - 2
        )
    ).
```

These are conservative arity-2 SCCs with:

- one tree-driving argument
- one invariant or symbolically threaded context argument
- shared dual-subtree descent
- branch-local context choice before the second subtree call
- nested non-recursive post-call control before the boolean rejoin

## Why This PR Exists

The previous arity-2 SCC work had already generalized the right backend plumbing:

- multi-argument helper signatures
- wrapper forwarding
- memo-key construction for multi-arg helpers
- symbolic context threading through shared subtree calls
- guarded branch-body lowering around those calls

That made it reasonable to audit the next nearby control combinations instead of assuming another emitter gap.

The audit result mattered:

- the richer arity-2 mutual-tree combinations already compiled natively on `main`
- the backend did not need another narrow patch
- the missing work was coverage and documentation, plus one incorrect test expectation

This PR records that support explicitly and keeps the test contract honest.

## Main Changes

### 1. Added focused target-level regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

Added regression coverage for:

- shared context update before the first subtree call, then branch-local second-call selection plus nested post-call control
- first subtree call at the current context, then branch-local context update before the second subtree call, plus nested post-call control

These tests verify that the generated TypR stays native and does not fall back to wrapped R.

### 2. Added real toolchain coverage

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

Added real `typr check` coverage for the same arity-2 SCC shapes.

That matters because this branch is intentionally documenting already-supported lowering, so the strongest proof is that the emitted program type-checks in the TypR toolchain, not just that a string shape looks plausible.

### 3. Corrected one invalid golden-string expectation

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

One new target-level test initially expected raw `@{ ... }@` guard syntax for two outer `if` conditions.
The emitted TypR was already valid; the assertion was wrong.

This PR fixes that test expectation so it matches the actual valid emitted code.

### 4. Updated documentation

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that conservative arity-2 tree-structural SCCs support:

- shared computed context updates before the first subtree call
- branch-local context updates before the second subtree call
- nested non-recursive post-call control before the shared boolean rejoin

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All passed.

## Scope Boundary

This PR is deliberately not another emitter expansion beyond the validated conservative subset.

It does not attempt:

- broader SCC lowering
- arbitrary recursive control-flow normalization
- new mutual-recursion families beyond the current conservative arity-2 tree subset

The audit conclusion here is useful on its own:

- nearby richer arity-2 mutual-tree control already works
- the next real frontier is broader SCC lowering design or a clearly confirmed new SCC gap, not another guessed arity-2 subcase
