### PR TITLE
Generalize native TypR mixed mutual tree values

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,15 @@ includes:
   non-recursive post-call control, shared context updates before that
   first subtree call, or branch-local context updates before the second
   subtree call, plus conservative integer-return tree-structural SCCs
-  with shared dual-subtree descent, guarded branch-local alias selection
-  before those shared subtree calls or direct recursive subtree calls
-  inside supported guarded branch bodies, and simple post-call arithmetic
-  recombination, including branch-local post-call arithmetic steps inside
-  those supported guarded branch bodies, over `value`, `left_result`,
-  `right_result`, and any threaded context args, including mixed-shape
-  SCCs where different predicates in the same group use different
-  supported shared-call or guarded branch-body forms,
+  with one-subtree or shared dual-subtree descent, guarded branch-local
+  alias selection before those shared subtree calls or direct recursive
+  subtree calls inside supported guarded branch bodies, and simple
+  post-call arithmetic recombination, including branch-local post-call
+  arithmetic steps inside those supported guarded branch bodies, over
+  `value`, `left_result`, `right_result`, and any threaded context args,
+  including mixed-shape SCCs where different predicates in the same group
+  use different supported one-subtree, shared-call, or guarded
+  branch-body forms,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -227,15 +227,16 @@ bring-up.
     call plus nested non-recursive post-call control, shared context
     updates before that first subtree call, or branch-local context
     updates before the second subtree call, plus conservative integer-
-    return tree-structural SCCs with shared dual-subtree descent,
-    guarded branch-local alias selection before those shared subtree
-    calls or direct recursive subtree calls inside supported guarded
-    branch bodies, and simple post-call arithmetic recombination,
-    including branch-local post-call arithmetic steps inside those
-    supported guarded branch bodies, over `value`, `left_result`,
-    `right_result`, and any threaded context args, including mixed-
-    shape SCCs where different predicates in the same group use
-    different supported shared-call or guarded branch-body forms
+    return tree-structural SCCs with one-subtree or shared dual-subtree
+    descent, guarded branch-local alias selection before those shared
+    subtree calls or direct recursive subtree calls inside supported
+    guarded branch bodies, and simple post-call arithmetic
+    recombination, including branch-local post-call arithmetic steps
+    inside those supported guarded branch bodies, over `value`,
+    `left_result`, `right_result`, and any threaded context args,
+    including mixed-shape SCCs where different predicates in the same
+    group use different supported one-subtree, shared-call, or guarded
+    branch-body forms
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -409,15 +409,15 @@ Current TypR lowering policy is intentionally mixed:
   calls, shared context updates before that first subtree call, branch-local
   context updates before the second subtree call, or multiple threaded
   context arguments carried through the same shared subtree-call families,
-  plus conservative integer-return tree-structural SCCs with shared
-  dual-subtree descent, guarded branch-local alias selection before those
-  shared subtree calls or direct recursive subtree calls inside supported
-  guarded branch bodies, and simple post-call arithmetic recombination,
-  including branch-local post-call arithmetic steps inside those
-  supported guarded branch bodies, over `value`, `left_result`,
+  plus conservative integer-return tree-structural SCCs with one-subtree
+  or shared dual-subtree descent, guarded branch-local alias selection
+  before those shared subtree calls or direct recursive subtree calls
+  inside supported guarded branch bodies, and simple post-call arithmetic
+  recombination, including branch-local post-call arithmetic steps inside
+  those supported guarded branch bodies, over `value`, `left_result`,
   `right_result`, and any threaded context args, including mixed-shape
   SCCs where different predicates in the same group use different
-  supported shared-call or guarded branch-body forms, using raw-expression
+  supported one-subtree, shared-call, or guarded branch-body forms, using raw-expression
   memoized helper bodies inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -98,16 +98,16 @@ This document focuses on architecture and rollout choices specific to TypR.
      context updates before that first subtree call, branch-local
      context updates before the second subtree call, and boolean return
      types, plus conservative integer-return tree-structural SCCs with
-     shared dual-subtree descent, guarded branch-local alias selection
-     before those shared subtree calls or direct recursive subtree calls
-     inside supported guarded branch bodies with one nested branch-local
-     control point around those calls, and simple post-call
+     one-subtree or shared dual-subtree descent, guarded branch-local
+     alias selection before those shared subtree calls or direct recursive
+     subtree calls inside supported guarded branch bodies with one nested
+     branch-local control point around those calls, and simple post-call
      arithmetic recombination, including branch-local post-call
      arithmetic steps inside those supported guarded branch bodies, over
      `value`, `left_result`, `right_result`, and any threaded context
      args, including mixed-shape SCCs where different predicates in the
