### PR TITLE
feat(wat): WASI I/O, SIMD v128 bindings, bulk memory operations

### DIFF
--- a/src/unifyweaver/bindings/wat_bindings.pl
+++ b/src/unifyweaver/bindings/wat_bindings.pl
@@ -14,7 +14,9 @@ init_wat_bindings :-
     register_wat_comparison_bindings,
     register_wat_bitwise_bindings,
     register_wat_conversion_bindings,
-    register_wat_memory_bindings.
+    register_wat_memory_bindings,
+    register_wat_bulk_memory_bindings,
+    register_wat_simd_bindings.
 
 register_wat_arithmetic_bindings :-
     declare_binding(wat, '+'/3, 'i64.add', [i64, i64], [i64],
@@ -79,3 +81,65 @@ register_wat_memory_bindings :-
         [deterministic, pattern(memory_op)]),
     declare_binding(wat, 'memory_grow'/2, 'memory.grow', [i32], [i32],
         [deterministic, pattern(memory_op)]).
+
+%% Bulk memory operations (WebAssembly bulk-memory-operations proposal)
+register_wat_bulk_memory_bindings :-
+    declare_binding(wat, 'memory_copy'/4, 'memory.copy', [i32, i32, i32], [],
+        [deterministic, pattern(bulk_memory_op),
+         description("Copy N bytes from src to dest in linear memory")]),
+    declare_binding(wat, 'memory_fill'/4, 'memory.fill', [i32, i32, i32], [],
+        [deterministic, pattern(bulk_memory_op),
+         description("Fill N bytes at dest with a byte value")]),
+    declare_binding(wat, 'memory_init'/5, 'memory.init', [i32, i32, i32], [],
+        [deterministic, pattern(bulk_memory_op),
+         description("Copy from passive data segment to linear memory")]),
+    declare_binding(wat, 'data_drop'/2, 'data.drop', [], [],
+        [deterministic, pattern(bulk_memory_op),
+         description("Drop a passive data segment")]).
+
+%% SIMD bindings (128-bit packed vectors)
+register_wat_simd_bindings :-
+    % i64x2 operations (2 x i64 lanes)
+    declare_binding(wat, 'v128_i64x2_add'/3, 'i64x2.add', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i64x2_sub'/3, 'i64x2.sub', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i64x2_mul'/3, 'i64x2.mul', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i64x2_neg'/2, 'i64x2.neg', [v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i64x2_eq'/3, 'i64x2.eq', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    % i32x4 operations (4 x i32 lanes)
+    declare_binding(wat, 'v128_i32x4_add'/3, 'i32x4.add', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i32x4_sub'/3, 'i32x4.sub', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i32x4_mul'/3, 'i32x4.mul', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    % v128 bitwise
+    declare_binding(wat, 'v128_and'/3, 'v128.and', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_or'/3, 'v128.or', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_xor'/3, 'v128.xor', [v128, v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_not'/2, 'v128.not', [v128], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    % Lane extract/replace
+    declare_binding(wat, 'v128_i64x2_extract'/3, 'i64x2.extract_lane', [v128], [i64],
+        [pure, deterministic, total, pattern(simd_lane_op),
+         description("Extract i64 from lane 0 or 1")]),
+    declare_binding(wat, 'v128_i64x2_replace'/4, 'i64x2.replace_lane', [v128, i64], [v128],
+        [pure, deterministic, total, pattern(simd_lane_op),
+         description("Replace i64 at lane 0 or 1")]),
+    % Splat (broadcast scalar to all lanes)
+    declare_binding(wat, 'v128_i64x2_splat'/2, 'i64x2.splat', [i64], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    declare_binding(wat, 'v128_i32x4_splat'/2, 'i32x4.splat', [i32], [v128],
+        [pure, deterministic, total, pattern(simd_op)]),
+    % Load/store v128
+    declare_binding(wat, 'v128_load'/2, 'v128.load', [i32], [v128],
+        [deterministic, pattern(simd_memory_op)]),
+    declare_binding(wat, 'v128_store'/3, 'v128.store', [i32, v128], [],
+        [deterministic, pattern(simd_memory_op)]).

--- a/src/unifyweaver/targets/wat_target.pl
+++ b/src/unifyweaver/targets/wat_target.pl
@@ -41,7 +41,21 @@
     % Indirect call tables (dynamic dispatch)
     wat_call_table/3,                    % +FuncSpecs, +Options, -TableCode
     wat_dispatch_func/4,                 % +DispatchName, +TypeSig, +Options, -Code
-    wat_compile_with_dispatch/4          % +DispatchSpec, +Options, +Functions, -Code
+    wat_compile_with_dispatch/4,         % +DispatchSpec, +Options, +Functions, -Code
+
+    % WASI I/O
+    wat_wasi_imports/1,                  % -ImportCode
+    wat_wasi_print_i64_func/1,           % -FuncCode
+    wat_wasi_print_str_func/1,           % -FuncCode
+    wat_compile_with_wasi/3,             % +PredIndicator, +Options, -WATCode
+
+    % SIMD helpers
+    wat_simd_dot_product_func/1,         % -FuncCode
+    wat_simd_sum_reduce_func/1,          % -FuncCode
+
+    % Bulk memory helpers
+    wat_bulk_memcpy_func/1,              % -FuncCode
+    wat_bulk_memset_func/1               % -FuncCode
 ]).
 
 :- use_module(library(lists)).
@@ -879,17 +893,7 @@ wat_compile_with_strings(PredIndicator, Options, Atoms, WATCode) :-
     string_concat("  (memory (export \"memory\") 1)\n", DataSegs, MemAndData),
     string_concat(MemAndData, LookupFunc, WithLookup),
     string_concat(WithLookup, EqFunc, StringSupport),
-    % Insert before closing paren of module
-    % Strip trailing whitespace, then find the final ')'
-    string_codes(BaseCode, BaseCodes),
-    reverse(BaseCodes, RevCodes),
-    strip_leading_ws(RevCodes, Stripped),
-    (   Stripped = [0')|RestRev]
-    ->  reverse(RestRev, PrefixCodes),
-        string_codes(Prefix, PrefixCodes),
-        format(string(WATCode), '~w\n~w)\n', [Prefix, StringSupport])
-    ;   WATCode = BaseCode
-    ).
+    inject_before_close(BaseCode, StringSupport, WATCode).
 
 strip_leading_ws([0' |T], R) :- !, strip_leading_ws(T, R).
 strip_leading_ws([0'\n|T], R) :- !, strip_leading_ws(T, R).
@@ -1308,6 +1312,187 @@ wat_compile_with_dispatch(dispatch(DispName, Params, Result), Options, Functions
 ~w
 ~w)
 ', [DispName, Count, MemDecl, TableCode, DispatchCode]).
+
+%% ============================================
+%% WASI I/O - Standard output via fd_write
+%% ============================================
+%%
+%% WASI (WebAssembly System Interface) provides fd_write for stdout.
+%% We import fd_write and provide helper functions for printing
+%% integers and strings from WAT modules.
+%%
+%% fd_write signature: (fd: i32, iovs: i32, iovs_len: i32, nwritten: i32) -> i32
+%% iov structure: [ptr: i32, len: i32] at a memory location
+
+%% wat_wasi_imports(-ImportCode)
+%%   Generate WASI import declarations for fd_write.
+wat_wasi_imports(ImportCode) :-
+    format(string(ImportCode),
+'  ;; WASI imports
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))~n', []).
+
+%% wat_wasi_print_i64_func(-FuncCode)
+%%   Generate a function that prints an i64 value to stdout as decimal.
+%%   Uses memory region starting at offset 60000 as scratch space.
+wat_wasi_print_i64_func(FuncCode) :-
+    format(string(FuncCode),
+'  ;; Print i64 to stdout as decimal
+  ;; Scratch space: 60000-60031 for digit buffer, 60032-60039 for iov
+  (func $print_i64 (export "print_i64") (param $val i64) (result i32)
+    (local $n i64) (local $pos i32) (local $neg i32)
+    (local $digit i32) (local $len i32)
+    ;; Handle negative
+    (if (i64.lt_s (local.get $val) (i64.const 0))
+      (then
+        (local.set $neg (i32.const 1))
+        (local.set $n (i64.sub (i64.const 0) (local.get $val)))
+      )
+      (else
+        (local.set $neg (i32.const 0))
+        (local.set $n (local.get $val))
+      )
+    )
+    ;; Convert digits right-to-left into buffer at 60000
+    (local.set $pos (i32.const 60031))
+    ;; Newline at end
+    (i32.store8 (local.get $pos) (i32.const 10))
+    (local.set $pos (i32.sub (local.get $pos) (i32.const 1)))
+    ;; Special case: 0
+    (if (i64.eqz (local.get $n))
+      (then
+        (i32.store8 (local.get $pos) (i32.const 48))
+        (local.set $pos (i32.sub (local.get $pos) (i32.const 1)))
+      )
+      (else
+        (block $done
+          (loop $digits
+            (br_if $done (i64.eqz (local.get $n)))
+            (local.set $digit (i32.wrap_i64 (i64.rem_u (local.get $n) (i64.const 10))))
+            (i32.store8 (local.get $pos) (i32.add (local.get $digit) (i32.const 48)))
+            (local.set $pos (i32.sub (local.get $pos) (i32.const 1)))
+            (local.set $n (i64.div_u (local.get $n) (i64.const 10)))
+            (br $digits)
+          )
+        )
+      )
+    )
+    ;; Minus sign if negative
+    (if (local.get $neg)
+      (then
+        (i32.store8 (local.get $pos) (i32.const 45))
+        (local.set $pos (i32.sub (local.get $pos) (i32.const 1)))
+      )
+    )
+    ;; Set up iov at 60032: ptr = pos+1, len = 60032 - (pos+1)
+    (local.set $pos (i32.add (local.get $pos) (i32.const 1)))
+    (local.set $len (i32.sub (i32.const 60032) (local.get $pos)))
+    (i32.store (i32.const 60032) (local.get $pos))
+    (i32.store (i32.const 60036) (local.get $len))
+    ;; fd_write(stdout=1, iovs=60032, iovs_len=1, nwritten=60040)
+    (call $fd_write (i32.const 1) (i32.const 60032) (i32.const 1) (i32.const 60040))
+  )~n', []).
+
+%% wat_wasi_print_str_func(-FuncCode)
+%%   Generate a function that prints a packed i64 string ref to stdout.
+%%   String ref: high 32 bits = offset, low 32 bits = length.
+wat_wasi_print_str_func(FuncCode) :-
+    format(string(FuncCode),
+'  ;; Print string ref (offset<<32|length) to stdout
+  ;; Uses iov at 60032
+  (func $print_str (export "print_str") (param $ref i64) (result i32)
+    (local $off i32) (local $len i32)
+    (local.set $off (i32.wrap_i64 (i64.shr_u (local.get $ref) (i64.const 32))))
+    (local.set $len (i32.wrap_i64 (local.get $ref)))
+    ;; Set up iov: ptr, len
+    (i32.store (i32.const 60032) (local.get $off))
+    (i32.store (i32.const 60036) (local.get $len))
+    ;; fd_write(stdout=1, iovs=60032, iovs_len=1, nwritten=60040)
+    (call $fd_write (i32.const 1) (i32.const 60032) (i32.const 1) (i32.const 60040))
+  )~n', []).
+
+%% wat_compile_with_wasi(+PredIndicator, +Options, -WATCode)
+%%   Compile a predicate to WAT with WASI I/O support.
+%%   The module includes fd_write import and print helpers.
+wat_compile_with_wasi(PredIndicator, Options, WATCode) :-
+    compile_predicate_to_wat(PredIndicator, Options, BaseCode),
+    wat_wasi_imports(WasiImports),
+    wat_wasi_print_i64_func(PrintI64),
+    wat_wasi_print_str_func(PrintStr),
+    string_concat(WasiImports, PrintI64, WasiCode1),
+    string_concat(WasiCode1, PrintStr, WasiCode),
+    % Inject WASI support into the module
+    inject_before_close(BaseCode, WasiCode, WATCode).
+
+%% ============================================
+%% SIMD HELPER FUNCTIONS
+%% ============================================
+%%
+%% Higher-level SIMD operations built from the v128 primitives.
+
+%% wat_simd_dot_product_func(-FuncCode)
+%%   Dot product of two i64x2 vectors: a0*b0 + a1*b1
+%%   Takes two v128 (each containing 2 x i64), returns i64 scalar.
+wat_simd_dot_product_func(FuncCode) :-
+    format(string(FuncCode),
+'  ;; SIMD dot product: (a0*b0 + a1*b1) for i64x2 vectors
+  (func $simd_dot_i64x2 (export "simd_dot_i64x2")
+    (param $a v128) (param $b v128) (result i64)
+    (local $prod v128)
+    (local.set $prod (i64x2.mul (local.get $a) (local.get $b)))
+    (i64.add
+      (i64x2.extract_lane 0 (local.get $prod))
+      (i64x2.extract_lane 1 (local.get $prod)))
+  )~n', []).
+
+%% wat_simd_sum_reduce_func(-FuncCode)
+%%   Sum-reduce an i64x2 vector: lane0 + lane1
+wat_simd_sum_reduce_func(FuncCode) :-
+    format(string(FuncCode),
+'  ;; SIMD sum reduce: lane0 + lane1 for i64x2
+  (func $simd_sum_i64x2 (export "simd_sum_i64x2")
+    (param $v v128) (result i64)
+    (i64.add
+      (i64x2.extract_lane 0 (local.get $v))
+      (i64x2.extract_lane 1 (local.get $v)))
+  )~n', []).
+
+%% ============================================
+%% BULK MEMORY HELPER FUNCTIONS
+%% ============================================
+%%
+%% Wrappers around bulk memory instructions for common patterns.
+
+%% wat_bulk_memcpy_func(-FuncCode)
+%%   memory.copy wrapper: copy N bytes from src to dest.
+wat_bulk_memcpy_func(FuncCode) :-
+    format(string(FuncCode),
+'  ;; Bulk memory copy: dest, src, len (all i32)
+  (func $memcpy (export "memcpy") (param $dest i32) (param $src i32) (param $len i32)
+    (memory.copy (local.get $dest) (local.get $src) (local.get $len))
+  )~n', []).
+
+%% wat_bulk_memset_func(-FuncCode)
+%%   memory.fill wrapper: fill N bytes at dest with a value.
+wat_bulk_memset_func(FuncCode) :-
+    format(string(FuncCode),
+'  ;; Bulk memory fill: dest, val, len (all i32)
+  (func $memset (export "memset") (param $dest i32) (param $val i32) (param $len i32)
+    (memory.fill (local.get $dest) (local.get $val) (local.get $len))
+  )~n', []).
+
+%% inject_before_close(+BaseCode, +Injection, -Result)
+%%   Inject code before the closing ')' of a WAT module.
+inject_before_close(BaseCode, Injection, Result) :-
+    string_codes(BaseCode, BaseCodes),
+    reverse(BaseCodes, RevCodes),
+    strip_leading_ws(RevCodes, Stripped),
+    (   Stripped = [0')|RestRev]
+    ->  reverse(RestRev, PrefixCodes),
+        string_codes(Prefix, PrefixCodes),
+        format(string(Result), '~w\n~w)\n', [Prefix, Injection])
+    ;   Result = BaseCode
+    ).
 
 %% combine_wat_conditions(+Conds, -Combined)
 combine_wat_conditions([C], C) :- !.

--- a/tests/core/test_wat_native_lowering.pl
+++ b/tests/core/test_wat_native_lowering.pl
@@ -604,4 +604,80 @@ test(dispatch_multi_param) :-
     has(Code, "(local.get $p1)"),
     has(Code, "(local.get $p2)").
 
+% ============================================================================
+% WASI I/O
+% ============================================================================
+
+test(wasi_imports) :-
+    wat_target:wat_wasi_imports(Code),
+    has(Code, "(import \"wasi_snapshot_preview1\" \"fd_write\""),
+    has(Code, "(func $fd_write").
+
+test(wasi_print_i64) :-
+    wat_target:wat_wasi_print_i64_func(Code),
+    has(Code, "(func $print_i64 (export \"print_i64\")"),
+    has(Code, "(param $val i64)"),
+    has(Code, "i64.rem_u"),
+    has(Code, "call $fd_write").
+
+test(wasi_print_str) :-
+    wat_target:wat_wasi_print_str_func(Code),
+    has(Code, "(func $print_str (export \"print_str\")"),
+    has(Code, "(param $ref i64)"),
+    has(Code, "i64.shr_u"),
+    has(Code, "call $fd_write").
+
+test(compile_with_wasi) :-
+    assert(user:(double(X, Y) :- Y is X * 2)),
+    wat_target:wat_compile_with_wasi(double/2, [], Code),
+    has(Code, "(import \"wasi_snapshot_preview1\""),
+    has(Code, "(func $print_i64"),
+    has(Code, "(func $print_str"),
+    has(Code, "(func $double"),
+    retractall(user:double(_, _)).
+
+% ============================================================================
+% SIMD helpers
+% ============================================================================
+
+test(simd_dot_product) :-
+    wat_target:wat_simd_dot_product_func(Code),
+    has(Code, "(func $simd_dot_i64x2"),
+    has(Code, "(param $a v128)"),
+    has(Code, "i64x2.mul"),
+    has(Code, "i64x2.extract_lane 0"),
+    has(Code, "i64x2.extract_lane 1").
+
+test(simd_sum_reduce) :-
+    wat_target:wat_simd_sum_reduce_func(Code),
+    has(Code, "(func $simd_sum_i64x2"),
+    has(Code, "i64x2.extract_lane 0"),
+    has(Code, "i64.add").
+
+% ============================================================================
+% Bulk memory helpers
+% ============================================================================
+
+test(bulk_memcpy) :-
+    wat_target:wat_bulk_memcpy_func(Code),
+    has(Code, "(func $memcpy (export \"memcpy\")"),
+    has(Code, "memory.copy").
+
+test(bulk_memset) :-
+    wat_target:wat_bulk_memset_func(Code),
+    has(Code, "(func $memset (export \"memset\")"),
+    has(Code, "memory.fill").
+
+% ============================================================================
+% Bindings registration
+% ============================================================================
+
+test(simd_bindings_registered) :-
+    wat_target:init_wat_target,
+    binding_registry:binding(wat, 'v128_i64x2_add'/3, 'i64x2.add', _, _, _).
+
+test(bulk_memory_bindings_registered) :-
+    wat_target:init_wat_target,
+    binding_registry:binding(wat, 'memory_copy'/4, 'memory.copy', _, _, _).
+
 :- end_tests(wat_native_lowering).


### PR DESCRIPTION
## Summary

- Add WASI I/O support (fd_write import, print_i64, print_str helpers)
- Add 18 SIMD v128 bindings + dot product and sum reduce helper functions
- Add 4 bulk memory bindings + memcpy/memset helper functions
- Refactor `inject_before_close/3` as shared utility

## 1. WASI I/O

Imports `fd_write` from `wasi_snapshot_preview1` to enable stdout output from WAT modules.

### New Predicates
- `wat_wasi_imports/1` — generates WASI import declaration
- `wat_wasi_print_i64_func/1` — prints i64 as decimal to stdout (handles negatives, zero)
- `wat_wasi_print_str_func/1` — prints packed string ref (offset<<32|length) to stdout
- `wat_compile_with_wasi/3` — injects WASI support into any compiled predicate module

### Implementation Details
- Uses scratch memory at offset 60000-60040 for digit buffer and iov structure
- `print_i64`: converts i64 → decimal digits right-to-left, handles sign, writes via `fd_write(stdout=1, ...)`
- `print_str`: unpacks offset/length from i64 ref, sets up iov, calls `fd_write`

## 2. SIMD (128-bit Vectors)

18 new bindings in `wat_bindings.pl`:

| Category | Bindings |
|----------|----------|
| i64x2 arithmetic | add, sub, mul, neg, eq |
| i32x4 arithmetic | add, sub, mul |
| v128 bitwise | and, or, xor, not |
| Lane ops | i64x2 extract_lane, replace_lane |
| Splat | i64x2.splat, i32x4.splat |
| Memory | v128.load, v128.store |

### Helper Functions
- `wat_simd_dot_product_func/1` — `simd_dot_i64x2(a, b)`: computes a0*b0 + a1*b1
- `wat_simd_sum_reduce_func/1` — `simd_sum_i64x2(v)`: computes lane0 + lane1

## 3. Bulk Memory Operations

4 new bindings:

| Binding | WAT Instruction | Description |
|---------|-----------------|-------------|
| `memory_copy/4` | `memory.copy` | Copy N bytes src→dest |
| `memory_fill/4` | `memory.fill` | Fill N bytes with value |
| `memory_init/5` | `memory.init` | Copy from passive data segment |
| `data_drop/2` | `data.drop` | Drop passive data segment |

### Helper Functions
- `wat_bulk_memcpy_func/1` — exported `memcpy(dest, src, len)` wrapper
- `wat_bulk_memset_func/1` — exported `memset(dest, val, len)` wrapper

## Refactoring

Extracted `inject_before_close/3` as a shared utility for injecting code before a WAT module's closing `)`. Used by both `wat_compile_with_strings/4` and `wat_compile_with_wasi/3`.

## Runtime Validation

| Feature | Test | Expected | Actual | Status |
|---------|------|----------|--------|--------|
| WASI | `print_str("Result: ")` | "Result: " on stdout | "Result: " | Pass |
| WASI | `print_i64(42)` | "42\n" on stdout | "42\n" | Pass |
| WASI | `print_str("Hello, WASI!")` | "Hello, WASI!" on stdout | "Hello, WASI!" | Pass |
| SIMD | `dot([3,4],[5,6])` | 39 | 39 | Pass |
| SIMD | `sum([10,20])` | 30 | 30 | Pass |
| SIMD | `add_sum([1,2]+[3,4])` | 10 | 10 | Pass |
| Bulk | `memcpy` read back byte 0 | 65 (A) | 65 | Pass |
| Bulk | `memset` fill with 66 | 66 (B) | 66 | Pass |
| Bulk | `memcpy` read offset byte 3 | 68 (D) | 68 | Pass |

## Tests (67 → 77, +10 new)

| Test | Feature |
|------|---------|
| `wasi_imports` | WASI import declaration |
| `wasi_print_i64` | Integer print function structure |
| `wasi_print_str` | String print function structure |
| `compile_with_wasi` | End-to-end WASI injection |
| `simd_dot_product` | Dot product function structure |
| `simd_sum_reduce` | Sum reduce function structure |
| `bulk_memcpy` | memory.copy wrapper |
| `bulk_memset` | memory.fill wrapper |
| `simd_bindings_registered` | SIMD bindings in registry |
| `bulk_memory_bindings_registered` | Bulk memory bindings in registry |

## Test plan

- [x] All 77 Prolog unit tests pass
- [x] wasi_test.wat, simd_test.wat, bulk_test.wat compile with wat2wasm
- [x] WASI output validated: correct decimal and string printing
- [x] SIMD validated: dot product, sum reduce, vector add+reduce
- [x] Bulk memory validated: memcpy, memset with byte-level verification
- [x] No regressions in existing WAT patterns
