### PR TITLE
Generalize native TypR n-ary mutual tree context threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ includes:
 - conservative boolean mutual-recursive predicate groups such as
   `is_even/1` / `is_odd/1`, `even_list/1` / `odd_list/1`,
   `even_left_tree/1` / `odd_left_tree/1`, and `even_tree/1` / `odd_tree/1`,
-  plus arity-2 tree-structural SCCs with one tree-driving argument and one
-  invariant context argument, including dual-subtree tree SCCs with
+  plus conservative `N`-ary tree-structural SCCs with one tree-driving
+  argument and one or more threaded context arguments, including dual-subtree
+  tree SCCs with
   alias-style prework, shared computed context updates, or guarded shared
   context selection before the two recursive subtree calls, or direct
   recursive subtree calls inside supported guarded branch bodies with

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -217,10 +217,10 @@ bring-up.
     symbolic context or alias state before the second call combined with
     that shared post-call control, nested non-recursive boolean post-call
     control after the shared dual-subtree calls, shared branch-local
-    guard prework before a nested mutual branch, and conservative arity-2
+    guard prework before a nested mutual branch, and conservative `N`-ary
     tree-structural SCCs with one
-    invariant context argument threaded through the shared dual-subtree
-    calls, shared computed context updates or guarded shared context
+    tree-driving argument and one or more threaded context arguments carried
+    through the shared dual-subtree calls, shared computed context updates or guarded shared context
     selection before those calls, and the same conservative guarded
     branch-body family, including branch bodies where one shared subtree
     call happens before guarded control that contains the second subtree

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -404,8 +404,9 @@ Current TypR lowering policy is intentionally mixed:
   and the same conservative guarded branch-body family, including branch
   bodies where one shared subtree call happens before guarded control that
   contains the second subtree call plus nested non-recursive post-call
-  control, shared context updates before that first subtree call, or
-  branch-local context updates before the second subtree call, using
+  control, shared context updates before that first subtree call, branch-local
+  context updates before the second subtree call, or multiple threaded
+  context arguments carried through the same shared subtree-call families, using
   raw-expression memoized helper bodies inside TypR rather than wrapped-R
   fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -89,13 +89,13 @@ This document focuses on architecture and rollout choices specific to TypR.
      call combined with that shared post-call control, nested
      non-recursive boolean post-call control after the shared dual-
      subtree calls, shared branch-local guard prework before a nested
-     mutual branch, conservative arity-2 tree-structural SCCs with one invariant
-     context argument threaded through the shared dual-subtree calls and
-     the same computed-context and guarded
+     mutual branch, conservative `N`-ary tree-structural SCCs with one
+     tree-driving argument and one or more threaded context arguments carried
+     through the shared dual-subtree calls and the same computed-context and guarded
      branch-body families, including branch bodies where one shared
      subtree call happens before guarded control that contains the second
      subtree call plus nested non-recursive post-call control, shared
-     context updates before that first subtree call, or branch-local
+     context updates before that first subtree call, branch-local
      context updates before the second subtree call, and
      boolean return types, emitted as TypR
      functions with raw-expression memoized helper bodies

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -263,7 +263,7 @@ typr_mutual_tree_dual_spec(GroupPredicates, Pred/Arity, Spec) :-
     }.
 
 typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
-    Arity =:= 2,
+    Arity >= 2,
     findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
     Clauses \= [],
     generic_typr_return_type(Pred/Arity, Clauses, "bool"),
@@ -274,12 +274,12 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
     BaseClauses \= [],
     maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
     sort(BaseConds0, BaseConditions),
-    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecHead =.. [_PredName, RecInputPattern|ContextVars],
     RecInputPattern = [ValueVar, LeftVar, RightVar],
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
     typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
-    ExtraArgMap0 = [ContextVar-"current_ctx"],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
     typr_mutual_tree_ordered_dual_context_goals(
         GroupPredicates,
         Goals,
@@ -288,7 +288,6 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
         ExtraArgMap0,
         Body
     ),
-    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, _ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
     atom_string(Pred, PredStr),
     Spec = mutual_spec{
         kind: tree_dual_body,
@@ -307,7 +306,7 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
     }.
 
 typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
-    Arity =:= 2,
+    Arity >= 2,
     findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
     Clauses \= [],
     generic_typr_return_type(Pred/Arity, Clauses, "bool"),
