### PR TITLE
feat: deepen Go + AWK targets for arity-3 recursive arithmetic

### DIFF
--- a/src/unifyweaver/targets/awk_target.pl
+++ b/src/unifyweaver/targets/awk_target.pl
@@ -97,9 +97,195 @@ compile_predicate_to_awk(PredIndicator, Options, AwkCode) :-
         is_tail_recursive_pattern(Pred, Clauses)
     ->  % Compile as tail recursion (while loop)
         compile_tail_recursion_to_awk(Pred, Arity, Clauses, Options, AwkCode)
+    ;   % Check if this is a general recursive pattern (non-tail)
+        functor(Head, Pred, Arity),
+        findall(Head-Body, user:clause(Head, Body), Clauses),
+        is_general_recursive_pattern_awk(Pred, Clauses)
+    ->  % Compile as fixpoint iteration
+        compile_general_recursive_to_awk(Pred, Arity, Clauses, Options, AwkCode)
     ;   % Continue with normal compilation
         compile_predicate_to_awk_normal(Pred, Arity, Options, AwkCode)
     ).
+
+%% ============================================
+%% GENERAL (NON-TAIL) RECURSION — Fixpoint
+%% ============================================
+%%
+%% AWK doesn't have native recursion, so we implement non-tail recursive
+%% predicates as fixpoint iteration: keep expanding the result relation
+%% until no new tuples are added (semi-naive evaluation in AWK).
+%%
+%% Pattern: category_ancestor(Cat, Parent, 1) :- category_parent(Cat, Parent).
+%%          category_ancestor(Cat, Ancestor, Hops) :- category_parent(Cat, Mid),
+%%              category_ancestor(Mid, Ancestor, H1), Hops is H1 + 1.
+%%
+%% Generated AWK:
+%%   BEGIN { load step relation into array }
+%%   END   { fixpoint loop expanding ancestor relation }
+
+%% is_general_recursive_pattern_awk(+Pred, +Clauses)
+is_general_recursive_pattern_awk(Pred, Clauses) :-
+    length(Clauses, Len), Len >= 2,
+    member(_-Body, Clauses),
+    contains_call_to_awk(Body, Pred),
+    \+ is_tail_recursive_pattern(Pred, Clauses).
+
+contains_call_to_awk(Goal, Pred) :-
+    Goal =.. [Pred|_], !.
+contains_call_to_awk((A, _), Pred) :-
+    contains_call_to_awk(A, Pred), !.
+contains_call_to_awk((_, B), Pred) :-
+    contains_call_to_awk(B, Pred).
+
+%% compile_general_recursive_to_awk(+Pred, +Arity, +Clauses, +Options, -AwkCode)
+compile_general_recursive_to_awk(Pred, Arity, Clauses, Options, AwkCode) :-
+    atom_string(Pred, PredStr),
+    option(field_separator(FieldSep), Options, '\t'),
+    % Partition clauses
+    partition(is_recursive_clause_awk(Pred), Clauses, _RecClauses, BaseClauses),
+    % Extract step relation from base case
+    (   BaseClauses = [_BaseHead-BaseBody|_]
+    ->  extract_goals_list_awk(BaseBody, BaseGoals),
+        (   BaseGoals = [StepGoal|_],
+            StepGoal =.. [StepRel|_],
+            atom_string(StepRel, StepRelStr)
+        ->  true
+        ;   StepRelStr = "step"
+        ),
+        % Collect step relation facts
+        functor(StepHead, StepRel, 2),
+        findall(A-B, (user:clause(StepHead, true), StepHead =.. [_,A,B]), StepFacts)
+    ;   StepRelStr = "step",
+        StepFacts = []
+    ),
+    % Build BEGIN block with step data
+    findall(InitLine,
+        (   member(K-V, StepFacts),
+            format(string(InitLine),
+                '    ~w["~w"] = ~w["~w"] " ~w"',
+                [StepRelStr, K, StepRelStr, K, V])
+        ),
+        InitLines),
+    % Also build individual edge lines for the fixpoint
+    findall(EdgeLine,
+        (   member(K-V, StepFacts),
+            format(string(EdgeLine),
+                '    edges[++ne] = "~w~w~w"',
+                [K, FieldSep, V])
+        ),
+        EdgeLines),
+    atomic_list_concat(InitLines, '\n', InitBlock),
+    atomic_list_concat(EdgeLines, '\n', EdgeBlock),
+    length(StepFacts, NEdges),
+    (   Arity =:= 3
+    ->  % Ternary: with counter
+        format(string(AwkCode),
+'# Fixpoint evaluation: ~w/~w (transitive closure with counter)
+# Step relation: ~w/2 (~w edges)
+BEGIN {
+    FS = "~w"
+    # Load step relation edges
+~w
+
+    # Initialize base case: direct edges have distance 1
+    for (i = 1; i <= ~w; i++) {
+        split(edges[i], e, FS)
+        key = e[1] FS e[2] FS 1
+        if (!(key in result)) {
+            result[key] = 1
+            delta[key] = 1
+            ndelta++
+        }
+    }
+
+    # Fixpoint: expand until no new tuples
+    while (ndelta > 0) {
+        ndelta = 0
+        for (d in delta) {
+            split(d, parts, FS)
+            cat = parts[1]
+            ancestor = parts[2]
+            hops = parts[3] + 0
+            # Join: step(X, cat) => ancestor(X, ancestor, hops+1)
+            for (i = 1; i <= ~w; i++) {
+                split(edges[i], e, FS)
+                if (e[2] == cat) {
+                    newkey = e[1] FS ancestor FS (hops + 1)
+                    if (!(newkey in result)) {
+                        result[newkey] = 1
+                        new_delta[newkey] = 1
+                        ndelta++
+                    }
+                }
+            }
+        }
+        delete delta
+        for (k in new_delta) delta[k] = 1
+        delete new_delta
+    }
+
+    # Output all results
+    for (key in result) {
+        print key
+    }
+}
+', [PredStr, Arity, StepRelStr, NEdges, FieldSep,
+    EdgeBlock, NEdges, NEdges])
+    ;   % Binary: no counter
+        format(string(AwkCode),
+'# Fixpoint evaluation: ~w/~w (transitive closure)
+# Step relation: ~w/2 (~w edges)
+BEGIN {
+    FS = "~w"
+~w
+
+    # Initialize base case
+    for (i = 1; i <= ~w; i++) {
+        split(edges[i], e, FS)
+        key = e[1] FS e[2]
+        if (!(key in result)) {
+            result[key] = 1
+            delta[key] = 1
+            ndelta++
+        }
+    }
+
+    # Fixpoint
+    while (ndelta > 0) {
+        ndelta = 0
+        for (d in delta) {
+            split(d, parts, FS)
+            cat = parts[1]
+            ancestor = parts[2]
+            for (i = 1; i <= ~w; i++) {
+                split(edges[i], e, FS)
+                if (e[2] == cat) {
+                    newkey = e[1] FS ancestor
+                    if (!(newkey in result)) {
+                        result[newkey] = 1
+                        new_delta[newkey] = 1
+                        ndelta++
+                    }
+                }
+            }
+        }
+        delete delta
+        for (k in new_delta) delta[k] = 1
+        delete new_delta
+    }
+
+    for (key in result) print key
+}
+', [PredStr, Arity, StepRelStr, NEdges, FieldSep,
+    EdgeBlock, NEdges, NEdges])
+    ).
+
+is_recursive_clause_awk(Pred, _Head-Body) :-
+    contains_call_to_awk(Body, Pred).
+
+extract_goals_list_awk((A, B), [A|Rest]) :- !,
+    extract_goals_list_awk(B, Rest).
+extract_goals_list_awk(Goal, [Goal]).
 
 %% compile_predicate_to_awk_normal(+Pred, +Arity, +Options, -AwkCode)
 %  Normal (non-aggregation) compilation path

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -5344,6 +5344,11 @@ compile_predicate_to_go_normal(Pred, Arity, Options, GoCode) :-
         format('Type: tail_recursion~n'),
         compile_tail_recursive_to_go(Pred, Arity, Clauses, ScriptBody),
         GenerateProgram = true
