### PR TITLE
docs: ILAsm target design — philosophy, specification, implementation plan

### DIFF
--- a/docs/design/ILASM_TARGET_IMPLEMENTATION_PLAN.md
+++ b/docs/design/ILASM_TARGET_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,204 @@
+# ILAsm Target — Implementation Plan
+
+## Context
+
+The shared compile_expression framework (22 targets with hooks,
+22 deepened with classify_goal_sequence) changes the implementation
+order for new targets. Previously, you'd start with recursion
+templates and bindings. Now, the shared framework provides
+non-recursive pattern support immediately via hooks — so we start
+with the scaffold and hooks, then add depth incrementally.
+
+## Phase 1: Scaffold + Hooks (immediate non-recursive support)
+
+**Goal:** ILAsm target compiles non-recursive predicates using the
+shared compile_expression framework.
+
+**Files to create:**
+
+1. `src/unifyweaver/targets/ilasm_target.pl` — module with:
+   - `compile_predicate_to_ilasm/3` — entry point
+   - `native_ilasm_clause_body` — clause dispatcher
+   - `native_ilasm_clause` — per-clause handler
+   - `ilasm_guard_condition` — guard rendering (CIL comparisons)
+   - `ilasm_output_goal` — output rendering (stloc)
+   - `ilasm_branch_value` — branch value extraction
+   - `ilasm_expr` — expression to CIL instructions
+   - 4 compile_expression hooks (render_output_goal, etc.)
+   - classify_goal_sequence integration from day one
+
+2. `src/unifyweaver/core/cil_bytecode.pl` — shared CIL layer:
+   - `cil_expr_to_instructions/3`
+   - `cil_guard_to_instructions/4`
+   - `cil_if_chain/3`
+   - `cil_resolve_value/3`
+   - CIL operator mapping
+
+3. Wire into `recursive_compiler.pl`:
+   - `use_module('../targets/ilasm_target', [])`
+   - `compile_non_recursive(ilasm, ...)`
+
+**Test predicates:**
+- `classify_sign/2` — multi-clause with guards
+- `label/2` — if-then-else output
+- `safe_double/2` — guard + arithmetic output
+
+**What works after Phase 1:**
+- Multi-clause dispatch (if/br chains)
+- Guards (comparison operators)
+- Arithmetic output (add/sub/mul/div)
+- If-then-else output (via compile_expression hooks)
+- Disjunction output (via classify_goal_sequence)
+- Guarded tail sequences (output then guard)
+
+## Phase 2: Component Registration
+
+**Goal:** Enable custom IL injection via the component system.
+
+**Files:**
+
+1. `src/unifyweaver/targets/ilasm_runtime/custom_ilasm.pl`:
+   - `init_component/2`
+   - `invoke_component/4`
+   - `compile_component/4`
+   - Register as `custom_ilasm` component type
+
+Follow the pattern from `csharp_runtime/custom_csharp.pl` and
+`jamaica_target.pl` component registration.
+
+## Phase 3: Binding Registry
+
+**Goal:** Map Prolog operations to .NET BCL calls.
+
+**File:** `src/unifyweaver/bindings/cil_asm_bindings.pl`
+
+Register as `ilasm` target in the binding registry. Follow the
+pattern from `jvm_asm_bindings.pl` which registers dual bindings
+for both Jamaica and Krakatau.
+
+Key bindings:
+- Arithmetic: `add`, `sub`, `mul`, `div`, `rem`
+- Math: `System.Math::Sqrt`, `System.Math::Abs`, etc.
+- String: `String::get_Length`, `String::Concat`
+- I/O: `Console::WriteLine`, `Console::ReadLine`
+- Conversion: `conv.i8`, `conv.r8`
+
+Wire into `ilasm_output_goal` and `ilasm_guard_condition` so
+classified goals can use bindings.
+
+## Phase 4: Recursion Patterns (multifile dispatch)
+
+**Goal:** Compile recursive predicates to CIL.
+
+Register for each pattern:
+
+### Tail Recursion
+```prolog
+tail_recursion:compile_tail_pattern(ilasm, PredStr, Arity, ..., Code) :-
+    %% CIL has .tail prefix — can express tail calls directly
+    %% OR transform to loop like JVM targets
+```
+
+CIL's `.tail` prefix is unique — it allows native tail call
+optimization without loop transformation. Consider supporting both:
+- `.tail call` for simple tail recursion
+- Loop transformation for complex patterns
+
+### Linear Recursion
+```prolog
+linear_recursion:compile_linear_pattern(ilasm, PredStr, Arity, ..., Code) :-
+    %% Transform to iterative loop (like JVM targets)
+```
+
+### Tree Recursion
+```prolog
+tree_recursion:compile_tree_pattern(ilasm, Pattern, Pred, Arity, UseMemo, Code) :-
+    %% Memoized with Dictionary<int64, int64>
+```
+
+### Mutual Recursion
+```prolog
+mutual_recursion:compile_mutual_pattern(ilasm, Predicates, ..., Code) :-
+    %% Multiple static methods calling each other
+```
+
+## Phase 5: Transitive Closure Template
+
+**Goal:** Composable TC templates for all 5 input modes.
+
+**Files:**
+```
+templates/targets/ilasm/
+    transitive_closure.mustache
+    tc_definitions.mustache
+    tc_input_stdin.mustache
+    tc_input_embedded.mustache
+    tc_input_file.mustache
+    tc_input_vfs.mustache      (placeholder — ILAsm not in browser)
+    tc_input_function.mustache
+    tc_interface_cli.mustache
+```
+
+Wire into `compile_transitive_closure(ilasm, ...)` using
+`compile_tc_from_template/6`.
+
+## Phase 6: Type Integration
+
+Add `resolve_type(Type, ilasm, CILType)` facts to
+`type_declarations.pl` for optional type annotations in
+generated IL method signatures.
+
+## Dependencies
+
+```
+Phase 1 (scaffold + hooks) ← no dependencies, start here
+  ↓
+Phase 2 (components) ← independent of Phase 1
+  ↓
+Phase 3 (bindings) ← independent, can parallel with Phase 2
+  ↓
+Phase 4 (recursion) ← depends on Phase 1 for basic IL generation
+  ↓
+Phase 5 (TC templates) ← independent of Phase 4
+  ↓
+Phase 6 (types) ← independent, can do anytime
+```
+
+## Relationship to Existing C# Target
+
+ILAsm does NOT replace the C# target. They serve different needs:
+
+| | C# Target | ILAsm Target |
+|---|---|---|
+| Output | C# source code | CIL assembly text |
+| Requires | C# compiler (csc/dotnet) | ILAsm assembler (ilasm) |
+| Use case | High-level, readable | Low-level, precise control |
+| Tail calls | Not native in C# | `.tail` prefix in CIL |
+| Fallback from | — | Could serve as C# fallback |
+| Component system | `custom_csharp` | `custom_ilasm` |
+
+## CIL-Specific Considerations
+
+### Stack Management
+CIL is stack-based. Every expression pushes results onto the
+evaluation stack. `.maxstack` must be declared. For complex
+expressions, track max stack depth during compilation.
+
+### Local Variables
+`.locals init (int64 v0, int64 v1, ...)` declares all locals
+upfront. VarMap indices map to local slot numbers.
+
+### Method Signatures
+`.method public static int64 predname(int64 arg0) cil managed`
+— explicit types in signatures. Use `resolve_type` for type
+selection.
+
+### Tail Calls
+`.tail` prefix before `call` enables tail call optimization.
+This is a CIL advantage over JVM — tail recursion can be
+expressed directly without loop transformation:
+```il
+.tail
+call int64 PrologGenerated.Program::is_odd(int64)
+ret
+```

