### PR TITLE
fix(go): composable TC template syntax error

### DIFF
--- a/templates/targets/go/tc_input_stdin.mustache
+++ b/templates/targets/go/tc_input_stdin.mustache
@@ -1,8 +1,1 @@
-	// Read {{base}} facts from stdin (format: from:to)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.SplitN(line, ":", 2)
-		if len(parts) == 2 {
-			query.AddFact(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
-		}
-	}
+

--- a/templates/targets/go/tc_interface_cli.mustache
+++ b/templates/targets/go/tc_interface_cli.mustache
@@ -1,8 +1,16 @@
+
 func main() {
 	query := New{{pred_cap}}Query()
 	scanner := bufio.NewScanner(os.Stdin)
 
-	{{> tc_input_stdin}}
+	// Read {{base}} facts from stdin (format: from:to)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 {
+			query.AddFact(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
 
 	args := os.Args[1:]
 	switch len(args) {


### PR DESCRIPTION
## Summary

Fix the Go composable transitive closure template that produced invalid Go code with "non-declaration statement outside function body" syntax errors.

## Root Cause

The composable template system concatenates: `tc_definitions + tc_input_stdin + tc_interface_cli`

Two problems:
1. `tc_input_stdin.mustache` contained bare `for scanner.Scan() { ... }` code that ended up between the `Check()` function closing brace and the `func main()` declaration — outside any function body
2. `tc_interface_cli.mustache` used `{{> tc_input_stdin}}` Mustache partial syntax, but the composable system concatenates rendered templates — it doesn't resolve partials, so the partial reference was rendered literally

## Fix

- **`tc_input_stdin.mustache`**: Made empty (the stdin code is now part of the CLI interface)
- **`tc_interface_cli.mustache`**: Contains the full `func main()` with stdin reading inline, argument parsing, and BFS query dispatch

This matches how the composable system works: `definitions + (empty) + cli` = valid Go program.

## Runtime Validation

| Query | Before | After |
|-------|--------|-------|
| `ancestor(a,d)` via a→b→c→d | Build error | `a:d` exit 0 |
| `ancestor(d,a)` | Build error | exit 1 |
| Monolithic path | Already worked | Still works |

## Test plan

- [x] All 115 JVM assembly tests pass
- [x] All 95 WAT tests pass
- [x] Go composable TC compiles and runs correctly
- [x] Go monolithic TC still works
- [x] Both positive and negative reachability queries correct
