### PR TITLE
feat: deepen all remaining targets with classify_goal_sequence + fix Rust dispatch bug

### DIFF
--- a/src/unifyweaver/targets/clojure_target.pl
+++ b/src/unifyweaver/targets/clojure_target.pl
@@ -681,10 +681,111 @@ clojure_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     clojure_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_clojure_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_clojure_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    clojure_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_clojure_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(clojure_guard_condition(VarMap), GuardGoals, Conditions),
     clojure_output_goals(OutputGoals, VarMap, Code).
+
+%% clojure_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+clojure_render_classified_goals([], _VarMap, [], []).
+clojure_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    clojure_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+clojure_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    clojure_output_goal(Goal, VarMap, LetBinding, VarMap1),
+    clojure_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(clojure_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = 'nil'
+    ),
+    format(string(IfLine), '  (if (and ~w)', [GuardExpr]),
+    format(string(RetLine), '    ~w', [OutName]),
+    CloseLine = '    nil)',
+    Lines = [LetBinding, IfLine, RetLine, CloseLine].
+clojure_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    clojure_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    clojure_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% clojure_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+clojure_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    clojure_guard_condition(VarMap, Goal, Cond).
+clojure_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    clojure_output_goal(Goal, VarMap0, Line, VarMapOut).
+clojure_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], [Line], VarMap0) :-
+    clojure_guard_condition(VarMap0, If, Cond),
+    clojure_branch_value(Then, VarMap0, ThenExpr),
+    clojure_branch_value(Else, VarMap0, ElseExpr),
+    format(string(Line), '  (if ~w ~w ~w)', [Cond, ThenExpr, ElseExpr]).
+clojure_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    clojure_output_goal(Goal, VarMap0, Line, VarMapOut).
+clojure_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% clojure_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+clojure_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    clojure_guard_condition(VarMap, Goal, Cond).
+clojure_render_classified_last(output(Goal, _, _), VarMap, [], [Line]) :-
+    clojure_output_goal_last(Goal, VarMap, Line).
+clojure_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], [Line]) :-
+    clojure_guard_condition(VarMap, If, Cond),
+    clojure_branch_value(Then, VarMap, ThenExpr),
+    clojure_branch_value(Else, VarMap, ElseExpr),
+    format(string(Line), '  (if ~w ~w ~w)', [Cond, ThenExpr, ElseExpr]).
+clojure_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    clojure_disj_cond_chain(Alternatives, VarMap, Lines).
+clojure_render_classified_last(passthrough(Goal), VarMap, [], [Line]) :-
+    clojure_output_goal_last(Goal, VarMap, Line).
+clojure_render_classified_last(_, _, [], []).
+
+%% clojure_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+clojure_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, clojure_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+clojure_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% clojure_disj_cond_chain(+Alternatives, +VarMap, -Lines)
+%  Renders disjunctions as a (cond ...) expression in Clojure.
+clojure_disj_cond_chain([], _, []).
+clojure_disj_cond_chain(Alternatives, VarMap, Lines) :-
+    CondOpen = '  (cond',
+    clojure_disj_cond_branches(Alternatives, VarMap, BranchLines),
+    CondClose = '  )',
+    append([[CondOpen], BranchLines, [CondClose]], Lines).
+
+%% clojure_disj_cond_branches(+Alternatives, +VarMap, -Lines)
+clojure_disj_cond_branches([], _, []).
+clojure_disj_cond_branches([Alt], VarMap, [KeyLine, ValLine]) :-
+    !,
+    clojure_branch_value(Alt, VarMap, ValExpr),
+    KeyLine = '    :else',
+    format(string(ValLine), '    ~w', [ValExpr]).
+clojure_disj_cond_branches([Alt|Rest], VarMap, [KeyLine, ValLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(clojure_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' ', CondParts),
+        format(string(CondExpr), '(and ~w)', [CondParts])
+    ;   CondExpr = 'true'
+    ),
+    clojure_branch_value(Alt, VarMap, ValExpr),
+    format(string(KeyLine), '    ~w', [CondExpr]),
+    format(string(ValLine), '    ~w', [ValExpr]),
+    clojure_disj_cond_branches(Rest, VarMap, RestLines).
 
 %% clojure_guard_condition(+VarMap, +Goal, -Condition)
 clojure_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/elixir_target.pl
+++ b/src/unifyweaver/targets/elixir_target.pl
@@ -318,10 +318,129 @@ elixir_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     elixir_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_elixir_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_elixir_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    elixir_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_elixir_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(elixir_guard_condition(VarMap), GuardGoals, Conditions),
     elixir_output_goals(OutputGoals, VarMap, Code).
+
+%% elixir_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+elixir_render_classified_goals([], _VarMap, [], []).
+elixir_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    elixir_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+elixir_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    elixir_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    elixir_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(elixir_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' and ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = '_'
+    ),
+    format(string(IfLine), '      if ~w do', [GuardExpr]),
+    format(string(RetLine), '        ~w', [OutName]),
+    EndLine = '      end',
+    Lines = [AssignLine, IfLine, RetLine, EndLine].
+elixir_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    elixir_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    elixir_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% elixir_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+elixir_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    elixir_guard_condition(VarMap, Goal, Cond).
+elixir_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    elixir_output_goal(Goal, VarMap0, Line, VarMapOut).
+elixir_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    elixir_guard_condition(VarMap0, If, Cond),
+    elixir_branch_value(Then, VarMap0, ThenExpr),
+    elixir_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '      if ~w do', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '      else',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    EndLine = '      end',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, EndLine].
+elixir_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    elixir_output_goal(Goal, VarMap0, Line, VarMapOut).
+elixir_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% elixir_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+elixir_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    elixir_guard_condition(VarMap, Goal, Cond).
+elixir_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    elixir_render_output_goal_last(Goal, VarMap, Lines).
+elixir_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    elixir_guard_condition(VarMap, If, Cond),
+    elixir_branch_value(Then, VarMap, ThenExpr),
+    elixir_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '      if ~w do', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '      else',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    EndLine = '      end',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, EndLine].
+elixir_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    elixir_disj_case_chain(Alternatives, VarMap, Lines).
+elixir_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    elixir_render_output_goal_last(Goal, VarMap, Lines).
+elixir_render_classified_last(_, _, [], []).
+
+%% elixir_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+elixir_render_output_goal_last(Goal, VarMap, Lines) :-
+    elixir_output_goal_last(Goal, VarMap, Lines, _VarMapOut),
+    !.
+elixir_render_output_goal_last(Goal, VarMap, [Line]) :-
+    elixir_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '      ~w', [Expr]).
+
+%% elixir_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+elixir_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, elixir_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+elixir_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% elixir_disj_case_chain(+Alternatives, +VarMap, -Lines)
+%  Renders disjunctions as a cond block in Elixir.
+elixir_disj_case_chain([], _, []).
+elixir_disj_case_chain(Alternatives, VarMap, Lines) :-
+    CondOpen = '      cond do',
+    elixir_disj_cond_branches(Alternatives, VarMap, BranchLines),
+    CondClose = '      end',
+    append([[CondOpen], BranchLines, [CondClose]], Lines).
+
+%% elixir_disj_cond_branches(+Alternatives, +VarMap, -Lines)
+elixir_disj_cond_branches([], _, []).
+elixir_disj_cond_branches([Alt], VarMap, [ArrowLine, RetLine]) :-
+    !,
+    elixir_branch_value(Alt, VarMap, ValExpr),
+    ArrowLine = '        true ->',
+    format(string(RetLine), '          ~w', [ValExpr]).
+elixir_disj_cond_branches([Alt|Rest], VarMap, [ArrowLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(elixir_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' and ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    elixir_branch_value(Alt, VarMap, ValExpr),
+    format(string(ArrowLine), '        ~w ->', [CondExpr]),
+    format(string(RetLine), '          ~w', [ValExpr]),
+    elixir_disj_cond_branches(Rest, VarMap, RestLines).
 
 %% elixir_guard_condition(+VarMap, +Goal, -Condition)
 elixir_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/fsharp_target.pl
+++ b/src/unifyweaver/targets/fsharp_target.pl
@@ -227,10 +227,135 @@ fsharp_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     fsharp_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_fsharp_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_fsharp_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    fsharp_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_fsharp_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(fsharp_guard_condition(VarMap), GuardGoals, Conditions),
     fsharp_output_goals(OutputGoals, VarMap, Code).
+
+%% fsharp_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+fsharp_render_classified_goals([], _VarMap, [], []).
+fsharp_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    fsharp_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+fsharp_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    fsharp_output_goal(Goal, VarMap, LetBinding, VarMap1),
+    fsharp_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(fsharp_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = '_'
+    ),
+    format(string(IfLine), '    if ~w then ~w else failwith "guard failed"', [GuardExpr, OutName]),
+    Lines = [LetBinding, IfLine].
+fsharp_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    fsharp_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    fsharp_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% fsharp_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+fsharp_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    fsharp_guard_condition(VarMap, Goal, Cond).
+fsharp_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    fsharp_output_goal(Goal, VarMap0, Line, VarMapOut).
+fsharp_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    fsharp_guard_condition(VarMap0, If, Cond),
+    fsharp_branch_value(Then, VarMap0, ThenExpr),
+    fsharp_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if ~w then', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    else',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine].
+fsharp_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    fsharp_output_goal(Goal, VarMap0, Line, VarMapOut).
+fsharp_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% fsharp_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+fsharp_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    fsharp_guard_condition(VarMap, Goal, Cond).
+fsharp_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    fsharp_render_output_goal_last(Goal, VarMap, Lines).
+fsharp_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    fsharp_guard_condition(VarMap, If, Cond),
+    fsharp_branch_value(Then, VarMap, ThenExpr),
+    fsharp_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if ~w then', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    else',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine].
+fsharp_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    fsharp_disj_if_chain(Alternatives, VarMap, Lines).
+fsharp_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    fsharp_render_output_goal_last(Goal, VarMap, Lines).
+fsharp_render_classified_last(_, _, [], []).
+
+%% fsharp_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+fsharp_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    fsharp_output_goal_last(Goal, VarMap, Expr, _VarMapOut),
+    !.
+fsharp_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    fsharp_branch_value(Goal, VarMap, Expr).
+
+%% fsharp_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+fsharp_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, fsharp_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+fsharp_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% fsharp_disj_if_chain(+Alternatives, +VarMap, -Lines)
+fsharp_disj_if_chain([], _, []).
+fsharp_disj_if_chain([Alt], VarMap, [ElseLine, RetLine]) :-
+    !,
+    fsharp_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    else',
+    format(string(RetLine), '        ~w', [ValExpr]).
+fsharp_disj_if_chain([Alt|Rest], VarMap, [IfLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(fsharp_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    fsharp_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if ~w then', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    fsharp_disj_elif_chain(Rest, VarMap, RestLines).
+
+%% fsharp_disj_elif_chain(+Alternatives, +VarMap, -Lines)
+fsharp_disj_elif_chain([], _, []).
+fsharp_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine]) :-
+    !,
+    fsharp_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    else',
+    format(string(RetLine), '        ~w', [ValExpr]).
+fsharp_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(fsharp_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    fsharp_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '    elif ~w then', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    fsharp_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% fsharp_guard_condition(+VarMap, +Goal, -Condition)
 fsharp_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/haskell_target.pl
+++ b/src/unifyweaver/targets/haskell_target.pl
@@ -283,10 +283,123 @@ haskell_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     haskell_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_haskell_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_haskell_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    haskell_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_haskell_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(haskell_guard_condition(VarMap), GuardGoals, Conditions),
     haskell_output_goals(OutputGoals, VarMap, Code).
+
+%% haskell_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+haskell_render_classified_goals([], _VarMap, [], []).
+haskell_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    haskell_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+haskell_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    haskell_output_goal(Goal, VarMap, LetBinding, VarMap1),
+    haskell_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(haskell_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = '_'
+    ),
+    format(string(IfLine), 'if ~w then ~w else error "guard failed"', [GuardExpr, OutName]),
+    Lines = [LetBinding, IfLine].
+haskell_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    haskell_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    haskell_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% haskell_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+haskell_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    haskell_guard_condition(VarMap, Goal, Cond).
+haskell_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    haskell_output_goal(Goal, VarMap0, Line, VarMapOut).
+haskell_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], [Line], VarMap0) :-
+    haskell_guard_condition(VarMap0, If, Cond),
+    haskell_branch_value(Then, VarMap0, ThenExpr),
+    haskell_branch_value(Else, VarMap0, ElseExpr),
+    format(string(Line), 'if ~w then ~w else ~w', [Cond, ThenExpr, ElseExpr]).
+haskell_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    haskell_output_goal(Goal, VarMap0, Line, VarMapOut).
+haskell_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% haskell_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+haskell_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    haskell_guard_condition(VarMap, Goal, Cond).
+haskell_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    haskell_render_output_goal_last(Goal, VarMap, Lines).
+haskell_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], [Line]) :-
+    haskell_guard_condition(VarMap, If, Cond),
+    haskell_branch_value(Then, VarMap, ThenExpr),
+    haskell_branch_value(Else, VarMap, ElseExpr),
+    format(string(Line), 'if ~w then ~w else ~w', [Cond, ThenExpr, ElseExpr]).
+haskell_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    haskell_disj_if_chain(Alternatives, VarMap, Lines).
+haskell_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    haskell_render_output_goal_last(Goal, VarMap, Lines).
+haskell_render_classified_last(_, _, [], []).
+
+%% haskell_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+haskell_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    haskell_output_goal_last(Goal, VarMap, Expr, _VarMapOut),
+    !.
+haskell_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    haskell_branch_value(Goal, VarMap, Expr).
+
+%% haskell_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+haskell_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, haskell_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+haskell_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% haskell_disj_if_chain(+Alternatives, +VarMap, -Lines)
+haskell_disj_if_chain([], _, []).
+haskell_disj_if_chain([Alt], VarMap, [Line]) :-
+    !,
+    haskell_branch_value(Alt, VarMap, ValExpr),
+    format(string(Line), 'else ~w', [ValExpr]).
+haskell_disj_if_chain([Alt|Rest], VarMap, [Line|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(haskell_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'True'
+    ),
+    haskell_branch_value(Alt, VarMap, ValExpr),
+    format(string(Line), 'if ~w then ~w', [CondExpr, ValExpr]),
+    haskell_disj_elif_chain(Rest, VarMap, RestLines).
+
+%% haskell_disj_elif_chain(+Alternatives, +VarMap, -Lines)
+haskell_disj_elif_chain([], _, []).
+haskell_disj_elif_chain([Alt], VarMap, [Line]) :-
+    !,
+    haskell_branch_value(Alt, VarMap, ValExpr),
+    format(string(Line), 'else ~w', [ValExpr]).
+haskell_disj_elif_chain([Alt|Rest], VarMap, [Line|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(haskell_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'True'
+    ),
+    haskell_branch_value(Alt, VarMap, ValExpr),
+    format(string(Line), 'else if ~w then ~w', [CondExpr, ValExpr]),
+    haskell_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% haskell_guard_condition(+VarMap, +Goal, -Condition)
 haskell_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/perl_target.pl
+++ b/src/unifyweaver/targets/perl_target.pl
@@ -1207,10 +1207,143 @@ perl_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     perl_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_perl_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_perl_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    perl_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_perl_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(perl_guard_condition(VarMap), GuardGoals, Conditions),
     perl_output_goals(OutputGoals, VarMap, Code).
+
+%% perl_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+perl_render_classified_goals([], _VarMap, [], []).
+perl_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    perl_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+perl_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    perl_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    perl_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(perl_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  format(string(OutRef), '$~w', [OutName])
+    ;   OutRef = "undef"
+    ),
+    format(string(IfLine), '    if (~w) {', [GuardExpr]),
+    format(string(RetLine), '        return ~w;', [OutRef]),
+    CloseLine = '    }',
+    Lines = [AssignLine, IfLine, RetLine, CloseLine].
+perl_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    perl_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    perl_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% perl_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+perl_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    perl_guard_condition(VarMap, Goal, Cond).
+perl_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    perl_output_goal(Goal, VarMap0, Line, VarMapOut).
+perl_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    perl_guard_condition(VarMap0, If, Cond),
+    perl_branch_value(Then, VarMap0, ThenExpr),
+    perl_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w;', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w;', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, '    }'].
+perl_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    perl_output_goal(Goal, VarMap0, Line, VarMapOut).
+perl_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% perl_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+perl_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    perl_guard_condition(VarMap, Goal, Cond).
+perl_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    perl_output_goal_last_lines(Goal, VarMap, Lines).
+perl_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    perl_guard_condition(VarMap, If, Cond),
+    perl_branch_value(Then, VarMap, ThenExpr),
+    perl_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w;', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w;', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, '    }'].
+perl_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    perl_disj_if_chain(Alternatives, VarMap, Lines).
+perl_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    perl_output_goal_last_lines(Goal, VarMap, Lines).
+perl_render_classified_last(_, _, [], []).
+
+%% perl_output_goal_last_lines(+Goal, +VarMap, -Lines)
+perl_output_goal_last_lines(Goal, VarMap, [Line]) :-
+    perl_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(RetPart), '\n    return $~w;', [OutName]),
+        atom_concat(AssignLine, RetPart, Line)
+    ;   Line = AssignLine
+    ).
+perl_output_goal_last_lines(Goal, VarMap, [Line]) :-
+    perl_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '    return ~w;', [Expr]).
+
+%% perl_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+perl_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, perl_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+perl_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% perl_disj_if_chain(+Alternatives, +VarMap, -Lines)
+perl_disj_if_chain([], _, []).
+perl_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    perl_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    CloseLine = '    }'.
+perl_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(perl_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "1"
+    ),
+    perl_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if (~w) {', [CondExpr]),
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    perl_disj_elsif_chain(Rest, VarMap, RestLines),
+    append([IfLine, RetLine], RestLines, Lines).
+
+perl_disj_elsif_chain([], _, []).
+perl_disj_elsif_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    perl_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    CloseLine = '    }'.
+perl_disj_elsif_chain([Alt|Rest], VarMap, [ElsifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(perl_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "1"
+    ),
+    perl_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElsifLine), '    } elsif (~w) {', [CondExpr]),
+    format(string(RetLine), '        return ~w;', [ValExpr]),
+    perl_disj_elsif_chain(Rest, VarMap, RestLines).
 
 %% perl_guard_condition(+VarMap, +Goal, -Condition)
 perl_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/ruby_target.pl
+++ b/src/unifyweaver/targets/ruby_target.pl
@@ -1089,10 +1089,143 @@ ruby_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     ruby_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_ruby_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_ruby_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    ruby_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_ruby_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(ruby_guard_condition(VarMap), GuardGoals, Conditions),
     ruby_output_goals(OutputGoals, VarMap, Code).
+
+%% ruby_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+ruby_render_classified_goals([], _VarMap, [], []).
+ruby_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    ruby_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+ruby_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    ruby_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    ruby_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(ruby_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "nil"
+    ),
+    format(string(IfLine), '  if ~w', [GuardExpr]),
+    format(string(RetLine), '    return ~w', [OutName]),
+    EndLine = '  end',
+    Lines = [AssignLine, IfLine, RetLine, EndLine].
+ruby_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    ruby_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    ruby_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% ruby_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+ruby_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    ruby_guard_condition(VarMap, Goal, Cond).
+ruby_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    ruby_output_goal(Goal, VarMap0, Line, VarMapOut).
+ruby_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    ruby_guard_condition(VarMap0, If, Cond),
+    ruby_branch_value(Then, VarMap0, ThenExpr),
+    ruby_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '  if ~w', [Cond]),
+    format(string(ThenLine), '    return ~w', [ThenExpr]),
+    ElseLine = '  else',
+    format(string(ElseRetLine), '    return ~w', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, '  end'].
+ruby_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    ruby_output_goal(Goal, VarMap0, Line, VarMapOut).
+ruby_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% ruby_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+ruby_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    ruby_guard_condition(VarMap, Goal, Cond).
+ruby_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    ruby_output_goal_last_lines(Goal, VarMap, Lines).
+ruby_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    ruby_guard_condition(VarMap, If, Cond),
+    ruby_branch_value(Then, VarMap, ThenExpr),
+    ruby_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '  if ~w', [Cond]),
+    format(string(ThenLine), '    return ~w', [ThenExpr]),
+    ElseLine = '  else',
+    format(string(ElseRetLine), '    return ~w', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, '  end'].
+ruby_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    ruby_disj_if_chain(Alternatives, VarMap, Lines).
+ruby_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    ruby_output_goal_last_lines(Goal, VarMap, Lines).
+ruby_render_classified_last(_, _, [], []).
+
+%% ruby_output_goal_last_lines(+Goal, +VarMap, -Lines)
+ruby_output_goal_last_lines(Goal, VarMap, [Line]) :-
+    ruby_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(RetPart), '\n  return ~w', [OutName]),
+        atom_concat(AssignLine, RetPart, Line)
+    ;   Line = AssignLine
+    ).
+ruby_output_goal_last_lines(Goal, VarMap, [Line]) :-
+    ruby_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '  return ~w', [Expr]).
+
+%% ruby_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+ruby_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, ruby_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+ruby_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% ruby_disj_if_chain(+Alternatives, +VarMap, -Lines)
+ruby_disj_if_chain([], _, []).
+ruby_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, EndLine]) :-
+    !,
+    ruby_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '  else',
+    format(string(RetLine), '    return ~w', [ValExpr]),
+    EndLine = '  end'.
+ruby_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(ruby_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    ruby_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '  if ~w', [CondExpr]),
+    format(string(RetLine), '    return ~w', [ValExpr]),
+    ruby_disj_elsif_chain(Rest, VarMap, RestLines),
+    append([IfLine, RetLine], RestLines, Lines).
+
+ruby_disj_elsif_chain([], _, []).
+ruby_disj_elsif_chain([Alt], VarMap, [ElseLine, RetLine, EndLine]) :-
+    !,
+    ruby_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '  else',
+    format(string(RetLine), '    return ~w', [ValExpr]),
+    EndLine = '  end'.
+ruby_disj_elsif_chain([Alt|Rest], VarMap, [ElsifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(ruby_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    ruby_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElsifLine), '  elsif ~w', [CondExpr]),
+    format(string(RetLine), '    return ~w', [ValExpr]),
+    ruby_disj_elsif_chain(Rest, VarMap, RestLines).
 
 %% ruby_guard_condition(+VarMap, +Goal, -Condition)
 ruby_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -3222,11 +3222,11 @@ compile_predicate_to_rust(PredIndicator, Options, RustCode) :-
         Backend \= none
     ->  format('  Mode: Database Backend (~w)~n', [Backend]),
         compile_db_backend_to_rust(Pred, Arity, Backend, Options, RustCode)
-    ;   functor(Head, Pred, Arity),
-        GoalModule:clause(Head, Body),
-        is_semantic_predicate(Body)
+    ;   functor(SemHead, Pred, Arity),
+        GoalModule:clause(SemHead, SemBody),
+        is_semantic_predicate(SemBody)
     ->  format('  Mode: Semantic Runtime~n'),
-        compile_semantic_mode(Pred, Arity, Head, Body, RustCode)
+        compile_semantic_mode(Pred, Arity, SemHead, SemBody, RustCode)
     ;   option(aggregation(AggOp), Options, none),
         AggOp \= none
     ->  option(field_delimiter(FieldDelim), Options, colon),
@@ -3236,9 +3236,11 @@ compile_predicate_to_rust(PredIndicator, Options, RustCode) :-
     ).
 
 is_semantic_predicate(Body) :-
