### PR TITLE
feat: all 16 non-TypR targets register compile_expression hooks

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -166,6 +166,10 @@ compile_non_recursive(ruby, Pred/Arity, FinalOptions, GeneratedCode) :-
     ruby_target:compile_predicate_to_ruby(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(typescript, Pred/Arity, FinalOptions, GeneratedCode) :-
     typescript_target:compile_predicate_to_typescript(Pred/Arity, FinalOptions, GeneratedCode).
+compile_non_recursive(haskell, Pred/Arity, FinalOptions, GeneratedCode) :-
+    haskell_target:compile_predicate_to_haskell(Pred/Arity, FinalOptions, GeneratedCode).
+compile_non_recursive(fsharp, Pred/Arity, FinalOptions, GeneratedCode) :-
+    fsharp_target:compile_predicate_to_fsharp(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(typr, Pred/Arity, FinalOptions, GeneratedCode) :-
     compile_predicate_to_typr(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(jython, Pred/Arity, FinalOptions, GeneratedCode) :-

--- a/src/unifyweaver/targets/clojure_target.pl
+++ b/src/unifyweaver/targets/clojure_target.pl
@@ -786,6 +786,40 @@ clojure_branch_value(is(_, Expr), VarMap, Value) :-
 clojure_branch_value(Goal, VarMap, Value) :-
     clojure_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register Clojure renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(clojure, Goal, VarMap, Line, VarName, VarMapOut) :-
+    clojure_output_goal(Goal, VarMap, Line, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, VarName)
+    ->  true
+    ;   VarName = "_"
+    ).
+
+clause_body_analysis:render_guard_condition(clojure, Goal, VarMap, CondStr) :-
+    clojure_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(clojure, Branch, VarMap, ExprStr) :-
+    clojure_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(clojure, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~w(if ~w', [Indent, Cond]),
+    clojure_indent_lines(ThenLines, Indent, IndentedThen),
+    (   ElseLines \= []
+    ->  clojure_indent_lines(ElseLines, Indent, IndentedElse),
+        format(string(CloseParen), '~w)', [Indent]),
+        append([IfLine|IndentedThen], IndentedElse, PreClose),
+        append(PreClose, [CloseParen], Lines)
+    ;   format(string(CloseParen), '~w)', [Indent]),
+        append([IfLine|IndentedThen], [CloseParen], Lines)
+    ).
+
+clojure_indent_lines([], _, []).
+clojure_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w  ~w', [Indent, Line]),
+    clojure_indent_lines(Rest, Indent, RestIndented).
+
 %% clojure_expr — convert Prolog expression to Clojure syntax
 clojure_expr(Var, VarMap, CExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/elixir_target.pl
+++ b/src/unifyweaver/targets/elixir_target.pl
@@ -442,6 +442,41 @@ elixir_branch_value(is(_, Expr), VarMap, Value) :-
 elixir_branch_value(Goal, VarMap, Value) :-
     elixir_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register Elixir renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(elixir, Goal, VarMap, Line, VarName, VarMapOut) :-
+    elixir_output_goal(Goal, VarMap, Line, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, VarName)
+    ->  true
+    ;   VarName = "_"
+    ).
+
+clause_body_analysis:render_guard_condition(elixir, Goal, VarMap, CondStr) :-
+    elixir_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(elixir, Branch, VarMap, ExprStr) :-
+    elixir_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(elixir, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif ~w do', [Indent, Cond]),
+    elixir_indent_lines(ThenLines, Indent, IndentedThen),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~welse', [Indent]),
+        elixir_indent_lines(ElseLines, Indent, IndentedElse),
+        format(string(EndLine), '~wend', [Indent]),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], PreEnd),
+        append(PreEnd, [EndLine], Lines)
+    ;   format(string(EndLine), '~wend', [Indent]),
+        append([IfLine|IndentedThen], [EndLine], Lines)
+    ).
+
+elixir_indent_lines([], _, []).
+elixir_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w  ~w', [Indent, Line]),
+    elixir_indent_lines(Rest, Indent, RestIndented).
+
 %% elixir_expr — convert Prolog expression to Elixir syntax
 elixir_expr(Var, VarMap, ExExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/fsharp_target.pl
+++ b/src/unifyweaver/targets/fsharp_target.pl
@@ -357,6 +357,38 @@ fsharp_branch_value(is(_, Expr), VarMap, Value) :-
 fsharp_branch_value(Goal, VarMap, Value) :-
     fsharp_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register F# renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(fsharp, Goal, VarMap, Line, VarName, VarMapOut) :-
+    fsharp_output_goal(Goal, VarMap, Line, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, VarName)
+    ->  true
+    ;   VarName = "_"
+    ).
+
+clause_body_analysis:render_guard_condition(fsharp, Goal, VarMap, CondStr) :-
+    fsharp_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(fsharp, Branch, VarMap, ExprStr) :-
+    fsharp_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(fsharp, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif ~w then', [Indent, Cond]),
+    fsharp_indent_lines(ThenLines, Indent, IndentedThen),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~welse', [Indent]),
+        fsharp_indent_lines(ElseLines, Indent, IndentedElse),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], Lines)
+    ;   append([IfLine|IndentedThen], [], Lines)
+    ).
+
+fsharp_indent_lines([], _, []).
+fsharp_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    fsharp_indent_lines(Rest, Indent, RestIndented).
+
 %% fsharp_expr — convert Prolog expression to F# syntax
 fsharp_expr(Var, VarMap, FsExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/haskell_target.pl
+++ b/src/unifyweaver/targets/haskell_target.pl
@@ -406,6 +406,39 @@ haskell_branch_value(is(_, Expr), VarMap, Value) :-
 haskell_branch_value(Goal, VarMap, Value) :-
     haskell_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register Haskell renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(haskell, Goal, VarMap, Line, VarName, VarMapOut) :-
+    haskell_output_goal(Goal, VarMap, Line, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, VarName)
+    ->  true
+    ;   VarName = "_"
+    ).
+
+clause_body_analysis:render_guard_condition(haskell, Goal, VarMap, CondStr) :-
+    haskell_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(haskell, Branch, VarMap, ExprStr) :-
+    haskell_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(haskell, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif ~w', [Indent, Cond]),
+    format(string(ThenHead), '~w  then', [Indent]),
+    haskell_indent_lines(ThenLines, Indent, IndentedThen),
+    (   ElseLines \= []
+    ->  format(string(ElseHead), '~w  else', [Indent]),
+        haskell_indent_lines(ElseLines, Indent, IndentedElse),
+        append([IfLine, ThenHead|IndentedThen], [ElseHead|IndentedElse], Lines)
+    ;   append([IfLine, ThenHead|IndentedThen], [], Lines)
+    ).
+
+haskell_indent_lines([], _, []).
+haskell_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    haskell_indent_lines(Rest, Indent, RestIndented).
+
 %% haskell_expr — convert Prolog expression to Haskell syntax
 haskell_expr(Var, VarMap, HsExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/jython_target.pl
+++ b/src/unifyweaver/targets/jython_target.pl
@@ -1463,6 +1463,42 @@ jython_branch_value(is(_, Expr), VarMap, Value) :-
 jython_branch_value(Goal, VarMap, Value) :-
     jython_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register Jython renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(jython, =(Var, Expr), VarMap0, Line, VarName, VarMapOut) :-
+    var(Var), !,
+    ensure_var(VarMap0, Var, VarName, VarMapOut),
+    jython_expr(Expr, VarMap0, ExprStr),
+    format(string(Line), '    ~w = ~w', [VarName, ExprStr]).
+clause_body_analysis:render_output_goal(jython, is(Var, Expr), VarMap0, Line, VarName, VarMapOut) :-
+    var(Var), !,
+    ensure_var(VarMap0, Var, VarName, VarMapOut),
+    jython_expr(Expr, VarMap0, ExprStr),
+    format(string(Line), '    ~w = ~w', [VarName, ExprStr]).
+
+clause_body_analysis:render_guard_condition(jython, Goal, VarMap, CondStr) :-
+    jython_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(jython, Branch, VarMap, ExprStr) :-
+    jython_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(jython, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif ~w:', [Indent, Cond]),
+    jython_indent_lines(ThenLines, Indent, IndentedThen),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~welse:', [Indent]),
+        jython_indent_lines(ElseLines, Indent, IndentedElse),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], Lines)
+    ;   Lines = [IfLine|IndentedThen]
+    ).
+
+jython_indent_lines([], _, []).
+jython_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    jython_indent_lines(Rest, Indent, RestIndented).
+
 %% jython_expr — convert Prolog expression to Jython syntax
 jython_expr(Var, VarMap, JExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/kotlin_target.pl
+++ b/src/unifyweaver/targets/kotlin_target.pl
@@ -1418,6 +1418,45 @@ kotlin_branch_value(is(_, Expr), VarMap, Value) :-
 kotlin_branch_value(Goal, VarMap, Value) :-
     kotlin_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register Kotlin renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(kotlin, =(Var, Expr), VarMap0, Line, VarName, VarMapOut) :-
+    var(Var), !,
+    ensure_var(VarMap0, Var, VarName, VarMapOut),
+    kotlin_expr(Expr, VarMap0, ExprStr),
+    format(string(Line), '    val ~w = ~w', [VarName, ExprStr]).
+clause_body_analysis:render_output_goal(kotlin, is(Var, Expr), VarMap0, Line, VarName, VarMapOut) :-
+    var(Var), !,
+    ensure_var(VarMap0, Var, VarName, VarMapOut),
+    kotlin_expr(Expr, VarMap0, ExprStr),
+    format(string(Line), '    val ~w = ~w', [VarName, ExprStr]).
+
+clause_body_analysis:render_guard_condition(kotlin, Goal, VarMap, CondStr) :-
+    kotlin_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(kotlin, Branch, VarMap, ExprStr) :-
+    kotlin_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(kotlin, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Indent, Cond]),
+    kotlin_indent_lines(ThenLines, Indent, IndentedThen),
+    format(string(CloseThen), '~w}', [Indent]),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~w} else {', [Indent]),
+        kotlin_indent_lines(ElseLines, Indent, IndentedElse),
+        format(string(CloseElse), '~w}', [Indent]),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], PreClose),
+        append(PreClose, [CloseElse], Lines)
+    ;   append([IfLine|IndentedThen], [CloseThen], Lines)
+    ).
+
+kotlin_indent_lines([], _, []).
+kotlin_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    kotlin_indent_lines(Rest, Indent, RestIndented).
+
 %% kotlin_expr — convert Prolog expression to Kotlin syntax
 kotlin_expr(Var, VarMap, KExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/scala_target.pl
+++ b/src/unifyweaver/targets/scala_target.pl
@@ -1262,6 +1262,45 @@ scala_branch_value(is(_, Expr), VarMap, Value) :-
 scala_branch_value(Goal, VarMap, Value) :-
     scala_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register Scala renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(scala, =(Var, Expr), VarMap0, Line, VarName, VarMapOut) :-
+    var(Var), !,
+    ensure_var(VarMap0, Var, VarName, VarMapOut),
+    scala_expr(Expr, VarMap0, ExprStr),
+    format(string(Line), '    val ~w = ~w', [VarName, ExprStr]).
+clause_body_analysis:render_output_goal(scala, is(Var, Expr), VarMap0, Line, VarName, VarMapOut) :-
+    var(Var), !,
+    ensure_var(VarMap0, Var, VarName, VarMapOut),
+    scala_expr(Expr, VarMap0, ExprStr),
+    format(string(Line), '    val ~w = ~w', [VarName, ExprStr]).
+
+clause_body_analysis:render_guard_condition(scala, Goal, VarMap, CondStr) :-
+    scala_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(scala, Branch, VarMap, ExprStr) :-
+    scala_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(scala, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Indent, Cond]),
+    scala_indent_lines(ThenLines, Indent, IndentedThen),
+    format(string(CloseThen), '~w}', [Indent]),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~w} else {', [Indent]),
+        scala_indent_lines(ElseLines, Indent, IndentedElse),
+        format(string(CloseElse), '~w}', [Indent]),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], PreClose),
+        append(PreClose, [CloseElse], Lines)
+    ;   append([IfLine|IndentedThen], [CloseThen], Lines)
+    ).
+
+scala_indent_lines([], _, []).
+scala_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    scala_indent_lines(Rest, Indent, RestIndented).
+
 %% scala_expr — convert Prolog expression to Scala syntax
 scala_expr(Var, VarMap, SExpr) :-
     var(Var), !,