--- a/docs/design/ILASM_TARGET_PHILOSOPHY.md
+++ b/docs/design/ILASM_TARGET_PHILOSOPHY.md
@@ -1,0 +1,108 @@
+# ILAsm Target — Philosophy
+
+## Why ILAsm
+
+ILAsm (IL Assembler) is the .NET equivalent of Krakatau/Jamaica for
+the JVM. It produces CIL (Common Intermediate Language) text that the
+.NET runtime assembles into PE executables. Adding ILAsm completes
+the "assembly target family" across all three major managed runtimes:
+
+| Runtime | Assembly target | Bytecode layer | Status |
+|---------|----------------|----------------|--------|
+| JVM | Jamaica (symbolic) | jvm_bytecode.pl | Done |
+| JVM | Krakatau (numeric) | jvm_bytecode.pl | Done |
+| .NET | ILAsm | **cil_bytecode.pl** (new) | Planned |
+| Android | smali/baksmali | (future) | Not started |
+
+## Architecture Decision: Shared CIL Layer
+
+Following the JVM pattern where Jamaica and Krakatau share
+`jvm_bytecode.pl` for expression compilation and guard translation,
+ILAsm should have a shared `cil_bytecode.pl` module. Even though
+ILAsm is currently the only .NET assembly target, this:
+
+1. Keeps CIL instruction generation separate from output formatting
+2. Enables future targets (e.g., a Mono-specific format, or
+   direct PE emission) to reuse the instruction logic
+3. Follows the proven pattern from JVM
+
+## Relationship to C#
+
+C# (`csharp_target.pl`, `csharp_native_target.pl`) already exists
+as a .NET target. ILAsm is NOT a replacement — it's a lower-level
+alternative, like Jamaica vs Java:
+
+| Level | JVM | .NET |
+|-------|-----|------|
+| High-level language | Java, Kotlin, Scala | C# |
+| Assembly text | Jamaica, Krakatau | **ILAsm** |
+| Binary | .class files | PE/DLL files |
+
+ILAsm is useful when:
+- You need precise control over stack layout and local variables
+- You're generating code for environments without a C# compiler
+- You want to bypass C# syntax constraints (e.g., tail calls,
+  explicit stack manipulation)
+- As a fallback target in the WAM compilation chain
+
+## The Recursive Template-Then-Lower Advantage
+
+Previous assembly targets were built with templates and basic
+`clause_guard_output_split`. The new architecture gives ILAsm
+`classify_goal_sequence` support from day one:
+
+1. **compile_expression hooks** — register 4 multifile renderers
+   and get ite output, disjunction, guarded tail for free
+2. **Shared clause_body_analysis** — the classification pipeline
+   handles pattern detection; ILAsm only provides rendering
+3. **compile_non_recursive routing** — non-recursive predicates
+   go through the full native lowering pipeline
+
+This means ILAsm doesn't need to start with recursion patterns
+and bindings — the shared framework handles non-recursive
+predicates immediately. Recursion patterns and bindings add
+depth incrementally.
+
+## Implementation Priority Order
+
+Traditional approach (used for most targets):
+```
+1. Recursion patterns (TC, tail, linear, tree) via templates
+2. Bindings
+3. Native lowering (if at all)
+```
+
+New approach (leveraging the shared framework):
+```
+1. Scaffold: module + compile_predicate_to_ilasm + basic output
+2. compile_expression hooks (4 renderers) → immediate ite/disj/guard support
+3. classify_goal_sequence integration → full non-recursive coverage
+4. Component registration → custom IL injection
+5. Bindings (cil_asm_bindings.pl) → .NET BCL mappings
+6. Recursion patterns (multifile dispatch) → iterative loops, memoization
+7. Transitive closure template → composable mustache
+```
+
+Steps 1-3 give a working target for non-recursive predicates.
+Steps 4-7 add depth. This is the reverse of the traditional order
+because the shared framework now provides the non-recursive
+infrastructure that previously required target-specific code.
+
+## CIL vs JVM Differences
+
+Key differences that affect code generation:
+
+| Aspect | JVM | CIL |
+|--------|-----|-----|
+| Stack | Operand stack | Evaluation stack (similar) |
+| Locals | `iload`/`istore` by index | `ldloc`/`stloc` by index |
+| Strings | `ldc` pushes constant | `ldstr` pushes string |
+| Method calls | `invokestatic`/`invokevirtual` | `call`/`callvirt` |
+| Branching | `goto`/`if_icmpXX` | `br`/`bge`/`bgt`/`beq` |
+| Returns | `ireturn`/`lreturn` | `ret` (single instruction) |
+| Type system | Separate int/long/float/double | Unified `int32`/`int64`/`float32`/`float64` |
+| Tail calls | No native support | `.tail` prefix |
+
+CIL's `.tail` prefix is significant — it means tail recursion can
+be expressed directly in IL without loop transformation, unlike JVM
+where we must transform to while loops.

