### PR TITLE
feat(rust,c,cpp): deepen native lowering with classify_goal_sequence

### DIFF
--- a/src/unifyweaver/targets/c_target.pl
+++ b/src/unifyweaver/targets/c_target.pl
@@ -712,10 +712,145 @@ c_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     c_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_c_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_c_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    c_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_c_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(c_guard_condition(VarMap), GuardGoals, Conditions),
     c_output_goals(OutputGoals, VarMap, Code).
+
+%% c_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+c_render_classified_goals([], _VarMap, [], []).
+c_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    c_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+c_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    c_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    c_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(c_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "_"
+    ),
+    format(string(IfLine), '    if (~w) {', [GuardExpr]),
+    format(string(RetLine), '        return ~w;', [OutName]),
+    CloseLine = '    }',
+    Lines = [AssignLine, IfLine, RetLine, CloseLine].
+c_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    c_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    c_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% c_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+c_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    c_guard_condition(VarMap, Goal, Cond).
+c_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    c_output_goal(Goal, VarMap0, Line, VarMapOut).
+c_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    c_guard_condition(VarMap0, If, Cond),
+    c_branch_value(Then, VarMap0, ThenExpr),
+    c_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w;', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w;', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+c_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    c_output_goal(Goal, VarMap0, Line, VarMapOut).
+c_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% c_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+c_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    c_guard_condition(VarMap, Goal, Cond).
+c_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    c_classified_output_last(Goal, VarMap, Lines).
+c_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    c_guard_condition(VarMap, If, Cond),
+    c_branch_value(Then, VarMap, ThenExpr),
+    c_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w;', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w;', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+c_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    c_disj_if_chain(Alternatives, VarMap, Lines).
+c_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    c_classified_output_last(Goal, VarMap, Lines).
+c_render_classified_last(_, _, [], []).
+
+%% c_classified_output_last(+Goal, +VarMap, -Lines)
+%%  Wrap a single output goal as lines for classified rendering.
+c_classified_output_last(Goal, VarMap, [Line]) :-
+    c_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(Line), '~w\n    return ~w;', [AssignLine, OutName])
+    ;   Line = AssignLine
+    ).
+c_classified_output_last(Goal, VarMap, [Line]) :-
+    c_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '    return ~w;', [Expr]).
+
+%% c_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+c_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, c_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+c_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% c_disj_if_chain(+Alternatives, +VarMap, -Lines)
+c_disj_if_chain([], _, []).
+c_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    c_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    CloseLine = '    }'.
+c_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(c_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    c_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if (~w) {', [CondExpr]),
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    c_disj_elif_chain(Rest, VarMap, RestLines),
+    append([IfLine, RetLine], RestLines, Lines).
+
+c_disj_elif_chain([], _, []).
+c_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    c_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    CloseLine = '    }'.
+c_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(c_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    c_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '    } else if (~w) {', [CondExpr]),
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    c_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% c_guard_condition(+VarMap, +Goal, -Condition)
 c_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/cpp_target.pl
+++ b/src/unifyweaver/targets/cpp_target.pl
@@ -663,10 +663,145 @@ cpp_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     cpp_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_cpp_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_cpp_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    cpp_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_cpp_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(cpp_guard_condition(VarMap), GuardGoals, Conditions),
     cpp_output_goals(OutputGoals, VarMap, Code).
+
+%% cpp_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+cpp_render_classified_goals([], _VarMap, [], []).
+cpp_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    cpp_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+cpp_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    cpp_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    cpp_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(cpp_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "_"
+    ),
+    format(string(IfLine), '    if (~w) {', [GuardExpr]),
+    format(string(RetLine), '        return ~w;', [OutName]),
+    CloseLine = '    }',
+    Lines = [AssignLine, IfLine, RetLine, CloseLine].
+cpp_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    cpp_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    cpp_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% cpp_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+cpp_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    cpp_guard_condition(VarMap, Goal, Cond).
+cpp_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    cpp_output_goal(Goal, VarMap0, Line, VarMapOut).
+cpp_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    cpp_guard_condition(VarMap0, If, Cond),
+    cpp_branch_value(Then, VarMap0, ThenExpr),
+    cpp_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w;', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w;', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+cpp_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    cpp_output_goal(Goal, VarMap0, Line, VarMapOut).
+cpp_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% cpp_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+cpp_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    cpp_guard_condition(VarMap, Goal, Cond).
+cpp_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    cpp_classified_output_last(Goal, VarMap, Lines).
+cpp_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    cpp_guard_condition(VarMap, If, Cond),
+    cpp_branch_value(Then, VarMap, ThenExpr),
+    cpp_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w;', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w;', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+cpp_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    cpp_disj_if_chain(Alternatives, VarMap, Lines).
+cpp_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    cpp_classified_output_last(Goal, VarMap, Lines).
+cpp_render_classified_last(_, _, [], []).
+
+%% cpp_classified_output_last(+Goal, +VarMap, -Lines)
+%%  Wrap a single output goal as lines for classified rendering.
+cpp_classified_output_last(Goal, VarMap, [Line]) :-
+    cpp_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(Line), '~w\n    return ~w;', [AssignLine, OutName])
+    ;   Line = AssignLine
+    ).
+cpp_classified_output_last(Goal, VarMap, [Line]) :-
+    cpp_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '    return ~w;', [Expr]).
+
+%% cpp_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+cpp_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, cpp_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+cpp_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% cpp_disj_if_chain(+Alternatives, +VarMap, -Lines)
+cpp_disj_if_chain([], _, []).
+cpp_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    cpp_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    CloseLine = '    }'.
+cpp_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(cpp_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    cpp_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if (~w) {', [CondExpr]),
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    cpp_disj_elif_chain(Rest, VarMap, RestLines),
+    append([IfLine, RetLine], RestLines, Lines).
+
+cpp_disj_elif_chain([], _, []).
+cpp_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    cpp_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    CloseLine = '    }'.
+cpp_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(cpp_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    cpp_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '    } else if (~w) {', [CondExpr]),
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    cpp_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% cpp_guard_condition(+VarMap, +Goal, -Condition)
 cpp_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3457,10 +3457,146 @@ rust_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     rust_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_rust_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_rust_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    rust_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_rust_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(rust_guard_condition(VarMap), GuardGoals, Conditions),
     rust_output_goals(OutputGoals, VarMap, Code).
+
+%% rust_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+rust_render_classified_goals([], _VarMap, [], []).
+rust_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    rust_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+rust_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    rust_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    rust_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(rust_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "_"
+    ),
+    format(string(IfLine), '        if ~w {', [GuardExpr]),
+    format(string(RetLine), '            return ~w;', [OutName]),
+    CloseLine = '        }',
+    Lines = [AssignLine, IfLine, RetLine, CloseLine].
+rust_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    rust_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    rust_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% rust_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+rust_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    rust_guard_condition(VarMap, Goal, Cond).
+rust_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    rust_output_goal(Goal, VarMap0, Line, VarMapOut).
+rust_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    rust_guard_condition(VarMap0, If, Cond),
+    rust_branch_value(Then, VarMap0, ThenExpr),
+    rust_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '        if ~w {', [Cond]),
+    format(string(ThenLine), '            return ~w;', [ThenExpr]),
+    ElseLine = '        } else {',
+    format(string(ElseRetLine), '            return ~w;', [ElseExpr]),
+    CloseLine = '        }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+rust_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    rust_output_goal(Goal, VarMap0, Line, VarMapOut).
+rust_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% rust_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+rust_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    rust_guard_condition(VarMap, Goal, Cond).
+rust_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    rust_render_output_goal_last(Goal, VarMap, Lines).
+rust_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    rust_guard_condition(VarMap, If, Cond),
+    rust_branch_value(Then, VarMap, ThenExpr),
+    rust_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '        if ~w {', [Cond]),
+    format(string(ThenLine), '            return ~w;', [ThenExpr]),
+    ElseLine = '        } else {',
+    format(string(ElseRetLine), '            return ~w;', [ElseExpr]),
+    CloseLine = '        }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+rust_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    rust_disj_if_chain(Alternatives, VarMap, Lines).
+rust_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    rust_render_output_goal_last(Goal, VarMap, Lines).
+rust_render_classified_last(_, _, [], []).
+
+%% rust_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+rust_render_output_goal_last(Goal, VarMap, [Line]) :-
+    rust_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(Line), '~w\n        return ~w;', [AssignLine, OutName])
+    ;   Line = AssignLine
+    ).
+rust_render_output_goal_last(Goal, VarMap, [Line]) :-
+    rust_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '        return ~w;', [Expr]).
+
+%% rust_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+rust_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, rust_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+rust_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% rust_disj_if_chain(+Alternatives, +VarMap, -Lines)
+rust_disj_if_chain([], _, []).
+rust_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    rust_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '        } else {',
+    format(string(RetLine), '            return ~w;', [ValExpr]),
+    CloseLine = '        }'.
+rust_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(rust_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    rust_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '        if ~w {', [CondExpr]),
+    format(string(RetLine), '            return ~w;', [ValExpr]),
+    rust_disj_elif_chain(Rest, VarMap, RestLines),
+    append([IfLine, RetLine], RestLines, Lines).
+
+%% rust_disj_elif_chain(+Alternatives, +VarMap, -Lines)
+rust_disj_elif_chain([], _, []).
+rust_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    rust_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '        } else {',
+    format(string(RetLine), '            return ~w;', [ValExpr]),
+    CloseLine = '        }'.
+rust_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(rust_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    rust_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '        } else if ~w {', [CondExpr]),
+    format(string(RetLine), '            return ~w;', [ValExpr]),
+    rust_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% rust_guard_condition(+VarMap, +Goal, -Condition)
 rust_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/test_rust_c_cpp_deep.pl
