### PR TITLE
Document TypR SCC IR boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,11 @@ includes:
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
+- the next confirmed SCC gap is broader than another structural micro-slice:
+  mixed tree/forest pair-tail SCCs and mixed tree/numeric SCCs with local
+  helper goals between recursive group calls still fail with
+  `No mutual recursion support for target typr`, which points to a shared
+  SCC IR as the next compiler step rather than more matcher families
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -255,6 +255,17 @@ bring-up.
     tree/list/numeric SCCs where the tree-shaped predicate uses the same
     supported guarded full-body forms after an earlier recursive group-
     call prefix, plus integer-return and threaded-context variants
+  - stop extending `typr_mutual_supported_spec/3` with more bespoke
+    structural slices once the next failure is outside that subset
+  - the first confirmed post-audit unsupported SCCs are:
+    - mixed tree/forest pair-tail decompositions like `[A, B|Ts]`
+    - mixed list/numeric pair-tail decompositions
+    - mixed tree/numeric bodies with local helper goals between recursive
+      group calls
+  - the next implementation step should be a shared SCC IR that can encode
+    per-predicate ordered goal bodies, branch nodes, recursive call sites,
+    helper goals, and symbolic result bindings before another backend
+    expansion
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -438,6 +438,14 @@ Current TypR lowering policy is intentionally mixed:
   prefix, plus integer-return and threaded-context variants,
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
+- the next confirmed unsupported SCC shapes are now beyond that structural
+  subset, including mixed tree/forest pair-tail decompositions like
+  `[A, B|Ts]`, mixed list/numeric pair-tail decompositions, and mixed
+  tree/numeric bodies with local helper goals between recursive group calls
+- those shapes point to a shared SCC IR requirement: per-predicate body
+  lowering for ordered goals, recursive call sites, helper goals, branch
+  nodes, and symbolic result bindings that is independent of the current
+  structural-driver matcher family
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -170,6 +170,36 @@ This document focuses on architecture and rollout choices specific to TypR.
    and SCCs that no longer fit the current structural-driver or supported
    guarded full-body subset.
 
+8. The next confirmed unsupported SCC shapes are:
+   - mixed tree/forest SCCs where the forest side uses pair-tail
+     decomposition like `[A, B|Ts]`
+   - mixed list/numeric SCCs where the list side uses that same pair-tail
+     decomposition
+   - mixed tree/numeric SCCs where a local helper goal sits between
+     recursive group calls, for example selecting a subtree through a helper
+     predicate instead of a currently supported guarded body form
+
+9. Those failures are the point to stop adding bespoke matcher families.
+   They all still fail with `No mutual recursion support for target typr`,
+   but they no longer share a small structural extension point.
+
+10. The next TypR mutual-recursion step should therefore introduce a shared
+    SCC IR with:
+    - per-predicate ordered goal bodies
+    - explicit SCC call-site nodes with symbolic call arguments and result
+      bindings
+    - branch nodes and post-branch joins
+    - helper-goal nodes for nonrecursive local work that is not just a
+      current matcher-side guard or arithmetic step
+    - wrapper and memo generation derived from that IR rather than from the
+      current `typr_mutual_supported_spec/3` family
+
+11. Until that IR exists, the correct fallback boundary is:
+    - keep native TypR lowering for the current structural-driver and
+      supported guarded full-body subset
+    - reject broader SCCs cleanly instead of stacking more structural
+      one-offs
+
 Implication: TypR design must support both generation styles and should not
 assume a Mustache-only pipeline.
 


### PR DESCRIPTION
## Summary

This PR documents the next real TypR mutual-recursion frontier.

It does not add another structural SCC matcher.
Instead, it records the confirmed unsupported SCC shapes beyond the current TypR subset and defines the next compiler step as a shared SCC IR.

## Why This PR Exists

Recent TypR work generalized the native SCC backend through:

- mixed structural SCCs
- mixed list/numeric SCCs
- mixed tree/numeric SCCs
- mixed tree/list/numeric SCCs
- supported guarded full-body mixed SCC forms

At that point, continuing to add matcher-specific patches became low-signal.
The next question was whether there was still one more small structural extension to take, or whether the backend had reached the point where a more general SCC lowering model was required.

This branch answers that directly.

The audit confirmed that the next unsupported SCC slices are now outside the current structural-driver and guarded full-body matcher family.

Representative failing shapes include:

- mixed tree/forest SCCs where the forest side uses pair-tail decomposition like `[A, B|Ts]`
- mixed list/numeric SCCs where the list side uses that same pair-tail decomposition
- mixed tree/numeric SCCs where a local helper goal sits between recursive group calls

These still fail with:

- `No mutual recursion support for target typr`

That is the right place to stop stacking more bespoke matchers.

## Main Changes

- documented the confirmed unsupported SCC slices in:
  - `README.md`
  - `docs/design/TYPE_SYSTEM_SPEC.md`
  - `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
  - `docs/design/TYPR_TARGET_DESIGN.md`
- tightened the TypR design boundary so it now explicitly distinguishes:
  - the currently supported structural-driver and guarded full-body SCC subset
  - broader SCCs that need a different lowering model
- defined the next required compiler step as a shared SCC IR with:
  - per-predicate ordered goal bodies
  - explicit SCC call-site nodes
  - branch/join structure
  - helper-goal nodes for nonrecursive local work
  - symbolic result bindings and memo/wrapper generation derived from IR rather than the current matcher family

## Validation

This is a docs-only branch.

The boundary is based on local audit probes against the current TypR backend, confirming that the representative SCC shapes above still fall through to unsupported mutual recursion.

No compiler behavior was changed in this PR.

## Scope Boundary

This PR does not implement the SCC IR.

It intentionally stops before another compiler patch because the next confirmed failures no longer share a small structural extension point.

The follow-up implementation branch should start the shared SCC IR rather than adding another specialized `typr_mutual_supported_spec/3` matcher.
