### PR TITLE
`feat: JVM asm feature parity round 2 — arrays, components, glue, imports`

### DIFF
--- a/src/unifyweaver/bindings/jvm_asm_bindings.pl
+++ b/src/unifyweaver/bindings/jvm_asm_bindings.pl
@@ -16,7 +16,10 @@ init_jvm_asm_bindings :-
     register_jvm_asm_bitwise_bindings,
     register_jvm_asm_math_bindings,
     register_jvm_asm_io_bindings,
-    register_jvm_asm_string_bindings.
+    register_jvm_asm_string_bindings,
+    register_jvm_asm_array_bindings,
+    register_jvm_asm_conversion_bindings,
+    register_jvm_asm_stack_bindings.
 
 %% declare_dual_binding(+Pred, +Instruction, +Inputs, +Outputs, +Options)
 %%   Register a binding for both jamaica and krakatau targets.
@@ -130,3 +133,69 @@ register_jvm_asm_string_bindings :-
         ['String'], ['String'],
         [pure, deterministic, total, pattern(function),
          description("Convert string to uppercase")]).
+
+%% Array operations
+register_jvm_asm_array_bindings :-
+    declare_dual_binding('newarray_int'/2, 'newarray int', [int], ['int[]'],
+        [deterministic, pattern(array_op),
+         description("Create new int array of given size")]),
+    declare_dual_binding('arraylength'/2, 'arraylength', ['array'], [int],
+        [pure, deterministic, total, pattern(array_op),
+         description("Get array length")]),
+    declare_dual_binding('iaload'/3, 'iaload', ['int[]', int], [int],
+        [deterministic, pattern(array_op),
+         description("Load int from array at index")]),
+    declare_dual_binding('iastore'/4, 'iastore', ['int[]', int, int], [],
+        [deterministic, pattern(array_op),
+         description("Store int into array at index")]),
+    declare_dual_binding('aaload'/3, 'aaload', ['Object[]', int], ['Object'],
+        [deterministic, pattern(array_op),
+         description("Load object reference from array")]),
+    declare_dual_binding('aastore'/4, 'aastore', ['Object[]', int, 'Object'], [],
+        [deterministic, pattern(array_op),
+         description("Store object reference into array")]),
+    declare_dual_binding('anewarray'/3, 'anewarray',  [int], ['Object[]'],
+        [deterministic, pattern(array_op),
+         description("Create new object array of given size")]),
+    declare_dual_binding('array_fill'/4,
+        'invokestatic java/util/Arrays fill ([II)V',
+        ['int[]', int], [],
+        [deterministic, pattern(array_op),
+         description("Fill int array with a value")]),
+    declare_dual_binding('array_sort'/2,
+        'invokestatic java/util/Arrays sort ([I)V',
+        ['int[]'], [],
+        [deterministic, pattern(array_op),
+         description("Sort int array in-place")]),
+    declare_dual_binding('array_copyof'/3,
+        'invokestatic java/util/Arrays copyOf ([II)[I',
+        ['int[]', int], ['int[]'],
+        [pure, deterministic, total, pattern(array_op),
+         description("Copy array to new array of given length")]).
+
+%% Type conversion operations
+register_jvm_asm_conversion_bindings :-
+    declare_dual_binding('i2l'/2, 'i2l', [int], [long],
+        [pure, deterministic, total, pattern(conversion)]),
+    declare_dual_binding('l2i'/2, 'l2i', [long], [int],
+        [pure, deterministic, total, pattern(conversion)]),
+    declare_dual_binding('i2f'/2, 'i2f', [int], [float],
+        [pure, deterministic, total, pattern(conversion)]),
+    declare_dual_binding('i2d'/2, 'i2d', [int], [double],
+        [pure, deterministic, total, pattern(conversion)]),
+    declare_dual_binding('f2i'/2, 'f2i', [float], [int],
+        [pure, deterministic, total, pattern(conversion)]),
+    declare_dual_binding('d2i'/2, 'd2i', [double], [int],
+        [pure, deterministic, total, pattern(conversion)]).
+
+%% Stack manipulation
+register_jvm_asm_stack_bindings :-
+    declare_dual_binding('dup'/1, 'dup', [], [],
+        [deterministic, pattern(stack_op),
+         description("Duplicate top of stack")]),
+    declare_dual_binding('swap'/1, 'swap', [], [],
+        [deterministic, pattern(stack_op),
+         description("Swap top two stack values")]),
+    declare_dual_binding('pop'/1, 'pop', [], [],
+        [deterministic, pattern(stack_op),
+         description("Pop top of stack")]).

