### PR TITLE
Start native TypR SCC helper goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,14 @@ includes:
   lowered to TypR
   functions that use raw-expression
   memoized helper bodies inside TypR instead of wrapped-R fallback
+- the first SCC IR-backed helper-goal slice is now in place:
+  mixed tree/numeric SCCs with a local nonrecursive helper goal between
+  recursive group calls now stay native in TypR instead of falling out with
+  `No mutual recursion support for target typr`
 - the next confirmed SCC gap is broader than another structural micro-slice:
-  mixed tree/numeric SCCs with local helper goals between recursive group
-  calls still fail with
-  `No mutual recursion support for target typr`, which points to a shared
-  SCC IR as the next compiler step rather than more matcher families
+  broader helper-goal nodes and richer branch/result structure still point
+  to a shared SCC IR as the next compiler step rather than more matcher
+  families
 - conservative `N`-ary structural tree-recursive predicates with one
   tree-driving argument and invariant context args, such as `tree_sum/2`,
   `tree_height/2`, `weighted_tree_sum/3`, `weighted_tree_affine_sum/4`,

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -258,15 +258,17 @@ bring-up.
     call prefix, plus integer-return and threaded-context variants
   - stop extending `typr_mutual_supported_spec/3` with more bespoke
     structural slices once the next failure is outside that subset
-  - the first SCC IR-backed slice should cover per-predicate ordered goal
-    bodies, and it now does so for mixed list/numeric pair-tail
-    decompositions
-  - the next confirmed unsupported SCCs are:
-    - mixed tree/numeric bodies with local helper goals between recursive
-      group calls
-  - the next implementation step should expand that shared SCC IR to
-    encode helper goals, richer branch nodes, and symbolic result bindings
-    before another backend expansion
+  - the first SCC IR-backed slice now covers per-predicate ordered goal
+    bodies for mixed list/numeric pair-tail decompositions
+  - the next SCC IR-backed slice now also covers mixed tree/numeric bodies
+    with a local nonrecursive helper goal between recursive group calls
+  - the next confirmed unsupported SCCs are broader than that conservative
+    helper case:
+    - helper-goal nodes that cannot be handled by local inline expansion
+    - richer branch nodes and symbolic result bindings beyond the current
+      conservative helper-goal path
+  - the next implementation step should therefore keep expanding the shared
+    SCC IR instead of adding more matcher families
   - conservative `N`-ary structural tree-recursive predicates lowered to
     TypR-valid functions with raw-expression structural helper bodies for
     the currently supported `[]` / `[V, L, R]` shape with invariant context

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -439,15 +439,14 @@ Current TypR lowering policy is intentionally mixed:
   prefix, plus integer-return and threaded-context variants,
   using raw-expression memoized helper bodies inside TypR rather than
   wrapped-R fallback
-- the next confirmed unsupported SCC shapes are now beyond that structural
-  subset, including mixed tree/numeric bodies with local helper goals
-  between recursive group calls
-- the first SCC IR-backed slice is now in place for per-predicate ordered
-  call bodies, which is enough to keep mixed list/numeric pair-tail
-  decompositions native
-- the next expansion point is still shared SCC IR lowering for helper
-  goals, branch nodes, and symbolic result bindings that is independent of
-  the current structural-driver matcher family
+- the first SCC IR-backed slices are now in place for per-predicate
+  ordered call bodies and for conservative mixed tree/numeric bodies with
+  a local nonrecursive helper goal between recursive group calls
+- the next confirmed unsupported SCC shapes are now beyond that
+  conservative helper-goal step, which means shared SCC IR lowering still
+  needs broader helper-goal nodes, branch nodes, and symbolic result
+  bindings that are independent of the current structural-driver matcher
+  family
 - conservative `N`-ary structural tree-recursive predicates may also lower
   to TypR-valid functions when they match the currently supported `[]` /
   `[V, L, R]` shape with one tree-driving argument, invariant context args,

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -172,20 +172,23 @@ This document focuses on architecture and rollout choices specific to TypR.
    and SCCs that no longer fit the current structural-driver or supported
    guarded full-body subset.
 
-8. The next confirmed unsupported SCC shapes are:
-   - mixed tree/numeric SCCs where a local helper goal sits between
-     recursive group calls, for example selecting a subtree through a helper
-     predicate instead of a currently supported guarded body form
-   - broader SCCs where a predicate body needs helper-goal nodes outside
-     the current structural-driver and guarded full-body subset
+8. The first SCC IR-backed slices are now in place for:
+   - per-predicate ordered call bodies, which keep mixed list/numeric
+     pair-tail decompositions native
+   - local nonrecursive helper goals between recursive group calls, which
+     now keep conservative mixed tree/numeric SCCs native
 
