### PR TITLE
Generalize native TypR mixed list numeric SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,11 @@ includes:
   branch-body forms, and mixed tree/list structural SCCs where tree-shaped
   predicates recurse through paired-forest helpers, including guarded
   branch-local paired-forest call selection on the tree side, while
-  list-shaped predicates recurse through head/tail decomposition,
+  list-shaped predicates recurse through head/tail decomposition, plus
+  mixed list/numeric SCCs where list-shaped predicates recurse through
+  head/tail decomposition while numeric predicates recurse through scalar
+  step descent or singleton-list re-entry, including integer-return and
+  threaded-context variants,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -240,7 +240,10 @@ bring-up.
     tree-shaped predicates recurse through paired-forest helpers,
     including guarded branch-local paired-forest call selection on the
     tree side, while list-shaped predicates recurse through head/tail
-    decomposition
+    decomposition, plus mixed list/numeric SCCs where list-shaped
+    predicates recurse through head/tail decomposition while numeric
+    predicates recurse through scalar step descent or singleton-list
+    re-entry, including integer-return and threaded-context variants
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -421,8 +421,12 @@ Current TypR lowering policy is intentionally mixed:
   mixed tree/list structural SCCs where tree-shaped predicates recurse
   through paired-forest helpers, including guarded branch-local paired-
   forest call selection on the tree side, while list-shaped predicates
-  recurse through head/tail decomposition, using raw-expression memoized
-  helper bodies inside TypR rather than wrapped-R fallback
+  recurse through head/tail decomposition, plus mixed list/numeric SCCs
+  where list-shaped predicates recurse through head/tail decomposition
+  while numeric predicates recurse through scalar step descent or
+  singleton-list re-entry, including integer-return and threaded-context
+  variants, using raw-expression memoized helper bodies inside TypR
+  rather than wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -111,7 +111,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      where tree-shaped predicates recurse through paired-forest helpers,
      including guarded branch-local paired-forest call selection on the
      tree side, while list-shaped predicates recurse through head/tail
-     decomposition,
+     decomposition, plus mixed list/numeric SCCs where list-shaped
+     predicates recurse through head/tail decomposition while numeric
+     predicates recurse through scalar step descent or singleton-list
+     re-entry, including integer-return and threaded-context variants,
      emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -84,6 +84,7 @@ compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
 
 typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
     (   typr_mutual_numeric_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_numeric_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_list_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, PredArity, Spec)
@@ -133,6 +134,67 @@ typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
         step_expr: StepExpr
     }.
 
+typr_mutual_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, HeadVar|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_numeric_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_recursive_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    RecGoals = [RecGoal],
+    partition(typr_mutual_numeric_condition_goal(HeadVar), PreGoals, Conditions, Computations),
+    maplist(typr_mutual_numeric_computation_goal, Computations),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_guard_expr(HeadVar, Conditions, GuardExpr),
+    typr_mutual_numeric_value_recursive_goal(
+        GroupPredicates,
+        HeadVar,
+        Computations,
+        ExtraArgMap,
+        RecGoal,
+        NextPred,
+        CallArgs,
+        PartVar
+    ),
+    atom_string(NextPred, NextPredStr),
+    format(string(NextHelperName), '~w_impl', [NextPredStr]),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_numeric_condition_varmap(HeadVar, ExtraArgMap, ResultVarMap0),
+    typr_mutual_result_expr_from_bindings(
+        PostBody,
+        OutputVar,
+        ResultVarMap0,
+        [result_binding(PartVar, left_result)],
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: GuardExpr,
+        body: value_branch_leaf([value_call_binding(left, branch_call(NextHelperName, CallArgs))], ResultExpr)
+    }.
+
 typr_mutual_list_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
     findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
@@ -177,6 +239,30 @@ typr_mutual_base_case_value(clause(Head, true), BaseExpr) :-
     Head =.. [_Pred, BaseValue],
     integer(BaseValue),
     typr_translate_r_expr(BaseValue, [], BaseExpr).
+
+typr_mutual_numeric_condition_goal(HeadVar, Goal) :-
+    (   Goal = (_ > _)
+    ;   Goal = (_ < _)
+    ;   Goal = (_ >= _)
+    ;   Goal = (_ =< _)
+    ;   Goal = (_ =:= _)
+    ;   Goal = (_ == _)
+    ),
+    term_variables(Goal, Vars),
+    member(V, Vars),
+    V == HeadVar.
+
+typr_mutual_numeric_computation_goal(Goal) :-
+    Goal = (_ is _).
+
+typr_mutual_numeric_value_base_case(ContextParamNames, clause(Head, true), base_case(BaseCondition, OutputExpr)) :-
+    Head =.. [_Pred, BaseValue|ContextAndOutputVars],
+    integer(BaseValue),
+    append(ContextVars, [BaseOutput], ContextAndOutputVars),
+    typr_translate_r_expr(BaseValue, [], BaseValueExpr),
+    format(string(BaseCondition), 'identical(current_input, ~w)', [BaseValueExpr]),
+    typr_mutual_tree_context_varmap(ContextVars, ContextParamNames, VarMap),
+    typr_translate_r_expr(BaseOutput, VarMap, OutputExpr).
 
 typr_mutual_list_base_case_length(clause(Head, true), 0) :-
     Head =.. [_Pred, []].
