### PR TITLE
Generalize native TypR SCC call slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ includes:
   predicates recurse through paired-forest helpers, including guarded
   branch-local paired-forest call selection on the tree side, while
   list-shaped predicates recurse through head/tail decomposition or fixed
-  two-element forest-pair decomposition, plus mixed list/numeric SCCs
+  two-element forest-pair decomposition or fixed pair-tail forest
+  decomposition like `[A, B|Ts]`, plus mixed list/numeric SCCs
   where list-shaped predicates recurse through head/tail decomposition
   while numeric predicates recurse through scalar step descent or
   singleton-list re-entry, plus mixed tree/numeric SCCs
@@ -297,7 +298,7 @@ includes:
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - the next confirmed SCC gap is broader than another structural micro-slice:
-  mixed tree/forest pair-tail SCCs and mixed tree/numeric SCCs with local
+  mixed list/numeric pair-tail SCCs and mixed tree/numeric SCCs with local
   helper goals between recursive group calls still fail with
   `No mutual recursion support for target typr`, which points to a shared
   SCC IR as the next compiler step rather than more matcher families

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -240,8 +240,9 @@ bring-up.
     tree-shaped predicates recurse through paired-forest helpers,
     including guarded branch-local paired-forest call selection on the
     tree side, while list-shaped predicates recurse through head/tail
-    decomposition or fixed two-element forest-pair decomposition, plus
-    mixed list/numeric SCCs where list-shaped
+    decomposition, fixed two-element forest-pair decomposition, or fixed
+    pair-tail forest decomposition like `[A, B|Ts]`, plus mixed
+    list/numeric SCCs where list-shaped
     predicates recurse through head/tail decomposition while numeric
     predicates recurse through scalar step descent or singleton-list
     re-entry, plus mixed tree/numeric SCCs where tree-shaped predicates
@@ -258,7 +259,6 @@ bring-up.
   - stop extending `typr_mutual_supported_spec/3` with more bespoke
     structural slices once the next failure is outside that subset
   - the first confirmed post-audit unsupported SCCs are:
-    - mixed tree/forest pair-tail decompositions like `[A, B|Ts]`
     - mixed list/numeric pair-tail decompositions
     - mixed tree/numeric bodies with local helper goals between recursive
       group calls

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -421,8 +421,9 @@ Current TypR lowering policy is intentionally mixed:
   mixed tree/list structural SCCs where tree-shaped predicates recurse
   through paired-forest helpers, including guarded branch-local paired-
   forest call selection on the tree side, while list-shaped predicates
-  recurse through head/tail decomposition or fixed two-element forest-
-  pair decomposition, plus mixed list/numeric SCCs
+  recurse through head/tail decomposition, fixed two-element forest-pair
+  decomposition, or fixed pair-tail forest decomposition like
+  `[A, B|Ts]`, plus mixed list/numeric SCCs
   where list-shaped predicates recurse through head/tail decomposition
   while numeric predicates recurse through scalar step descent or
   singleton-list re-entry, plus mixed tree/numeric SCCs where tree-shaped
@@ -439,8 +440,7 @@ Current TypR lowering policy is intentionally mixed:
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
 - the next confirmed unsupported SCC shapes are now beyond that structural
-  subset, including mixed tree/forest pair-tail decompositions like
-  `[A, B|Ts]`, mixed list/numeric pair-tail decompositions, and mixed
+  subset, including mixed list/numeric pair-tail decompositions and mixed
   tree/numeric bodies with local helper goals between recursive group calls
 - those shapes point to a shared SCC IR requirement: per-predicate body
   lowering for ordered goals, recursive call sites, helper goals, branch

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -120,9 +120,11 @@ This document focuses on architecture and rollout choices specific to TypR.
      predicates recurse through scalar step descent or constructed tree
      re-entry, plus mixed tree/list/numeric SCCs where tree-shaped
      predicates recurse through current-value and paired-forest helpers
-     while list-shaped predicates recurse through head/tail decomposition
-     and numeric predicates recurse through scalar step descent or
-     constructed tree re-entry, including mixed tree/numeric and mixed
+     while list-shaped predicates recurse through head/tail decomposition,
+     fixed two-element forest-pair decomposition, or fixed pair-tail
+     forest decomposition like `[A, B|Ts]`, and numeric predicates recurse
+     through scalar step descent or constructed tree re-entry, including
+     mixed tree/numeric and mixed
      tree/list/numeric SCCs where the tree-shaped predicate uses the same
      supported guarded full-body forms after an earlier recursive group-
      call prefix, plus integer-return and threaded-context variants,
