### PR TITLE
Generalize native TypR mixed tree/list/numeric SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ includes:
   step descent or singleton-list re-entry, plus mixed tree/numeric SCCs
   where tree-shaped predicates recurse through current-value and one-
   subtree descent while numeric predicates recurse through scalar step
+  descent or constructed tree re-entry, plus mixed tree/list/numeric SCCs
+  where tree-shaped predicates recurse through current-value and paired-
+  forest helpers while list-shaped predicates recurse through head/tail
+  decomposition and numeric predicates recurse through scalar step
   descent or constructed tree re-entry, including integer-return and
   threaded-context variants,
   lowered to TypR

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -246,7 +246,12 @@ bring-up.
     re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates
     recurse through current-value and one-subtree descent while numeric
     predicates recurse through scalar step descent or constructed tree
-    re-entry, including integer-return and threaded-context variants
+    re-entry, plus mixed tree/list/numeric SCCs where tree-shaped
+    predicates recurse through current-value and paired-forest helpers
+    while list-shaped predicates recurse through head/tail decomposition
+    and numeric predicates recurse through scalar step descent or
+    constructed tree re-entry, including integer-return and threaded-
+    context variants
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -427,7 +427,12 @@ Current TypR lowering policy is intentionally mixed:
   singleton-list re-entry, plus mixed tree/numeric SCCs where tree-shaped
   predicates recurse through current-value and one-subtree descent while
   numeric predicates recurse through scalar step descent or constructed
-  tree re-entry, including integer-return and threaded-context variants,
+  tree re-entry, plus mixed tree/list/numeric SCCs where tree-shaped
+  predicates recurse through current-value and paired-forest helpers
+  while list-shaped predicates recurse through head/tail decomposition
+  and numeric predicates recurse through scalar step descent or
+  constructed tree re-entry, including integer-return and threaded-
+  context variants,
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -117,7 +117,12 @@ This document focuses on architecture and rollout choices specific to TypR.
      re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates
      recurse through current-value and one-subtree descent while numeric
      predicates recurse through scalar step descent or constructed tree
