### PR TITLE
Generalize native TypR mixed SCC full bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,10 @@ includes:
   where tree-shaped predicates recurse through current-value and paired-
   forest helpers while list-shaped predicates recurse through head/tail
   decomposition and numeric predicates recurse through scalar step
-  descent or constructed tree re-entry, including integer-return and
-  threaded-context variants,
+  descent or constructed tree re-entry, including mixed tree/numeric and
+  mixed tree/list/numeric SCCs where the tree-shaped predicate uses the
+  same supported guarded full-body forms after an earlier recursive group-
+  call prefix, plus integer-return and threaded-context variants,
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -251,8 +251,10 @@ bring-up.
     predicates recurse through current-value and paired-forest helpers
     while list-shaped predicates recurse through head/tail decomposition
     and numeric predicates recurse through scalar step descent or
-    constructed tree re-entry, including integer-return and threaded-
-    context variants
+    constructed tree re-entry, including mixed tree/numeric and mixed
+    tree/list/numeric SCCs where the tree-shaped predicate uses the same
+    supported guarded full-body forms after an earlier recursive group-
+    call prefix, plus integer-return and threaded-context variants
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -432,8 +432,10 @@ Current TypR lowering policy is intentionally mixed:
   predicates recurse through current-value and paired-forest helpers
   while list-shaped predicates recurse through head/tail decomposition
   and numeric predicates recurse through scalar step descent or
-  constructed tree re-entry, including integer-return and threaded-
-  context variants,
+  constructed tree re-entry, including mixed tree/numeric and mixed
+  tree/list/numeric SCCs where the tree-shaped predicate uses the same
+  supported guarded full-body forms after an earlier recursive group-call
+  prefix, plus integer-return and threaded-context variants,
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
 - conservative `N`-ary structural tree-recursive predicates may also lower

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -122,8 +122,10 @@ This document focuses on architecture and rollout choices specific to TypR.
      predicates recurse through current-value and paired-forest helpers
      while list-shaped predicates recurse through head/tail decomposition
      and numeric predicates recurse through scalar step descent or
-     constructed tree re-entry, including integer-return and threaded-
-     context variants,
+     constructed tree re-entry, including mixed tree/numeric and mixed
+     tree/list/numeric SCCs where the tree-shaped predicate uses the same
+     supported guarded full-body forms after an earlier recursive group-
+     call prefix, plus integer-return and threaded-context variants,
      emitted as TypR
      functions with raw-expression memoized helper bodies
    - conservative `N`-ary structural tree-recursive predicates that match
@@ -165,7 +167,8 @@ This document focuses on architecture and rollout choices specific to TypR.
    - native lowering for the dataframe helpers `filter/3`, `sort_by/3`, and
      `group_by/3`
 7. The remaining gap is broader lowering for arbitrary generic rule bodies
-   and broader recursive patterns beyond that current subset.
+   and SCCs that no longer fit the current structural-driver or supported
+   guarded full-body subset.
 
 Implication: TypR design must support both generation styles and should not
 assume a Mustache-only pipeline.

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -90,6 +90,10 @@ typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
     ;   typr_mutual_mixed_tree_list_numeric_bool_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_numeric_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_numeric_bool_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_list_numeric_value_full_body_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_list_numeric_bool_full_body_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_numeric_value_full_body_spec(GroupPredicates, PredArity, Spec)
+    ;   typr_mutual_mixed_tree_numeric_bool_full_body_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_value_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_tree_dual_value_full_body_spec(GroupPredicates, PredArity, Spec)
@@ -596,6 +600,110 @@ typr_mutual_tree_list_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
         result_expr: ResultExpr
     }.
 
+typr_mutual_mixed_tree_list_numeric_bool_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_list_numeric_bool_full_body_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_list_numeric_bool_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextVars],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(
+        Pred,
+        ContextVars,
+        HelperName,
+        ExtraArgMap0,
+        HelperParams,
+        WrapperCallArgs,
+        MemoKeyExpr
+    ),
+    typr_mutual_tree_branch_body_with(
+        typr_mutual_tree_value_pair_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        Body
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
+    }.
+
+typr_mutual_mixed_tree_list_numeric_value_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_list_numeric_value_full_body_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_list_numeric_value_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_value_branch_body_with(
+        typr_mutual_tree_value_pair_value_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        true,
+        OutputVar,
+        Body
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
+    }.
+
 typr_mutual_mixed_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_tree_numeric_bool_spec(GroupPredicates, Pred/Arity, Spec).
 
