### PR TITLE
`feat(wat): indirect call tables, dynamic dispatch, multi-module runtime`

### DIFF
--- a/src/unifyweaver/targets/wat_target.pl
+++ b/src/unifyweaver/targets/wat_target.pl
@@ -36,7 +36,12 @@
     % Multi-module import/export linking
     wat_module_imports/3,                % +ImportSpecs, +Options, -ImportCode
     wat_module_exports/3,                % +ExportSpecs, +Options, -ExportCode
-    wat_link_modules/3                   % +ModuleSpecs, +Options, -LinkedCode
+    wat_link_modules/3,                  % +ModuleSpecs, +Options, -LinkedCode
+
+    % Indirect call tables (dynamic dispatch)
+    wat_call_table/3,                    % +FuncSpecs, +Options, -TableCode
+    wat_dispatch_func/4,                 % +DispatchName, +TypeSig, +Options, -Code
+    wat_compile_with_dispatch/4          % +DispatchSpec, +Options, +Functions, -Code
 ]).
 
 :- use_module(library(lists)).
@@ -1165,6 +1170,144 @@ gen_linked_func(func(Name, Params, Result, Body), Line) :-
 
 gen_func_param(param(Name, Type), Str) :-
     format(string(Str), '(param $~w ~w) ', [Name, Type]).
+
+%% ============================================
+%% INDIRECT CALL TABLES (Dynamic Dispatch)
+%% ============================================
+%%
+%% WAT supports indirect function calls via tables + call_indirect.
+%% This enables dynamic dispatch: select a function at runtime by index.
+%%
+%% Use cases in Prolog compilation:
+%%   - Multi-clause dispatch (select clause by guard index)
+%%   - Higher-order predicates (call/N simulation)
+%%   - Module-level function pointers
+%%
+%% Table entry: each function registered in the table gets an index (0-based).
+%% Dispatch: call_indirect with a type signature and the index on the stack.
+
+%% wat_call_table(+FuncSpecs, +Options, -TableCode)
+%%   Generate a WAT function table, type declaration, and element segment.
+%%
+%%   FuncSpecs: list of table_func(Name, Params, Result, Body)
+%%     Name: function name (string/atom)
+%%     Params: list of WAT types [i64, i32, ...]
+%%     Result: return type (i64, i32, void)
+%%     Body: WAT body string
+%%
+%%   Generates:
+%%     (type $dispatch_t (func (param ...) (result ...)))
+%%     (table N funcref)
+%%     (elem (i32.const 0) $func0 $func1 ...)
+%%     (func $func0 ...) (func $func1 ...)
+wat_call_table(FuncSpecs, Options, TableCode) :-
+    length(FuncSpecs, Count),
+    (   Count > 0
+    ->  % Build type signature from first func (all must match)
+        FuncSpecs = [table_func(_, Params, Result, _)|_],
+        maplist(param_to_wat, Params, ParamStrs),
+        atomics_to_string(ParamStrs, ParamCode),
+        result_to_wat(Result, ResultCode),
+        format(string(TypeDecl),
+            '  (type $dispatch_t (func ~w~w))~n', [ParamCode, ResultCode]),
+
+        % Table declaration
+        format(string(TableDecl),
+            '  (table ~w funcref)~n', [Count]),
+
+        % Element segment
+        maplist(table_func_name, FuncSpecs, FuncNames),
+        atomic_list_concat(FuncNames, ' ', NameList),
+        format(string(ElemDecl),
+            '  (elem (i32.const 0) ~w)~n', [NameList]),
+
+        % Function bodies
+        maplist(gen_table_func(Params, Result, Options), FuncSpecs, FuncBodies),
+        atomics_to_string(FuncBodies, FuncCode),
+
+        atomics_to_string([TypeDecl, TableDecl, ElemDecl, FuncCode], TableCode)
+    ;   TableCode = ""
+    ).
+
+table_func_name(table_func(Name, _, _, _), Ref) :-
+    format(string(Ref), '$~w', [Name]).
+
+gen_table_func(Params, Result, _Options, table_func(Name, _, _, Body), Code) :-
+    length(Params, ParamCount),
+    gen_indexed_params(1, ParamCount, Params, ParamDecls),
+    atomics_to_string(ParamDecls, ParamCode),
+    result_to_wat(Result, ResultCode),
+    format(string(Code),
+'  (func $~w ~w~w
+~w
+  )~n', [Name, ParamCode, ResultCode, Body]).
+
+gen_indexed_params(_, 0, _, []) :- !.
+gen_indexed_params(I, Remaining, [Type|RestTypes], [Str|RestStrs]) :-
+    format(string(Str), '(param $p~w ~w) ', [I, Type]),
+    I1 is I + 1,
+    R1 is Remaining - 1,
+    gen_indexed_params(I1, R1, RestTypes, RestStrs).
+
+%% wat_dispatch_func(+DispatchName, +TypeSig, +Options, -Code)
+%%   Generate a dispatch function that does call_indirect with a
+%%   runtime index parameter.
+%%
+%%   TypeSig: type_sig(Params, Result)
+%%     Params: list of WAT types for the dispatched function's params
+%%     Result: return type
+%%
+%%   The generated function takes (index i32, params...) and calls
+%%   the function at table[index] with the remaining params.
+wat_dispatch_func(DispatchName, type_sig(Params, Result), _Options, Code) :-
+    % Build named param list for the dispatch function
+    length(Params, ParamCount),
+    gen_named_params(1, ParamCount, Params, NamedParamStrs),
+    atomics_to_string(NamedParamStrs, FwdParamCode),
+    result_to_wat(Result, ResultCode),
+
+    % Generate local.get for each forwarded param
+    gen_forward_gets(1, ParamCount, ForwardGets),
+    atomics_to_string(ForwardGets, ForwardCode),
+
+    format(string(Code),
+'  (func $~w (export "~w") (param $idx i32) ~w~w
+    ~w(call_indirect (type $dispatch_t) (local.get $idx))
+  )~n', [DispatchName, DispatchName, FwdParamCode, ResultCode, ForwardCode]).
+
+gen_named_params(_, 0, _, []) :- !.
+gen_named_params(I, Remaining, [Type|RestTypes], [Str|RestStrs]) :-
+    format(string(Str), '(param $p~w ~w) ', [I, Type]),
+    I1 is I + 1,
+    R1 is Remaining - 1,
+    gen_named_params(I1, R1, RestTypes, RestStrs).
+
+gen_forward_gets(_, 0, []) :- !.
+gen_forward_gets(I, Remaining, [Str|Rest]) :-
+    format(string(Str), '(local.get $p~w) ', [I]),
+    I1 is I + 1,
+    R1 is Remaining - 1,
+    gen_forward_gets(I1, R1, Rest).
+
+%% wat_compile_with_dispatch(+DispatchSpec, +Options, +Functions, -Code)
+%%   Compile a complete module with a function table and dispatch function.
+%%
+%%   DispatchSpec: dispatch(Name, Params, Result)
+%%   Functions: list of table_func(Name, Params, Result, Body)
+wat_compile_with_dispatch(dispatch(DispName, Params, Result), Options, Functions, Code) :-
+    wat_call_table(Functions, Options, TableCode),
+    wat_dispatch_func(DispName, type_sig(Params, Result), Options, DispatchCode),
+    wat_memory_decl(Options, MemDecl),
+    length(Functions, Count),
+    format(string(Code),
+'(module
+  ;; Generated by UnifyWeaver WAT Target - Dynamic Dispatch
+  ;; Dispatch: ~w (table of ~w functions)
+
+~w
+~w
+~w)
+', [DispName, Count, MemDecl, TableCode, DispatchCode]).
 
 %% combine_wat_conditions(+Conds, -Combined)
 combine_wat_conditions([C], C) :- !.

