### PR TITLE
Start TypR SCC IR extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,10 @@ includes:
   list-shaped predicates recurse through head/tail decomposition or fixed
   two-element forest-pair decomposition or fixed pair-tail forest
   decomposition like `[A, B|Ts]`, plus mixed list/numeric SCCs
-  where list-shaped predicates recurse through head/tail decomposition
-  while numeric predicates recurse through scalar step descent or
-  singleton-list re-entry, plus mixed tree/numeric SCCs
+  where list-shaped predicates recurse through head/tail or pair-tail
+  decomposition like `[A, B|Ts]` while numeric predicates recurse through
+  scalar step descent, singleton-list re-entry, or fixed pair-list
+  re-entry, plus mixed tree/numeric SCCs
   where tree-shaped predicates recurse through current-value and one-
   subtree descent while numeric predicates recurse through scalar step
   descent or constructed tree re-entry, plus mixed tree/list/numeric SCCs
@@ -298,8 +299,8 @@ includes:
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
 - the next confirmed SCC gap is broader than another structural micro-slice:
-  mixed list/numeric pair-tail SCCs and mixed tree/numeric SCCs with local
-  helper goals between recursive group calls still fail with
+  mixed tree/numeric SCCs with local helper goals between recursive group
+  calls still fail with
   `No mutual recursion support for target typr`, which points to a shared
   SCC IR as the next compiler step rather than more matcher families
 - conservative `N`-ary structural tree-recursive predicates with one

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -258,14 +258,15 @@ bring-up.
     call prefix, plus integer-return and threaded-context variants
   - stop extending `typr_mutual_supported_spec/3` with more bespoke
     structural slices once the next failure is outside that subset
-  - the first confirmed post-audit unsupported SCCs are:
-    - mixed list/numeric pair-tail decompositions
+  - the first SCC IR-backed slice should cover per-predicate ordered goal
+    bodies, and it now does so for mixed list/numeric pair-tail
+    decompositions
+  - the next confirmed unsupported SCCs are:
     - mixed tree/numeric bodies with local helper goals between recursive
       group calls
-  - the next implementation step should be a shared SCC IR that can encode
-    per-predicate ordered goal bodies, branch nodes, recursive call sites,
-    helper goals, and symbolic result bindings before another backend
-    expansion
+  - the next implementation step should expand that shared SCC IR to
+    encode helper goals, richer branch nodes, and symbolic result bindings
+    before another backend expansion
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -440,12 +440,14 @@ Current TypR lowering policy is intentionally mixed:
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
 - the next confirmed unsupported SCC shapes are now beyond that structural
-  subset, including mixed list/numeric pair-tail decompositions and mixed
-  tree/numeric bodies with local helper goals between recursive group calls
-- those shapes point to a shared SCC IR requirement: per-predicate body
-  lowering for ordered goals, recursive call sites, helper goals, branch
-  nodes, and symbolic result bindings that is independent of the current
-  structural-driver matcher family
+  subset, including mixed tree/numeric bodies with local helper goals
+  between recursive group calls
+- the first SCC IR-backed slice is now in place for per-predicate ordered
+  call bodies, which is enough to keep mixed list/numeric pair-tail
+  decompositions native
+- the next expansion point is still shared SCC IR lowering for helper
+  goals, branch nodes, and symbolic result bindings that is independent of
+  the current structural-driver matcher family
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -173,17 +173,19 @@ This document focuses on architecture and rollout choices specific to TypR.
    guarded full-body subset.
 
 8. The next confirmed unsupported SCC shapes are:
-   - mixed list/numeric SCCs where the list side uses pair-tail
-     decomposition like `[A, B|Ts]`
    - mixed tree/numeric SCCs where a local helper goal sits between
      recursive group calls, for example selecting a subtree through a helper
      predicate instead of a currently supported guarded body form
+   - broader SCCs where a predicate body needs helper-goal nodes outside
+     the current structural-driver and guarded full-body subset
 
 9. Those failures are the point to stop adding bespoke matcher families.
