### PR TITLE
Generalize native TypR asymmetric mutual recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,9 @@ includes:
   inside supported guarded branch bodies, and simple post-call arithmetic
   recombination, including branch-local post-call arithmetic steps inside
   those supported guarded branch bodies, over `value`, `left_result`,
-  `right_result`, and any threaded context args,
+  `right_result`, and any threaded context args, including mixed-shape
+  SCCs where different predicates in the same group use different
+  supported shared-call or guarded branch-body forms,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -233,7 +233,9 @@ bring-up.
     branch bodies, and simple post-call arithmetic recombination,
     including branch-local post-call arithmetic steps inside those
     supported guarded branch bodies, over `value`, `left_result`,
-    `right_result`, and any threaded context args
+    `right_result`, and any threaded context args, including mixed-
+    shape SCCs where different predicates in the same group use
+    different supported shared-call or guarded branch-body forms
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -415,7 +415,9 @@ Current TypR lowering policy is intentionally mixed:
   guarded branch bodies, and simple post-call arithmetic recombination,
   including branch-local post-call arithmetic steps inside those
   supported guarded branch bodies, over `value`, `left_result`,
-  `right_result`, and any threaded context args, using raw-expression
+  `right_result`, and any threaded context args, including mixed-shape
+  SCCs where different predicates in the same group use different
+  supported shared-call or guarded branch-body forms, using raw-expression
   memoized helper bodies inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -105,7 +105,9 @@ This document focuses on architecture and rollout choices specific to TypR.
      arithmetic recombination, including branch-local post-call
      arithmetic steps inside those supported guarded branch bodies, over
      `value`, `left_result`, `right_result`, and any threaded context
-     args, emitted as TypR
+     args, including mixed-shape SCCs where different predicates in the
+     same group use different supported shared-call or guarded branch-
+     body forms, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -81,8 +81,10 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
     (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_dual_value_full_body_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_value_branch_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_value_spec(Predicates), Predicates, Specs)
+    ;   maplist(typr_mutual_tree_dual_body_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_context_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_branch_spec(Predicates), Predicates, Specs)
     ;   maplist(typr_mutual_tree_dual_spec(Predicates), Predicates, Specs)
@@ -249,6 +251,61 @@ typr_mutual_tree_base_tree_varmap([ValueVar, [], []], [ValueVar-'.subset2(curren
     var(ValueVar),
     !.
 typr_mutual_tree_base_tree_varmap([_Value, [], []], []).
+
+typr_mutual_tree_dual_value_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, RecInputPattern|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(
+        Pred,
+        ContextVars,
+        HelperName,
+        ExtraArgMap0,
+        HelperParams,
+        WrapperCallArgs,
+        MemoKeyExpr
+    ),
+    typr_mutual_tree_value_branch_body(
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        true,
+        OutputVar,
+        Body
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
+    }.
 
 typr_mutual_tree_dual_value_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity >= 2,
@@ -684,6 +741,57 @@ typr_mutual_wrapper_arg_names(Arity, Names) :-
         between(1, Arity, Index),
         format(string(Name), 'arg~d', [Index])
     ), Names).
+
+typr_mutual_tree_dual_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern|ContextVars],
+    RecInputPattern = [ValueVar, LeftVar, RightVar],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(
+        Pred,
+        ContextVars,
+        HelperName,
+        ExtraArgMap0,
+        HelperParams,
+        WrapperCallArgs,
+        MemoKeyExpr
+    ),
+    typr_mutual_tree_branch_body(
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        Body
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
+    }.
 
 typr_mutual_tree_dual_branch_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
@@ -1737,6 +1845,52 @@ typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
     atomic_list_concat(Lines, '\n', Code).
 typr_mutual_helper_code(GroupName, true, Spec, Code) :-
     Kind = Spec.kind,
