### PR TITLE
fix(c,cpp,rust): composable TC partial bug, cross-target 9-target validation

### DIFF
--- a/templates/targets/c/tc_input_stdin.mustache
+++ b/templates/targets/c/tc_input_stdin.mustache
@@ -1,10 +1,1 @@
-    /* Read {{base}} facts from stdin */
-    while (fgets(line, sizeof(line), stdin)) {
-        char* colon = strchr(line, ':');
-        if (!colon) continue;
-        *colon = '\0';
-        char* to = colon + 1;
-        size_t len = strlen(to);
-        if (len > 0 && to[len-1] == '\n') to[len-1] = '\0';
-        add_edge(line, to);
-    }
+

--- a/templates/targets/c/tc_interface_cli.mustache
+++ b/templates/targets/c/tc_interface_cli.mustache
@@ -1,7 +1,17 @@
+
 int main(int argc, char** argv) {
     char line[MAX_LINE];
 
-    {{> tc_input_stdin}}
+    /* Read {{base}} facts from stdin */
+    while (fgets(line, sizeof(line), stdin)) {
+        char* colon = strchr(line, ':');
+        if (!colon) continue;
+        *colon = '\0';
+        char* to = colon + 1;
+        size_t len = strlen(to);
+        if (len > 0 && to[len-1] == '\n') to[len-1] = '\0';
+        add_edge(line, to);
+    }
 
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <start> [target]\n", argv[0]);

--- a/templates/targets/cpp/tc_input_stdin.mustache
+++ b/templates/targets/cpp/tc_input_stdin.mustache
@@ -1,10 +1,1 @@
-    // Read {{base}} facts from stdin
-    while (std::getline(std::cin, line)) {
-        if (line.empty()) continue;
-        size_t pos = line.find(':');
-        if (pos != std::string::npos) {
-            std::string from = line.substr(0, pos);
-            std::string to = line.substr(pos + 1);
-            query.addFact(from, to);
-        }
-    }
+

--- a/templates/targets/cpp/tc_interface_cli.mustache
+++ b/templates/targets/cpp/tc_interface_cli.mustache
@@ -1,8 +1,18 @@
+
 int main(int argc, char** argv) {
     {{pred_cap}}Query query;
     std::string line;
 
-    {{> tc_input_stdin}}
+    // Read {{base}} facts from stdin
+    while (std::getline(std::cin, line)) {
+        if (line.empty()) continue;
+        size_t pos = line.find(':');
+        if (pos != std::string::npos) {
+            std::string from = line.substr(0, pos);
+            std::string to = line.substr(pos + 1);
+            query.addFact(from, to);
+        }
+    }
 
     if (argc < 2) {
         std::cerr << "Usage: " << argv[0] << " <start> [target]" << std::endl;

--- a/templates/targets/rust/tc_input_stdin.mustache
+++ b/templates/targets/rust/tc_input_stdin.mustache
@@ -1,8 +1,1 @@
-    // Read {{base}} facts from stdin (format: from:to)
-    for line in stdin.lock().lines() {
-        if let Ok(line) = line {
-            if let Some((from, to)) = line.split_once(':') {
-                query.add_fact(from.trim(), to.trim());
-            }
-        }
-    }
+

--- a/templates/targets/rust/tc_interface_cli.mustache
+++ b/templates/targets/rust/tc_interface_cli.mustache
@@ -1,8 +1,16 @@
+
 fn main() {
     let mut query = {{pred_cap}}Query::new();
     let stdin = io::stdin();
 
-    {{> tc_input_stdin}}
+    // Read {{base}} facts from stdin (format: from:to)
+    for line in stdin.lock().lines() {
+        if let Ok(line) = line {
+            if let Some((from, to)) = line.split_once(':') {
+                query.add_fact(from.trim(), to.trim());
+            }
+        }
+    }
 
     let args: Vec<String> = std::env::args().collect();
     match args.len() {


### PR DESCRIPTION
## Summary

- Fix the same `{{> tc_input_stdin}}` Mustache partial bug in C, C++, and Rust composable TC templates (same pattern as Go fix in PR #1044)
- Cross-target runtime validate transitive closures across **9 targets** with identical results
- Audit confirms no remaining targets have the partial bug

## Bug

The composable template system concatenates: `tc_definitions + tc_input_stdin + tc_interface_cli`

Three targets had `{{> tc_input_stdin}}` Mustache partial syntax in their `tc_interface_cli.mustache` files, but the system doesn't resolve partials — it renders each template independently and concatenates the results. This caused:
- **C**: code outside function body (`while(fgets(...))` between function close and `int main()`)
- **C++**: same pattern (`while(std::getline(...))` outside function)
- **Rust**: same pattern (`for line in stdin.lock().lines()` outside `fn main()`)

## Fix

Same approach as Go (PR #1044): inline the stdin reading code into `tc_interface_cli.mustache`, make `tc_input_stdin.mustache` empty.

| Target | Before | After |
|--------|--------|-------|
| C | `{{> tc_input_stdin}}` in main | `while(fgets(...))` directly in main |
| C++ | `{{> tc_input_stdin}}` in main | `while(std::getline(...))` directly in main |
| Rust | `{{> tc_input_stdin}}` in main | `for line in stdin.lock().lines()` directly in main |

## Audit Results

Scanned all 26 target `tc_interface_cli.mustache` files for `{{>` partial references:

| Status | Targets |
|--------|---------|
| Fixed in this PR | C, C++, Rust |
| Fixed in PR #1044 | Go |
| Never had the bug | All other 22 targets |

## Cross-Target Runtime Validation (9 targets)

Same graph `a->b->c->d`, query `ancestor(a, d)`:

| Target | Tool | Result |
|--------|------|--------|
| C | cc | `a:d` exit 0 |
| C++ | g++ | `a:d` exit 0 |
| Rust | rustc | `a:d` exit 0 |
| Go | go run | `a:d` exit 0 |
| Lua | lua | `a:d` exit 0 |
| Python | python3 | `a:d` exit 0 |
| AWK | gawk | `a:d` exit 0 |
| Jamaica | assembler + java | `a:d` exit 0 |
| Krakatau | krak2 + java | `a:d` exit 0 |

All 9 targets produce identical output.

## Test plan

- [x] All 115 JVM assembly tests pass
- [x] All 95 WAT tests pass (no regressions)
- [x] C composable TC compiles and runs correctly
- [x] C++ composable TC compiles and runs correctly
- [x] Rust composable TC compiles and runs correctly
- [x] 9-target cross-validation: all identical results
- [x] Audit: no remaining targets have the partial bug