-9. Those failures are the point to stop adding bespoke matcher families.
-   The first SCC IR-backed slice is now in place for per-predicate ordered
-   call bodies, which is enough to keep mixed list/numeric pair-tail
-   decompositions native, but the remaining failures no longer share a
-   small structural extension point.
+9. The next confirmed unsupported SCC shapes are broader than that
+   conservative helper-goal step:
+   - helper-goal nodes outside the current local inline expansion model
+   - broader SCCs where a predicate body needs richer branch or result
+     structure outside the current structural-driver and guarded full-body
+     subset
 
-10. The next TypR mutual-recursion step should therefore expand that shared
+10. Those failures are the point to stop adding bespoke matcher families.
+    The remaining gaps no longer share a small structural extension point.
+
+11. The next TypR mutual-recursion step should therefore expand that shared
     SCC IR with:
     - per-predicate ordered goal bodies
     - explicit SCC call-site nodes with symbolic call arguments and result
@@ -196,7 +199,7 @@ This document focuses on architecture and rollout choices specific to TypR.
     - wrapper and memo generation derived from that IR rather than from the
       current `typr_mutual_supported_spec/3` family
 
-11. Until that IR exists, the correct fallback boundary is:
+12. Until that IR exists, the correct fallback boundary is:
     - keep native TypR lowering for the current structural-driver and
       supported guarded full-body subset
     - reject broader SCCs cleanly instead of stacking more structural

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -2560,6 +2560,21 @@ typr_mutual_tree_value_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, 
         Body
     ).
 
+typr_mutual_tree_value_branch_body_with(Matcher, GroupPredicates, Goals0, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
+    typr_mutual_expand_helper_goals(GroupPredicates, Goals0, Goals),
+    Goals0 \= Goals,
+    !,
+    typr_mutual_tree_value_branch_body_with(
+        Matcher,
+        GroupPredicates,
+        Goals,
+        ValueVar,
+        AliasMap0,
+        ExtraArgMap0,
+        PostBody,
+        OutputVar,
+        Body
+    ).
 typr_mutual_tree_value_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap0, PostBody, OutputVar, Body) :-
     append(PrefixGoals, [NestedIfGoal|TailPostGoals], Goals),
     PrefixGoals \= [],
