### PR TITLE
feat: JVM string ops, input source seeds, cross-target TC validation

### DIFF
--- a/src/unifyweaver/bindings/jvm_asm_bindings.pl
+++ b/src/unifyweaver/bindings/jvm_asm_bindings.pl
@@ -15,7 +15,8 @@ init_jvm_asm_bindings :-
     register_jvm_asm_comparison_bindings,
     register_jvm_asm_bitwise_bindings,
     register_jvm_asm_math_bindings,
-    register_jvm_asm_io_bindings.
+    register_jvm_asm_io_bindings,
+    register_jvm_asm_string_bindings.
 
 %% declare_dual_binding(+Pred, +Instruction, +Inputs, +Outputs, +Options)
 %%   Register a binding for both jamaica and krakatau targets.
@@ -87,3 +88,45 @@ register_jvm_asm_io_bindings :-
         ['String'], [],
         [deterministic, pattern(io_op),
          description("Print string to stdout")]).
+
+register_jvm_asm_string_bindings :-
+    declare_dual_binding('string_equals'/3,
+        'invokevirtual java/lang/String equals (Ljava/lang/Object;)Z',
+        ['String', 'String'], [boolean],
+        [pure, deterministic, total, pattern(function),
+         description("Compare two strings for equality")]),
+    declare_dual_binding('string_concat'/3,
+        'invokevirtual java/lang/String concat (Ljava/lang/String;)Ljava/lang/String;',
+        ['String', 'String'], ['String'],
+        [pure, deterministic, total, pattern(function),
+         description("Concatenate two strings")]),
+    declare_dual_binding('string_length'/2,
+        'invokevirtual java/lang/String length ()I',
+        ['String'], [int],
+        [pure, deterministic, total, pattern(function),
+         description("Get string length")]),
+    declare_dual_binding('string_valueof'/2,
+        'invokestatic java/lang/String valueOf (I)Ljava/lang/String;',
+        [int], ['String'],
+        [pure, deterministic, total, pattern(function),
+         description("Convert int to string")]),
+    declare_dual_binding('string_charat'/3,
+        'invokevirtual java/lang/String charAt (I)C',
+        ['String', int], [char],
+        [pure, deterministic, total, pattern(function),
+         description("Get character at index")]),
+    declare_dual_binding('string_substring'/4,
+        'invokevirtual java/lang/String substring (II)Ljava/lang/String;',
+        ['String', int, int], ['String'],
+        [pure, deterministic, total, pattern(function),
+         description("Extract substring by start and end index")]),
+    declare_dual_binding('string_tolower'/2,
+        'invokevirtual java/lang/String toLowerCase ()Ljava/lang/String;',
+        ['String'], ['String'],
+        [pure, deterministic, total, pattern(function),
+         description("Convert string to lowercase")]),
+    declare_dual_binding('string_toupper'/2,
+        'invokevirtual java/lang/String toUpperCase ()Ljava/lang/String;',
+        ['String'], ['String'],
+        [pure, deterministic, total, pattern(function),
+         description("Convert string to uppercase")]).

--- a/src/unifyweaver/core/input_source.pl
+++ b/src/unifyweaver/core/input_source.pl
@@ -157,6 +157,22 @@ seed_statement(haskell, _BasePred, From, To, Statement) :-
 seed_statement(powershell, _BasePred, From, To, Statement) :-
     format(string(Statement), 'Add-Fact "~w" "~w"', [From, To]).
 