@@ -318,14 +317,14 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
     BaseClauses \= [],
     maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
     sort(BaseConds0, BaseConditions),
-    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecHead =.. [_PredName, RecInputPattern|ContextVars],
     RecInputPattern = [ValueVar, LeftVar, RightVar],
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
     append(PreGoals, RecGoals, Goals),
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
-    ExtraArgMap0 = [ContextVar-"current_ctx"],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap, PreGuardExpr),
     maplist(
         typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap),
@@ -334,20 +333,14 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
     ),
     select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
     select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
-    LeftCallArgs = ['.subset2(current_input, 2)', CurrentCtxExpr],
-    RightCallArgs = ['.subset2(current_input, 3)', CurrentCtxExpr],
+    LeftCallArgs = ['.subset2(current_input, 2)'|CurrentCtxExprs],
+    RightCallArgs = ['.subset2(current_input, 3)'|CurrentCtxExprs],
     atom_string(Pred, PredStr),
     atom_string(LeftNextPred, LeftNextPredStr),
     atom_string(RightNextPred, RightNextPredStr),
-    format(string(HelperName), '~w_impl', [PredStr]),
     format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
     format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
     typr_mutual_tree_top_guard_expr(PreGuardExpr, GuardExpr),
-    format(
-        string(MemoKeyExpr),
-        'paste0("~w:", paste(deparse(list(current_input, current_ctx)), collapse=""))',
-        [PredStr]
-    ),
     Spec = mutual_spec{
         kind: tree_dual,
         pred: Pred,
@@ -356,8 +349,8 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
         typed_arg_list: TypedArgList,
         return_type: "bool",
         helper_name: HelperName,
-        helper_params: ["current_input", "current_ctx"],
-        wrapper_call_args: ["arg1", "arg2"],
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
         memo_key_expr: MemoKeyExpr,
         left_call: branch_call(LeftNextHelperName, LeftCallArgs),
         right_call: branch_call(RightNextHelperName, RightCallArgs),
@@ -365,17 +358,43 @@ typr_mutual_tree_dual_context_spec(GroupPredicates, Pred/Arity, Spec) :-
         guard_expr: GuardExpr
     }.
 
-typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr) :-
+typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr) :-
     atom_string(Pred, PredStr),
     format(string(HelperName), '~w_impl', [PredStr]),
-    ExtraArgMap = [ContextVar-"current_ctx"],
-    HelperParams = ["current_input", "current_ctx"],
-    WrapperCallArgs = ["arg1", "arg2"],
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    typr_mutual_tree_context_varmap(ContextVars, ContextParamNames, ExtraArgMap),
+    HelperParams = ["current_input"|ContextParamNames],
+    length(ContextVars, ContextArity),
+    WrapperArity is ContextArity + 1,
+    typr_mutual_wrapper_arg_names(WrapperArity, WrapperCallArgs),
+    atomic_list_concat(HelperParams, ', ', HelperParamText),
     format(
         string(MemoKeyExpr),
-        'paste0("~w:", paste(deparse(list(current_input, current_ctx)), collapse=""))',
-        [PredStr]
+        'paste0("~w:", paste(deparse(list(~w)), collapse=""))',
+        [PredStr, HelperParamText]
     ).
+
+typr_mutual_tree_context_param_names([], []).
+typr_mutual_tree_context_param_names([_], ["current_ctx"]) :-
+    !.
+typr_mutual_tree_context_param_names([_|Rest], ["current_ctx"|Names]) :-
+    typr_mutual_tree_context_param_names(Rest, 2, Names).
+
+typr_mutual_tree_context_param_names([], _Index, []).
+typr_mutual_tree_context_param_names([_|Rest], Index, [Name|Names]) :-
+    format(string(Name), 'current_ctx_~d', [Index]),
+    NextIndex is Index + 1,
+    typr_mutual_tree_context_param_names(Rest, NextIndex, Names).
+
+typr_mutual_tree_context_varmap([], [], []).
+typr_mutual_tree_context_varmap([Var|Vars], [Name|Names], [Var-Name|Pairs]) :-
+    typr_mutual_tree_context_varmap(Vars, Names, Pairs).
+
+typr_mutual_wrapper_arg_names(Arity, Names) :-
+    findall(Name, (
+        between(1, Arity, Index),
+        format(string(Name), 'arg~d', [Index])
+    ), Names).
 
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
@@ -472,7 +491,7 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     }.
 
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
-    Arity =:= 2,
+    Arity >= 2,
     findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
     Clauses \= [],
     generic_typr_return_type(Pred/Arity, Clauses, "bool"),
