### PR TITLE
feat: deepen final 5 targets + sub_term audit — all 18 targets complete

### DIFF
--- a/src/unifyweaver/targets/awk_target.pl
+++ b/src/unifyweaver/targets/awk_target.pl
@@ -2669,10 +2669,157 @@ awk_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     awk_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_awk_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_awk_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    awk_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_awk_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(awk_guard_condition(VarMap), GuardGoals, Conditions),
     awk_output_goals(OutputGoals, VarMap, Code).
+
+%% awk_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+awk_render_classified_goals([], _VarMap, [], []).
+awk_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    awk_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+awk_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    awk_classified_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    awk_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(awk_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "_"
+    ),
+    format(string(IfLine), '    if (~w) {', [GuardExpr]),
+    format(string(RetLine), '        return ~w', [OutName]),
+    CloseLine = '    }',
+    Lines = [AssignLine, IfLine, RetLine, CloseLine].
+awk_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    awk_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    awk_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% awk_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+awk_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    awk_guard_condition(VarMap, Goal, Cond).
+awk_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    awk_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+awk_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    awk_guard_condition(VarMap0, If, Cond),
+    awk_classified_branch_value(Then, VarMap0, ThenExpr),
+    awk_classified_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+awk_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    awk_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+awk_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% awk_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+awk_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    awk_guard_condition(VarMap, Goal, Cond).
+awk_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    awk_classified_output_last(Goal, VarMap, Lines).
+awk_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    awk_guard_condition(VarMap, If, Cond),
+    awk_classified_branch_value(Then, VarMap, ThenExpr),
+    awk_classified_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        return ~w', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        return ~w', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+awk_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    awk_disj_if_chain(Alternatives, VarMap, Lines).
+awk_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    awk_classified_output_last(Goal, VarMap, Lines).
+awk_render_classified_last(_, _, [], []).
+
+%% awk_classified_output_goal(+Goal, +VarMap0, -Line, -VarMapOut)
+%%  Inline singular output goal handler for AWK (no standalone awk_output_goal).
+awk_classified_output_goal(_Module:Goal, VarMap0, Line, VarMapOut) :-
+    !, awk_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+awk_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        awk_expr(Expr, VarMap0, ExprStr),
+        format(string(Line), '    ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        awk_expr(ArithExpr, VarMap0, ExprStr),
+        format(string(Line), '    ~w = ~w', [VarName, ExprStr])
+    ;   VarName = "_", VarMapOut = VarMap0,
+        Line = "    # unsupported output goal"
+    ).
+
+%% awk_classified_branch_value(+Branch, +VarMap, -ExprStr)
+%%  Inline branch value extractor for AWK (mirrors awk_branch_value).
+awk_classified_branch_value(Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    awk_branch_value(LastGoal, VarMap, ExprStr).
+
+%% awk_classified_output_last(+Goal, +VarMap, -Lines)
+%%  Wrap a single output goal as lines for classified rendering (last position).
+awk_classified_output_last(Goal, VarMap, [Line]) :-
+    awk_classified_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(Line), '~w\n    return ~w', [AssignLine, OutName])
+    ;   Line = AssignLine
+    ).
+awk_classified_output_last(Goal, VarMap, [Line]) :-
+    awk_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '    return ~w', [Expr]).
+
+%% awk_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+awk_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, awk_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+awk_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% awk_disj_if_chain(+Alternatives, +VarMap, -Lines)
+awk_disj_if_chain([], _, []).
+awk_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    awk_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        return ~w', [ValExpr]),
+    CloseLine = '    }'.
+awk_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(awk_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = "1"
+    ),
+    awk_branch_value(Alt, VarMap, ValExpr),
+    (   Rest = []
+    ->  format(string(ThisLine), '    if (~w) {\n        return ~w\n    }', [CondExpr, ValExpr]),
+        Lines = [ThisLine]
+    ;   format(string(IfLine), '    if (~w) {', [CondExpr]),
+        format(string(RetLine), '        return ~w', [ValExpr]),
+        awk_disj_if_chain(Rest, VarMap, ChainLines),
+        (   ChainLines = ['    } else {'|_]
+        ->  Lines = [IfLine, RetLine|ChainLines]
+        ;   CloseLine = '    }',
+            append([IfLine, RetLine, CloseLine], ChainLines, Lines)
+        )
+    ).
 
 %% awk_guard_condition(+VarMap, +Goal, -Condition)
 awk_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/jython_target.pl
