### PR TITLE
Generalize native TypR mixed structural SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,9 @@ includes:
   `value`, `left_result`, `right_result`, and any threaded context args,
   including mixed-shape SCCs where different predicates in the same group
   use different supported one-subtree, shared-call, or guarded
-  branch-body forms,
+  branch-body forms, and mixed tree/list structural SCCs where tree-shaped
+  predicates recurse through paired-forest helpers while list-shaped
+  predicates recurse through head/tail decomposition,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -236,7 +236,9 @@ bring-up.
     `left_result`, `right_result`, and any threaded context args,
     including mixed-shape SCCs where different predicates in the same
     group use different supported one-subtree, shared-call, or guarded
-    branch-body forms
+    branch-body forms, and mixed tree/list structural SCCs where
+    tree-shaped predicates recurse through paired-forest helpers while
+    list-shaped predicates recurse through head/tail decomposition
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -417,8 +417,11 @@ Current TypR lowering policy is intentionally mixed:
   those supported guarded branch bodies, over `value`, `left_result`,
   `right_result`, and any threaded context args, including mixed-shape
   SCCs where different predicates in the same group use different
-  supported one-subtree, shared-call, or guarded branch-body forms, using raw-expression
-  memoized helper bodies inside TypR rather than wrapped-R fallback
+  supported one-subtree, shared-call, or guarded branch-body forms, and
+  mixed tree/list structural SCCs where tree-shaped predicates recurse
+  through paired-forest helpers while list-shaped predicates recurse
+  through head/tail decomposition, using raw-expression memoized helper
+  bodies inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -107,7 +107,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      `value`, `left_result`, `right_result`, and any threaded context
      args, including mixed-shape SCCs where different predicates in the
      same group use different supported one-subtree, shared-call, or
