### PR TITLE
feat: VB.NET composable TC validated, deepen C/Rust/Lua native lowering

### DIFF
--- a/tests/core/test_c_native_lowering.pl
+++ b/tests/core/test_c_native_lowering.pl
@@ -129,6 +129,44 @@ test(c_uses_exit) :-
     retractall(user:only_pos(_, _)).
 
 % ============================================================================
+% Expanded: three-clause classify
+% ============================================================================
+
+test(three_clause_classify) :-
+    assert(user:(grade(X, low) :- X < 50)),
+    assert(user:(grade(X, mid) :- X >= 50, X < 80)),
+    assert(user:(grade(X, high) :- X >= 80)),
+    compile_c(grade/2, Code),
+    has(Code, "arg1 < 50"),
+    has(Code, "arg1 >= 50"),
+    has(Code, "arg1 >= 80"),
+    has(Code, "\"low\""),
+    has(Code, "\"high\""),
+    retractall(user:grade(_, _)).
+
+test(mod_guard) :-
+    assert(user:(parity(X, even) :- 0 =:= X mod 2)),
+    assert(user:(parity(X, odd) :- 0 =\= X mod 2)),
+    compile_c(parity/2, Code),
+    has(Code, "%"),
+    has(Code, "\"even\""),
+    has(Code, "\"odd\""),
+    retractall(user:parity(_, _)).
+
+test(complex_arithmetic) :-
+    assert(user:(formula(X, Y) :- Y is (X * X) + (X * 2) + 1)),
+    compile_c(formula/2, Code),
+    has(Code, "arg1 * arg1"),
+    has(Code, "arg1 * 2"),
+    retractall(user:formula(_, _)).
+
+test(negation_output) :-
+    assert(user:(negate(X, Y) :- Y is 0 - X)),
+    compile_c(negate/2, Code),
+    has(Code, "0 - arg1"),
+    retractall(user:negate(_, _)).
+
+% ============================================================================
 % Verify shared module is loaded
 % ============================================================================
 

--- a/tests/core/test_lua_native_lowering.pl
+++ b/tests/core/test_lua_native_lowering.pl
@@ -130,6 +130,41 @@ test(lua_uses_error) :-
     retractall(user:only_pos(_, _)).
 
 % ============================================================================
+% Expanded: three-clause, mod guards, complex arithmetic
+% ============================================================================
+
+test(three_clause_classify) :-
+    assert(user:(tier(X, low) :- X < 50)),
+    assert(user:(tier(X, mid) :- X >= 50, X < 80)),
+    assert(user:(tier(X, high) :- X >= 80)),
+    compile_lua(tier/2, Code),
+    has(Code, "arg1 < 50"),
+    has(Code, "arg1 >= 80"),
+    has(Code, "\"low\""),
+    has(Code, "\"high\""),
+    retractall(user:tier(_, _)).
+
+test(mod_guard) :-
+    assert(user:(parity(X, even) :- 0 =:= X mod 2)),
+    assert(user:(parity(X, odd) :- 0 =\= X mod 2)),
+    compile_lua(parity/2, Code),
+    has(Code, "%"),  % Lua uses % for modulo
+    has(Code, "\"even\""),
+    retractall(user:parity(_, _)).
+
+test(complex_arithmetic) :-
+    assert(user:(formula(X, Y) :- Y is (X * X) + (X * 2) + 1)),
+    compile_lua(formula/2, Code),
+    has(Code, "arg1 * arg1"),
+    retractall(user:formula(_, _)).
+
+test(negation_output) :-
+    assert(user:(negate(X, Y) :- Y is 0 - X)),
+    compile_lua(negate/2, Code),
+    has(Code, "0 - arg1"),
+    retractall(user:negate(_, _)).
+
+% ============================================================================
 % Verify shared module is loaded
 % ============================================================================
 

