### PR TITLE
feat: deepen WAT, Jamaica, Krakatau with classify_goal_sequence

### DIFF
--- a/src/unifyweaver/core/jvm_bytecode.pl
+++ b/src/unifyweaver/core/jvm_bytecode.pl
@@ -364,12 +364,64 @@ jvm_clauses_to_branches([Head-Body|Rest], Arity1, VarStyle, Result) :-
         append(InputArgs, [OutputArg], AllArgs),
         build_head_varmap(InputArgs, 1, VarMap),
         normalize_goals(Body, Goals),
-        once(clause_guard_output_split(Goals, VarMap, Guards, Outputs)),
-        jvm_compile_guards(Guards, VarMap, VarStyle, GuardInstrs),
-        jvm_output_to_bytecode(OutputArg, Outputs, VarMap, VarStyle, ValueInstrs)
+        %% Try classify_goal_sequence first for advanced patterns
+        (   classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+            ClassifiedGoals \= [],
+            jvm_compile_classified(ClassifiedGoals, OutputArg, VarMap, VarStyle, GuardInstrs, ValueInstrs)
+        ->  true
+        ;   %% Fallback to basic split
+            once(clause_guard_output_split(Goals, VarMap, Guards, Outputs)),
+            jvm_compile_guards(Guards, VarMap, VarStyle, GuardInstrs),
+            jvm_output_to_bytecode(OutputArg, Outputs, VarMap, VarStyle, ValueInstrs)
+        )
     ->  Result = [branch(GuardInstrs, ValueInstrs)|RestBranches]
     ;   Result = RestBranches
     ).
+
+%% jvm_compile_classified(+ClassifiedGoals, +OutputArg, +VarMap, +VarStyle, -GuardInstrs, -ValueInstrs)
+%  Compile classified goals to JVM bytecode instruction lists.
+jvm_compile_classified(ClassifiedGoals, OutputArg, VarMap, VarStyle, GuardInstrs, ValueInstrs) :-
+    %% Collect guard instructions
+    findall(GInstrs, (
+        member(guard(G, _), ClassifiedGoals),
+        jvm_guard_to_bytecode(G, VarMap, VarStyle, "NEXT", GInstrs)
+    ), GuardInstrLists),
+    append(GuardInstrLists, GuardInstrs),
+    %% Find output value
+    (   member(output(Goal, _, _), ClassifiedGoals)
+    ->  jvm_classified_output(Goal, OutputArg, VarMap, VarStyle, ValueInstrs)
+    ;   member(output_ite(If, Then, Else, _), ClassifiedGoals)
+    ->  jvm_classified_ite(If, Then, Else, VarMap, VarStyle, ValueInstrs)
+    ;   %% Fallback: use OutputArg directly
+        jvm_output_to_bytecode(OutputArg, [], VarMap, VarStyle, ValueInstrs)
+    ).
+
+%% jvm_classified_output(+Goal, +OutputArg, +VarMap, +VarStyle, -Instrs)
+jvm_classified_output(Goal, _OutputArg, VarMap, VarStyle, Instrs) :-
+    (   Goal = (_ is ArithExpr)
+    ->  jvm_expr_to_bytecode(ArithExpr, VarMap, VarStyle, Instrs)
+    ;   Goal = (_ = Expr)
+    ->  jvm_expr_to_bytecode(Expr, VarMap, VarStyle, Instrs)
+    ;   jvm_expr_to_bytecode(Goal, VarMap, VarStyle, Instrs)
+    ).
+
+%% jvm_classified_ite(+If, +Then, +Else, +VarMap, +VarStyle, -Instrs)
+jvm_classified_ite(If, Then, Else, VarMap, VarStyle, Instrs) :-
+    %% Compile condition
+    jvm_guard_to_bytecode(If, VarMap, VarStyle, "ITE_else", CondInstrs),
+    %% Compile then branch value
+    normalize_goals(Then, ThenGoals),
+    last(ThenGoals, ThenLast),
+    jvm_classified_output(ThenLast, _, VarMap, VarStyle, ThenInstrs),
+    %% Compile else branch value
+    normalize_goals(Else, ElseGoals),
+    last(ElseGoals, ElseLast),
+    jvm_classified_output(ElseLast, _, VarMap, VarStyle, ElseInstrs),
+    %% Assemble: cond -> then_value, goto end; else: else_value; end:
+    append(CondInstrs, ThenInstrs, PreGoto),
+    append(PreGoto, ["goto ITE_end", "ITE_else:"], PreElse),
+    append(PreElse, ElseInstrs, PreEnd),
+    append(PreEnd, ["ITE_end:"], Instrs).
 
 jvm_compile_guards([], _, _, []).
 jvm_compile_guards([G|Gs], VarMap, VarStyle, AllInstrs) :-

