### PR TITLE
ci(csharp-query): show cache smoke diff results

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -440,6 +440,8 @@ jobs:
               "- Compare URL: `"$($env:CACHE_SMOKE_DIFF_COMPARE_URL)`"",
               "- Compare artifact: `"$($env:COMPARE_ARTIFACT_NAME)`"",
               "- Diff JSON artifact: `"$($env:CACHE_SMOKE_DIFF_ARTIFACT_NAME)`"",
+              "- Baseline overall result: `"$($diff.overallResult.baseline)`"",
+              "- Compare overall result: `"$($diff.overallResult.compare)`"",
               "- Overall result delta: `"$($diff.overallResult.delta)`"",
               "- Baseline total duration: `"$($diff.totalDuration.baseline)`"",
               "- Compare total duration: `"$($diff.totalDuration.compare)`"",

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -225,6 +225,8 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - generated-at delta when both timestamps are present
         - GitHub compare URL derived from the resolved SHAs
         - artifact names
+        - baseline overall result
+        - compare overall result
         - overall result delta
         - baseline total duration
         - compare total duration


### PR DESCRIPTION
  ## Summary
  Extend the manual C# query cache-smoke diff job summary so it shows the baseline and compare overall
  results alongside the existing overall-result delta.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Added the following fields to the manual diff job summary:
    - baseline overall result
    - compare overall result
    - overall result delta
  - Updated `docs/targets/csharp-query-runtime.md` to document the added overall-result fields

  ## Why
  The manual diff workflow already exposed the overall-result delta, but not the two underlying values
  that produced it. This change makes the summary easier to interpret at a glance without opening the
  JSON artifact.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-
  runtime.md`
  - Confirmed the summary now renders:
    - `diff.overallResult.baseline`
    - `diff.overallResult.compare`
    - `diff.overallResult.delta`