-    (   sub_term(crawler_run(_, _), Body)
-    ;   sub_term(graph_search(_, _, _, _, _), Body)
-    ;   sub_term(graph_search(_, _, _, _), Body)
+    %% Use copy_term to avoid binding variables in Body
+    copy_term(Body, BodyCopy),
+    (   sub_term(Sub, BodyCopy), nonvar(Sub), functor(Sub, crawler_run, 2)
+    ;   sub_term(Sub, BodyCopy), nonvar(Sub), functor(Sub, graph_search, 5)
+    ;   sub_term(Sub, BodyCopy), nonvar(Sub), functor(Sub, graph_search, 4)
     ).
 
 compile_semantic_mode(Pred, _Arity, Head, Body, RustCode) :-

--- a/src/unifyweaver/targets/typescript_target.pl
+++ b/src/unifyweaver/targets/typescript_target.pl
@@ -743,10 +743,143 @@ ts_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     ts_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_ts_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_ts_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    ts_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_ts_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(ts_guard_condition(VarMap), GuardGoals, Conditions),
     ts_output_goals(OutputGoals, VarMap, Code).
+
+%% ts_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+ts_render_classified_goals([], _VarMap, [], []).
+ts_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    ts_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+ts_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    ts_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    ts_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(ts_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "undefined"
+    ),
+    format(string(IfLine), '  if (~w) {', [GuardExpr]),
+    format(string(RetLine), '    return ~w;', [OutName]),
+    CloseLine = '  }',
+    Lines = [AssignLine, IfLine, RetLine, CloseLine].
+ts_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    ts_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    ts_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% ts_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+ts_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    ts_guard_condition(VarMap, Goal, Cond).
+ts_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    ts_output_goal(Goal, VarMap0, Line, VarMapOut).
+ts_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    ts_guard_condition(VarMap0, If, Cond),
+    ts_branch_value(Then, VarMap0, ThenExpr),
+    ts_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '  if (~w) {', [Cond]),
+    format(string(ThenLine), '    return ~w;', [ThenExpr]),
+    ElseLine = '  } else {',
+    format(string(ElseRetLine), '    return ~w;', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, '  }'].
+ts_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    ts_output_goal(Goal, VarMap0, Line, VarMapOut).
+ts_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% ts_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+ts_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    ts_guard_condition(VarMap, Goal, Cond).
+ts_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    ts_output_goal_last_lines(Goal, VarMap, Lines).
+ts_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    ts_guard_condition(VarMap, If, Cond),
+    ts_branch_value(Then, VarMap, ThenExpr),
+    ts_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '  if (~w) {', [Cond]),
+    format(string(ThenLine), '    return ~w;', [ThenExpr]),
+    ElseLine = '  } else {',
+    format(string(ElseRetLine), '    return ~w;', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, '  }'].
+ts_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    ts_disj_if_chain(Alternatives, VarMap, Lines).
+ts_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    ts_output_goal_last_lines(Goal, VarMap, Lines).
+ts_render_classified_last(_, _, [], []).
+
+%% ts_output_goal_last_lines(+Goal, +VarMap, -Lines)
+ts_output_goal_last_lines(Goal, VarMap, [Line]) :-
+    ts_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(RetPart), '\n  return ~w;', [OutName]),
+        atom_concat(AssignLine, RetPart, Line)
+    ;   Line = AssignLine
+    ).
+ts_output_goal_last_lines(Goal, VarMap, [Line]) :-
+    ts_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '  return ~w;', [Expr]).
+
+%% ts_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+ts_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, ts_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+ts_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% ts_disj_if_chain(+Alternatives, +VarMap, -Lines)
+ts_disj_if_chain([], _, []).
+ts_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    ts_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '  } else {',
+    format(string(RetLine), '    return ~w;', [ValExpr]),
+    CloseLine = '  }'.
+ts_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(ts_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    ts_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '  if (~w) {', [CondExpr]),
+    format(string(RetLine), '    return ~w;', [ValExpr]),
+    ts_disj_else_if_chain(Rest, VarMap, RestLines),
+    append([IfLine, RetLine], RestLines, Lines).
+
+ts_disj_else_if_chain([], _, []).
+ts_disj_else_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    ts_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '  } else {',
+    format(string(RetLine), '    return ~w;', [ValExpr]),
+    CloseLine = '  }'.
+ts_disj_else_if_chain([Alt|Rest], VarMap, [ElseIfLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(ts_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "true"
+    ),
+    ts_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElseIfLine), '  } else if (~w) {', [CondExpr]),
+    format(string(RetLine), '    return ~w;', [ValExpr]),
+    ts_disj_else_if_chain(Rest, VarMap, RestLines).
 
 %% ts_guard_condition(+VarMap, +Goal, -Condition)
 ts_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/test_all_deep.pl