+    Kind == tree_dual_value_full_body,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseCases = Spec.base_cases,
+    GuardExpr = Spec.guard_expr,
+    Body = Spec.body,
+    typr_mutual_tree_value_base_branch_lines(GroupName, BaseCases, BaseLines),
+    typr_mutual_tree_dual_value_full_body_recursive_branch_lines(
+        GroupName,
+        GuardExpr,
+        Body,
+        RecursiveLines
+    ),
+    typr_mutual_stop_lines(PredStr, StopLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    typr_mutual_tree_key_line(Spec, PredStr, KeyLine),
+    format_string_return('        if (exists(key, envir=~w_memo, inherits=FALSE)) {', [GroupName], MemoCheckLine),
+    format_string_return('            get(key, envir=~w_memo, inherits=FALSE)', [GroupName], MemoGetLine),
+    append([HelperLine, KeyLine, MemoCheckLine, MemoGetLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, StopLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(_GroupName, false, Spec, Code) :-
+    Kind = Spec.kind,
+    Kind == tree_dual_value_full_body,
+    PredStr = Spec.pred_str,
+    HelperName = Spec.helper_name,
+    BaseCases = Spec.base_cases,
+    GuardExpr = Spec.guard_expr,
+    Body = Spec.body,
+    typr_mutual_tree_value_base_branch_lines_no_memo(BaseCases, BaseLines),
+    typr_mutual_tree_dual_value_full_body_recursive_branch_lines_no_memo(
+        GuardExpr,
+        Body,
+        RecursiveLines
+    ),
+    typr_mutual_stop_lines_no_memo(PredStr, StopLines),
+    typr_mutual_helper_line(Spec, HelperName, HelperLine),
+    append([HelperLine], BaseLines, Lines0),
+    append(Lines0, RecursiveLines, Lines1),
+    append(Lines1, StopLines, Lines2),
+    append(Lines2, ['    };'], Lines),
+    atomic_list_concat(Lines, '\n', Code).
+typr_mutual_helper_code(GroupName, true, Spec, Code) :-
+    Kind = Spec.kind,
     Kind == tree_dual_value,
     PredStr = Spec.pred_str,
     HelperName = Spec.helper_name,
@@ -2393,6 +2547,46 @@ typr_mutual_tree_dual_value_recursive_branch_lines_no_memo(
         RightLine,
         ResultLine
     ].
+
+typr_mutual_tree_dual_value_full_body_recursive_branch_lines(
+    GroupName,
+    'TRUE',
+    Body,
+    Lines
+) :-
+    !,
+    typr_mutual_tree_value_body_lines(Body, '            ', BodyLines),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    append(['        } else {'], BodyLines, Lines0),
+    append(Lines0, [AssignLine, '            result'], Lines).
+typr_mutual_tree_dual_value_full_body_recursive_branch_lines(
+    GroupName,
+    GuardExpr,
+    Body,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    typr_mutual_tree_value_body_lines(Body, '            ', BodyLines),
+    format(string(AssignLine), '            assign(key, result, envir=~w_memo);', [GroupName]),
+    append([IfLine], BodyLines, Lines0),
+    append(Lines0, [AssignLine, '            result'], Lines).
+
+typr_mutual_tree_dual_value_full_body_recursive_branch_lines_no_memo(
+    'TRUE',
+    Body,
+    Lines
+) :-
+    !,
+    typr_mutual_tree_value_body_lines_no_memo(Body, '            ', BodyLines),
+    append(['        } else {'], BodyLines, Lines).
+typr_mutual_tree_dual_value_full_body_recursive_branch_lines_no_memo(
+    GuardExpr,
+    Body,
+    Lines
+) :-
+    format(string(IfLine), '        } else if (~w) {', [GuardExpr]),
+    typr_mutual_tree_value_body_lines_no_memo(Body, '            ', BodyLines),
+    append([IfLine], BodyLines, Lines).
 
 typr_mutual_tree_dual_value_branch_recursive_branch_lines(
     GroupName,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -433,8 +433,8 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_recursion_path
     once(sub_string(Code, _, _, _, "let typr_mutual_even_tree <- fn(arg1: [#N, Any]): bool")),
     once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree <- fn(arg1: [#N, Any]): bool")),
     once(sub_string(Code, _, _, _, "typr_mutual_even_tree_typr_mutual_odd_tree_memo <- new.env(hash=TRUE, parent=emptyenv())")),
-    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree:\", paste(deparse(current_input), collapse=\"\"));")),
-    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_tree:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree:\", paste(deparse(list(current_input)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_tree:\", paste(deparse(list(current_input)), collapse=\"\"));")),
     once(sub_string(Code, _, _, _, "length(current_input) == 0")),
     once(sub_string(Code, _, _, _, "length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_impl(.subset2(current_input, 2));")),
@@ -470,8 +470,8 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_prework_path) 
     once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_pre <- fn(arg1: [#N, Any]): bool")),
     once(sub_string(Code, _, _, _, "let typr_mutual_odd_tree_pre <- fn(arg1: [#N, Any]): bool")),
     once(sub_string(Code, _, _, _, "typr_mutual_even_tree_pre_typr_mutual_odd_tree_pre_memo <- new.env(hash=TRUE, parent=emptyenv())")),
-    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_pre:\", paste(deparse(current_input), collapse=\"\"));")),
-    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_tree_pre:\", paste(deparse(current_input), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_even_tree_pre:\", paste(deparse(list(current_input)), collapse=\"\"));")),
+    once(sub_string(Code, _, _, _, "key <- paste0(\"typr_mutual_odd_tree_pre:\", paste(deparse(list(current_input)), collapse=\"\"));")),
     once(sub_string(Code, _, _, _, "length(current_input) == 0")),
     once(sub_string(Code, _, _, _, "length(current_input) == 3 && length(.subset2(current_input, 2)) == 0 && length(.subset2(current_input, 3)) == 0")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_pre_impl(.subset2(current_input, 2));")),
@@ -3659,6 +3659,110 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_contex
     once(sub_string(Code, _, _, _, "result = ((((.subset2(current_input, 1) * current_ctx) - left_result) + right_result) + current_ctx);")),
     \+ sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_branch_part_impl(.subset2(current_input, 3), current_ctx);"),
     \+ sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_branch_part_impl(.subset2(current_input, 2), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_asymmetric_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_asym([])),
+    assertz(user:(typr_mutual_even_tree_asym([_, L, R]) :-
+        typr_mutual_odd_tree_asym(L),
+        typr_mutual_odd_tree_asym(R)
+    )),
+    assertz(user:typr_mutual_odd_tree_asym([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_asym([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_asym(L),
+            typr_mutual_even_tree_asym(R)
+        ;   typr_mutual_even_tree_asym(R),
+            typr_mutual_even_tree_asym(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_asym/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_asym/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_asym/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_asym/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_asym/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_even_tree_asym/1, typr_mutual_odd_tree_asym/1")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_even_tree_asym <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_mutual_even_tree_asym_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_odd_tree_asym_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_odd_tree_asym_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_even_tree_asym_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_even_tree_asym_impl(.subset2(current_input, 2));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_asymmetric_group) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree_asym([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree_asym([V, L, R], S) :-
+        typr_mutual_sum_odd_tree_asym(L, SL),
+        typr_mutual_sum_odd_tree_asym(R, SR),
+        S is V + SL + SR
+    )),
+    assertz(user:typr_mutual_sum_odd_tree_asym([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree_asym([V, L, R], S) :-
+        ( V > 0 ->
+            typr_mutual_sum_even_tree_asym(L, SL),
+            typr_mutual_sum_even_tree_asym(R, SR)
+        ;   typr_mutual_sum_even_tree_asym(R, SR),
+            typr_mutual_sum_even_tree_asym(L, SL)
+        ),
+        S is V - SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_asym/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_asym/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_asym/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_asym/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree_asym/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree_asym/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree_asym/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_tree_asym/2, typr_mutual_sum_odd_tree_asym/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_tree_asym <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_even_tree_asym_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_tree_asym_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_asym_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) - left_result) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_context_asymmetric_group) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree_asym([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree_asym([V, L, R], W, S) :-
+        typr_mutual_weight_odd_tree_asym(L, W, SL),
+        typr_mutual_weight_odd_tree_asym(R, W, SR),
+        S is (V * W) + SL + SR
+    )),
+    assertz(user:typr_mutual_weight_odd_tree_asym([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree_asym([V, L, R], W, S) :-
+        ( V > W ->
+            typr_mutual_weight_even_tree_asym(L, W, SL),
+            typr_mutual_weight_even_tree_asym(R, W, SR)
+        ;   typr_mutual_weight_even_tree_asym(R, W, SR),
+            typr_mutual_weight_even_tree_asym(L, W, SL)
+        ),
+        S is (V * W) - SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_asym/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_asym/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_asym/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_asym/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_asym/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_asym/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree_asym/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree_asym/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree_asym/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_weight_even_tree_asym/3, typr_mutual_weight_odd_tree_asym/3")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_weight_even_tree_asym <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_weight_even_tree_asym_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_odd_tree_asym_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_odd_tree_asym_impl(.subset2(current_input, 3), current_ctx);")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) * current_ctx) - left_result) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2609,6 +2609,115 @@ test(structural_tree_dual_mutual_integer_context_branch_local_recombine_output_c
     retractall(user:typr_mutual_weight_even_tree_branch_part(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_branch_part(_, _, _)).
 
+test(structural_tree_dual_mutual_asymmetric_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_even_tree_asym([])),
+    assertz(user:(typr_mutual_even_tree_asym([_, L, R]) :-
+        typr_mutual_odd_tree_asym(L),
+        typr_mutual_odd_tree_asym(R)
+    )),
+    assertz(user:typr_mutual_odd_tree_asym([_, [], []])),
+    assertz(user:(typr_mutual_odd_tree_asym([V, L, R]) :-
+        ( V > 0 ->
+            typr_mutual_even_tree_asym(L),
+            typr_mutual_even_tree_asym(R)
+        ;   typr_mutual_even_tree_asym(R),
+            typr_mutual_even_tree_asym(L)
+        )
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_even_tree_asym/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_odd_tree_asym/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_mutual_even_tree_asym/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_mutual_odd_tree_asym/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_mutual_even_tree_asym/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_even_tree_asym(_)),
+    retractall(user:typr_mutual_odd_tree_asym(_)).
+
+test(structural_tree_dual_mutual_integer_asymmetric_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_tree_asym([], 0)),
+    assertz(user:(typr_mutual_sum_even_tree_asym([V, L, R], S) :-
+        typr_mutual_sum_odd_tree_asym(L, SL),
+        typr_mutual_sum_odd_tree_asym(R, SR),
+        S is V + SL + SR
+    )),
+    assertz(user:typr_mutual_sum_odd_tree_asym([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_tree_asym([V, L, R], S) :-
+        ( V > 0 ->
+            typr_mutual_sum_even_tree_asym(L, SL),
+            typr_mutual_sum_even_tree_asym(R, SR)
+        ;   typr_mutual_sum_even_tree_asym(R, SR),
+            typr_mutual_sum_even_tree_asym(L, SL)
+        ),
+        S is V - SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_asym/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_tree_asym/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_asym/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_tree_asym/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_tree_asym/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_tree_asym/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_tree_asym/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_even_tree_asym(_, _)),
+    retractall(user:typr_mutual_sum_odd_tree_asym(_, _)).
+
+test(structural_tree_dual_mutual_integer_context_asymmetric_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_even_tree_asym([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_even_tree_asym([V, L, R], W, S) :-
+        typr_mutual_weight_odd_tree_asym(L, W, SL),
+        typr_mutual_weight_odd_tree_asym(R, W, SR),
+        S is (V * W) + SL + SR
+    )),
+    assertz(user:typr_mutual_weight_odd_tree_asym([_, [], []], _W1, 1)),
+    assertz(user:(typr_mutual_weight_odd_tree_asym([V, L, R], W, S) :-
+        ( V > W ->
+            typr_mutual_weight_even_tree_asym(L, W, SL),
+            typr_mutual_weight_even_tree_asym(R, W, SR)
+        ;   typr_mutual_weight_even_tree_asym(R, W, SR),
+            typr_mutual_weight_even_tree_asym(L, W, SL)
+        ),
+        S is (V * W) - SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_asym/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_asym/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_even_tree_asym/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_asym/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_asym/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_odd_tree_asym/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_even_tree_asym/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_odd_tree_asym/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_even_tree_asym/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_weight_even_tree_asym(_, _, _)),
+    retractall(user:typr_mutual_weight_odd_tree_asym(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR extends the conservative native TypR mutual-recursion backend to support mixed-shape tree-structural SCCs.

Before this PR, TypR could lower several conservative mutual-tree shapes natively, but it still rejected SCCs where different predicates in the same group used different supported body forms.

The first real asymmetry gap was:

- one predicate using a straight shared dual-subtree call shape
- another predicate in the same SCC using a supported guarded branch-body shape
- boolean or integer-return recombination staying TypR-translatable

Representative boolean shape now supported:

```prolog
typr_mutual_even_tree_asym([]).
typr_mutual_even_tree_asym([_, L, R]) :-
    typr_mutual_odd_tree_asym(L),
    typr_mutual_odd_tree_asym(R).

typr_mutual_odd_tree_asym([_, [], []]).
typr_mutual_odd_tree_asym([V, L, R]) :-
    ( V > 0 ->
        typr_mutual_even_tree_asym(L),
        typr_mutual_even_tree_asym(R)
    ;   typr_mutual_even_tree_asym(R),
        typr_mutual_even_tree_asym(L)
    ).
```

Representative integer-return shape now supported:

```prolog
typr_mutual_sum_even_tree_asym([], 0).
typr_mutual_sum_even_tree_asym([V, L, R], S) :-
    typr_mutual_sum_odd_tree_asym(L, SL),
    typr_mutual_sum_odd_tree_asym(R, SR),
    S is V + SL + SR.

typr_mutual_sum_odd_tree_asym([_, [], []], 1).
typr_mutual_sum_odd_tree_asym([V, L, R], S) :-
    ( V > 0 ->
        typr_mutual_sum_even_tree_asym(L, SL),
        typr_mutual_sum_even_tree_asym(R, SR)
    ;   typr_mutual_sum_even_tree_asym(R, SR),
        typr_mutual_sum_even_tree_asym(L, SL)
    ),
    S is V - SL + SR.
```

and the same mixed-shape family with threaded context arguments.

Before this PR, these SCCs still failed with:

- `Error: No mutual recursion support for target typr`

After this PR, they lower natively to TypR, pass real `typr check`, and stay inside the existing memoized-helper TypR model.

## Why This PR Exists

The recent SCC work had already covered many conservative mutual-tree cases:

- boolean tree SCCs with shared dual-subtree descent
- guarded branch-local alias selection before shared subtree calls
- direct recursive subtree calls inside supported guarded branch bodies
- nested guarded control around those calls
- integer-return tree SCCs with simple arithmetic recombination
- branch-local post-call arithmetic recombination
- threaded context arguments through the same shared-call families

What still broke was not another branch-body subcase in isolation.

It was asymmetry across the SCC group itself:

- each predicate could already match a supported TypR mutual-tree pattern on its own
- but the group compiler still wanted every predicate in the SCC to fit the same narrow mutual-tree matcher

This PR closes that gap by generalizing the mutual-tree backend to a common full-body path for dual-subtree SCCs, instead of adding another one-off asymmetric matcher.

## Main Changes

### 1. Added common full-body mutual-tree lowering for mixed-shape SCCs

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The mutual-tree backend now has a common full-body path for:

- conservative boolean dual-subtree tree SCCs
- conservative integer-return dual-subtree tree SCCs
- the same families with threaded context arguments

That full-body path can represent:

- straight shared dual-subtree call bodies
- supported guarded branch bodies
- mixed groups where different predicates use different supported body forms

### 2. Generalized helper emission instead of adding another tree-only special case

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

For integer-return SCCs, the backend now emits a full-body value form instead of requiring both predicates to share the same older straight or branch-specific matcher.

For boolean SCCs, the backend now uses the same branch-body family for mixed-shape dual-subtree groups, including arity-1 tree SCCs that previously had no common body path.

This is the useful generalization in the PR.

### 3. Added focused regression coverage for asymmetric SCC groups

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level coverage verifies:

- asymmetric boolean tree mutual recursion
- asymmetric integer-return tree mutual recursion
- asymmetric integer-return tree mutual recursion with one threaded context argument

### 4. Added real toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

The new mixed-shape SCC families now go through real `typr check`, not only string-shape assertions.

### 5. Updated TypR docs

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that conservative mutual tree SCCs may stay native when different predicates in the same group use different supported shared-call or guarded branch-body forms.

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- arbitrary SCC lowering
- non-tree asymmetric SCC normalization
- mutual recursion where the predicates do not share the same basic tree-driver / dual-subtree decomposition
- arbitrary generic-body lowering for SCCs

That leaves the next high-signal follow-up clear:

- broader SCC lowering beyond the shared dual-subtree tree model, not another small tree-only asymmetry tweak