+seed_statement(jamaica, _BasePred, From, To, Statement) :-
+    format(string(Statement),
+        '    ldc "~w"\n    ldc "~w"\n    invokestatic addFact(String, String)void',
+        [From, To]).
+
+seed_statement(krakatau, _BasePred, From, To, Statement) :-
+    format(string(Statement),
+        '    ldc "~w"\n    ldc "~w"\n    invokestatic AncestorQuery addFact (Ljava/lang/String;Ljava/lang/String;)V',
+        [From, To]).
+
+seed_statement(awk, _BasePred, From, To, Statement) :-
+    format(string(Statement), '    add_fact("~w", "~w")', [From, To]).
+
+seed_statement(vbnet, _BasePred, From, To, Statement) :-
+    format(string(Statement), '        query.AddFact("~w", "~w")', [From, To]).
+
 bash_literal(Value, Literal) :-
     (   number(Value)
     ->  format(string(Literal), '~w', [Value])

--- a/src/unifyweaver/core/jvm_bytecode.pl
+++ b/src/unifyweaver/core/jvm_bytecode.pl
@@ -39,7 +39,14 @@
     jvm_multicall_recursion_bytecode/4,  % +PredStr, +Arity, +VarStyle, -Instructions
     jvm_direct_multicall_bytecode/4,     % +PredStr, +Arity, +VarStyle, -Instructions
     jvm_mutual_recursion_bytecode/4, % +Predicates, +ClassName, +VarStyle, -Instructions
-    jvm_entry_method_bytecode/4      % +PredStr, +Arity, +VarStyle, -Instructions
+    jvm_entry_method_bytecode/4,     % +PredStr, +Arity, +VarStyle, -Instructions
+
+    % String operations
+    jvm_string_equals_bytecode/4,    % +VarA, +VarB, +VarMap, -Instructions
+    jvm_string_concat_bytecode/4,    % +VarA, +VarB, +VarMap, -Instructions
+    jvm_tostring_bytecode/3,         % +Var, +VarMap, -Instructions
+    jvm_println_bytecode/3,          % +Var, +VarMap, -Instructions
+    jvm_load_string/2                % +StringValue, -Instruction
 ]).
 
 :- use_module('../core/clause_body_analysis').
@@ -454,6 +461,77 @@ instr_stack_effect(Instr, Effect) :-
     ;   sub_string(Instr, _, _, _, "goto")    -> Effect = 0
     ;   Effect = 0  % labels, gotos, etc.
     ).
+
+%% ============================================
+%% STRING OPERATIONS
+%% ============================================
+
+%% jvm_load_string(+StringValue, -Instruction)
+%%   Load a string constant onto the stack.
+jvm_load_string(Value, Instr) :-
+    format(string(Instr), '    ldc "~w"', [Value]).
+
+%% jvm_string_equals_bytecode(+ExprA, +ExprB, +VarMap, -Instructions)
+%%   Compare two strings for equality. Result: 1 (true) or 0 (false) on stack.
+%%   Uses String.equals(Object) which returns boolean.
+jvm_string_equals_bytecode(ExprA, ExprB, VarMap, Instructions) :-
+    jvm_resolve_string_operand(ExprA, VarMap, LoadA),
+    jvm_resolve_string_operand(ExprB, VarMap, LoadB),
+    append(LoadA, LoadB, Operands),
+    append(Operands,
+        ["    invokevirtual java/lang/String equals (Ljava/lang/Object;)Z"],
+        Instructions).
+
+%% jvm_string_concat_bytecode(+ExprA, +ExprB, +VarMap, -Instructions)
+%%   Concatenate two strings. Result: new String on stack.
+%%   Uses String.concat(String).
+jvm_string_concat_bytecode(ExprA, ExprB, VarMap, Instructions) :-
+    jvm_resolve_string_operand(ExprA, VarMap, LoadA),
+    jvm_resolve_string_operand(ExprB, VarMap, LoadB),
+    append(LoadA, LoadB, Operands),
+    append(Operands,
+        ["    invokevirtual java/lang/String concat (Ljava/lang/String;)Ljava/lang/String;"],
+        Instructions).
+
+%% jvm_tostring_bytecode(+Expr, +VarMap, -Instructions)
+%%   Convert an int on the stack to a String via String.valueOf(int).
+jvm_tostring_bytecode(Expr, VarMap, Instructions) :-
+    jvm_expr_to_bytecode(Expr, VarMap, symbolic, LoadExpr),
+    append(LoadExpr,
+        ["    invokestatic java/lang/String valueOf (I)Ljava/lang/String;"],
+        Instructions).
+
+%% jvm_println_bytecode(+Expr, +VarMap, -Instructions)
+%%   Print a value to stdout followed by newline.
+%%   Works for both int and String (uses Object overload).
+jvm_println_bytecode(Expr, VarMap, Instructions) :-
+    jvm_resolve_string_operand(Expr, VarMap, LoadExpr),
+    Instructions0 = [
+        "    getstatic java/lang/System out Ljava/io/PrintStream;"
+    ],
+    append(Instructions0, LoadExpr, WithValue),
+    append(WithValue,
+        ["    invokevirtual java/io/PrintStream println (Ljava/lang/Object;)V"],
+        Instructions).
+
+%% jvm_resolve_string_operand(+Expr, +VarMap, -Instructions)
+%%   Resolve an expression to bytecode that leaves a String/Object on stack.
+jvm_resolve_string_operand(Expr, _VarMap, [Instr]) :-
+    atom(Expr),
+    \+ lookup_var(Expr, _VarMap, _),
+    !,
+    jvm_load_string(Expr, Instr).
+jvm_resolve_string_operand(Expr, VarMap, [Instr]) :-
+    (var(Expr) ; atom(Expr)),
+    lookup_var(Expr, VarMap, Name),
+    !,
+    format(string(Instr), '    aload ~w', [Name]).
+jvm_resolve_string_operand(Expr, _VarMap, [Instr]) :-
+    string(Expr),
+    !,
+    format(string(Instr), '    ldc "~w"', [Expr]).
+jvm_resolve_string_operand(Expr, VarMap, Instructions) :-
+    jvm_expr_to_bytecode(Expr, VarMap, symbolic, Instructions).
 
 %% ============================================
 %% RECURSION PATTERN GENERATORS