--- a/tests/core/test_wat_native_lowering.pl
+++ b/tests/core/test_wat_native_lowering.pl
@@ -542,4 +542,66 @@ test(link_empty_exports) :-
     wat_target:wat_module_exports([], [], Code),
     Code == "".
 
+% ============================================================================
+% Indirect call tables (dynamic dispatch)
+% ============================================================================
+
+test(call_table_basic) :-
+    wat_target:wat_call_table(
+        [table_func(double, [i64], i64,
+            "    (i64.mul (local.get $p1) (i64.const 2))"),
+         table_func(triple, [i64], i64,
+            "    (i64.mul (local.get $p1) (i64.const 3))")],
+        [],
+        Code),
+    has(Code, "(type $dispatch_t (func"),
+    has(Code, "(table 2 funcref)"),
+    has(Code, "(elem (i32.const 0) $double $triple)"),
+    has(Code, "(func $double"),
+    has(Code, "(func $triple").
+
+test(dispatch_func) :-
+    wat_target:wat_dispatch_func(
+        "apply",
+        type_sig([i64], i64),
+        [],
+        Code),
+    has(Code, "(func $apply (export \"apply\")"),
+    has(Code, "(param $idx i32)"),
+    has(Code, "call_indirect (type $dispatch_t)").
+
+test(compile_with_dispatch) :-
+    wat_target:wat_compile_with_dispatch(
+        dispatch("compute", [i64], i64),
+        [],
+        [table_func(inc, [i64], i64,
+            "    (i64.add (local.get $p1) (i64.const 1))"),
+         table_func(dec, [i64], i64,
+            "    (i64.sub (local.get $p1) (i64.const 1))"),
+         table_func(dbl, [i64], i64,
+            "    (i64.mul (local.get $p1) (i64.const 2))")],
+        Code),
+    has(Code, "(module"),
+    has(Code, "Dynamic Dispatch"),
+    has(Code, "(table 3 funcref)"),
+    has(Code, "(elem (i32.const 0) $inc $dec $dbl)"),
+    has(Code, "(func $compute (export \"compute\")"),
+    has(Code, "call_indirect").
+
+test(call_table_empty) :-
+    wat_target:wat_call_table([], [], Code),
+    Code == "".
+
+test(dispatch_multi_param) :-
+    wat_target:wat_dispatch_func(
+        "binop",
+        type_sig([i64, i64], i64),
+        [],
+        Code),
+    has(Code, "(param $idx i32)"),
+    has(Code, "(param $p1 i64)"),
+    has(Code, "(param $p2 i64)"),
+    has(Code, "(local.get $p1)"),
+    has(Code, "(local.get $p2)").
+
 :- end_tests(wat_native_lowering).


