### PR TITLE
Generalize native TypR mixed structural branch SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,9 @@ includes:
   including mixed-shape SCCs where different predicates in the same group
   use different supported one-subtree, shared-call, or guarded
   branch-body forms, and mixed tree/list structural SCCs where tree-shaped
-  predicates recurse through paired-forest helpers while list-shaped
-  predicates recurse through head/tail decomposition,
+  predicates recurse through paired-forest helpers, including guarded
+  branch-local paired-forest call selection on the tree side, while
+  list-shaped predicates recurse through head/tail decomposition,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -237,8 +237,10 @@ bring-up.
     including mixed-shape SCCs where different predicates in the same
     group use different supported one-subtree, shared-call, or guarded
     branch-body forms, and mixed tree/list structural SCCs where
-    tree-shaped predicates recurse through paired-forest helpers while
-    list-shaped predicates recurse through head/tail decomposition
+    tree-shaped predicates recurse through paired-forest helpers,
+    including guarded branch-local paired-forest call selection on the
+    tree side, while list-shaped predicates recurse through head/tail
+    decomposition
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -419,9 +419,10 @@ Current TypR lowering policy is intentionally mixed:
   SCCs where different predicates in the same group use different
   supported one-subtree, shared-call, or guarded branch-body forms, and
   mixed tree/list structural SCCs where tree-shaped predicates recurse
-  through paired-forest helpers while list-shaped predicates recurse
-  through head/tail decomposition, using raw-expression memoized helper
-  bodies inside TypR rather than wrapped-R fallback
+  through paired-forest helpers, including guarded branch-local paired-
+  forest call selection on the tree side, while list-shaped predicates
+  recurse through head/tail decomposition, using raw-expression memoized
+  helper bodies inside TypR rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -108,8 +108,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      args, including mixed-shape SCCs where different predicates in the
      same group use different supported one-subtree, shared-call, or
      guarded branch-body forms, and mixed tree/list structural SCCs
-     where tree-shaped predicates recurse through paired-forest helpers
-     while list-shaped predicates recurse through head/tail decomposition,
+     where tree-shaped predicates recurse through paired-forest helpers,
+     including guarded branch-local paired-forest call selection on the
+     tree side, while list-shaped predicates recurse through head/tail
+     decomposition,
      emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -199,19 +199,25 @@ typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, Goal0, 
     typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, [], Goal0, NextPred, CallArgs).
 
 typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, NextPred, CallArgs) :-
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap),
+    typr_mutual_tree_pair_recursive_goal_with_aliases(GroupPredicates, AliasMap, ExtraArgMap, Goal0, NextPred, CallArgs).
+
+typr_mutual_tree_pair_recursive_goal_with_aliases(GroupPredicates, AliasMap, ExtraArgMap, Goal0, NextPred, CallArgs) :-
     typr_strip_module_goal(Goal0, Goal),
     Goal =.. [NextPred, RecArg|ExtraArgs],
     length(ExtraArgs, ExtraArity),
     Arity is ExtraArity + 1,
     memberchk(NextPred/Arity, GroupPredicates),
     RecArg = [PairLeft, PairRight],
-    PairLeft == LeftVar,
-    PairRight == RightVar,
-    typr_mutual_tree_pair_expr(PairExpr),
+    typr_mutual_tree_pair_expr(AliasMap, PairLeft, PairRight, PairExpr),
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [PairExpr|ExtraArgExprs].
 
 typr_mutual_tree_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, NextPred, CallArgs, OutputVar) :-
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap),
+    typr_mutual_tree_pair_value_recursive_goal_with_aliases(GroupPredicates, AliasMap, ExtraArgMap, Goal0, NextPred, CallArgs, OutputVar).
+
+typr_mutual_tree_pair_value_recursive_goal_with_aliases(GroupPredicates, AliasMap, ExtraArgMap, Goal0, NextPred, CallArgs, OutputVar) :-
     typr_strip_module_goal(Goal0, Goal),
     Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
     append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
@@ -220,11 +226,18 @@ typr_mutual_tree_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, E
     Arity is TailArity + 1,
     memberchk(NextPred/Arity, GroupPredicates),
     RecArg = [PairLeft, PairRight],