@@ -483,10 +502,10 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     BaseClauses \= [],
     maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
     sort(BaseConds0, BaseConditions),
-    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecHead =.. [_PredName, RecInputPattern|ContextVars],
     RecInputPattern = [ValueVar, LeftVar, RightVar],
     typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
-    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
     Goals = [BranchGoal],
@@ -518,7 +537,7 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     }.
 
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
-    Arity =:= 2,
+    Arity >= 2,
     findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
     Clauses \= [],
     generic_typr_return_type(Pred/Arity, Clauses, "bool"),
@@ -529,7 +548,7 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     BaseClauses \= [],
     maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
     sort(BaseConds0, BaseConditions),
-    RecHead =.. [_PredName, RecInputPattern, ContextVar],
+    RecHead =.. [_PredName, RecInputPattern|ContextVars],
     RecInputPattern = [ValueVar, LeftVar, RightVar],
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
@@ -540,7 +559,7 @@ typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
     typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
-    typr_mutual_tree_context_fields(Pred, ContextVar, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
     typr_mutual_tree_branch_prework(
         ThenGoals,
         ValueVar,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -91,6 +91,8 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_ctx_pre_branch_call_post(_, _)),
     retractall(user:typr_mutual_even_tree_ctx_branch_step_post(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_branch_step_post(_, _)),
+    retractall(user:typr_mutual_even_tree_ctx2(_, _, _)),
+    retractall(user:typr_mutual_odd_tree_ctx2(_, _, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -3176,6 +3178,45 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_branch
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx_branch_step_post_impl(.subset2(current_input, 3), (current_ctx + 2));")),
     once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) >= (current_ctx + 1)) {")),
     once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) >= (current_ctx + 2)) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_multi_context_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx2([], _T0, _B0)),
