### PR TITLE
ci(csharp-query): show cache smoke diff durations

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -441,6 +441,8 @@ jobs:
               "- Compare artifact: `"$($env:COMPARE_ARTIFACT_NAME)`"",
               "- Diff JSON artifact: `"$($env:CACHE_SMOKE_DIFF_ARTIFACT_NAME)`"",
               "- Overall result delta: `"$($diff.overallResult.delta)`"",
+              "- Baseline total duration: `"$($diff.totalDuration.baseline)`"",
+              "- Compare total duration: `"$($diff.totalDuration.compare)`"",
               "- Total duration delta: `"$($diff.totalDuration.delta)`"",
               "- Fail on status regression: $(if ($thresholds.failOnStatusRegression) { 'true' } else { 'false' })",
               "- Max total duration delta seconds: $(if ($null -eq $thresholds.maxTotalDurationDeltaSeconds) { 'disabled' } else { $thresholds.maxTotalDurationDeltaSeconds })",

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -226,6 +226,8 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - GitHub compare URL derived from the resolved SHAs
         - artifact names
         - overall result delta
+        - baseline total duration
+        - compare total duration
         - total duration delta
         - per-slice `admission` / `reuse` / `lru` status deltas
         - per-slice `admission` / `reuse` / `lru` duration deltas


### PR DESCRIPTION
  ## Summary
  Extend the manual C# query cache-smoke diff job summary so it shows the baseline and compare total
  durations alongside the existing total-duration delta.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Added the following fields to the manual diff job summary:
    - baseline total duration
    - compare total duration
    - total duration delta
  - Updated `docs/targets/csharp-query-runtime.md` to document the added duration fields

  ## Why
  The manual diff workflow already exposed the total-duration delta, but not the two totals that produced
  it. This change makes the summary easier to interpret at a glance without opening the JSON artifact.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Confirmed the summary now renders:
    - `diff.totalDuration.baseline`
    - `diff.totalDuration.compare`
    - `diff.totalDuration.delta`