### PR TITLE
Generalize native TypR mixed tree numeric SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,10 @@ includes:
   list-shaped predicates recurse through head/tail decomposition, plus
   mixed list/numeric SCCs where list-shaped predicates recurse through
   head/tail decomposition while numeric predicates recurse through scalar
-  step descent or singleton-list re-entry, including integer-return and
+  step descent or singleton-list re-entry, plus mixed tree/numeric SCCs
+  where tree-shaped predicates recurse through current-value and one-
+  subtree descent while numeric predicates recurse through scalar step
+  descent or constructed tree re-entry, including integer-return and
   threaded-context variants,
   lowered to TypR
   functions that use raw-expression

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -243,6 +243,9 @@ bring-up.
     decomposition, plus mixed list/numeric SCCs where list-shaped
     predicates recurse through head/tail decomposition while numeric
     predicates recurse through scalar step descent or singleton-list
+    re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates
+    recurse through current-value and one-subtree descent while numeric
+    predicates recurse through scalar step descent or constructed tree
     re-entry, including integer-return and threaded-context variants
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -424,9 +424,12 @@ Current TypR lowering policy is intentionally mixed:
   recurse through head/tail decomposition, plus mixed list/numeric SCCs
   where list-shaped predicates recurse through head/tail decomposition
   while numeric predicates recurse through scalar step descent or
-  singleton-list re-entry, including integer-return and threaded-context
-  variants, using raw-expression memoized helper bodies inside TypR
-  rather than wrapped-R fallback
+  singleton-list re-entry, plus mixed tree/numeric SCCs where tree-shaped
+  predicates recurse through current-value and one-subtree descent while
+  numeric predicates recurse through scalar step descent or constructed
+  tree re-entry, including integer-return and threaded-context variants,
+  using raw-expression memoized helper bodies inside TypR rather than
+  wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -114,6 +114,9 @@ This document focuses on architecture and rollout choices specific to TypR.
      decomposition, plus mixed list/numeric SCCs where list-shaped
      predicates recurse through head/tail decomposition while numeric
      predicates recurse through scalar step descent or singleton-list