-   They all still fail with `No mutual recursion support for target typr`,
-   but they no longer share a small structural extension point.
+   The first SCC IR-backed slice is now in place for per-predicate ordered
+   call bodies, which is enough to keep mixed list/numeric pair-tail
+   decompositions native, but the remaining failures no longer share a
+   small structural extension point.
 
-10. The next TypR mutual-recursion step should therefore introduce a shared
+10. The next TypR mutual-recursion step should therefore expand that shared
     SCC IR with:
     - per-predicate ordered goal bodies
     - explicit SCC call-site nodes with symbolic call arguments and result

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -79,8 +79,14 @@ mutual_recursion:compile_mutual_pattern(typr, Predicates, MemoEnabled, _MemoStra
 
 compile_typr_mutual_recursion_group(Predicates0, MemoEnabled, Code) :-
     sort(Predicates0, Predicates),
-    maplist(typr_mutual_supported_spec(Predicates), Predicates, Specs),
+    maplist(typr_mutual_pred_spec(Predicates), Predicates, Specs),
     typr_mutual_group_code(Specs, MemoEnabled, Code).
+
+typr_mutual_pred_spec(GroupPredicates, PredArity, Spec) :-
+    typr_mutual_supported_spec(GroupPredicates, PredArity, Spec),
+    !.
+typr_mutual_pred_spec(GroupPredicates, PredArity, Spec) :-
+    typr_mutual_ir_supported_spec(GroupPredicates, PredArity, Spec).
 
 typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
     (   typr_mutual_numeric_spec(GroupPredicates, PredArity, Spec)
@@ -105,6 +111,59 @@ typr_mutual_supported_spec(GroupPredicates, PredArity, Spec) :-
     ;   typr_mutual_tree_dual_spec(GroupPredicates, PredArity, Spec)
     ;   typr_mutual_tree_spec(GroupPredicates, PredArity, Spec)
     ).
+
+typr_mutual_ir_supported_spec(GroupPredicates, PredArity, Spec) :-
+    typr_mutual_extract_pred_ir(GroupPredicates, PredArity, PredIR),
+    typr_mutual_ir_pred_to_spec(PredIR, Spec).
+
+typr_mutual_extract_pred_ir(GroupPredicates, PredArity, PredIR) :-
+    typr_mutual_list_pair_tail_bool_ir(GroupPredicates, PredArity, PredIR).
+typr_mutual_extract_pred_ir(GroupPredicates, PredArity, PredIR) :-
+    typr_mutual_list_pair_tail_value_ir(GroupPredicates, PredArity, PredIR).
+
+typr_mutual_ir_pred_to_spec(PredIR, Spec) :-
+    ordered_bool_body = PredIR.ir_kind,
+    OrderedCalls = PredIR.ordered_calls,
+    maplist(typr_mutual_ir_call_step, OrderedCalls, Steps),
+    Spec = mutual_spec{
+        kind: tree_dual_body,
+        pred: PredIR.pred,
+        arity: PredIR.arity,
+        pred_str: PredIR.pred_str,
+        typed_arg_list: PredIR.typed_arg_list,
+        return_type: PredIR.return_type,
+        helper_name: PredIR.helper_name,
+        base_conditions: PredIR.base_conditions,
+        guard_expr: PredIR.guard_expr,
+        body: branch_steps(Steps)
+    }.
+typr_mutual_ir_pred_to_spec(PredIR, Spec) :-
+    ordered_value_body = PredIR.ir_kind,
+    OrderedCalls = PredIR.ordered_calls,
+    maplist(typr_mutual_ir_value_call_binding, OrderedCalls, CallBindings),
+    Spec = mutual_spec{
+        kind: tree_dual_value_full_body,
+        pred: PredIR.pred,
+        arity: PredIR.arity,
+        pred_str: PredIR.pred_str,
+        typed_arg_list: PredIR.typed_arg_list,
+        return_type: PredIR.return_type,
+        helper_name: PredIR.helper_name,
+        helper_params: PredIR.helper_params,
+        wrapper_call_args: PredIR.wrapper_call_args,
+        memo_key_expr: PredIR.memo_key_expr,
+        base_cases: PredIR.base_cases,
+        guard_expr: PredIR.guard_expr,
+        body: value_branch_leaf(CallBindings, PredIR.result_expr)
+    }.
+
+typr_mutual_ir_call_step(ir_call(ResultKey, NextPred, CallArgs), step_call(ResultKey, branch_call(HelperName, CallArgs))) :-
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]).
+
+typr_mutual_ir_value_call_binding(ir_call(ResultKey, NextPred, CallArgs), value_call_binding(ResultKey, branch_call(HelperName, CallArgs))) :-
+    atom_string(NextPred, NextPredStr),
+    format(string(HelperName), '~w_impl', [NextPredStr]).
 
 typr_mutual_numeric_spec(GroupPredicates, Pred/Arity, Spec) :-
     Arity =:= 1,
