### PR TITLE
Generalize native TypR tree/forest pair SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,11 @@ includes:
   branch-body forms, and mixed tree/list structural SCCs where tree-shaped
   predicates recurse through paired-forest helpers, including guarded
   branch-local paired-forest call selection on the tree side, while
-  list-shaped predicates recurse through head/tail decomposition, plus
-  mixed list/numeric SCCs where list-shaped predicates recurse through
-  head/tail decomposition while numeric predicates recurse through scalar
-  step descent or singleton-list re-entry, plus mixed tree/numeric SCCs
+  list-shaped predicates recurse through head/tail decomposition or fixed
+  two-element forest-pair decomposition, plus mixed list/numeric SCCs
+  where list-shaped predicates recurse through head/tail decomposition
+  while numeric predicates recurse through scalar step descent or
+  singleton-list re-entry, plus mixed tree/numeric SCCs
   where tree-shaped predicates recurse through current-value and one-
   subtree descent while numeric predicates recurse through scalar step
   descent or constructed tree re-entry, plus mixed tree/list/numeric SCCs

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -240,7 +240,8 @@ bring-up.
     tree-shaped predicates recurse through paired-forest helpers,
     including guarded branch-local paired-forest call selection on the
     tree side, while list-shaped predicates recurse through head/tail
-    decomposition, plus mixed list/numeric SCCs where list-shaped
+    decomposition or fixed two-element forest-pair decomposition, plus
+    mixed list/numeric SCCs where list-shaped
     predicates recurse through head/tail decomposition while numeric
     predicates recurse through scalar step descent or singleton-list
     re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -421,7 +421,8 @@ Current TypR lowering policy is intentionally mixed:
   mixed tree/list structural SCCs where tree-shaped predicates recurse
   through paired-forest helpers, including guarded branch-local paired-
   forest call selection on the tree side, while list-shaped predicates
-  recurse through head/tail decomposition, plus mixed list/numeric SCCs
+  recurse through head/tail decomposition or fixed two-element forest-
+  pair decomposition, plus mixed list/numeric SCCs
   where list-shaped predicates recurse through head/tail decomposition
   while numeric predicates recurse through scalar step descent or
   singleton-list re-entry, plus mixed tree/numeric SCCs where tree-shaped

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -111,7 +111,8 @@ This document focuses on architecture and rollout choices specific to TypR.
      where tree-shaped predicates recurse through paired-forest helpers,
      including guarded branch-local paired-forest call selection on the
      tree side, while list-shaped predicates recurse through head/tail
-     decomposition, plus mixed list/numeric SCCs where list-shaped
+     decomposition or fixed two-element forest-pair decomposition, plus
+     mixed list/numeric SCCs where list-shaped
      predicates recurse through head/tail decomposition while numeric
      predicates recurse through scalar step descent or singleton-list
      re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -332,6 +332,9 @@ typr_mutual_tree_pair_arg_expr(AliasMap, PairArg, Expr) :-
 typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, Goal0, CallSpec) :-
     typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, [], Goal0, CallSpec).
 
+typr_mutual_list_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, Goal0, CallSpec) :-
+    typr_mutual_list_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, [], Goal0, CallSpec).
+
 typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, ExtraArgMap, Goal0, call_spec(Side, NextPred, CallArgs)) :-
     typr_strip_module_goal(Goal0, Goal),
     Goal =.. [NextPred, RecArg|ExtraArgs],
@@ -344,6 +347,22 @@ typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar, Ext
     ;   RecArg == TailVar
     ->  Side = right,
         DriverExpr = 'tail(current_input, -1)'
+    ),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_list_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, call_spec(Side, NextPred, CallArgs)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    (   RecArg == LeftVar
+    ->  Side = left,
+        DriverExpr = '.subset2(current_input, 1)'
+    ;   RecArg == RightVar
+    ->  Side = right,
+        DriverExpr = '.subset2(current_input, 2)'
     ),
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [DriverExpr|ExtraArgExprs].
@@ -365,6 +384,41 @@ typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, HeadVar, TailVa
     ),
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_list_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, value_call_spec(Side, NextPred, CallArgs, OutputVar)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    (   RecArg == LeftVar
+    ->  Side = left,
+        DriverExpr = '.subset2(current_input, 1)'
+    ;   RecArg == RightVar
+    ->  Side = right,
+        DriverExpr = '.subset2(current_input, 2)'
+    ),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
+typr_mutual_list_dual_driver([HeadVar|TailVar], head_tail, HeadVar, TailVar, 'length(current_input) > 0') :-
+    var(TailVar),
+    !.
+typr_mutual_list_dual_driver([LeftVar, RightVar], pair, LeftVar, RightVar, 'length(current_input) == 2') :-
+    var(LeftVar),
+    var(RightVar).
+
+typr_mutual_list_dual_recursive_goal(head_tail, GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec) :-
+    typr_mutual_list_head_tail_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
+typr_mutual_list_dual_recursive_goal(pair, GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec) :-
+    typr_mutual_list_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
+
+typr_mutual_list_dual_value_recursive_goal(head_tail, GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec) :-
+    typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
+typr_mutual_list_dual_value_recursive_goal(pair, GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec) :-
+    typr_mutual_list_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
 
 typr_mutual_tree_value_subtree_driver_expr(ValueVar, _AliasMap, RecArg, left, '.subset2(current_input, 1)') :-
     var(RecArg),