@@ -1314,15 +1400,26 @@ typr_mutual_guard_expr(HeadVar, Conditions, GuardExpr) :-
     list_to_set(Exprs0, Exprs),
     atomic_list_concat(Exprs, ' && ', GuardExpr).
 
-typr_mutual_step_expr(HeadVar, _Computations, RecArg, "current_input") :-
+typr_mutual_step_expr(HeadVar, Computations, RecArg, StepExpr) :-
+    typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, StepExpr).
+
+typr_mutual_recursive_arg_expr(HeadVar, _Computations, RecArg, "current_input") :-
     var(RecArg),
     RecArg == HeadVar,
     !.
-typr_mutual_step_expr(HeadVar, Computations, RecArg, StepExpr) :-
-    member(RecArg is StepTerm, Computations),
+typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg0, StepExpr) :-
+    nonvar(RecArg0),
+    RecArg0 = [RecArg],
+    !,
+    typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, InnerExpr),
+    format(string(StepExpr), 'list(~w)', [InnerExpr]).
+typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, StepExpr) :-
+    var(RecArg),
+    member(StepVar is StepTerm, Computations),
+    StepVar == RecArg,
     !,
     typr_translate_r_expr(StepTerm, [HeadVar-"current_input"], StepExpr).
-typr_mutual_step_expr(_HeadVar, _Computations, RecArg, StepExpr) :-
+typr_mutual_recursive_arg_expr(_HeadVar, _Computations, RecArg, StepExpr) :-
     atomic(RecArg),
     !,
     typr_translate_r_expr(RecArg, [], StepExpr).
