### PR TITLE
ci(csharp-query): show cache smoke diff JSON path

### DIFF
--- a/.github/workflows/csharp_query_cache_smoke_diff.yml
+++ b/.github/workflows/csharp_query_cache_smoke_diff.yml
@@ -440,6 +440,7 @@ jobs:
               "- Compare URL: `"$($env:CACHE_SMOKE_DIFF_COMPARE_URL)`"",
               "- Compare artifact: `"$($env:COMPARE_ARTIFACT_NAME)`"",
               "- Diff JSON artifact: `"$($env:CACHE_SMOKE_DIFF_ARTIFACT_NAME)`"",
+              "- Diff JSON path: `"$($env:CACHE_SMOKE_DIFF_JSON_PATH)`"",
               "- Baseline overall result: `"$($diff.overallResult.baseline)`"",
               "- Compare overall result: `"$($diff.overallResult.compare)`"",
               "- Overall result delta: `"$($diff.overallResult.delta)`"",

--- a/docs/targets/csharp-query-runtime.md
+++ b/docs/targets/csharp-query-runtime.md
@@ -225,6 +225,7 @@ The Prolog test suite can generate per-plan C# console projects in codegen-only 
         - generated-at delta when both timestamps are present
         - GitHub compare URL derived from the resolved SHAs
         - artifact names
+        - resolved diff JSON path
         - baseline overall result
         - compare overall result
         - overall result delta


### PR DESCRIPTION
  ## Summary
  Extend the manual C# query cache-smoke diff job summary so it shows the resolved local diff JSON path alongside the
  diff artifact name.

  ## What changed
  - Updated `.github/workflows/csharp_query_cache_smoke_diff.yml`
  - Added the following field to the manual diff job summary:
    - diff JSON path
  - Updated `docs/targets/csharp-query-runtime.md` to document the added diff-JSON-path field

  ## Why
  The manual diff workflow already surfaced the uploaded diff artifact name, but it still did not show the actual local
  JSON file path that the workflow generated and uploaded. This change makes the summary more directly auditable.

  ## Validation
  - `git diff --check -- .github/workflows/csharp_query_cache_smoke_diff.yml docs/targets/csharp-query-runtime.md`
  - Confirmed the summary now renders:
    - `CACHE_SMOKE_DIFF_JSON_PATH`