### PR TITLE
Generalize native TypR non-boolean mutual recombination

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,9 @@ includes:
   with shared dual-subtree descent, guarded branch-local alias selection
   before those shared subtree calls or direct recursive subtree calls
   inside supported guarded branch bodies, and simple post-call arithmetic
-  recombination over `value`, `left_result`, `right_result`, and any
-  threaded context args,
+  recombination, including branch-local post-call arithmetic steps inside
+  those supported guarded branch bodies, over `value`, `left_result`,
+  `right_result`, and any threaded context args,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -230,8 +230,10 @@ bring-up.
     return tree-structural SCCs with shared dual-subtree descent,
     guarded branch-local alias selection before those shared subtree
     calls or direct recursive subtree calls inside supported guarded
-    branch bodies, and simple post-call arithmetic recombination over
-    `value`, `left_result`, `right_result`, and any threaded context args
+    branch bodies, and simple post-call arithmetic recombination,
+    including branch-local post-call arithmetic steps inside those
+    supported guarded branch bodies, over `value`, `left_result`,
+    `right_result`, and any threaded context args
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -412,10 +412,11 @@ Current TypR lowering policy is intentionally mixed:
   plus conservative integer-return tree-structural SCCs with shared
   dual-subtree descent, guarded branch-local alias selection before those
   shared subtree calls or direct recursive subtree calls inside supported
-  guarded branch bodies, and simple post-call arithmetic recombination
-  over `value`, `left_result`, `right_result`, and any threaded context
-  args, using raw-expression memoized helper bodies inside TypR rather
-  than wrapped-R fallback
+  guarded branch bodies, and simple post-call arithmetic recombination,
+  including branch-local post-call arithmetic steps inside those
+  supported guarded branch bodies, over `value`, `left_result`,
+  `right_result`, and any threaded context args, using raw-expression
+  memoized helper bodies inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -102,8 +102,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      before those shared subtree calls or direct recursive subtree calls
      inside supported guarded branch bodies with one nested branch-local
      control point around those calls, and simple post-call
-     arithmetic recombination over `value`, `left_result`, `right_result`,
-     and any threaded context args, emitted as TypR
+     arithmetic recombination, including branch-local post-call
+     arithmetic steps inside those supported guarded branch bodies, over
+     `value`, `left_result`, `right_result`, and any threaded context
+     args, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -949,6 +949,12 @@ split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, Po
     PostGoals \= [],
     \+ typr_contains_mutual_recursive_goal(GroupPredicates, PostGoals).
 
+split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals) :-
+    split_typr_mutual_non_recursive_prefix(GroupPredicates, Goals, PreGoals, RecAndPostGoals),
+    take_typr_mutual_recursive_goal_prefix(GroupPredicates, RecAndPostGoals, RecGoals, PostGoals),
+    RecGoals = [_|[_|_]],
+    \+ typr_contains_mutual_recursive_goal(GroupPredicates, PostGoals).
+
 split_typr_mutual_non_recursive_prefix(_GroupPredicates, [], [], []).
 split_typr_mutual_non_recursive_prefix(GroupPredicates, [Goal|Rest], [], [Goal|Rest]) :-
     typr_goal_calls_mutual_group(GroupPredicates, Goal),
@@ -1075,10 +1081,11 @@ typr_mutual_tree_value_side_calls(CallSpecs0, LeftCall, RightCall, LeftOutputVar
     RightCall = branch_call(RightHelperName, RightCallArgs).
 
 typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
-    append(PreGoals, [NestedIfGoal], Goals),
+    append(PreGoals, [NestedIfGoal|TailPostGoals], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
     GuardExpr == none,
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_tree_value_branch_post_body(TailPostGoals, PostBody, CombinedPostBody),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
     typr_mutual_tree_value_branch_body(
@@ -1087,7 +1094,7 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
         ValueVar,
         AliasMap,
         ExtraArgMap1,
-        PostBody,
+        CombinedPostBody,
         OutputVar,
         ThenBody
     ),
@@ -1099,25 +1106,25 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
         ValueVar,
         AliasMap,
         ExtraArgMap1,
-        PostBody,
+        CombinedPostBody,
         OutputVar,
         ElseBody
     ),
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     Body = value_branch_if(BranchConditionExpr, ThenBody, ElseBody).
 typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
-    append(PreGoals, RecGoals, Goals),
-    RecGoals = [GoalA, GoalB],
+    split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, BranchPostGoals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
     GuardExpr == none,
     maplist(
         typr_mutual_tree_value_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1),
-        [GoalA, GoalB],
+        RecGoals,
         GoalSpecs0
     ),
     typr_mutual_tree_value_side_calls(GoalSpecs0, LeftCall, RightCall, LeftOutputVar, RightOutputVar),