+++ b/src/unifyweaver/targets/jython_target.pl
@@ -1386,10 +1386,149 @@ jython_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     jython_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_jython_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_jython_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    jython_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_jython_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(jython_guard_condition(VarMap), GuardGoals, Conditions),
     jython_output_goals(OutputGoals, VarMap, Code).
+
+%% jython_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+jython_render_classified_goals([], _VarMap, [], []).
+jython_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    jython_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+jython_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    jython_classified_output_goal(Goal, VarMap, LetBinding, VarMap1),
+    jython_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(jython_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' and ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = '_'
+    ),
+    format(string(IfLine), '    if ~w:', [GuardExpr]),
+    format(string(RetLine), '        return ~w', [OutName]),
+    Lines = [LetBinding, IfLine, RetLine].
+jython_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    jython_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    jython_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% jython_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+jython_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    jython_guard_condition(VarMap, Goal, Cond).
+jython_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    jython_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+jython_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    jython_guard_condition(VarMap0, If, Cond),
+    jython_branch_value(Then, VarMap0, ThenExpr),
+    jython_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if ~w:', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    else:',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine].
+jython_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    jython_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+jython_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% jython_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+jython_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    jython_guard_condition(VarMap, Goal, Cond).
+jython_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    jython_render_output_goal_last(Goal, VarMap, Lines).
+jython_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    jython_guard_condition(VarMap, If, Cond),
+    jython_branch_value(Then, VarMap, ThenExpr),
+    jython_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if ~w:', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    else:',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine].
+jython_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    jython_disj_if_chain(Alternatives, VarMap, Lines).
+jython_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    jython_render_output_goal_last(Goal, VarMap, Lines).
+
+%% jython_classified_output_goal(+Goal, +VarMap0, -Line, -VarMapOut)
+jython_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        jython_expr(Expr, VarMap0, ExprStr),
+        format(string(Line), '    ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        jython_expr(ArithExpr, VarMap0, ExprStr),
+        format(string(Line), '    ~w = ~w', [VarName, ExprStr])
+    ;   VarMapOut = VarMap0,
+        Line = '    # unsupported'
+    ).
+
+%% jython_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+jython_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    jython_output_goal_last(Goal, VarMap, Expr),
+    !.
+jython_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    jython_branch_value(Goal, VarMap, Expr).
+
+%% jython_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+jython_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, jython_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+jython_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% jython_disj_if_chain(+Alternatives, +VarMap, -Lines)
+jython_disj_if_chain([], _, []).
+jython_disj_if_chain([Alt], VarMap, [ElseLine, RetLine]) :-
+    !,
+    jython_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    else:',
+    format(string(RetLine), '        ~w', [ValExpr]).
+jython_disj_if_chain([Alt|Rest], VarMap, [IfLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(jython_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' and ', CondExpr)
+    ;   CondExpr = 'True'
+    ),
+    jython_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if ~w:', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    jython_disj_elif_chain(Rest, VarMap, RestLines).
+
+%% jython_disj_elif_chain(+Alternatives, +VarMap, -Lines)
+jython_disj_elif_chain([], _, []).
+jython_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine]) :-
+    !,
+    jython_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    else:',
+    format(string(RetLine), '        ~w', [ValExpr]).
+jython_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(jython_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' and ', CondExpr)
+    ;   CondExpr = 'True'
+    ),
+    jython_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '    elif ~w:', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    jython_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% jython_guard_condition(+VarMap, +Goal, -Condition)
 jython_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/kotlin_target.pl
+++ b/src/unifyweaver/targets/kotlin_target.pl
@@ -1341,10 +1341,151 @@ kotlin_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     kotlin_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_kotlin_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_kotlin_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    kotlin_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_kotlin_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(kotlin_guard_condition(VarMap), GuardGoals, Conditions),
     kotlin_output_goals(OutputGoals, VarMap, Code).