### PR DESCRIPTION
## Summary

- Add WAT indirect call tables (`funcref` table + `call_indirect`) for dynamic dispatch
- Runtime validate multi-module linking with `wasmtime --preload`
- 5 new Prolog tests (62 → 67 total)

## Indirect Call Tables

WAT's `call_indirect` instruction enables dynamic dispatch: a function is selected at runtime by an i32 index into a `funcref` table. This maps naturally to Prolog compilation patterns:

| Use Case | Mapping |
|----------|---------|
| Multi-clause dispatch | Each clause → table entry, guard result → index |
| Higher-order predicates | `call/N` → `call_indirect` with function index |
| Module-level function pointers | Exported dispatch function wraps table |

### Generated WAT Structure

```wat
(type $dispatch_t (func (param i64) (result i64)))
(table 3 funcref)
(elem (i32.const 0) $inc $dec $dbl)

(func $inc (param $p1 i64) (result i64) ...)
(func $dec (param $p1 i64) (result i64) ...)
(func $dbl (param $p1 i64) (result i64) ...)

(func $compute (export "compute") (param $idx i32) (param $p1 i64) (result i64)
  (local.get $p1) (call_indirect (type $dispatch_t) (local.get $idx))
)
```

### New Predicates

- `wat_call_table/3` — generates `(type)`, `(table N funcref)`, `(elem ...)`, and function bodies from a list of `table_func(Name, Params, Result, Body)` specs
- `wat_dispatch_func/4` — generates a dispatch function that takes `(idx i32, params...)` and calls `call_indirect` with the index
- `wat_compile_with_dispatch/4` — assembles a complete module with table, dispatch function, and memory

## Multi-Module Runtime Validation

Tested cross-module imports with `wasmtime --preload`:

**Library module (`mathlib.wat`):**
```wat
(func $square (export "square") (param $x i64) (result i64)
  (i64.mul (local.get $x) (local.get $x)))
(func $cube (export "cube") (param $x i64) (result i64)
  (i64.mul (local.get $x) (i64.mul (local.get $x) (local.get $x))))
```

**App module (`app_linked.wat`):**
```wat
(import "mathlib" "square" (func $square (param i64) (result i64)))
(import "mathlib" "cube" (func $cube (param i64) (result i64)))
(func $sum_sq_cube (export "sum_sq_cube") (param $n i64) (result i64)
  (i64.add (call $square (local.get $n)) (call $cube (local.get $n))))
```

**Runtime:**
```bash
wasmtime --preload mathlib=mathlib.wasm --invoke sum_sq_cube app_linked.wasm 3
# → 36 (= 9 + 27 = 3² + 3³)
```

## Runtime Test Results

| Test | Command | Expected | Actual | Status |
|------|---------|----------|--------|--------|
| dispatch inc | `compute(0, 10)` | 11 | 11 | Pass |
| dispatch dec | `compute(1, 10)` | 9 | 9 | Pass |
| dispatch dbl | `compute(2, 10)` | 20 | 20 | Pass |
| mathlib square | `square(5)` | 25 | 25 | Pass |
| mathlib cube | `cube(3)` | 27 | 27 | Pass |
| linked sum_sq_cube | `--preload mathlib sum_sq_cube(3)` | 36 | 36 | Pass |
| linked sum_sq_cube | `--preload mathlib sum_sq_cube(5)` | 150 | 150 | Pass |

## Tests (62 → 67, +5 new)

| Test | Feature |
|------|---------|
| `call_table_basic` | Table type, funcref, elem segment generation |
| `dispatch_func` | Dispatch function with call_indirect |
| `compile_with_dispatch` | Full dispatch module assembly |
| `call_table_empty` | Empty table edge case |
| `dispatch_multi_param` | Multi-parameter dispatch (2 params) |

## Test plan

- [x] All 67 Prolog unit tests pass
- [x] `dispatch.wat`, `mathlib.wat`, `app_linked.wat` compile with `wat2wasm`
- [x] Dynamic dispatch runtime validated (3 functions × index selection)
- [x] Multi-module linking runtime validated with `wasmtime --preload`
- [x] No regressions in existing 10 WAT patterns
