### PR TITLE
Keep native TypR nested non-boolean mutual branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ includes:
   tree SCCs with
   alias-style prework, shared computed context updates, or guarded shared
   context selection before the two recursive subtree calls, or direct
-  recursive subtree calls inside supported guarded branch bodies with
+  recursive subtree calls inside supported guarded branch bodies with one
+  nested branch-local control point around those calls and
   limited branch-local alias or guard state around those calls, including
   one nested branch-local control point around those calls before the
   shared boolean rejoin, one nested branch-local control point between the

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -404,7 +404,9 @@ Current TypR lowering policy is intentionally mixed:
   and the same conservative guarded branch-body family, including branch
   bodies where one shared subtree call happens before guarded control that
   contains the second subtree call plus nested non-recursive post-call
-  control, shared context updates before that first subtree call, branch-local
+  control, or direct recursive subtree calls inside supported guarded
+  branch bodies with one nested branch-local control point around those
+  calls, shared context updates before that first subtree call, branch-local
   context updates before the second subtree call, or multiple threaded
   context arguments carried through the same shared subtree-call families,
   plus conservative integer-return tree-structural SCCs with shared

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -100,7 +100,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      types, plus conservative integer-return tree-structural SCCs with
      shared dual-subtree descent, guarded branch-local alias selection
      before those shared subtree calls or direct recursive subtree calls
-     inside supported guarded branch bodies, and simple post-call
+     inside supported guarded branch bodies with one nested branch-local
+     control point around those calls, and simple post-call
      arithmetic recombination over `value`, `left_result`, `right_result`,
      and any threaded context args, emitted as TypR
      functions with raw-expression memoized helper bodies

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -346,6 +346,74 @@ typr_mutual_tree_dual_value_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Goals = [BranchGoal|PostGoals],
     PostGoals \= [],
     typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_value_branch_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        PostBody,
+        OutputVar,
+        ThenBody
+    ),
+    typr_mutual_tree_value_branch_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        PostBody,
+        OutputVar,
+        ElseBody
+    ),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap0, ExtraArgMap0, BranchConditionExpr),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        branch_condition_expr: BranchConditionExpr,
+        then_body: ThenBody,
+        else_body: ElseBody
+    }.
+
+typr_mutual_tree_dual_value_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, RecInputPattern|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [BranchGoal|PostGoals],
+    PostGoals \= [],
+    typr_if_then_else_goal(BranchGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
@@ -1005,6 +1073,66 @@ typr_mutual_tree_value_side_calls(CallSpecs0, LeftCall, RightCall, LeftOutputVar
     format(string(RightHelperName), '~w_impl', [RightNextPredStr]),
     LeftCall = branch_call(LeftHelperName, LeftCallArgs),
     RightCall = branch_call(RightHelperName, RightCallArgs).
+
+typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    append(PreGoals, [NestedIfGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
+    GuardExpr == none,
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_value_branch_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        PostBody,
+        OutputVar,
+        ThenBody
+    ),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_value_branch_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        PostBody,
+        OutputVar,
+        ElseBody
+    ),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    Body = value_branch_if(BranchConditionExpr, ThenBody, ElseBody).
+typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    append(PreGoals, RecGoals, Goals),
+    RecGoals = [GoalA, GoalB],
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
+    GuardExpr == none,
+    maplist(
+        typr_mutual_tree_value_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1),
+        [GoalA, GoalB],
+        GoalSpecs0
+    ),
+    typr_mutual_tree_value_side_calls(GoalSpecs0, LeftCall, RightCall, LeftOutputVar, RightOutputVar),
+    typr_mutual_tree_value_result_expr(
+        PostBody,
+        OutputVar,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        LeftOutputVar,
+        RightOutputVar,
+        ResultExpr
+    ),
+    Body = value_branch_leaf(LeftCall, RightCall, ResultExpr).
+
+typr_mutual_tree_value_result_expr(PostBody, OutputVar, ValueVar, AliasMap, ExtraArgMap, LeftOutputVar, RightOutputVar, ResultExpr) :-
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, ResultVarMap0),
+    update_typr_expr_varmap(ResultVarMap0, LeftOutputVar, left_result, ResultVarMap1),
+    update_typr_expr_varmap(ResultVarMap1, RightOutputVar, right_result, ResultVarMap),
+    linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr).
 
 typr_mutual_extra_arg_expr(ExtraArgMap, Arg, Expr) :-
     var(Arg),