@@ -171,10 +173,8 @@ This document focuses on architecture and rollout choices specific to TypR.
    guarded full-body subset.
 
 8. The next confirmed unsupported SCC shapes are:
-   - mixed tree/forest SCCs where the forest side uses pair-tail
+   - mixed list/numeric SCCs where the list side uses pair-tail
      decomposition like `[A, B|Ts]`
-   - mixed list/numeric SCCs where the list side uses that same pair-tail
-     decomposition
    - mixed tree/numeric SCCs where a local helper goal sits between
      recursive group calls, for example selecting a subtree through a helper
      predicate instead of a currently supported guarded body form

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -371,6 +371,25 @@ typr_mutual_list_pair_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraAr
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [DriverExpr|ExtraArgExprs].
 
+typr_mutual_list_pair_tail_recursive_goal(GroupPredicates, FirstVar, SecondVar, TailVar, ExtraArgMap, Goal0, call_spec(Slot, NextPred, CallArgs)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraArgs],
+    length(ExtraArgs, ExtraArity),
+    Arity is ExtraArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    (   RecArg == FirstVar
+    ->  Slot = first,
+        DriverExpr = '.subset2(current_input, 1)'
+    ;   RecArg == SecondVar
+    ->  Slot = second,
+        DriverExpr = '.subset2(current_input, 2)'
+    ;   RecArg == TailVar
+    ->  Slot = tail,
+        DriverExpr = 'tail(current_input, -2)'
+    ),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
 typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, HeadVar, TailVar, ExtraArgMap, Goal0, value_call_spec(Side, NextPred, CallArgs, OutputVar)) :-
     typr_strip_module_goal(Goal0, Goal),
     Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
@@ -407,12 +426,37 @@ typr_mutual_list_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, E
     maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
     CallArgs = [DriverExpr|ExtraArgExprs].
 
+typr_mutual_list_pair_tail_value_recursive_goal(GroupPredicates, FirstVar, SecondVar, TailVar, ExtraArgMap, Goal0, value_call_spec(Slot, NextPred, CallArgs, OutputVar)) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Goal =.. [NextPred, RecArg|ExtraAndOutputArgs],
+    append(ExtraArgs, [OutputVar], ExtraAndOutputArgs),
+    var(OutputVar),
+    length(ExtraAndOutputArgs, TailArity),
+    Arity is TailArity + 1,
+    memberchk(NextPred/Arity, GroupPredicates),
+    (   RecArg == FirstVar
+    ->  Slot = first,
+        DriverExpr = '.subset2(current_input, 1)'
+    ;   RecArg == SecondVar
+    ->  Slot = second,
+        DriverExpr = '.subset2(current_input, 2)'
+    ;   RecArg == TailVar
+    ->  Slot = tail,
+        DriverExpr = 'tail(current_input, -2)'
+    ),
+    maplist(typr_mutual_extra_arg_expr(ExtraArgMap), ExtraArgs, ExtraArgExprs),
+    CallArgs = [DriverExpr|ExtraArgExprs].
+
 typr_mutual_list_dual_driver([HeadVar|TailVar], head_tail, HeadVar, TailVar, 'length(current_input) > 0') :-
     var(TailVar),
     !.
 typr_mutual_list_dual_driver([LeftVar, RightVar], pair, LeftVar, RightVar, 'length(current_input) == 2') :-
     var(LeftVar),
     var(RightVar).
+
+typr_mutual_list_pair_tail_driver([FirstVar, SecondVar|TailVar], pair_tail, FirstVar, SecondVar, TailVar, 'length(current_input) > 1') :-
+    var(TailVar),
+    !.
 
 typr_mutual_list_dual_recursive_goal(head_tail, GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec) :-
     typr_mutual_list_head_tail_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