-     same group use different supported shared-call or guarded branch-
-     body forms, emitted as TypR
+     same group use different supported one-subtree, shared-call, or
+     guarded branch-body forms, emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -1063,6 +1063,12 @@ split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGo
     RecGoals = [_|[_|_]],
     \+ typr_contains_mutual_recursive_goal(GroupPredicates, PostGoals).
 
+split_typr_mutual_recursive_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals) :-
+    split_typr_mutual_non_recursive_prefix(GroupPredicates, Goals, PreGoals, RecAndPostGoals),
+    take_typr_mutual_recursive_goal_prefix(GroupPredicates, RecAndPostGoals, RecGoals, PostGoals),
+    RecGoals = [_|_],
+    \+ typr_contains_mutual_recursive_goal(GroupPredicates, PostGoals).
+
 split_typr_mutual_non_recursive_prefix(_GroupPredicates, [], [], []).
 split_typr_mutual_non_recursive_prefix(GroupPredicates, [Goal|Rest], [], [Goal|Rest]) :-
     typr_goal_calls_mutual_group(GroupPredicates, Goal),
@@ -1188,6 +1194,32 @@ typr_mutual_tree_value_side_calls(CallSpecs0, LeftCall, RightCall, LeftOutputVar
     LeftCall = branch_call(LeftHelperName, LeftCallArgs),
     RightCall = branch_call(RightHelperName, RightCallArgs).
 
+typr_mutual_tree_value_call_bindings(CallSpecs0, CallBindings, ResultBindings) :-
+    findall(
+        Side,
+        member(value_call_spec(Side, _NextPred, _CallArgs, _OutputVar), CallSpecs0),
+        Sides0
+    ),
+    sort(Sides0, UniqueSides),
+    length(Sides0, SideCount),
+    length(UniqueSides, SideCount),
+    typr_mutual_tree_value_call_binding(CallSpecs0, left, LeftCallBindings, LeftResultBindings),
+    typr_mutual_tree_value_call_binding(CallSpecs0, right, RightCallBindings, RightResultBindings),
+    append(LeftCallBindings, RightCallBindings, CallBindings),
+    append(LeftResultBindings, RightResultBindings, ResultBindings).
+
+typr_mutual_tree_value_call_binding(CallSpecs0, Side, [value_call_binding(Side, Call)], [result_binding(OutputVar, ResultName)]) :-
+    member(value_call_spec(Side, NextPred, CallArgs, OutputVar), CallSpecs0),
+    !,
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]),
+    Call = branch_call(HelperName, CallArgs),
+    typr_mutual_tree_result_name(Side, ResultName).
+typr_mutual_tree_value_call_binding(_CallSpecs0, _Side, [], []).
+
+typr_mutual_tree_result_name(left, left_result).
+typr_mutual_tree_result_name(right, right_result).
+
 typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
     append(PreGoals, [NestedIfGoal|TailPostGoals], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
@@ -1221,7 +1253,7 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     Body = value_branch_if(BranchConditionExpr, ThenBody, ElseBody).
 typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
-    split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, BranchPostGoals),
+    split_typr_mutual_recursive_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, BranchPostGoals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
     GuardExpr == none,
     maplist(
@@ -1229,19 +1261,18 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
         RecGoals,
         GoalSpecs0
     ),
-    typr_mutual_tree_value_side_calls(GoalSpecs0, LeftCall, RightCall, LeftOutputVar, RightOutputVar),
+    typr_mutual_tree_value_call_bindings(GoalSpecs0, CallBindings, ResultBindings),
     typr_mutual_tree_value_branch_post_body(BranchPostGoals, PostBody, CombinedPostBody),