@@ -2920,6 +2935,140 @@ typr_mutual_tree_branch_call(call_spec(_Side, NextPred, CallArgs), branch_call(H
     atom_string(NextPred, NextPredStr),
     format(string(HelperName), '~w_impl', [NextPredStr]).
 
+typr_mutual_expand_helper_goals(GroupPredicates, Goals0, Goals) :-
+    typr_mutual_expand_helper_goals(GroupPredicates, [], Goals0, Goals).
+
+typr_mutual_expand_helper_goals(_GroupPredicates, _Seen, [], []).
+typr_mutual_expand_helper_goals(GroupPredicates, Seen, [Goal0|Rest0], Goals) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Rest0 \= [],
+    typr_mutual_inline_local_helper_goal(GroupPredicates, Seen, Goal, Seen1, HelperGoals0),
+    append(HelperPreGoals0, [HelperBranchGoal], HelperGoals0),
+    typr_if_then_else_goal(HelperBranchGoal, IfGoal, ThenGoal0, ElseGoal0),
+    typr_mutual_expand_helper_goals(GroupPredicates, Seen1, HelperPreGoals0, HelperPreGoals),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    append(ThenGoals0, Rest0, ThenGoalsWithTail0),
+    typr_mutual_resolve_alias_prefix(ThenGoalsWithTail0, ThenGoalsWithTail1),
+    typr_mutual_expand_helper_goals(GroupPredicates, Seen1, ThenGoalsWithTail1, ThenGoals),
+    typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+    append(ElseGoals0, Rest0, ElseGoalsWithTail0),
+    typr_mutual_resolve_alias_prefix(ElseGoalsWithTail0, ElseGoalsWithTail1),
+    typr_mutual_expand_helper_goals(GroupPredicates, Seen1, ElseGoalsWithTail1, ElseGoals),
+    typr_goals_to_body(ThenGoals, ThenBody),
+    typr_goals_to_body(ElseGoals, ElseBody),
+    append(HelperPreGoals, [(IfGoal -> ThenBody ; ElseBody)], Goals),
+    !.
+typr_mutual_expand_helper_goals(GroupPredicates, Seen, [Goal0|Rest0], Goals) :-
+    typr_strip_module_goal(Goal0, Goal),
+    Rest0 \= [],
+    typr_mutual_inline_local_helper_goal(GroupPredicates, Seen, Goal, Seen1, HelperGoals0),
+    append(HelperPreGoals0, [HelperBranchGoal], HelperGoals0),
+    typr_if_then_goal(HelperBranchGoal, IfGoal, ThenGoal0),
+    typr_mutual_expand_helper_goals(GroupPredicates, Seen1, HelperPreGoals0, HelperPreGoals),
+    typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+    append(ThenGoals0, Rest0, ThenGoalsWithTail0),
+    typr_mutual_resolve_alias_prefix(ThenGoalsWithTail0, ThenGoalsWithTail1),
+    typr_mutual_expand_helper_goals(GroupPredicates, Seen1, ThenGoalsWithTail1, ThenGoals),
+    typr_goals_to_body(ThenGoals, ThenBody),
+    append(HelperPreGoals, [(IfGoal -> ThenBody)], Goals),
+    !.
+typr_mutual_expand_helper_goals(GroupPredicates, Seen, [Goal0|Rest0], Goals) :-
+    typr_mutual_expand_helper_goal(GroupPredicates, Seen, Goal0, ExpandedGoalList),
+    typr_mutual_expand_helper_goals(GroupPredicates, Seen, Rest0, RestGoals),
+    append(ExpandedGoalList, RestGoals, Goals).
+
+typr_mutual_expand_helper_goal(GroupPredicates, Seen, Goal0, ExpandedGoals) :-
+    typr_strip_module_goal(Goal0, Goal),
+    (   typr_if_then_else_goal(Goal, IfGoal, ThenGoal0, ElseGoal0)
+    ->  typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+        typr_mutual_expand_helper_goals(GroupPredicates, Seen, ThenGoals0, ThenGoals),
+        typr_mutual_goal_list(ElseGoal0, ElseGoals0),
+        typr_mutual_expand_helper_goals(GroupPredicates, Seen, ElseGoals0, ElseGoals),
+        typr_goals_to_body(ThenGoals, ThenBody),
+        typr_goals_to_body(ElseGoals, ElseBody),
+        ExpandedGoals = [(IfGoal -> ThenBody ; ElseBody)]
+    ;   typr_if_then_goal(Goal, IfGoal, ThenGoal0)
+    ->  typr_mutual_goal_list(ThenGoal0, ThenGoals0),
+        typr_mutual_expand_helper_goals(GroupPredicates, Seen, ThenGoals0, ThenGoals),
+        typr_goals_to_body(ThenGoals, ThenBody),
+        ExpandedGoals = [(IfGoal -> ThenBody)]
+    ;   typr_mutual_inline_local_helper_goal(GroupPredicates, Seen, Goal, Seen1, HelperGoals0)
+    ->  typr_mutual_expand_helper_goals(GroupPredicates, Seen1, HelperGoals0, ExpandedGoals)
+    ;   ExpandedGoals = [Goal]
+    ).
+
+typr_mutual_inline_local_helper_goal(GroupPredicates, Seen, Goal, [Pred/Arity|Seen], HelperGoals) :-
+    compound(Goal),
+    functor(Goal, Pred, Arity),
+    \+ memberchk(Pred/Arity, GroupPredicates),
+    \+ memberchk(Pred/Arity, Seen),
+    predicate_property(user:Goal, number_of_clauses(_)),
+    \+ predicate_property(user:Goal, built_in),
+    \+ predicate_property(user:Goal, imported_from(_)),
+    findall(Head-Body, predicate_clause(user, Pred, Arity, Head, Body), Clauses),
+    Clauses = [Head-Body],
+    copy_term(Head-Body, HeadCopy-BodyCopy),
+    Goal = HeadCopy,
+    \+ typr_mutual_helper_body_calls_mutual_group(GroupPredicates, BodyCopy),
+    typr_mutual_inline_helper_body_goals(BodyCopy, HelperGoals).
+
+typr_mutual_helper_body_calls_mutual_group(GroupPredicates, Body) :-
+    sub_term(SubGoal0, Body),
+    nonvar(SubGoal0),
+    typr_goal_calls_mutual_group(GroupPredicates, SubGoal0),
+    !.
+
+typr_mutual_inline_helper_body_goals(true, []) :-
+    !.
+typr_mutual_inline_helper_body_goals(Body, Goals) :-
+    typr_mutual_goal_list(Body, Goals0),
+    exclude(==(true), Goals0, Goals1),
+    maplist(typr_strip_module_goal, Goals1, Goals).
+
+typr_mutual_resolve_alias_prefix([Goal|Rest], Goals) :-
+    Goal = (Left = Right),
+    var(Left),
+    var(Right),
+    !,
+    (   term_contains_var_by_identity(Left, Rest)
+    ->  AliasVar = Left,
+        Replacement = Right
+    ;   AliasVar = Right,
+        Replacement = Left
+    ),
+    typr_mutual_goals_replace_var(Rest, AliasVar, Replacement, Rest1),
+    typr_mutual_resolve_alias_prefix(Rest1, Goals).
+typr_mutual_resolve_alias_prefix(Goals, Goals).
+
+typr_mutual_goals_replace_var([], _Var, _Replacement, []).
+typr_mutual_goals_replace_var([Goal0|Rest0], Var, Replacement, [Goal|Rest]) :-
+    typr_mutual_term_replace_var(Goal0, Var, Replacement, Goal),
+    typr_mutual_goals_replace_var(Rest0, Var, Replacement, Rest).
+
+typr_mutual_term_replace_var(Term0, Var, Replacement, Term) :-
+    var(Term0),
+    !,
+    (   Term0 == Var
+    ->  Term = Replacement
+    ;   Term = Term0
+    ).
+typr_mutual_term_replace_var(Term, _Var, _Replacement, Term) :-
+    atomic(Term),
+    !.
+typr_mutual_term_replace_var(Term0, Var, Replacement, Term) :-
+    Term0 =.. [Functor|Args0],
+    maplist(typr_mutual_term_replace_var_var(Var, Replacement), Args0, Args),
+    Term =.. [Functor|Args].
+
+typr_mutual_term_replace_var_var(Var, Replacement, Term0, Term) :-
+    typr_mutual_term_replace_var(Term0, Var, Replacement, Term).
+
+term_contains_var_by_identity(Var, Term) :-
+    sub_term(SubTerm, Term),
+    var(SubTerm),
+    SubTerm == Var,
+    !.
+
 typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, Body) :-
     typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, [], Body).
 
