### PR TITLE
feat: Python native lowering — 18 TypR patterns, binding registry, pandas ops, type hints

### DIFF
--- a/docs/design/CLAUSE_BODY_ANALYSIS_EXTRACTION.md
+++ b/docs/design/CLAUSE_BODY_ANALYSIS_EXTRACTION.md
@@ -179,40 +179,31 @@ touching Prolog:
 | Generic R fallback IIFE | `generic_r_wrapper.mustache` |
 | TC template (monolithic) | Split like other targets |
 
-## Revised Implementation Order
+## Implementation Status
 
-### Step 1: Wire TypR to the shared module
+### Step 1: Wire TypR to shared module — DEFERRED
 
-Replace TypR's duplicated predicates with imports from
-`clause_body_analysis`:
-- `normalize_typr_goals` → `normalize_goals`
-- `typr_if_then_else_goal` → `if_then_else_goal`
-- `typr_if_then_goal` → `if_then_goal`
-- `typr_disjunction_alternatives` → `disjunction_alternatives`
-- `build_head_varmap` (TypR) → `build_head_varmap` (shared)
+TypR is under active development by Codex. Wiring it to the
+shared module would interfere. Instead, we improved the shared
+module and used it in the Python target as proof of concept.
 
-This is a mechanical refactor. The shared versions are
-functionally identical. Verify TypR tests still pass after.
+### Step 2: Python target uses shared module — DONE
 
-### Step 2: Audit target usage depth
+Python now uses `classify_goal_sequence` for all non-recursive
+predicate compilation. Nearly every TypR native lowering pattern
+has been implemented (18 of 20 applicable patterns).
 
-The shared module has `classify_goal/3`, `analyze_clauses/2`,
-`translate_expr/3` — but most targets only use
-`clause_guard_output_split`. Audit which targets could use
-more of the shared analysis to handle more predicate structures.
+50 tests across 4 test files, all passing.
 
-### Step 3: TypR template extraction
+### Step 3: TypR template extraction — FUTURE
 
-Move TypR's large format strings (tree recursion body, mutual
-recursion wrapper, linear recursion loops) into `.mustache` files.
-Independent of the shared module work.
+Move TypR's large format strings into `.mustache` files.
+Deferred to avoid interfering with Codex's TypR development.
 
-### Step 4: Identify shared module gaps
+### Step 4: Apply to more targets — FUTURE
 
-Compare what TypR's native lowering can handle vs what the
-shared module provides. The gap is TypR's more sophisticated
-multi-result output handling, container patterns, and guarded
-tail sequences. These may be worth adding to the shared module.
+The Python implementation is the template for upgrading Go,
+Rust, C, etc. to use `classify_goal_sequence`.
 
 ## Fallback Chains (Possible Future Work)
 

--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -144,9 +144,17 @@ classify_goal(_, _, unknown).
 %% is_guard_goal(+Goal, +VarMap)
 %  A goal is a guard if it's a comparison or type check that produces no
 %  new variable bindings (only tests existing values).
+is_guard_goal(true, _) :- !.
+is_guard_goal(fail, _) :- !.
+is_guard_goal(false, _) :- !.
 is_guard_goal(_Module:Goal, VarMap) :-
     !,
     is_guard_goal(Goal, VarMap).
+%% If-then-else used as guard (no output variables)
+is_guard_goal(Goal, VarMap) :-
+    if_then_else_goal(Goal, _, _, _),
+    \+ is_output_goal(Goal, VarMap),
+    !.
 is_guard_goal(Goal, _VarMap) :-
     compound(Goal),
     Goal =.. [Op, _, _],
@@ -511,6 +519,7 @@ expr_op(+, '+').
 expr_op(-, '-').
 expr_op(*, '*').
 expr_op(/, '/').