@@ -705,12 +759,16 @@ typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     BaseClauses \= [],
     maplist(typr_mutual_list_empty_base_condition, BaseClauses, BaseConds0),
     sort(BaseConds0, BaseConditions),
-    RecHead =.. [_PredName, [HeadVar|TailVar]],
-    var(TailVar),
+    RecHead =.. [_PredName, RecInputPattern],
+    typr_mutual_list_dual_driver(RecInputPattern, DriverKind, LeftVar, RightVar, GuardExpr),
     typr_mutual_goal_list(RecBody, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
     Goals = [GoalA, GoalB],
-    maplist(typr_mutual_list_head_tail_recursive_goal(GroupPredicates, HeadVar, TailVar), [GoalA, GoalB], GoalSpecs0),
+    maplist(
+        typr_mutual_list_dual_recursive_goal(DriverKind, GroupPredicates, LeftVar, RightVar, []),
+        [GoalA, GoalB],
+        GoalSpecs0
+    ),
     select(call_spec(left, LeftNextPred, LeftCallArgs), GoalSpecs0, GoalSpecs1),
     select(call_spec(right, RightNextPred, RightCallArgs), GoalSpecs1, []),
     atom_string(Pred, PredStr),
@@ -730,7 +788,7 @@ typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
         left_call: branch_call(LeftNextHelperName, LeftCallArgs),
         right_call: branch_call(RightNextHelperName, RightCallArgs),
         base_conditions: BaseConditions,
-        guard_expr: 'length(current_input) > 0'
+        guard_expr: GuardExpr
     }.
 
 typr_mutual_mixed_tree_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -794,8 +852,8 @@ typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
     RecClauses = [clause(RecHead, RecBody)],
     BaseClauses \= [],
-    RecHead =.. [_PredName, [HeadVar|TailVar]|ContextAndOutputVars],
-    var(TailVar),
+    RecHead =.. [_PredName, RecInputPattern|ContextAndOutputVars],
+    typr_mutual_list_dual_driver(RecInputPattern, DriverKind, LeftVar, RightVar, GuardExpr),
     append(ContextVars, [OutputVar], ContextAndOutputVars),
     var(OutputVar),
     typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
@@ -806,7 +864,7 @@ typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     PreGoals == [],
     typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
     maplist(
-        typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, HeadVar, TailVar, ExtraArgMap),
+        typr_mutual_list_dual_value_recursive_goal(DriverKind, GroupPredicates, LeftVar, RightVar, ExtraArgMap),
         RecGoals,
         GoalSpecs0
     ),
@@ -837,7 +895,7 @@ typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
         wrapper_call_args: WrapperCallArgs,
         memo_key_expr: MemoKeyExpr,
         base_cases: BaseCases,
-        guard_expr: 'length(current_input) > 0',
+        guard_expr: GuardExpr,
         left_call: branch_call(LeftNextHelperName, LeftCallArgs),
         right_call: branch_call(RightNextHelperName, RightCallArgs),
         result_expr: ResultExpr

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -174,6 +174,12 @@ cleanup_typr_test :-
     retractall(user:nested_multi_result_choice_clause(_, _)),
     retractall(user:two_level_nested_multi_result_choice(_, _)),
     retractall(user:two_level_nested_multi_result_choice_clause(_, _)),