+    typr_mutual_tree_value_branch_post_body(BranchPostGoals, PostBody, CombinedPostBody),
     typr_mutual_tree_value_result_expr(
-        PostBody,
+        CombinedPostBody,
         OutputVar,
         ValueVar,
         AliasMap,
@@ -1127,6 +1134,17 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
         ResultExpr
     ),
     Body = value_branch_leaf(LeftCall, RightCall, ResultExpr).
+
+typr_mutual_tree_value_branch_post_body(BranchPostGoals, PostBody, CombinedPostBody) :-
+    typr_mutual_tree_value_post_body_goals(PostBody, SharedPostGoals),
+    append(BranchPostGoals, SharedPostGoals, CombinedPostGoals),
+    typr_goals_to_body(CombinedPostGoals, CombinedPostBody).
+
+typr_mutual_tree_value_post_body_goals(true, []) :-
+    !.
+typr_mutual_tree_value_post_body_goals(PostBody, Goals) :-
+    typr_mutual_goal_list(PostBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals).
 
 typr_mutual_tree_value_result_expr(PostBody, OutputVar, ValueVar, AliasMap, ExtraArgMap, LeftOutputVar, RightOutputVar, ResultExpr) :-
     typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, ResultVarMap0),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -105,10 +105,14 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_sum_odd_tree_recursive_branch(_, _)),
     retractall(user:typr_mutual_sum_even_tree_nested_recursive_branch(_, _)),
     retractall(user:typr_mutual_sum_odd_tree_nested_recursive_branch(_, _)),