@@ -505,6 +564,112 @@ typr_mutual_list_pair_tail_branch_step(call_spec(Slot, NextPred, CallArgs), step
     atom_string(NextPred, NextPredStr),
     format(string(HelperName), '~w_impl', [NextPredStr]),
     typr_mutual_tree_result_name(Slot, ResultName).
+
+typr_mutual_ir_call_from_spec(call_spec(ResultKey, NextPred, CallArgs), ir_call(ResultKey, NextPred, CallArgs)).
+
+typr_mutual_ir_value_call_from_spec(
+    value_call_spec(ResultKey, NextPred, CallArgs, OutputVar),
+    ir_call(ResultKey, NextPred, CallArgs),
+    result_binding(OutputVar, ResultName)
+) :-
+    typr_mutual_tree_result_name(ResultKey, ResultName).
+
+typr_mutual_list_pair_tail_bool_ir(GroupPredicates, Pred/Arity, PredIR) :-
+    Arity =:= 1,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "bool"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    maplist(typr_mutual_list_empty_base_condition, BaseClauses, BaseConds0),
+    sort(BaseConds0, BaseConditions),
+    RecHead =.. [_PredName, RecInputPattern],
+    typr_mutual_list_pair_tail_driver(RecInputPattern, pair_tail, FirstVar, SecondVar, TailVar, GuardExpr),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals_allow_empty_post(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    PostGoals == [],
+    RecGoals = [_, _, _],
+    maplist(
+        typr_mutual_list_pair_tail_recursive_goal(GroupPredicates, FirstVar, SecondVar, TailVar, []),
+        RecGoals,
+        CallSpecs0
+    ),
+    typr_mutual_list_pair_tail_call_specs(CallSpecs0, OrderedSpecs),
+    maplist(typr_mutual_ir_call_from_spec, OrderedSpecs, OrderedCalls),
+    atom_string(Pred, PredStr),
+    format(string(HelperName), '~w_impl', [PredStr]),
+    PredIR = scc_ir_pred{
+        ir_kind: ordered_bool_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "bool",
+        helper_name: HelperName,
+        base_conditions: BaseConditions,
+        guard_expr: GuardExpr,
+        ordered_calls: OrderedCalls
+    }.
+
+typr_mutual_list_pair_tail_value_ir(GroupPredicates, Pred/Arity, PredIR) :-
+    Arity >= 2,
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses \= [],
+    generic_typr_return_type(Pred/Arity, Clauses, "int"),
+    build_typed_arg_list(Pred/Arity, none, Arity, explicit, TypedArgList),
+    findall(clause(Head, Body), predicate_clause(user, Pred, Arity, Head, Body), ClauseTerms),
+    partition(typr_is_mutual_recursive_clause(GroupPredicates), ClauseTerms, RecClauses, BaseClauses),
+    RecClauses = [clause(RecHead, RecBody)],
+    BaseClauses \= [],
+    RecHead =.. [_PredName, RecInputPattern|ContextAndOutputVars],
+    typr_mutual_list_pair_tail_driver(RecInputPattern, pair_tail, FirstVar, SecondVar, TailVar, GuardExpr),
+    append(ContextVars, [OutputVar], ContextAndOutputVars),
+    var(OutputVar),
+    typr_mutual_tree_context_param_names(ContextVars, ContextParamNames),
+    maplist(typr_mutual_list_empty_value_base_case(ContextParamNames), BaseClauses, BaseCases),
+    typr_mutual_goal_list(RecBody, Goals0),
+    maplist(typr_strip_module_goal, Goals0, Goals),
+    split_typr_mutual_multicall_goals(GroupPredicates, Goals, PreGoals, RecGoals, PostGoals),
+    PreGoals == [],
+    RecGoals = [_, _, _],
+    typr_mutual_tree_context_fields(Pred, ContextVars, HelperName, ExtraArgMap, HelperParams, WrapperCallArgs, MemoKeyExpr),
+    maplist(
+        typr_mutual_list_pair_tail_value_recursive_goal(GroupPredicates, FirstVar, SecondVar, TailVar, ExtraArgMap),
+        RecGoals,
+        CallSpecs0
+    ),
+    typr_mutual_list_pair_tail_value_call_specs(CallSpecs0, OrderedSpecs),
+    maplist(typr_mutual_ir_value_call_from_spec, OrderedSpecs, OrderedCalls, ResultBindings),
+    typr_goals_to_body(PostGoals, PostBody),
+    typr_mutual_result_expr_from_bindings(
+        PostBody,
+        OutputVar,
+        ExtraArgMap,
+        ResultBindings,
+        ResultExpr
+    ),
+    atom_string(Pred, PredStr),
+    PredIR = scc_ir_pred{
+        ir_kind: ordered_value_body,
+        pred: Pred,
+        arity: Arity,
+        pred_str: PredStr,
+        typed_arg_list: TypedArgList,
+        return_type: "int",
+        helper_name: HelperName,
+        helper_params: HelperParams,
+        wrapper_call_args: WrapperCallArgs,
+        memo_key_expr: MemoKeyExpr,
+        base_cases: BaseCases,
+        guard_expr: GuardExpr,
+        ordered_calls: OrderedCalls,
+        result_expr: ResultExpr
+    }.
 
 typr_mutual_tree_value_subtree_driver_expr(ValueVar, _AliasMap, RecArg, left, '.subset2(current_input, 1)') :-
     var(RecArg),
@@ -2160,6 +2325,18 @@ typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg0, StepExpr) :-
     !,
     typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, InnerExpr),
     format(string(StepExpr), 'list(~w, list(), list())', [InnerExpr]).
+typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg0, StepExpr) :-
+    nonvar(RecArg0),
+    is_list(RecArg0),
+    RecArg0 = [_, _|_],
+    !,
+    maplist(
+        typr_mutual_recursive_arg_list_item_expr(HeadVar, Computations),
+        RecArg0,
+        ItemExprs
+    ),
+    atomic_list_concat(ItemExprs, ', ', ArgsText),
+    format(string(StepExpr), 'list(~w)', [ArgsText]).
 typr_mutual_recursive_arg_expr(HeadVar, Computations, RecArg, StepExpr) :-
     var(RecArg),
     member(StepVar is StepTerm, Computations),
@@ -2170,6 +2347,13 @@ typr_mutual_recursive_arg_expr(_HeadVar, _Computations, RecArg, StepExpr) :-
     atomic(RecArg),
     !,
     typr_translate_r_expr(RecArg, [], StepExpr).
+
+typr_mutual_recursive_arg_list_item_expr(_HeadVar, _Computations, Item, 'list()') :-
+    nonvar(Item),
+    Item == [],
+    !.
+typr_mutual_recursive_arg_list_item_expr(HeadVar, Computations, Item, Expr) :-
+    typr_mutual_recursive_arg_expr(HeadVar, Computations, Item, Expr).
 
 typr_mutual_goal_list((A, B), Goals) :-
     !,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -4115,6 +4115,114 @@ test(recursive_compiler_supports_typr_mixed_list_numeric_mutual_integer_context_
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_mixed_list_numeric_pair_tail_mutual_boolean_group) :-
+    clear_type_declarations,
+    assertz(user:typr_pair_tail_list_num_ok([])),
+    assertz(user:(typr_pair_tail_list_num_ok([A, B|Ts]) :-
+        typr_pair_tail_num_list_ok(A),
+        typr_pair_tail_num_list_ok(B),
+        typr_pair_tail_list_num_ok(Ts)
+    )),
+    assertz(user:typr_pair_tail_num_list_ok(0)),
+    assertz(user:typr_pair_tail_num_list_ok(1)),
+    assertz(user:(typr_pair_tail_num_list_ok(N) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        typr_pair_tail_list_num_ok([N1, N2])
+    )),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_list_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_num_list_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_pair_tail_list_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_pair_tail_list_num_ok/1, typr_pair_tail_num_list_ok/1")),
+    once(sub_string(Code, _, _, _, "let typr_pair_tail_list_num_ok <- fn(arg1: [#N, Any]): bool")),
+    once(sub_string(Code, _, _, _, "first_result = typr_pair_tail_num_list_ok_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "second_result = typr_pair_tail_num_list_ok_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "tail_result = typr_pair_tail_list_num_ok_impl(tail(current_input, -2));")),
+    once(sub_string(Code, _, _, _, "result = first_result && second_result && tail_result;")),
+    once(sub_string(Code, _, _, _, "result = typr_pair_tail_list_num_ok_impl(list((current_input + -1), (current_input + -2)));")),
+    \+ sub_string(Code, _, _, _, "result = typr_pair_tail_list_num_ok_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_list_numeric_pair_tail_mutual_integer_group) :-
+    clear_type_declarations,
+    assertz(user:typr_pair_tail_list_num_sum([], 0)),
+    assertz(user:(typr_pair_tail_list_num_sum([A, B|Ts], S) :-
+        typr_pair_tail_num_list_sum(A, SA),
+        typr_pair_tail_num_list_sum(B, SB),
+        typr_pair_tail_list_num_sum(Ts, ST),
+        S is SA + SB + ST
+    )),
+    assertz(user:typr_pair_tail_num_list_sum(0, 0)),
+    assertz(user:typr_pair_tail_num_list_sum(1, 1)),
+    assertz(user:(typr_pair_tail_num_list_sum(N, S) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        typr_pair_tail_list_num_sum([N1, N2], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_sum/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_list_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_num_list_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_pair_tail_list_num_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_pair_tail_list_num_sum/2, typr_pair_tail_num_list_sum/2")),
+    once(sub_string(Code, _, _, _, "let typr_pair_tail_list_num_sum <- fn(arg1: [#N, Any], arg2: int): int")),
+    once(sub_string(Code, _, _, _, "first_result = typr_pair_tail_num_list_sum_impl(.subset2(current_input, 1));")),
+    once(sub_string(Code, _, _, _, "second_result = typr_pair_tail_num_list_sum_impl(.subset2(current_input, 2));")),
+    once(sub_string(Code, _, _, _, "tail_result = typr_pair_tail_list_num_sum_impl(tail(current_input, -2));")),
+    once(sub_string(Code, _, _, _, "result = ((first_result + second_result) + tail_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_pair_tail_list_num_sum_impl(list((current_input + -1), (current_input + -2)));")),
+    once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_pair_tail_list_num_sum_impl((current_input + -1));"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_list_numeric_pair_tail_mutual_integer_context_group) :-
+    clear_type_declarations,
+    assertz(user:typr_pair_tail_list_num_weight([], _W0, 0)),
+    assertz(user:(typr_pair_tail_list_num_weight([A, B|Ts], W, S) :-
+        typr_pair_tail_num_list_weight(A, W, SA),
+        typr_pair_tail_num_list_weight(B, W, SB),
+        typr_pair_tail_list_num_weight(Ts, W, ST),
+        S is SA + SB + ST
+    )),
+    assertz(user:typr_pair_tail_num_list_weight(0, _W1, 0)),
+    assertz(user:typr_pair_tail_num_list_weight(1, W, W)),
+    assertz(user:(typr_pair_tail_num_list_weight(N, W, S) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        typr_pair_tail_list_num_weight([N1, N2], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_weight/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_list_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_num_list_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_pair_tail_list_num_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_pair_tail_list_num_weight/3, typr_pair_tail_num_list_weight/3")),
+    once(sub_string(Code, _, _, _, "let typr_pair_tail_list_num_weight <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+    once(sub_string(Code, _, _, _, "first_result = typr_pair_tail_num_list_weight_impl(.subset2(current_input, 1), current_ctx);")),
+    once(sub_string(Code, _, _, _, "second_result = typr_pair_tail_num_list_weight_impl(.subset2(current_input, 2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "tail_result = typr_pair_tail_list_num_weight_impl(tail(current_input, -2), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((first_result + second_result) + tail_result);")),
+    once(sub_string(Code, _, _, _, "left_result = typr_pair_tail_list_num_weight_impl(list((current_input + -1), (current_input + -2)), current_ctx);")),
+    once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
+    \+ sub_string(Code, _, _, _, "left_result = typr_pair_tail_list_num_weight_impl((current_input + -1), current_ctx);"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_boolean_group) :-
     clear_type_declarations,
     assertz(user:typr_tree_num_ok([])),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -3069,6 +3069,115 @@ test(mixed_list_numeric_mutual_integer_context_output_checks_with_typr, [conditi
     retractall(user:typr_mutual_weight_list_num(_, _, _)),
     retractall(user:typr_mutual_weight_num_list(_, _, _)).
 
+test(mixed_list_numeric_pair_tail_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_pair_tail_list_num_ok([])),
+    assertz(user:(typr_pair_tail_list_num_ok([A, B|Ts]) :-
+        typr_pair_tail_num_list_ok(A),
+        typr_pair_tail_num_list_ok(B),
+        typr_pair_tail_list_num_ok(Ts)
+    )),
+    assertz(user:typr_pair_tail_num_list_ok(0)),
+    assertz(user:typr_pair_tail_num_list_ok(1)),
+    assertz(user:(typr_pair_tail_num_list_ok(N) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        typr_pair_tail_list_num_ok([N1, N2])
+    )),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_ok/1, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_ok/1, 1, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_list_num_ok/1, bool)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_num_list_ok/1, bool)),
+    once(recursive_compiler:compile_recursive(typr_pair_tail_list_num_ok/1, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_pair_tail_list_num_ok(_)),
+    retractall(user:typr_pair_tail_num_list_ok(_)).
+
+test(mixed_list_numeric_pair_tail_mutual_integer_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_pair_tail_list_num_sum([], 0)),
+    assertz(user:(typr_pair_tail_list_num_sum([A, B|Ts], S) :-
+        typr_pair_tail_num_list_sum(A, SA),
+        typr_pair_tail_num_list_sum(B, SB),
+        typr_pair_tail_list_num_sum(Ts, ST),
+        S is SA + SB + ST
+    )),
+    assertz(user:typr_pair_tail_num_list_sum(0, 0)),
+    assertz(user:typr_pair_tail_num_list_sum(1, 1)),
+    assertz(user:(typr_pair_tail_num_list_sum(N, S) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        typr_pair_tail_list_num_sum([N1, N2], Parts),
+        S is N + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_sum/2, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_sum/2, 2, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_sum/2, 1, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_sum/2, 2, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_list_num_sum/2, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_num_list_sum/2, integer)),
+    once(recursive_compiler:compile_recursive(typr_pair_tail_list_num_sum/2, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_pair_tail_list_num_sum(_, _)),
+    retractall(user:typr_pair_tail_num_list_sum(_, _)).
+
+test(mixed_list_numeric_pair_tail_mutual_integer_context_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:typr_pair_tail_list_num_weight([], _W0, 0)),
+    assertz(user:(typr_pair_tail_list_num_weight([A, B|Ts], W, S) :-
+        typr_pair_tail_num_list_weight(A, W, SA),
+        typr_pair_tail_num_list_weight(B, W, SB),
+        typr_pair_tail_list_num_weight(Ts, W, ST),
+        S is SA + SB + ST
+    )),
+    assertz(user:typr_pair_tail_num_list_weight(0, _W1, 0)),
+    assertz(user:typr_pair_tail_num_list_weight(1, W, W)),
+    assertz(user:(typr_pair_tail_num_list_weight(N, W, S) :-
+        N > 1,
+        N1 is N - 1,
+        N2 is N - 2,
+        typr_pair_tail_list_num_weight([N1, N2], W, Parts),
+        S is (N * W) + Parts
+    )),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_weight/3, 1, list(any))),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_list_num_weight/3, 3, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_weight/3, 1, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_weight/3, 2, integer)),
+    assertz(type_declarations:uw_type(typr_pair_tail_num_list_weight/3, 3, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_list_num_weight/3, integer)),
+    assertz(type_declarations:uw_return_type(typr_pair_tail_num_list_weight/3, integer)),
+    once(recursive_compiler:compile_recursive(typr_pair_tail_list_num_weight/3, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:typr_pair_tail_list_num_weight(_, _, _)),
+    retractall(user:typr_pair_tail_num_list_weight(_, _, _)).
+
 test(mixed_tree_numeric_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:typr_tree_num_ok([])),


### PR DESCRIPTION
## Summary

This PR starts SCC IR-backed lowering for native TypR mutual recursion.

It keeps conservative mixed list/numeric SCCs native when the list-side predicate uses pair-tail decomposition like `[A, B|Ts]` and the numeric-side predicate re-enters the list side with a constructed pair.

Representative supported shapes now include:

- boolean mixed list/numeric pair-tail SCCs such as `typr_pair_tail_list_num_ok/1` and `typr_pair_tail_num_list_ok/1`
- integer-return mixed list/numeric pair-tail SCCs such as `typr_pair_tail_list_num_sum/2` and `typr_pair_tail_num_list_sum/2`
- context-threaded integer-return mixed list/numeric pair-tail SCCs such as `typr_pair_tail_list_num_weight/3` and `typr_pair_tail_num_list_weight/3`

## Why This PR Exists

The SCC IR boundary work identified mixed list/numeric pair-tail SCCs as the first real unsupported slice beyond the old matcher family.

That made this the right proving case for IR extraction:

- it is still conservative and structurally analyzable
- it requires ordered per-predicate SCC call bodies rather than another homogeneous whole-group matcher
- it confirms that the next step should be IR-backed per-predicate lowering, not more `typr_mutual_supported_spec/3` families

Before this change, these SCCs failed because the native TypR mutual backend could not:

- extract ordered call bodies for pair-tail list predicates like `[A, B|Ts]`
- lower a mixed list/numeric SCC through a per-predicate fallback path
- preserve constructed pair re-entry on the numeric side as a wrapped TypR list value

## Main Changes

- kept the legacy `typr_mutual_supported_spec/3` matcher path intact in `src/unifyweaver/targets/typr_target.pl`
- added an IR-backed per-predicate fallback for ordered SCC call bodies
- used that fallback for mixed list/numeric pair-tail predicates with three ordered calls:
  - first numeric call on `A`
  - second numeric call on `B`
  - recursive list call on `Ts`
- generalized recursive-argument lowering so numeric-side constructed pair re-entry stays wrapped as `list(x, y)` instead of dropping the pair structure
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR docs to mark mixed list/numeric pair-tail SCCs as supported and to narrow the next unsupported SCC boundary accordingly

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not replace the full mutual-recursion backend.

It introduces the first real IR-backed SCC path while keeping the legacy matcher family in place for the already-supported subset.

The next confirmed unsupported SCC slices are still broader than this change, including:

- mixed tree/numeric SCCs with helper goals between recursive group calls
- broader SCC groups that no longer fit the current structural-driver or supported guarded full-body subset

Those should continue through the shared SCC IR path rather than another run of bespoke matcher families.