--- a/src/unifyweaver/core/jvm_bytecode.pl
+++ b/src/unifyweaver/core/jvm_bytecode.pl
@@ -46,7 +46,13 @@
     jvm_string_concat_bytecode/4,    % +VarA, +VarB, +VarMap, -Instructions
     jvm_tostring_bytecode/3,         % +Var, +VarMap, -Instructions
     jvm_println_bytecode/3,          % +Var, +VarMap, -Instructions
-    jvm_load_string/2                % +StringValue, -Instruction
+    jvm_load_string/2,               % +StringValue, -Instruction
+
+    % Array operations
+    jvm_newarray_bytecode/3,         % +Type, +SizeExpr, -Instructions
+    jvm_array_load_bytecode/4,       % +ArrayVar, +IndexExpr, +VarMap, -Instructions
+    jvm_array_store_bytecode/5,      % +ArrayVar, +IndexExpr, +ValueExpr, +VarMap, -Instructions
+    jvm_arraylength_bytecode/3       % +ArrayVar, +VarMap, -Instructions
 ]).
 
 :- use_module('../core/clause_body_analysis').
@@ -532,6 +538,65 @@ jvm_resolve_string_operand(Expr, _VarMap, [Instr]) :-
     format(string(Instr), '    ldc "~w"', [Expr]).
 jvm_resolve_string_operand(Expr, VarMap, Instructions) :-
     jvm_expr_to_bytecode(Expr, VarMap, symbolic, Instructions).
+
+%% ============================================
+%% ARRAY OPERATIONS
+%% ============================================
+
+%% jvm_newarray_bytecode(+Type, +SizeExpr, -Instructions)
+%%   Create a new array of the given type and size.
+jvm_newarray_bytecode(int, SizeExpr, Instructions) :-
+    (   integer(SizeExpr)
+    ->  jvm_load_const(SizeExpr, LoadSize), Instructions = [LoadSize, "    newarray int"]
+    ;   format(string(Load), '    iload ~w', [SizeExpr]),
+        Instructions = [Load, "    newarray int"]
+    ).
+jvm_newarray_bytecode(object(ClassName), SizeExpr, Instructions) :-
+    (   integer(SizeExpr)
+    ->  jvm_load_const(SizeExpr, LoadSize)
+    ;   format(string(LoadSize), '    iload ~w', [SizeExpr])
+    ),
+    format(string(ANew), '    anewarray ~w', [ClassName]),
+    Instructions = [LoadSize, ANew].
+
+%% jvm_array_load_bytecode(+ArrayVar, +IndexExpr, +VarMap, -Instructions)
+%%   Load an element from an array. Leaves value on stack.
+jvm_array_load_bytecode(ArrayVar, IndexExpr, VarMap, Instructions) :-
+    (   lookup_var(ArrayVar, VarMap, AName)
+    ->  format(string(LoadArr), '    aload ~w', [AName])
+    ;   format(string(LoadArr), '    aload ~w', [ArrayVar])
+    ),
+    (   integer(IndexExpr)
+    ->  jvm_load_const(IndexExpr, LoadIdx)
+    ;   lookup_var(IndexExpr, VarMap, IName),
+        format(string(LoadIdx), '    iload ~w', [IName])
+    ),
+    Instructions = [LoadArr, LoadIdx, "    iaload"].
+
+%% jvm_array_store_bytecode(+ArrayVar, +IndexExpr, +ValueExpr, +VarMap, -Instructions)
+%%   Store a value into an array.
+jvm_array_store_bytecode(ArrayVar, IndexExpr, ValueExpr, VarMap, Instructions) :-
+    (   lookup_var(ArrayVar, VarMap, AName)
+    ->  format(string(LoadArr), '    aload ~w', [AName])
+    ;   format(string(LoadArr), '    aload ~w', [ArrayVar])
+    ),
+    (   integer(IndexExpr)
+    ->  jvm_load_const(IndexExpr, LoadIdx)
+    ;   lookup_var(IndexExpr, VarMap, IName),
+        format(string(LoadIdx), '    iload ~w', [IName])
+    ),
+    jvm_expr_to_bytecode(ValueExpr, VarMap, symbolic, ValueInstrs),
+    append([LoadArr, LoadIdx], ValueInstrs, Pre),
+    append(Pre, ["    iastore"], Instructions).
+
+%% jvm_arraylength_bytecode(+ArrayVar, +VarMap, -Instructions)
+%%   Get the length of an array. Leaves int on stack.
+jvm_arraylength_bytecode(ArrayVar, VarMap, Instructions) :-
+    (   lookup_var(ArrayVar, VarMap, AName)
+    ->  format(string(LoadArr), '    aload ~w', [AName])
+    ;   format(string(LoadArr), '    aload ~w', [ArrayVar])
+    ),
+    Instructions = [LoadArr, "    arraylength"].
 
 %% ============================================
 %% RECURSION PATTERN GENERATORS