--- a/tests/core/test_rust_native_lowering.pl
+++ b/tests/core/test_rust_native_lowering.pl
@@ -129,6 +129,42 @@ test(rust_uses_i64_type) :-
     retractall(user:id2(_, _)).
 
 % ============================================================================
+% Expanded: three-clause classify
+% ============================================================================
+
+test(three_clause_classify) :-
+    assert(user:(grade(X, low) :- X < 50)),
+    assert(user:(grade(X, mid) :- X >= 50, X < 80)),
+    assert(user:(grade(X, high) :- X >= 80)),
+    compile_rs(grade/2, Code),
+    has(Code, "arg1 < 50"),
+    has(Code, "arg1 >= 80"),
+    has(Code, "\"low\""),
+    has(Code, "\"high\""),
+    retractall(user:grade(_, _)).
+
+test(mod_guard) :-
+    assert(user:(parity(X, even) :- 0 =:= X mod 2)),
+    assert(user:(parity(X, odd) :- 0 =\= X mod 2)),
+    compile_rs(parity/2, Code),
+    has(Code, "%"),
+    has(Code, "\"even\""),
+    retractall(user:parity(_, _)).
+
+test(complex_arithmetic) :-
+    assert(user:(formula(X, Y) :- Y is (X * X) + (X * 2) + 1)),
+    compile_rs(formula/2, Code),
+    has(Code, "arg1 * arg1"),
+    has(Code, "arg1 * 2"),
+    retractall(user:formula(_, _)).
+
+test(negation_output) :-
+    assert(user:(negate(X, Y) :- Y is 0 - X)),
+    compile_rs(negate/2, Code),
+    has(Code, "0 - arg1"),
+    retractall(user:negate(_, _)).
+
+% ============================================================================
 % Verify shared module is loaded
 % ============================================================================
 


### PR DESCRIPTION
## Summary

- Runtime validate VB.NET composable TC (4 queries including find_all)
- Deepen C, Rust, Lua native lowering tests from 12 to 16 each (+12 new tests total)
- Total validated TC targets: 10

## VB.NET Composable TC Validation

Tested via proot debian (dotnet 9.0.308), graph `a->b->c->d, a->e->f`:

| Query | Result |
|-------|--------|
| `ancestor(a, d)` | `a:d` exit 0 |
| `ancestor(d, a)` | exit 1 |
| `ancestor(a, f)` | `a:f` exit 0 |
| `find_all(a)` | `a:b a:e a:c a:d` exit 0 |

No `{{>` partial bugs — VB.NET templates use correct concatenation pattern.

## Cross-Target TC Validation (10 targets)

| Target | Tool | Status |
|--------|------|--------|
| C | cc | Pass |
| C++ | g++ | Pass |
| Rust | rustc | Pass |
| Go | go run | Pass |
| Lua | lua | Pass |
| Python | python3 | Pass |
| AWK | gawk | Pass |
| Jamaica | assembler + java | Pass |
| Krakatau | krak2 + java | Pass |
| VB.NET | dotnet (proot) | Pass |

## Deepened Tests (+4 per target)

| Test | C | Rust | Lua | Description |
|------|:---:|:---:|:---:|-------------|
| `three_clause_classify` | Pass | Pass | Pass | 3-branch if/else chain |
| `mod_guard` | Pass | Pass | Pass | `X mod 2` in guard |
| `complex_arithmetic` | Pass | Pass | Pass | `(X*X) + (X*2) + 1` |
| `negation_output` | Pass | Pass | Pass | `0 - X` subtraction |

Note: Pre-existing failures in `nested_if_then_else` and `three_way_nested` tests (C, Rust, Lua) are unchanged and not related to this PR.

## Test plan

- [x] All 12 new tests pass (4 per target × 3 targets)
- [x] 115/115 JVM assembly tests pass
- [x] 95/95 WAT tests pass
- [x] VB.NET composable TC runtime validated (4 queries)
- [x] No new regressions