@@ -423,6 +467,44 @@ typr_mutual_list_dual_value_recursive_goal(head_tail, GroupPredicates, LeftVar, 
     typr_mutual_list_head_tail_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
 typr_mutual_list_dual_value_recursive_goal(pair, GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec) :-
     typr_mutual_list_pair_value_recursive_goal(GroupPredicates, LeftVar, RightVar, ExtraArgMap, Goal0, CallSpec).
+
+typr_mutual_list_pair_tail_call_specs(CallSpecs0, [FirstSpec, SecondSpec, TailSpec]) :-
+    select(call_spec(first, FirstNextPred, FirstCallArgs), CallSpecs0, CallSpecs1),
+    select(call_spec(second, SecondNextPred, SecondCallArgs), CallSpecs1, CallSpecs2),
+    select(call_spec(tail, TailNextPred, TailCallArgs), CallSpecs2, []),
+    FirstSpec = call_spec(first, FirstNextPred, FirstCallArgs),
+    SecondSpec = call_spec(second, SecondNextPred, SecondCallArgs),
+    TailSpec = call_spec(tail, TailNextPred, TailCallArgs).
+
+typr_mutual_list_pair_tail_value_call_specs(CallSpecs0, [FirstSpec, SecondSpec, TailSpec]) :-
+    select(value_call_spec(first, FirstNextPred, FirstCallArgs, FirstOutputVar), CallSpecs0, CallSpecs1),
+    select(value_call_spec(second, SecondNextPred, SecondCallArgs, SecondOutputVar), CallSpecs1, CallSpecs2),
+    select(value_call_spec(tail, TailNextPred, TailCallArgs, TailOutputVar), CallSpecs2, []),
+    FirstSpec = value_call_spec(first, FirstNextPred, FirstCallArgs, FirstOutputVar),
+    SecondSpec = value_call_spec(second, SecondNextPred, SecondCallArgs, SecondOutputVar),
+    TailSpec = value_call_spec(tail, TailNextPred, TailCallArgs, TailOutputVar).
+
+typr_mutual_list_pair_tail_value_call_bindings(CallSpecs0, CallBindings, ResultBindings) :-
+    typr_mutual_list_pair_tail_value_call_specs(CallSpecs0, OrderedSpecs),
+    maplist(typr_mutual_list_pair_tail_value_call_binding, OrderedSpecs, CallBindings, ResultBindings).
+
+typr_mutual_list_pair_tail_value_call_binding(
+    value_call_spec(Slot, NextPred, CallArgs, OutputVar),
+    value_call_binding(ResultName, branch_call(HelperName, CallArgs)),
+    result_binding(OutputVar, ResultName)
+) :-
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]),
+    typr_mutual_tree_result_name(Slot, ResultName).
+
+typr_mutual_list_pair_tail_branch_steps(CallSpecs0, Steps) :-
+    typr_mutual_list_pair_tail_call_specs(CallSpecs0, OrderedSpecs),
+    maplist(typr_mutual_list_pair_tail_branch_step, OrderedSpecs, Steps).
+
+typr_mutual_list_pair_tail_branch_step(call_spec(Slot, NextPred, CallArgs), step_call(ResultName, branch_call(HelperName, CallArgs))) :-
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]),
+    typr_mutual_tree_result_name(Slot, ResultName).
 
 typr_mutual_tree_value_subtree_driver_expr(ValueVar, _AliasMap, RecArg, left, '.subset2(current_input, 1)') :-
     var(RecArg),
@@ -926,6 +1008,8 @@ typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_tree_to_list_bool_spec(GroupPredicates, Pred/Arity, Spec).
 typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec).
+typr_mutual_mixed_tree_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_list_tree_pair_tail_bool_spec(GroupPredicates, Pred/Arity, Spec).
 
 typr_mutual_tree_to_list_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
@@ -1003,10 +1087,50 @@ typr_mutual_list_tree_dual_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
         guard_expr: GuardExpr
     }.
 
+typr_mutual_list_tree_pair_tail_bool_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_list_empty_base_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern],
+    typr_mutual_list_pair_tail_driver(RecInputPattern, pair_tail, FirstVar, SecondVar, TailVar, GuardExpr),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    Goals = [GoalA, GoalB, GoalC],
+    maplist(
+        typr_mutual_list_pair_tail_recursive_goal(GroupPredicates, FirstVar, SecondVar, TailVar, []),
+        [GoalA, GoalB, GoalC],
+        GoalSpecs0
+    ),
+    typr_mutual_list_pair_tail_branch_steps(GoalSpecs0, Steps),
+    atom_string(Pred, PredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    Spec = mutual_spec{
+        kind: tree_dual_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        base_conditions: BaseConditions,
+        guard_expr: GuardExpr,
+        body: branch_steps(Steps)
+    }.
+
 typr_mutual_mixed_tree_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_tree_to_list_value_spec(GroupPredicates, Pred/Arity, Spec).
 typr_mutual_mixed_tree_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec).