-    PairLeft == LeftVar,
-    PairRight == RightVar,
-    typr_mutual_tree_pair_expr(PairExpr),
+    typr_mutual_tree_pair_expr(AliasMap, PairLeft, PairRight, PairExpr),
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [PairExpr|ExtraArgExprs].
+
+typr_mutual_tree_pair_expr(AliasMap, PairLeft, PairRight, PairExpr) :-
+    typr_mutual_tree_pair_arg_expr(AliasMap, PairLeft, LeftExpr),
+    typr_mutual_tree_pair_arg_expr(AliasMap, PairRight, RightExpr),
+    format(string(PairExpr), 'list(~w, ~w)', [LeftExpr, RightExpr]).
+
+typr_mutual_tree_pair_arg_expr(AliasMap, PairArg, Expr) :-
+    typr_mutual_tree_lookup_side(PairArg, AliasMap, Side),
+    typr_mutual_tree_side_step_expr(Side, Expr).
 
 typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, Goal0, CallSpec) :-
     typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, [], Goal0, CallSpec).
@@ -280,27 +293,24 @@ typr_mutual_tree_to_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     BaseClauses \= [],
     maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
     sort(BaseConds0, BaseConditions),
-    RecHead =.. [_PredName, [_, LeftVar, RightVar]],
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]],
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
-    Goals = [RecGoal],
-    typr_mutual_tree_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, RecGoal, NextPred, [StepExpr]),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_pair_bool_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body),
     atom_string(Pred, PredStr),
-    atom_string(NextPred, NextPredStr),
     format(string(HelperName), '~w_impl', [PredStr]),
-    format(string(NextHelperName), '~w_impl', [NextPredStr]),
     Spec = mutual_spec{
-        kind: tree,
+        kind: tree_dual_body,
         pred: Pred,
         arity: Arity,
         pred_str: PredStr,
         typed_arg_list: TypedArgList,
         return_type: "bool",
         helper_name: HelperName,
-        next_helper_name: NextHelperName,
         base_conditions: BaseConditions,
         guard_expr: 'length(current_input) == 3',
-        step_expr: StepExpr
+        body: Body
     }.
 
 typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -365,21 +375,17 @@ typr_mutual_tree_to_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
-    split_typr_mutual_recursive_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
-    PreGoals == [],
-    RecGoals = [RecGoal],
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
     typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
-    typr_mutual_tree_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, RecGoal, NextPred, CallArgs, PartVar),
-    atom_string(NextPred, NextPredStr),
-    format(string(NextHelperName), '~w_impl', [NextPredStr]),
-    typr_goals_to_body(PostGoals, PostBody),
-    typr_mutual_tree_condition_varmap(ValueVar, [], ExtraArgMap, ResultVarMap0),
-    typr_mutual_result_expr_from_bindings(
-        PostBody,
+    typr_mutual_tree_pair_value_branch_body(
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap,
+        true,
         OutputVar,
-        ResultVarMap0,
-        [result_binding(PartVar, left_result)],
-        ResultExpr
+        Body
     ),
     atom_string(Pred, PredStr),
     Spec = mutual_spec{
@@ -395,7 +401,7 @@ typr_mutual_tree_to_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
         memo_key_expr: MemoKeyExpr,
         base_cases: BaseCases,
         guard_expr: 'length(current_input) == 3',
-        body: value_branch_leaf([value_call_binding(left, branch_call(NextHelperName, CallArgs))], ResultExpr)
+        body: Body
     }.
 
 typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -1556,6 +1562,85 @@ typr_mutual_tree_value_branch_post_body(BranchPostGoals, PostBody, CombinedPostB
     typr_mutual_tree_value_post_body_goals(PostBody, SharedPostGoals),
     append(BranchPostGoals, SharedPostGoals, CombinedPostGoals),
     typr_goals_to_body(CombinedPostGoals, CombinedPostBody).
+
+typr_mutual_tree_pair_bool_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+    append(PreGoals, [NestedIfGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_pair_bool_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ThenBody),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_pair_bool_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ElseBody),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, BranchConditionExpr),
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_if(BranchConditionExpr, ThenBody, ElseBody),
+        Body
+    ).
+typr_mutual_tree_pair_bool_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
+    append(PreGoals, [RecGoal], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, AliasMap, GuardExpr),
+    typr_mutual_tree_pair_recursive_goal_with_aliases(GroupPredicates, AliasMap, [], RecGoal, NextPred, CallArgs),
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]),
+    typr_mutual_tree_guard_wrap(
+        GuardExpr,
+        branch_single_call(branch_call(HelperName, CallArgs)),
+        Body
+    ).
+
+typr_mutual_tree_pair_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    append(PreGoals, [NestedIfGoal|TailPostGoals], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
+    GuardExpr == none,
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_tree_value_branch_post_body(TailPostGoals, PostBody, CombinedPostBody),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    typr_mutual_tree_pair_value_branch_body(
+        GroupPredicates,
+        ThenGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        CombinedPostBody,
+        OutputVar,
+        ThenBody
+    ),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    typr_mutual_tree_pair_value_branch_body(
+        GroupPredicates,
+        ElseGoals,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        CombinedPostBody,
+        OutputVar,
+        ElseBody
+    ),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    Body = value_branch_if(BranchConditionExpr, ThenBody, ElseBody).
+typr_mutual_tree_pair_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    append(PreGoals, [RecGoal|BranchPostGoals], Goals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
+    GuardExpr == none,
+    typr_mutual_tree_pair_value_recursive_goal_with_aliases(GroupPredicates, AliasMap, ExtraArgMap1, RecGoal, NextPred, CallArgs, PartVar),
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]),
+    typr_mutual_tree_value_branch_post_body(BranchPostGoals, PostBody, CombinedPostBody),
+    typr_mutual_tree_value_result_expr_from_bindings(
+        CombinedPostBody,
+        OutputVar,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        [result_binding(PartVar, left_result)],
+        ResultExpr
+    ),
+    Body = value_branch_leaf([value_call_binding(left, branch_call(HelperName, CallArgs))], ResultExpr).
 
 typr_mutual_tree_value_post_body_goals(true, []) :-
     !.