+    retractall(user:typr_tree_pair_ok(_)),
+    retractall(user:typr_forest_pair_ok(_)),
+    retractall(user:typr_tree_pair_sum(_, _)),
+    retractall(user:typr_forest_pair_sum(_, _)),
+    retractall(user:typr_tree_pair_weight(_, _, _)),
+    retractall(user:typr_forest_pair_weight(_, _, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -4315,6 +4321,94 @@ test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_integer_con
     once(sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_weight_impl(list((current_input + -1), list(), list()), current_ctx);")),
     once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
     \+ sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_weight_impl((current_input + -1), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_tree_pair_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_ok([])),
+    assertz(user:(typr_tree_pair_ok([_, L, R]) :-
+        typr_forest_pair_ok([L, R])
+    )),
+    assertz(user:typr_forest_pair_ok([])),
+    assertz(user:(typr_forest_pair_ok([L, R]) :-
+        typr_tree_pair_ok(L),
+        typr_tree_pair_ok(R)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_pair_ok/1, typr_tree_pair_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_pair_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "let typr_forest_pair_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_pair_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_pair_ok_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 2")),
+    once(sub_string(Code, _, _, _, "result = typr_forest_pair_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_tree_pair_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_sum([], 0)),
+    assertz(user:(typr_tree_pair_sum([V, L, R], S) :-
+        typr_forest_pair_sum([L, R], Parts),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_pair_sum([], 0)),
+    assertz(user:(typr_forest_pair_sum([L, R], S) :-
+        typr_tree_pair_sum(L, SL),
+        typr_tree_pair_sum(R, SR),
+        S is SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_pair_sum/2, typr_tree_pair_sum/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_pair_sum <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_pair_sum_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_pair_sum_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 2")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_tree_pair_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_weight([], _W0, 0)),
+    assertz(user:(typr_tree_pair_weight([V, L, R], W, S) :-
+        typr_forest_pair_weight([L, R], W, Parts),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_pair_weight([], _W1, 0)),
+    assertz(user:(typr_forest_pair_weight([L, R], W, S) :-
+        typr_tree_pair_weight(L, W, SL),
+        typr_tree_pair_weight(R, W, SR),
+        S is SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_pair_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_pair_weight/3, typr_tree_pair_weight/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_pair_weight <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_pair_weight_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_pair_weight_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "length(current_input) == 2")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -3298,6 +3298,100 @@ test(mixed_tree_list_numeric_mutual_integer_context_output_checks_with_typr, [co
     retractall(user:typr_forest_tree_num_weight(_, _, _)),
     retractall(user:typr_num_forest_tree_weight(_, _, _)).
 
+test(tree_pair_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_ok([])),
+    assertz(user:(typr_tree_pair_ok([_, L, R]) :-
+        typr_forest_pair_ok([L, R])
+    )),
+    assertz(user:typr_forest_pair_ok([])),
+    assertz(user:(typr_forest_pair_ok([L, R]) :-
+        typr_tree_pair_ok(L),
+        typr_tree_pair_ok(R)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_pair_ok(_)),
+    retractall(user:typr_forest_pair_ok(_)).
+
+test(tree_pair_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_sum([], 0)),
+    assertz(user:(typr_tree_pair_sum([V, L, R], S) :-
+        typr_forest_pair_sum([L, R], Parts),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_pair_sum([], 0)),
+    assertz(user:(typr_forest_pair_sum([L, R], S) :-
+        typr_tree_pair_sum(L, SL),
+        typr_tree_pair_sum(R, SR),
+        S is SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_pair_sum(_, _)),
+    retractall(user:typr_forest_pair_sum(_, _)).
+
+test(tree_pair_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_weight([], _W0, 0)),
+    assertz(user:(typr_tree_pair_weight([V, L, R], W, S) :-
+        typr_forest_pair_weight([L, R], W, Parts),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_pair_weight([], _W1, 0)),
+    assertz(user:(typr_forest_pair_weight([L, R], W, S) :-
+        typr_tree_pair_weight(L, W, SL),
+        typr_tree_pair_weight(R, W, SR),
+        S is SL + SR
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_pair_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_pair_weight(_, _, _)),
+    retractall(user:typr_forest_pair_weight(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR generalizes native TypR mutual-recursion lowering for conservative tree/forest SCCs where the forest-side predicate uses fixed pair decomposition instead of head/tail list decomposition.

TypR now keeps these SCCs native when:

- a tree-shaped predicate recurses through a paired-forest helper over `[L, R]`
- a forest-shaped predicate recurses through a fixed two-element pair `[L, R]`
- the result stays within the existing boolean or integer-return native TypR mutual-recursion model

Representative supported shapes now include:

- boolean tree/forest-pair SCCs such as `typr_tree_pair_ok/1` and `typr_forest_pair_ok/1`
- integer-return tree/forest-pair SCCs such as `typr_tree_pair_sum/2` and `typr_forest_pair_sum/2`
- context-threaded integer-return tree/forest-pair SCCs such as `typr_tree_pair_weight/3` and `typr_forest_pair_weight/3`

## Why This PR Exists

The broader-driver SCC audit found the first real gap beyond the current head/tail list driver:

- mixed tree/list SCCs already worked when the list side used head/tail decomposition
- but the next conservative step still failed:
- the tree side recursed through a paired-forest helper
- the forest side itself was a fixed two-element pair predicate
- both predicates still stayed within a narrow structural recursion model

Those SCCs were failing with:

- `Error: No mutual recursion support for target typr`

This PR fixes that by generalizing the list-side mutual matcher to support fixed pair decomposition as well as head/tail decomposition.

## Main Changes

- generalized the list-side mutual recursive-call matcher in `src/unifyweaver/targets/typr_target.pl`
- added pair-list recursive goal and value-goal lowering for fixed two-element forest pairs
- added a shared list dual-driver selector so the mixed tree/list backend can reuse the same path for:
- head/tail list decomposition
- fixed pair decomposition
- reused the existing mixed tree/list mutual helper emitters instead of adding another isolated backend
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR docs to explicitly include fixed forest-pair decomposition in the supported mixed tree/list SCC subset

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not attempt arbitrary SCC lowering.

It keeps the TypR mutual-recursion backend conservative:

- predicates in the SCC still need analyzable structural-driver decomposition
- this change focuses on mixed tree/forest SCCs where the forest side uses fixed two-element pair decomposition
- broader generic-body SCC lowering remains out of scope