@@ -2934,6 +3083,11 @@ typr_mutual_tree_branch_body(GroupPredicates, Goals, ValueVar, AliasMap0, ExtraA
         Body
     ).
 
+typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals0, ValueVar, AliasMap0, ExtraArgMap, Body) :-
+    typr_mutual_expand_helper_goals(GroupPredicates, Goals0, Goals),
+    Goals0 \= Goals,
+    !,
+    typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body).
 typr_mutual_tree_branch_body_with(Matcher, GroupPredicates, Goals, ValueVar, AliasMap0, ExtraArgMap, Body) :-
     append(PreGoals, [NestedIfGoal], Goals),
     typr_mutual_tree_branch_prework(PreGoals, ValueVar, AliasMap0, ExtraArgMap, AliasMap, ExtraArgMap1, GuardExpr),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -184,6 +184,13 @@ cleanup_typr_test :-
     retractall(user:typr_num_tree_ok_branch(_)),
     retractall(user:typr_tree_num_sum_branch(_, _)),
     retractall(user:typr_num_tree_sum_branch(_, _)),
+    retractall(user:typr_tree_num_ok_helper(_)),
+    retractall(user:typr_num_tree_ok_helper(_)),
+    retractall(user:typr_tree_num_sum_helper(_, _)),
+    retractall(user:typr_num_tree_sum_helper(_, _)),
+    retractall(user:typr_tree_num_weight_helper(_, _, _)),
+    retractall(user:typr_num_tree_weight_helper(_, _, _)),
+    retractall(user:typr_pick_tree_helper(_, _, _, _)),
     retractall(user:typr_tree_forest_num_weight_branch(_, _, _)),
     retractall(user:typr_forest_tree_num_weight_branch(_, _, _)),
     retractall(user:typr_num_forest_tree_weight_branch(_, _, _)),
@@ -191,6 +198,19 @@ cleanup_typr_test :-
     retractall(user:filter_rows(_, _)),
     retractall(user:group_rows(_, _)),
     retractall(user:numeric_input(_)).