-    typr_mutual_tree_value_result_expr(
+    typr_mutual_tree_value_result_expr_from_bindings(
         CombinedPostBody,
         OutputVar,
         ValueVar,
         AliasMap,
         ExtraArgMap1,
-        LeftOutputVar,
-        RightOutputVar,
+        ResultBindings,
         ResultExpr
     ),
-    Body = value_branch_leaf(LeftCall, RightCall, ResultExpr).
+    Body = value_branch_leaf(CallBindings, ResultExpr).
 
 typr_mutual_tree_value_branch_post_body(BranchPostGoals, PostBody, CombinedPostBody) :-
     typr_mutual_tree_value_post_body_goals(PostBody, SharedPostGoals),
@@ -1259,6 +1290,14 @@ typr_mutual_tree_value_result_expr(PostBody, OutputVar, ValueVar, AliasMap, Extr
     update_typr_expr_varmap(ResultVarMap0, LeftOutputVar, left_result, ResultVarMap1),
     update_typr_expr_varmap(ResultVarMap1, RightOutputVar, right_result, ResultVarMap),
     linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr).
+
+typr_mutual_tree_value_result_expr_from_bindings(PostBody, OutputVar, ValueVar, AliasMap, ExtraArgMap, ResultBindings, ResultExpr) :-
+    typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, ResultVarMap0),
+    foldl(typr_mutual_tree_result_binding_varmap, ResultBindings, ResultVarMap0, ResultVarMap),
+    linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr).
+
+typr_mutual_tree_result_binding_varmap(result_binding(OutputVar, ResultName), VarMap0, VarMap) :-
+    update_typr_expr_varmap(VarMap0, OutputVar, ResultName, VarMap).
 
 typr_mutual_extra_arg_expr(ExtraArgMap, Arg, Expr) :-
     var(Arg),