@@ -1665,6 +1762,24 @@ typr_mutual_tree_value_result_expr_from_bindings(PostBody, OutputVar, ValueVar, 
 typr_mutual_result_expr_from_bindings(PostBody, OutputVar, ResultVarMap0, ResultBindings, ResultExpr) :-
     foldl(typr_mutual_tree_result_binding_varmap, ResultBindings, ResultVarMap0, ResultVarMap),
     linear_recursive_output_expr(PostBody, OutputVar, ResultVarMap, ResultExpr).
+
+typr_mutual_numeric_condition_varmap(HeadVar, ExtraArgMap, VarMap) :-
+    (   var(HeadVar)
+    ->  VarMap = [HeadVar-"current_input"|ExtraArgMap]
+    ;   VarMap = ExtraArgMap
+    ).
+
+typr_mutual_numeric_value_recursive_goal(GroupPredicates, HeadVar, Computations, ExtraArgMap, Goal0, NextPred, CallArgs, OutputVar) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    typr_mutual_step_expr(HeadVar, Computations, RecArg, StepExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [StepExpr|ExtraArgExprs].
 
 typr_mutual_tree_result_binding_varmap(result_binding(OutputVar, ResultName), VarMap0, VarMap) :-
     update_typr_expr_varmap(VarMap0, OutputVar, ResultName, VarMap).

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -4002,4 +4002,102 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_bra
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_list_num_ok([])),
+    assertz(user:(typr_list_num_ok([N|Ns]) :-
+        typr_num_list_ok(N),
+        typr_list_num_ok(Ns)
+    )),
+    assertz(user:typr_num_list_ok(0)),
+    assertz(user:(typr_num_list_ok(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_list_num_ok([N1])
+    )),
+    assertz(type_declarations:uw_type(typr_list_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_list_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_list_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_list_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_list_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_list_num_ok/1, typr_num_list_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_list_num_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "typr_num_list_ok_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_list_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_list_num_ok_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "result = typr_list_num_ok_impl(list((current_input + -1)));")),
+    \+ sub_string(Code, _, _, _, "result = typr_list_num_ok_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_list_num([], 0)),
+    assertz(user:(typr_mutual_sum_list_num([N|Ns], S) :-
+        typr_mutual_sum_num_list(N, SN),
+        typr_mutual_sum_list_num(Ns, SS),
+        S is SN + SS
+    )),
+    assertz(user:typr_mutual_sum_num_list(0, 0)),
+    assertz(user:(typr_mutual_sum_num_list(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_mutual_sum_list_num([N1], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_list_num/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_list_num/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_num_list/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_num_list/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_list_num/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_num_list/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_list_num/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_list_num/2, typr_mutual_sum_num_list/2")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_sum_list_num <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_sum_num_list_impl <- function(current_input) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_num_list_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_list_num_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_list_num_impl(list((current_input + -1)));")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_sum_list_num_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_list_num([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_list_num([N|Ns], W, S) :-
+        typr_mutual_weight_num_list(N, W, SN),
+        typr_mutual_weight_list_num(Ns, W, SS),
+        S is SN + SS
+    )),
+    assertz(user:typr_mutual_weight_num_list(0, _W1, 0)),
+    assertz(user:(typr_mutual_weight_num_list(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_mutual_weight_list_num([N1], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_list_num/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_list_num/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_list_num/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_num_list/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_num_list/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_num_list/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_list_num/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_num_list/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_list_num/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_weight_list_num/3, typr_mutual_weight_num_list/3")),
+    once(sub_string(Code, _, _, _, "let typr_mutual_weight_list_num <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "typr_mutual_weight_num_list_impl <- function(current_input, current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_num_list_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_list_num_impl(tail(current_input, -1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_list_num_impl(list((current_input + -1)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_weight_list_num_impl((current_input + -1), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -2969,6 +2969,106 @@ test(mixed_tree_list_mutual_integer_context_branch_output_checks_with_typr, [con
     retractall(user:typr_tree_weight_sum_branch(_, _, _)),
     retractall(user:typr_forest_weight_sum_branch(_, _, _)).
 
+test(mixed_list_numeric_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_list_num_ok([])),
+    assertz(user:(typr_list_num_ok([N|Ns]) :-
+        typr_num_list_ok(N),
+        typr_list_num_ok(Ns)
+    )),
+    assertz(user:typr_num_list_ok(0)),
+    assertz(user:(typr_num_list_ok(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_list_num_ok([N1])
+    )),
+    assertz(type_declarations:uw_type(typr_list_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_list_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_list_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_list_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_list_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_list_num_ok(_)),
+    retractall(user:typr_num_list_ok(_)).
+
+test(mixed_list_numeric_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_sum_list_num([], 0)),
+    assertz(user:(typr_mutual_sum_list_num([N|Ns], S) :-
+        typr_mutual_sum_num_list(N, SN),
+        typr_mutual_sum_list_num(Ns, SS),
+        S is SN + SS
+    )),
+    assertz(user:typr_mutual_sum_num_list(0, 0)),
+    assertz(user:(typr_mutual_sum_num_list(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_mutual_sum_list_num([N1], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_sum_list_num/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_sum_list_num/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_num_list/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_sum_num_list/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_list_num/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_sum_num_list/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_sum_list_num/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_sum_list_num(_, _)),
+    retractall(user:typr_mutual_sum_num_list(_, _)).
+
+test(mixed_list_numeric_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_mutual_weight_list_num([], _W0, 0)),
+    assertz(user:(typr_mutual_weight_list_num([N|Ns], W, S) :-
+        typr_mutual_weight_num_list(N, W, SN),
+        typr_mutual_weight_list_num(Ns, W, SS),
+        S is SN + SS
+    )),
+    assertz(user:typr_mutual_weight_num_list(0, _W1, 0)),
+    assertz(user:(typr_mutual_weight_num_list(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_mutual_weight_list_num([N1], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_mutual_weight_list_num/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_mutual_weight_list_num/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_list_num/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_num_list/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_num_list/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_mutual_weight_num_list/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_list_num/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_mutual_weight_num_list/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_mutual_weight_list_num/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_mutual_weight_list_num(_, _, _)),
+    retractall(user:typr_mutual_weight_num_list(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR generalizes native TypR mutual-recursion lowering for mixed list/numeric SCCs.

It extends the current SCC backend so list-shaped predicates and numeric predicates can stay native in the same mutual-recursion group when the numeric side re-enters the list side through a singleton-list wrapper.

Representative supported shapes now include:

- boolean mixed list/numeric SCCs such as `typr_list_num_ok/1` and `typr_num_list_ok/1`
- integer-return mixed list/numeric SCCs such as `typr_mutual_sum_list_num/2` and `typr_mutual_sum_num_list/2`
- context-threaded integer-return mixed list/numeric SCCs such as `typr_mutual_weight_list_num/3` and `typr_mutual_weight_num_list/3`

## Why This PR Exists

The SCC audit found a real gap beyond the current structural tree/list surface:

- list-shaped predicates recursing through head/tail decomposition already worked
- numeric predicates recursing through scalar step descent already worked
- but mixed list/numeric SCCs were not preserving singleton-list re-entry on the numeric side

That meant the emitted TypR could silently drop the list wrapper and call the list-side helper with a scalar expression instead of `list(step_expr)`.

This PR fixes that at the shared mutual-call expression layer instead of adding another one-off backend.

## Main Changes

- generalized recursive-call argument lowering in `src/unifyweaver/targets/typr_target.pl` so wrapped driver shapes like singleton-list re-entry are preserved across mutual-recursion paths
- made the numeric value matcher self-contained by replacing non-imported helper usage with local TypR-target helpers
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR support docs to explicitly include mixed list/numeric SCCs

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not attempt broad arbitrary SCC lowering.

It keeps the TypR mutual-recursion backend conservative:

- mixed list/numeric SCCs still need analyzable recursive-call structure
- this change focuses on preserving wrapped driver expressions like singleton-list re-entry across the existing mutual-recursion lowering paths
- broader generic-body SCC lowering remains out of scope
