### PR TITLE
feat: AWK and VB.NET register compile_expression hooks — 22 of 23 targets complete

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -41,6 +41,7 @@
 :- use_module('../targets/jamaica_target', []).     % registers multifile hooks for Jamaica
 :- use_module('../targets/krakatau_target', []).    % registers multifile hooks for Krakatau
 :- use_module('../targets/llvm_target', []).        % registers multifile hooks for LLVM
+:- use_module('../targets/vbnet_target', []).       % registers multifile hooks for VB.NET
 :- use_module(template_system).
 :- use_module(input_source).
 :- use_module(library(lists)).

--- a/src/unifyweaver/targets/awk_target.pl
+++ b/src/unifyweaver/targets/awk_target.pl
@@ -2746,6 +2746,46 @@ awk_branch_value(is(_, Expr), VarMap, Value) :-
 awk_branch_value(Goal, VarMap, Value) :-
     awk_expr(Goal, VarMap, Value).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register AWK renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(awk, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        awk_expr(Expr, VarMap, ExprStr),
+        format(string(Line), '    ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        awk_expr(ArithExpr, VarMap, ExprStr),
+        format(string(Line), '    ~w = ~w', [VarName, ExprStr])
+    ;   VarName = "_", VarMapOut = VarMap,
+        Line = "    # unsupported output goal"
+    ).
+
+clause_body_analysis:render_guard_condition(awk, Goal, VarMap, CondStr) :-
+    awk_guard_condition(VarMap, Goal, CondStr).
+
+clause_body_analysis:render_branch_value(awk, Branch, VarMap, ExprStr) :-
+    awk_branch_value(Branch, VarMap, ExprStr).
+
+clause_body_analysis:render_ite_block(awk, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wif (~w) {', [Indent, Cond]),
+    awk_indent_lines(ThenLines, Indent, IndentedThen),
+    format(string(CloseBrace), '~w}', [Indent]),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~w} else {', [Indent]),
+        awk_indent_lines(ElseLines, Indent, IndentedElse),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], Pre),
+        append(Pre, [CloseBrace], Lines)
+    ;   append([IfLine|IndentedThen], [CloseBrace], Lines)
+    ).
+
+awk_indent_lines([], _, []).
+awk_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    awk_indent_lines(Rest, Indent, RestIndented).
+
 %% awk_expr — convert Prolog expression to AWK syntax
 awk_expr(Var, VarMap, AExpr) :-
     var(Var), !,

--- a/src/unifyweaver/targets/vbnet_target.pl
+++ b/src/unifyweaver/targets/vbnet_target.pl
@@ -475,6 +475,52 @@ vbnet_output_goals(Outputs, VarMap, Value) :-
     ;   vbnet_resolve_value(LastGoal, VarMap, Value)
     ).
 
+% ============================================================================
+% MULTIFILE HOOKS — Register VB.NET renderers for shared compile_expression
+% ============================================================================
+
+clause_body_analysis:render_output_goal(vbnet, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        vbnet_resolve_value(Expr, VarMap, ExprStr),
+        format(string(Line), '        Dim ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        vbnet_arith_expr(ArithExpr, VarMap, ExprStr),
+        format(string(Line), '        Dim ~w = ~w', [VarName, ExprStr])
+    ;   VarName = "_", VarMapOut = VarMap,
+        Line = "        ' unsupported output goal"
+    ).
+
+clause_body_analysis:render_guard_condition(vbnet, Goal, VarMap, CondStr) :-
+    vbnet_guard_condition(Goal, VarMap, CondStr).
+
+clause_body_analysis:render_branch_value(vbnet, Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    (   goal_output_var(LastGoal, _)
+    ->  vbnet_expr(LastGoal, VarMap, ExprStr)
+    ;   vbnet_resolve_value(LastGoal, VarMap, ExprStr)
+    ).
+
+clause_body_analysis:render_ite_block(vbnet, Cond, ThenLines, ElseLines, Indent, _ReturnVars, Lines) :-
+    format(string(IfLine), '~wIf ~w Then', [Indent, Cond]),
+    vbnet_indent_lines(ThenLines, Indent, IndentedThen),
+    (   ElseLines \= []
+    ->  format(string(ElseLine), '~wElse', [Indent]),
+        vbnet_indent_lines(ElseLines, Indent, IndentedElse),
+        format(string(EndLine), '~wEnd If', [Indent]),
+        append([IfLine|IndentedThen], [ElseLine|IndentedElse], Pre),
+        append(Pre, [EndLine], Lines)
+    ;   format(string(EndLine), '~wEnd If', [Indent]),
+        append([IfLine|IndentedThen], [EndLine], Lines)
+    ).
+
+vbnet_indent_lines([], _, []).
+vbnet_indent_lines([Line|Rest], Indent, [Indented|RestIndented]) :-
+    format(string(Indented), '~w    ~w', [Indent, Line]),
+    vbnet_indent_lines(Rest, Indent, RestIndented).
+
 %% vbnet_expr(+Goal, +VarMap, -Expr)
 vbnet_expr(Goal, VarMap, Expr) :-
     Goal = (_Var = RHS),

--- a/test_awk_vbnet_hooks.pl
+++ b/test_awk_vbnet_hooks.pl
@@ -1,0 +1,19 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+test_hook(Target) :-
+    format('~w hooks: ', [Target]),
+    build_head_varmap([X, L], 1, VarMap),
+    Goal = (X > 0 -> L = positive ; L = negative),
+    (   compile_expression(Target, Goal, VarMap, Code, _, _),
+        Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+run :-
+    test_hook(awk),
+    test_hook(vbnet),
+    nl, writeln('=== AWK + VB.NET HOOK TESTS DONE ===').


### PR DESCRIPTION
## Summary

Registers compile_expression hooks for AWK and VB.NET, completing the rollout to all targets that have guard/output rendering predicates. The shared framework now covers **22 of 23 non-TypR targets**.

## Targets added

| Target | If/else syntax | Notes |
|--------|---------------|-------|
| AWK | `if (cond) { ... } else { ... }` | C-like; inline output_goal wrapper (no singular predicate) |
| VB.NET | `If cond Then ... Else ... End If` | Uses `Dim` for assignment; inline branch_value wrapper |

## Framework completion status

| Status | Targets | Count |
|--------|---------|-------|
| ✅ Hooks registered | Python, Go, Lua, C, C++, Rust, Perl, Ruby, TypeScript, Haskell, F#, Clojure, Elixir, Scala, Kotlin, Jython, WAT, Jamaica, Krakatau, LLVM, AWK, VB.NET | 22 |
| ❌ Different model | SQL (CTEs), Bash (stream compiler), PowerShell (stream compiler), R (own generation) | 4 |
| ❌ Excluded | TypR (Codex-maintained) | 1 |

The 4 remaining targets without hooks genuinely don't fit the compile_expression model — they don't produce functions with if/else dispatch. SQL generates recursive CTEs, Bash/PowerShell use the stream compiler pipeline, and R has its own code generation path.

## Test plan

- [x] AWK hook test — produces non-empty code from compile_expression
- [x] VB.NET hook test — produces non-empty code from compile_expression
- [x] All Python tests pass (58+)
- [x] All shared framework tests pass
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