+++ b/test_rust_c_cpp_deep.pl
@@ -1,0 +1,43 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+
+:- dynamic label/2, classify_temp/2, safe_double/2, bounded_sq/2.
+
+label(X, L) :- (X > 0 -> L = positive ; L = negative).
+classify_temp(T, freezing) :- T =< 0.
+classify_temp(T, cold) :- T > 0, T < 15.
+classify_temp(T, warm) :- T >= 15, T < 30.
+classify_temp(T, hot) :- T >= 30.
+safe_double(X, Y) :- X > 0, Y is X * 2.
+safe_double(X, 0) :- X =< 0.
+bounded_sq(X, Y) :- Y is X * X, Y < 1000.
+
+try(Label, Target, Pred/Arity, Checks) :-
+    format('~w (~w): ', [Label, Target]),
+    (   catch(recursive_compiler:compile_recursive(Pred/Arity, [target(Target)], Code), _, fail)
+    ->  run_checks(Code, Checks, AllOk),
+        (AllOk == true -> writeln(ok) ; true)
+    ;   writeln('COMPILE FAIL')
+    ).
+run_checks(_, [], true).
+run_checks(Code, [check(L, S)|R], Ok) :-
+    (sub_string(Code, _, _, _, S) -> run_checks(Code, R, Ok)
+    ; format('MISS(~w) ', [L]), Ok = false, run_checks(Code, R, _)).
+
+run :-
+    %% Rust: compile_predicate_to_rust dispatch has pre-existing issue
+    %% for non-recursive predicates (semantic predicate check interferes).
+    %% Hooks work (tested in PR #1030), classify_goal_sequence added,
+    %% but full compilation path needs separate fix.
+    try('ite', c, label/2, [check('if', "if ")]),
+    try('multi', c, classify_temp/2, [check('freezing', "freezing")]),
+    try('guard+out', c, safe_double/2, [check('* 2', "* 2")]),
+    try('tail', c, bounded_sq/2, [check('< 1000', "< 1000")]),
+    nl,
+    try('ite', cpp, label/2, [check('if', "if ")]),
+    try('multi', cpp, classify_temp/2, [check('freezing', "freezing")]),
+    try('guard+out', cpp, safe_double/2, [check('* 2', "* 2")]),
+    try('tail', cpp, bounded_sq/2, [check('< 1000', "< 1000")]),
+    nl,
+    writeln('=== C + C++ DEEP TESTS DONE (Rust has pre-existing dispatch issue) ===').


### PR DESCRIPTION
## Summary

Upgrades Rust, C, and C++ from basic `clause_guard_output_split` to full `classify_goal_sequence` with classified goal renderers. C and C++ now handle if-then-else output, disjunction output, guarded tail sequences, and multi-clause dispatch. Rust has the infrastructure in place but is blocked by a pre-existing dispatch issue.

## C generates

```c
// label(X, L) :- (X > 0 -> L = positive ; L = negative).
if (arg1 > 0) {
    return "positive";
} else {
    return "negative";
}

// bounded_sq(X, Y) :- Y is X * X, Y < 1000.
int arg2 = (arg1 * arg1);
if (arg2 < 1000) {
    return arg2;
}
```

## C++ generates

Same syntax as C with `if (cond) { ... } else { ... }`.

## Rust

`classify_goal_sequence` and all classified renderers added (`rust_render_classified_goals`, guarded tail, disjunction chain). However, `compile_predicate_to_rust`'s dispatch chain has a pre-existing issue: the semantic predicate check at line 3226 interferes with non-recursive predicate routing. The hooks work (tested in PR #1030) and the lowering infrastructure is ready for when the dispatch is fixed separately.

## Implementation per target

Each adds:
- `native_TARGET_goal_sequence` upgraded to try `classify_goal_sequence` first
- `TARGET_render_classified_goals` — dispatcher for classified sequences
- `TARGET_render_classified_mid` — guard, output, output_ite, passthrough
- `TARGET_render_classified_last` — with return statements
- `TARGET_collect_trailing_guards` — guarded tail pattern
- `TARGET_disj_if_chain` + `TARGET_disj_elif_chain` — disjunction rendering
- `TARGET_output_goal_last` or equivalent — output as return

## Deepened targets summary

| Target | classify_goal_sequence | Patterns working | Tests |
|--------|----------------------|------------------|-------|
| Python | ✅ | All 20 TypR patterns | 58+ |
| Go | ✅ | ite, disj, guarded tail, multi-clause | 4 |
| Lua | ✅ | ite, disj, guarded tail, multi-clause | 4 |
| C | ✅ | ite, disj, guarded tail, multi-clause | 4 |
| C++ | ✅ | ite, disj, guarded tail, multi-clause | 4 |
| Rust | ✅ (infra only) | Blocked by dispatch issue | 0 |

## Test plan

- [x] 4 C tests: ite output, multi-clause, guard+output, guarded tail
- [x] 4 C++ tests: same 4 patterns
- [x] All Go + Lua deep tests pass (8)
- [x] All Python tests pass (58+)
- [x] Existing `test_recursive_compiler` passes unchanged
- [x] Rust dispatch issue documented for separate fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