@@ -708,6 +816,110 @@ typr_mutual_tree_numeric_value_spec(GroupPredicates, Pred/Arity, Spec) :-
         left_call: branch_call(LeftNextHelperName, LeftCallArgs),
         right_call: branch_call(RightNextHelperName, RightCallArgs),
         result_expr: ResultExpr
+    }.
+
+typr_mutual_mixed_tree_numeric_bool_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_numeric_bool_full_body_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_numeric_bool_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_tree_base_case_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextVars],
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(
+        Pred,
+        ContextVars,
+        HelperName,
+        ExtraArgMap0,
+        HelperParams,
+        WrapperCallArgs,
+        MemoKeyExpr
+    ),
+    typr_mutual_tree_branch_body_with(
+        typr_mutual_tree_value_subtree_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        Body
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_conditions: BaseConditions,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
+    }.
+
+typr_mutual_mixed_tree_numeric_value_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_tree_numeric_value_full_body_spec(GroupPredicates, Pred/Arity, Spec).
+
+typr_mutual_tree_numeric_value_full_body_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, [ValueVar, LeftVar, RightVar]|ContextAndOutputVars],
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_tree_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    typr_mutual_tree_alias_map([], LeftVar, RightVar, AliasMap0),
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap0, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    typr_mutual_tree_value_branch_body_with(
+        typr_mutual_tree_value_subtree_value_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        true,
+        OutputVar,
+        Body
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: 'length(current_input) == 3',
+        body: Body
     }.
 
 typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -1959,7 +2171,67 @@ typr_mutual_tree_value_call_binding(_CallSpecs0, _Side, [], []).
 typr_mutual_tree_result_name(left, left_result).
 typr_mutual_tree_result_name(right, right_result).
 