--- a/test_functional_hooks.pl
+++ b/test_functional_hooks.pl
@@ -1,0 +1,29 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+:- dynamic classify_sign/2.
+classify_sign(0, zero).
+classify_sign(X, positive) :- X > 0.
+classify_sign(X, negative) :- X < 0.
+
+test_hook(Target) :-
+    format('~w hooks: ', [Target]),
+    build_head_varmap([X, L], 1, VarMap),
+    Goal = (X > 0 -> L = positive ; L = negative),
+    (   compile_expression(Target, Goal, VarMap, Code, _, _),
+        Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+run :-
+    test_hook(haskell),
+    test_hook(fsharp),
+    test_hook(clojure),
+    test_hook(elixir),
+    test_hook(scala),
+    test_hook(kotlin),
+    test_hook(jython),
+    nl, writeln('=== ALL 7 FUNCTIONAL TARGET HOOK TESTS DONE ===').


### PR DESCRIPTION
## Summary

Completes the shared `compile_expression` framework rollout. All 16 non-TypR targets now register the 4 multifile renderer hooks, producing language-idiomatic if/else syntax through the same shared classification and dispatch pipeline. TypR remains outside by design (Codex-maintained).

## Targets and syntax

| Target | If/else syntax | Group |
|--------|---------------|-------|
| Python | `if cond: ... else: ...` | Imperative |
| Go | `if cond { ... } else { ... }` | Imperative |
| Lua | `if cond then ... else ... end` | Imperative |
| C | `if (cond) { ... } else { ... }` | Imperative |
| C++ | `if (cond) { ... } else { ... }` | Imperative |
| Rust | `if cond { ... } else { ... }` | Imperative |
| Perl | `if (cond) { ... } else { ... }` | Imperative |
| Ruby | `if cond ... elsif ... else ... end` | Imperative |
| TypeScript | `if (cond) { ... } else { ... }` | Scripting |
| **Haskell** | `if cond then ... else ...` | Functional (NEW) |
| **F#** | `if cond then ... else ...` | Functional (NEW) |
| **Clojure** | `(if cond then-expr else-expr)` | Functional (NEW) |
| **Elixir** | `if cond do ... else ... end` | Functional (NEW) |
| **Scala** | `if (cond) { ... } else { ... }` | JVM (NEW) |
| **Kotlin** | `if (cond) { ... } else { ... }` | JVM (NEW) |
| **Jython** | `if cond: ... else: ...` | JVM (NEW) |

## Implementation notes

- **Scala, Kotlin, Jython** lack singular `_output_goal` predicates. Their `render_output_goal` hooks create inline wrappers handling `=(Var, Expr)` and `is(Var, Expr)` via the target's `_expr` predicate. Scala/Kotlin use `val` keyword; Jython uses plain assignment.
- **Clojure** uses S-expression form `(if cond ...)` with 2-space indentation — the most structurally different from imperative targets.
- **Haskell/F#** use expression-based `if/then/else` without braces.
- Added `compile_non_recursive` clauses for Haskell and F#.

## Changes

| File | Hooks added |
|------|------------|
| `haskell_target.pl` | 4 hooks + `haskell_indent_lines/3` |
| `fsharp_target.pl` | 4 hooks + `fsharp_indent_lines/3` |
| `clojure_target.pl` | 4 hooks + `clojure_indent_lines/3` |
| `elixir_target.pl` | 4 hooks + `elixir_indent_lines/3` |
| `scala_target.pl` | 4 hooks + inline output_goal + `scala_indent_lines/3` |
| `kotlin_target.pl` | 4 hooks + inline output_goal + `kotlin_indent_lines/3` |
| `jython_target.pl` | 4 hooks + inline output_goal + `jython_indent_lines/3` |
| `recursive_compiler.pl` | `compile_non_recursive` for Haskell, F# |

## Test plan

- [x] 7 hook tests — all functional/JVM targets produce non-empty code from `compile_expression` with ite goal
- [x] All Python tests still pass (58+)
- [x] All shared framework tests pass (5)
- [x] Go + Lua tests pass
- [x] Rust, C, C++, Perl, Ruby, TypeScript tests pass
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