+    retractall(user:typr_mutual_sum_even_tree_branch_part(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree_branch_part(_, _)),
     retractall(user:typr_mutual_weight_even_tree_recursive_branch(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_recursive_branch(_, _, _)),
     retractall(user:typr_mutual_weight_even_tree_nested_recursive_branch(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_nested_recursive_branch(_, _, _)),
+    retractall(user:typr_mutual_weight_even_tree_branch_part(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree_branch_part(_, _, _)),
     retractall(user:fib(_, _)),
     retractall(user:tree_sum(_, _)),
     retractall(user:tree_height(_, _)),
@@ -3561,6 +3565,100 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_contex
     once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) * current_ctx) + left_result) + right_result);")),
     \+ sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 3), current_ctx);"),
     \+ sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_nested_recursive_branch_impl(.subset2(current_input, 2), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_branch_local_recombine_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree_branch_part([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree_branch_part([V, L, R], S) :-
+        ( V > 0 ->
+            typr_mutual_sum_odd_tree_branch_part(L, SL),
+            typr_mutual_sum_odd_tree_branch_part(R, SR),
+            Part is V + SL + SR
+        ;   typr_mutual_sum_odd_tree_branch_part(R, SR),
+            typr_mutual_sum_odd_tree_branch_part(L, SL),
+            Part is V - SL + SR
+        ),
+        S is Part + 1
+    )),
+    assertz(user:typr_mutual_sum_odd_tree_branch_part([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree_branch_part([V, L, R], S) :-
+        ( V > 0 ->
+            typr_mutual_sum_even_tree_branch_part(L, SL),
+            typr_mutual_sum_even_tree_branch_part(R, SR),
+            Part is V + SL + SR
+        ;   typr_mutual_sum_even_tree_branch_part(R, SR),
+            typr_mutual_sum_even_tree_branch_part(L, SL),
+            Part is V - SL + SR
+        ),
+        S is Part + 1
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_branch_part/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_branch_part/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_branch_part/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_branch_part/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree_branch_part/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree_branch_part/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree_branch_part/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_tree_branch_part/2, typr_mutual_sum_odd_tree_branch_part/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_tree_branch_part <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_even_tree_branch_part_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_tree_branch_part_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_branch_part_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) + left_result) + right_result) + 1);")),
+    once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) - left_result) + right_result) + 1);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_tree_branch_part_impl(.subset2(current_input, 3));"),
+    \+ sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_branch_part_impl(.subset2(current_input, 2));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_context_branch_local_recombine_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree_branch_part([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree_branch_part([V, L, R], W, S) :-
+        ( V > W ->
+            typr_mutual_weight_odd_tree_branch_part(L, W, SL),
+            typr_mutual_weight_odd_tree_branch_part(R, W, SR),
+            Part is (V * W) + SL + SR
+        ;   typr_mutual_weight_odd_tree_branch_part(R, W, SR),
+            typr_mutual_weight_odd_tree_branch_part(L, W, SL),
+            Part is (V * W) - SL + SR
+        ),
+        S is Part + W
+    )),
+    assertz(user:typr_mutual_weight_odd_tree_branch_part([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree_branch_part([V, L, R], W, S) :-
+        ( V > W ->
+            typr_mutual_weight_even_tree_branch_part(L, W, SL),
+            typr_mutual_weight_even_tree_branch_part(R, W, SR),
+            Part is (V * W) + SL + SR
+        ;   typr_mutual_weight_even_tree_branch_part(R, W, SR),
+            typr_mutual_weight_even_tree_branch_part(L, W, SL),
+            Part is (V * W) - SL + SR
+        ),
+        S is Part + W
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_branch_part/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_branch_part/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_branch_part/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_branch_part/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_branch_part/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_branch_part/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree_branch_part/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree_branch_part/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree_branch_part/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_weight_even_tree_branch_part/3, typr_mutual_weight_odd_tree_branch_part/3")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_weight_even_tree_branch_part <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_weight_even_tree_branch_part_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_branch_part_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_branch_part_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((((.subset2(current_input, 1) * current_ctx) + left_result) + right_result) + current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((((.subset2(current_input, 1) * current_ctx) - left_result) + right_result) + current_ctx);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_branch_part_impl(.subset2(current_input, 3), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_branch_part_impl(.subset2(current_input, 2), current_ctx);"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2517,6 +2517,98 @@ test(structural_tree_dual_mutual_integer_context_nested_recursive_branch_output_
     retractall(user:typr_mutual_weight_even_tree_nested_recursive_branch(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_nested_recursive_branch(_, _, _)).
 
+test(structural_tree_dual_mutual_integer_branch_local_recombine_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree_branch_part([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree_branch_part([V, L, R], S) :-
+        ( V > 0 ->
+            typr_mutual_sum_odd_tree_branch_part(L, SL),
+            typr_mutual_sum_odd_tree_branch_part(R, SR),
+            Part is V + SL + SR
+        ;   typr_mutual_sum_odd_tree_branch_part(R, SR),
+            typr_mutual_sum_odd_tree_branch_part(L, SL),
+            Part is V - SL + SR
+        ),
+        S is Part + 1
+    )),
+    assertz(user:typr_mutual_sum_odd_tree_branch_part([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree_branch_part([V, L, R], S) :-
+        ( V > 0 ->
+            typr_mutual_sum_even_tree_branch_part(L, SL),
+            typr_mutual_sum_even_tree_branch_part(R, SR),
+            Part is V + SL + SR
+        ;   typr_mutual_sum_even_tree_branch_part(R, SR),
+            typr_mutual_sum_even_tree_branch_part(L, SL),
+            Part is V - SL + SR
+        ),
+        S is Part + 1
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_branch_part/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_branch_part/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_branch_part/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_branch_part/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree_branch_part/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree_branch_part/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree_branch_part/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_even_tree_branch_part(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree_branch_part(_, _)).
+
+test(structural_tree_dual_mutual_integer_context_branch_local_recombine_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree_branch_part([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree_branch_part([V, L, R], W, S) :-
+        ( V > W ->
+            typr_mutual_weight_odd_tree_branch_part(L, W, SL),
+            typr_mutual_weight_odd_tree_branch_part(R, W, SR),
+            Part is (V * W) + SL + SR
+        ;   typr_mutual_weight_odd_tree_branch_part(R, W, SR),
+            typr_mutual_weight_odd_tree_branch_part(L, W, SL),
+            Part is (V * W) - SL + SR
+        ),
+        S is Part + W
+    )),
+    assertz(user:typr_mutual_weight_odd_tree_branch_part([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree_branch_part([V, L, R], W, S) :-
+        ( V > W ->
+            typr_mutual_weight_even_tree_branch_part(L, W, SL),
+            typr_mutual_weight_even_tree_branch_part(R, W, SR),
+            Part is (V * W) + SL + SR
+        ;   typr_mutual_weight_even_tree_branch_part(R, W, SR),
+            typr_mutual_weight_even_tree_branch_part(L, W, SL),
+            Part is (V * W) - SL + SR
+        ),
+        S is Part + W
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_branch_part/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_branch_part/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_branch_part/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_branch_part/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_branch_part/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_branch_part/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree_branch_part/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree_branch_part/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree_branch_part/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_weight_even_tree_branch_part(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree_branch_part(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR mutual-recursion backend for integer-return tree-structural SCCs.

It adds support for the next confirmed SCC recombination slice after the earlier non-boolean mutual-tree branch work:

- branch-local post-call symbolic value steps after the two recursive subtree calls
- a later shared outer result step
- native TypR emission through the existing memoized-helper model

Representative shapes now supported:

```prolog
typr_mutual_sum_even_tree_branch_part([], 0).
typr_mutual_sum_even_tree_branch_part([V, L, R], S) :-
    ( V > 0 ->
        typr_mutual_sum_odd_tree_branch_part(L, SL),
        typr_mutual_sum_odd_tree_branch_part(R, SR),
        Part is V + SL + SR
    ;   typr_mutual_sum_odd_tree_branch_part(R, SR),
        typr_mutual_sum_odd_tree_branch_part(L, SL),
        Part is V - SL + SR
    ),
    S is Part + 1.

typr_mutual_sum_odd_tree_branch_part([_, [], []], 1).
typr_mutual_sum_odd_tree_branch_part([V, L, R], S) :-
    ( V > 0 ->
        typr_mutual_sum_even_tree_branch_part(L, SL),
        typr_mutual_sum_even_tree_branch_part(R, SR),
        Part is V + SL + SR
    ;   typr_mutual_sum_even_tree_branch_part(R, SR),
        typr_mutual_sum_even_tree_branch_part(L, SL),
        Part is V - SL + SR
    ),
    S is Part + 1.
```

and the same shape with a threaded context argument:

```prolog
typr_mutual_weight_even_tree_branch_part([], _W0, 0).
typr_mutual_weight_even_tree_branch_part([V, L, R], W, S) :-
    ( V > W ->
        typr_mutual_weight_odd_tree_branch_part(L, W, SL),
        typr_mutual_weight_odd_tree_branch_part(R, W, SR),
        Part is (V * W) + SL + SR
    ;   typr_mutual_weight_odd_tree_branch_part(R, W, SR),
        typr_mutual_weight_odd_tree_branch_part(L, W, SL),
        Part is (V * W) - SL + SR
    ),
    S is Part + W.
```

Before this PR, these shapes still failed with:

- `Error: No mutual recursion support for target typr`

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

The previous non-boolean SCC work already covered:

- integer-return tree-structural SCCs with shared dual-subtree descent
- guarded branch-local alias selection before shared subtree calls
- direct recursive subtree calls inside supported guarded branch bodies
- direct recursive subtree calls inside one nested guarded branch body
- simple post-call arithmetic recombination when the result expression came directly from the shared outer tail

That still left a real next gap:

- non-boolean mutual tree recursion where each branch does the two recursive subtree calls, then computes a branch-local symbolic intermediate like `Part is ...`, and only after that does a later shared result step run

This PR closes that gap by generalizing the existing value-returning mutual-tree branch-body pipeline instead of adding another special-purpose emitter.

## Main Changes

### 1. Generalized non-boolean mutual-tree branch-body parsing

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The value-returning mutual-tree path now allows a branch leaf to contain:

- optional alias/context prework
- the recursive subtree-call prefix
- optional branch-local post-call symbolic goals
- a later shared outer result tail

That is the useful generalization in this PR.

### 2. Added reusable post-body composition for nested value branches

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

Nested value-branch bodies now compose their local post-call goals with the shared outer post-body instead of requiring the final result expression to come only from the outer tail.

That keeps the implementation coherent across:

- flat branch leaves
- nested value-returning branch bodies
- threaded context arguments

### 3. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level tests verify:

- integer-return mutual tree SCCs with branch-local post-call arithmetic recombination
- context-threaded variants of the same shape
- native TypR output without wrapped-R fallback

### 4. Added real toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

Both new SCC families now go through real `typr check`, not only string-shape assertions.

### 5. Updated TypR docs

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that conservative integer-return tree SCCs may stay native when branch-local post-call arithmetic steps happen inside the supported guarded branch-body family.

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- general SCC lowering
- arbitrary non-boolean SCC result types
- asymmetric SCC call structures
- a broad recursive IR rewrite for mutual recursion

That leaves the next high-signal follow-up clear:

- broader asymmetric SCC lowering or broader non-boolean SCC result forms, not another small tree-only recombination tweak