+typr_mutual_mixed_tree_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    typr_mutual_list_tree_pair_tail_value_spec(GroupPredicates, Pred/Arity, Spec).
 
 typr_mutual_tree_to_list_value_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity >= 2,
@@ -1111,6 +1235,59 @@ typr_mutual_list_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
         left_call: branch_call(LeftNextHelperName, LeftCallArgs),
         right_call: branch_call(RightNextHelperName, RightCallArgs),
         result_expr: ResultExpr
+    }.
+
+typr_mutual_list_tree_pair_tail_value_spec(GroupPredicates, Pred/Arity, Spec) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, RecInputPattern|ContextAndOutputVars],
+    typr_mutual_list_pair_tail_driver(RecInputPattern, pair_tail, FirstVar, SecondVar, TailVar, GuardExpr),
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_list_empty_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    RecGoals = [_, _, _],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    maplist(
+        typr_mutual_list_pair_tail_value_recursive_goal(GroupPredicates, FirstVar, SecondVar, TailVar, ExtraArgMap),
+        RecGoals,
+        CallSpecs0
+    ),
+    typr_mutual_list_pair_tail_value_call_bindings(CallSpecs0, CallBindings, ResultBindings),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_result_expr_from_bindings(
+        PostBody,
+        OutputVar,
+        ExtraArgMap,
+        ResultBindings,
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: GuardExpr,
+        body: value_branch_leaf(CallBindings, ResultExpr)
     }.
 
 typr_mutual_tree_dual_value_spec(GroupPredicates, Pred/Arity, Spec) :-
@@ -2170,6 +2347,15 @@ typr_mutual_tree_value_call_binding(_CallSpecs0, _Side, [], []).
 
 typr_mutual_tree_result_name(left, left_result).
 typr_mutual_tree_result_name(right, right_result).
+typr_mutual_tree_result_name(first, first_result).
+typr_mutual_tree_result_name(second, second_result).
+typr_mutual_tree_result_name(tail, tail_result).
+typr_mutual_tree_result_name(ResultName, ResultName) :-
+    string(ResultName),
+    !.
+typr_mutual_tree_result_name(ResultName, ResultNameStr) :-
+    atom(ResultName),
+    atom_string(ResultName, ResultNameStr).
 
 typr_mutual_tree_side_recursive_goal(GroupPredicates, _ValueVar, AliasMap, ExtraArgMap, Goal0, CallSpec) :-
     typr_mutual_tree_recursive_goal(GroupPredicates, AliasMap, ExtraArgMap, Goal0, CallSpec).