--- a/docs/design/ILASM_TARGET_SPECIFICATION.md
+++ b/docs/design/ILASM_TARGET_SPECIFICATION.md
@@ -1,0 +1,203 @@
+# ILAsm Target — Specification
+
+## Module Structure
+
+```
+src/unifyweaver/
+  targets/
+    ilasm_target.pl              — Target module, compilation entry point
+  core/
+    cil_bytecode.pl              — Shared CIL instruction generation
+  bindings/
+    cil_asm_bindings.pl          — .NET BCL instruction bindings
+
+templates/targets/ilasm/
+    transitive_closure.mustache  — TC template (composable)
+    tc_definitions.mustache      — BFS functions in IL
+    tc_input_*.mustache          — Input mode variants
+    tc_interface_cli.mustache    — CLI entry point
+```
+
+## CIL Instruction Generation (`cil_bytecode.pl`)
+
+### Expression Compilation
+
+```prolog
+%% cil_expr_to_instructions(+Expr, +VarMap, -Instructions)
+%  Compile a Prolog arithmetic expression to CIL stack instructions.
+cil_expr_to_instructions(Var, VarMap, ['ldloc', VarName]) :-
+    var(Var), lookup_var(Var, VarMap, VarName).
+cil_expr_to_instructions(N, _, ['ldc.i8', N]) :-
+    integer(N).
+cil_expr_to_instructions(A + B, VarMap, Instrs) :-
+    cil_expr_to_instructions(A, VarMap, AI),
+    cil_expr_to_instructions(B, VarMap, BI),
+    append(AI, BI, AB),
+    append(AB, ['add'], Instrs).
+%% ... similar for -, *, /, mod
+```
+
+### Guard Compilation
+
+```prolog
+%% cil_guard_to_instructions(+Guard, +VarMap, +FalseLabel, -Instructions)
+cil_guard_to_instructions(A > B, VarMap, Label, Instrs) :-
+    cil_expr_to_instructions(A, VarMap, AI),
+    cil_expr_to_instructions(B, VarMap, BI),
+    append(AI, BI, AB),
+    append(AB, [format_atom('ble ~w', [Label])], Instrs).
+```
+
+### If-Chain Assembly
+
+```prolog
+%% cil_if_chain(+Branches, +LabelPrefix, -Instructions)
+%  Assemble pre-compiled branches into CIL if/else chain with labels.
+```
+
+## ILAsm Output Format
+
+### Function Template
+
+```il
+.method public static int64 classify_sign(int64 arg1) cil managed {
+    .maxstack 4
+    .locals init (int64 v1)
+
+    // Guard: arg1 == 0
+    ldarg.0
+    ldc.i8 0
+    beq CLAUSE_0
+
+    // Guard: arg1 > 0
+    ldarg.0
+    ldc.i8 0
+    bgt CLAUSE_1
+
+    // Else: negative
+    ldstr "negative"
+    ret
+
+CLAUSE_0:
+    ldstr "zero"
+    ret
+
+CLAUSE_1:
+    ldstr "positive"
+    ret
+}
+```
+
+### Complete Assembly
+
+```il
+.assembly extern mscorlib {}
+.assembly PrologGenerated {}
+
+.class public auto ansi PrologGenerated.Program extends [mscorlib]System.Object {
+
+    // Generated functions here
+
+    .method public static void Main(string[] args) cil managed {
+        .entrypoint
+        // CLI dispatch
+    }
+}
+```
+
+## compile_expression Hooks
+
+```prolog
+%% render_output_goal(ilasm, Goal, VarMap, Line, VarName, VarMapOut)
+clause_body_analysis:render_output_goal(ilasm, Goal, VarMap, Line, VarName, VarMapOut) :-
+    (   Goal = (Var = Expr), var(Var)
+    ->  ensure_var(VarMap, Var, VarName, VarMapOut),
+        cil_expr_to_instructions(Expr, VarMap, ExprInstrs),
+        cil_instructions_to_text(ExprInstrs, ExprText),
+        format(string(Line), '~w\n    stloc ~w', [ExprText, VarName])
+    ;   ...
+    ).
+
+%% render_guard_condition(ilasm, Goal, VarMap, CondStr)
+clause_body_analysis:render_guard_condition(ilasm, Goal, VarMap, CondStr) :-
+    cil_guard_to_instructions(Goal, VarMap, "L_false", Instrs),
+    cil_instructions_to_text(Instrs, CondStr).
+
+%% render_ite_block(ilasm, Cond, ThenLines, ElseLines, ...)
+clause_body_analysis:render_ite_block(ilasm, Cond, ThenLines, ElseLines, _Indent, _RetVars, Lines) :-
+    %% CIL uses label-based branching, not structured if/else
+    append([Cond, 'L_then:'|ThenLines], ['br L_end', 'L_else:'|ElseLines], Pre),
+    append(Pre, ['L_end:'], Lines).
+```
+
+## Component Integration
+
+```prolog
+%% Register ILAsm as a component type
+:- initialization((
+    catch(
+        register_component_type(source, custom_ilasm, custom_ilasm, [
+            description('Injects custom CIL assembly as a component')
+        ]),
+        _, true
+    )
+)).
+
+%% compile_component for custom IL injection
+ilasm_compile_component(Name, Config, _Options, Code) :-
+    member(code(ILCode), Config),
+    format(string(Code), '// Component: ~w\n~w', [Name, ILCode]).
+```
+
+## Binding Registry
+
+```prolog
+%% cil_asm_bindings.pl — .NET BCL instruction bindings
+
+init_cil_asm_bindings :-
+    %% Arithmetic
+    declare_binding(ilasm, add/3, 'add', [int64, int64], [int64], [pure]),
+    declare_binding(ilasm, sub/3, 'sub', [int64, int64], [int64], [pure]),
+    declare_binding(ilasm, mul/3, 'mul', [int64, int64], [int64], [pure]),
+    declare_binding(ilasm, div/3, 'div', [int64, int64], [int64], [pure]),
+    declare_binding(ilasm, mod/3, 'rem', [int64, int64], [int64], [pure]),
+
+    %% Math (System.Math calls)
+    declare_binding(ilasm, sqrt/2, 'call float64 [mscorlib]System.Math::Sqrt(float64)',
+        [float64], [float64], [pure]),
+    declare_binding(ilasm, abs/2, 'call int64 [mscorlib]System.Math::Abs(int64)',
+        [int64], [int64], [pure]),
+
+    %% String operations
+    declare_binding(ilasm, length/2, 'callvirt instance int32 [mscorlib]System.String::get_Length()',
+        [string], [int32], [pure]),
+
+    %% Console I/O
+    declare_binding(ilasm, print/1, 'call void [mscorlib]System.Console::WriteLine(string)',
+        [string], [], [effect(io)]).
+```
+
+## Type Mapping
+
+```prolog
+%% type_declarations.pl additions
+resolve_type(atom, ilasm, "string").
+resolve_type(string, ilasm, "string").
+resolve_type(integer, ilasm, "int64").
+resolve_type(float, ilasm, "float64").
+resolve_type(number, ilasm, "float64").
+resolve_type(boolean, ilasm, "bool").
+resolve_type(any, ilasm, "object").
+resolve_type(list(Type), ilasm, Concrete) :-
+    resolve_type(Type, ilasm, Inner),
+    format(string(Concrete), "class [mscorlib]System.Collections.Generic.List`1<~w>", [Inner]).
+```
+
+## Seed Statements (Input Source)
+
+```prolog
+seed_statement(ilasm, _BasePred, From, To, Statement) :-
+    format(string(Statement),
+        '    ldstr "~w"\n    ldstr "~w"\n    call void PrologGenerated.Program::AddFact(string, string)',
+        [From, To]).
+```


### PR DESCRIPTION
## Summary

Three design documents for a .NET ILAsm (CIL assembly) target, completing the assembly target family across managed runtimes. The documents account for the shared compile_expression framework, which changes the traditional implementation order for new targets.

## Assembly target family

| Runtime | Target | Bytecode layer | Status |
|---------|--------|----------------|--------|
| JVM | Jamaica (symbolic) | jvm_bytecode.pl | Done |
| JVM | Krakatau (numeric) | jvm_bytecode.pl | Done |
| .NET | **ILAsm** | cil_bytecode.pl (new) | **Designed** |
| Android | smali/baksmali | (future) | Not started |

## Key design decisions

### Hooks first, not recursion templates first

The shared compile_expression framework (22 targets with hooks) changes the implementation order. Previously new targets started with recursion patterns and bindings. Now:

```
1. Scaffold + hooks → immediate ite/disjunction/guarded tail support
2. Components → custom IL injection
3. Bindings → .NET BCL mappings
4. Recursion patterns → iterative loops, .tail calls, memoization
5. TC templates → composable input modes
```

Phase 1 alone gives a working target for non-recursive predicates.

### CIL .tail prefix

CIL has native tail call support via the `.tail` prefix — unlike JVM which requires loop transformation for tail recursion. This means tail-recursive Prolog predicates can compile to `.tail call` instructions directly, preserving the recursive structure while getting optimization from the runtime.

### Shared cil_bytecode.pl

Following the JVM pattern where Jamaica and Krakatau share `jvm_bytecode.pl`, ILAsm will have a shared `cil_bytecode.pl` for CIL instruction generation, guard compilation, and if-chain assembly.

### Component system integration

Follows the pattern from `custom_csharp.pl` and Jamaica/Krakatau — register `custom_ilasm` as a component type for injecting raw CIL assembly as components.

## Documents

| Document | Content |
|----------|---------|
| `ILASM_TARGET_PHILOSOPHY.md` | Why ILAsm, architecture decisions, CIL vs JVM differences, implementation priority rationale |
| `ILASM_TARGET_SPECIFICATION.md` | CIL instruction API, compile_expression hooks, component registration, binding registry, type mapping, seed statements |
| `ILASM_TARGET_IMPLEMENTATION_PLAN.md` | 6-phase plan with dependencies, relationship to C# target, CIL-specific considerations (stack management, locals, .tail calls) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
