### PR TITLE
feat: deepen LLVM with classify_goal_sequence — all 22 targets complete

### DIFF
--- a/src/unifyweaver/core/recursive_compiler.pl
+++ b/src/unifyweaver/core/recursive_compiler.pl
@@ -181,6 +181,8 @@ compile_non_recursive(jamaica, Pred/Arity, FinalOptions, GeneratedCode) :-
     jamaica_target:compile_predicate_to_jamaica(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(krakatau, Pred/Arity, FinalOptions, GeneratedCode) :-
     krakatau_target:compile_predicate_to_krakatau(Pred/Arity, FinalOptions, GeneratedCode).
+compile_non_recursive(llvm, Pred/Arity, FinalOptions, GeneratedCode) :-
+    llvm_target:compile_predicate_to_llvm(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(typr, Pred/Arity, FinalOptions, GeneratedCode) :-
     compile_predicate_to_typr(Pred/Arity, FinalOptions, GeneratedCode).
 compile_non_recursive(jython, Pred/Arity, FinalOptions, GeneratedCode) :-

--- a/src/unifyweaver/targets/llvm_target.pl
+++ b/src/unifyweaver/targets/llvm_target.pl
@@ -1352,22 +1352,78 @@ native_llvm_clause(_PredSpec, Head, Body, Conditions, ResultExpr) :-
     ->  llvm_resolve_value(VarMap, OutputHeadArg, Value),
         ResultExpr = result{value: Value, setup: "", setup2: ""},
         GoalConditions = []
-    ;   (   Arity > 1, nonvar(OutputHeadArg)
-        ->  clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
-            maplist(llvm_goal_to_condition(VarMap), GuardGoals, GoalConditions),
-            (   OutputGoals == []
-            ->  llvm_resolve_value(VarMap, OutputHeadArg, Value),
-                ResultExpr = result{value: Value, setup: "", setup2: ""}
-            ;   llvm_output_expr(OutputGoals, VarMap, Value, SetupCode),
+    ;   %% Try classify_goal_sequence for advanced patterns
+        (   classify_goal_sequence(Goals, VarMap, ClassifiedGoals),
+            ClassifiedGoals \= [],
+            llvm_render_classified(ClassifiedGoals, VarMap, OutputHeadArg, Arity, GoalConditions, ResultExpr)
+        ->  true
+        ;   %% Fallback to basic split
+            (   Arity > 1, nonvar(OutputHeadArg)
+            ->  clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
+                maplist(llvm_goal_to_condition(VarMap), GuardGoals, GoalConditions),
+                (   OutputGoals == []
+                ->  llvm_resolve_value(VarMap, OutputHeadArg, Value),
+                    ResultExpr = result{value: Value, setup: "", setup2: ""}
+                ;   llvm_output_expr(OutputGoals, VarMap, Value, SetupCode),
+                    ResultExpr = result{value: Value, setup: SetupCode, setup2: SetupCode}
+                )
+            ;   clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
+                maplist(llvm_goal_to_condition(VarMap), GuardGoals, GoalConditions),
+                llvm_output_expr(OutputGoals, VarMap, Value, SetupCode),
                 ResultExpr = result{value: Value, setup: SetupCode, setup2: SetupCode}
             )
-        ;   clause_guard_output_split(Goals, VarMap, GuardGoals, OutputGoals),
-            maplist(llvm_goal_to_condition(VarMap), GuardGoals, GoalConditions),
-            llvm_output_expr(OutputGoals, VarMap, Value, SetupCode),
-            ResultExpr = result{value: Value, setup: SetupCode, setup2: SetupCode}
         )
     ),
     append(HeadConditions, GoalConditions, Conditions).
+
+%% llvm_render_classified(+ClassifiedGoals, +VarMap, +OutputHeadArg, +Arity, -Conditions, -ResultExpr)
+%  Render classified goals for LLVM IR output.
+llvm_render_classified(ClassifiedGoals, VarMap, OutputHeadArg, Arity, Conditions, ResultExpr) :-
+    %% Collect guard conditions
+    findall(C, (
+        member(guard(G, _), ClassifiedGoals),
+        llvm_goal_to_condition(VarMap, G, C)
+    ), Conditions),
+    %% Find the output value
+    (   member(output(Goal, _, _), ClassifiedGoals)
+    ->  (   Goal = (_ is ArithExpr)
+        ->  llvm_arith_expr(ArithExpr, VarMap, Value, SetupCode),
+            ResultExpr = result{value: Value, setup: SetupCode, setup2: SetupCode}
+        ;   Goal = (_ = Expr)
+        ->  llvm_resolve_value(VarMap, Expr, Value),
+            ResultExpr = result{value: Value, setup: "", setup2: ""}
+        ;   llvm_resolve_value(VarMap, Goal, Value),
+            ResultExpr = result{value: Value, setup: "", setup2: ""}
+        )
+    ;   member(output_ite(If, Then, Else, _), ClassifiedGoals)
+    ->  %% If-then-else: compile both branches
+        llvm_goal_to_condition(VarMap, If, IfCond),
+        llvm_branch_value_from_goals(Then, VarMap, ThenVal),
+        llvm_branch_value_from_goals(Else, VarMap, ElseVal),
+        format(string(SetupCode),
+'  %%ite_cond = ~w
+  br i1 %%ite_cond, label %%ite_then, label %%ite_else
+ite_then:
+  br label %%ite_end
+ite_else:
+  br label %%ite_end
+ite_end:
+  %%ite_result = phi i64 [~w, %%ite_then], [~w, %%ite_else]', [IfCond, ThenVal, ElseVal]),
+        ResultExpr = result{value: "%ite_result", setup: SetupCode, setup2: SetupCode}
+    ;   Arity > 1, nonvar(OutputHeadArg)
+    ->  llvm_resolve_value(VarMap, OutputHeadArg, Value),
+        ResultExpr = result{value: Value, setup: "", setup2: ""}
+    ;   ResultExpr = result{value: "0", setup: "", setup2: ""}
+    ).
+
+%% llvm_branch_value_from_goals(+Branch, +VarMap, -Value)
+llvm_branch_value_from_goals(Branch, VarMap, Value) :-
+    normalize_goals(Branch, Goals),
+    last(Goals, LastGoal),
+    (   LastGoal = (_ = Expr) -> llvm_resolve_value(VarMap, Expr, Value)
+    ;   LastGoal = (_ is Expr) -> llvm_arith_expr(Expr, VarMap, Value, _)
+    ;   llvm_resolve_value(VarMap, LastGoal, Value)
+    ).
 
 %% llvm_head_conditions(+HeadArgs, +Index, +Arity, -Conditions)
 llvm_head_conditions([], _, _, []).


### PR DESCRIPTION
## Summary

Upgrades the LLVM target to use `classify_goal_sequence` for advanced pattern detection, completing the deepening rollout across all targets with native lowering predicates. Also adds the missing `compile_non_recursive(llvm, ...)` clause.

**All 22 targets** are now deepened with `classify_goal_sequence`.

## LLVM if-then-else output

LLVM IR uses SSA-style phi nodes for branch merging:

```llvm
%ite_cond = icmp sgt i64 %arg1, 0
br i1 %ite_cond, label %ite_then, label %ite_else
ite_then:
  br label %ite_end
ite_else:
  br label %ite_end
ite_end:
  %ite_result = phi i64 [then_val, %ite_then], [else_val, %ite_else]
```

## Complete deepened target list (22/22)

| Group | Targets | Count |
|-------|---------|-------|
| Imperative | Python, Go, Lua, C, C++, Rust, Perl, Ruby | 8 |
| Scripting | TypeScript, AWK, Jython | 3 |
| JVM | Scala, Kotlin | 2 |
| Functional | Haskell, F#, Clojure, Elixir | 4 |
| Assembly | WAT, Jamaica, Krakatau, LLVM | 4 |
| Other | VB.NET | 1 |
| **Total** | | **22** |

Remaining: SQL, Bash, PowerShell, R (different compilation models), TypR (Codex-maintained).

## Test plan

- [x] LLVM hook test — produces non-empty code from `compile_expression`
- [x] LLVM compilation — `classify_sign/2` and `safe_double/2` compile
- [x] All other assembly target tests pass (WAT, Jamaica, Krakatau)
- [x] All Python tests pass (58+)
- [x] Existing `test_recursive_compiler` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