--- a/tests/core/test_jvm_asm_native_lowering.pl
+++ b/tests/core/test_jvm_asm_native_lowering.pl
@@ -21,6 +21,7 @@
 :- use_module('../../src/unifyweaver/core/jvm_bytecode').
 :- use_module('../../src/unifyweaver/core/target_registry').
 :- use_module('../../src/unifyweaver/core/recursive_compiler').
+:- use_module('../../src/unifyweaver/core/input_source').
 
 test_jvm_asm_native_lowering :-
     run_tests([jvm_asm_native_lowering]).
@@ -505,6 +506,77 @@ test(cross_target_mod_guard) :-
     has(JaCode, "irem"),
     has(KrCode, "irem"),
     retractall(user:mod_test(_, _)).
+
+% ============================================================================
+% String operations (shared bytecode layer)
+% ============================================================================
+
+test(jvm_load_string) :-
+    jvm_bytecode:jvm_load_string(hello, Instr),
+    has(Instr, "ldc \"hello\"").
+
+test(jvm_string_equals) :-
+    jvm_bytecode:jvm_string_equals_bytecode(hello, world, [], Instrs),
+    last(Instrs, Last),
+    has(Last, "equals").
+
+test(jvm_string_concat) :-
+    jvm_bytecode:jvm_string_concat_bytecode(foo, bar, [], Instrs),
+    last(Instrs, Last),
+    has(Last, "concat").
+
+test(jvm_tostring) :-
+    jvm_bytecode:jvm_tostring_bytecode(42, [], Instrs),
+    last(Instrs, Last),
+    has(Last, "valueOf").
+
+test(jvm_println) :-
+    jvm_bytecode:jvm_println_bytecode(hello, [], Instrs),
+    once(member(I, Instrs)),
+    has(I, "System").
+
+% ============================================================================
+% String bindings
+% ============================================================================
+
+test(string_equals_binding) :-
+    jamaica_target:init_jamaica_target,
+    once(binding_registry:binding(jamaica, 'string_equals'/3, _, _, _, _)).
+
+test(string_concat_binding) :-
+    once(binding_registry:binding(krakatau, 'string_concat'/3, _, _, _, _)).
+
+test(string_length_binding) :-
+    once(binding_registry:binding(jamaica, 'string_length'/2, _, _, _, _)).
+
+test(string_toupper_binding) :-
+    once(binding_registry:binding(krakatau, 'string_toupper'/2, _, _, _, _)).
+
+% ============================================================================
+% Input source seed statements
+% ============================================================================
+
+test(jamaica_seed_statement) :-
+    input_source:seed_statement(jamaica, _, alice, bob, Stmt),
+    has(Stmt, "ldc \"alice\""),
+    has(Stmt, "ldc \"bob\""),
+    has(Stmt, "invokestatic addFact").
+
+test(krakatau_seed_statement) :-
+    input_source:seed_statement(krakatau, _, alice, bob, Stmt),
+    has(Stmt, "ldc \"alice\""),
+    has(Stmt, "ldc \"bob\""),
+    has(Stmt, "invokestatic").
+
+test(awk_seed_statement) :-
+    input_source:seed_statement(awk, _, alice, bob, Stmt),
+    has(Stmt, "add_fact"),
+    has(Stmt, "\"alice\"").
+
+test(vbnet_seed_statement) :-
+    input_source:seed_statement(vbnet, _, alice, bob, Stmt),
+    has(Stmt, "AddFact"),
+    has(Stmt, "\"alice\"").
 
 % ============================================================================
 % Transitive closure templates