--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -175,6 +175,12 @@ compile_non_recursive(haskell, Pred/Arity, FinalOptions, GeneratedCode) :-
     haskell_target:compile_predicate_to_haskell(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(fsharp, Pred/Arity, FinalOptions, GeneratedCode) :-
     fsharp_target:compile_predicate_to_fsharp(Pred/Arity, FinalOptions, GeneratedCode).
+compile_non_recursive(wat, Pred/Arity, FinalOptions, GeneratedCode) :-
+    wat_target:compile_predicate_to_wat(Pred/Arity, FinalOptions, GeneratedCode).
+compile_non_recursive(jamaica, Pred/Arity, FinalOptions, GeneratedCode) :-
+    jamaica_target:compile_predicate_to_jamaica(Pred/Arity, FinalOptions, GeneratedCode).
+compile_non_recursive(krakatau, Pred/Arity, FinalOptions, GeneratedCode) :-
+    krakatau_target:compile_predicate_to_krakatau(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(typr, Pred/Arity, FinalOptions, GeneratedCode) :-
     compile_predicate_to_typr(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(jython, Pred/Arity, FinalOptions, GeneratedCode) :-

--- a/src/unifyweaver/targets/wat_target.pl
+++ b/src/unifyweaver/targets/wat_target.pl
@@ -718,6 +718,8 @@ native_wat_clause_body(PredStr/Arity, Clauses, FuncBody) :-
     branches_to_wat_if_chain(Branches, PredStr, Arity, FuncBody).
 
 %% native_wat_clause(+Head, +Body, -Cond, -Value)
+%  Uses classify_goal_sequence for advanced pattern detection,
+%  with fallback to clause_guard_output_split.
 native_wat_clause(Head, Body, Cond, Value) :-
     Head =.. [_|HeadArgs],
     length(HeadArgs, Arity),
@@ -731,7 +733,13 @@ native_wat_clause(Head, Body, Cond, Value) :-
         if_then_else_goal(SingleGoal, If, Then, Else)
     ->  wat_if_then_else_output(If, Then, Else, VarMap, Value),
         Cond = none
-    ;   (   Arity > 1, nonvar(OutputHeadArg)
+    ;   %% Try classify_goal_sequence for advanced patterns
+        classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+        ClassifiedGoals \= [],
+        wat_render_classified(ClassifiedGoals, VarMap, OutputHeadArg, Arity, Cond, Value)
+    ->  true
+    ;   %% Fallback to basic split
+        (   Arity > 1, nonvar(OutputHeadArg)
         ->  once(clause_guard_output_split(Goals, VarMap, Guards, _Outputs)),
             wat_head_conditions(Guards, VarMap, Cond),
             wat_literal(OutputHeadArg, Value)
@@ -740,6 +748,40 @@ native_wat_clause(Head, Body, Cond, Value) :-
             wat_output_goals(Outputs, VarMap, Value)
         )
     ).
+
+%% wat_render_classified(+ClassifiedGoals, +VarMap, +OutputHeadArg, +Arity, -Cond, -Value)
+%  Render classified goals for WAT output.
+wat_render_classified(ClassifiedGoals, VarMap, OutputHeadArg, Arity, Cond, Value) :-
+    %% Collect guard conditions
+    findall(C, (
+        member(guard(G, _), ClassifiedGoals),
+        wat_guard_condition(G, VarMap, C)
+    ), GuardConds),
+    (GuardConds = [] -> Cond = none ; combine_wat_conditions(GuardConds, Cond)),
+    %% Find the output value
+    (   member(output_ite(If, Then, Else, _), ClassifiedGoals)
+    ->  wat_if_then_else_output(If, Then, Else, VarMap, Value)
+    ;   member(output(Goal, _, _), ClassifiedGoals)
+    ->  (   Goal = (_ is ArithExpr)
+        ->  wat_arith_expr(ArithExpr, VarMap, Value)
+        ;   Goal = (_ = Expr)
+        ->  wat_resolve_value(Expr, VarMap, Value)
+        ;   wat_resolve_value(Goal, VarMap, Value)
+        )
+    ;   Arity > 1, nonvar(OutputHeadArg)
+    ->  wat_literal(OutputHeadArg, Value)
+    ;   Value = "(i64.const 0)"
+    ).
+
+%% Handle guarded tail: output followed by guard
+wat_render_classified(ClassifiedGoals, VarMap, _OutputHeadArg, _Arity, Cond, Value) :-
+    ClassifiedGoals = [output(Goal, _, _), guard(GuardGoal, _)|_],
+    !,
+    (   Goal = (_ is ArithExpr) -> wat_arith_expr(ArithExpr, VarMap, Value)
+    ;   Goal = (_ = Expr) -> wat_resolve_value(Expr, VarMap, Value)
+    ;   wat_resolve_value(Goal, VarMap, Value)
+    ),
+    wat_guard_condition(GuardGoal, VarMap, Cond).
 
 %% wat_head_conditions(+Guards, +VarMap, -Cond)
 wat_head_conditions([], _VarMap, none) :- !.

--- a/test_assembly_deep.pl
+++ b/test_assembly_deep.pl
@@ -1,0 +1,42 @@
+:- encoding(utf8).
+:- ['src/unifyweaver/init'].
+:- use_module('src/unifyweaver/core/recursive_compiler').
+:- use_module('src/unifyweaver/core/clause_body_analysis').
+
+:- dynamic classify_sign/2, safe_double/2.
+
+classify_sign(0, zero).
+classify_sign(X, positive) :- X > 0.
+classify_sign(X, negative) :- X < 0.
+
+safe_double(X, Y) :- X > 0, Y is X * 2.
+safe_double(X, 0) :- X =< 0.
+
+test_hook(Target) :-
+    format('~w hook: ', [Target]),
+    build_head_varmap([X, L], 1, VarMap),
+    Goal = (X > 0 -> L = positive ; L = negative),
+    (   compile_expression(Target, Goal, VarMap, Code, _, _), Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+test_compile(Target, Pred/Arity) :-
+    format('~w ~w/~w: ', [Target, Pred, Arity]),
+    (   catch(recursive_compiler:compile_recursive(Pred/Arity, [target(Target)], Code), _, fail),
+        Code \= ""
+    ->  writeln(ok)
+    ;   writeln('FAIL')
+    ).
+
+run :-
+    test_hook(wat), test_hook(jamaica), test_hook(krakatau),
+    nl,
+    test_compile(wat, classify_sign/2),
+    test_compile(wat, safe_double/2),
+    test_compile(jamaica, classify_sign/2),
+    test_compile(jamaica, safe_double/2),
+    test_compile(krakatau, classify_sign/2),
+    test_compile(krakatau, safe_double/2),
+    nl,
+    writeln('=== ASSEMBLY DEEP TESTS DONE ===').


### PR DESCRIPTION
## Summary

Upgrades all 3 assembly targets to use `classify_goal_sequence` for advanced pattern detection. WAT gets the upgrade directly; Jamaica and Krakatau benefit through the shared `jvm_bytecode.pl` layer. Also adds missing `compile_non_recursive` clauses for all three targets.

This completes the deepening rollout — **all 21 targets** with native lowering predicates now have full `classify_goal_sequence` support.

## Changes

### WAT
`native_wat_clause` now tries `classify_goal_sequence` before `clause_guard_output_split`. Added `wat_render_classified` which handles:
- Guard collection → WAT comparison S-expressions
- Output goals → WAT arithmetic/value expressions
- If-then-else output → WAT `(if (result i64) ...)` blocks
- Guarded tail → output then conditional guard

### JVM shared layer (Jamaica + Krakatau)
`jvm_clauses_to_branches` in `jvm_bytecode.pl` now tries `classify_goal_sequence` first. Added:
- `jvm_compile_classified` — dispatches classified goals to bytecode
- `jvm_classified_output` — compiles output goals to JVM instructions
- `jvm_classified_ite` — compiles if-then-else as label-based branching with goto

Both Jamaica (symbolic var style) and Krakatau (numeric var style) benefit from the shared upgrade.

### compile_non_recursive
Added `compile_non_recursive` clauses for WAT, Jamaica, and Krakatau — these were missing, which prevented non-recursive predicates from compiling through the standard dispatch chain.

## Complete deepened target list (21/21)

| Group | Targets | Count |
|-------|---------|-------|
| Imperative | Python, Go, Lua, C, C++, Rust, Perl, Ruby | 8 |
| Scripting | TypeScript, AWK, Jython | 3 |
| JVM | Scala, Kotlin | 2 |
| Functional | Haskell, F#, Clojure, Elixir | 4 |
| Assembly | WAT, Jamaica, Krakatau | 3 |
| Other | VB.NET | 1 |
| **Total** | | **21** |

## Test plan

- [x] 3 hook tests — WAT, Jamaica, Krakatau produce non-empty code from `compile_expression`
- [x] 6 compilation tests — `classify_sign/2` and `safe_double/2` compile for all 3 targets
- [x] All previous deep tests pass (Rust/C/C++, Go/Lua, functional, Scala/Kotlin/Jython/AWK/VB.NET)
- [x] All Python tests pass (58+)
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