+
+%% kotlin_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+kotlin_render_classified_goals([], _VarMap, [], []).
+kotlin_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    kotlin_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+kotlin_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    kotlin_classified_output_goal(Goal, VarMap, LetBinding, VarMap1),
+    kotlin_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(kotlin_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = '_'
+    ),
+    format(string(IfLine), '    if (~w) ~w else throw RuntimeException("guard failed")', [GuardExpr, OutName]),
+    Lines = [LetBinding, IfLine].
+kotlin_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    kotlin_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    kotlin_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% kotlin_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+kotlin_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    kotlin_guard_condition(VarMap, Goal, Cond).
+kotlin_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    kotlin_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+kotlin_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    kotlin_guard_condition(VarMap0, If, Cond),
+    kotlin_branch_value(Then, VarMap0, ThenExpr),
+    kotlin_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+kotlin_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    kotlin_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+kotlin_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% kotlin_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+kotlin_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    kotlin_guard_condition(VarMap, Goal, Cond).
+kotlin_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    kotlin_render_output_goal_last(Goal, VarMap, Lines).
+kotlin_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    kotlin_guard_condition(VarMap, If, Cond),
+    kotlin_branch_value(Then, VarMap, ThenExpr),
+    kotlin_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+kotlin_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    kotlin_disj_if_chain(Alternatives, VarMap, Lines).
+kotlin_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    kotlin_render_output_goal_last(Goal, VarMap, Lines).
+
+%% kotlin_classified_output_goal(+Goal, +VarMap0, -Line, -VarMapOut)
+kotlin_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        kotlin_expr(Expr, VarMap0, ExprStr),
+        format(string(Line), '    val ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        kotlin_expr(ArithExpr, VarMap0, ExprStr),
+        format(string(Line), '    val ~w = ~w', [VarName, ExprStr])
+    ;   VarMapOut = VarMap0,
+        Line = '    // unsupported'
+    ).
+
+%% kotlin_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+kotlin_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    kotlin_output_goal_last(Goal, VarMap, Expr),
+    !.
+kotlin_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    kotlin_branch_value(Goal, VarMap, Expr).
+
+%% kotlin_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+kotlin_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, kotlin_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+kotlin_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% kotlin_disj_if_chain(+Alternatives, +VarMap, -Lines)
+kotlin_disj_if_chain([], _, []).
+kotlin_disj_if_chain([Alt], VarMap, [ElseLine, RetLine]) :-
+    !,
+    kotlin_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        ~w', [ValExpr]).
+kotlin_disj_if_chain([Alt|Rest], VarMap, [IfLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(kotlin_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    kotlin_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if (~w) {', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    kotlin_disj_elif_chain(Rest, VarMap, RestLines).
+
+%% kotlin_disj_elif_chain(+Alternatives, +VarMap, -Lines)
+kotlin_disj_elif_chain([], _, []).
+kotlin_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    kotlin_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        ~w', [ValExpr]),
+    CloseLine = '    }'.
+kotlin_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(kotlin_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    kotlin_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '    } else if (~w) {', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    kotlin_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% kotlin_guard_condition(+VarMap, +Goal, -Condition)
 kotlin_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/scala_target.pl
+++ b/src/unifyweaver/targets/scala_target.pl
@@ -1185,10 +1185,151 @@ scala_head_conditions([HeadArg|Rest], Index, Arity, Conditions) :-
     scala_head_conditions(Rest, NextIndex, Arity, RestConditions).
 
 %% native_scala_goal_sequence(+Goals, +VarMap, -Conditions, -Code)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_scala_goal_sequence(Goals, VarMap, Conditions, Code) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    scala_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    atomic_list_concat(Lines, '\n', Code),
+    !.
 native_scala_goal_sequence(Goals, VarMap, Conditions, Code) :-
     clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
     maplist(scala_guard_condition(VarMap), GuardGoals, Conditions),
     scala_output_goals(OutputGoals, VarMap, Code).
+
+%% scala_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+scala_render_classified_goals([], _VarMap, [], []).
+scala_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    scala_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+scala_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    scala_classified_output_goal(Goal, VarMap, LetBinding, VarMap1),
+    scala_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(scala_guard_condition(VarMap1), GuardGoals, GuardConds),
+    atomic_list_concat(GuardConds, ' && ', GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = '_'
+    ),
+    format(string(IfLine), '    if (~w) ~w else throw new RuntimeException("guard failed")', [GuardExpr, OutName]),
+    Lines = [LetBinding, IfLine].
+scala_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    scala_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    scala_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% scala_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+scala_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    scala_guard_condition(VarMap, Goal, Cond).
+scala_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    scala_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+scala_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    scala_guard_condition(VarMap0, If, Cond),
+    scala_branch_value(Then, VarMap0, ThenExpr),
+    scala_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+scala_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    scala_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+scala_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% scala_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+scala_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    scala_guard_condition(VarMap, Goal, Cond).
+scala_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    scala_render_output_goal_last(Goal, VarMap, Lines).
+scala_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    scala_guard_condition(VarMap, If, Cond),
+    scala_branch_value(Then, VarMap, ThenExpr),
+    scala_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '    if (~w) {', [Cond]),
+    format(string(ThenLine), '        ~w', [ThenExpr]),
+    ElseLine = '    } else {',
+    format(string(ElseRetLine), '        ~w', [ElseExpr]),
+    CloseLine = '    }',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, CloseLine].
+scala_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    scala_disj_if_chain(Alternatives, VarMap, Lines).
+scala_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    scala_render_output_goal_last(Goal, VarMap, Lines).
+
+%% scala_classified_output_goal(+Goal, +VarMap0, -Line, -VarMapOut)
+scala_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        scala_expr(Expr, VarMap0, ExprStr),
+        format(string(Line), '    val ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        scala_expr(ArithExpr, VarMap0, ExprStr),
+        format(string(Line), '    val ~w = ~w', [VarName, ExprStr])
+    ;   VarMapOut = VarMap0,
+        Line = '    // unsupported'
+    ).
+
+%% scala_render_output_goal_last(+Goal, +VarMap, -Lines)
+%  3-arg wrapper used by classified goal renderers.
+scala_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    scala_output_goal_last(Goal, VarMap, Expr),
+    !.
+scala_render_output_goal_last(Goal, VarMap, [Expr]) :-
+    scala_branch_value(Goal, VarMap, Expr).
+
+%% scala_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+scala_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, scala_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+scala_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% scala_disj_if_chain(+Alternatives, +VarMap, -Lines)
+scala_disj_if_chain([], _, []).
+scala_disj_if_chain([Alt], VarMap, [ElseLine, RetLine]) :-
+    !,
+    scala_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        ~w', [ValExpr]).
+scala_disj_if_chain([Alt|Rest], VarMap, [IfLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(scala_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    scala_branch_value(Alt, VarMap, ValExpr),
+    format(string(IfLine), '    if (~w) {', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    scala_disj_elif_chain(Rest, VarMap, RestLines).
+
+%% scala_disj_elif_chain(+Alternatives, +VarMap, -Lines)
+scala_disj_elif_chain([], _, []).
+scala_disj_elif_chain([Alt], VarMap, [ElseLine, RetLine, CloseLine]) :-
+    !,
+    scala_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '    } else {',
+    format(string(RetLine), '        ~w', [ValExpr]),
+    CloseLine = '    }'.
+scala_disj_elif_chain([Alt|Rest], VarMap, [ElifLine, RetLine|RestLines]) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  maplist(scala_guard_condition(VarMap), Guards, CondStrs),
+        atomic_list_concat(CondStrs, ' && ', CondExpr)
+    ;   CondExpr = 'true'
+    ),
+    scala_branch_value(Alt, VarMap, ValExpr),
+    format(string(ElifLine), '    } else if (~w) {', [CondExpr]),
+    format(string(RetLine), '        ~w', [ValExpr]),
+    scala_disj_elif_chain(Rest, VarMap, RestLines).
 
 %% scala_guard_condition(+VarMap, +Goal, -Condition)
 scala_guard_condition(VarMap, _Module:Goal, Condition) :-

--- a/src/unifyweaver/targets/vbnet_target.pl
+++ b/src/unifyweaver/targets/vbnet_target.pl
@@ -431,9 +431,7 @@ native_vbnet_clause(Head, Body, _InputArity, Cond, Value) :-
             clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
             vbnet_head_conditions(Guards, VarMap, Cond),
             vbnet_literal(OutputHeadArg, Value)
-        ;   clause_guard_output_split(Goals, VarMap, Guards, Outputs),
-            vbnet_head_conditions(Guards, VarMap, Cond),
-            vbnet_output_goals(Outputs, VarMap, Value)
+        ;   native_vbnet_goal_sequence(Goals, VarMap, Cond, Value)
         )
     ).
 
@@ -473,6 +471,172 @@ vbnet_output_goals(Outputs, VarMap, Value) :-
     (   goal_output_var(LastGoal, _)
     ->  vbnet_expr(LastGoal, VarMap, Value)
     ;   vbnet_resolve_value(LastGoal, VarMap, Value)
+    ).
+
+%% native_vbnet_goal_sequence(+Goals, +VarMap, -Cond, -Value)
+%  Uses classify_goal_sequence for advanced pattern detection.
+%  Falls back to clause_guard_output_split if classification fails.
+native_vbnet_goal_sequence(Goals, VarMap, Cond, Value) :-
+    classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+    ClassifiedGoals \= [],
+    vbnet_render_classified_goals(ClassifiedGoals, VarMap, Conditions, Lines),
+    Lines \= [],
+    (   Conditions = []
+    ->  Cond = "True"
+    ;   combine_vbnet_conditions(Conditions, Cond)
+    ),
+    atomic_list_concat(Lines, '\n', Value),
+    !.
+native_vbnet_goal_sequence(Goals, VarMap, Cond, Value) :-
+    clause_guard_output_split(Goals, VarMap, Guards, Outputs),
+    vbnet_head_conditions(Guards, VarMap, Cond),
+    vbnet_output_goals(Outputs, VarMap, Value).
+
+%% vbnet_render_classified_goals(+ClassifiedGoals, +VarMap, -Conditions, -Lines)
+vbnet_render_classified_goals([], _VarMap, [], []).
+vbnet_render_classified_goals([Classified], VarMap, Conds, Lines) :-
+    !,
+    vbnet_render_classified_last(Classified, VarMap, Conds, Lines).
+%% Guarded tail: output followed by guard(s)
+vbnet_render_classified_goals([output(Goal, _, _)|Rest], VarMap, [], Lines) :-
+    Rest = [guard(_, _)|_],
+    !,
+    vbnet_classified_output_goal(Goal, VarMap, AssignLine, VarMap1),
+    vbnet_collect_trailing_guards(Rest, VarMap1, GuardGoals, _Remaining),
+    maplist(vbnet_guard_condition_flip(VarMap1), GuardGoals, GuardConds),
+    combine_vbnet_conditions(GuardConds, GuardExpr),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMap1, OutName)
+    ->  true
+    ;   OutName = "_"
+    ),
+    format(string(IfLine), '        If ~w Then', [GuardExpr]),
+    format(string(RetLine), '            Return ~w', [OutName]),
+    EndLine = '        End If',
+    Lines = [AssignLine, IfLine, RetLine, EndLine].
+vbnet_render_classified_goals([Classified|Rest], VarMap, Conds, Lines) :-
+    vbnet_render_classified_mid(Classified, VarMap, MidConds, MidLines, VarMap1),
+    vbnet_render_classified_goals(Rest, VarMap1, RestConds, RestLines),
+    append(MidConds, RestConds, Conds),
+    append(MidLines, RestLines, Lines).
+
+%% vbnet_guard_condition_flip(+VarMap, +Goal, -Cond)
+%%  Wrapper with swapped arg order for maplist compatibility.
+vbnet_guard_condition_flip(VarMap, Goal, Cond) :-
+    vbnet_guard_condition(Goal, VarMap, Cond).
+
+%% vbnet_render_classified_mid(+Classified, +VarMap, -Conds, -Lines, -VarMapOut)
+vbnet_render_classified_mid(guard(Goal, _), VarMap, [Cond], [], VarMap) :-
+    vbnet_guard_condition(Goal, VarMap, Cond).
+vbnet_render_classified_mid(output(Goal, _, _), VarMap0, [], [Line], VarMapOut) :-
+    vbnet_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+vbnet_render_classified_mid(output_ite(If, Then, Else, _SharedVars), VarMap0, [], Lines, VarMap0) :-
+    vbnet_guard_condition(If, VarMap0, Cond),
+    vbnet_classified_branch_value(Then, VarMap0, ThenExpr),
+    vbnet_classified_branch_value(Else, VarMap0, ElseExpr),
+    format(string(IfLine), '        If ~w Then', [Cond]),
+    format(string(ThenLine), '            Return ~w', [ThenExpr]),
+    ElseLine = '        Else',
+    format(string(ElseRetLine), '            Return ~w', [ElseExpr]),
+    EndLine = '        End If',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, EndLine].
+vbnet_render_classified_mid(passthrough(Goal), VarMap0, [], [Line], VarMapOut) :-
+    vbnet_classified_output_goal(Goal, VarMap0, Line, VarMapOut).
+vbnet_render_classified_mid(_, VarMap, [], [], VarMap).
+
+%% vbnet_render_classified_last(+Classified, +VarMap, -Conds, -Lines)
+vbnet_render_classified_last(guard(Goal, _), VarMap, [Cond], []) :-
+    vbnet_guard_condition(Goal, VarMap, Cond).
+vbnet_render_classified_last(output(Goal, _, _), VarMap, [], Lines) :-
+    vbnet_classified_output_last(Goal, VarMap, Lines).
+vbnet_render_classified_last(output_ite(If, Then, Else, _), VarMap, [], Lines) :-
+    vbnet_guard_condition(If, VarMap, Cond),
+    vbnet_classified_branch_value(Then, VarMap, ThenExpr),
+    vbnet_classified_branch_value(Else, VarMap, ElseExpr),
+    format(string(IfLine), '        If ~w Then', [Cond]),
+    format(string(ThenLine), '            Return ~w', [ThenExpr]),
+    ElseLine = '        Else',
+    format(string(ElseRetLine), '            Return ~w', [ElseExpr]),
+    EndLine = '        End If',
+    Lines = [IfLine, ThenLine, ElseLine, ElseRetLine, EndLine].
+vbnet_render_classified_last(output_disj(Alternatives, _SharedVars), VarMap, [], Lines) :-
+    vbnet_disj_if_chain(Alternatives, VarMap, Lines).
+vbnet_render_classified_last(passthrough(Goal), VarMap, [], Lines) :-
+    vbnet_classified_output_last(Goal, VarMap, Lines).
+vbnet_render_classified_last(_, _, [], []).
+
+%% vbnet_classified_output_goal(+Goal, +VarMap0, -Line, -VarMapOut)
+%%  Inline singular output goal handler for VB.NET (no standalone vbnet_output_goal).
+vbnet_classified_output_goal(Goal, VarMap0, Line, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        vbnet_resolve_value(Expr, VarMap0, ExprStr),
+        format(string(Line), '        Dim ~w = ~w', [VarName, ExprStr])
+    ;   Goal = (Var is ArithExpr), var(Var)
+    ->  ensure_var(VarMap0, Var, VarName, VarMapOut),
+        vbnet_arith_expr(ArithExpr, VarMap0, ExprStr),
+        format(string(Line), '        Dim ~w = ~w', [VarName, ExprStr])
+    ;   VarName = "_", VarMapOut = VarMap0,
+        Line = "        ' unsupported output goal"
+    ).
+
+%% vbnet_classified_branch_value(+Branch, +VarMap, -ExprStr)
+%%  Inline branch value extractor for VB.NET.
+vbnet_classified_branch_value(Branch, VarMap, ExprStr) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    (   goal_output_var(LastGoal, _)
+    ->  vbnet_expr(LastGoal, VarMap, ExprStr)
+    ;   vbnet_resolve_value(LastGoal, VarMap, ExprStr)
+    ).
+
+%% vbnet_classified_output_last(+Goal, +VarMap, -Lines)
+%%  Wrap a single output goal as lines for classified rendering (last position).
+vbnet_classified_output_last(Goal, VarMap, [Line]) :-
+    vbnet_classified_output_goal(Goal, VarMap, AssignLine, VarMapOut),
+    (   goal_output_var(Goal, OutVar), lookup_var(OutVar, VarMapOut, OutName)
+    ->  format(string(Line), '~w\n        Return ~w', [AssignLine, OutName])
+    ;   Line = AssignLine
+    ).
+vbnet_classified_output_last(Goal, VarMap, [Line]) :-
+    vbnet_classified_branch_value(Goal, VarMap, Expr),
+    format(string(Line), '        Return ~w', [Expr]).
+
+%% vbnet_collect_trailing_guards(+ClassifiedGoals, +VarMap, -GuardGoals, -Remaining)
+vbnet_collect_trailing_guards([guard(Goal, _)|Rest], VarMap, [Goal|Guards], Remaining) :-
+    !, vbnet_collect_trailing_guards(Rest, VarMap, Guards, Remaining).
+vbnet_collect_trailing_guards(Remaining, _, [], Remaining).
+
+%% vbnet_disj_if_chain(+Alternatives, +VarMap, -Lines)
+vbnet_disj_if_chain([], _, []).
+vbnet_disj_if_chain([Alt], VarMap, [ElseLine, RetLine, EndLine]) :-
+    !,
+    vbnet_classified_branch_value(Alt, VarMap, ValExpr),
+    ElseLine = '        Else',
+    format(string(RetLine), '            Return ~w', [ValExpr]),
+    EndLine = '        End If'.
+vbnet_disj_if_chain([Alt|Rest], VarMap, Lines) :-
+    normalize_goals(Alt, Goals),
+    clause_guard_output_split(Goals, VarMap, Guards, _Outputs),
+    (   Guards \= []
+    ->  findall(C, (member(G, Guards), vbnet_guard_condition(G, VarMap, C)), CondStrs),
+        combine_vbnet_conditions(CondStrs, CondExpr)
+    ;   CondExpr = "True"
+    ),
+    vbnet_classified_branch_value(Alt, VarMap, ValExpr),
+    (   Rest = []
+    ->  format(string(ThisLine), '        If ~w Then\n            Return ~w\n        End If', [CondExpr, ValExpr]),
+        Lines = [ThisLine]
+    ;   format(string(IfLine), '        If ~w Then', [CondExpr]),
+        format(string(RetLine), '            Return ~w', [ValExpr]),
+        vbnet_disj_if_chain(Rest, VarMap, ChainLines),
+        (   ChainLines = ['        Else'|_]
+        ->  Lines = [IfLine, RetLine|ChainLines]
+        ;   (   ChainLines = ['        ElseIf'|_]
+            ->  Lines = [IfLine, RetLine|ChainLines]
+            ;   EndLine = '        End If',
+                append([IfLine, RetLine, EndLine], ChainLines, Lines)
+            )
+        )
     ).
 
 % ============================================================================

--- a/test_final_deep.pl
+++ b/test_final_deep.pl
@@ -1,0 +1,18 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+test_hook(Target) :-
+    format('~w: ', [Target]),
+    build_head_varmap([X, L], 1, VarMap),
+    Goal = (X > 0 -> L = positive ; L = negative),
+    (   compile_expression(Target, Goal, VarMap, Code, _, _), Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+run :-
+    test_hook(scala), test_hook(kotlin), test_hook(jython),
+    test_hook(awk), test_hook(vbnet),
+    nl, writeln('=== ALL 5 FINAL DEEPENED TARGETS DONE ===').


### PR DESCRIPTION
## Summary

Deepens the last 5 targets with `classify_goal_sequence` and audits all targets for the `sub_term` unification bug fixed in Rust. **All 18 non-TypR targets with native lowering predicates now have full classified goal rendering.**

## Targets deepened (5 new)

| Target | If/else syntax | Output goal handling |
|--------|---------------|---------------------|
| Scala | `if (cond) { val x = expr } else { ... }` | Inline via `scala_expr` + `val` |
| Kotlin | `if (cond) { val x = expr } else { ... }` | Inline via `kotlin_expr` + `val` |
| Jython | `if cond: x = expr elif: ... else: ...` | Inline via `jython_expr` (no keyword) |
| AWK | `if (cond) { x = expr } else { ... }` | Inline via `awk_expr` (no keyword) |
| VB.NET | `If cond Then Dim x = expr ElseIf ... End If` | Inline via `vbnet_arith_expr` + `Dim` |

These 5 targets lack singular `_output_goal` predicates, so classified renderers create inline handlers using `ensure_var` + the target's `_expr` predicate.

## sub_term audit

Checked all targets for the same bug fixed in Rust PR #1037 (`sub_term` with unification matching free variables via unbound clause body variables). Results:

| Target | sub_term usage | Status |
|--------|---------------|--------|
| Rust | 3 instances | ✅ Fixed (PR #1037) |
| TypR | 3 instances | ⚠️ Codex-maintained, not modified |
| All others | 0 instances | ✅ Not affected |

## Complete deepened target list (18/18)

| Group | Targets |
|-------|---------|
| Imperative | Python, Go, Lua, C, C++, Rust, Perl, Ruby |
| Scripting | TypeScript, AWK, Jython |
| JVM | Scala, Kotlin |
| Functional | Haskell, F#, Clojure, Elixir |
| Other | VB.NET |

Remaining without deepening: SQL, Bash, PowerShell, R (different compilation models — no guard/output predicates), TypR (Codex-maintained).

## Test plan

- [x] 5 hook tests — Scala, Kotlin, Jython, AWK, VB.NET all produce non-empty code
- [x] All previous deep tests pass (Rust/C/C++ 12, Go/Lua 8, 7 functional)
- [x] All Python tests pass (58+)
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