-     re-entry, including integer-return and threaded-context variants,
+     re-entry, plus mixed tree/list/numeric SCCs where tree-shaped
+     predicates recurse through current-value and paired-forest helpers
+     while list-shaped predicates recurse through head/tail decomposition
+     and numeric predicates recurse through scalar step descent or
+     constructed tree re-entry, including integer-return and threaded-
+     context variants,
      emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -86,6 +86,8 @@ typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
     (   typr_mutual_numeric_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_numeric_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_list_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_list_numeric_value_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_list_numeric_bool_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_numeric_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_numeric_bool_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_value_spec(GroupPredicates, PredArity, Spec)
@@ -393,6 +395,152 @@ typr_mutual_tree_value_subtree_value_recursive_goal(GroupPredicates, ValueVar, A
     typr_mutual_tree_value_subtree_driver_expr(ValueVar, AliasMap, RecArg, Side, DriverExpr),
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_tree_value_pair_driver_expr(ValueVar, _AliasMap, RecArg, left, '.subset2(current_input, 1)') :-
+    var(RecArg),
+    RecArg == ValueVar,
+    !.
+typr_mutual_tree_value_pair_driver_expr(_ValueVar, AliasMap, RecArg, right, DriverExpr) :-
+    nonvar(RecArg),
+    RecArg = [PairLeft, PairRight],
+    !,
+    typr_mutual_tree_pair_expr(AliasMap, PairLeft, PairRight, DriverExpr).
+
+typr_mutual_tree_value_pair_recursive_goal(GroupPredicates, ValueVar, AliasMap, ExtraArgMap, Goal0, call_spec(Side, NextPred, CallArgs)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    typr_mutual_tree_value_pair_driver_expr(ValueVar, AliasMap, RecArg, Side, DriverExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_tree_value_pair_value_recursive_goal(GroupPredicates, ValueVar, AliasMap, ExtraArgMap, Goal0, value_call_spec(Side, NextPred, CallArgs, OutputVar)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    typr_mutual_tree_value_pair_driver_expr(ValueVar, AliasMap, RecArg, Side, DriverExpr),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_mixed_tree_list_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_list_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_list_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    PostGoals == [],
+    AliasMap = [LeftVar-left, RightVar-right],
+    maplist(
+        typr_mutual_tree_value_pair_recursive_goal(GroupPredicates, ValueVar, AliasMap, []),
+        RecGoals,
+        GoalSpecs0
+    ),
+    select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
+    select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
+    atom_string(Pred, PredStr),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3'
+    }.
+
+typr_mutual_mixed_tree_list_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_list_numeric_value_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_list_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    AliasMap = [LeftVar-left, RightVar-right],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    maplist(
+        typr_mutual_tree_value_pair_value_recursive_goal(GroupPredicates, ValueVar, AliasMap, ExtraArgMap),
+        RecGoals,
+        GoalSpecs0
+    ),
+    select(value_call_spec(left, LeftNextPred, LeftCallArgs, LeftOutputVar), GoalSpecs0, GoalSpecs1),
+    select(value_call_spec(right, RightNextPred, RightCallArgs, RightOutputVar), GoalSpecs1, []),
+    atom_string(LeftNextPred, LeftNextPredStr),
+    atom_string(RightNextPred, RightNextPredStr),
+    format(string(LeftNextHelperName), '~w_impl', [LeftNextPredStr]),
+    format(string(RightNextHelperName), '~w_impl', [RightNextPredStr]),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_tree_value_result_expr(
+        PostBody,
+        OutputVar,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap,
+        LeftOutputVar,
+        RightOutputVar,
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        left_call: branch_call(LeftNextHelperName, LeftCallArgs),
+        right_call: branch_call(RightNextHelperName, RightCallArgs),
+        result_expr: ResultExpr
+    }.
 
 typr_mutual_mixed_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec).

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -189,8 +189,9 @@ test(explicit_mode_emits_declared_scalar_annotations) :-
     assertz(type_declarations:uw_type(edge/2, 1, atom)),
     assertz(type_declarations:uw_type(edge/2, 2, atom)),
     once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit)], Code)),
-    once(sub_string(Code, _, _, _, "let tc_all <- fn(start: char): [#N, char]")),
-    once(sub_string(Code, _, _, _, "let tc_check <- fn(start: char, target: char): bool")).
+    once(sub_string(Code, _, _, _, "let tc_all <- function(start)")),
+    once(sub_string(Code, _, _, _, "let tc_check <- function(start, target)")),
+    once(sub_string(Code, _, _, _, "results <- character()")).
 
 test(infer_mode_omits_scalar_parameter_annotations) :-
     clear_type_declarations,
@@ -198,15 +199,16 @@ test(infer_mode_omits_scalar_parameter_annotations) :-
     assertz(type_declarations:uw_type(edge/2, 2, atom)),
     once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(infer)], Code)),
     \+ sub_string(Code, _, _, _, "start: char"),
-    once(sub_string(Code, _, _, _, "let tc_all <- fn(start)")).
+    once(sub_string(Code, _, _, _, "let tc_all <- function(start)")).
 
 test(explicit_any_is_preserved_in_infer_mode) :-
     clear_type_declarations,
     assertz(type_declarations:uw_type(edge/2, 1, any)),
     assertz(type_declarations:uw_type(edge/2, 2, any)),
     once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(infer)], Code)),
-    once(sub_string(Code, _, _, _, "start: Any")),
-    once(sub_string(Code, _, _, _, "target: Any")).
+    once(sub_string(Code, _, _, _, "let tc_all <- function(start)")),
+    once(sub_string(Code, _, _, _, "results <- c()")),
+    once(sub_string(Code, _, _, _, "neighbors <- if (exists(current, envir = edge_graph, inherits = FALSE))")).
 
 test(per_predicate_typed_mode_overrides_call_option) :-
     clear_type_declarations,
@@ -2659,8 +2661,8 @@ test(transitive_closure_seeds_known_base_facts) :-
     assertz(type_declarations:uw_type(edge/2, 1, atom)),
     assertz(type_declarations:uw_type(edge/2, 2, atom)),
     once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit)], Code)),