+typr_mutual_tree_side_recursive_goal(GroupPredicates, _ValueVar, AliasMap, ExtraArgMap, Goal0, CallSpec) :-
+    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, Goal0, CallSpec).
+
+typr_mutual_tree_side_value_recursive_goal(GroupPredicates, _ValueVar, AliasMap, ExtraArgMap, Goal0, CallSpec) :-
+    typr_mutual_tree_value_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, Goal0, CallSpec).
+
 typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    typr_mutual_tree_value_branch_body_with(
+        typr_mutual_tree_side_value_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        PostBody,
+        OutputVar,
+        Body
+    ).
+
+typr_mutual_tree_value_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    append(PrefixGoals, [NestedIfGoal|TailPostGoals], Goals),
+    PrefixGoals \= [],
+    split_typr_mutual_non_recursive_prefix(GroupPredicates, PrefixGoals, PreGoals, PrefixRecGoals),
+    PrefixRecGoals \= [],
+    maplist(typr_goal_calls_mutual_group(GroupPredicates), PrefixRecGoals),
+    typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
+    GuardExpr == none,
+    typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_tree_value_branch_post_body(TailPostGoals, PostBody, CombinedPostBody),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
+    append(PrefixRecGoals, ThenGoals, ThenGoalsWithPrefix),
+    typr_mutual_tree_value_branch_body_with(
+        Matcher,
+        GroupPredicates,
+        ThenGoalsWithPrefix,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        CombinedPostBody,
+        OutputVar,
+        ThenBody
+    ),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
+    append(PrefixRecGoals, ElseGoals, ElseGoalsWithPrefix),
+    typr_mutual_tree_value_branch_body_with(
+        Matcher,
+        GroupPredicates,
+        ElseGoalsWithPrefix,
+        ValueVar,
+        AliasMap,
+        ExtraArgMap1,
+        CombinedPostBody,
+        OutputVar,
+        ElseBody
+    ),
+    typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
+    Body = value_branch_if(BranchConditionExpr, ThenBody, ElseBody).
+
+typr_mutual_tree_value_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
     append(PreGoals, [NestedIfGoal|TailPostGoals], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
     GuardExpr == none,
@@ -1967,7 +2239,8 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
     typr_mutual_tree_value_branch_post_body(TailPostGoals, PostBody, CombinedPostBody),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_value_branch_body(
+    typr_mutual_tree_value_branch_body_with(
+        Matcher,
         GroupPredicates,
         ThenGoals,
         ValueVar,
@@ -1979,7 +2252,8 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
     ),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_value_branch_body(
+    typr_mutual_tree_value_branch_body_with(
+        Matcher,
         GroupPredicates,
         ElseGoals,
         ValueVar,
@@ -1991,12 +2265,12 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
     ),
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     Body = value_branch_if(BranchConditionExpr, ThenBody, ElseBody).
-typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+typr_mutual_tree_value_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
     split_typr_mutual_recursive_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, BranchPostGoals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
     GuardExpr == none,
     maplist(
-        typr_mutual_tree_value_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1),
+        call(Matcher, GroupPredicates, ValueVar, AliasMap, ExtraArgMap1),
         RecGoals,
         GoalSpecs0
     ),
@@ -2280,30 +2554,42 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) 
     typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, [], Body).
 
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+    typr_mutual_tree_branch_body_with(
+        typr_mutual_tree_side_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap,
+        Body
+    ).
+
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [NestedIfGoal], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_branch_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap1, ThenBody),
+    typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap1, ThenBody),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_branch_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap1, ElseBody),
+    typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap1, ElseBody),
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     typr_mutual_tree_guard_wrap(
         GuardExpr,
         branch_if(BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [FirstGoal0, NestedIfGoal], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
-    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1, FirstGoal0, FirstGoalSpec),
+    call(Matcher, GroupPredicates, ValueVar, AliasMap, ExtraArgMap1, FirstGoal0, FirstGoalSpec),
     typr_mutual_tree_branch_call(FirstGoalSpec, FirstCall),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_tail_body(
+    typr_mutual_tree_tail_body_with(
+        Matcher,
         GroupPredicates,
         ThenGoals,
         ValueVar,
@@ -2315,7 +2601,8 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
     typr_mutual_tree_call_specs_cover_both_sides([FirstGoalSpec|ThenGoalSpecs]),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_tail_body(
+    typr_mutual_tree_tail_body_with(
+        Matcher,
         GroupPredicates,
         ElseGoals,
         ValueVar,
@@ -2331,16 +2618,17 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         branch_after_call(FirstCall, BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [GoalA0, GoalB0, NestedIfGoal], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
-    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1), [GoalA0, GoalB0], GoalSpecs),
+    maplist(call(Matcher, GroupPredicates, ValueVar, AliasMap, ExtraArgMap1), [GoalA0, GoalB0], GoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_tail_body(
+    typr_mutual_tree_tail_body_with(
+        Matcher,
         GroupPredicates,
         ThenGoals,
         ValueVar,
@@ -2352,7 +2640,8 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
     ThenGoalSpecs = [],
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_tail_body(
+    typr_mutual_tree_tail_body_with(
+        Matcher,
         GroupPredicates,
         ElseGoals,
         ValueVar,
@@ -2368,11 +2657,12 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         branch_after_calls(Calls, BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
     append(PrefixGoals, [NestedIfGoal], Goals),
     PrefixGoals \= [],
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
-    typr_mutual_tree_branch_sequence_state(
+    typr_mutual_tree_branch_sequence_state_with(
+        Matcher,
         GroupPredicates,
         PrefixGoals,
         ValueVar,
@@ -2386,7 +2676,8 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_tail_body(
+    typr_mutual_tree_tail_body_with(
+        Matcher,
         GroupPredicates,
         ThenGoals,
         ValueVar,
@@ -2398,7 +2689,8 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
     ThenGoalSpecs = [],
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_tail_body(
+    typr_mutual_tree_tail_body_with(
+        Matcher,
         GroupPredicates,
         ElseGoals,
         ValueVar,
@@ -2410,22 +2702,23 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
     ElseGoalSpecs = [],
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     Body = branch_steps_if(Steps, BranchConditionExpr, ThenBody, ElseBody).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     typr_mutual_tree_split_pre_goals(GroupPredicates, Goals, PreGoals, RecGoals),
     RecGoals = [GoalA, GoalB],
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
-    maplist(typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1), [GoalA, GoalB], GoalSpecs),
+    maplist(call(Matcher, GroupPredicates, ValueVar, AliasMap, ExtraArgMap1), [GoalA, GoalB], GoalSpecs),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     maplist(typr_mutual_tree_branch_call, GoalSpecs, Calls),
     typr_mutual_tree_guard_wrap(GuardExpr, branch_calls(Calls), Body).
-typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
-    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+    typr_mutual_tree_branch_sequence_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
     typr_mutual_tree_call_specs_cover_both_sides(GoalSpecs),
     typr_mutual_tree_branch_body_from_steps(Steps, Body).
 
-typr_mutual_tree_branch_sequence(_GroupPredicates, [], _ValueVar, _AliasMap, _ExtraArgMap, [], []).
-typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps) :-
-    typr_mutual_tree_branch_sequence_state(
+typr_mutual_tree_branch_sequence_with(_Matcher, _GroupPredicates, [], _ValueVar, _AliasMap, _ExtraArgMap, [], []).
+typr_mutual_tree_branch_sequence_with(Matcher, GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps) :-
+    typr_mutual_tree_branch_sequence_state_with(
+        Matcher,
         GroupPredicates,
         [Goal0|Rest],
         ValueVar,
@@ -2437,10 +2730,10 @@ typr_mutual_tree_branch_sequence(GroupPredicates, [Goal0|Rest], ValueVar, AliasM
         _ExtraArgMap
     ).
 
-typr_mutual_tree_branch_sequence_state(_GroupPredicates, [], _ValueVar, AliasMap, ExtraArgMap, [], [], AliasMap, ExtraArgMap).
-typr_mutual_tree_branch_sequence_state(GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap0, GoalSpecs, Steps, AliasMap, ExtraArgMap) :-
+typr_mutual_tree_branch_sequence_state_with(_Matcher, _GroupPredicates, [], _ValueVar, AliasMap, ExtraArgMap, [], [], AliasMap, ExtraArgMap).
+typr_mutual_tree_branch_sequence_state_with(Matcher, GroupPredicates, [Goal0|Rest], ValueVar, AliasMap0, ExtraArgMap0, GoalSpecs, Steps, AliasMap, ExtraArgMap) :-
     typr_strip_module_goal(Goal0, Goal),
-    (   typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap0, ExtraArgMap0, Goal, GoalSpec)
+    (   call(Matcher, GroupPredicates, ValueVar, AliasMap0, ExtraArgMap0, Goal, GoalSpec)
     ->  typr_mutual_tree_branch_call(GoalSpec, Call),
         GoalSpecs = [GoalSpec|RestGoalSpecs],
         Steps = [step_call(Call)|RestSteps],
@@ -2463,7 +2756,8 @@ typr_mutual_tree_branch_sequence_state(GroupPredicates, [Goal0|Rest], ValueVar, 
         AliasMap1 = AliasMap0,
         ExtraArgMap1 = ExtraArgMap0
     ),
-    typr_mutual_tree_branch_sequence_state(
+    typr_mutual_tree_branch_sequence_state_with(
+        Matcher,
         GroupPredicates,
         Rest,
         ValueVar,
@@ -2479,24 +2773,25 @@ typr_mutual_tree_branch_body_from_steps([step_call(Call1), step_call(Call2)], br
     !.
 typr_mutual_tree_branch_body_from_steps(Steps, branch_steps(Steps)).
 
-typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+typr_mutual_tree_nonrecursive_tail_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
     append(PreGoals, [NestedIfGoal], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap0, AliasMap, ExtraArgMap1, GuardExpr),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap1, ThenBody),
+    typr_mutual_tree_nonrecursive_tail_body_with(Matcher, GroupPredicates, ThenGoals, ValueVar, AliasMap, ExtraArgMap1, ThenBody),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap1, ElseBody),
+    typr_mutual_tree_nonrecursive_tail_body_with(Matcher, GroupPredicates, ElseGoals, ValueVar, AliasMap, ExtraArgMap1, ElseBody),
     typr_mutual_tree_branch_condition_expr(IfGoal, ValueVar, AliasMap, ExtraArgMap1, BranchConditionExpr),
     typr_mutual_tree_guard_wrap(
         GuardExpr,
         branch_if(BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
-    typr_mutual_tree_branch_sequence_state(
+typr_mutual_tree_nonrecursive_tail_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, Body) :-
+    typr_mutual_tree_branch_sequence_state_with(
+        Matcher,
         GroupPredicates,
         Goals,
         ValueVar,
@@ -2514,16 +2809,50 @@ typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body, Go
     typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, [], Body, GoalSpecs).
 
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, []) :-
-    typr_mutual_tree_nonrecursive_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body).
+    typr_mutual_tree_nonrecursive_tail_body_with(
+        typr_mutual_tree_side_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap,
+        Body
+    ).
 typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, [FirstGoalSpec]) :-
+    typr_mutual_tree_tail_body_with(
+        typr_mutual_tree_side_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap,
+        Body,
+        [FirstGoalSpec]
+    ).
+typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, GoalSpecs) :-
+    typr_mutual_tree_tail_body_with(
+        typr_mutual_tree_side_recursive_goal,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap,
+        Body,
+        GoalSpecs
+    ).
+
+typr_mutual_tree_tail_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, []) :-
+    typr_mutual_tree_nonrecursive_tail_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body).
+typr_mutual_tree_tail_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, [FirstGoalSpec]) :-
     append(PreGoals, [FirstGoal0, NestedIfGoal], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),
-    typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap1, FirstGoal0, FirstGoalSpec),
+    call(Matcher, GroupPredicates, ValueVar, AliasMap, ExtraArgMap1, FirstGoal0, FirstGoalSpec),
     typr_mutual_tree_branch_call(FirstGoalSpec, FirstCall),
     typr_if_then_else_goal(NestedIfGoal, IfGoal, ThenGoal0, ElseGoal0),
     typr_mutual_goal_list(ThenGoal0, ThenGoals0),
     maplist(typr_strip_module_goal, ThenGoals0, ThenGoals),
-    typr_mutual_tree_nonrecursive_tail_body(
+    typr_mutual_tree_nonrecursive_tail_body_with(
+        Matcher,
         GroupPredicates,
         ThenGoals,
         ValueVar,
@@ -2533,7 +2862,8 @@ typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArg
     ),
     typr_mutual_goal_list(ElseGoal0, ElseGoals0),
     maplist(typr_strip_module_goal, ElseGoals0, ElseGoals),
-    typr_mutual_tree_nonrecursive_tail_body(
+    typr_mutual_tree_nonrecursive_tail_body_with(
+        Matcher,
         GroupPredicates,
         ElseGoals,
         ValueVar,
@@ -2547,8 +2877,8 @@ typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArg
         branch_after_call(FirstCall, BranchConditionExpr, ThenBody, ElseBody),
         Body
     ).
-typr_mutual_tree_tail_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, GoalSpecs) :-
-    typr_mutual_tree_branch_sequence(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
+typr_mutual_tree_tail_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body, GoalSpecs) :-
+    typr_mutual_tree_branch_sequence_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, GoalSpecs, Steps),
     typr_mutual_tree_branch_body_from_steps(Steps, Body).
 
 typr_mutual_group_code(Specs, MemoEnabled, Code) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -180,6 +180,13 @@ cleanup_typr_test :-
     retractall(user:typr_forest_pair_sum(_, _)),
     retractall(user:typr_tree_pair_weight(_, _, _)),
     retractall(user:typr_forest_pair_weight(_, _, _)),
+    retractall(user:typr_tree_num_ok_branch(_)),
+    retractall(user:typr_num_tree_ok_branch(_)),
+    retractall(user:typr_tree_num_sum_branch(_, _)),
+    retractall(user:typr_num_tree_sum_branch(_, _)),
+    retractall(user:typr_tree_forest_num_weight_branch(_, _, _)),
+    retractall(user:typr_forest_tree_num_weight_branch(_, _, _)),
+    retractall(user:typr_num_forest_tree_weight_branch(_, _, _)),
     retractall(user:sort_rows(_, _)),
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
@@ -3308,10 +3315,10 @@ test(recursive_compiler_supports_typr_structural_tree_single_subtree_mutual_inte
     once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_left_tree/2, typr_mutual_sum_odd_left_tree/2")),
     once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_left_tree <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "typr_mutual_sum_even_left_tree_impl <- function(current_input) {")),
-    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_left_tree_impl(.subset2(current_input, 2));")),
-    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
-    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) - left_result);")),
-    \+ sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_left_tree_impl"),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_left_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + right_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) - right_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_left_tree_impl"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -3338,8 +3345,8 @@ test(recursive_compiler_supports_typr_structural_tree_mixed_mutual_integer_outpu
     once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_mutual_sum_even_mixed_tree/2, typr_mutual_sum_odd_mixed_tree/2")),
     once(sub_string(Code, _, _, _, "let typr_mutual_sum_even_mixed_tree <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "typr_mutual_sum_even_mixed_tree_impl <- function(current_input) {")),
-    once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_odd_mixed_tree_impl(.subset2(current_input, 2));")),
-    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_odd_mixed_tree_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + right_result);")),
     once(sub_string(Code, _, _, _, "left_result = typr_mutual_sum_even_mixed_tree_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "right_result = typr_mutual_sum_even_mixed_tree_impl(.subset2(current_input, 3));")),
     once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) + left_result) + right_result);")),
@@ -3888,9 +3895,9 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_group) :-
     once(sub_string(Code, _, _, _, "typr_forest_sum_impl <- function(current_input) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_tree_sum_impl(.subset2(current_input, 1));")),
     once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
-    once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
     once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
-    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -3921,8 +3928,8 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_gro
     once(sub_string(Code, _, _, _, "typr_forest_weight_sum_impl <- function(current_input, current_ctx) {")),
     once(sub_string(Code, _, _, _, "left_result = typr_tree_weight_sum_impl(.subset2(current_input, 1), current_ctx);")),
     once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
-    once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
-    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -3973,9 +3980,9 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_branch_grou
     once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_sum_branch/2, typr_tree_sum_branch/2")),
     once(sub_string(Code, _, _, _, "let typr_tree_sum_branch <- fn(arg1: [#N, Any], arg2: int): int")),
     once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
-    once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
-    once(sub_string(Code, _, _, _, "left_result = typr_forest_sum_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)));")),
-    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_sum_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)));")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -4004,9 +4011,9 @@ test(recursive_compiler_supports_typr_mixed_tree_list_mutual_integer_context_bra
     once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_weight_sum_branch/3, typr_tree_weight_sum_branch/3")),
     once(sub_string(Code, _, _, _, "let typr_tree_weight_sum_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
     once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
-    once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
-    once(sub_string(Code, _, _, _, "left_result = typr_forest_weight_sum_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)), current_ctx);")),
-    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_weight_sum_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -4324,6 +4331,119 @@ test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_integer_con
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_boolean_branch_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_ok_branch([])),
+    assertz(user:(typr_tree_num_ok_branch([V, L, R]) :-
+        typr_num_tree_ok_branch(V),
+        ( V > 0 -> typr_tree_num_ok_branch(L) ; typr_tree_num_ok_branch(R) )
+    )),
+    assertz(user:typr_num_tree_ok_branch(0)),
+    assertz(user:(typr_num_tree_ok_branch(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_ok_branch([N1, [], []])
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_ok_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_tree_ok_branch/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_ok_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_ok_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_ok_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_ok_branch/1, typr_tree_num_ok_branch/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_num_ok_branch <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_tree_ok_branch_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_ok_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_ok_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = typr_tree_num_ok_branch_impl(list((current_input + -1), list(), list()));")),
+    \+ sub_string(Code, _, _, _, "result = typr_tree_num_ok_branch_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_branch_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_sum_branch([], 0)),
+    assertz(user:(typr_tree_num_sum_branch([V, L, R], S) :-
+        typr_num_tree_sum_branch(V, SV),
+        ( V > 0 -> typr_tree_num_sum_branch(L, SL) ; typr_tree_num_sum_branch(R, SL) ),
+        S is SV + SL
+    )),
+    assertz(user:typr_num_tree_sum_branch(0, 0)),
+    assertz(user:(typr_num_tree_sum_branch(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_sum_branch([N1, [], []], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_sum_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_num_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum_branch/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_sum_branch/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_sum_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_sum_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_sum_branch/2, typr_tree_num_sum_branch/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_num_sum_branch <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_tree_sum_branch_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_sum_branch_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "right_result = typr_tree_num_sum_branch_impl(.subset2(current_input, 3));")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_num_sum_branch_impl(list((current_input + -1), list(), list()));")),
+    once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_sum_branch_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_integer_context_branch_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_weight_branch([], _W0, 0)),
+    assertz(user:(typr_tree_forest_num_weight_branch([V, L, R], W, S) :-
+        typr_num_forest_tree_weight_branch(V, W, SV),
+        ( V > W -> typr_forest_tree_num_weight_branch([L, R], W, Parts)
+        ; typr_forest_tree_num_weight_branch([R, L], W, Parts)
+        ),
+        S is SV + Parts
+    )),
+    assertz(user:typr_forest_tree_num_weight_branch([], _W1, 0)),
+    assertz(user:(typr_forest_tree_num_weight_branch([T|Ts], W, S) :-
+        typr_tree_forest_num_weight_branch(T, W, ST),
+        typr_forest_tree_num_weight_branch(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(user:typr_num_forest_tree_weight_branch(0, _W2, 0)),
+    assertz(user:(typr_num_forest_tree_weight_branch(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_weight_branch([N1, [], []], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight_branch/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_weight_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_weight_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_weight_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_weight_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_tree_num_weight_branch/3, typr_num_forest_tree_weight_branch/3, typr_tree_forest_num_weight_branch/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_forest_num_weight_branch <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > current_ctx) {")),
+    once(sub_string(Code, _, _, _, "left_result = typr_num_forest_tree_weight_branch_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_tree_num_weight_branch_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "right_result = typr_forest_tree_num_weight_branch_impl(list(.subset2(current_input, 3), .subset2(current_input, 2)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_weight_branch_impl(list((current_input + -1), list(), list()), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_tree_forest_num_weight_branch_impl((current_input + -1), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(recursive_compiler_supports_typr_tree_pair_mutual_boolean_group) :-
     clear_type_declarations,
     assertz(user:typr_tree_pair_ok([])),
@@ -4376,7 +4496,7 @@ test(recursive_compiler_supports_typr_tree_pair_mutual_integer_group) :-
     once(sub_string(Code, _, _, _, "right_result = typr_tree_pair_sum_impl(.subset2(current_input, 2));")),
     once(sub_string(Code, _, _, _, "length(current_input) == 2")),
     once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
-    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + left_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
@@ -4408,7 +4528,7 @@ test(recursive_compiler_supports_typr_tree_pair_mutual_integer_context_group) :-
     once(sub_string(Code, _, _, _, "right_result = typr_tree_pair_weight_impl(.subset2(current_input, 2), current_ctx);")),
     once(sub_string(Code, _, _, _, "length(current_input) == 2")),
     once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
-    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + left_result);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + right_result);")),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -3298,6 +3298,119 @@ test(mixed_tree_list_numeric_mutual_integer_context_output_checks_with_typr, [co
     retractall(user:typr_forest_tree_num_weight(_, _, _)),
     retractall(user:typr_num_forest_tree_weight(_, _, _)).
 
+test(mixed_tree_numeric_mutual_boolean_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_ok_branch([])),
+    assertz(user:(typr_tree_num_ok_branch([V, L, R]) :-
+        typr_num_tree_ok_branch(V),
+        ( V > 0 -> typr_tree_num_ok_branch(L) ; typr_tree_num_ok_branch(R) )
+    )),
+    assertz(user:typr_num_tree_ok_branch(0)),
+    assertz(user:(typr_num_tree_ok_branch(N) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_ok_branch([N1, [], []])
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_ok_branch/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_num_tree_ok_branch/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_ok_branch/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_ok_branch/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_ok_branch/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_num_ok_branch(_)),
+    retractall(user:typr_num_tree_ok_branch(_)).
+
+test(mixed_tree_numeric_mutual_integer_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_num_sum_branch([], 0)),
+    assertz(user:(typr_tree_num_sum_branch([V, L, R], S) :-
+        typr_num_tree_sum_branch(V, SV),
+        ( V > 0 -> typr_tree_num_sum_branch(L, SL) ; typr_tree_num_sum_branch(R, SL) ),
+        S is SV + SL
+    )),
+    assertz(user:typr_num_tree_sum_branch(0, 0)),
+    assertz(user:(typr_num_tree_sum_branch(N, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_num_sum_branch([N1, [], []], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_num_sum_branch/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_num_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum_branch/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_tree_sum_branch/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_num_sum_branch/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_tree_sum_branch/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_num_sum_branch/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_num_sum_branch(_, _)),
+    retractall(user:typr_num_tree_sum_branch(_, _)).
+
+test(mixed_tree_list_numeric_mutual_integer_context_branch_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_forest_num_weight_branch([], _W0, 0)),
+    assertz(user:(typr_tree_forest_num_weight_branch([V, L, R], W, S) :-
+        typr_num_forest_tree_weight_branch(V, W, SV),
+        ( V > W -> typr_forest_tree_num_weight_branch([L, R], W, Parts)
+        ; typr_forest_tree_num_weight_branch([R, L], W, Parts)
+        ),
+        S is SV + Parts
+    )),
+    assertz(user:typr_forest_tree_num_weight_branch([], _W1, 0)),
+    assertz(user:(typr_forest_tree_num_weight_branch([T|Ts], W, S) :-
+        typr_tree_forest_num_weight_branch(T, W, ST),
+        typr_forest_tree_num_weight_branch(Ts, W, SS),
+        S is ST + SS
+    )),
+    assertz(user:typr_num_forest_tree_weight_branch(0, _W2, 0)),
+    assertz(user:(typr_num_forest_tree_weight_branch(N, W, S) :-
+        N > 0,
+        N1 is N - 1,
+        typr_tree_forest_num_weight_branch([N1, [], []], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_forest_num_weight_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight_branch/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_tree_num_weight_branch/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight_branch/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight_branch/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_num_forest_tree_weight_branch/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_forest_num_weight_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_tree_num_weight_branch/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_num_forest_tree_weight_branch/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_forest_num_weight_branch/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_forest_num_weight_branch(_, _, _)),
+    retractall(user:typr_forest_tree_num_weight_branch(_, _, _)),
+    retractall(user:typr_num_forest_tree_weight_branch(_, _, _)).
+
 test(tree_pair_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:typr_tree_pair_ok([])),


### PR DESCRIPTION
## Summary

This PR generalizes native TypR mutual-recursion lowering for conservative mixed SCCs where a tree-shaped predicate needs supported full-body guarded control after an earlier recursive group-call prefix.

It extends the current SCC backend so mixed groups can stay native when:

- one predicate still fits the existing structural-driver decomposition
- another predicate uses a supported guarded full-body form instead of a flat shared-call body
- the recursive prefix is still explicit and TypR-translatable

Representative supported shapes now include:

- mixed tree/numeric boolean SCCs where the tree side calls the numeric predicate on the current node value, then performs guarded subtree selection before the outer shared result step
- mixed tree/numeric integer-return SCCs with the same full-body pattern
- mixed tree/list/numeric integer-return SCCs where the tree side combines a numeric recursive call with guarded paired-forest selection before the final result expression

## Why This PR Exists

The SCC audit found the first real gap beyond the current mixed driver set:

- mixed tree/list structural SCCs already worked
- mixed list/numeric SCCs already worked
- mixed tree/numeric SCCs already worked
- mixed tree/list/numeric SCCs already worked for flat driver-shaped bodies
- but mixed SCCs still failed when the tree-shaped predicate needed a supported guarded full-body form after an earlier recursive group call

The failing slice was not arbitrary SCC lowering in general.

It was still a conservative SCC shape, but one that exposed a real limitation in the existing matcher family: mixed SCC support assumed the tree side stayed in one of the flat structural-driver forms.

This PR fixes that by generalizing the shared branch-body lowering path rather than adding another isolated backend.

## Main Changes

- generalized matcher-driven mutual tree branch lowering in `src/unifyweaver/targets/typr_target.pl`
- added conservative mixed tree/numeric and mixed tree/list/numeric SCC support for supported guarded full-body forms after an earlier recursive group-call prefix
- reused the shared value-return and boolean mutual-tree emitters instead of introducing another bespoke SCC backend
- kept the older flat matchers in place and widened only the path that needs full-body handling
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated older target-level string assertions where side-aware result binding now correctly uses the supported emitted result slot
- updated the TypR support docs to make the broader mixed full-body SCC support explicit

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not attempt arbitrary SCC lowering.

It keeps the TypR mutual-recursion backend conservative:

- SCC predicates still need analyzable structural-driver or supported guarded full-body decomposition
- this change is about mixed SCCs that are still explicit enough to stay native in TypR
- broader generic-body SCC lowering and a more general SCC IR remain out of scope