--- a/src/unifyweaver/glue/jvm_glue.pl
+++ b/src/unifyweaver/glue/jvm_glue.pl
@@ -183,6 +183,8 @@ jvm_target(jython).
 jvm_target(scala).
 jvm_target(kotlin).
 jvm_target(clojure).
+jvm_target(jamaica).
+jvm_target(krakatau).
 
 % ============================================================================
 % GENERIC BRIDGE GENERATOR

--- a/src/unifyweaver/targets/jamaica_target.pl
+++ b/src/unifyweaver/targets/jamaica_target.pl
@@ -18,7 +18,11 @@
     compile_tree_recursion_jamaica/3,
     compile_multicall_recursion_jamaica/3,
     compile_direct_multicall_jamaica/3,
-    compile_mutual_recursion_jamaica/2
+    compile_mutual_recursion_jamaica/2,
+    % Component system
+    jamaica_type_info/1,
+    jamaica_validate_config/1,
+    jamaica_compile_component/4
 ]).
 
 :- use_module(library(lists)).
@@ -37,6 +41,30 @@
         true
     )
 ), now).
+
+%% ============================================
+%% IMPORT MANAGEMENT
+%% ============================================
+
+:- dynamic jamaica_import/1.
+
+clear_jamaica_imports :-
+    retractall(jamaica_import(_)).
+
+collect_jamaica_import(Import) :-
+    (   jamaica_import(Import) -> true
+    ;   assert(jamaica_import(Import))
+    ).
+
+get_jamaica_imports(Imports) :-
+    findall(I, jamaica_import(I), Imports).
+
+format_jamaica_imports(Imports, Code) :-
+    maplist(format_one_import, Imports, Lines),
+    atomic_list_concat(Lines, '\n', Code).
+
+format_one_import(Import, Line) :-
+    format(string(Line), 'import ~w;', [Import]).
 
 % Advanced recursion multifile hooks
 :- use_module('../core/advanced/tail_recursion', []).
@@ -343,6 +371,32 @@ clause_body_analysis:render_ite_block(jamaica, Cond, ThenLines, ElseLines, _Inde
         append(Pre, [EndLabel], Lines)
     ;   append([CondLine, ThenLabel|ThenLines], [EndLabel], Lines)
     ).
+
+%% ============================================
+%% COMPONENT SYSTEM HOOKS
+%% ============================================
+
+jamaica_type_info(info(
+    name('Custom Jamaica Component'),
+    version('1.0.0'),
+    description('Injects custom Jamaica JVM assembly code as a component')
+)).
+
+jamaica_validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+jamaica_compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+    atom_string(Name, NameStr),
+    format(string(Code),
+'  // Custom Component: ~w
+  public static int comp_~w(int input) {
+~w
+  }
+', [NameStr, NameStr, Body]).
 
 ensure_string(Atom, Str) :- atom(Atom), !, atom_string(Atom, Str).
 ensure_string(Str, Str) :- string(Str), !.

--- a/src/unifyweaver/targets/krakatau_target.pl
+++ b/src/unifyweaver/targets/krakatau_target.pl
@@ -18,7 +18,10 @@
     compile_tree_recursion_krakatau/3,
     compile_multicall_recursion_krakatau/3,
     compile_direct_multicall_krakatau/3,
-    compile_mutual_recursion_krakatau/2
+    compile_mutual_recursion_krakatau/2,
+    krakatau_type_info/1,
+    krakatau_validate_config/1,
+    krakatau_compile_component/4
 ]).
 
 :- use_module(library(lists)).
@@ -345,3 +348,31 @@ clause_body_analysis:render_ite_block(krakatau, Cond, ThenLines, ElseLines, _Ind
         append(Pre, ['L_end:'], Lines)
     ;   append([Cond, 'L_then:'|ThenLines], ['L_end:'], Lines)
     ).