+
+setup_typr_mixed_tree_numeric_helper_test_state :-
+    cleanup_typr_mixed_tree_numeric_helper_test_state.
+
+cleanup_typr_mixed_tree_numeric_helper_test_state :-
+    clear_type_declarations,
+    retractall(user:typr_tree_num_ok_helper(_)),
+    retractall(user:typr_num_tree_ok_helper(_)),
+    retractall(user:typr_tree_num_sum_helper(_, _)),
+    retractall(user:typr_num_tree_sum_helper(_, _)),
+    retractall(user:typr_tree_num_weight_helper(_, _, _)),
+    retractall(user:typr_num_tree_weight_helper(_, _, _)),
+    retractall(user:typr_pick_tree_helper(_, _, _, _)).
 
 :- begin_tests(typr_target, [
     setup(setup_typr_test),
@@ -4317,6 +4337,134 @@ test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_context_
     \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_impl((current_input + -1), current_ctx);"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_boolean_helper_group) :-
+    setup_call_cleanup(
+        setup_typr_mixed_tree_numeric_helper_test_state,
+        (
+            assertz(user:typr_tree_num_ok_helper([])),
+            assertz(user:(typr_tree_num_ok_helper([V, L, R]) :-
+                typr_num_tree_ok_helper(V),
+                typr_pick_tree_helper(V, L, R, T),
+                typr_tree_num_ok_helper(T)
+            )),
+            assertz(user:typr_num_tree_ok_helper(0)),
+            assertz(user:(typr_num_tree_ok_helper(N) :-
+                N > 0,
+                N1 is N - 1,
+                typr_tree_num_ok_helper([N1, [], []])
+            )),
+            assertz(user:(typr_pick_tree_helper(V, L, R, T) :-
+                ( V > 0 -> T = L ; T = R )
+            )),
+            assertz(type_declarations:uw_type(typr_tree_num_ok_helper/1, 1, list(any))),
+            assertz(type_declarations:uw_type(typr_num_tree_ok_helper/1, 1, integer)),
+            assertz(type_declarations:uw_return_type(typr_tree_num_ok_helper/1, bool)),
+            assertz(type_declarations:uw_return_type(typr_num_tree_ok_helper/1, bool)),
+            once(recursive_compiler:compile_recursive(typr_tree_num_ok_helper/1, [target(typr), typed_mode(explicit)], Code)),
+            once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_ok_helper/1, typr_tree_num_ok_helper/1")),
+            once(sub_string(Code, _, _, _, "let typr_tree_num_ok_helper <- fn(arg1: [#N, Any]): bool")),
+            once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+            once(sub_string(Code, _, _, _, "left_result = typr_num_tree_ok_helper_impl(.subset2(current_input, 1));")),
+            once(sub_string(Code, _, _, _, "right_result = typr_tree_num_ok_helper_impl(.subset2(current_input, 2));")),
+            once(sub_string(Code, _, _, _, "right_result = typr_tree_num_ok_helper_impl(.subset2(current_input, 3));")),
+            once(sub_string(Code, _, _, _, "result = typr_tree_num_ok_helper_impl(list((current_input + -1), list(), list()));")),
+            \+ sub_string(Code, _, _, _, "result = typr_tree_num_ok_helper_impl((current_input + -1));"),
+            \+ sub_string(Code, _, _, _, "(function("),
+            generated_typr_is_valid(Code, exit(0))
+        ),
+        cleanup_typr_mixed_tree_numeric_helper_test_state
+    ).
+
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_helper_group) :-
+    setup_call_cleanup(
+        setup_typr_mixed_tree_numeric_helper_test_state,
+        (
+            assertz(user:typr_tree_num_sum_helper([], 0)),
+            assertz(user:(typr_tree_num_sum_helper([V, L, R], S) :-
+                typr_num_tree_sum_helper(V, SV),
+                typr_pick_tree_helper(V, L, R, T),
+                typr_tree_num_sum_helper(T, ST),
+                S is SV + ST
+            )),
+            assertz(user:typr_num_tree_sum_helper(0, 0)),
+            assertz(user:(typr_num_tree_sum_helper(N, S) :-
+                N > 0,
+                N1 is N - 1,
+                typr_tree_num_sum_helper([N1, [], []], Parts),
+                S is N + Parts
+            )),
+            assertz(user:(typr_pick_tree_helper(V, L, R, T) :-
+                ( V > 0 -> T = L ; T = R )
+            )),
+            assertz(type_declarations:uw_type(typr_tree_num_sum_helper/2, 1, list(any))),
+            assertz(type_declarations:uw_type(typr_tree_num_sum_helper/2, 2, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_sum_helper/2, 1, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_sum_helper/2, 2, integer)),
+            assertz(type_declarations:uw_return_type(typr_tree_num_sum_helper/2, integer)),
+            assertz(type_declarations:uw_return_type(typr_num_tree_sum_helper/2, integer)),
+            once(recursive_compiler:compile_recursive(typr_tree_num_sum_helper/2, [target(typr), typed_mode(explicit)], Code)),
+            once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_sum_helper/2, typr_tree_num_sum_helper/2")),
+            once(sub_string(Code, _, _, _, "let typr_tree_num_sum_helper <- fn(arg1: [#N, Any], arg2: int): int")),
+            once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+            once(sub_string(Code, _, _, _, "left_result = typr_num_tree_sum_helper_impl(.subset2(current_input, 1));")),
+            once(sub_string(Code, _, _, _, "right_result = typr_tree_num_sum_helper_impl(.subset2(current_input, 2));")),
+            once(sub_string(Code, _, _, _, "right_result = typr_tree_num_sum_helper_impl(.subset2(current_input, 3));")),
+            once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+            once(sub_string(Code, _, _, _, "left_result = typr_tree_num_sum_helper_impl(list((current_input + -1), list(), list()));")),
+            once(sub_string(Code, _, _, _, "result = (current_input + left_result);")),
+            \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_sum_helper_impl((current_input + -1));"),
+            \+ sub_string(Code, _, _, _, "(function("),
+            generated_typr_is_valid(Code, exit(0))
+        ),
+        cleanup_typr_mixed_tree_numeric_helper_test_state
+    ).
+
+test(recursive_compiler_supports_typr_mixed_tree_numeric_mutual_integer_context_helper_group) :-
+    setup_call_cleanup(
+        setup_typr_mixed_tree_numeric_helper_test_state,
+        (
+            assertz(user:typr_tree_num_weight_helper([], _W0, 0)),
+            assertz(user:(typr_tree_num_weight_helper([V, L, R], W, S) :-
+                typr_num_tree_weight_helper(V, W, SV),
+                typr_pick_tree_helper(V, L, R, T),
+                typr_tree_num_weight_helper(T, W, ST),
+                S is SV + ST
+            )),
+            assertz(user:typr_num_tree_weight_helper(0, _W1, 0)),
+            assertz(user:(typr_num_tree_weight_helper(N, W, S) :-
+                N > 0,
+                N1 is N - 1,
+                typr_tree_num_weight_helper([N1, [], []], W, Parts),
+                S is (N * W) + Parts
+            )),
+            assertz(user:(typr_pick_tree_helper(V, L, R, T) :-
+                ( V > 0 -> T = L ; T = R )
+            )),
+            assertz(type_declarations:uw_type(typr_tree_num_weight_helper/3, 1, list(any))),
+            assertz(type_declarations:uw_type(typr_tree_num_weight_helper/3, 2, integer)),
+            assertz(type_declarations:uw_type(typr_tree_num_weight_helper/3, 3, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_weight_helper/3, 1, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_weight_helper/3, 2, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_weight_helper/3, 3, integer)),
+            assertz(type_declarations:uw_return_type(typr_tree_num_weight_helper/3, integer)),
+            assertz(type_declarations:uw_return_type(typr_num_tree_weight_helper/3, integer)),
+            once(recursive_compiler:compile_recursive(typr_tree_num_weight_helper/3, [target(typr), typed_mode(explicit)], Code)),
+            once(sub_string(Code, _, _, _, "# Mutual recursion group: typr_num_tree_weight_helper/3, typr_tree_num_weight_helper/3")),
+            once(sub_string(Code, _, _, _, "let typr_tree_num_weight_helper <- fn(arg1: [#N, Any], arg2: int, arg3: int): int")),
+            once(sub_string(Code, _, _, _, "if (.subset2(current_input, 1) > 0) {")),
+            once(sub_string(Code, _, _, _, "left_result = typr_num_tree_weight_helper_impl(.subset2(current_input, 1), current_ctx);")),
+            once(sub_string(Code, _, _, _, "right_result = typr_tree_num_weight_helper_impl(.subset2(current_input, 2), current_ctx);")),
+            once(sub_string(Code, _, _, _, "right_result = typr_tree_num_weight_helper_impl(.subset2(current_input, 3), current_ctx);")),
+            once(sub_string(Code, _, _, _, "result = (left_result + right_result);")),
+            once(sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_helper_impl(list((current_input + -1), list(), list()), current_ctx);")),
+            once(sub_string(Code, _, _, _, "result = ((current_input * current_ctx) + left_result);")),
+            \+ sub_string(Code, _, _, _, "left_result = typr_tree_num_weight_helper_impl((current_input + -1), current_ctx);"),
+            \+ sub_string(Code, _, _, _, "(function("),
+            generated_typr_is_valid(Code, exit(0))
+        ),
+        cleanup_typr_mixed_tree_numeric_helper_test_state
+    ).
 
 test(recursive_compiler_supports_typr_mixed_tree_list_numeric_mutual_boolean_group) :-
     clear_type_declarations,

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -10,6 +10,19 @@
 run_all_tests :-
     run_tests([typr_toolchain]).
 
+setup_typr_mixed_tree_numeric_helper_toolchain_state :-
+    cleanup_typr_mixed_tree_numeric_helper_toolchain_state.
+
+cleanup_typr_mixed_tree_numeric_helper_toolchain_state :-
+    clear_type_declarations,
+    retractall(user:typr_tree_num_ok_helper(_)),
+    retractall(user:typr_num_tree_ok_helper(_)),
+    retractall(user:typr_tree_num_sum_helper(_, _)),
+    retractall(user:typr_num_tree_sum_helper(_, _)),
+    retractall(user:typr_tree_num_weight_helper(_, _, _)),
+    retractall(user:typr_num_tree_weight_helper(_, _, _)),
+    retractall(user:typr_pick_tree_helper(_, _, _, _)).
+
 :- begin_tests(typr_toolchain).
 
 test(generated_output_checks_with_typr, [condition(typr_cli_available)]) :-
@@ -3277,6 +3290,127 @@ test(mixed_tree_numeric_mutual_integer_context_output_checks_with_typr, [conditi
     ),
     retractall(user:typr_tree_num_weight(_, _, _)),
     retractall(user:typr_num_tree_weight(_, _, _)).
+
+test(mixed_tree_numeric_mutual_boolean_helper_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    setup_call_cleanup(
+        setup_typr_mixed_tree_numeric_helper_toolchain_state,
+        (
+            assertz(user:typr_tree_num_ok_helper([])),
+            assertz(user:(typr_tree_num_ok_helper([V, L, R]) :-
+                typr_num_tree_ok_helper(V),
+                typr_pick_tree_helper(V, L, R, T),
+                typr_tree_num_ok_helper(T)
+            )),
+            assertz(user:typr_num_tree_ok_helper(0)),
+            assertz(user:(typr_num_tree_ok_helper(N) :-
+                N > 0,
+                N1 is N - 1,
+                typr_tree_num_ok_helper([N1, [], []])
+            )),
+            assertz(user:(typr_pick_tree_helper(V, L, R, T) :-
+                ( V > 0 -> T = L ; T = R )
+            )),
+            assertz(type_declarations:uw_type(typr_tree_num_ok_helper/1, 1, list(any))),
+            assertz(type_declarations:uw_type(typr_num_tree_ok_helper/1, 1, integer)),
+            assertz(type_declarations:uw_return_type(typr_tree_num_ok_helper/1, bool)),
+            assertz(type_declarations:uw_return_type(typr_num_tree_ok_helper/1, bool)),
+            once(recursive_compiler:compile_recursive(typr_tree_num_ok_helper/1, [target(typr), typed_mode(explicit)], Code)),
+            setup_call_cleanup(
+                create_smoke_project(ProjectDir),
+                (
+                    write_generated_typr_program(ProjectDir, Code),
+                    run_typr(ProjectDir, ['check']),
+                    maybe_build_with_r(ProjectDir)
+                ),
+                delete_directory_and_contents(ProjectDir)
+            )
+        ),
+        cleanup_typr_mixed_tree_numeric_helper_toolchain_state
+    ).
+
+test(mixed_tree_numeric_mutual_integer_helper_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    setup_call_cleanup(
+        setup_typr_mixed_tree_numeric_helper_toolchain_state,
+        (
+            assertz(user:typr_tree_num_sum_helper([], 0)),
+            assertz(user:(typr_tree_num_sum_helper([V, L, R], S) :-
+                typr_num_tree_sum_helper(V, SV),
+                typr_pick_tree_helper(V, L, R, T),
+                typr_tree_num_sum_helper(T, ST),
+                S is SV + ST
+            )),
+            assertz(user:typr_num_tree_sum_helper(0, 0)),
+            assertz(user:(typr_num_tree_sum_helper(N, S) :-
+                N > 0,
+                N1 is N - 1,
+                typr_tree_num_sum_helper([N1, [], []], Parts),
+                S is N + Parts
+            )),
+            assertz(user:(typr_pick_tree_helper(V, L, R, T) :-
+                ( V > 0 -> T = L ; T = R )
+            )),
+            assertz(type_declarations:uw_type(typr_tree_num_sum_helper/2, 1, list(any))),
+            assertz(type_declarations:uw_type(typr_tree_num_sum_helper/2, 2, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_sum_helper/2, 1, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_sum_helper/2, 2, integer)),
+            assertz(type_declarations:uw_return_type(typr_tree_num_sum_helper/2, integer)),
+            assertz(type_declarations:uw_return_type(typr_num_tree_sum_helper/2, integer)),
+            once(recursive_compiler:compile_recursive(typr_tree_num_sum_helper/2, [target(typr), typed_mode(explicit)], Code)),
+            setup_call_cleanup(
+                create_smoke_project(ProjectDir),
+                (
+                    write_generated_typr_program(ProjectDir, Code),
+                    run_typr(ProjectDir, ['check']),
+                    maybe_build_with_r(ProjectDir)
+                ),
+                delete_directory_and_contents(ProjectDir)
+            )
+        ),
+        cleanup_typr_mixed_tree_numeric_helper_toolchain_state
+    ).
+
+test(mixed_tree_numeric_mutual_integer_context_helper_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    setup_call_cleanup(
+        setup_typr_mixed_tree_numeric_helper_toolchain_state,
+        (
+            assertz(user:typr_tree_num_weight_helper([], _W0, 0)),
+            assertz(user:(typr_tree_num_weight_helper([V, L, R], W, S) :-
+                typr_num_tree_weight_helper(V, W, SV),
+                typr_pick_tree_helper(V, L, R, T),
+                typr_tree_num_weight_helper(T, W, ST),
+                S is SV + ST
+            )),
+            assertz(user:typr_num_tree_weight_helper(0, _W1, 0)),
+            assertz(user:(typr_num_tree_weight_helper(N, W, S) :-
+                N > 0,
+                N1 is N - 1,
+                typr_tree_num_weight_helper([N1, [], []], W, Parts),
+                S is (N * W) + Parts
+            )),
+            assertz(user:(typr_pick_tree_helper(V, L, R, T) :-
+                ( V > 0 -> T = L ; T = R )
+            )),
+            assertz(type_declarations:uw_type(typr_tree_num_weight_helper/3, 1, list(any))),
+            assertz(type_declarations:uw_type(typr_tree_num_weight_helper/3, 2, integer)),
+            assertz(type_declarations:uw_type(typr_tree_num_weight_helper/3, 3, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_weight_helper/3, 1, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_weight_helper/3, 2, integer)),
+            assertz(type_declarations:uw_type(typr_num_tree_weight_helper/3, 3, integer)),
+            assertz(type_declarations:uw_return_type(typr_tree_num_weight_helper/3, integer)),
+            assertz(type_declarations:uw_return_type(typr_num_tree_weight_helper/3, integer)),
+            once(recursive_compiler:compile_recursive(typr_tree_num_weight_helper/3, [target(typr), typed_mode(explicit)], Code)),
+            setup_call_cleanup(
+                create_smoke_project(ProjectDir),
+                (
+                    write_generated_typr_program(ProjectDir, Code),
+                    run_typr(ProjectDir, ['check']),
+                    maybe_build_with_r(ProjectDir)
+                ),
+                delete_directory_and_contents(ProjectDir)
+            )
+        ),
+        cleanup_typr_mixed_tree_numeric_helper_toolchain_state
+    ).
 
 test(mixed_tree_list_numeric_mutual_boolean_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,


### PR DESCRIPTION
# Start Native TypR SCC Helper Goals

## Summary

This PR extends the new SCC IR-backed TypR lowering path to support local nonrecursive helper goals inside conservative mutual-recursion groups.

It keeps mixed tree/numeric SCCs native when a tree-shaped predicate does:

- one recursive group call
- then a local helper predicate call
- then another recursive group call based on the helper-selected subtree

Representative supported shapes now include:

- boolean mixed tree/numeric helper SCCs such as `typr_tree_num_ok_helper/1` and `typr_num_tree_ok_helper/1`
- integer-return mixed tree/numeric helper SCCs such as `typr_tree_num_sum_helper/2` and `typr_num_tree_sum_helper/2`
- context-threaded integer-return mixed tree/numeric helper SCCs such as `typr_tree_num_weight_helper/3` and `typr_num_tree_weight_helper/3`

## Why This PR Exists

The SCC IR extraction work identified mixed tree/numeric SCCs with local helper goals between recursive group calls as the next confirmed unsupported slice.

That made this the right next proving case:

- it is still conservative and structurally analyzable
- it requires helper-goal expansion in ordered per-predicate SCC bodies
- it pushes the SCC IR path forward without adding another `typr_mutual_supported_spec/3` matcher family

Before this change, these SCCs failed because the TypR mutual backend could not:

- expand a local nonrecursive helper goal into the enclosing SCC body
- preserve shared variable identity across helper-selected subtree aliases
- continue native lowering after the helper goal when later recursive group calls depended on the helper result

## Main Changes

- kept the legacy mutual matcher family intact in `src/unifyweaver/targets/typr_target.pl`
- added helper-goal preprocessing for the SCC IR-backed path
- inlined conservative local helper predicates with exactly one clause into the surrounding ordered SCC body
- expanded nested `if -> then ; else` helper bodies while preserving the remaining tail goals in each branch
- resolved alias prefixes through explicit variable substitution so shared value-return expressions keep the correct variable identity
- reused the widened helper-goal path for boolean, integer-return, and context-threaded mixed tree/numeric SCCs
- added target-level regression coverage in `tests/test_typr_target.pl`
- added real `typr check` coverage in `tests/test_typr_toolchain.pl`
- updated the TypR docs to mark this SCC IR helper-goal slice as supported and to narrow the next unsupported boundary accordingly

Files updated:

- `src/unifyweaver/targets/typr_target.pl`
- `tests/test_typr_target.pl`
- `tests/test_typr_toolchain.pl`
- `README.md`
- `docs/design/TYPE_SYSTEM_SPEC.md`
- `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation

Validated with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not introduce the full SCC IR yet.

It adds the first helper-goal-aware SCC IR slice while keeping the earlier matcher family and the earlier IR-backed call-body path in place.

The next confirmed unsupported SCC frontier is still broader than this change, including richer helper-goal and branch/join structure such as:

- mixed tree/numeric SCCs that need branch/result joins beyond the current ordered helper-goal slice
- broader SCC groups that no longer fit the current structural-driver plus supported guarded full-body subset

Those should continue through the shared SCC IR path rather than another round of bespoke structural matcher families.