+     re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates
+     recurse through current-value and one-subtree descent while numeric
+     predicates recurse through scalar step descent or constructed tree
      re-entry, including integer-return and threaded-context variants,
      emitted as TypR
      functions with raw-expression memoized helper bodies

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -86,6 +86,8 @@ typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
     (   typr_mutual_numeric_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_numeric_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_list_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_numeric_value_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_numeric_bool_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_tree_dual_value_full_body_spec(GroupPredicates, PredArity, Spec)
@@ -361,6 +363,150 @@ typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, HeadVar, TailVa
     ),
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_tree_value_subtree_driver_expr(ValueVar, _AliasMap, RecArg, left, '.subset2(current_input, 1)') :-
+    var(RecArg),
+    RecArg == ValueVar,
+    !.
+typr_mutual_tree_value_subtree_driver_expr(_ValueVar, AliasMap, RecArg, right, DriverExpr) :-
+    typr_mutual_tree_lookup_side(RecArg, AliasMap, Side),
+    typr_mutual_tree_side_step_expr(Side, DriverExpr).
+
+typr_mutual_tree_value_subtree_recursive_goal(GroupPredicates, ValueVar, AliasMap, ExtraArgMap, Goal0, call_spec(Side, NextPred, CallArgs)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    typr_mutual_tree_value_subtree_driver_expr(ValueVar, AliasMap, RecArg, Side, DriverExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_tree_value_subtree_value_recursive_goal(GroupPredicates, ValueVar, AliasMap, ExtraArgMap, Goal0, value_call_spec(Side, NextPred, CallArgs, OutputVar)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    typr_mutual_tree_value_subtree_driver_expr(ValueVar, AliasMap, RecArg, Side, DriverExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_mixed_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    PostGoals == [],
+    AliasMap = [LeftVar-left, RightVar-right],
+    maplist(
+        typr_mutual_tree_value_subtree_recursive_goal(GroupPredicates, ValueVar, AliasMap, []),
+        RecGoals,
+        GoalSpecs0
+    ),
+    select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
+    select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
+    atom_string(Pred, PredStr),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3'
+    }.
+
+typr_mutual_mixed_tree_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_numeric_value_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    AliasMap = [LeftVar-left, RightVar-right],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    maplist(
+        typr_mutual_tree_value_subtree_value_recursive_goal(GroupPredicates, ValueVar, AliasMap, ExtraArgMap),
+        RecGoals,
+        GoalSpecs0
+    ),
+    select(value_call_spec(left, LeftNextPred, LeftCallArgs, LeftOutputVar), GoalSpecs0, GoalSpecs1),
+    select(value_call_spec(right, RightNextPred, RightCallArgs, RightOutputVar), GoalSpecs1, []),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_tree_value_result_expr(
+        PostBody,
+        OutputVar,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap,
+        LeftOutputVar,
+        RightOutputVar,
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        result_expr: ResultExpr
+    }.
 
 typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_tree_to_list_bool_spec(GroupPredicates, Pred/Arity, Spec).
@@ -1413,6 +1559,12 @@ typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg0, StepExpr) :-
     !,
     typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, InnerExpr),
     format(string(StepExpr), 'list(~w)', [InnerExpr]).
+typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg0, StepExpr) :-
+    nonvar(RecArg0),
+    RecArg0 = [RecArg, [], []],
+    !,
+    typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, InnerExpr),
+    format(string(StepExpr), 'list(~w, list(), list())', [InnerExpr]).
 typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, StepExpr) :-
     var(RecArg),
     member(StepVar is StepTerm, Computations),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -4100,4 +4100,99 @@ test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_integer_context_
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_ok([])),
+    assertz(user:(typr_tree_num_ok([V, L, _]) :-
+        typr_num_tree_ok(V),
+        typr_tree_num_ok(L)
+    )),
+    assertz(user:typr_num_tree_ok(0)),
+    assertz(user:(typr_num_tree_ok(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_ok([N1, [], []])
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_tree_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_ok/1, typr_tree_num_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_num_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_tree_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_ok_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = typr_tree_num_ok_impl(list((current_input + -1), list(), list()));")),
+    \+ sub_string(Code, _, _, _, "result = typr_tree_num_ok_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_sum([], 0)),
+    assertz(user:(typr_tree_num_sum([V, L, _], S) :-
+        typr_num_tree_sum(V, SV),
+        typr_tree_num_sum(L, SL),
+        S is SV + SL
+    )),
+    assertz(user:typr_num_tree_sum(0, 0)),
+    assertz(user:(typr_num_tree_sum(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_sum([N1, [], []], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_sum/2, typr_tree_num_sum/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_num_sum <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_tree_sum_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_sum_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_num_sum_impl(list((current_input + -1), list(), list()));")),
+    once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_sum_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_weight([], _W0, 0)),
+    assertz(user:(typr_tree_num_weight([V, L, _], W, S) :-
+        typr_num_tree_weight(V, W, SV),
+        typr_tree_num_weight(L, W, SL),
+        S is SV + SL
+    )),
+    assertz(user:typr_num_tree_weight(0, _W1, 0)),
+    assertz(user:(typr_num_tree_weight(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_weight([N1, [], []], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_weight/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_weight/3, typr_tree_num_weight/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_num_weight <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_tree_weight_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_weight_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_impl(list((current_input + -1), list(), list()), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_impl((current_input + -1), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -3069,6 +3069,106 @@ test(mixed_list_numeric_mutual_integer_context_output_checks_with_typr, [conditi
     retractall(user:typr_mutual_weight_list_num(_, _, _)),
     retractall(user:typr_mutual_weight_num_list(_, _, _)).
 
+test(mixed_tree_numeric_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_ok([])),
+    assertz(user:(typr_tree_num_ok([V, L, _]) :-
+        typr_num_tree_ok(V),
+        typr_tree_num_ok(L)
+    )),
+    assertz(user:typr_num_tree_ok(0)),
+    assertz(user:(typr_num_tree_ok(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_ok([N1, [], []])
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_tree_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_num_ok(_)),
+    retractall(user:typr_num_tree_ok(_)).
+
+test(mixed_tree_numeric_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_sum([], 0)),
+    assertz(user:(typr_tree_num_sum([V, L, _], S) :-
+        typr_num_tree_sum(V, SV),
+        typr_tree_num_sum(L, SL),
+        S is SV + SL
+    )),
+    assertz(user:typr_num_tree_sum(0, 0)),
+    assertz(user:(typr_num_tree_sum(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_sum([N1, [], []], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_num_sum(_, _)),
+    retractall(user:typr_num_tree_sum(_, _)).
+
+test(mixed_tree_numeric_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_weight([], _W0, 0)),
+    assertz(user:(typr_tree_num_weight([V, L, _], W, S) :-
+        typr_num_tree_weight(V, W, SV),
+        typr_tree_num_weight(L, W, SL),
+        S is SV + SL
+    )),
+    assertz(user:typr_num_tree_weight(0, _W1, 0)),
+    assertz(user:(typr_num_tree_weight(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_weight([N1, [], []], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_weight/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_num_weight(_, _, _)),
+    retractall(user:typr_num_tree_weight(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR generalizes native TypR mutual-recursion lowering for mixed tree/numeric SCCs.

It extends the current SCC backend so tree-shaped predicates and numeric predicates can stay native in the same mutual-recursion group when the tree side recurses through current-value plus one-subtree descent and the numeric side re-enters the tree side through a constructed tree wrapper.

Representative supported shapes now include:

- boolean mixed tree/numeric SCCs such as `typr_tree_num_ok/1` and `typr_num_tree_ok/1`
- integer-return mixed tree/numeric SCCs such as `typr_tree_num_sum/2` and `typr_num_tree_sum/2`
- context-threaded integer-return mixed tree/numeric SCCs such as `typr_tree_num_weight/3` and `typr_num_tree_weight/3`

## Why This PR Exists

The SCC audit found a real gap beyond the current structural-driver subset:

- tree-shaped predicates recursing through conservative tree drivers already worked
- numeric predicates recursing through scalar step descent already worked
- mixed list/numeric SCCs already preserved singleton-list re-entry
- but mixed tree/numeric SCCs were still not preserving constructed tree re-entry on the numeric side, and the tree side had no matching mixed tree/numeric path

That meant conservative mixed tree/numeric SCCs were still failing with:

- `Error: No mutual recursion support for target typr`

This PR fixes that at the shared mutual-recursion layer instead of adding another isolated one-off backend.

## Main Changes

- added mixed tree/numeric mutual-recursion spec selection in `src/unifyweaver/targets/typr_target.pl`
- added shared tree-side lowering for current-value plus one-subtree recursive drivers
- generalized shared recursive-call argument lowering so numeric mutual paths preserve constructed tree re-entry like `list(step_expr, list(), list())`
- kept the same native TypR mutual backend model across boolean, integer-return, and threaded-context variants
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR support docs to explicitly include mixed tree/numeric SCCs

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not attempt broad arbitrary SCC lowering.

It keeps the TypR mutual-recursion backend conservative:

- mixed tree/numeric SCCs still need analyzable recursive-call structure
- this change focuses on tree-shaped predicates with current-value plus one-subtree descent and numeric predicates with scalar step descent plus constructed tree re-entry
- arbitrary generic-body lowering and broader non-structural SCC lowering remain out of scope
