### PR TITLE
Keep native TypR non-boolean mutual tree recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,10 @@ includes:
   guarded control that contains the second subtree call plus nested
   non-recursive post-call control, shared context updates before that
   first subtree call, or branch-local context updates before the second
-  subtree call,
+  subtree call, plus conservative integer-return tree-structural SCCs
+  with shared dual-subtree descent and simple post-call arithmetic
+  recombination over `value`, `left_result`, `right_result`, and any
+  threaded context args,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -226,7 +226,10 @@ bring-up.
     call happens before guarded control that contains the second subtree
     call plus nested non-recursive post-call control, shared context
     updates before that first subtree call, or branch-local context
-    updates before the second subtree call
+    updates before the second subtree call, plus conservative integer-
+    return tree-structural SCCs with shared dual-subtree descent and
+    simple post-call arithmetic recombination over `value`,
+    `left_result`, `right_result`, and any threaded context args
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -406,9 +406,12 @@ Current TypR lowering policy is intentionally mixed:
   contains the second subtree call plus nested non-recursive post-call
   control, shared context updates before that first subtree call, branch-local
   context updates before the second subtree call, or multiple threaded
-  context arguments carried through the same shared subtree-call families, using
-  raw-expression memoized helper bodies inside TypR rather than wrapped-R
-  fallback
+  context arguments carried through the same shared subtree-call families,
+  plus conservative integer-return tree-structural SCCs with shared
+  dual-subtree descent and simple post-call arithmetic recombination over
+  `value`, `left_result`, `right_result`, and any threaded context args,
+  using raw-expression memoized helper bodies inside TypR rather than
+  wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -96,8 +96,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      subtree call happens before guarded control that contains the second
      subtree call plus nested non-recursive post-call control, shared
      context updates before that first subtree call, branch-local
-     context updates before the second subtree call, and
-     boolean return types, emitted as TypR
+     context updates before the second subtree call, and boolean return
+     types, plus conservative integer-return tree-structural SCCs with
+     shared dual-subtree descent and simple post-call arithmetic
+     recombination over `value`, `left_result`, `right_result`, and any
+     threaded context args, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -81,6 +81,7 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
     (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_dual_value_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_context_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_branch_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_spec(Predicates), Predicates, Specs)
@@ -174,6 +175,79 @@ typr_mutual_list_base_case_length(clause(Head, true), 0) :-
 typr_mutual_list_base_case_length(clause(Head, true), 1) :-
     Head =.. [_Pred, [Elem]],
     var(Elem).
+
+typr_mutual_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, RecInputPattern|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap, PreGuardExpr),
+    maplist(typr_mutual_tree_value_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap), RecGoals, CallSpecs0),
+    select(value_call_spec(left, LeftNextPred, LeftCallArgs, LeftOutputVar), CallSpecs0, CallSpecs1),
+    select(value_call_spec(right, RightNextPred, RightCallArgs, RightOutputVar), CallSpecs1, []),
+    typr_mutual_tree_top_guard_expr(PreGuardExpr, GuardExpr),
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, ResultVarMap0),
+    update_typr_expr_varmap(ResultVarMap0, LeftOutputVar, left_result, ResultVarMap1),
+    update_typr_expr_varmap(ResultVarMap1, RightOutputVar, right_result, ResultVarMap),
+    typr_goals_to_body(PostGoals, PostBody),
+    linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr),
+    atom_string(Pred, PredStr),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual_value,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: GuardExpr,
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        result_expr: ResultExpr
+    }.
+
+typr_mutual_tree_value_base_case(ContextParamNames, clause(Head, true), base_case(BaseCondition, OutputExpr)) :-
+    typr_mutual_tree_base_case_condition(clause(Head, true), BaseCondition),
+    Head =.. [_Pred, BaseTree|ContextAndOutputVars],
+    append(ContextVars, [BaseOutput], ContextAndOutputVars),
+    typr_mutual_tree_base_case_varmap(BaseTree, ContextVars, ContextParamNames, VarMap),
+    typr_translate_r_expr(BaseOutput, VarMap, OutputExpr).
+
+typr_mutual_tree_base_case_varmap(BaseTree, ContextVars, ContextParamNames, VarMap) :-
+    typr_mutual_tree_context_varmap(ContextVars, ContextParamNames, ContextVarMap),
+    typr_mutual_tree_base_tree_varmap(BaseTree, TreeVarMap),
+    append(TreeVarMap, ContextVarMap, VarMap).
+
+typr_mutual_tree_base_tree_varmap([], []) :-
+    !.
+typr_mutual_tree_base_tree_varmap([ValueVar, [], []], [ValueVar-'.subset2(current_input, 1)']) :-
+    var(ValueVar),
+    !.
+typr_mutual_tree_base_tree_varmap([_Value, [], []], []).
 
 typr_mutual_tree_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