-     guarded branch-body forms, emitted as TypR
+     guarded branch-body forms, and mixed tree/list structural SCCs
+     where tree-shaped predicates recurse through paired-forest helpers
+     while list-shaped predicates recurse through head/tail decomposition,
+     emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
      the currently supported `[]` / `[V, L, R]` shape with one tree-driving

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -79,18 +79,23 @@ mutual_recursion:compile_mutual_pattern(typr, Predicates, MemoEnabled, _MemoStra
 
 compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
-    (   maplist(typr_mutual_numeric_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_list_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_value_full_body_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_value_branch_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_value_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_body_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_context_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_branch_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_dual_spec(Predicates), Predicates, Specs)
-    ;   maplist(typr_mutual_tree_spec(Predicates), Predicates, Specs)
-    ),
+    maplist(typr_mutual_supported_spec(Predicates), Predicates, Specs),
     typr_mutual_group_code(Specs, MemoEnabled, Code).
+
+typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
+    (   typr_mutual_numeric_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_list_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_list_value_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_value_full_body_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_value_branch_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_value_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_body_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_context_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_branch_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_dual_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_tree_spec(GroupPredicates, PredArity, Spec)
+    ).
 
 typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
@@ -178,6 +183,279 @@ typr_mutual_list_base_case_length(clause(Head, true), 0) :-
 typr_mutual_list_base_case_length(clause(Head, true), 1) :-
     Head =.. [_Pred, [Elem]],
     var(Elem).
+
+typr_mutual_list_empty_base_condition(clause(Head, true), 'length(current_input) == 0') :-
+    Head =.. [_Pred, []|_].
+
+typr_mutual_list_empty_value_base_case(ContextParamNames, clause(Head, true), base_case('length(current_input) == 0', OutputExpr)) :-
+    Head =.. [_Pred, []|ContextAndOutputVars],
+    append(ContextVars, [BaseOutput], ContextAndOutputVars),
+    typr_mutual_tree_context_varmap(ContextVars, ContextParamNames, VarMap),
+    typr_translate_r_expr(BaseOutput, VarMap, OutputExpr).
+
+typr_mutual_tree_pair_expr('list(.subset2(current_input, 2), .subset2(current_input, 3))').
+
+typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, Goal0, NextPred, CallArgs) :-
+    typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, [], Goal0, NextPred, CallArgs).
+
+typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, NextPred, CallArgs) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    RecArg = [PairLeft, PairRight],
+    PairLeft == LeftVar,
+    PairRight == RightVar,
+    typr_mutual_tree_pair_expr(PairExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [PairExpr|ExtraArgExprs].
+
+typr_mutual_tree_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, NextPred, CallArgs, OutputVar) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    RecArg = [PairLeft, PairRight],
+    PairLeft == LeftVar,
+    PairRight == RightVar,
+    typr_mutual_tree_pair_expr(PairExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [PairExpr|ExtraArgExprs].
+
+typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, Goal0, CallSpec) :-
+    typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, [], Goal0, CallSpec).
+
+typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, ExtraArgMap, Goal0, call_spec(Side, NextPred, CallArgs)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    (   RecArg == HeadVar
+    ->  Side = left,
+        DriverExpr = '.subset2(current_input, 1)'
+    ;   RecArg == TailVar
+    ->  Side = right,
+        DriverExpr = 'tail(current_input, -1)'
+    ),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, HeadVar, TailVar, ExtraArgMap, Goal0, value_call_spec(Side, NextPred, CallArgs, OutputVar)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    (   RecArg == HeadVar
+    ->  Side = left,
+        DriverExpr = '.subset2(current_input, 1)'
+    ;   RecArg == TailVar
+    ->  Side = right,
+        DriverExpr = 'tail(current_input, -1)'
+    ),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_to_list_bool_spec(GroupPredicates, Pred/Arity, Spec).
+typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_to_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, [_, LeftVar, RightVar]],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [RecGoal],
+    typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, RecGoal, NextPred, [StepExpr]),
+    atom_string(Pred, PredStr),
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(NextHelperName), '~w_impl', [NextPredStr]),
+    Spec = mutual_spec{
+        kind: tree,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        next_helper_name: NextHelperName,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        step_expr: StepExpr
+    }.
+
+typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_list_empty_base_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, [HeadVar|TailVar]],
+    var(TailVar),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [GoalA, GoalB],
+    maplist(typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar), [GoalA, GoalB], GoalSpecs0),
+    select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
+    select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
+    atom_string(Pred, PredStr),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) > 0'
+    }.
+
+typr_mutual_mixed_tree_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_to_list_value_spec(GroupPredicates, Pred/Arity, Spec).
+typr_mutual_mixed_tree_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_to_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_recursive_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    RecGoals = [RecGoal],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, RecGoal, NextPred, CallArgs, PartVar),
+    atom_string(NextPred, NextPredStr),
+    format(string(NextHelperName), '~w_impl', [NextPredStr]),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_tree_condition_varmap(ValueVar, [], ExtraArgMap, ResultVarMap0),
+    typr_mutual_result_expr_from_bindings(
+        PostBody,
+        OutputVar,
+        ResultVarMap0,
+        [result_binding(PartVar, left_result)],
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        body: value_branch_leaf([value_call_binding(left, branch_call(NextHelperName, CallArgs))], ResultExpr)
+    }.
+
+typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, [HeadVar|TailVar]|ContextAndOutputVars],
+    var(TailVar),
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_list_empty_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    maplist(
+        typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, HeadVar, TailVar, ExtraArgMap),
+        RecGoals,
+        GoalSpecs0
+    ),
+    select(value_call_spec(left, LeftNextPred, LeftCallArgs, LeftOutputVar), GoalSpecs0, GoalSpecs1),
+    select(value_call_spec(right, RightNextPred, RightCallArgs, RightOutputVar), GoalSpecs1, []),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_result_expr_from_bindings(
+        PostBody,
+        OutputVar,
+        ExtraArgMap,
+        [result_binding(LeftOutputVar, left_result), result_binding(RightOutputVar, right_result)],
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) > 0',
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        result_expr: ResultExpr
+    }.
 
 typr_mutual_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity >= 2,
@@ -1287,12 +1565,19 @@ typr_mutual_tree_value_post_body_goals(PostBody, Goals) :-
 
 typr_mutual_tree_value_result_expr(PostBody, OutputVar, ValueVar, AliasMap, ExtraArgMap, LeftOutputVar, RightOutputVar, ResultExpr) :-
     typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, ResultVarMap0),