@@ -2860,13 +2899,10 @@ typr_mutual_tree_value_body_lines_from(value_branch_if(BranchConditionExpr, Then
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
-typr_mutual_tree_value_body_lines_from(value_branch_leaf(LeftCall, RightCall, ResultExpr), Prefix, Lines) :-
-    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
-    typr_mutual_tree_call_expr(RightCall, RightExpr),
-    format(string(LeftLine), '~wleft_result = ~w;', [Prefix, LeftExpr]),
-    format(string(RightLine), '~wright_result = ~w;', [Prefix, RightExpr]),
+typr_mutual_tree_value_body_lines_from(value_branch_leaf(CallBindings, ResultExpr), Prefix, Lines) :-
+    typr_mutual_tree_value_call_binding_lines(CallBindings, Prefix, CallLines),
     format(string(ResultLine), '~wresult = ~w;', [Prefix, ResultExpr]),
-    Lines = [LeftLine, RightLine, ResultLine].
+    append(CallLines, [ResultLine], Lines).
 
 typr_mutual_tree_value_body_lines_no_memo(Body, Prefix, Lines) :-
     typr_mutual_tree_value_body_lines_no_memo_from(Body, Prefix, Lines).
@@ -2882,13 +2918,17 @@ typr_mutual_tree_value_body_lines_no_memo_from(value_branch_if(BranchConditionEx
     append(Lines0, [ElseLine], Lines1),
     append(Lines1, ElseLines, Lines2),
     append(Lines2, [EndLine], Lines).
-typr_mutual_tree_value_body_lines_no_memo_from(value_branch_leaf(LeftCall, RightCall, ResultExpr), Prefix, Lines) :-
-    typr_mutual_tree_call_expr(LeftCall, LeftExpr),
-    typr_mutual_tree_call_expr(RightCall, RightExpr),
-    format(string(LeftLine), '~wleft_result = ~w;', [Prefix, LeftExpr]),
-    format(string(RightLine), '~wright_result = ~w;', [Prefix, RightExpr]),
+typr_mutual_tree_value_body_lines_no_memo_from(value_branch_leaf(CallBindings, ResultExpr), Prefix, Lines) :-
+    typr_mutual_tree_value_call_binding_lines(CallBindings, Prefix, CallLines),
     format(string(ResultLine), '~w~w', [Prefix, ResultExpr]),
-    Lines = [LeftLine, RightLine, ResultLine].
+    append(CallLines, [ResultLine], Lines).
+
+typr_mutual_tree_value_call_binding_lines([], _Prefix, []).
+typr_mutual_tree_value_call_binding_lines([value_call_binding(Side, Call)|Rest], Prefix, [CallLine|RestLines]) :-
+    typr_mutual_tree_result_name(Side, ResultName),
+    typr_mutual_tree_call_expr(Call, CallExpr),
+    format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
+    typr_mutual_tree_value_call_binding_lines(Rest, Prefix, RestLines).
 
 typr_mutual_tree_branch_body_lines(Body, Prefix, Lines) :-
     typr_mutual_tree_branch_body_lines_from(Body, Prefix, 1, Lines).

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -93,6 +93,10 @@ cleanup_typr_test :-
     retractall(user:typr_mutual_odd_tree_ctx_branch_step_post(_, _)),
     retractall(user:typr_mutual_even_tree_ctx2(_, _, _)),
     retractall(user:typr_mutual_odd_tree_ctx2(_, _, _)),
+    retractall(user:typr_mutual_sum_even_left_tree(_, _)),
+    retractall(user:typr_mutual_sum_odd_left_tree(_, _)),
+    retractall(user:typr_mutual_sum_even_mixed_tree(_, _)),
+    retractall(user:typr_mutual_sum_odd_mixed_tree(_, _)),
     retractall(user:typr_mutual_sum_even_tree(_, _)),
     retractall(user:typr_mutual_sum_odd_tree(_, _)),
     retractall(user:typr_mutual_weight_even_tree(_, _, _)),
@@ -3271,6 +3275,66 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_output
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_tree_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) + left_result) + right_result);")),
     once(sub_string(Code, _, _, _, "result = (((.subset2(current_input, 1) + left_result) + right_result) + 1);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_single_subtree_mutual_integer_output_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_left_tree([], 0)),
+    assertz(user:(typr_mutual_sum_even_left_tree([V, L, _], S) :-
+        typr_mutual_sum_odd_left_tree(L, SL),
+        S is V + SL
+    )),
+    assertz(user:typr_mutual_sum_odd_left_tree([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_left_tree([V, L, _], S) :-
+        typr_mutual_sum_even_left_tree(L, SL),
+        S is V - SL
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_left_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_left_tree/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_left_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_left_tree/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_left_tree/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_left_tree/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_left_tree/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_left_tree/2, typr_mutual_sum_odd_left_tree/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_left_tree <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_even_left_tree_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_left_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) - left_result);")),
+    \+ sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_left_tree_impl"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_structural_tree_mixed_mutual_integer_output_path) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_mixed_tree([], 0)),
+    assertz(user:(typr_mutual_sum_even_mixed_tree([V, L, _], S) :-
+        typr_mutual_sum_odd_mixed_tree(L, SL),
+        S is V + SL
+    )),
+    assertz(user:typr_mutual_sum_odd_mixed_tree([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_mixed_tree([V, L, R], S) :-
+        typr_mutual_sum_even_mixed_tree(L, SL),
+        typr_mutual_sum_even_mixed_tree(R, SR),
+        S is V + SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_mixed_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_mixed_tree/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_mixed_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_mixed_tree/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_mixed_tree/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_mixed_tree/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_mixed_tree/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_mixed_tree/2, typr_mutual_sum_odd_mixed_tree/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_mixed_tree <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_even_mixed_tree_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_mixed_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_even_mixed_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_even_mixed_tree_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) + left_result) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2226,6 +2226,69 @@ test(structural_tree_dual_mutual_integer_output_checks_with_typr, [condition(typ
     retractall(user:typr_mutual_sum_even_tree(_, _)),
     retractall(user:typr_mutual_sum_odd_tree(_, _)).
 
+test(structural_tree_single_subtree_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_left_tree([], 0)),
+    assertz(user:(typr_mutual_sum_even_left_tree([V, L, _], S) :-
+        typr_mutual_sum_odd_left_tree(L, SL),
+        S is V + SL
+    )),
+    assertz(user:typr_mutual_sum_odd_left_tree([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_left_tree([V, L, _], S) :-
+        typr_mutual_sum_even_left_tree(L, SL),
+        S is V - SL
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_left_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_left_tree/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_left_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_left_tree/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_left_tree/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_left_tree/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_left_tree/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_even_left_tree(_, _)),
+    retractall(user:typr_mutual_sum_odd_left_tree(_, _)).
+
+test(structural_tree_mixed_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_even_mixed_tree([], 0)),
+    assertz(user:(typr_mutual_sum_even_mixed_tree([V, L, _], S) :-
+        typr_mutual_sum_odd_mixed_tree(L, SL),
+        S is V + SL
+    )),
+    assertz(user:typr_mutual_sum_odd_mixed_tree([_, [], []], 1)),
+    assertz(user:(typr_mutual_sum_odd_mixed_tree([V, L, R], S) :-
+        typr_mutual_sum_even_mixed_tree(L, SL),
+        typr_mutual_sum_even_mixed_tree(R, SR),
+        S is V + SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_mixed_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_even_mixed_tree/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_mixed_tree/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_odd_mixed_tree/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_even_mixed_tree/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_odd_mixed_tree/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_even_mixed_tree/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_even_mixed_tree(_, _)),
+    retractall(user:typr_mutual_sum_odd_mixed_tree(_, _)).
+
 test(structural_tree_dual_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:typr_mutual_weight_even_tree([], _W0, 0)),


### PR DESCRIPTION
# Generalize Native TypR Mixed Mutual Tree Values

## Summary

This PR generalizes the native TypR backend for conservative non-boolean mutual tree recursion.

Before this PR, integer-return mutual tree SCCs only stayed native when every predicate in the group fit the shared dual-subtree value path.

That left two real gaps:

- pure one-subtree integer-return mutual tree SCCs
- mixed-shape integer-return mutual tree SCCs where one predicate uses one-subtree descent and another uses dual-subtree descent

Both shapes now lower natively to TypR and pass real `typr check`.

Representative one-subtree shape now supported:

```prolog
typr_mutual_sum_even_left_tree([], 0).
typr_mutual_sum_even_left_tree([V, L, _], S) :-
    typr_mutual_sum_odd_left_tree(L, SL),
    S is V + SL.

typr_mutual_sum_odd_left_tree([_, [], []], 1).
typr_mutual_sum_odd_left_tree([V, L, _], S) :-
    typr_mutual_sum_even_left_tree(L, SL),
    S is V - SL.
```

Representative mixed-shape SCC now supported:

```prolog
typr_mutual_sum_even_mixed_tree([], 0).
typr_mutual_sum_even_mixed_tree([V, L, _], S) :-
    typr_mutual_sum_odd_mixed_tree(L, SL),
    S is V + SL.

typr_mutual_sum_odd_mixed_tree([_, [], []], 1).
typr_mutual_sum_odd_mixed_tree([V, L, R], S) :-
    typr_mutual_sum_even_mixed_tree(L, SL),
    typr_mutual_sum_even_mixed_tree(R, SR),
    S is V + SL + SR.
```

## Why This PR Exists

The previous SCC work already covered:

- boolean mutual tree SCCs across several conservative shapes
- integer-return dual-subtree tree SCCs
- guarded branch-body and mixed-shape dual-subtree SCCs
- threaded context arguments through the existing mutual tree families

The next real SCC gap was lower-level than another branch-body variant:

- the integer-return mutual-tree path still assumed dual-subtree recursive-call prefixes
- it could not lower one-subtree value SCCs
- mixed one-/dual-subtree groups therefore failed too

This PR fixes that by generalizing the value-returning mutual-tree path rather than adding another narrow special case.

## Main Changes

### 1. Generalized value-return mutual-tree recursive-goal splitting

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The native TypR mutual-tree value path now accepts one or more recursive subtree calls before the nonrecursive result tail, instead of requiring exactly two calls.

### 2. Added side-aware result binding for one-call and two-call leaves

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The result-expression pipeline now binds only the recursive outputs that are actually present:

- `left_result` for one-subtree descent
- `left_result` and `right_result` for dual-subtree descent

That keeps result translation correct across both pure one-subtree and mixed one-/dual-subtree SCCs.

### 3. Generalized value-body emission

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

Native TypR helper emission for value-return mutual-tree leaves now emits the recursive call lines from a list of side-aware call bindings instead of assuming a fixed left/right pair.

### 4. Added focused regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level tests cover:

- integer-return one-subtree mutual tree SCCs
- integer-return mixed one-/dual-subtree mutual tree SCCs

### 5. Added real toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

Both new SCC families now go through real `typr check`.

### 6. Updated TypR docs

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that conservative integer-return tree SCCs may stay native for:

- one-subtree descent
- shared dual-subtree descent
- mixed-shape groups that combine those supported forms

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- arbitrary SCC lowering
- non-tree SCC generalization
- arbitrary generic-body lowering for SCCs
- mutual groups whose predicates fall outside the current structural tree-driver model

The next high-signal follow-up is broader SCC lowering beyond the current tree-driver model, not another tree-only micro-slice.