### PR DESCRIPTION
## Summary

- Add string operations to the shared JVM bytecode layer and bindings
- Wire Jamaica, Krakatau, AWK, VB.NET into the input source system (seed statements)
- Cross-target runtime validate transitive closures across 4 targets

## String Operations

### Shared bytecode layer (`jvm_bytecode.pl`)

| Predicate | JVM Instructions |
|-----------|-----------------|
| `jvm_load_string/2` | `ldc "value"` |
| `jvm_string_equals_bytecode/4` | `invokevirtual String.equals` |
| `jvm_string_concat_bytecode/4` | `invokevirtual String.concat` |
| `jvm_tostring_bytecode/3` | `invokestatic String.valueOf(I)` |
| `jvm_println_bytecode/3` | `getstatic System.out` + `invokevirtual println` |
| `jvm_resolve_string_operand/3` | Dispatches atoms, vars, string literals |

### Bindings (`jvm_asm_bindings.pl`, 8 new)

| Binding | JVM Method |
|---------|-----------|
| `string_equals/3` | `String.equals(Object)Z` |
| `string_concat/3` | `String.concat(String)` |
| `string_length/2` | `String.length()I` |
| `string_valueof/2` | `String.valueOf(I)` |
| `string_charat/3` | `String.charAt(I)C` |
| `string_substring/4` | `String.substring(II)` |
| `string_tolower/2` | `String.toLowerCase()` |
| `string_toupper/2` | `String.toUpperCase()` |

## Input Source Integration

Added `seed_statement/5` clauses for 4 targets in `input_source.pl` (follows PR #1014 pattern):

| Target | Seed format |
|--------|-------------|
| Jamaica | `ldc "from" / ldc "to" / invokestatic addFact(String, String)void` |
| Krakatau | `ldc "from" / ldc "to" / invokestatic Class addFact (descriptors)V` |
| AWK | `add_fact("from", "to")` |
| VB.NET | `query.AddFact("from", "to")` |

## Cross-Target Runtime Validation

Same graph `a->b->c->d, a->e->f` tested across 4 targets:

| Query | Krakatau | Jamaica | AWK | Python |
|-------|:---:|:---:|:---:|:---:|
| `ancestor(a, d)` | `a:d` exit 0 | `a:d` exit 0 | `a:d` exit 0 | `a:d` exit 0 |
| `ancestor(d, a)` | exit 1 | exit 1 | exit 1 | exit 1 |
| `ancestor(a, f)` | `a:f` exit 0 | `a:f` exit 0 | `a:f` exit 0 | `a:f` exit 0 |

All 4 targets produce byte-for-byte identical output for all queries.

## Tests (75 → 88, +13 new)

| Test | Feature |
|------|---------|
| `jvm_load_string` | String constant loading |
| `jvm_string_equals` | String equality bytecode |
| `jvm_string_concat` | String concatenation bytecode |
| `jvm_tostring` | Int-to-string conversion |
| `jvm_println` | Print to stdout |
| `string_equals_binding` | Jamaica binding registered |
| `string_concat_binding` | Krakatau binding registered |
| `string_length_binding` | Jamaica binding registered |
| `string_toupper_binding` | Krakatau binding registered |
| `jamaica_seed_statement` | Correct bytecode for seed facts |
| `krakatau_seed_statement` | Correct bytecode with descriptors |
| `awk_seed_statement` | Correct add_fact call |
| `vbnet_seed_statement` | Correct AddFact call |

## Test plan

- [x] All 88 JVM assembly tests pass
- [x] All 95 WAT tests pass (no regressions)
- [x] Cross-target TC validated: Krakatau, Jamaica, AWK, Python
- [x] String operations generate correct JVM bytecodes
- [x] Bindings registered for both jamaica and krakatau
- [x] Seed statements generate correct target-language code