-    update_typr_expr_varmap(ResultVarMap0, LeftOutputVar, left_result, ResultVarMap1),
-    update_typr_expr_varmap(ResultVarMap1, RightOutputVar, right_result, ResultVarMap),
-    linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr).
+    typr_mutual_result_expr_from_bindings(
+        PostBody,
+        OutputVar,
+        ResultVarMap0,
+        [result_binding(LeftOutputVar, left_result), result_binding(RightOutputVar, right_result)],
+        ResultExpr
+    ).
 
 typr_mutual_tree_value_result_expr_from_bindings(PostBody, OutputVar, ValueVar, AliasMap, ExtraArgMap, ResultBindings, ResultExpr) :-
     typr_mutual_tree_condition_varmap(ValueVar, AliasMap, ExtraArgMap, ResultVarMap0),
+    typr_mutual_result_expr_from_bindings(PostBody, OutputVar, ResultVarMap0, ResultBindings, ResultExpr).
+
+typr_mutual_result_expr_from_bindings(PostBody, OutputVar, ResultVarMap0, ResultBindings, ResultExpr) :-
     foldl(typr_mutual_tree_result_binding_varmap, ResultBindings, ResultVarMap0, ResultVarMap),
     linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr).
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -3830,4 +3830,92 @@ test(recursive_compiler_supports_typr_structural_tree_dual_mutual_integer_contex
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_mixed_tree_list_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_ok([])),
+    assertz(user:(typr_tree_ok([_, L, R]) :-
+        typr_forest_ok([L, R])
+    )),
+    assertz(user:typr_forest_ok([])),
+    assertz(user:(typr_forest_ok([T|Ts]) :-
+        typr_tree_ok(T),
+        typr_forest_ok(Ts)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_ok/1, typr_tree_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_forest_ok_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_ok_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "result = typr_forest_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_sum([], 0)),
+    assertz(user:(typr_tree_sum([V, L, R], S) :-
+        typr_forest_sum([L, R], Parts),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_sum([], 0)),
+    assertz(user:(typr_forest_sum([T|Ts], S) :-
+        typr_tree_sum(T, ST),
+        typr_forest_sum(Ts, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_sum/2, typr_tree_sum/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_sum <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_forest_sum_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_sum_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_weight_sum([], _W0, 0)),
+    assertz(user:(typr_tree_weight_sum([V, L, R], W, S) :-
+        typr_forest_weight_sum([L, R], W, Parts),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_weight_sum([], _W1, 0)),
+    assertz(user:(typr_forest_weight_sum([T|Ts], W, S) :-
+        typr_tree_weight_sum(T, W, ST),
+        typr_forest_weight_sum(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_weight_sum/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_weight_sum/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_weight_sum/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_weight_sum/3, typr_tree_weight_sum/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_weight_sum <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "typr_forest_weight_sum_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_weight_sum_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_impl(tail(current_input, -1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2781,6 +2781,100 @@ test(structural_tree_dual_mutual_integer_context_asymmetric_output_checks_with_t
     retractall(user:typr_mutual_weight_even_tree_asym(_, _, _)),
     retractall(user:typr_mutual_weight_odd_tree_asym(_, _, _)).
 
+test(mixed_tree_list_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_ok([])),
+    assertz(user:(typr_tree_ok([_, L, R]) :-
+        typr_forest_ok([L, R])
+    )),
+    assertz(user:typr_forest_ok([])),
+    assertz(user:(typr_forest_ok([T|Ts]) :-
+        typr_tree_ok(T),
+        typr_forest_ok(Ts)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_ok(_)),
+    retractall(user:typr_forest_ok(_)).
+
+test(mixed_tree_list_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_sum([], 0)),
+    assertz(user:(typr_tree_sum([V, L, R], S) :-
+        typr_forest_sum([L, R], Parts),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_sum([], 0)),
+    assertz(user:(typr_forest_sum([T|Ts], S) :-
+        typr_tree_sum(T, ST),
+        typr_forest_sum(Ts, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_sum(_, _)),
+    retractall(user:typr_forest_sum(_, _)).
+
+test(mixed_tree_list_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_weight_sum([], _W0, 0)),
+    assertz(user:(typr_tree_weight_sum([V, L, R], W, S) :-
+        typr_forest_weight_sum([L, R], W, Parts),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_weight_sum([], _W1, 0)),
+    assertz(user:(typr_forest_weight_sum([T|Ts], W, S) :-
+        typr_tree_weight_sum(T, W, ST),
+        typr_forest_weight_sum(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_weight_sum/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_weight_sum/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_weight_sum/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_weight_sum(_, _, _)),
+    retractall(user:typr_forest_weight_sum(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR generalizes the native TypR mutual-recursion backend so conservative SCCs no longer require every predicate in the group to share the same structural decomposition.

Before this PR, TypR mutual recursion already covered a broad tree-structural subset, including:

- boolean tree SCCs
- integer-return tree SCCs
- mixed one-/dual-subtree tree SCCs
- threaded context arguments through those tree families

But the first real gap beyond that tree-only model was mixed tree/list structural SCCs.

Representative boolean shape that previously failed:

```prolog
typr_tree_ok([]).
typr_tree_ok([_, L, R]) :-
    typr_forest_ok([L, R]).

typr_forest_ok([]).
typr_forest_ok([T|Ts]) :-
    typr_tree_ok(T),
    typr_forest_ok(Ts).
```

Representative integer-return shape that previously failed:

```prolog
typr_tree_sum([], 0).
typr_tree_sum([V, L, R], S) :-
    typr_forest_sum([L, R], Parts),
    S is V + Parts.

typr_forest_sum([], 0).
typr_forest_sum([T|Ts], S) :-
    typr_tree_sum(T, ST),
    typr_forest_sum(Ts, SS),
    S is ST + SS.
```

Those SCCs were failing with `No mutual recursion support for target typr`.

They now lower natively and pass real `typr check`.

## Why This PR Exists

The previous SCC work had already exhausted a long run of tree-only subcases.

The next high-signal audit target was the first conservative SCC family where predicates in the same group do not share the same driver shape:

- one predicate is tree-driven
- another predicate is list-driven
- both still stay within a narrow structural recursion model

That turned out to be a real compiler gap, not just a missing regression test.

This PR fixes that gap by generalizing mutual-spec selection per predicate and reusing the existing native helper emitters, instead of adding another whole-group one-off matcher.

## Main Changes

### 1. Generalized mutual-spec selection from whole-group to per-predicate matching

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR SCC backend no longer requires the whole group to fit one narrow matcher family.

Each predicate in the SCC can now select the supported native mutual-recursion spec that matches its own structural shape.

That is the key generalization that makes mixed structural SCCs possible.

### 2. Added conservative mixed tree/list boolean SCC lowering

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

New supported boolean family:

- tree-shaped predicate recurses through a paired-forest helper over `[L, R]`
- list-shaped predicate recurses through head/tail decomposition
- native boolean rejoin stays in TypR

### 3. Added conservative mixed tree/list integer-return SCC lowering

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

New supported integer-return family:

- tree-shaped predicate recurses through a paired-forest helper and then performs a TypR-translatable arithmetic recombination
- list-shaped predicate performs head/tail recursive descent with a TypR-translatable arithmetic recombination
- threaded context arguments are carried through that same family

### 4. Reused existing helper emitters instead of adding isolated codegen paths

Updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The new mixed SCC support is built by reusing existing native helper kinds where possible:

- single-call tree helpers
- dual-call boolean helpers
- value-return mutual helper bodies
- existing memo-key and wrapper plumbing

That keeps this as a real generalization, not a special-case formatter.

### 5. Added focused target-level regression coverage

Updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

New target-level tests cover:

- mixed tree/list boolean SCCs
- mixed tree/list integer-return SCCs
- mixed tree/list integer-return SCCs with a threaded context argument

### 6. Added real toolchain validation

Updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl).

All new mixed SCC families now go through real `typr check`.

### 7. Updated TypR docs

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now explicitly state that the native TypR SCC subset includes conservative mixed tree/list structural SCCs.

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All passed.

## Scope Boundary

This is still conservative SCC lowering.

It does not attempt:

- arbitrary SCC lowering
- arbitrary generic-body lowering for mutual recursion
- mixed-driver groups that fall outside the current structural tree/list model
- a full rewrite of mutual recursion into a general SCC IR

The next real frontier is broader SCC lowering beyond the current structural-driver model, not another tree/list micro-slice.