@@ -4097,8 +4283,8 @@ typr_mutual_tree_value_body_lines_no_memo_from(value_branch_leaf(CallBindings, R
     append(CallLines, [ResultLine], Lines).
 
 typr_mutual_tree_value_call_binding_lines([], _Prefix, []).
-typr_mutual_tree_value_call_binding_lines([value_call_binding(Side, Call)|Rest], Prefix, [CallLine|RestLines]) :-
-    typr_mutual_tree_result_name(Side, ResultName),
+typr_mutual_tree_value_call_binding_lines([value_call_binding(ResultKey, Call)|Rest], Prefix, [CallLine|RestLines]) :-
+    typr_mutual_tree_result_name(ResultKey, ResultName),
     typr_mutual_tree_call_expr(Call, CallExpr),
     format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     typr_mutual_tree_value_call_binding_lines(Rest, Prefix, RestLines).
@@ -4233,25 +4419,30 @@ typr_mutual_tree_branch_body_lines_no_memo_from(branch_steps(Steps), Prefix, Ind
 typr_mutual_tree_branch_body_lines_no_memo_from(branch_calls(Calls), Prefix, 1, Lines) :-
     typr_mutual_tree_dual_branch_call_lines_no_memo(Calls, Prefix, Lines).
 
-typr_mutual_tree_branch_steps_lines([], Prefix, _Index, [ResultLine]) :-
-    format(string(ResultLine), '~wresult = left_result && right_result;', [Prefix]).
-typr_mutual_tree_branch_steps_lines([step_guard(GuardExpr)|Rest], Prefix, Index, Lines) :-
+typr_mutual_tree_branch_steps_lines(Steps, Prefix, Index, Lines) :-
+    typr_mutual_tree_step_initial_results(Index, InitialResults),
+    typr_mutual_tree_branch_steps_lines(Steps, Prefix, Index, InitialResults, Lines).
+
+typr_mutual_tree_branch_steps_lines([], Prefix, _Index, ResultNames0, [ResultLine]) :-
+    reverse(ResultNames0, ResultNames),
+    typr_mutual_tree_boolean_rejoin_expr(ResultNames, ResultExpr),
+    format(string(ResultLine), '~wresult = ~w;', [Prefix, ResultExpr]).
+typr_mutual_tree_branch_steps_lines([step_guard(GuardExpr)|Rest], Prefix, Index, ResultNames, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    typr_mutual_tree_branch_steps_lines(Rest, NestedPrefix, Index, StepLines),
+    typr_mutual_tree_branch_steps_lines(Rest, NestedPrefix, Index, ResultNames, StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_steps_lines([step_call(BranchCall)|Rest], Prefix, Index, Lines) :-
-    typr_mutual_tree_step_result_name(Index, ResultName),
+typr_mutual_tree_branch_steps_lines([StepCall|Rest], Prefix, Index, ResultNames0, Lines) :-
+    typr_mutual_tree_step_call_result(StepCall, Index, ResultName, BranchCall, NextIndex),
     typr_mutual_tree_call_expr(BranchCall, CallExpr),
     format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    NextIndex is Index + 1,
-    typr_mutual_tree_branch_steps_lines(Rest, NestedPrefix, NextIndex, StepLines),
+    typr_mutual_tree_branch_steps_lines(Rest, NestedPrefix, NextIndex, [ResultName|ResultNames0], StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
@@ -4278,13 +4469,12 @@ typr_mutual_tree_branch_steps_if_lines([step_guard(GuardExpr)|Rest], Prefix, Ind
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_steps_if_lines([step_call(BranchCall)|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
-    typr_mutual_tree_step_result_name(Index, ResultName),
+typr_mutual_tree_branch_steps_if_lines([StepCall|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    typr_mutual_tree_step_call_result(StepCall, Index, ResultName, BranchCall, NextIndex),
     typr_mutual_tree_call_expr(BranchCall, CallExpr),
     format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    NextIndex is Index + 1,
     typr_mutual_tree_branch_steps_if_lines(Rest, NestedPrefix, NextIndex, BranchConditionExpr, ThenBody, ElseBody, StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
@@ -4292,25 +4482,30 @@ typr_mutual_tree_branch_steps_if_lines([step_call(BranchCall)|Rest], Prefix, Ind
     append([CallLine, IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
 
-typr_mutual_tree_branch_steps_lines_no_memo([], Prefix, _Index, [ResultLine]) :-
-    format(string(ResultLine), '~wresult', [Prefix]).
-typr_mutual_tree_branch_steps_lines_no_memo([step_guard(GuardExpr)|Rest], Prefix, Index, Lines) :-
+typr_mutual_tree_branch_steps_lines_no_memo(Steps, Prefix, Index, Lines) :-
+    typr_mutual_tree_step_initial_results(Index, InitialResults),
+    typr_mutual_tree_branch_steps_lines_no_memo(Steps, Prefix, Index, InitialResults, Lines).
+
+typr_mutual_tree_branch_steps_lines_no_memo([], Prefix, _Index, ResultNames0, [ResultLine]) :-
+    reverse(ResultNames0, ResultNames),
+    typr_mutual_tree_boolean_rejoin_expr(ResultNames, ResultExpr),
+    format(string(ResultLine), '~w~w', [Prefix, ResultExpr]).
+typr_mutual_tree_branch_steps_lines_no_memo([step_guard(GuardExpr)|Rest], Prefix, Index, ResultNames, Lines) :-
     format(string(IfLine), '~wif (~w) {', [Prefix, GuardExpr]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, Index, StepLines),
+    typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, Index, ResultNames, StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_steps_lines_no_memo([step_call(BranchCall)|Rest], Prefix, Index, Lines) :-
-    typr_mutual_tree_step_result_name(Index, ResultName),
+typr_mutual_tree_branch_steps_lines_no_memo([StepCall|Rest], Prefix, Index, ResultNames0, Lines) :-
+    typr_mutual_tree_step_call_result(StepCall, Index, ResultName, BranchCall, NextIndex),
     typr_mutual_tree_call_expr(BranchCall, CallExpr),
     format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    NextIndex is Index + 1,
-    typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, NextIndex, StepLines),
+    typr_mutual_tree_branch_steps_lines_no_memo(Rest, NestedPrefix, NextIndex, [ResultName|ResultNames0], StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
     format(string(EndLine), '~w}', [Prefix]),
@@ -4337,13 +4532,12 @@ typr_mutual_tree_branch_steps_if_lines_no_memo([step_guard(GuardExpr)|Rest], Pre
     format(string(EndLine), '~w}', [Prefix]),
     append([IfLine], StepLines, Lines0),
     append(Lines0, [ElseLine, FalseLine, EndLine], Lines).
-typr_mutual_tree_branch_steps_if_lines_no_memo([step_call(BranchCall)|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
-    typr_mutual_tree_step_result_name(Index, ResultName),
+typr_mutual_tree_branch_steps_if_lines_no_memo([StepCall|Rest], Prefix, Index, BranchConditionExpr, ThenBody, ElseBody, Lines) :-
+    typr_mutual_tree_step_call_result(StepCall, Index, ResultName, BranchCall, NextIndex),
     typr_mutual_tree_call_expr(BranchCall, CallExpr),
     format(string(CallLine), '~w~w = ~w;', [Prefix, ResultName, CallExpr]),
     format(string(IfLine), '~wif (~w) {', [Prefix, ResultName]),
     atom_concat(Prefix, '    ', NestedPrefix),
-    NextIndex is Index + 1,
     typr_mutual_tree_branch_steps_if_lines_no_memo(Rest, NestedPrefix, NextIndex, BranchConditionExpr, ThenBody, ElseBody, StepLines),
     format(string(ElseLine), '~w} else {', [Prefix]),
     format(string(FalseLine), '~w    result = FALSE;', [Prefix]),
@@ -4353,6 +4547,33 @@ typr_mutual_tree_branch_steps_if_lines_no_memo([step_call(BranchCall)|Rest], Pre
 
 typr_mutual_tree_step_result_name(1, left_result).
 typr_mutual_tree_step_result_name(2, right_result).
+typr_mutual_tree_step_result_name(Index, ResultName) :-
+    Index >= 3,
+    format(string(ResultName), 'call_result_~w', [Index]).
+
+typr_mutual_tree_step_initial_results(1, []).
+typr_mutual_tree_step_initial_results(2, [left_result]).
+typr_mutual_tree_step_initial_results(3, [right_result, left_result]).
+typr_mutual_tree_step_initial_results(Index, ResultNames) :-
+    Index >= 4,
+    PrevIndex is Index - 1,
+    typr_mutual_tree_step_initial_results(PrevIndex, PrevNames),
+    typr_mutual_tree_step_result_name(PrevIndex, PrevResultName),
+    ResultNames = [PrevResultName|PrevNames].
+
+typr_mutual_tree_step_call_result(step_call(BranchCall), Index, ResultName, BranchCall, NextIndex) :-
+    !,
+    typr_mutual_tree_step_result_name(Index, ResultName),
+    NextIndex is Index + 1.
+typr_mutual_tree_step_call_result(step_call(ResultKey, BranchCall), Index, ResultName, BranchCall, NextIndex) :-
+    typr_mutual_tree_result_name(ResultKey, ResultName),
+    NextIndex is Index + 1.
+
+typr_mutual_tree_boolean_rejoin_expr([ResultName], ResultName) :-
+    !.
+typr_mutual_tree_boolean_rejoin_expr([ResultName|Rest], Expr) :-
+    typr_mutual_tree_boolean_rejoin_expr(Rest, RestExpr),
+    format(string(Expr), '~w && ~w', [ResultName, RestExpr]).
 
 typr_mutual_tree_call_expr(branch_call(HelperName, CallArgs), CallExpr) :-
     atomic_list_concat(CallArgs, ', ', CallArgsText),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -4532,4 +4532,95 @@ test(recursive_compiler_supports_typr_tree_pair_mutual_integer_context_group) :-
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_tree_pair_tail_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_tail_ok([])),
+    assertz(user:(typr_tree_pair_tail_ok([_, L, R]) :-
+        typr_forest_pair_tail_ok([L, R])
+    )),
+    assertz(user:typr_forest_pair_tail_ok([])),
+    assertz(user:(typr_forest_pair_tail_ok([A, B|Ts]) :-
+        typr_tree_pair_tail_ok(A),
+        typr_tree_pair_tail_ok(B),
+        typr_forest_pair_tail_ok(Ts)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_tail_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_tail_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_tail_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_pair_tail_ok/1, typr_tree_pair_tail_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_tree_pair_tail_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "first_result = typr_tree_pair_tail_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "second_result = typr_tree_pair_tail_ok_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "tail_result = typr_forest_pair_tail_ok_impl(tail(current_input, -2));")),
+    once(sub_string(Code, _, _, _, "result = first_result && second_result && tail_result;")),
+    once(sub_string(Code, _, _, _, "result = typr_forest_pair_tail_ok_impl(list(.subset2(current_input, 2), .subset2(current_input, 3)));")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_tree_pair_tail_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_tail_sum([], 0)),
+    assertz(user:(typr_tree_pair_tail_sum([V, L, R], S) :-
+        typr_forest_pair_tail_sum([L, R], Parts),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_pair_tail_sum([], 0)),
+    assertz(user:(typr_forest_pair_tail_sum([A, B|Ts], S) :-
+        typr_tree_pair_tail_sum(A, SA),
+        typr_tree_pair_tail_sum(B, SB),
+        typr_forest_pair_tail_sum(Ts, ST),
+        S is SA + SB + ST
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_tail_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_tail_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_tail_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_pair_tail_sum/2, typr_tree_pair_tail_sum/2")),
+    once(sub_string(Code, _, _, _, "let typr_tree_pair_tail_sum <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "first_result = typr_tree_pair_tail_sum_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "second_result = typr_tree_pair_tail_sum_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "tail_result = typr_forest_pair_tail_sum_impl(tail(current_input, -2));")),
+    once(sub_string(Code, _, _, _, "result = ((first_result + second_result) + tail_result);")),
+    once(sub_string(Code, _, _, _, "result = (.subset2(current_input, 1) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_tree_pair_tail_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_tail_weight([], _W0, 0)),
+    assertz(user:(typr_tree_pair_tail_weight([V, L, R], W, S) :-
+        typr_forest_pair_tail_weight([L, R], W, Parts),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_pair_tail_weight([], _W1, 0)),
+    assertz(user:(typr_forest_pair_tail_weight([A, B|Ts], W, S) :-
+        typr_tree_pair_tail_weight(A, W, SA),
+        typr_tree_pair_tail_weight(B, W, SB),
+        typr_forest_pair_tail_weight(Ts, W, ST),
+        S is SA + SB + ST
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_tail_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_tail_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_tail_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_forest_pair_tail_weight/3, typr_tree_pair_tail_weight/3")),
+    once(sub_string(Code, _, _, _, "let typr_tree_pair_tail_weight <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "first_result = typr_tree_pair_tail_weight_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "second_result = typr_tree_pair_tail_weight_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "tail_result = typr_forest_pair_tail_weight_impl(tail(current_input, -2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((first_result + second_result) + tail_result);")),
+    once(sub_string(Code, _, _, _, "result = ((.subset2(current_input, 1) * current_ctx) + right_result);")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -3505,6 +3505,103 @@ test(tree_pair_mutual_integer_context_output_checks_with_typr, [condition(typr_c
     retractall(user:typr_tree_pair_weight(_, _, _)),
     retractall(user:typr_forest_pair_weight(_, _, _)).
 
+test(tree_pair_tail_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_tail_ok([])),
+    assertz(user:(typr_tree_pair_tail_ok([_, L, R]) :-
+        typr_forest_pair_tail_ok([L, R])
+    )),
+    assertz(user:typr_forest_pair_tail_ok([])),
+    assertz(user:(typr_forest_pair_tail_ok([A, B|Ts]) :-
+        typr_tree_pair_tail_ok(A),
+        typr_tree_pair_tail_ok(B),
+        typr_forest_pair_tail_ok(Ts)
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_tail_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_tail_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_tail_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_pair_tail_ok(_)),
+    retractall(user:typr_forest_pair_tail_ok(_)).
+
+test(tree_pair_tail_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_tail_sum([], 0)),
+    assertz(user:(typr_tree_pair_tail_sum([V, L, R], S) :-
+        typr_forest_pair_tail_sum([L, R], Parts),
+        S is V + Parts
+    )),
+    assertz(user:typr_forest_pair_tail_sum([], 0)),
+    assertz(user:(typr_forest_pair_tail_sum([A, B|Ts], S) :-
+        typr_tree_pair_tail_sum(A, SA),
+        typr_tree_pair_tail_sum(B, SB),
+        typr_forest_pair_tail_sum(Ts, ST),
+        S is SA + SB + ST
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_tail_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_tail_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_tail_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_pair_tail_sum(_, _)),
+    retractall(user:typr_forest_pair_tail_sum(_, _)).
+
+test(tree_pair_tail_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_tree_pair_tail_weight([], _W0, 0)),
+    assertz(user:(typr_tree_pair_tail_weight([V, L, R], W, S) :-
+        typr_forest_pair_tail_weight([L, R], W, Parts),
+        S is (V * W) + Parts
+    )),
+    assertz(user:typr_forest_pair_tail_weight([], _W1, 0)),
+    assertz(user:(typr_forest_pair_tail_weight([A, B|Ts], W, S) :-
+        typr_tree_pair_tail_weight(A, W, SA),
+        typr_tree_pair_tail_weight(B, W, SB),
+        typr_forest_pair_tail_weight(Ts, W, ST),
+        S is SA + SB + ST
+    )),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_tree_pair_tail_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_forest_pair_tail_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_tree_pair_tail_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_forest_pair_tail_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_tree_pair_tail_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_tree_pair_tail_weight(_, _, _)),
+    retractall(user:typr_forest_pair_tail_weight(_, _, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
# Generalize Native TypR Tree/Forest Pair-Tail SCCs

## Summary

This PR generalizes native TypR mutual-recursion lowering for conservative tree/forest SCCs where the forest-side predicate uses fixed pair-tail decomposition like `[A, B|Ts]`.

TypR now keeps these SCCs native when:

- a tree-shaped predicate recurses through a forest helper
- the forest-shaped predicate processes a pair-tail list with three SCC calls:
  - first tree call on `A`
  - second tree call on `B`
  - recursive forest call on `Ts`
- the result stays within the existing boolean or integer-return native TypR mutual-recursion model

Representative supported shapes now include:

- boolean tree/forest pair-tail SCCs such as `typr_tree_pair_tail_ok/1` and `typr_forest_pair_tail_ok/1`
- integer-return tree/forest pair-tail SCCs such as `typr_tree_pair_tail_sum/2` and `typr_forest_pair_tail_sum/2`
- context-threaded integer-return tree/forest pair-tail SCCs such as `typr_tree_pair_tail_weight/3` and `typr_forest_pair_tail_weight/3`

## Why This PR Exists

The SCC IR boundary audit confirmed that the next unsupported slices included pair-tail decompositions like `[A, B|Ts]`.

That made this the right proving case for the SCC IR skeleton branch:

- it is still conservative and structurally analyzable
- but it already breaks the old `left_result` / `right_result` assumption in the mutual-recursion emitter
- it needs an ordered call model with three result slots, not just a binary pair

Before this change, these SCCs failed because the native TypR mutual backend could not represent:

- three ordered SCC calls in one list-side body
- explicit result bindings for `first`, `second`, and `tail`
- pair-tail forest decomposition in the mixed tree/list mutual path

## Main Changes

- generalized mutual SCC result binding in `src/unifyweaver/targets/typr_target.pl` from fixed `left` / `right` names to explicit call slots
- added pair-tail list-driver support for mixed tree/forest SCCs using:
  - `.subset2(current_input, 1)`
  - `.subset2(current_input, 2)`
  - `tail(current_input, -2)`
- added ordered boolean and value-return call lowering for pair-tail forest bodies
- reused that same generalized slot machinery for:
  - boolean SCC rejoin
  - integer-return SCC recombination
  - threaded-context mutual helpers
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR docs to mark mixed tree/forest pair-tail decomposition as supported and to narrow the next unsupported SCC boundary accordingly

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not implement the shared SCC IR.

It uses the first conservative unsupported slice to generalize the current mutual-recursion emitter in a way that is still compatible with the existing matcher family.

The remaining confirmed unsupported slices are still broader than this change, including:

- mixed list/numeric pair-tail SCCs
- mixed tree/numeric SCCs with helper goals between recursive group calls

Those should go through the shared SCC IR step rather than another long run of bespoke matcher families.
