### PR TITLE
feat: WAT, Jamaica, Krakatau, LLVM register compile_expression hooks

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -37,6 +37,10 @@
 :- use_module('../targets/perl_target', []).     % registers multifile tail/linear patterns for Perl
 :- use_module('../targets/typescript_target', [compile_predicate_to_typescript/3]).
 :- use_module('../targets/python_target', [compile_predicate_to_python/3]).
+:- use_module('../targets/wat_target', []).        % registers multifile hooks for WAT
+:- use_module('../targets/jamaica_target', []).     % registers multifile hooks for Jamaica
+:- use_module('../targets/krakatau_target', []).    % registers multifile hooks for Krakatau
+:- use_module('../targets/llvm_target', []).        % registers multifile hooks for LLVM
 :- use_module(template_system).
 :- use_module(input_source).
 :- use_module(library(lists)).

--- a/src/unifyweaver/targets/jamaica_target.pl
+++ b/src/unifyweaver/targets/jamaica_target.pl
@@ -295,3 +295,55 @@ write_jamaica_program(Code, Filename) :-
     write(Stream, Code),
     close(Stream),
     format('Jamaica program written to: ~w~n', [Filename]).
+
+% ============================================================================
+% MULTIFILE HOOKS — Register Jamaica renderers for shared compile_expression
+% ============================================================================
+%
+% Jamaica produces JVM assembly text. Output goals become istore/astore
+% instructions. Guards become comparison + branch instructions.
+
+clause_body_analysis:render_output_goal(jamaica, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        jvm_bytecode:jvm_expr_to_bytecode(Expr, VarMap, symbolic, ExprInstrs),
+        maplist(ensure_string, ExprInstrs, StrInstrs),
+        atomic_list_concat(StrInstrs, '\n', ExprCode),
+        format(string(Line), '~w\nastore ~w', [ExprCode, VarName])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        jvm_bytecode:jvm_expr_to_bytecode(ArithExpr, VarMap, symbolic, ExprInstrs),
+        maplist(ensure_string, ExprInstrs, StrInstrs),
+        atomic_list_concat(StrInstrs, '\n', ExprCode),
+        format(string(Line), '~w\nlstore ~w', [ExprCode, VarName])
+    ;   VarName = "_", VarMapOut = VarMap,
+        Line = "; unsupported output goal"
+    ).
+
+clause_body_analysis:render_guard_condition(jamaica, Goal, VarMap, CondStr) :-
+    jvm_bytecode:jvm_guard_to_bytecode(Goal, VarMap, symbolic, "L_false", Instrs),
+    maplist(ensure_string, Instrs, StrInstrs),
+    atomic_list_concat(StrInstrs, '\n', CondStr).
+
+clause_body_analysis:render_branch_value(jamaica, Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    (   LastGoal = (_ = Expr) -> true ; LastGoal = (_ is Expr) -> true ; Expr = LastGoal),
+    jvm_bytecode:jvm_expr_to_bytecode(Expr, VarMap, symbolic, Instrs),
+    maplist(ensure_string, Instrs, StrInstrs),
+    atomic_list_concat(StrInstrs, '\n', ExprStr).
+
+clause_body_analysis:render_ite_block(jamaica, Cond, ThenLines, ElseLines, _Indent, _ReturnVars, Lines) :-
+    format(string(CondLine), '~w', [Cond]),
+    format(string(ThenLabel), 'L_then:', []),
+    format(string(ElseLabel), 'L_else:', []),
+    format(string(EndLabel), 'L_end:', []),
+    (   ElseLines \= []
+    ->  append([CondLine, ThenLabel|ThenLines], ['goto L_end', ElseLabel|ElseLines], Pre),
+        append(Pre, [EndLabel], Lines)
+    ;   append([CondLine, ThenLabel|ThenLines], [EndLabel], Lines)
+    ).
+
+ensure_string(Atom, Str) :- atom(Atom), !, atom_string(Atom, Str).
+ensure_string(Str, Str) :- string(Str), !.
+ensure_string(Term, Str) :- term_string(Term, Str).

--- a/src/unifyweaver/targets/krakatau_target.pl
+++ b/src/unifyweaver/targets/krakatau_target.pl
@@ -304,3 +304,44 @@ write_krakatau_program(Code, Filename) :-
     write(Stream, Code),
     close(Stream),
     format('Krakatau program written to: ~w~n', [Filename]).
+
+% ============================================================================
+% MULTIFILE HOOKS — Register Krakatau renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(krakatau, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        jvm_bytecode:jvm_expr_to_bytecode(Expr, VarMap, numeric, ExprInstrs),
+        maplist(ensure_string, ExprInstrs, StrInstrs),
+        atomic_list_concat(StrInstrs, '\n', ExprCode),
+        format(string(Line), '~w\n    lstore ~w', [ExprCode, VarName])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        jvm_bytecode:jvm_expr_to_bytecode(ArithExpr, VarMap, numeric, ExprInstrs),
+        maplist(ensure_string, ExprInstrs, StrInstrs),
+        atomic_list_concat(StrInstrs, '\n', ExprCode),
+        format(string(Line), '~w\n    lstore ~w', [ExprCode, VarName])
+    ;   VarName = "_", VarMapOut = VarMap,
+        Line = "    ; unsupported output goal"
+    ).
+
+clause_body_analysis:render_guard_condition(krakatau, Goal, VarMap, CondStr) :-
+    jvm_bytecode:jvm_guard_to_bytecode(Goal, VarMap, numeric, "L_false", Instrs),
+    maplist(ensure_string, Instrs, StrInstrs),
+    atomic_list_concat(StrInstrs, '\n', CondStr).
+
+clause_body_analysis:render_branch_value(krakatau, Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    (   LastGoal = (_ = Expr) -> true ; LastGoal = (_ is Expr) -> true ; Expr = LastGoal),
+    jvm_bytecode:jvm_expr_to_bytecode(Expr, VarMap, numeric, Instrs),
+    maplist(ensure_string, Instrs, StrInstrs),
+    atomic_list_concat(StrInstrs, '\n', ExprStr).
+
+clause_body_analysis:render_ite_block(krakatau, Cond, ThenLines, ElseLines, _Indent, _ReturnVars, Lines) :-
+    (   ElseLines \= []
+    ->  append([Cond, 'L_then:'|ThenLines], ['    goto L_end', 'L_else:'|ElseLines], Pre),
+        append(Pre, ['L_end:'], Lines)
+    ;   append([Cond, 'L_then:'|ThenLines], ['L_end:'], Lines)
+    ).

--- a/src/unifyweaver/targets/llvm_target.pl
+++ b/src/unifyweaver/targets/llvm_target.pl
@@ -1606,3 +1606,46 @@ llvm_gen_blocks([branch(Conditions, ResultExpr)|Rest], BranchIdx, _Reg, [EntryBl
                 ThenLabel, ResultExpr.setup, ResultExpr.value])
     ),
     llvm_gen_blocks(Rest, NextIdx, 0, RestBlocks).
+
+% ============================================================================
+% MULTIFILE HOOKS — Register LLVM renderers for shared compile_expression
+% ============================================================================
+%
+% LLVM IR produces SSA-style instructions. Output goals become
+% alloca/store instructions. Guards become icmp + br instructions.
+
+clause_body_analysis:render_output_goal(llvm, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        llvm_resolve_value(VarMap, Expr, LLVMVal),
+        format(string(Line), '  %%~w = add i64 ~w, 0', [VarName, LLVMVal])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        llvm_arith_expr(ArithExpr, VarMap, LLVMVal, SetupCode),
+        (   SetupCode \= ""
+        ->  format(string(Line), '~w\n  %%~w = add i64 ~w, 0', [SetupCode, VarName, LLVMVal])
+        ;   format(string(Line), '  %%~w = add i64 ~w, 0', [VarName, LLVMVal])
+        )
+    ;   VarName = "_", VarMapOut = VarMap,
+        Line = "  ; unsupported output goal"
+    ).
+
+clause_body_analysis:render_guard_condition(llvm, Goal, VarMap, CondStr) :-
+    llvm_goal_to_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(llvm, Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    (   LastGoal = (_ = Expr) -> llvm_resolve_value(VarMap, Expr, ExprStr)
+    ;   LastGoal = (_ is Expr) -> llvm_arith_expr(Expr, VarMap, ExprStr, _)
+    ;   llvm_resolve_value(VarMap, LastGoal, ExprStr)
+    ).
+
+clause_body_analysis:render_ite_block(llvm, Cond, ThenLines, ElseLines, _Indent, _ReturnVars, Lines) :-
+    format(string(CmpLine), '  %%cmp_ce = ~w', [Cond]),
+    format(string(BrLine), '  br i1 %%cmp_ce, label %%then_ce, label %%else_ce', []),
+    (   ElseLines \= []
+    ->  append([CmpLine, BrLine, 'then_ce:'|ThenLines], ['  br label %%end_ce', 'else_ce:'|ElseLines], Pre),
+        append(Pre, ['  br label %%end_ce', 'end_ce:'], Lines)
+    ;   append([CmpLine, BrLine, 'then_ce:'|ThenLines], ['  br label %%end_ce', 'end_ce:'], Lines)
+    ).

--- a/src/unifyweaver/targets/wat_target.pl
+++ b/src/unifyweaver/targets/wat_target.pl
@@ -771,6 +771,57 @@ wat_cmp_op(=\=, "i64.ne").
 wat_cmp_op(==, "i64.eq").
 wat_cmp_op(\==, "i64.ne").
 
+% ============================================================================
+% MULTIFILE HOOKS — Register WAT renderers for shared compile_expression
+% ============================================================================
+%
+% WAT produces S-expression text, which fits the hook model.
+% Output goals produce (local.set $var expr) lines.
+% Guards produce condition S-expressions.
+% ITE blocks produce (if (result type) cond (then ...) (else ...)).
+
+clause_body_analysis:render_output_goal(wat, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        wat_resolve_value(Expr, VarMap, ExprStr),
+        format(string(Line), '(local.set $~w ~w)', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        wat_arith_expr(ArithExpr, VarMap, ExprStr),
+        format(string(Line), '(local.set $~w ~w)', [VarName, ExprStr])
+    ;   VarName = "_", VarMapOut = VarMap,
+        Line = ";; unsupported output goal"
+    ).
+
+clause_body_analysis:render_guard_condition(wat, Goal, VarMap, CondStr) :-
+    wat_guard_condition(Goal, VarMap, CondStr).
+
+clause_body_analysis:render_branch_value(wat, Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    wat_expr(LastGoal, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(wat, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~w(if (result i64) ~w', [Indent, Cond]),
+    wat_indent_lines(ThenLines, Indent, IndentedThen),
+    format(string(ThenOpen), '~w  (then', [Indent]),
+    format(string(ThenClose), '~w  )', [Indent]),
+    (   ElseLines \= []
+    ->  format(string(ElseOpen), '~w  (else', [Indent]),
+        wat_indent_lines(ElseLines, Indent, IndentedElse),
+        format(string(ElseClose), '~w  )', [Indent]),
+        format(string(EndLine), '~w)', [Indent]),
+        append([IfLine, ThenOpen|IndentedThen], [ThenClose, ElseOpen|IndentedElse], Pre),
+        append(Pre, [ElseClose, EndLine], Lines)
+    ;   format(string(EndLine), '~w)', [Indent]),
+        append([IfLine, ThenOpen|IndentedThen], [ThenClose, EndLine], Lines)
+    ).
+
+wat_indent_lines([], _, []).
+wat_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    wat_indent_lines(Rest, Indent, RestIndented).
+
 %% wat_output_goals(+Outputs, +VarMap, -Value)
 wat_output_goals(Outputs, VarMap, Value) :-
     last(Outputs, LastGoal),

--- a/test_assembly_hooks.pl
+++ b/test_assembly_hooks.pl
@@ -1,0 +1,21 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+test_hook(Target) :-
+    format('~w hooks: ', [Target]),
+    build_head_varmap([X, L], 1, VarMap),
+    Goal = (X > 0 -> L = positive ; L = negative),
+    (   compile_expression(Target, Goal, VarMap, Code, _, _),
+        Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+run :-
+    test_hook(wat),
+    test_hook(jamaica),
+    test_hook(krakatau),
+    test_hook(llvm),
+    nl, writeln('=== ALL 4 ASSEMBLY TARGET HOOK TESTS DONE ===').


### PR DESCRIPTION
## Summary

Registers the 4 multifile renderer hooks for all 4 assembly/low-level targets. These adapt the shared `compile_expression` framework to instruction-based output — producing assembly text (one instruction per line) instead of indented code blocks.

This brings the shared framework to **20 targets** total.

## Assembly syntax per target

| Target | Output format | If/else model |
|--------|--------------|---------------|
| WAT | S-expression text | `(if (result i64) cond (then ...) (else ...))` |
| Jamaica | JVM symbolic assembly | Label-based branches: `L_then:` / `L_else:` / `goto L_end` |
| Krakatau | Krakatau bytecode text | Label-based branches (numeric var style) |
| LLVM | SSA-style IR | `%cmp = icmp ...` / `br i1 %cmp, label %then, label %else` |

## Adaptation to instruction-based targets

The hooks produce instruction text instead of code blocks:

- **`render_output_goal`**: WAT produces `(local.set $var expr)`. JVM targets produce `expr_bytecode + lstore/astore`. LLVM produces `%var = add i64 val, 0`.
- **`render_guard_condition`**: WAT produces `(i64.gt_s ...)`. JVM targets use `jvm_guard_to_bytecode`. LLVM uses `llvm_goal_to_condition`.
- **`render_branch_value`**: All delegate to their target's expression compiler.
- **`render_ite_block`**: WAT uses nested S-expressions. JVM uses label + goto. LLVM uses SSA labels + br.

JVM targets (Jamaica, Krakatau) use the shared `jvm_bytecode.pl` layer for expression and guard compilation, with `symbolic` vs `numeric` variable styles.

## Changes

- `wat_target.pl`: 4 hooks + `wat_indent_lines/3`
- `jamaica_target.pl`: 4 hooks + `ensure_string/2` (uses `jvm_bytecode` for expressions)
- `krakatau_target.pl`: 4 hooks (uses `jvm_bytecode` with numeric var style)
- `llvm_target.pl`: 4 hooks producing SSA-style IR
- `recursive_compiler.pl`: added `use_module` for WAT, Jamaica, Krakatau, LLVM

## Framework coverage

| Group | Targets | Count |
|-------|---------|-------|
| Imperative | Python, Go, Lua, C, C++, Rust, Perl, Ruby | 8 |
| JVM/managed | Scala, Kotlin, Jython, Clojure | 4 |
| Functional | Haskell, F#, Elixir | 3 |
| Scripting | TypeScript | 1 |
| Assembly | WAT, Jamaica, Krakatau, LLVM | 4 |
| **Total** | | **20** |

Remaining without hooks: AWK, VB.NET (have predicates), SQL/Bash/PowerShell/R (different compilation models), TypR (Codex-maintained).

## Test plan

- [x] 4 assembly hook tests — all produce non-empty code from `compile_expression`
- [x] All functional target tests pass (7)
- [x] All imperative/scripting target tests pass (6)
- [x] All Python tests pass (58+)
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