+++ b/test_all_deep.pl
@@ -1,0 +1,21 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+:- dynamic label/2.
+label(X, L) :- (X > 0 -> L = positive ; L = negative).
+
+test_hook(Target) :-
+    format('~w: ', [Target]),
+    build_head_varmap([X, L], 1, VarMap),
+    Goal = (X > 0 -> L = positive ; L = negative),
+    (   compile_expression(Target, Goal, VarMap, Code, _, _), Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+run :-
+    test_hook(perl), test_hook(ruby), test_hook(typescript),
+    test_hook(haskell), test_hook(fsharp), test_hook(elixir), test_hook(clojure),
+    nl, writeln('=== ALL 7 ADDITIONAL DEEPENED TARGETS DONE ===').

--- a/test_rust_c_cpp_deep.pl
+++ b/test_rust_c_cpp_deep.pl
@@ -26,10 +26,13 @@ run_checks(Code, [check(L, S)|R], Ok) :-
     ; format('MISS(~w) ', [L]), Ok = false, run_checks(Code, R, _)).
 
 run :-
-    %% Rust: compile_predicate_to_rust dispatch has pre-existing issue
-    %% for non-recursive predicates (semantic predicate check interferes).
-    %% Hooks work (tested in PR #1030), classify_goal_sequence added,
-    %% but full compilation path needs separate fix.
+    %% Rust
+    try('ite', rust, label/2, [check('if', "if ")]),
+    try('multi', rust, classify_temp/2, [check('freezing', "freezing")]),
+    try('guard+out', rust, safe_double/2, [check('* 2', "* 2")]),
+    try('tail', rust, bounded_sq/2, [check('< 1000', "< 1000")]),
+    nl,
+    %% C
     try('ite', c, label/2, [check('if', "if ")]),
     try('multi', c, classify_temp/2, [check('freezing', "freezing")]),
     try('guard+out', c, safe_double/2, [check('* 2', "* 2")]),
@@ -40,4 +43,4 @@ run :-
     try('guard+out', cpp, safe_double/2, [check('* 2', "* 2")]),
     try('tail', cpp, bounded_sq/2, [check('< 1000', "< 1000")]),
     nl,
-    writeln('=== C + C++ DEEP TESTS DONE (Rust has pre-existing dispatch issue) ===').
+    writeln('=== RUST + C + C++ DEEP TESTS DONE ===').


### PR DESCRIPTION
## Summary

Deepens 8 more targets with full `classify_goal_sequence` support and fixes a Rust dispatch bug that blocked non-recursive predicate compilation. **13 targets** now have the full classified goal rendering pipeline — ite output, disjunction output, guarded tail sequences, and multi-clause dispatch.

## Rust dispatch fix

`is_semantic_predicate` used `sub_term` with unification, which matched ANY compound term in clause bodies via free variables. A predicate like `label(X, L) :- (X > 0 -> L = positive ; L = negative)` was incorrectly classified as semantic because `sub_term(crawler_run(_, _), Body)` unified `crawler_run(_, _)` with unbound variables in the body.

Fixed with `copy_term` + `nonvar` + `functor` checks — only matches actual `crawler_run/2` and `graph_search/4,5` terms, not free variables.

## Targets deepened (8 new)

| Target | If/else syntax |
|--------|---------------|
| **Rust** | `if cond { ... } else { ... }` (now working!) |
| **Perl** | `if (cond) { ... } elsif (cond) { ... } else { ... }` |
| **Ruby** | `if cond ... elsif cond ... else ... end` |
| **TypeScript** | `if (cond) { ... } else if (cond) { ... } else { ... }` |
| **Haskell** | `if cond then ... else ...` |
| **F#** | `if cond then ... elif cond then ... else ...` |
| **Elixir** | `if cond do ... else ... end` |
| **Clojure** | `(if cond then-expr else-expr)` |

## All deepened targets (13 total)

| Target | Status | Tests |
|--------|--------|-------|
| Python | Reference (58+ tests) | All 20 TypR patterns |
| Go | ✅ | 4 pattern tests |
| Lua | ✅ | 4 pattern tests |
| C | ✅ | 4 pattern tests |
| C++ | ✅ | 4 pattern tests |
| Rust | ✅ (dispatch fixed) | 4 pattern tests |
| Perl | ✅ NEW | hook test |
| Ruby | ✅ NEW | hook test |
| TypeScript | ✅ NEW | hook test |
| Haskell | ✅ NEW | hook test |
| F# | ✅ NEW | hook test |
| Elixir | ✅ NEW | hook test |
| Clojure | ✅ NEW | hook test |

## Test plan

- [x] 12 Rust + C + C++ tests (4 patterns × 3 targets, including Rust now passing)
- [x] 7 additional target hook tests (Perl, Ruby, TypeScript, Haskell, F#, Elixir, Clojure)
- [x] 8 Go + Lua deep tests
- [x] All Python tests pass (58+)
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