@@ -3272,6 +3357,9 @@ typr_mutual_tree_branch_body_lines_from(branch_guard(GuardExpr, Body), Prefix, I
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], BodyLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_from(branch_single_call(BranchCall), Prefix, _Index, [ResultLine]) :-
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(ResultLine), '~wresult = ~w;', [Prefix, CallExpr]).
 typr_mutual_tree_branch_body_lines_from(branch_steps(Steps), Prefix, Index, Lines) :-
     typr_mutual_tree_branch_steps_lines(Steps, Prefix, Index, Lines).
 typr_mutual_tree_branch_body_lines_from(branch_calls(Calls), Prefix, 1, Lines) :-
@@ -3334,6 +3422,9 @@ typr_mutual_tree_branch_body_lines_no_memo_from(branch_guard(GuardExpr, Body), P
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], BodyLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
+typr_mutual_tree_branch_body_lines_no_memo_from(branch_single_call(BranchCall), Prefix, _Index, [ResultLine]) :-
+    typr_mutual_tree_call_expr(BranchCall, CallExpr),
+    format(string(ResultLine), '~w~w', [Prefix, CallExpr]).
 typr_mutual_tree_branch_body_lines_no_memo_from(branch_steps(Steps), Prefix, Index, Lines) :-
     typr_mutual_tree_branch_steps_lines_no_memo(Steps, Prefix, Index, Lines).
 typr_mutual_tree_branch_body_lines_no_memo_from(branch_calls(Calls), Prefix, 1, Lines) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -3918,4 +3918,88 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_gro
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_mixed_tree_list_mutual_boolean_branch_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_ok_branch([])),
+    assertz(user:(typr_tree_ok_branch([V, L, R]) :-
+        ( V > 0 -> typr_forest_ok_branch([L, R]) ; typr_forest_ok_branch([R, L]) )
+    )),
+    assertz(user:typr_forest_ok_branch([])),
+    assertz(user:(typr_forest_ok_branch([T|Ts]) :-
+        typr_tree_ok_branch(T),
+        typr_forest_ok_branch(Ts)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_ok_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_ok_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_ok_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_ok_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_ok_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_ok_branch/1, typr_tree_ok_branch/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_ok_branch <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "result = typr_forest_ok_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "result = typr_forest_ok_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_branch_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_sum_branch([], 0)),
+    assertz(user:(typr_tree_sum_branch([V, L, R], S) :-
+        ( V > 0 -> typr_forest_sum_branch([L, R], Parts) ; typr_forest_sum_branch([R, L], Parts) ),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_sum_branch([], 0)),
+    assertz(user:(typr_forest_sum_branch([T|Ts], S) :-
+        typr_tree_sum_branch(T, ST),
+        typr_forest_sum_branch(Ts, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_sum_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_sum_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_sum_branch/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_sum_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_sum_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_sum_branch/2, typr_tree_sum_branch/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_sum_branch <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)));")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_branch_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_weight_sum_branch([], _W0, 0)),
+    assertz(user:(typr_tree_weight_sum_branch([V, L, R], W, S) :-
+        ( V > W -> typr_forest_weight_sum_branch([L, R], W, Parts) ; typr_forest_weight_sum_branch([R, L], W, Parts) ),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_weight_sum_branch([], _W1, 0)),
+    assertz(user:(typr_forest_weight_sum_branch([T|Ts], W, S) :-
+        typr_tree_weight_sum_branch(T, W, ST),
+        typr_forest_weight_sum_branch(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_weight_sum_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_weight_sum_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_weight_sum_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_weight_sum_branch/3, typr_tree_weight_sum_branch/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_weight_sum_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2875,6 +2875,100 @@ test(mixed_tree_list_mutual_integer_context_output_checks_with_typr, [condition(
     retractall(user:typr_tree_weight_sum(_, _, _)),
     retractall(user:typr_forest_weight_sum(_, _, _)).
 
+test(mixed_tree_list_mutual_boolean_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_ok_branch([])),
+    assertz(user:(typr_tree_ok_branch([V, L, R]) :-
+        ( V > 0 -> typr_forest_ok_branch([L, R]) ; typr_forest_ok_branch([R, L]) )
+    )),
+    assertz(user:typr_forest_ok_branch([])),
+    assertz(user:(typr_forest_ok_branch([T|Ts]) :-
+        typr_tree_ok_branch(T),
+        typr_forest_ok_branch(Ts)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_ok_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_ok_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_ok_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_ok_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_ok_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_ok_branch(_)),
+    retractall(user:typr_forest_ok_branch(_)).
+
+test(mixed_tree_list_mutual_integer_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_sum_branch([], 0)),
+    assertz(user:(typr_tree_sum_branch([V, L, R], S) :-
+        ( V > 0 -> typr_forest_sum_branch([L, R], Parts) ; typr_forest_sum_branch([R, L], Parts) ),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_sum_branch([], 0)),
+    assertz(user:(typr_forest_sum_branch([T|Ts], S) :-
+        typr_tree_sum_branch(T, ST),
+        typr_forest_sum_branch(Ts, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_sum_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_sum_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_sum_branch/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_sum_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_sum_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_sum_branch(_, _)),
+    retractall(user:typr_forest_sum_branch(_, _)).
+
+test(mixed_tree_list_mutual_integer_context_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_weight_sum_branch([], _W0, 0)),
+    assertz(user:(typr_tree_weight_sum_branch([V, L, R], W, S) :-
+        ( V > W -> typr_forest_weight_sum_branch([L, R], W, Parts) ; typr_forest_weight_sum_branch([R, L], W, Parts) ),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_weight_sum_branch([], _W1, 0)),
+    assertz(user:(typr_forest_weight_sum_branch([T|Ts], W, S) :-
+        typr_tree_weight_sum_branch(T, W, ST),
+        typr_forest_weight_sum_branch(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_weight_sum_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_weight_sum_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_weight_sum_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_weight_sum_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_weight_sum_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_weight_sum_branch(_, _, _)),
+    retractall(user:typr_forest_weight_sum_branch(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
# Generalize Native TypR Mixed Structural Branch SCCs

## Summary

This PR generalizes native TypR mutual-recursion lowering for mixed structural SCCs.

It extends the existing mixed tree/list SCC support so tree-shaped predicates are no longer limited to a bare paired-forest call. TypR now keeps conservative mixed tree/list SCCs native when the tree-side predicate uses guarded branch-local paired-forest call selection before the shared result step.

Representative supported shapes now include:

- boolean mixed tree/list SCCs such as `typr_tree_ok_branch/1` and `typr_forest_ok_branch/1`
- integer-return mixed tree/list SCCs such as `typr_tree_sum_branch/2` and `typr_forest_sum_branch/2`
- context-threaded integer-return mixed tree/list SCCs such as `typr_tree_weight_sum_branch/3` and `typr_forest_weight_sum_branch/3`

## Why This PR Exists

The prior mixed tree/list TypR path handled only the simple structural-driver case:

- tree-shaped predicates recursing through a direct paired-forest helper call
- list-shaped predicates recursing through head/tail decomposition

The first real broader-driver SCC gap was the next conservative step beyond that subset:

- the tree-shaped predicate had guarded branch-local control
- each branch selected a paired-forest call shape such as `[L, R]` versus `[R, L]`
- the SCC still remained structurally analyzable and TypR-translatable

Those shapes were still falling out of the TypR mutual-recursion backend with:

- `Error: No mutual recursion support for target typr`

This PR closes that gap without jumping to a broad arbitrary-SCC rewrite.

## Main Changes

- generalized mixed tree/list mutual-recursion matching in `src/unifyweaver/targets/typr_target.pl`
- added alias-aware paired-forest call recognition for tree-to-list recursive calls
- widened the mixed tree/list value path so integer-return and context-threaded variants reuse the existing full-body lowering path instead of another one-off backend
- reused the existing native TypR branch-body emitters so the new support stays in the same structural lowering model
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR design and implementation docs to make the broader mixed structural SCC subset explicit

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not attempt general SCC lowering.

It keeps the TypR mutual-recursion backend conservative:

- mixed structural SCCs still need analyzable driver decomposition
- this change focuses on mixed tree/list groups with guarded tree-side paired-forest call selection
- arbitrary generic-body lowering and broader non-structural SCC lowering remain out of scope