+    assertz(user:(typr_mutual_even_tree_ctx2([V, L, R], T, B) :-
+        T1 is T + 1,
+        B1 is B + 2,
+        typr_mutual_odd_tree_ctx2(L, T1, B1),
+        typr_mutual_odd_tree_ctx2(R, T1, B1),
+        V >= T,
+        V >= B
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx2([_, [], []], _T1, _B1)),
+    assertz(user:(typr_mutual_odd_tree_ctx2([V, L, R], T, B) :-
+        T1 is T + 1,
+        B1 is B + 2,
+        typr_mutual_even_tree_ctx2(L, T1, B1),
+        typr_mutual_even_tree_ctx2(R, T1, B1),
+        V >= T,
+        V >= B
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx2/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx2/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx2/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx2/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx2/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx2/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx2/3, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx2/3, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx2/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_ctx2/3, typr_mutual_odd_tree_ctx2/3")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_ctx2 <- fn(arg1: [#N, Any], arg2: int, arg3: int): bool {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_ctx2_impl <- function(current_input, current_ctx, current_ctx_2) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_ctx2:\", paste(deparse(list(current_input, current_ctx, current_ctx_2)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx2_impl(.subset2(current_input, 2), (current_ctx + 1), (current_ctx_2 + 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx2_impl(.subset2(current_input, 3), (current_ctx + 1), (current_ctx_2 + 2));")),
+    once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= current_ctx_2 }@) {")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2152,6 +2152,47 @@ test(structural_tree_dual_mutual_context_branch_step_second_call_post_output_che
     retractall(user:typr_mutual_even_tree_ctx_branch_step_post(_, _)),
     retractall(user:typr_mutual_odd_tree_ctx_branch_step_post(_, _)).
 
+test(structural_tree_dual_mutual_multi_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_ctx2([], _T0, _B0)),
+    assertz(user:(typr_mutual_even_tree_ctx2([V, L, R], T, B) :-
+        T1 is T + 1,
+        B1 is B + 2,
+        typr_mutual_odd_tree_ctx2(L, T1, B1),
+        typr_mutual_odd_tree_ctx2(R, T1, B1),
+        V >= T,
+        V >= B
+    )),
+    assertz(user:typr_mutual_odd_tree_ctx2([_, [], []], _T1, _B1)),
+    assertz(user:(typr_mutual_odd_tree_ctx2([V, L, R], T, B) :-
+        T1 is T + 1,
+        B1 is B + 2,
+        typr_mutual_even_tree_ctx2(L, T1, B1),
+        typr_mutual_even_tree_ctx2(R, T1, B1),
+        V >= T,
+        V >= B
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx2/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx2/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_ctx2/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx2/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx2/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_ctx2/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_ctx2/3, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_ctx2/3, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_ctx2/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_ctx2(_, _, _)),
+    retractall(user:typr_mutual_odd_tree_ctx2(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR broadens the conservative native TypR mutual-recursion backend for tree-structural boolean SCCs from:

- one tree-driving argument plus one invariant context argument

to:

- one tree-driving argument plus one or more threaded context arguments

The first confirmed SCC gap from the broader audit was an arity-3 tree mutual-recursion shape like:

```prolog
typr_mutual_even_tree_ctx2([], _T0, _B0).
typr_mutual_even_tree_ctx2([V, L, R], T, B) :-
    T1 is T + 1,
    B1 is B + 2,
    typr_mutual_odd_tree_ctx2(L, T1, B1),
    typr_mutual_odd_tree_ctx2(R, T1, B1),
    V >= T,
    V >= B.

typr_mutual_odd_tree_ctx2([_, [], []], _T1, _B1).
typr_mutual_odd_tree_ctx2([V, L, R], T, B) :-
    T1 is T + 1,
    B1 is B + 2,
    typr_mutual_even_tree_ctx2(L, T1, B1),
    typr_mutual_even_tree_ctx2(R, T1, B1),
    V >= T,
    V >= B.
```

Before this PR, TypR failed on that SCC family with:

- `Error: No mutual recursion support for target typr`

After this PR, it lowers natively to TypR, passes real `typr check`, and stays inside the existing memoized-helper TypR model.

## Why This PR Exists

The previous SCC work had already generalized several important pieces:

- multi-argument helper signatures
- wrapper forwarding
- memo-key construction for multi-arg helpers
- symbolic extra-arg threading through conservative mutual-tree branch bodies

But the actual mutual-tree matcher and helper setup still stopped at a hard-coded arity-2 assumption:

- one tree-driving argument
- exactly one extra context argument named `current_ctx`

That meant the first broader SCC audit immediately found a real, local gap:

- conservative tree mutual recursion with two threaded context values still had no TypR path

This PR closes that gap by generalizing the mutual-tree context plumbing instead of adding a one-off arity-3 matcher.

## Main Changes

### 1. Generalized mutual-tree context setup from arity-2 to N-ary

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The mutual-tree backend no longer hard-codes:

- `Arity =:= 2`
- `ExtraArgMap = [ContextVar-"current_ctx"]`
- helper params `current_input, current_ctx`
- wrapper call args `arg1, arg2`

It now derives:

- one or more context parameter names
- the extra-arg varmap
- helper signatures
- wrapper forwarding
- memo-key construction

from the full extra-arg list.

For one context arg it still preserves the existing names and shapes.
For later args it emits stable names like:

- `current_ctx_2`
- `current_ctx_3`

### 2. Generalized conservative tree mutual specs to accept one or more extra args

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The existing mutual-tree context and guarded branch-body families now accept:

- one tree-driving argument
- one or more threaded context arguments
- boolean return type
- the same conservative dual-subtree call/rejoin structure

This keeps the scope narrow while removing the unnecessary arity-2-only boundary.

### 3. Added focused regression coverage for the first real gap

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New coverage verifies:

- arity-3 mutual-tree wrapper signatures
- multi-context helper signatures
- memo keys over all helper params
- both subtree calls carrying the updated context pair
- native TypR output without wrapped-R fallback

### 4. Added real toolchain validation for the new SCC family

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new arity-3 mutual-tree shape is checked with real `typr check`, not only string-shape assertions.

### 5. Documentation updated

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now state the actual supported generalization explicitly:

- conservative tree-structural SCCs can carry one or more threaded context arguments through the existing shared dual-subtree call families

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- non-boolean SCC result recombination
- asymmetric mutual call structures beyond the current conservative tree subset

The same audit that found the arity-3 context gap also checked two broader SCC classes that still fail cleanly:

- non-boolean SCC result recombination
- asymmetric mutual call structure

That makes the next high-signal follow-up clear:

- conservative non-boolean mutual recursion, not another narrower tree-shape variation