+expr_op(//, 'floor_div').
 expr_op(mod, '%').
 expr_op(and, '&&').
 expr_op(or, '||').

--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -503,6 +503,7 @@ expr_op(<, '<').
 expr_op(>=, '>=').
 expr_op(=<, '<=').
 expr_op(=:=, '==').
+expr_op(=\=, '!=').
 expr_op(==, '==').
 expr_op(\=, '!=').
 expr_op(\==, '!=').

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -3012,16 +3012,10 @@ python_arg_split(Arity, ClausePairs, InputArity) :-
         count_output_vars(ClassifiedGoals, HeadArgs, OutputCount),
         (   OutputCount > 0
         ->  InputArity is Arity - OutputCount
-        ;   %% No body outputs: check if this is truly boolean
-            %% Boolean only if: all guards, last arg is a fresh variable
-            %% (not a constant, not a repeated variable from earlier position)
-            last(HeadArgs, LastArg),
-            append(EarlierArgs, [LastArg], HeadArgs),
-            (   forall(member(CG, ClassifiedGoals), CG = guard(_, _)),
-                var(LastArg),
-                \+ var_member_by_identity(LastArg, EarlierArgs)  %% not repeated
-            ->  InputArity = Arity  %% Boolean: all args are inputs
-            ;   InputArity is Arity - 1  %% Last arg is output
+        ;   %% No body outputs: boolean or output-from-head?
+            (   python_is_boolean_predicate(HeadArgs, Goals, VarMap)
+            ->  InputArity = Arity
+            ;   InputArity is Arity - 1
             )
         )
     ;   %% Pure fact: count unique variables to find input count
@@ -3044,6 +3038,18 @@ python_fact_input_count(HeadArgs, InputCount) :-
     ->  InputCount = RawCount  %% has repeated vars — use detected count
     ;   InputCount is max(1, Arity - 1)  %% all unique — last is output
     ).
+
+%% python_is_boolean_predicate(+HeadArgs, +Goals, +VarMap)
+%  True if a predicate is boolean: all body goals are guards AND the last
+%  head arg is a fresh variable (not constant, not repeated from earlier).
+python_is_boolean_predicate(HeadArgs, Goals, VarMap) :-
+    classify_goal_sequence(Goals, VarMap, CGs),
+    CGs \= [],
+    forall(member(CG, CGs), CG = guard(_, _)),
+    last(HeadArgs, LastArg),
+    var(LastArg),
+    append(EarlierArgs, [LastArg], HeadArgs),
+    \+ var_member_by_identity(LastArg, EarlierArgs).
 
 python_count_first_occurrences([], _, Count, Count).
 python_count_first_occurrences([Arg|Rest], Seen, Acc, Count) :-
@@ -3213,12 +3219,7 @@ native_python_clause(_PredSpec, Head, Body, Condition, Code) :-
     (   Goals == []
     ->  python_fact_input_count(HeadArgs, InputCount)
     ;   %% Check if all body goals are guards (boolean predicate)
-        classify_goal_sequence(Goals, VarMap, CGs),
-        last(HeadArgs, LastHA),
-        append(EarlierHA, [LastHA], HeadArgs),
-        (   forall(member(CG, CGs), CG = guard(_, _)),
-            var(LastHA),
-            \+ var_member_by_identity(LastHA, EarlierHA)
+        (   python_is_boolean_predicate(HeadArgs, Goals, VarMap)
         ->  InputCount = Arity
         ;   InputCount is Arity - 1
         )

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -3688,6 +3688,35 @@ python_expr(max(A, B), VarMap, PyExpr) :-
     python_expr(A, VarMap, PyA),
     python_expr(B, VarMap, PyB),
     format(string(PyExpr), 'max(~w, ~w)', [PyA, PyB]).
+python_expr(sqrt(A), VarMap, PyExpr) :-
+    !,
+    python_expr(A, VarMap, PyA),
+    format(string(PyExpr), 'math.sqrt(~w)', [PyA]).
+python_expr(sin(A), VarMap, PyExpr) :-
+    !,
+    python_expr(A, VarMap, PyA),
+    format(string(PyExpr), 'math.sin(~w)', [PyA]).
+python_expr(cos(A), VarMap, PyExpr) :-
+    !,
+    python_expr(A, VarMap, PyA),
+    format(string(PyExpr), 'math.cos(~w)', [PyA]).
+python_expr(log(A), VarMap, PyExpr) :-
+    !,
+    python_expr(A, VarMap, PyA),
+    format(string(PyExpr), 'math.log(~w)', [PyA]).
+python_expr(round(A), VarMap, PyExpr) :-
+    !,
+    python_expr(A, VarMap, PyA),
+    format(string(PyExpr), 'round(~w)', [PyA]).
+%% General unary function call fallback
+python_expr(Expr, VarMap, PyExpr) :-
+    compound(Expr),
+    Expr =.. [Fn, Arg],
+    \+ expr_op(Fn, _),
+    Fn \= (-),
+    !,
+    python_expr(Arg, VarMap, PyArg),
+    format(string(PyExpr), '~w(~w)', [Fn, PyArg]).
 python_expr(Atom, _VarMap, PyExpr) :-
     atom(Atom), !,
     python_literal(Atom, PyExpr).
@@ -3735,7 +3764,7 @@ python_op('!=', '!=').
 python_op('+', '+').
 python_op('-', '-').
 python_op('*', '*').
-python_op('/', '//').
+python_op('/', '/').
 python_op('%', '%').
 python_op('&&', 'and').
 python_op('||', 'or').

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -3012,7 +3012,11 @@ python_arg_split(Arity, ClausePairs, InputArity) :-
         count_output_vars(ClassifiedGoals, HeadArgs, OutputCount),
         (   OutputCount > 0
         ->  InputArity is Arity - OutputCount
-        ;   InputArity is Arity - 1
+        ;   %% No outputs: check if all goals are guards (boolean predicate)
+            (   forall(member(CG, ClassifiedGoals), CG = guard(_, _))
+            ->  InputArity = Arity  %% All guards, all args are inputs
+            ;   InputArity is Arity - 1
+            )
         )
     ;   %% Pure fact: count unique variables to find input count
         python_fact_input_count(HeadArgs, InputArity)
@@ -3202,7 +3206,12 @@ native_python_clause(_PredSpec, Head, Body, Condition, Code) :-
     normalize_goals(Body, Goals),
     (   Goals == []
     ->  python_fact_input_count(HeadArgs, InputCount)
-    ;   InputCount is Arity - 1
+    ;   %% Check if all body goals are guards (boolean predicate)
+        classify_goal_sequence(Goals, VarMap, CGs),
+        (   forall(member(CG, CGs), CG = guard(_, _))
+        ->  InputCount = Arity  %% Boolean: all args are inputs
+        ;   InputCount is Arity - 1
+        )
     ),
     length(InputHeadArgs, InputCount),
     append(InputHeadArgs, OutputHeadArgs, HeadArgs),
@@ -3224,13 +3233,16 @@ native_python_clause(_PredSpec, Head, Body, Condition, Code) :-
                 format(string(Code), '    return ~w', [OutputLit])
             ;   python_output_goals(OutputGoals, VarMap, Code)
             )
-        ;   % Output is a variable
-            (   var(OutputHeadArg),
+        ;   % Output is a variable (or boolean with no output args)
+            (   OutputHeadArgs == []
+            ->  % Boolean predicate (all args are inputs, no output args)
+                maplist(python_guard_condition(VarMap), Goals, GoalConditions),
+                Code = '    return True'
+            ;   var(OutputHeadArg),
                 lookup_var(OutputHeadArg, VarMap, OutputArgName),
-                %% Check it's also an INPUT arg (appears earlier in head)
+                %% Check it's also an INPUT arg (e.g., max2(X,Y,X) — output = input X)
                 var_member_by_identity(OutputHeadArg, InputHeadArgs)
-            ->  % Output var is an input arg (e.g., max2(X,Y,X) — output = input X)
-                %% All goals are guards, return the input arg
+            ->  % Output var is an input arg
                 clause_guard_output_split(Goals, VarMap, GuardGoals, _OutputGoals),
                 maplist(python_guard_condition(VarMap), GuardGoals, GoalConditions),
                 format(string(Code), '    return ~w', [OutputArgName])

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -3002,19 +3002,52 @@ compile_non_recursive_predicate(Name, Arity, Clauses, Options, PythonCode) :-
 python_arg_split(1, _, 1) :- !.
 python_arg_split(Arity, ClausePairs, InputArity) :-
     Arity >= 2,
-    %% Count output args from the first clause
     ClausePairs = [Head-Body|_],
     Head =.. [_|HeadArgs],
     build_head_varmap(HeadArgs, 1, VarMap),
     normalize_goals(Body, Goals),
-    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
-    count_output_vars(ClassifiedGoals, HeadArgs, OutputCount),
-    (   OutputCount > 0
-    ->  InputArity is Arity - OutputCount
-    ;   InputArity is Arity - 1  %% default: last arg is output
+    (   Goals \= []
+    ->  %% Count output args from classified body goals
+        classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+        count_output_vars(ClassifiedGoals, HeadArgs, OutputCount),
+        (   OutputCount > 0
+        ->  InputArity is Arity - OutputCount
+        ;   InputArity is Arity - 1
+        )
+    ;   %% Pure fact: count unique variables to find input count
+        python_fact_input_count(HeadArgs, InputArity)
     ),
     InputArity >= 1,
     !.
+
+%% python_fact_input_count(+HeadArgs, -InputCount)
+%  For pure facts, count the number of distinct first-occurrence variables.
+%  e.g. swap(X, Y, Y, X) → 2 distinct vars (X, Y) → 2 inputs
+%  For all-constant facts like factorial_base(0, 1), default to Arity-1
+%  (last arg is output convention).
+python_fact_input_count(HeadArgs, InputCount) :-
+    python_count_first_occurrences(HeadArgs, [], 0, RawCount),
+    length(HeadArgs, Arity),
+    %% If all args are constants or first-occurrences, use Arity-1
+    %% (the repeated-variable pattern like swap needs fewer inputs)
+    (   RawCount < Arity
+    ->  InputCount = RawCount  %% has repeated vars — use detected count
+    ;   InputCount is max(1, Arity - 1)  %% all unique — last is output
+    ).
+
+python_count_first_occurrences([], _, Count, Count).
+python_count_first_occurrences([Arg|Rest], Seen, Acc, Count) :-
+    (   var(Arg), \+ var_member_by_identity(Arg, Seen)
+    ->  %% First occurrence of this variable — it's an input
+        Acc1 is Acc + 1,
+        python_count_first_occurrences(Rest, [Arg|Seen], Acc1, Count)
+    ;   var(Arg)
+    ->  %% Repeated variable — it's an output (alias of earlier input)
+        python_count_first_occurrences(Rest, Seen, Acc, Count)
+    ;   %% Constant — it's an input (pattern match)
+        Acc1 is Acc + 1,
+        python_count_first_occurrences(Rest, Seen, Acc1, Count)
+    ).
 python_arg_split(Arity, _, InputArity) :-
     InputArity is max(1, Arity - 1).
 
@@ -3165,17 +3198,21 @@ native_python_clause(_PredSpec, Head, Body, Condition, Code) :-
     Arity >= 2,
     % Build VarMap from head arguments
     build_head_varmap(HeadArgs, 1, VarMap),
-    % Extract head conditions — only from input args (not the output arg)
-    % The last argument is treated as the output
-    append(InputHeadArgs, [OutputHeadArg], HeadArgs),
+    % Determine input/output split
+    normalize_goals(Body, Goals),
+    (   Goals == []
+    ->  python_fact_input_count(HeadArgs, InputCount)
+    ;   InputCount is Arity - 1
+    ),
+    length(InputHeadArgs, InputCount),
+    append(InputHeadArgs, OutputHeadArgs, HeadArgs),
+    (OutputHeadArgs = [OutputHeadArg|_] -> true ; OutputHeadArg = _),
     % Conditions from input args only
     python_head_conditions(InputHeadArgs, 1, HeadConditions),
     % Process body goals
-    normalize_goals(Body, Goals),
     (   Goals == []
-    ->  % Pure fact clause: return the output arg value
-        python_resolve_value(VarMap, OutputHeadArg, OutputExpr),
-        format(string(Code), '    return ~w', [OutputExpr]),
+    ->  % Pure fact clause: determine outputs and return
+        python_fact_return(HeadArgs, InputHeadArgs, VarMap, Code),
         GoalConditions = []
     ;   % Body goals: check if output arg is bound in head (constant)
         (   Arity > 1, nonvar(OutputHeadArg)
@@ -3208,6 +3245,29 @@ native_python_clause(_PredSpec, Head, Body, Condition, Code) :-
 %% python_head_conditions(+HeadArgs, +Index, -Conditions)
 %  Generate conditions from head argument patterns.
 %  Variables produce no condition; constants produce equality checks.
+%% python_fact_return(+HeadArgs, +InputArgs, +VarMap, -Code)
+%  Generate return statement for a pure fact clause.
+%  Single output: return value. Multiple outputs: return tuple.
+python_fact_return(HeadArgs, InputHeadArgs, VarMap, Code) :-
+    length(HeadArgs, Arity),
+    length(InputHeadArgs, InputCount),
+    OutputCount is Arity - InputCount,
+    (   OutputCount =:= 1
+    ->  %% Single output (last arg)
+        last(HeadArgs, OutputArg),
+        python_resolve_value(VarMap, OutputArg, OutputExpr),
+        format(string(Code), '    return ~w', [OutputExpr])
+    ;   OutputCount > 1
+    ->  %% Multi-output: return tuple of output args
+        length(OutputArgs, OutputCount),
+        append(_, OutputArgs, HeadArgs),
+        maplist(python_resolve_value(VarMap), OutputArgs, OutputExprs),
+        atomic_list_concat(OutputExprs, ', ', TupleInner),
+        format(string(Code), '    return (~w)', [TupleInner])
+    ;   %% No outputs (all args are inputs, fact predicate)
+        Code = '    return True'
+    ).
+
 python_head_conditions([], _, []).
 python_head_conditions([HeadArg|Rest], Index, Conditions) :-
     (   var(HeadArg)
@@ -3790,7 +3850,11 @@ branches_to_python_if_chain([branch(Condition, ClauseCode)|Rest], Code) :-
 branches_to_python_elif_chain([branch(Condition, ClauseCode)], Code) :-
     !,
     indent_python(ClauseCode, IndentedCode),
-    format(string(Code), '    elif ~w:\n~w', [Condition, IndentedCode]).
+    %% Use 'else' for catch-all conditions (True, no guards)
+    (   (Condition == 'True' ; Condition == "True")
+    ->  format(string(Code), '    else:\n~w', [IndentedCode])
+    ;   format(string(Code), '    elif ~w:\n~w', [Condition, IndentedCode])
+    ).
 branches_to_python_elif_chain([branch(Condition, ClauseCode)|Rest], Code) :-
     indent_python(ClauseCode, IndentedCode),
     branches_to_python_elif_chain(Rest, RestCode),

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -2979,6 +2979,10 @@ compile_procedural_mode(Name, Arity, Module, Options, PythonCode) :-
 
 %% compile_non_recursive_predicate(+Name, +Arity, +Clauses, +Options, -PythonCode)
 compile_non_recursive_predicate(Name, Arity, Clauses, Options, PythonCode) :-
+    % Ensure bindings are loaded
+    (   binding(python, length/2, _, _, _, _) -> true
+    ;   catch(init_python_bindings, _, true)
+    ),
     % Try native clause body lowering first
     pairs_from_clauses(Clauses, ClausePairs),
     native_python_clause_body(Name/Arity, ClausePairs, NativeBody),
@@ -3636,6 +3640,19 @@ python_disj_elif_return_lines([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines])
 python_guard_condition(_VarMap, true, 'True') :- !.
 python_guard_condition(_VarMap, fail, 'False') :- !.
 python_guard_condition(_VarMap, false, 'False') :- !.
+%% Binding command guard (zero-output binding used as boolean test)
+python_guard_condition(VarMap, Goal, Condition) :-
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    binding(python, Pred/Arity, TargetName, Inputs, [], _Options),
+    !,
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(InArgs, InCount),
+    append(InArgs, [], Args),
+    maplist(python_resolve_value(VarMap), InArgs, ResolvedArgs),
+    atomic_list_concat(ResolvedArgs, ', ', ArgsStr),
+    format(string(Condition), '~w(~w)', [TargetName, ArgsStr]).
 python_guard_condition(VarMap, _Module:Goal, Condition) :-
     !,
     python_guard_condition(VarMap, Goal, Condition).
@@ -3718,15 +3735,37 @@ python_output_goal_last(is(Var, Expr), VarMap, [Line], VarMap) :-
     !,
     python_expr(Expr, VarMap, PyExpr),
     format(string(Line), '    return ~w', [PyExpr]).
+%% Binding output as last goal — return the binding result directly
+python_output_goal_last(Goal, VarMap, [Line], VarMap) :-
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    binding(python, Pred/Arity, TargetName, Inputs, [_], _Options),
+    !,
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(InArgs, InCount),
+    append(InArgs, [_OutArg], Args),
+    maplist(python_resolve_value(VarMap), InArgs, ResolvedArgs),
+    atomic_list_concat(ResolvedArgs, ', ', ArgsStr),
+    format(string(Line), '    return ~w(~w)', [TargetName, ArgsStr]).
 python_output_goal_last(Goal, VarMap0, [AssignLine, ReturnLine], VarMapOut) :-
     % Fallback: assign then return
     python_output_goal(Goal, VarMap0, AssignLine, VarMapOut),
-    % Find what variable was just assigned
+    % Find what variable was just assigned (try goal_output_var, then VarMap diff)
     (   goal_output_var(Goal, OutVar),
         lookup_var(OutVar, VarMapOut, OutName)
     ->  format(string(ReturnLine), '    return ~w', [OutName])
+    ;   %% VarMap diff: find newly added variable
+        python_varmap_new_var(VarMap0, VarMapOut, OutName)
+    ->  format(string(ReturnLine), '    return ~w', [OutName])
     ;   ReturnLine = '    return None'
     ).
+
+%% python_varmap_new_var(+OldVarMap, +NewVarMap, -NewVarName)
+%  Find a variable name in NewVarMap that wasn't in OldVarMap.
+python_varmap_new_var(OldVarMap, NewVarMap, Name) :-
+    member(Var-Name, NewVarMap),
+    \+ member(Var-_, OldVarMap).
 
 %% python_output_goal(+Goal, +VarMap, -Line, -VarMapOut)
 %  Convert an output goal to a Python assignment line.
@@ -3750,6 +3789,41 @@ python_output_goal(=(Var, Expr), VarMap, Line, VarMap) :-
     !,
     python_expr(Expr, VarMap, PyExpr),
     format(string(Line), '    ~w = ~w', [Var, PyExpr]).
+%% Binding output: predicate with registered Python binding and single output
+python_output_goal(Goal, VarMap0, Line, VarMapOut) :-
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    binding(python, Pred/Arity, TargetName, Inputs, [_], _Options),
+    !,
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(InArgs, InCount),
+    append(InArgs, [OutArg], Args),
+    maplist(python_resolve_value(VarMap0), InArgs, ResolvedArgs),
+    atomic_list_concat(ResolvedArgs, ', ', ArgsStr),
+    ensure_var(VarMap0, OutArg, VarName, VarMapOut),
+    format(string(Line), '    ~w = ~w(~w)', [VarName, TargetName, ArgsStr]).
+%% DataFrame filter (pandas equivalent of TypR's @{ subset(...) }@)
+python_output_goal(filter(DF, Expr, Out), VarMap0, Line, VarMapOut) :-
+    !,
+    python_resolve_value(VarMap0, DF, PyDF),
+    python_expr(Expr, VarMap0, PyExpr),
+    ensure_var(VarMap0, Out, VarName, VarMapOut),
+    format(string(Line), '    ~w = ~w[~w]', [VarName, PyDF, PyExpr]).
+%% DataFrame sort_by (pandas equivalent)
+python_output_goal(sort_by(DF, Col, Out), VarMap0, Line, VarMapOut) :-
+    !,
+    python_resolve_value(VarMap0, DF, PyDF),
+    python_resolve_value(VarMap0, Col, PyCol),
+    ensure_var(VarMap0, Out, VarName, VarMapOut),
+    format(string(Line), '    ~w = ~w.sort_values(~w)', [VarName, PyDF, PyCol]).
+%% DataFrame group_by (pandas equivalent)
+python_output_goal(group_by(DF, Col, Out), VarMap0, Line, VarMapOut) :-
+    !,
+    python_resolve_value(VarMap0, DF, PyDF),
+    python_resolve_value(VarMap0, Col, PyCol),
+    ensure_var(VarMap0, Out, VarName, VarMapOut),
+    format(string(Line), '    ~w = ~w.groupby(~w)', [VarName, PyDF, PyCol]).
 
 %% python_if_then_else_output(+If, +Then, +Else, +VarMap, -Lines, -VarMapOut)
 %  Generate if/else for output assignment within a clause body.

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -2985,10 +2985,12 @@ compile_non_recursive_predicate(Name, Arity, Clauses, Options, PythonCode) :-
     !,
     % Determine input/output arg split
     python_arg_split(Arity, ClausePairs, InputArity),
-    build_python_arg_list(InputArity, ArgList),
+    %% Build typed or untyped arg list
+    python_typed_arg_list(Name/Arity, InputArity, ArgList),
+    python_return_annotation(Name/Arity, RetAnnotation),
     format(string(FuncCode),
-'def ~w(~w):
-~w', [Name, ArgList, NativeBody]),
+'def ~w(~w)~w:
+~w', [Name, ArgList, RetAnnotation, NativeBody]),
     header(Header),
     helpers(Helpers),
     generate_python_main(Options, Main),
@@ -3037,6 +3039,44 @@ python_fact_input_count(HeadArgs, InputCount) :-
     (   RawCount < Arity
     ->  InputCount = RawCount  %% has repeated vars — use detected count
     ;   InputCount is max(1, Arity - 1)  %% all unique — last is output
+    ).
+
+%% python_typed_arg_list(+PredSpec, +InputArity, -ArgList)
+%  Build arg list with type hints if uw_type declarations exist.
+%  No type hints if no declarations — follows user's convention.
+python_typed_arg_list(Name/Arity, InputArity, ArgList) :-
+    (   has_python_type_annotations(Name/Arity)
+    ->  python_typed_args(Name/Arity, 1, InputArity, Args),
+        atomic_list_concat(Args, ', ', ArgList)
+    ;   build_python_arg_list(InputArity, ArgList)
+    ).
+
+has_python_type_annotations(Name/Arity) :-
+    functor(Head, Name, Arity),
+    (   clause(type_declarations:uw_type(Name/Arity, _, _), true)
+    ;   clause(user:uw_type(Name/Arity, _, _), true)
+    ), !.
+
+python_typed_args(_PredSpec, I, InputArity, []) :- I > InputArity, !.
+python_typed_args(Name/Arity, I, InputArity, [TypedArg|Rest]) :-
+    format(string(ArgName), 'arg~w', [I]),
+    (   (clause(type_declarations:uw_type(Name/Arity, I, Type), true)
+        ; clause(user:uw_type(Name/Arity, I, Type), true)),
+        type_declarations:resolve_type(Type, python, PyType)
+    ->  format(string(TypedArg), '~w: ~w', [ArgName, PyType])
+    ;   TypedArg = ArgName
+    ),
+    I1 is I + 1,
+    python_typed_args(Name/Arity, I1, InputArity, Rest).
+
+%% python_return_annotation(+PredSpec, -Annotation)
+%  Add -> ReturnType annotation if uw_return_type exists.
+python_return_annotation(Name/Arity, Annotation) :-
+    (   (clause(type_declarations:uw_return_type(Name/Arity, Type), true)
+        ; clause(user:uw_return_type(Name/Arity, Type), true)),
+        type_declarations:resolve_type(Type, python, PyType)
+    ->  format(string(Annotation), ' -> ~w', [PyType])
+    ;   Annotation = ""
     ).
 
 %% python_is_boolean_predicate(+HeadArgs, +Goals, +VarMap)
@@ -3331,11 +3371,41 @@ python_render_classified_goals([], _VarMap, [], []).
 python_render_classified_goals([Classified], VarMap, Conds, Lines) :-
     !,
     python_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s) — assign first, then conditional return
+python_render_classified_goals([output(Goal, Var, _Expr)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    python_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    %% Collect trailing guards
+    collect_trailing_guards(Rest, VarMap1, GuardGoals, Remaining),
+    maplist(python_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' and ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "None"
+    ),
+    (   Remaining == []
+    ->  %% All trailing goals are guards — conditional return
+        format(string(IfLine), '    if ~w:', [GuardExpr]),
+        format(string(RetLine), '        return ~w', [OutName]),
+        Lines = [AssignLine, IfLine, RetLine]
+    ;   %% More goals after guards — emit guard as assertion, continue
+        format(string(IfLine), '    if not (~w):', [GuardExpr]),
+        format(string(RaiseLine), '        raise ValueError("Guard failed")', []),
+        python_render_classified_goals(Remaining, VarMap1, _, RemLines),
+        append([AssignLine, IfLine, RaiseLine], RemLines, Lines)
+    ).
 python_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
     python_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
     python_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
     append(MidConds, RestConds, Conds),
     append(MidLines, RestLines, Lines).
+
+%% collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !,
+    collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+collect_trailing_guards(Remaining, _, [], Remaining).
 
 %% python_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
 %  Render a non-last classified goal.

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -3633,9 +3633,17 @@ python_disj_elif_return_lines([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines])
 
 %% python_guard_condition(+VarMap, +Goal, -Condition)
 %  Convert a guard goal to a Python condition string.
+python_guard_condition(_VarMap, true, 'True') :- !.
+python_guard_condition(_VarMap, fail, 'False') :- !.
+python_guard_condition(_VarMap, false, 'False') :- !.
 python_guard_condition(VarMap, _Module:Goal, Condition) :-
     !,
     python_guard_condition(VarMap, Goal, Condition).
+%% Simplify (If -> true ; fail) to just If
+python_guard_condition(VarMap, Goal, Condition) :-
+    if_then_else_goal(Goal, IfGoal, true, fail),
+    !,
+    python_guard_condition(VarMap, IfGoal, Condition).
 python_guard_condition(VarMap, Goal, Condition) :-
     if_then_else_goal(Goal, IfGoal, ThenGoal, ElseGoal),
     !,
@@ -3918,6 +3926,7 @@ python_op('+', '+').
 python_op('-', '-').
 python_op('*', '*').
 python_op('/', '/').
+python_op('floor_div', '//').
 python_op('%', '%').
 python_op('&&', 'and').
 python_op('||', 'or').

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -3012,10 +3012,16 @@ python_arg_split(Arity, ClausePairs, InputArity) :-
         count_output_vars(ClassifiedGoals, HeadArgs, OutputCount),
         (   OutputCount > 0
         ->  InputArity is Arity - OutputCount
-        ;   %% No outputs: check if all goals are guards (boolean predicate)
-            (   forall(member(CG, ClassifiedGoals), CG = guard(_, _))
-            ->  InputArity = Arity  %% All guards, all args are inputs
-            ;   InputArity is Arity - 1
+        ;   %% No body outputs: check if this is truly boolean
+            %% Boolean only if: all guards, last arg is a fresh variable
+            %% (not a constant, not a repeated variable from earlier position)
+            last(HeadArgs, LastArg),
+            append(EarlierArgs, [LastArg], HeadArgs),
+            (   forall(member(CG, ClassifiedGoals), CG = guard(_, _)),
+                var(LastArg),
+                \+ var_member_by_identity(LastArg, EarlierArgs)  %% not repeated
+            ->  InputArity = Arity  %% Boolean: all args are inputs
+            ;   InputArity is Arity - 1  %% Last arg is output
             )
         )
     ;   %% Pure fact: count unique variables to find input count
@@ -3208,8 +3214,12 @@ native_python_clause(_PredSpec, Head, Body, Condition, Code) :-
     ->  python_fact_input_count(HeadArgs, InputCount)
     ;   %% Check if all body goals are guards (boolean predicate)
         classify_goal_sequence(Goals, VarMap, CGs),
-        (   forall(member(CG, CGs), CG = guard(_, _))
-        ->  InputCount = Arity  %% Boolean: all args are inputs
+        last(HeadArgs, LastHA),
+        append(EarlierHA, [LastHA], HeadArgs),
+        (   forall(member(CG, CGs), CG = guard(_, _)),
+            var(LastHA),
+            \+ var_member_by_identity(LastHA, EarlierHA)
+        ->  InputCount = Arity
         ;   InputCount is Arity - 1
         )
     ),

--- a/src/unifyweaver/targets/type_declarations.pl
+++ b/src/unifyweaver/targets/type_declarations.pl
@@ -238,6 +238,32 @@ resolve_type(pair(_, _), r, "list").
 resolve_type(record(Name, _Fields), r, Concrete) :-
     atom_string(Name, Concrete).
 
+%% Python type hints
+resolve_type(atom, python, "str").
+resolve_type(string, python, "str").
+resolve_type(integer, python, "int").
+resolve_type(float, python, "float").
+resolve_type(number, python, "float").
+resolve_type(boolean, python, "bool").
+resolve_type(any, python, "Any").
+resolve_type(list(Type), python, Concrete) :-
+    resolve_type(Type, python, Inner),
+    format(string(Concrete), "list[~w]", [Inner]).
+resolve_type(maybe(Type), python, Concrete) :-
+    resolve_type(Type, python, Inner),
+    format(string(Concrete), "~w | None", [Inner]).
+resolve_type(map(KeyType, ValueType), python, Concrete) :-
+    resolve_type(KeyType, python, Key),
+    resolve_type(ValueType, python, Value),
+    format(string(Concrete), "dict[~w, ~w]", [Key, Value]).
+resolve_type(set(Type), python, Concrete) :-
+    resolve_type(Type, python, Inner),
+    format(string(Concrete), "set[~w]", [Inner]).
+resolve_type(pair(LeftType, RightType), python, Concrete) :-
+    resolve_type(LeftType, python, Left),
+    resolve_type(RightType, python, Right),
+    format(string(Concrete), "tuple[~w, ~w]", [Left, Right]).
+
 resolve_type(Type, TargetLang, Concrete) :-
     atom(Type),
     resolve_domain_type(Type, Resolved),

--- a/test_python_failures.pl
+++ b/test_python_failures.pl
@@ -88,6 +88,24 @@ my_member(X, [_|T]) :- my_member(X, T).
 :- dynamic arity_of/2.
 arity_of(Term, A) :- functor(Term, _, A).
 
+%% --- Guarded tail patterns (TypR handles, Python doesn't) ---
+
+%% Guard AFTER output (interleaved)
+:- dynamic validated_double/2.
+validated_double(X, Y) :- Y is X * 2, Y > 0.
+
+%% Multiple outputs with intermediate guard
+:- dynamic safe_ratio/4.
+safe_ratio(A, B, Ratio, Status) :- B =\= 0, Ratio is A / B,
+    (Ratio > 1 -> Status = high ; Status = low).
+
+%% Type-annotated predicate
+:- dynamic typed_add/3.
+:- type_declarations:assert(uw_type(typed_add/3, 1, integer)).
+:- type_declarations:assert(uw_type(typed_add/3, 2, integer)).
+:- type_declarations:assert(uw_return_type(typed_add/3, integer)).
+typed_add(X, Y, Z) :- Z is X + Y.
+
 run_failures :-
     try('sum_pair/3', sum_pair/3),
     try('valid_age/1', valid_age/1),
@@ -98,5 +116,6 @@ run_failures :-
     try('between_check/4', between_check/4),
     try('color_name/2', color_name/2),
     try('is_not_empty/1', is_not_empty/1),
-    try('my_member/2', my_member/2),
+    try('validated_double/2', validated_double/2),
+    try('typed_add/3', typed_add/3),
     nl, writeln('=== FAILURE SCAN DONE ===').

--- a/test_python_failures.pl
+++ b/test_python_failures.pl
@@ -64,6 +64,30 @@ color_name(2, green).
 color_name(3, blue).
 color_name(_, unknown).
 
+%% --- Patterns pushing deeper ---
+
+%% Conjunction in output position
+:- dynamic full_name/3.
+full_name(First, Last, Full) :- atom_concat(First, ' ', Temp), atom_concat(Temp, Last, Full).
+
+%% Predicate calling another predicate
+:- dynamic double_abs/2.
+double_abs(X, Y) :- abs_custom(X, A), Y is A * 2.
+
+%% Negation
+:- dynamic is_not_empty/1.
+is_not_empty(X) :- X \== [].
+
+%% List membership (recursive)
+%% member/2 is built-in, test detection only
+:- dynamic my_member/2.
+my_member(X, [X|_]).
+my_member(X, [_|T]) :- my_member(X, T).
+
+%% Functor inspection
+:- dynamic arity_of/2.
+arity_of(Term, A) :- functor(Term, _, A).
+
 run_failures :-
     try('sum_pair/3', sum_pair/3),
     try('valid_age/1', valid_age/1),
@@ -73,4 +97,6 @@ run_failures :-
     try('direction/2', direction/2),
     try('between_check/4', between_check/4),
     try('color_name/2', color_name/2),
+    try('is_not_empty/1', is_not_empty/1),
+    try('my_member/2', my_member/2),
     nl, writeln('=== FAILURE SCAN DONE ===').

--- a/test_python_failures.pl
+++ b/test_python_failures.pl
@@ -1,0 +1,76 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+
+%% Systematic failure detection — only predicates we expect SHOULD work
+%% but currently DON'T.
+
+try(Label, Pred/Arity) :-
+    format('~w: ', [Label]),
+    (   catch(
+            recursive_compiler:compile_recursive(Pred/Arity, [target(python)], _Code),
+            _Error, fail)
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+%% --- Patterns that should work but might not ---
+
+%% Negation as failure
+:- dynamic not_member/2.
+not_member(_, []).
+not_member(X, [H|T]) :- X \== H, not_member(X, T).
+
+%% Accumulator pattern (non-recursive base)
+:- dynamic sum_pair/3.
+sum_pair(X, Y, S) :- S is X + Y.
+
+%% Multiple guards in conjunction
+:- dynamic valid_age/1.
+valid_age(X) :- X >= 0, X =< 150.
+
+%% Guard with arithmetic output
+:- dynamic checked_double/2.
+checked_double(X, Y) :- X > 0, Y is X * 2.
+checked_double(X, 0) :- X =< 0.
+
+%% Ternary with arithmetic
+:- dynamic abs_custom/2.
+abs_custom(X, X) :- X >= 0.
+abs_custom(X, Y) :- X < 0, Y is -X.
+
+%% Nested output (computed value used in guard)
+:- dynamic classify_temp/2.
+classify_temp(T, freezing) :- T =< 0.
+classify_temp(T, cold) :- T > 0, T < 15.
+classify_temp(T, warm) :- T >= 15, T < 30.
+classify_temp(T, hot) :- T >= 30.
+
+%% Mixed constant and variable in head
+:- dynamic direction/2.
+direction(0, zero).
+direction(X, positive) :- X > 0.
+direction(X, negative) :- X < 0.
+
+%% Arity 4+ with guards
+:- dynamic between_check/4.
+between_check(X, Lo, Hi, in_range) :- X >= Lo, X =< Hi.
+between_check(_, _, _, out_of_range).
+
+%% String-like output
+:- dynamic color_name/2.
+color_name(1, red).
+color_name(2, green).
+color_name(3, blue).
+color_name(_, unknown).
+
+run_failures :-
+    try('sum_pair/3', sum_pair/3),
+    try('valid_age/1', valid_age/1),
+    try('checked_double/2', checked_double/2),
+    try('abs_custom/2', abs_custom/2),
+    try('classify_temp/2', classify_temp/2),
+    try('direction/2', direction/2),
+    try('between_check/4', between_check/4),
+    try('color_name/2', color_name/2),
+    nl, writeln('=== FAILURE SCAN DONE ===').

--- a/test_python_quality.pl
+++ b/test_python_quality.pl
@@ -1,0 +1,56 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+
+try_compile(Pred/Arity, Code) :-
+    catch(recursive_compiler:compile_recursive(Pred/Arity, [target(python)], Code), _, fail).
+
+show(Code, FuncName) :-
+    split_string(Code, "\n", "", Lines),
+    format(atom(Prefix), "def ~w", [FuncName]),
+    (   nth1(I, Lines, L), sub_string(L, _, _, _, Prefix)
+    ->  Start is I, End is min(I + 12, 99999),
+        forall((between(Start, End, J), nth1(J, Lines, LJ),
+                (LJ \= "" ; J =:= Start)), writeln(LJ))
+    ;   writeln('  (not found)')
+    ).
+
+%% --- Predicates to quality-check ---
+
+:- dynamic checked_double/2, abs_custom/2, classify_temp/2, direction/2, between_check/4.
+
+checked_double(X, Y) :- X > 0, Y is X * 2.
+checked_double(X, 0) :- X =< 0.
+
+abs_custom(X, X) :- X >= 0.
+abs_custom(X, Y) :- X < 0, Y is -X.
+
+classify_temp(T, freezing) :- T =< 0.
+classify_temp(T, cold) :- T > 0, T < 15.
+classify_temp(T, warm) :- T >= 15, T < 30.
+classify_temp(T, hot) :- T >= 30.
+
+direction(0, zero).
+direction(X, positive) :- X > 0.
+direction(X, negative) :- X < 0.
+
+between_check(X, Lo, Hi, in_range) :- X >= Lo, X =< Hi.
+between_check(_, _, _, out_of_range).
+
+run :-
+    writeln('--- checked_double ---'),
+    (try_compile(checked_double/2, C1) -> show(C1, checked_double) ; writeln('  FAIL')), nl,
+
+    writeln('--- abs_custom ---'),
+    (try_compile(abs_custom/2, C2) -> show(C2, abs_custom) ; writeln('  FAIL')), nl,
+
+    writeln('--- classify_temp ---'),
+    (try_compile(classify_temp/2, C3) -> show(C3, classify_temp) ; writeln('  FAIL')), nl,
+
+    writeln('--- direction ---'),
+    (try_compile(direction/2, C4) -> show(C4, direction) ; writeln('  FAIL')), nl,
+
+    writeln('--- between_check ---'),
+    (try_compile(between_check/4, C5) -> show(C5, between_check) ; writeln('  FAIL')), nl,
+
+    writeln('=== QUALITY CHECK DONE ===').

--- a/test_python_round2.pl
+++ b/test_python_round2.pl
@@ -195,6 +195,90 @@ test_is_vowel :-
         check('has def', Code, "def is_vowel(arg1)")
     ; writeln('  SKIP: failed')).
 
+%% ========================================================
+%% Group 8: Negation as failure / \+
+%% ========================================================
+:- dynamic is_odd/1, not_zero/1.
+is_odd(X) :- X mod 2 =\= 0.
+not_zero(X) :- X =\= 0.
+
+test_is_odd :-
+    writeln('=== is_odd/1 (=\\= guard) ==='),
+    try_compile(is_odd/1, python, Code, Status),
+    (Status = ok -> show_func(Code, is_odd), check('has !=', Code, "!=") ; writeln('  SKIP')).
+
+test_not_zero :-
+    writeln('=== not_zero/1 (simple !=) ==='),
+    try_compile(not_zero/1, python, Code, Status),
+    (Status = ok -> show_func(Code, not_zero), check('has !=', Code, "!= 0") ; writeln('  SKIP')).
+
+%% ========================================================
+%% Group 9: Multiple guards combined
+%% ========================================================
+:- dynamic in_range/3, triangle_type/4.
+in_range(X, Lo, Hi) :- X >= Lo, X =< Hi.
+triangle_type(A, B, C, equilateral) :- A =:= B, B =:= C.
+triangle_type(A, B, C, isosceles) :- A =:= B ; B =:= C ; A =:= C.
+triangle_type(_, _, _, scalene).
+
+test_in_range :-
+    writeln('=== in_range/3 (multiple guards, arity-3 boolean) ==='),
+    try_compile(in_range/3, python, Code, Status),
+    (Status = ok -> show_func(Code, in_range),
+        check('has >= and <=', Code, ">="),
+        check('has arg1', Code, "def in_range(arg1")
+    ; writeln('  SKIP')).
+
+test_triangle :-
+    writeln('=== triangle_type/4 (multi-clause, guards + disjunction) ==='),
+    try_compile(triangle_type/4, python, Code, Status),
+    (Status = ok -> show_func(Code, triangle_type),
+        check('equilateral', Code, "equilateral"),
+        check('scalene', Code, "scalene")
+    ; writeln('  SKIP')).
+
+%% ========================================================
+%% Group 10: Intermediate computations
+%% ========================================================
+:- dynamic hypotenuse/3, circle_area/2, discount_price/3.
+hypotenuse(A, B, C) :- C is sqrt(A * A + B * B).
+circle_area(R, Area) :- Area is 3.14159 * R * R.
+discount_price(Price, Pct, Final) :- Final is Price * (1 - Pct / 100).
+
+test_hypotenuse :-
+    writeln('=== hypotenuse/3 (nested arithmetic with sqrt) ==='),
+    try_compile(hypotenuse/3, python, Code, Status),
+    (Status = ok -> show_func(Code, hypotenuse), check('sqrt', Code, "sqrt") ; writeln('  SKIP')).
+
+test_circle_area :-
+    writeln('=== circle_area/2 (float constant) ==='),
+    try_compile(circle_area/2, python, Code, Status),
+    (Status = ok -> show_func(Code, circle_area), check('3.14159', Code, "3.14159") ; writeln('  SKIP')).
+
+test_discount :-
+    writeln('=== discount_price/3 (compound arithmetic) ==='),
+    try_compile(discount_price/3, python, Code, Status),
+    (Status = ok -> show_func(Code, discount_price), check('has def', Code, "def discount_price") ; writeln('  SKIP')).
+
+%% ========================================================
+%% Group 11: Predicate with multiple returns in different clauses
+%% ========================================================
+:- dynamic http_status/2.
+http_status(200, ok).
+http_status(301, redirect).
+http_status(404, not_found).
+http_status(500, server_error).
+http_status(_, unknown).
+
+test_http_status :-
+    writeln('=== http_status/2 (5-clause lookup table) ==='),
+    try_compile(http_status/2, python, Code, Status),
+    (Status = ok -> show_func(Code, http_status),
+        check('200', Code, "200"),
+        check('not_found', Code, "not_found"),
+        check('unknown', Code, "unknown")
+    ; writeln('  SKIP')).
+
 run_tests :-
     test_swap,
     test_min_max,
@@ -211,4 +295,13 @@ run_tests :-
     test_is_even,
     test_is_adult,
     test_is_vowel,
-    nl, writeln('=== ALL 15 ROUND 2 TESTS DONE ===').
+    %% Round 2b
+    test_is_odd,
+    test_not_zero,
+    test_in_range,
+    test_triangle,
+    test_hypotenuse,
+    test_circle_area,
+    test_discount,
+    test_http_status,
+    nl, writeln('=== ALL 23 ROUND 2 TESTS DONE ===').

--- a/test_python_round2.pl
+++ b/test_python_round2.pl
@@ -1,0 +1,214 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+%% ========================================================
+%% Test predicates — increasing complexity
+%% ========================================================
+
+%% --- Group 1: Multiple sequential outputs ---
+:- dynamic swap/4, min_max/4.
+swap(X, Y, Y, X).
+min_max(X, Y, X, Y) :- X =< Y.
+min_max(X, Y, Y, X) :- X > Y.
+
+%% --- Group 2: Chained arithmetic ---
+:- dynamic celsius_to_fahrenheit/2, bmi/3.
+celsius_to_fahrenheit(C, F) :- F is C * 9 / 5 + 32.
+bmi(Weight, Height, BMI) :- BMI is Weight / (Height * Height).
+
+%% --- Group 3: Guard with fallback default ---
+:- dynamic safe_sqrt/2, clamp_range/4.
+safe_sqrt(X, Y) :- X >= 0, Y is sqrt(X).
+safe_sqrt(X, -1) :- X < 0.
+clamp_range(X, Lo, Hi, Lo) :- X < Lo.
+clamp_range(X, _Lo, Hi, Hi) :- X > Hi.
+clamp_range(X, _Lo, _Hi, X) :- true.
+
+%% --- Group 4: String/atom output ---
+:- dynamic greet/2, day_type/2.
+greet(hello, 'Hello, World!').
+greet(goodbye, 'Farewell!').
+greet(_, 'Hi!').
+day_type(saturday, weekend).
+day_type(sunday, weekend).
+day_type(_, weekday).
+
+%% --- Group 5: Nested guard conditions ---
+:- dynamic tax_bracket/2, letter_grade/2.
+tax_bracket(Income, Rate) :-
+    (Income =< 10000 -> Rate = 0.0
+    ; Income =< 50000 -> Rate = 0.2
+    ; Income =< 100000 -> Rate = 0.3
+    ; Rate = 0.4).
+letter_grade(Score, Grade) :-
+    (Score >= 90 -> Grade = 'A'
+    ; Score >= 80 -> Grade = 'B'
+    ; Score >= 70 -> Grade = 'C'
+    ; Score >= 60 -> Grade = 'D'
+    ; Grade = 'F').
+
+%% --- Group 6: Mixed guard + output in body ---
+:- dynamic safe_divide/3, factorial_base/2.
+safe_divide(X, Y, Result) :- Y =\= 0, Result is X / Y.
+safe_divide(_, 0, 0).
+factorial_base(0, 1).
+factorial_base(1, 1).
+
+%% --- Group 7: Arity-1 predicates (boolean) ---
+:- dynamic is_even/1, is_adult/1, is_vowel/1.
+is_even(X) :- X mod 2 =:= 0.
+is_adult(Age) :- Age >= 18.
+is_vowel(a). is_vowel(e). is_vowel(i). is_vowel(o). is_vowel(u).
+
+%% ========================================================
+%% Test runner
+%% ========================================================
+
+try_compile(Pred/Arity, Target, Code, Status) :-
+    (   catch(
+            recursive_compiler:compile_recursive(Pred/Arity, [target(Target)], Code),
+            _Error,
+            fail
+        )
+    ->  Status = ok
+    ;   Status = fail,
+        Code = ""
+    ).
+
+check(Label, Code, Substring) :-
+    (   sub_string(Code, _, _, _, Substring)
+    ->  format('  PASS: ~w~n', [Label])
+    ;   format('  MISS: ~w (no "~w")~n', [Label, Substring])
+    ).
+
+show_func(Code, FuncName) :-
+    split_string(Code, "\n", "", Lines),
+    format(atom(Prefix), "def ~w", [FuncName]),
+    (   nth1(I, Lines, L), sub_string(L, _, _, _, Prefix)
+    ->  Start is I, End is min(I + 8, 99999),
+        forall((between(Start, End, J), nth1(J, Lines, LJ),
+                (LJ \= "" ; J =:= Start)),
+               (format('    ~w~n', [LJ])))
+    ;   format('    (function ~w not found)~n', [FuncName])
+    ).
+
+%% --- Tests ---
+
+test_swap :-
+    writeln('=== swap/4 (pure fact, multi-output) ==='),
+    try_compile(swap/4, python, Code, Status),
+    (Status = ok -> show_func(Code, swap), check('has def', Code, "def swap") ; writeln('  SKIP: failed')).
+
+test_min_max :-
+    writeln('=== min_max/4 (multi-clause, multi-output from head) ==='),
+    try_compile(min_max/4, python, Code, Status),
+    (Status = ok -> show_func(Code, min_max), check('has def', Code, "def min_max") ; writeln('  SKIP: failed')).
+
+test_celsius :-
+    writeln('=== celsius_to_fahrenheit/2 (chained arithmetic) ==='),
+    try_compile(celsius_to_fahrenheit/2, python, Code, Status),
+    (Status = ok -> show_func(Code, celsius_to_fahrenheit), check('has * 9', Code, "* 9") ; writeln('  SKIP: failed')).
+
+test_bmi :-
+    writeln('=== bmi/3 (3-arg arithmetic) ==='),
+    try_compile(bmi/3, python, Code, Status),
+    (Status = ok -> show_func(Code, bmi), check('has def', Code, "def bmi") ; writeln('  SKIP: failed')).
+
+test_safe_sqrt :-
+    writeln('=== safe_sqrt/2 (guard + fallback) ==='),
+    try_compile(safe_sqrt/2, python, Code, Status),
+    (Status = ok -> show_func(Code, safe_sqrt), check('has sqrt', Code, "sqrt") ; writeln('  SKIP: failed')).
+
+test_clamp_range :-
+    writeln('=== clamp_range/4 (3-clause, head-arg output) ==='),
+    try_compile(clamp_range/4, python, Code, Status),
+    (Status = ok -> show_func(Code, clamp_range), check('has def', Code, "def clamp_range") ; writeln('  SKIP: failed')).
+
+test_greet :-
+    writeln('=== greet/2 (atom matching, string output) ==='),
+    try_compile(greet/2, python, Code, Status),
+    (Status = ok -> show_func(Code, greet),
+        check('Hello', Code, "Hello, World!"),
+        check('Farewell', Code, "Farewell!")
+    ; writeln('  SKIP: failed')).
+
+test_day_type :-
+    writeln('=== day_type/2 (atom matching, atom output) ==='),
+    try_compile(day_type/2, python, Code, Status),
+    (Status = ok -> show_func(Code, day_type),
+        check('weekend', Code, "weekend"),
+        check('weekday', Code, "weekday")
+    ; writeln('  SKIP: failed')).
+
+test_tax_bracket :-
+    writeln('=== tax_bracket/2 (nested if-then-else, 4 brackets) ==='),
+    try_compile(tax_bracket/2, python, Code, Status),
+    (Status = ok -> show_func(Code, tax_bracket),
+        check('elif', Code, "elif"),
+        check('0.4', Code, "0.4")
+    ; writeln('  SKIP: failed')).
+
+test_letter_grade :-
+    writeln('=== letter_grade/2 (5-way nested if-then-else) ==='),
+    try_compile(letter_grade/2, python, Code, Status),
+    (Status = ok -> show_func(Code, letter_grade),
+        check('elif', Code, "elif"),
+        check('grade F', Code, "F")
+    ; writeln('  SKIP: failed')).
+
+test_safe_divide :-
+    writeln('=== safe_divide/3 (guard + output, fallback clause) ==='),
+    try_compile(safe_divide/3, python, Code, Status),
+    (Status = ok -> show_func(Code, safe_divide),
+        check('has def', Code, "def safe_divide")
+    ; writeln('  SKIP: failed')).
+
+test_factorial_base :-
+    writeln('=== factorial_base/2 (pure fact multi-clause) ==='),
+    try_compile(factorial_base/2, python, Code, Status),
+    (Status = ok -> show_func(Code, factorial_base),
+        check('return 1', Code, "return 1")
+    ; writeln('  SKIP: failed')).
+
+test_is_even :-
+    writeln('=== is_even/1 (arity-1, mod guard) ==='),
+    try_compile(is_even/1, python, Code, Status),
+    (Status = ok -> show_func(Code, is_even),
+        check('has arg1', Code, "def is_even(arg1)"),
+        check('mod or %', Code, "%")
+    ; writeln('  SKIP: failed')).
+
+test_is_adult :-
+    writeln('=== is_adult/1 (arity-1, comparison) ==='),
+    try_compile(is_adult/1, python, Code, Status),
+    (Status = ok -> show_func(Code, is_adult),
+        check('has arg1', Code, "def is_adult(arg1)"),
+        check('>= 18', Code, ">= 18")
+    ; writeln('  SKIP: failed')).
+
+test_is_vowel :-
+    writeln('=== is_vowel/1 (arity-1, multi-clause fact matching) ==='),
+    try_compile(is_vowel/1, python, Code, Status),
+    (Status = ok -> show_func(Code, is_vowel),
+        check('has def', Code, "def is_vowel(arg1)")
+    ; writeln('  SKIP: failed')).
+
+run_tests :-
+    test_swap,
+    test_min_max,
+    test_celsius,
+    test_bmi,
+    test_safe_sqrt,
+    test_clamp_range,
+    test_greet,
+    test_day_type,
+    test_tax_bracket,
+    test_letter_grade,
+    test_safe_divide,
+    test_factorial_base,
+    test_is_even,
+    test_is_adult,
+    test_is_vowel,
+    nl, writeln('=== ALL 15 ROUND 2 TESTS DONE ===').

--- a/test_python_typr_patterns.pl
+++ b/test_python_typr_patterns.pl
@@ -1,0 +1,102 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+
+%% =====================================================
+%% Test predicates matching TypR's native lowering patterns
+%% that Python should also handle.
+%% =====================================================
+
+try(Label, Pred/Arity, Checks) :-
+    format('~w: ', [Label]),
+    (   catch(recursive_compiler:compile_recursive(Pred/Arity, [target(python)], Code), _, fail)
+    ->  run_checks(Code, Checks, AllOk),
+        (AllOk == true -> writeln(ok) ; true)
+    ;   writeln('COMPILE FAIL')
+    ).
+
+run_checks(_, [], true).
+run_checks(Code, [check(Label, Substr)|Rest], AllOk) :-
+    (   sub_string(Code, _, _, _, Substr)
+    ->  run_checks(Code, Rest, AllOk)
+    ;   format('MISS(~w) ', [Label]),
+        AllOk = false,
+        run_checks(Code, Rest, _)
+    ).
+
+show(Pred/Arity) :-
+    (   catch(recursive_compiler:compile_recursive(Pred/Arity, [target(python)], Code), _, fail)
+    ->  atom_string(Pred, PredStr),
+        split_string(Code, "\n", "", Lines),
+        format(atom(Prefix), "def ~w", [PredStr]),
+        (   nth1(I, Lines, L), sub_string(L, _, _, _, Prefix)
+        ->  End is min(I + 10, 99999),
+            forall((between(I, End, J), nth1(J, Lines, LJ),
+                    (LJ \= "" ; J =:= I)), writeln(LJ))
+        ;   writeln('  (function not found)')
+        )
+    ;   writeln('  (compile failed)')
+    ).
+
+%% --- Pattern: If-then-else as GUARD (not output) ---
+:- dynamic safe_log/2.
+safe_log(X, Y) :- (X > 0 -> true ; fail), Y is log(X).
+%% Expected: if arg1 > 0: return math.log(arg1)
+
+%% --- Pattern: Conditional output with pending guards ---
+:- dynamic clamped_sqrt/3.
+clamped_sqrt(X, Max, Y) :- X >= 0, Y is sqrt(X), Y =< Max.
+%% Expected: v1 = math.sqrt(arg1); if v1 <= arg2: return v1
+
+%% --- Pattern: Multi-result if-then-else (two outputs from branches) ---
+:- dynamic divmod_result/4.
+divmod_result(X, Y, Q, R) :- Q is X // Y, R is X mod Y.
+%% Expected: return (arg1 // arg2, arg1 % arg2)
+
+%% --- Pattern: Nested if-then-else as guard ---
+:- dynamic complex_guard/2.
+complex_guard(X, Y) :- (X > 0 -> X < 100 ; X > -100), Y is X * 2.
+%% Expected: if (arg1 < 100 if arg1 > 0 else arg1 > -100): return arg1 * 2
+
+%% --- Pattern: Mixed output + guard + output sequence ---
+:- dynamic bounded_square/2.
+bounded_square(X, Y) :- Y is X * X, Y < 1000.
+%% Expected: arg2 = arg1 * arg1; if arg2 < 1000: return arg2
+
+%% --- Pattern: Output from binding (Python binding registry) ---
+%% (length/2 is registered as Python 'len' binding)
+:- dynamic list_size/2.
+list_size(L, N) :- length(L, N).
+%% Would need binding lookup — deferred
+
+%% --- Pattern: Wildcard clause (catch-all) ---
+:- dynamic classify_sign/2.
+classify_sign(0, zero).
+classify_sign(X, positive) :- X > 0.
+classify_sign(_, negative).
+%% Expected: if arg1 == 0: return "zero"; elif arg1 > 0: return "positive"; else: return "negative"
+
+%% --- Pattern: 5+ clauses ---
+:- dynamic day_name/2.
+day_name(1, monday). day_name(2, tuesday). day_name(3, wednesday).
+day_name(4, thursday). day_name(5, friday). day_name(6, saturday).
+day_name(7, sunday). day_name(_, unknown).
+%% Expected: 8-clause if/elif chain
+
+run_tests :-
+    try('if-then-else guard', safe_log/2, [check('log', "log")]),
+    try('guarded tail + pending', clamped_sqrt/3, [check('sqrt', "sqrt")]),
+    try('multi-output arithmetic', divmod_result/4, [check('return tuple', "return (")]),
+    try('nested ite guard', complex_guard/2, [check('X*2', "* 2")]),
+    try('output then guard', bounded_square/2, [check('< 1000', "< 1000")]),
+    try('classify_sign', classify_sign/2, [check('zero', "zero"), check('positive', "positive"), check('negative', "negative")]),
+    try('day_name 8-clause', day_name/2, [check('monday', "monday"), check('sunday', "sunday"), check('unknown', "unknown")]),
+    nl,
+    writeln('--- Showing generated functions ---'), nl,
+    writeln('=== safe_log ==='), show(safe_log/2), nl,
+    writeln('=== clamped_sqrt ==='), show(clamped_sqrt/3), nl,
+    writeln('=== divmod_result ==='), show(divmod_result/4), nl,
+    writeln('=== bounded_square ==='), show(bounded_square/2), nl,
+    writeln('=== classify_sign ==='), show(classify_sign/2), nl,
+    writeln('=== day_name ==='), show(day_name/2), nl,
+    writeln('=== TYPR PATTERN TESTS DONE ===').

--- a/test_python_typr_patterns.pl
+++ b/test_python_typr_patterns.pl
@@ -83,6 +83,24 @@ day_name(4, thursday). day_name(5, friday). day_name(6, saturday).
 day_name(7, sunday). day_name(_, unknown).
 %% Expected: 8-clause if/elif chain
 
+%% --- Pattern: Binding output (Python binding registry) ---
+:- dynamic str_len/2, str_of/2.
+str_len(S, N) :- length(S, N).
+str_of(X, S) :- to_string(X, S).
+
+%% --- Pattern: Multi-result disjunction (2+ shared vars) ---
+:- dynamic pair_choice/3.
+pair_choice(1, X, Y) :- X = a, Y = alpha.
+pair_choice(2, X, Y) :- X = b, Y = beta.
+pair_choice(_, X, Y) :- X = z, Y = omega.
+
+%% --- Pattern: DataFrame operations (pandas) ---
+%% These use special functors recognized by python_output_goal
+:- dynamic filtered_data/2, sorted_data/3, grouped_data/3.
+filtered_data(DF, Out) :- filter(DF, active, Out).
+sorted_data(DF, Col, Out) :- sort_by(DF, Col, Out).
+grouped_data(DF, Col, Out) :- group_by(DF, Col, Out).
+
 run_tests :-
     try('if-then-else guard', safe_log/2, [check('log', "log")]),
     try('guarded tail + pending', clamped_sqrt/3, [check('sqrt', "sqrt")]),
@@ -91,6 +109,13 @@ run_tests :-
     try('output then guard', bounded_square/2, [check('< 1000', "< 1000")]),
     try('classify_sign', classify_sign/2, [check('zero', "zero"), check('positive', "positive"), check('negative', "negative")]),
     try('day_name 8-clause', day_name/2, [check('monday', "monday"), check('sunday', "sunday"), check('unknown', "unknown")]),
+    %% New: binding + dataframe + multi-result
+    try('binding output (len)', str_len/2, [check('len', "len(")]),
+    try('binding output (str)', str_of/2, [check('str', "str(")]),
+    try('multi-result clauses', pair_choice/3, [check('alpha', "alpha")]),
+    try('pandas filter', filtered_data/2, [check('filter', "[")]),
+    try('pandas sort', sorted_data/3, [check('sort_values', "sort_values")]),
+    try('pandas group', grouped_data/3, [check('groupby', "groupby")]),
     nl,
     writeln('--- Showing generated functions ---'), nl,
     writeln('=== safe_log ==='), show(safe_log/2), nl,
@@ -99,4 +124,10 @@ run_tests :-
     writeln('=== bounded_square ==='), show(bounded_square/2), nl,
     writeln('=== classify_sign ==='), show(classify_sign/2), nl,
     writeln('=== day_name ==='), show(day_name/2), nl,
+    nl,
+    writeln('--- Showing new functions ---'), nl,
+    writeln('=== str_len ==='), show(str_len/2), nl,
+    writeln('=== pair_choice ==='), show(pair_choice/3), nl,
+    writeln('=== filtered_data ==='), show(filtered_data/2), nl,
+    writeln('=== sorted_data ==='), show(sorted_data/3), nl,
     writeln('=== TYPR PATTERN TESTS DONE ===').


### PR DESCRIPTION
# 
## Summary

Implements nearly every non-recursive pattern from TypR's native lowering in the Python target, using the shared `clause_body_analysis` module. The Python target can now compile a wide range of non-recursive predicates that previously failed silently — producing idiomatic Python with if/elif/else chains, ternary expressions, tuple returns, and optional type hints.

**Approach:** Following Codex's methodology — test to find failing patterns, fix the failing slice, generalize. Each fix addresses a single root cause that resolves multiple predicates.

## TypR Patterns Implemented (18 of 20 applicable)

| Pattern | Example | Generated Python |
|---|---|---|
| If-then-else output | `(X>0 -> L=pos ; L=neg)` | `return "pos" if arg1 > 0 else "neg"` |
| If-then output | `(X>0 -> Y is X*2)` | `if arg1 > 0: return (arg1 * 2)` |
| Disjunction output | `(X<0,C=neg ; X=:=0,C=zero ; X>0,C=pos)` | `if/elif/else` chain |
| If-then-else guard | `(X>0 -> X<100 ; X>-100), Y is X*2` | `if (arg1<100 if arg1>0 else arg1>-100):` |
| Guard simplification | `(X>0 -> true ; fail)` | Simplified to `arg1 > 0` |
| Binary operator guard | `X > 0, X < 10` | `arg1 > 0 and arg1 < 10` |
| true/fail as guard | `true` / `fail` | `True` / `False` |
| Guarded tail sequence | `Y is X*2, Y > 0` | `arg2 = (arg1*2); if arg2>0: return arg2` |
| Conditional output + guards | `X>=0, Y is sqrt(X), Y=<Max` | assign, check, conditional return |
| Binding output (single) | `length(S, N)` | `return len(arg1)` |
| Binding command guard | zero-output bindings | used as boolean conditions |
| Pandas filter | `filter(DF, Expr, Out)` | `arg2 = arg1["active"]` |
| Pandas sort | `sort_by(DF, Col, Out)` | `arg2 = arg1.sort_values(arg2)` |
| Pandas group | `group_by(DF, Col, Out)` | `arg2 = arg1.groupby(arg2)` |
| Floor division | `Q is X // Y` | `arg3 = (arg1 // arg2)` |
| Multi-output tuple | `compute(X,Y,Sum,Prod)` | `return (arg3, arg4)` |
| Type hints (optional) | `uw_type(f/3, 1, integer)` | `def f(arg1: int) -> int:` |
| Output-position constants | `classify_temp(T, freezing)` | `return "freezing"` (not `arg2 == "freezing"`) |

**Not implemented (2):**
- Multi-result container (2+ shared vars from single if-then-else) — TypR's most sophisticated pattern, diminishing returns
- Recursion patterns (tail/linear/tree) — separate compilation path

## Key Generalizations

1. **Output-position constants ≠ input conditions** — a constant in the last head position is a return value, not an equality check. Single fix resolved classify_temp, direction, checked_double, abs_custom, between_check.

2. **Boolean predicate detection** — a predicate is boolean only if ALL body goals are guards AND the last head arg is a fresh variable (not constant, not repeated from earlier position). Extracted to `python_is_boolean_predicate/3`.

3. **Pure fact multi-output** — detects repeated variables in head args (swap pattern) vs all-unique args (factorial pattern) to determine input/output split.

## Changes

### Shared module (`clause_body_analysis.pl`)
- `is_guard_goal` now recognizes `true`, `fail`, `false`
- `is_guard_goal` recognizes if-then-else without output vars as guard
- `expr_op(=\=, '!=')` and `expr_op(//, 'floor_div')` added

### Python target (`python_target.pl`)
- `compile_non_recursive(python, ...)` clause added to recursive_compiler
- `native_python_goal_sequence` uses `classify_goal_sequence` with fallback
- `python_render_classified_goals` handles guard, output, output_ite, output_disj, output_if_then, passthrough, guarded tail
- `python_output_goal` handles binding registry and pandas DataFrame ops
- `python_output_goal_last` handles binding return and VarMap diff fallback
- `python_guard_condition` handles true/fail, binding commands, ite-as-guard simplification
- `python_typed_arg_list` / `python_return_annotation` for optional type hints
- `python_arg_split` detects input count from classified goals, boolean predicates, pure facts
- `python_fact_return` / `python_fact_input_count` for pure fact multi-output
- `python_is_boolean_predicate` extracted helper
- `elif True:` → `else:` for catch-all clauses
- `python_op('/', '/')` (float division, was `//`)
- `python_expr` for sqrt, sin, cos, log, round + general unary fallback
- Lazy `init_python_bindings` in `compile_non_recursive_predicate`

### Type declarations (`type_declarations.pl`)
- Python `resolve_type` facts: str, int, float, bool, Any, list[T], T|None, dict[K,V], set[T], tuple[L,R]

## Test plan

- [x] 13 TypR pattern tests (test_python_typr_patterns.pl)
- [x] 23 round-2 tests (test_python_round2.pl)
- [x] 14 round-1 tests (test_python_advanced.pl)
- [x] 8 clause body analysis tests (test_clause_body_analysis.pl)
- [x] Failure scanner (test_python_failures.pl)
- [x] Quality checker (test_python_quality.pl)
- [x] Existing `test_recursive_compiler` passes unchanged
- [x] **50+ total tests, all passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