@@ -653,6 +727,39 @@ typr_mutual_goal_list((A, B), Goals) :-
     append(GoalsA, GoalsB, Goals).
 typr_mutual_goal_list(Goal, [Goal]).
 
+split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals) :-
+    split_typr_mutual_non_recursive_prefix(GroupPredicates, Goals, PreGoals, RecAndPostGoals),
+    take_typr_mutual_recursive_goal_prefix(GroupPredicates, RecAndPostGoals, RecGoals, PostGoals),
+    RecGoals = [_|[_|_]],
+    PostGoals \= [],
+    \+ typr_contains_mutual_recursive_goal(GroupPredicates, PostGoals).
+
+split_typr_mutual_non_recursive_prefix(_GroupPredicates, [], [], []).
+split_typr_mutual_non_recursive_prefix(GroupPredicates, [Goal|Rest], [], [Goal|Rest]) :-
+    typr_goal_calls_mutual_group(GroupPredicates, Goal),
+    !.
+split_typr_mutual_non_recursive_prefix(GroupPredicates, [Goal|Rest], [Goal|PreGoals], PostGoals) :-
+    split_typr_mutual_non_recursive_prefix(GroupPredicates, Rest, PreGoals, PostGoals).
+
+take_typr_mutual_recursive_goal_prefix(GroupPredicates, [Goal|Rest], [Goal|RecGoals], PostGoals) :-
+    typr_goal_calls_mutual_group(GroupPredicates, Goal),
+    !,
+    take_typr_mutual_recursive_goal_prefix(GroupPredicates, Rest, RecGoals, PostGoals).
+take_typr_mutual_recursive_goal_prefix(_GroupPredicates, Goals, [], Goals).
+
+typr_goal_calls_mutual_group(GroupPredicates, Goal0) :-
+    nonvar(Goal0),
+    typr_strip_module_goal(Goal0, Goal),
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    memberchk(Pred/Arity, GroupPredicates).
+
+typr_contains_mutual_recursive_goal(GroupPredicates, [Goal|_]) :-
+    typr_goal_calls_mutual_group(GroupPredicates, Goal),
+    !.
+typr_contains_mutual_recursive_goal(GroupPredicates, [_|Rest]) :-
+    typr_contains_mutual_recursive_goal(GroupPredicates, Rest).
+
 typr_strip_module_goal(_Module:Goal, StrippedGoal) :-
     !,
     typr_strip_module_goal(Goal, StrippedGoal).
@@ -723,6 +830,19 @@ typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, Goal0, c
     Goal =.. [NextPred, RecArg|ExtraArgs],
     length(ExtraArgs, ExtraArity),
     Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    typr_mutual_tree_lookup_side(RecArg, AliasMap, Side),