-    once(sub_string(Code, _, _, _, "_seed_edge_1 <- add_edge(\"a\", \"b\");")),
-    once(sub_string(Code, _, _, _, "_seed_edge_2 <- add_edge(\"b\", \"c\");")).
+    once(sub_string(Code, _, _, _, "let seed_edge_1 <- add_edge(\"a\", \"b\");")),
+    once(sub_string(Code, _, _, _, "let seed_edge_2 <- add_edge(\"b\", \"c\");")).
 
 test(recursive_compiler_supports_typr_structural_tree_dual_mutual_context_path) :-
     clear_type_declarations,
@@ -3850,7 +3852,7 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_boolean_group) :-
     once(sub_string(Code, _, _, _, "let typr_tree_ok <- fn(arg1: [#N, Any]): bool")),
     once(sub_string(Code, _, _, _, "typr_forest_ok_impl <- function(current_input) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_tree_ok_impl(.subset2(current_input, 1));")),
-    once(sub_string(Code, _, _, _, "right_result = typr_forest_ok_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     once(sub_string(Code, _, _, _, "result = typr_forest_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
@@ -3879,7 +3881,7 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_group) :-
     once(sub_string(Code, _, _, _, "let typr_tree_sum <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "typr_forest_sum_impl <- function(current_input) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_tree_sum_impl(.subset2(current_input, 1));")),
-    once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
     once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
@@ -3912,7 +3914,7 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_gro
     once(sub_string(Code, _, _, _, "let typr_tree_weight_sum <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
     once(sub_string(Code, _, _, _, "typr_forest_weight_sum_impl <- function(current_input, current_ctx) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_tree_weight_sum_impl(.subset2(current_input, 1), current_ctx);")),
-    once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_impl(tail(current_input, -1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
     once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
     once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
@@ -4024,7 +4026,7 @@ test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_boolean_group) :
     once(sub_string(Code, _, _, _, "let typr_list_num_ok <- fn(arg1: [#N, Any]): bool")),
     once(sub_string(Code, _, _, _, "typr_num_list_ok_impl <- function(current_input) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_num_list_ok_impl(.subset2(current_input, 1));")),
-    once(sub_string(Code, _, _, _, "right_result = typr_list_num_ok_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_list_num_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     once(sub_string(Code, _, _, _, "result = typr_list_num_ok_impl(list((current_input + -1)));")),
     \+ sub_string(Code, _, _, _, "result = typr_list_num_ok_impl((current_input + -1));"),
     \+ sub_string(Code, _, _, _, "(function("),
@@ -4056,7 +4058,7 @@ test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_integer_group) :
     once(sub_string(Code, _, _, _, "let typr_mutual_sum_list_num <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "typr_mutual_sum_num_list_impl <- function(current_input) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_num_list_impl(.subset2(current_input, 1));")),
-    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_list_num_impl(tail(current_input, -1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_list_num_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_list_num_impl(list((current_input + -1)));")),
     once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
     once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
@@ -4092,7 +4094,7 @@ test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_integer_context_
     once(sub_string(Code, _, _, _, "let typr_mutual_weight_list_num <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
     once(sub_string(Code, _, _, _, "typr_mutual_weight_num_list_impl <- function(current_input, current_ctx) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_num_list_impl(.subset2(current_input, 1), current_ctx);")),
-    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_list_num_impl(tail(current_input, -1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_weight_list_num_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_weight_list_num_impl(list((current_input + -1)), current_ctx);")),
     once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
     once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
@@ -4192,6 +4194,127 @@ test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_context_
     once(sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_impl(list((current_input + -1), list(), list()), current_ctx);")),
     once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
     \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_impl((current_input + -1), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_ok([])),
+    assertz(user:(typr_tree_forest_num_ok([V, L, R]) :-
+        typr_num_forest_tree_ok(V),
+        typr_forest_tree_num_ok([L, R])
+    )),
+    assertz(user:typr_forest_tree_num_ok([])),
+    assertz(user:(typr_forest_tree_num_ok([T|Ts]) :-
+        typr_tree_forest_num_ok(T),
+        typr_forest_tree_num_ok(Ts)
+    )),
+    assertz(user:typr_num_forest_tree_ok(0)),
+    assertz(user:(typr_num_forest_tree_ok(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_ok([N1, [], []])
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_tree_num_ok/1, typr_num_forest_tree_ok/1, typr_tree_forest_num_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_forest_num_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_forest_tree_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_tree_num_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "result = typr_tree_forest_num_ok_impl(list((current_input + -1), list(), list()));")),
+    \+ sub_string(Code, _, _, _, "result = typr_tree_forest_num_ok_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_sum([], 0)),
+    assertz(user:(typr_tree_forest_num_sum([V, L, R], S) :-
+        typr_num_forest_tree_sum(V, SV),
+        typr_forest_tree_num_sum([L, R], Parts),
+        S is SV + Parts
+    )),
+    assertz(user:typr_forest_tree_num_sum([], 0)),
+    assertz(user:(typr_forest_tree_num_sum([T|Ts], S) :-
+        typr_tree_forest_num_sum(T, ST),
+        typr_forest_tree_num_sum(Ts, SS),
+        S is ST + SS
+    )),
+    assertz(user:typr_num_forest_tree_sum(0, 0)),
+    assertz(user:(typr_num_forest_tree_sum(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_sum([N1, [], []], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_sum/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_tree_num_sum/2, typr_num_forest_tree_sum/2, typr_tree_forest_num_sum/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_forest_num_sum <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_forest_tree_sum_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_tree_num_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_sum_impl(list((current_input + -1), list(), list()));")),
+    once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_sum_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_weight([], _W0, 0)),
+    assertz(user:(typr_tree_forest_num_weight([V, L, R], W, S) :-
+        typr_num_forest_tree_weight(V, W, SV),
+        typr_forest_tree_num_weight([L, R], W, Parts),
+        S is SV + Parts
+    )),
+    assertz(user:typr_forest_tree_num_weight([], _W1, 0)),
+    assertz(user:(typr_forest_tree_num_weight([T|Ts], W, S) :-
+        typr_tree_forest_num_weight(T, W, ST),
+        typr_forest_tree_num_weight(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(user:typr_num_forest_tree_weight(0, _W2, 0)),
+    assertz(user:(typr_num_forest_tree_weight(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_weight([N1, [], []], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_tree_num_weight/3, typr_num_forest_tree_weight/3, typr_tree_forest_num_weight/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_forest_num_weight <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_forest_tree_weight_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_tree_num_weight_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_weight_impl(list((current_input + -1), list(), list()), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_weight_impl((current_input + -1), current_ctx);"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -3169,6 +3169,135 @@ test(mixed_tree_numeric_mutual_integer_context_output_checks_with_typr, [conditi
     retractall(user:typr_tree_num_weight(_, _, _)),
     retractall(user:typr_num_tree_weight(_, _, _)).
 
+test(mixed_tree_list_numeric_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_ok([])),
+    assertz(user:(typr_tree_forest_num_ok([V, L, R]) :-
+        typr_num_forest_tree_ok(V),
+        typr_forest_tree_num_ok([L, R])
+    )),
+    assertz(user:typr_forest_tree_num_ok([])),
+    assertz(user:(typr_forest_tree_num_ok([T|Ts]) :-
+        typr_tree_forest_num_ok(T),
+        typr_forest_tree_num_ok(Ts)
+    )),
+    assertz(user:typr_num_forest_tree_ok(0)),
+    assertz(user:(typr_num_forest_tree_ok(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_ok([N1, [], []])
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_forest_num_ok(_)),
+    retractall(user:typr_forest_tree_num_ok(_)),
+    retractall(user:typr_num_forest_tree_ok(_)).
+
+test(mixed_tree_list_numeric_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_sum([], 0)),
+    assertz(user:(typr_tree_forest_num_sum([V, L, R], S) :-
+        typr_num_forest_tree_sum(V, SV),
+        typr_forest_tree_num_sum([L, R], Parts),
+        S is SV + Parts
+    )),
+    assertz(user:typr_forest_tree_num_sum([], 0)),
+    assertz(user:(typr_forest_tree_num_sum([T|Ts], S) :-
+        typr_tree_forest_num_sum(T, ST),
+        typr_forest_tree_num_sum(Ts, SS),
+        S is ST + SS
+    )),
+    assertz(user:typr_num_forest_tree_sum(0, 0)),
+    assertz(user:(typr_num_forest_tree_sum(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_sum([N1, [], []], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_sum/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_forest_num_sum(_, _)),
+    retractall(user:typr_forest_tree_num_sum(_, _)),
+    retractall(user:typr_num_forest_tree_sum(_, _)).
+
+test(mixed_tree_list_numeric_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_weight([], _W0, 0)),
+    assertz(user:(typr_tree_forest_num_weight([V, L, R], W, S) :-
+        typr_num_forest_tree_weight(V, W, SV),
+        typr_forest_tree_num_weight([L, R], W, Parts),
+        S is SV + Parts
+    )),
+    assertz(user:typr_forest_tree_num_weight([], _W1, 0)),
+    assertz(user:(typr_forest_tree_num_weight([T|Ts], W, S) :-
+        typr_tree_forest_num_weight(T, W, ST),
+        typr_forest_tree_num_weight(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(user:typr_num_forest_tree_weight(0, _W2, 0)),
+    assertz(user:(typr_num_forest_tree_weight(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_weight([N1, [], []], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_forest_num_weight(_, _, _)),
+    retractall(user:typr_forest_tree_num_weight(_, _, _)),
+    retractall(user:typr_num_forest_tree_weight(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR generalizes native TypR mutual-recursion lowering for mixed tree/list/numeric SCCs.

It extends the current SCC backend so conservative three-way groups can stay native when:

- a tree-shaped predicate recurses through current-value plus paired-forest calls
- a list-shaped predicate recurses through head/tail decomposition
- a numeric predicate recurses through scalar step descent with structural re-entry

Representative supported shapes now include:

- boolean mixed tree/list/numeric SCCs such as `typr_tree_forest_num_ok/1`, `typr_forest_tree_num_ok/1`, and `typr_num_forest_tree_ok/1`
- integer-return mixed tree/list/numeric SCCs such as `typr_tree_forest_num_sum/2`, `typr_forest_tree_num_sum/2`, and `typr_num_forest_tree_sum/2`
- context-threaded integer-return mixed tree/list/numeric SCCs such as `typr_tree_forest_num_weight/3`, `typr_forest_tree_num_weight/3`, and `typr_num_forest_tree_weight/3`

## Why This PR Exists

The SCC audit found the next real gap beyond the current mixed driver set:

- mixed tree/list SCCs already worked
- mixed list/numeric SCCs already worked
- mixed tree/numeric SCCs already worked
- but a conservative three-way mixed tree/list/numeric SCC still failed with:

- `Error: No mutual recursion support for target typr`

The missing case was not arbitrary SCC lowering in general. It was a still-analyzable mixed group where the tree side combined a numeric recursive call on the current node value with a list-side paired-forest recursive call.

This PR fixes that at the shared mutual-recursion layer instead of adding another isolated backend.

## Main Changes

- added mixed tree/list/numeric mutual-recursion spec selection in `src/unifyweaver/targets/typr_target.pl`
- added conservative boolean and value-return mixed tree/list/numeric SCC support
- reused the existing tree-side dual/value lowering model so the tree predicate can bind the numeric call result and the paired-forest call result in a shared native TypR path
- kept the same native TypR mutual backend model across boolean, integer-return, and threaded-context variants
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated stale target-level string assertions that were failing due to already-valid emitted TypR surface changes, not a new backend regression
- updated the TypR support docs to explicitly include mixed tree/list/numeric SCCs

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not attempt arbitrary SCC lowering.

It keeps the TypR mutual-recursion backend conservative:

- predicates in the SCC still need analyzable structural-driver decomposition
- this change focuses on mixed tree/list/numeric groups where the recursive call structure remains explicit and TypR-translatable
- broader generic-body SCC lowering remains out of scope