@@ -1680,6 +1808,35 @@ typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     append(Lines1, StopLines, Lines2),
     append(Lines2, ['    };'], Lines),
     atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_value_body,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseCases = Spec.base_cases,
+    GuardExpr = Spec.guard_expr,
+    BranchConditionExpr = Spec.branch_condition_expr,
+    ThenBody = Spec.then_body,
+    ElseBody = Spec.else_body,
+    typr_mutual_tree_value_base_branch_lines(GroupName, BaseCases, BaseLines),
+    typr_mutual_tree_dual_value_body_recursive_branch_lines(
+        GroupName,
+        GuardExpr,
+        BranchConditionExpr,
+        ThenBody,
+        ElseBody,
+        RecursiveLines
+    ),
+    typr_mutual_stop_lines(PredStr, StopLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, StopLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
 typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     Kind = Spec.kind,
     Kind == tree_dual_value_branch,
@@ -1704,6 +1861,31 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
         ElseRightCall,
         ThenResultExpr,
         ElseResultExpr,
+        RecursiveLines
+    ),
+    typr_mutual_stop_lines_no_memo(PredStr, StopLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, StopLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_value_body,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseCases = Spec.base_cases,
+    GuardExpr = Spec.guard_expr,
+    BranchConditionExpr = Spec.branch_condition_expr,
+    ThenBody = Spec.then_body,
+    ElseBody = Spec.else_body,
+    typr_mutual_tree_value_base_branch_lines_no_memo(BaseCases, BaseLines),
+    typr_mutual_tree_dual_value_body_recursive_branch_lines_no_memo(
+        GuardExpr,
+        BranchConditionExpr,
+        ThenBody,
+        ElseBody,
         RecursiveLines
     ),
     typr_mutual_stop_lines_no_memo(PredStr, StopLines),
@@ -2344,6 +2526,40 @@ typr_mutual_tree_dual_value_branch_recursive_branch_lines_no_memo(
         '            }'
     ].
 
+typr_mutual_tree_dual_value_body_recursive_branch_lines(
+    GroupName,
+    GuardExpr,
+    BranchConditionExpr,
+    ThenBody,
+    ElseBody,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    format(string(BranchIfLine), '            if (~w) {', [BranchConditionExpr]),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    typr_mutual_tree_value_body_lines(ThenBody, '                ', ThenLines),
+    typr_mutual_tree_value_body_lines(ElseBody, '                ', ElseLines),
+    append([IfLine, BranchIfLine], ThenLines, Lines0),
+    append(Lines0, ['            } else {'], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, ['            }', AssignLine, '            result'], Lines).
+
+typr_mutual_tree_dual_value_body_recursive_branch_lines_no_memo(
+    GuardExpr,
+    BranchConditionExpr,
+    ThenBody,
+    ElseBody,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    format(string(BranchIfLine), '            if (~w) {', [BranchConditionExpr]),
+    typr_mutual_tree_value_body_lines_no_memo(ThenBody, '                ', ThenLines),
+    typr_mutual_tree_value_body_lines_no_memo(ElseBody, '                ', ElseLines),
+    append([IfLine, BranchIfLine], ThenLines, Lines0),
+    append(Lines0, ['            } else {'], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, ['            }'], Lines).
+
 typr_mutual_tree_dual_branch_recursive_branch_lines(
     GroupName,
     GuardExpr,
@@ -2417,6 +2633,50 @@ typr_mutual_tree_dual_body_recursive_branch_lines_no_memo(
     format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
     typr_mutual_tree_branch_body_lines_no_memo(Body, '            ', BodyLines),
     append([IfLine], BodyLines, Lines).
+
+typr_mutual_tree_value_body_lines(Body, Prefix, Lines) :-
+    typr_mutual_tree_value_body_lines_from(Body, Prefix, Lines).
+
+typr_mutual_tree_value_body_lines_from(value_branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_value_body_lines_from(ThenBody, NestedPrefix, ThenLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    typr_mutual_tree_value_body_lines_from(ElseBody, NestedPrefix, ElseLines),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], ThenLines, Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
+typr_mutual_tree_value_body_lines_from(value_branch_leaf(LeftCall, RightCall, ResultExpr), Prefix, Lines) :-
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '~wleft_result = ~w;', [Prefix, LeftExpr]),
+    format(string(RightLine), '~wright_result = ~w;', [Prefix, RightExpr]),
+    format(string(ResultLine), '~wresult = ~w;', [Prefix, ResultExpr]),
+    Lines = [LeftLine, RightLine, ResultLine].
+
+typr_mutual_tree_value_body_lines_no_memo(Body, Prefix, Lines) :-
+    typr_mutual_tree_value_body_lines_no_memo_from(Body, Prefix, Lines).
+
+typr_mutual_tree_value_body_lines_no_memo_from(value_branch_if(BranchConditionExpr, ThenBody, ElseBody), Prefix, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Prefix, BranchConditionExpr]),
+    atom_concat(Prefix, '    ', NestedPrefix),
+    typr_mutual_tree_value_body_lines_no_memo_from(ThenBody, NestedPrefix, ThenLines),
+    format(string(ElseLine), '~w} else {', [Prefix]),
+    typr_mutual_tree_value_body_lines_no_memo_from(ElseBody, NestedPrefix, ElseLines),
+    format(string(EndLine), '~w}', [Prefix]),
+    append([IfLine], ThenLines, Lines0),
+    append(Lines0, [ElseLine], Lines1),
+    append(Lines1, ElseLines, Lines2),
+    append(Lines2, [EndLine], Lines).
+typr_mutual_tree_value_body_lines_no_memo_from(value_branch_leaf(LeftCall, RightCall, ResultExpr), Prefix, Lines) :-
+    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
+    typr_mutual_tree_call_expr(RightCall, RightExpr),
+    format(string(LeftLine), '~wleft_result = ~w;', [Prefix, LeftExpr]),
+    format(string(RightLine), '~wright_result = ~w;', [Prefix, RightExpr]),
+    format(string(ResultLine), '~w~w', [Prefix, ResultExpr]),
+    Lines = [LeftLine, RightLine, ResultLine].
 
 typr_mutual_tree_branch_body_lines(Body, Prefix, Lines) :-
     typr_mutual_tree_branch_body_lines_from(Body, Prefix, 1, Lines).

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -103,8 +103,12 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_weight_odd_tree_branch_calls(_, _, _)),
     retractall(user:typr_mutual_sum_even_tree_recursive_branch(_, _)),
     retractall(user:typr_mutual_sum_odd_tree_recursive_branch(_, _)),
+    retractall(user:typr_mutual_sum_even_tree_nested_recursive_branch(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree_nested_recursive_branch(_, _)),
     retractall(user:typr_mutual_weight_even_tree_recursive_branch(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_recursive_branch(_, _, _)),
+    retractall(user:typr_mutual_weight_even_tree_nested_recursive_branch(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree_nested_recursive_branch(_, _, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -3455,6 +3459,108 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_contex
     once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) * current_ctx) + left_result) + right_result);")),
     \+ sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_recursive_branch_impl(.subset2(current_input, 3), current_ctx);"),
     \+ sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_recursive_branch_impl(.subset2(current_input, 2), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_nested_recursive_branch_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree_nested_recursive_branch([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree_nested_recursive_branch([V, L, R], S) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL),
+                typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR)
+            ;   typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR),
+                typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL)
+            )
+        ;   typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL),
+            typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR)
+        ),
+        S is V + SL + SR
+    )),
+    assertz(user:typr_mutual_sum_odd_tree_nested_recursive_branch([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree_nested_recursive_branch([V, L, R], S) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_sum_even_tree_nested_recursive_branch(L, SL),
+                typr_mutual_sum_even_tree_nested_recursive_branch(R, SR)
+            ;   typr_mutual_sum_even_tree_nested_recursive_branch(R, SR),
+                typr_mutual_sum_even_tree_nested_recursive_branch(L, SL)
+            )
+        ;   typr_mutual_sum_even_tree_nested_recursive_branch(L, SL),
+            typr_mutual_sum_even_tree_nested_recursive_branch(R, SR)
+        ),
+        S is V + SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_nested_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_nested_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_nested_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_nested_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree_nested_recursive_branch/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree_nested_recursive_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree_nested_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_tree_nested_recursive_branch/2, typr_mutual_sum_odd_tree_nested_recursive_branch/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_tree_nested_recursive_branch <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_even_tree_nested_recursive_branch_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 10) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 3));"),
+    \+ sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 2));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_context_nested_recursive_branch_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree_nested_recursive_branch([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree_nested_recursive_branch([V, L, R], W, S) :-
+        ( V > W ->
+            ( V > W + 10 ->
+                typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL),
+                typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR)
+            ;   typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR),
+                typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL)
+            )
+        ;   typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL),
+            typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR)
+        ),
+        S is (V * W) + SL + SR
+    )),
+    assertz(user:typr_mutual_weight_odd_tree_nested_recursive_branch([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree_nested_recursive_branch([V, L, R], W, S) :-
+        ( V > W ->
+            ( V > W + 10 ->
+                typr_mutual_weight_even_tree_nested_recursive_branch(L, W, SL),
+                typr_mutual_weight_even_tree_nested_recursive_branch(R, W, SR)
+            ;   typr_mutual_weight_even_tree_nested_recursive_branch(R, W, SR),
+                typr_mutual_weight_even_tree_nested_recursive_branch(L, W, SL)
+            )
+        ;   typr_mutual_weight_even_tree_nested_recursive_branch(L, W, SL),
+            typr_mutual_weight_even_tree_nested_recursive_branch(R, W, SR)
+        ),
+        S is (V * W) + SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree_nested_recursive_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_weight_even_tree_nested_recursive_branch/3, typr_mutual_weight_odd_tree_nested_recursive_branch/3")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_weight_even_tree_nested_recursive_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_weight_even_tree_nested_recursive_branch_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > (current_ctx + 10)) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) * current_ctx) + left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 3), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 2), current_ctx);"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2417,6 +2417,106 @@ test(structural_tree_dual_mutual_integer_context_recursive_branch_output_checks_
     retractall(user:typr_mutual_weight_even_tree_recursive_branch(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_recursive_branch(_, _, _)).
 
+test(structural_tree_dual_mutual_integer_nested_recursive_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree_nested_recursive_branch([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree_nested_recursive_branch([V, L, R], S) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL),
+                typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR)
+            ;   typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR),
+                typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL)
+            )
+        ;   typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL),
+            typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR)
+        ),
+        S is V + SL + SR
+    )),
+    assertz(user:typr_mutual_sum_odd_tree_nested_recursive_branch([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree_nested_recursive_branch([V, L, R], S) :-
+        ( V > 0 ->
+            ( V > 10 ->
+                typr_mutual_sum_even_tree_nested_recursive_branch(L, SL),
+                typr_mutual_sum_even_tree_nested_recursive_branch(R, SR)
+            ;   typr_mutual_sum_even_tree_nested_recursive_branch(R, SR),
+                typr_mutual_sum_even_tree_nested_recursive_branch(L, SL)
+            )
+        ;   typr_mutual_sum_even_tree_nested_recursive_branch(L, SL),
+            typr_mutual_sum_even_tree_nested_recursive_branch(R, SR)
+        ),
+        S is V + SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_nested_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_nested_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_nested_recursive_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_nested_recursive_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree_nested_recursive_branch/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree_nested_recursive_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree_nested_recursive_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_even_tree_nested_recursive_branch(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree_nested_recursive_branch(_, _)).
+
+test(structural_tree_dual_mutual_integer_context_nested_recursive_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree_nested_recursive_branch([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree_nested_recursive_branch([V, L, R], W, S) :-
+        ( V > W ->
+            ( V > W + 10 ->
+                typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL),
+                typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR)
+            ;   typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR),
+                typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL)
+            )
+        ;   typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL),
+            typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR)
+        ),
+        S is (V * W) + SL + SR
+    )),
+    assertz(user:typr_mutual_weight_odd_tree_nested_recursive_branch([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree_nested_recursive_branch([V, L, R], W, S) :-
+        ( V > W ->
+            ( V > W + 10 ->
+                typr_mutual_weight_even_tree_nested_recursive_branch(L, W, SL),
+                typr_mutual_weight_even_tree_nested_recursive_branch(R, W, SR)
+            ;   typr_mutual_weight_even_tree_nested_recursive_branch(R, W, SR),
+                typr_mutual_weight_even_tree_nested_recursive_branch(L, W, SL)
+            )
+        ;   typr_mutual_weight_even_tree_nested_recursive_branch(L, W, SL),
+            typr_mutual_weight_even_tree_nested_recursive_branch(R, W, SR)
+        ),
+        S is (V * W) + SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree_nested_recursive_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree_nested_recursive_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree_nested_recursive_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_weight_even_tree_nested_recursive_branch(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree_nested_recursive_branch(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR mutual-recursion backend for integer-return tree-structural SCCs.

It adds support for the next confirmed failing slice after the earlier non-boolean mutual-tree branch work:

- direct recursive subtree calls inside a nested guarded branch body
- simple post-branch arithmetic recombination over `value`, `left_result`, `right_result`, and any threaded context args
- native TypR emission through the existing memoized-helper model

Representative shapes now supported:

```prolog
typr_mutual_sum_even_tree_nested_recursive_branch([], 0).
typr_mutual_sum_even_tree_nested_recursive_branch([V, L, R], S) :-
    ( V > 0 ->
        ( V > 10 ->
            typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL),
            typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR)
        ;   typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR),
            typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL)
        )
    ;   typr_mutual_sum_odd_tree_nested_recursive_branch(L, SL),
        typr_mutual_sum_odd_tree_nested_recursive_branch(R, SR)
    ),
    S is V + SL + SR.

typr_mutual_sum_odd_tree_nested_recursive_branch([_, [], []], 1).
typr_mutual_sum_odd_tree_nested_recursive_branch([V, L, R], S) :-
    ( V > 0 ->
        ( V > 10 ->
            typr_mutual_sum_even_tree_nested_recursive_branch(L, SL),
            typr_mutual_sum_even_tree_nested_recursive_branch(R, SR)
        ;   typr_mutual_sum_even_tree_nested_recursive_branch(R, SR),
            typr_mutual_sum_even_tree_nested_recursive_branch(L, SL)
        )
    ;   typr_mutual_sum_even_tree_nested_recursive_branch(L, SL),
        typr_mutual_sum_even_tree_nested_recursive_branch(R, SR)
    ),
    S is V + SL + SR.
```

and the same shape with a threaded context argument:

```prolog
typr_mutual_weight_even_tree_nested_recursive_branch([], _W0, 0).
typr_mutual_weight_even_tree_nested_recursive_branch([V, L, R], W, S) :-
    ( V > W ->
        ( V > W + 10 ->
            typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL),
            typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR)
        ;   typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR),
            typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL)
        )
    ;   typr_mutual_weight_odd_tree_nested_recursive_branch(L, W, SL),
        typr_mutual_weight_odd_tree_nested_recursive_branch(R, W, SR)
    ),
    S is (V * W) + SL + SR.
```

Before this PR, these shapes still failed with:

- `Error: No mutual recursion support for target typr`

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

The previous non-boolean SCC work already covered:

- integer-return tree-structural SCCs with shared dual-subtree descent
- guarded branch-local alias selection before shared subtree calls
- direct recursive subtree calls inside one supported guarded branch body
- simple arithmetic recombination after those calls

That still left a real next gap:

- non-boolean mutual tree recursion where the direct recursive subtree calls sit inside a nested guarded branch body rather than only one top-level guarded branch

This PR closes that gap by widening the existing value-returning mutual-tree path instead of adding another divergent emitter.

## Main Changes

### 1. Added a nested non-boolean mutual-tree spec path

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

TypR mutual recursion now recognizes a conservative integer-return tree SCC shape with:

- one tree-driving argument
- zero or more threaded context args
- one output arg
- an outer guarded branch
- one nested guarded branch body that contains the direct recursive subtree calls
- shared arithmetic recombination after the outer branch

### 2. Reused the existing value-returning mutual-tree backend

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The implementation extends the current value-returning mutual-tree path with a small nested branch-body AST instead of introducing another special-purpose emitter.

That keeps the useful generalization in one place:

- branch-specific left/right subtree calls
- branch-specific result expressions
- subtree identity preserved even when call order swaps across branches
- memoized helper emission reused for both flat and nested value-returning tree SCCs

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level tests verify:

- integer-return nested guarded recursive branch-body SCCs
- context-threaded nested guarded recursive branch-body SCCs
- native TypR output without wrapped-R fallback

### 4. Added real toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

Both new SCC families now go through real `typr check`, not only string-shape assertions.

### 5. Updated TypR docs

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that conservative integer-return tree SCCs may stay native when direct recursive subtree calls appear inside one nested branch-local control point around the guarded branch-body path.

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- richer non-boolean SCC recombination than simple arithmetic post-call expressions
- asymmetric SCC call structures
- arbitrary non-boolean SCC result types

That leaves the next high-signal follow-up clear:

- broader non-boolean SCC recombination or broader SCC lowering design, not another tree-only micro-slice