+    typr_mutual_tree_side_step_expr(Side, StepExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [StepExpr|ExtraArgExprs].
+
+typr_mutual_tree_value_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, Goal0, value_call_spec(Side, NextPred, CallArgs, OutputVar)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
     memberchk(NextPred/Arity, GroupPredicates),
     typr_mutual_tree_lookup_side(RecArg, AliasMap, Side),
     typr_mutual_tree_side_step_expr(Side, StepExpr),
@@ -1314,6 +1434,60 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     atomic_list_concat(Lines, '\n', Code).
 typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     Kind = Spec.kind,
+    Kind == tree_dual_value,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseCases = Spec.base_cases,
+    GuardExpr = Spec.guard_expr,
+    LeftCall = Spec.left_call,
+    RightCall = Spec.right_call,
+    ResultExpr = Spec.result_expr,
+    typr_mutual_tree_value_base_branch_lines(GroupName, BaseCases, BaseLines),
+    typr_mutual_tree_dual_value_recursive_branch_lines(
+        GroupName,
+        GuardExpr,
+        LeftCall,
+        RightCall,
+        ResultExpr,
+        RecursiveLines
+    ),
+    typr_mutual_stop_lines(PredStr, StopLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, StopLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_value,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseCases = Spec.base_cases,
+    GuardExpr = Spec.guard_expr,
+    LeftCall = Spec.left_call,
+    RightCall = Spec.right_call,
+    ResultExpr = Spec.result_expr,
+    typr_mutual_tree_value_base_branch_lines_no_memo(BaseCases, BaseLines),
+    typr_mutual_tree_dual_value_recursive_branch_lines_no_memo(
+        GuardExpr,
+        LeftCall,
+        RightCall,
+        ResultExpr,
+        RecursiveLines
+    ),
+    typr_mutual_stop_lines_no_memo(PredStr, StopLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, StopLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
     Kind == tree_dual_branch,
     PredStr = Spec.pred_str,
     HelperName = Spec.helper_name,
@@ -1565,6 +1739,34 @@ typr_mutual_tree_base_branch_lines_no_memo_rest([BaseCondition|Rest], [IfLine, '
     format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
     typr_mutual_tree_base_branch_lines_no_memo_rest(Rest, RestLines).
 
+typr_mutual_tree_value_base_branch_lines(GroupName, [base_case(BaseCondition, BaseExpr)|Rest], Lines) :-
+    format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
+    format(string(ResultLine), '            result = ~w;', [BaseExpr]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [IfLine, ResultLine, AssignLine, '            result'|RestLines],
+    typr_mutual_tree_value_base_branch_lines_rest(GroupName, Rest, RestLines).
+
+typr_mutual_tree_value_base_branch_lines_rest(_GroupName, [], []).
+typr_mutual_tree_value_base_branch_lines_rest(GroupName, [base_case(BaseCondition, BaseExpr)|Rest], [
+    IfLine, ResultLine, AssignLine, '            result'|RestLines
+]) :-
+    format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
+    format(string(ResultLine), '            result = ~w;', [BaseExpr]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    typr_mutual_tree_value_base_branch_lines_rest(GroupName, Rest, RestLines).
+
+typr_mutual_tree_value_base_branch_lines_no_memo([base_case(BaseCondition, BaseExpr)|Rest], Lines) :-
+    format(string(IfLine), '        if (~w) {', [BaseCondition]),
+    format(string(ResultLine), '            ~w', [BaseExpr]),
+    Lines = [IfLine, ResultLine|RestLines],
+    typr_mutual_tree_value_base_branch_lines_no_memo_rest(Rest, RestLines).
+
+typr_mutual_tree_value_base_branch_lines_no_memo_rest([], []).
+typr_mutual_tree_value_base_branch_lines_no_memo_rest([base_case(BaseCondition, BaseExpr)|Rest], [IfLine, ResultLine|RestLines]) :-
+    format(string(IfLine), '        } else if (~w) {', [BaseCondition]),
+    format(string(ResultLine), '            ~w', [BaseExpr]),
+    typr_mutual_tree_value_base_branch_lines_no_memo_rest(Rest, RestLines).
+
 typr_mutual_recursive_branch_lines(GroupName, 'TRUE', NextHelperName, StepExpr, Lines) :-
     !,
     format(string(ResultLine), '            result = ~w(~w);', [NextHelperName, StepExpr]),
@@ -1677,6 +1879,92 @@ typr_mutual_tree_dual_recursive_branch_lines_no_memo(
         LeftLine,
         RightLine,
         '            left_result && right_result'
+    ].
+
+typr_mutual_tree_dual_value_recursive_branch_lines(
+    GroupName,
+    'TRUE',
+    LeftCall,
+    RightCall,
+    ResultExpr,
+    Lines
+) :-
+    !,
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
+    format(string(ResultLine), '            result = ~w;', [ResultExpr]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [
+        '        } else {',
+        LeftLine,
+        RightLine,
+        ResultLine,
+        AssignLine,
+        '            result'
+    ].
+typr_mutual_tree_dual_value_recursive_branch_lines(
+    GroupName,
+    GuardExpr,
+    LeftCall,
+    RightCall,
+    ResultExpr,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
+    format(string(ResultLine), '            result = ~w;', [ResultExpr]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    Lines = [
+        IfLine,
+        LeftLine,
+        RightLine,
+        ResultLine,
+        AssignLine,
+        '            result'
+    ].
+
+typr_mutual_tree_dual_value_recursive_branch_lines_no_memo(
+    'TRUE',
+    LeftCall,
+    RightCall,
+    ResultExpr,
+    Lines
+) :-
+    !,
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
+    format(string(ResultLine), '            ~w', [ResultExpr]),
+    Lines = [
+        '        } else {',
+        LeftLine,
+        RightLine,
+        ResultLine
+    ].
+typr_mutual_tree_dual_value_recursive_branch_lines_no_memo(
+    GuardExpr,
+    LeftCall,
+    RightCall,
+    ResultExpr,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '            left_result = ~w;', [LeftExpr]),
+    format(string(RightLine), '            right_result = ~w;', [RightExpr]),
+    format(string(ResultLine), '            ~w', [ResultExpr]),
+    Lines = [
+        IfLine,
+        LeftLine,
+        RightLine,
+        ResultLine
     ].
 
 typr_mutual_tree_dual_branch_recursive_branch_lines(
@@ -2052,6 +2340,20 @@ typr_mutual_false_lines(GroupName, [
     '        }'
 ]) :-
     format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]).
+
+typr_mutual_stop_lines(PredStr, [
+    '        } else {',
+    StopLine,
+    '        }'
+]) :-
+    format(string(StopLine), '            stop("No matching mutual recursive clause for ~w")', [PredStr]).
+
+typr_mutual_stop_lines_no_memo(PredStr, [
+    '        } else {',
+    StopLine,
+    '        }'
+]) :-
+    format(string(StopLine), '            stop("No matching mutual recursive clause for ~w")', [PredStr]).
 
 compile_typr_tail_recursive_accumulator(_Module:Pred/Arity, TypedMode, Clauses, Code) :-
     Arity =:= 3,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -93,6 +93,10 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_ctx_branch_step_post(_, _)),
     retractall(user:typr_mutual_even_tree_ctx2(_, _, _)),
     retractall(user:typr_mutual_odd_tree_ctx2(_, _, _)),
+    retractall(user:typr_mutual_sum_even_tree(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree(_, _)),
+    retractall(user:typr_mutual_weight_even_tree(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree(_, _, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -3217,6 +3221,74 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_multi_context_
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_ctx2_impl(.subset2(current_input, 2), (current_ctx + 1), (current_ctx_2 + 2));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_ctx2_impl(.subset2(current_input, 3), (current_ctx + 1), (current_ctx_2 + 2));")),
     once(sub_string(Code, _, _, _, "if (@{ .subset2(current_input, 1) >= current_ctx_2 }@) {")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_output_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree([V, L, R], S) :-
+        typr_mutual_sum_odd_tree(L, SL),
+        typr_mutual_sum_odd_tree(R, SR),
+        S is V + SL + SR
+    )),
+    assertz(user:typr_mutual_sum_odd_tree([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree([V, L, R], S) :-
+        typr_mutual_sum_even_tree(L, SL),
+        typr_mutual_sum_even_tree(R, SR),
+        S is V + SL + SR + 1
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_tree/2, typr_mutual_sum_odd_tree/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_tree <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_odd_tree <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_even_tree_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_odd_tree_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_sum_even_tree:\", paste(deparse(list(current_input)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) + left_result) + right_result) + 1);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_context_output_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree([V, L, R], W, S) :-
+        typr_mutual_weight_odd_tree(L, W, SL),
+        typr_mutual_weight_odd_tree(R, W, SR),
+        S is (V * W) + SL + SR
+    )),
+    assertz(user:typr_mutual_weight_odd_tree([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree([V, L, R], W, S) :-
+        typr_mutual_weight_even_tree(L, W, SL),
+        typr_mutual_weight_even_tree(R, W, SR),
+        S is (V * W) + SL + SR + 1
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_weight_even_tree/3, typr_mutual_weight_odd_tree/3")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_weight_even_tree <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_weight_even_tree_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_weight_even_tree:\", paste(deparse(list(current_input, current_ctx)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) * current_ctx) + left_result) + right_result);")),
+    once(sub_string(Code, _, _, _, "result = ((((.subset2(current_input, 1) * current_ctx) + left_result) + right_result) + 1);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2193,6 +2193,74 @@ test(structural_tree_dual_mutual_multi_context_output_checks_with_typr, [conditi
     retractall(user:typr_mutual_even_tree_ctx2(_, _, _)),
     retractall(user:typr_mutual_odd_tree_ctx2(_, _, _)).
 
+test(structural_tree_dual_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree([V, L, R], S) :-
+        typr_mutual_sum_odd_tree(L, SL),
+        typr_mutual_sum_odd_tree(R, SR),
+        S is V + SL + SR
+    )),
+    assertz(user:typr_mutual_sum_odd_tree([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree([V, L, R], S) :-
+        typr_mutual_sum_even_tree(L, SL),
+        typr_mutual_sum_even_tree(R, SR),
+        S is V + SL + SR + 1
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_even_tree(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree(_, _)).
+
+test(structural_tree_dual_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree([V, L, R], W, S) :-
+        typr_mutual_weight_odd_tree(L, W, SL),
+        typr_mutual_weight_odd_tree(R, W, SR),
+        S is (V * W) + SL + SR
+    )),
+    assertz(user:typr_mutual_weight_odd_tree([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree([V, L, R], W, S) :-
+        typr_mutual_weight_even_tree(L, W, SL),
+        typr_mutual_weight_even_tree(R, W, SR),
+        S is (V * W) + SL + SR + 1
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_weight_even_tree(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR mutual-recursion backend beyond the current boolean-only tree SCC model.

It adds support for conservative integer-return tree-structural SCCs with:

- shared dual-subtree descent
- simple post-call arithmetic recombination over `value`, `left_result`, `right_result`, and any threaded context args
- native TypR emission through the existing memoized-helper model

The first confirmed failing SCC shapes from the broader audit were:

```prolog
typr_mutual_sum_even_tree([], 0).
typr_mutual_sum_even_tree([V, L, R], S) :-
    typr_mutual_sum_odd_tree(L, SL),
    typr_mutual_sum_odd_tree(R, SR),
    S is V + SL + SR.

typr_mutual_sum_odd_tree([_, [], []], 1).
typr_mutual_sum_odd_tree([V, L, R], S) :-
    typr_mutual_sum_even_tree(L, SL),
    typr_mutual_sum_even_tree(R, SR),
    S is V + SL + SR + 1.
```

and the same shape with one threaded context argument:

```prolog
typr_mutual_weight_even_tree([], _W0, 0).
typr_mutual_weight_even_tree([V, L, R], W, S) :-
    typr_mutual_weight_odd_tree(L, W, SL),
    typr_mutual_weight_odd_tree(R, W, SR),
    S is (V * W) + SL + SR.

typr_mutual_weight_odd_tree([_, [], []], _W1, 1).
typr_mutual_weight_odd_tree([V, L, R], W, S) :-
    typr_mutual_weight_even_tree(L, W, SL),
    typr_mutual_weight_even_tree(R, W, SR),
    S is (V * W) + SL + SR + 1.
```

Before this PR, TypR failed on these non-boolean SCC families with:

- `Error: No mutual recursion support for target typr`

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

The previous SCC work had already generalized several important mutual-tree pieces:

- multi-argument helper signatures
- wrapper forwarding
- memo-key construction for multi-arg helpers
- symbolic context threading through conservative tree SCCs

But the actual mutual backend still assumed:

- boolean result rejoin
- boolean failure handling
- boolean-only helper bodies for tree SCCs

That meant the first broader SCC audit immediately found a real next gap:

- non-boolean tree mutual recursion with straightforward numeric recombination still had no TypR path

This PR closes that gap by introducing a narrow value-returning mutual-tree path, not by trying to turn the whole SCC backend into a general-purpose recursive IR in one step.

## Main Changes

### 1. Added a conservative non-boolean mutual-tree spec

Updated `src/unifyweaver/targets/typr_target.pl`.

TypR mutual recursion now recognizes a conservative integer-return tree SCC shape with:

- one tree-driving argument
- zero or more threaded context args
- one output arg
- two recursive subtree calls
- a simple arithmetic result expression after the calls

### 2. Generalized mutual-goal splitting for grouped SCC analysis

Updated `src/unifyweaver/targets/typr_target.pl`.

The new path uses a reusable mutual-group multicall splitter instead of another hard-coded tree-only matcher. That is the useful generalization in this PR.

### 3. Added value-returning helper emission

Updated `src/unifyweaver/targets/typr_target.pl`.

The mutual backend now has a dedicated value-returning helper path for tree SCCs that:

- emits integer base cases
- computes `left_result` and `right_result`
- computes `result = <translated arithmetic expression>`
- preserves memoization and wrapper forwarding

### 4. Added regression coverage for the first confirmed failing shapes

Updated `tests/test_typr_target.pl`.

New target-level coverage verifies:

- integer-return dual-subtree tree SCCs
- weighted integer-return dual-subtree tree SCCs with one context arg
- native TypR output without wrapped-R fallback

### 5. Added real toolchain validation

Updated `tests/test_typr_toolchain.pl`.

Both new SCC families now go through real `typr check`, not only string-shape assertions.

### 6. Documentation updated

Updated:

- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

The docs now state that the conservative mutual-tree TypR subset is no longer boolean-only. It also covers integer-return tree SCCs when the post-call recombination remains simple and analyzable.

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- non-boolean mutual recursion with richer branch-local result recombination
- asymmetric mutual call structures
- arbitrary non-boolean SCC result types

That leaves the next high-signal follow-up clear:

- broader non-boolean SCC recombination, not another boolean tree-only micro-slice