+
+%% ============================================
+%% COMPONENT SYSTEM HOOKS
+%% ============================================
+
+krakatau_type_info(info(
+    name('Custom Krakatau Component'),
+    version('1.0.0'),
+    description('Injects custom Krakatau JVM bytecode as a component')
+)).
+
+krakatau_validate_config(Config) :-
+    (   member(code(Code), Config), string(Code)
+    ->  true
+    ;   throw(error(missing_or_invalid_code_option))
+    ).
+
+krakatau_compile_component(Name, Config, _Options, Code) :-
+    member(code(Body), Config),
+    atom_string(Name, NameStr),
+    format(string(Code),
+'.method public static comp_~w : (I)I
+    .limit stack 10
+    .limit locals 10
+    ; Custom Component: ~w
+~w
+.end method
+', [NameStr, NameStr, Body]).

--- a/tests/core/test_jvm_asm_native_lowering.pl
+++ b/tests/core/test_jvm_asm_native_lowering.pl
@@ -22,6 +22,7 @@
 :- use_module('../../src/unifyweaver/core/target_registry').
 :- use_module('../../src/unifyweaver/core/recursive_compiler').
 :- use_module('../../src/unifyweaver/core/input_source').
+:- use_module('../../src/unifyweaver/glue/jvm_glue').
 
 test_jvm_asm_native_lowering :-
     run_tests([jvm_asm_native_lowering]).
@@ -577,6 +578,116 @@ test(vbnet_seed_statement) :-
     input_source:seed_statement(vbnet, _, alice, bob, Stmt),
     has(Stmt, "AddFact"),
     has(Stmt, "\"alice\"").
+
+% ============================================================================
+% Expanded bindings (array, conversion, stack)
+% ============================================================================
+
+test(array_newarray_binding) :-
+    once(binding_registry:binding(jamaica, 'newarray_int'/2, 'newarray int', _, _, _)).
+
+test(array_iaload_binding) :-
+    once(binding_registry:binding(krakatau, 'iaload'/3, 'iaload', _, _, _)).
+
+test(array_iastore_binding) :-
+    once(binding_registry:binding(jamaica, 'iastore'/4, 'iastore', _, _, _)).
+
+test(array_sort_binding) :-
+    once(binding_registry:binding(krakatau, 'array_sort'/2, _, _, _, _)).
+
+test(conversion_i2l_binding) :-
+    once(binding_registry:binding(jamaica, 'i2l'/2, 'i2l', _, _, _)).
+
+test(stack_dup_binding) :-
+    once(binding_registry:binding(krakatau, 'dup'/1, 'dup', _, _, _)).
+
+% ============================================================================
+% Array operations (shared bytecode layer)
+% ============================================================================
+
+test(jvm_newarray_int) :-
+    jvm_bytecode:jvm_newarray_bytecode(int, 10, Instrs),
+    last(Instrs, Last),
+    has(Last, "newarray int").
+
+test(jvm_array_load) :-
+    jvm_bytecode:jvm_array_load_bytecode(arr, 2, [arr-arr], Instrs),
+    once(member(I, Instrs)),
+    has(I, "aload"),
+    last(Instrs, Last),
+    has(Last, "iaload").
+
+test(jvm_array_store) :-
+    jvm_bytecode:jvm_array_store_bytecode(arr, 0, 42, [arr-arr], Instrs),
+    last(Instrs, Last),
+    has(Last, "iastore").
+
+test(jvm_arraylength) :-
+    jvm_bytecode:jvm_arraylength_bytecode(arr, [arr-arr], Instrs),
+    last(Instrs, Last),
+    has(Last, "arraylength").
+
+% ============================================================================
+% Component system hooks
+% ============================================================================
+
+test(jamaica_type_info) :-
+    jamaica_target:jamaica_type_info(info(name(N), _, _)),
+    has(N, "Jamaica").
+
+test(jamaica_validate_config) :-
+    jamaica_target:jamaica_validate_config([code("test body")]).
+
+test(jamaica_compile_component) :-
+    jamaica_target:jamaica_compile_component(test_comp,
+        [code("    iload arg1\n    ireturn")], [], Code),
+    has(Code, "comp_test_comp"),
+    has(Code, "public static int").
+
+test(krakatau_type_info) :-
+    krakatau_target:krakatau_type_info(info(name(N), _, _)),
+    has(N, "Krakatau").
+
+test(krakatau_compile_component) :-
+    krakatau_target:krakatau_compile_component(test_comp,
+        [code("    iload_0\n    ireturn")], [], Code),
+    has(Code, "comp_test_comp"),
+    has(Code, ".method public static").
+
+% ============================================================================
+% Import management
+% ============================================================================
+
+test(jamaica_import_management) :-
+    jamaica_target:clear_jamaica_imports,
+    jamaica_target:collect_jamaica_import('java.util.HashMap'),
+    jamaica_target:collect_jamaica_import('java.util.ArrayList'),
+    jamaica_target:collect_jamaica_import('java.util.HashMap'),  % duplicate
+    jamaica_target:get_jamaica_imports(Imports),
+    length(Imports, 2),  % deduplicated
+    jamaica_target:clear_jamaica_imports.
+
+test(jamaica_format_imports) :-
+    jamaica_target:format_jamaica_imports(
+        ['java.util.HashMap', 'java.util.ArrayList'], Code),
+    has(Code, "import java.util.HashMap;"),
+    has(Code, "import java.util.ArrayList;").
+
+% ============================================================================
+% Glue support
+% ============================================================================
+
+test(jamaica_is_jvm_target) :-
+    jvm_glue:jvm_target(jamaica).
+
+test(krakatau_is_jvm_target) :-
+    jvm_glue:jvm_target(krakatau).
+
+test(jamaica_can_bridge_java) :-
+    jvm_glue:can_use_direct(jamaica, java).
+
+test(krakatau_can_bridge_kotlin) :-
+    jvm_glue:can_use_direct(krakatau, kotlin).
 
 % ============================================================================
 % Transitive closure templates


### PR DESCRIPTION
## Summary

Close remaining feature gaps between Jamaica/Krakatau and mature targets. Bindings expanded from 33 to 52, full component system hooks added, import management for Jamaica, and glue/bridge integration.

## Feature Parity Progress

| Feature | Before | After | Target |
|---------|:---:|:---:|:---:|
| Bindings | 33 | 52 | ~50+ (Java has 38) |
| Component system | Registration only | Full (type_info + validate + compile) | WAT-level |
| Import management | None | Jamaica: full (clear/collect/get/format) | Java-level |
| Glue/bridge | Not integrated | Both in jvm_target/1 | Java-level |
| Array operations | None | 4 bytecode helpers + 10 bindings | New capability |

## Changes

### Expanded Bindings (`jvm_asm_bindings.pl`)

| Category | New Bindings | Count |
|----------|-------------|-------|
| Array ops | newarray_int, arraylength, iaload, iastore, aaload, aastore, anewarray, array_fill, array_sort, array_copyof | 10 |
| Conversions | i2l, l2i, i2f, i2d, f2i, d2i | 6 |
| Stack | dup, swap, pop | 3 |

### Array Operations (`jvm_bytecode.pl`)

| Predicate | Purpose |
|-----------|---------|
| `jvm_newarray_bytecode/3` | Create int[] or Object[] |
| `jvm_array_load_bytecode/4` | Load element by index |
| `jvm_array_store_bytecode/5` | Store value at index |
| `jvm_arraylength_bytecode/3` | Get array length |

### Component System

Both targets now have WAT-level component support:
- `*_type_info/1` — component metadata
- `*_validate_config/1` — validate code option
- `*_compile_component/4` — generate component method (Jamaica: Java-like, Krakatau: directive syntax)

### Import Management (Jamaica)

- `clear_jamaica_imports/0` — reset tracked imports
- `collect_jamaica_import/1` — add import (deduplicates)
- `get_jamaica_imports/1` — retrieve all imports
- `format_jamaica_imports/2` — format as `import pkg.Class;` lines

### Glue/Bridge (`jvm_glue.pl`)

Added `jvm_target(jamaica)` and `jvm_target(krakatau)` — both targets can now bridge directly with all other JVM targets (java, kotlin, scala, jython, clojure).

## Tests (88 → 109, +21 new)

| Category | Tests |
|----------|-------|
| Array bindings | 4 (newarray, iaload, iastore, sort) |
| Conversion/stack bindings | 2 (i2l, dup) |
| Array bytecode | 4 (newarray, load, store, length) |
| Component hooks | 5 (type_info, validate, compile × 2 targets) |
| Import management | 2 (collect/get/dedup, format) |
| Glue | 4 (jvm_target × 2, can_bridge × 2) |

## Test plan

- [x] All 109 JVM assembly tests pass
- [x] All 95 WAT tests pass (no regressions)
- [x] Array bindings registered for both targets
- [x] Component compilation generates correct syntax per target
- [x] Import deduplication works
- [x] Both targets recognized as JVM targets in glue system