+    ;   is_general_recursive_pattern_go(Pred, Arity, Clauses) ->
+        % General (non-tail) recursive pattern with arithmetic counter
+        format('Type: general_recursion_arity_~w~n', [Arity]),
+        compile_general_recursive_to_go(Pred, Arity, Clauses, ScriptBody),
+        GenerateProgram = true
     ;   Clauses = [SingleHead-SingleBody], SingleBody \= true ->
         % Single rule
         format('Type: single_rule~n'),
@@ -6509,6 +6514,182 @@ count_recursive_calls_go_((A, B), Pred, Acc, Count) :- !,
     count_recursive_calls_go_(A, Pred, Acc, Acc1),
     count_recursive_calls_go_(B, Pred, Acc1, Count).
 count_recursive_calls_go_(_, _, Acc, Acc).
+
+%% ============================================
+%% GENERAL (NON-TAIL) RECURSION — Arity 3
+%% ============================================
+%%
+%% Handles transitive closure with counter patterns:
+%%   category_ancestor(Cat, Parent, 1) :- category_parent(Cat, Parent).
+%%   category_ancestor(Cat, Ancestor, Hops) :-
+%%       category_parent(Cat, Mid),
+%%       category_ancestor(Mid, Ancestor, H1),
+%%       Hops is H1 + 1.
+%%
+%% Generates a recursive Go function with visited-set cycle detection.
+
+%% is_general_recursive_pattern_go(+Pred, +Arity, +Clauses)
+%  Detect non-tail general recursion (has base + recursive clauses,
+%  recursive call is NOT in tail position).
+is_general_recursive_pattern_go(Pred, Arity, Clauses) :-
+    Arity >= 2,
+    partition(is_recursive_clause_go(Pred), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    % Not tail-recursive (recursive call is not last goal)
+    \+ is_tail_recursive_pattern(Pred, Clauses).
+
+%% is_recursive_clause_go(+Pred, +Clause)
+is_recursive_clause_go(Pred, _Head-Body) :-
+    contains_call_to(Body, Pred).
+
+contains_call_to(Goal, Pred) :-
+    Goal =.. [Pred|_], !.
+contains_call_to((A, _), Pred) :-
+    contains_call_to(A, Pred), !.
+contains_call_to((_, B), Pred) :-
+    contains_call_to(B, Pred).
+
+%% compile_general_recursive_to_go(+Pred, +Arity, +Clauses, -GoCode)
+compile_general_recursive_to_go(Pred, Arity, Clauses, GoCode) :-
+    atom_string(Pred, PredStr),
+    partition(is_recursive_clause_go(Pred), Clauses, RecClauses, BaseClauses),
+    (   Arity =:= 3
+    ->  compile_ternary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode)
+    ;   Arity =:= 2
+    ->  compile_binary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode)
+    ;   format(string(GoCode), '// General recursion for arity ~w not yet supported\n', [Arity])
+    ).
+
+%% compile_ternary_recursive_go(+PredStr, +BaseClauses, +RecClauses, -GoCode)
+%%
+%% For category_ancestor(Cat, Ancestor, Hops) pattern:
+%% - Base case: lookup step relation, yield (result, constant)
+%% - Recursive: step through intermediate, recurse, compute counter
+compile_ternary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode) :-
+    % Extract base case info
+    (   BaseClauses = [BaseHead-BaseBody|_]
+    ->  BaseHead =.. [_|BaseArgs],
+        extract_goals_list_go(BaseBody, BaseGoals),
+        % Find the step relation in base case
+        (   BaseGoals = [StepGoal|_],
+            StepGoal =.. [StepRel|_],
+            atom_string(StepRel, StepRelStr)
+        ->  true
+        ;   StepRelStr = "unknown"
+        ),
+        % Find the constant in position 3
+        (   length(BaseArgs, 3),
+            nth1(3, BaseArgs, BaseConst),
+            number(BaseConst)
+        ->  format(string(BaseConstStr), "~w", [BaseConst])
+        ;   BaseConstStr = "1"
+        )
+    ;   StepRelStr = "unknown",
+        BaseConstStr = "1"
+    ),
+    % Extract recursive case arithmetic
+    (   RecClauses = [_RecHead-RecBody|_]
+    ->  extract_goals_list_go(RecBody, RecGoals),
+        % Find arithmetic: Hops is H1 + Increment
+        (   member((_ is ArithExpr), RecGoals),
+            ArithExpr = (_ + Incr),
+            number(Incr)
+        ->  format(string(IncrStr), "~w", [Incr])
+        ;   IncrStr = "1"
+        )
+    ;   IncrStr = "1"
+    ),
+    % Generate Go code
+    format(string(GoCode),
+'// Transitive closure with counter: ~w/3
+// Step relation: ~w/2
+type ~wResult struct {
+\tValue  string
+\tCounter int
+}
+
+var ~wData [][]string // populated from facts
+
+func ~w(arg1 string, visited map[string]bool) []~wResult {
+\tif visited[arg1] {
+\t\treturn nil
+\t}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {
+\t\tnewVisited[k] = v
+\t}
+\tnewVisited[arg1] = true
+
+\tvar results []~wResult
+
+\t// Scan step relation
+\tfor _, row := range ~wData {
+\t\tif len(row) >= 2 && row[0] == arg1 {
+\t\t\tmid := row[1]
+\t\t\t// Base case: direct step
+\t\t\tresults = append(results, ~wResult{mid, ~s})
+\t\t\t// Recursive case
+\t\t\tfor _, sub := range ~w(mid, newVisited) {
+\t\t\t\tresults = append(results, ~wResult{sub.Value, sub.Counter + ~s})
+\t\t\t}
+\t\t}
+\t}
+\treturn results
+}
+', [PredStr, StepRelStr,
+    PredStr, StepRelStr,
+    PredStr, PredStr,
+    PredStr,
+    StepRelStr,
+    PredStr, BaseConstStr,
+    PredStr,
+    PredStr, IncrStr]).
+
+%% compile_binary_recursive_go(+PredStr, +BaseClauses, +RecClauses, -GoCode)
+compile_binary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode) :-
+    % Extract step relation from base case
+    (   BaseClauses = [_BaseHead-BaseBody|_]
+    ->  extract_goals_list_go(BaseBody, BaseGoals),
+        (   BaseGoals = [StepGoal|_],
+            StepGoal =.. [StepRel|_],
+            atom_string(StepRel, StepRelStr)
+        ->  true
+        ;   StepRelStr = "unknown"
+        )
+    ;   StepRelStr = "unknown"
+    ),
+    format(string(GoCode),
+'// Transitive closure: ~w/2
+// Step relation: ~w/2
+var ~wData [][]string
+
+func ~w(arg1 string, visited map[string]bool) []string {
+\tif visited[arg1] {
+\t\treturn nil
+\t}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {
+\t\tnewVisited[k] = v
+\t}
+\tnewVisited[arg1] = true
+
+\tvar results []string
+\tfor _, row := range ~wData {
+\t\tif len(row) >= 2 && row[0] == arg1 {
+\t\t\tmid := row[1]
+\t\t\tresults = append(results, mid)
+\t\t\tresults = append(results, ~w(mid, newVisited)...)
+\t\t}
+\t}
+\treturn results
+}
+', [PredStr, StepRelStr, StepRelStr, PredStr, StepRelStr, PredStr]).
+
+%% extract_goals_list_go(+Body, -Goals)
+extract_goals_list_go((A, B), [A|Rest]) :- !,
+    extract_goals_list_go(B, Rest).
+extract_goals_list_go(Goal, [Goal]).
 
 %% ============================================
 %% MUTUAL RECURSION


### PR DESCRIPTION
## Summary

  - **Go target**: Add `compile_general_recursive_to_go` for non-tail recursive predicates with arithmetic counters.
  Generates recursive Go function with `map[string]bool` visited set, base case yielding `(result, constant)`, recursive
   case with counter increment.
  - **AWK target**: Add semi-naive fixpoint evaluation for general recursion. AWK has no native recursion, so non-tail
  recursive predicates compile to iterative delta-set expansion in a BEGIN block — same strategy as the C# query
  engine's FixpointNode but in AWK.

  Both targets now compile `category_ancestor/3` (transitive closure with hop counter) for the cross-target effective
  distance benchmark.

  ## Gap Matrix Update

  | Target | Arity-3 TC + Arithmetic | Approach |
  |---|---|---|
  | SWI-Prolog | ✅ | Native |
  | Python | ✅ (PR #1054) | Recursive generator with visited set |
  | Go | ✅ (this PR) | Recursive function with visited map |
  | AWK | ✅ (this PR) | Semi-naive fixpoint iteration |
  | C# Query | ❌ (deferred to Codex) | Needs `is/2` support in FixpointNode IR |

  ## Next Steps

  - Build end-to-end compiled runners for each target
  - Validate output matches SWI-Prolog reference on dev dataset
  - Scale to 50K articles for performance comparison

  ## Test plan

  - [x] Go compiles `category_ancestor/3` with visited-map cycle detection + counter arithmetic
  - [x] AWK compiles `category_ancestor/3` as fixpoint iteration with delta sets + counter tracking
  - [ ] End-to-end execution validation against SWI-Prolog reference output
  - [ ] Integration with `effective_distance/3` aggregation layer

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  9 tasks (5 done, 1 in progress, 3 open)
  ✔ Create dataset generation script (Phase 0)
  ✔ Write benchmark Prolog program (Phase 1)
  ◼ Compile to C# Query Engine target (Phase 2.1)
  ◻ Compile to Go target (Phase 2.2)
  ◻ Compile to AWK target (Phase 2.3)
  ◻ Compile to Python target (Phase 2.4)
  ✔ Deepen Go target: arity-3 recursive arithmetic
  ✔ Deepen AWK target: fix variable resolution in recursive arithmetic
  ✔ Deepen Python target: support arity-3 recursion