### PR TITLE
fix(csharp): parameterized query engine compiles category_ancestor/3

### DIFF
--- a/docs/proposals/CROSS_TARGET_EFFECTIVE_DISTANCE_THEORY.md
+++ b/docs/proposals/CROSS_TARGET_EFFECTIVE_DISTANCE_THEORY.md
@@ -187,6 +187,23 @@ effective_distance(Article, Folder, Deff) :-
 No single step requires a new primitive. The challenge is composing them
 correctly in each target language.
 
+### Note on Arity Generalization
+
+The current deepening work (Go, AWK, Python) adds arity-3 support for
+recursive predicates with arithmetic counters. This is sufficient for the
+benchmark but is **not a general solution** — the implementations are
+arity-specific (arity-2 and arity-3 handlers). A future improvement should
+generalize to **arity-N** recursive predicates by:
+
+- Extracting input/output/accumulator roles from mode declarations
+- Generating variable-arity worker functions with positional argument mapping
+- Handling arbitrary arithmetic expressions in any argument position
+
+The C# parameterized query engine already handles this generically via its
+IR-based `FixpointNode` — the plan compiler resolves variable bindings
+positionally without arity-specific code. The other targets' native deepening
+should converge toward a similar arity-agnostic approach.
+
 ## Future Work: Tree Construction from Effective Distance
 
 The effective distance computation has a natural extension to **tree/mindmap

--- a/examples/benchmark/effective_distance_csharp.pl
+++ b/examples/benchmark/effective_distance_csharp.pl
@@ -1,22 +1,49 @@
 %% ==========================================================================
 %% Cross-Target Effective Distance Benchmark — C# Query Engine version
 %%
-%% This variant drops the explicit Visited list from category_ancestor/4
-%% because the C# Query Engine's FixpointNode handles cycle detection
-%% automatically via semi-naive evaluation with HashSet deduplication.
+%% The C# parameterized query engine handles is/2 arithmetic and cycle
+%% detection (via semi-naive FixpointNode) natively. Two adjustments
+%% from the generic Prolog version:
 %%
-%% The predicates are otherwise identical to effective_distance.pl.
+%% 1. No explicit Visited list — FixpointNode handles cycle detection
+%%    automatically via delta-set convergence with HashSet deduplication.
+%%
+%% 2. Base case constant moved from head to body — the query plan
+%%    compiler requires variables in head positions, with binding
+%%    done via is/2 in the body. So instead of:
+%%      category_ancestor(Cat, Parent, 1) :- category_parent(Cat, Parent).
+%%    we write:
+%%      category_ancestor(Cat, Parent, Hops) :- category_parent(Cat, Parent), Hops is 1.
+%%
+%% 3. Mode declarations required — the parameterized query engine needs
+%%    user:mode/1 declarations to identify input (+) vs output (-) args.
+%%
+%% Usage:
+%%   swipl -l examples/benchmark/effective_distance_csharp.pl \
+%%         -l data/benchmark/dev/facts.pl \
+%%         -g "use_module('src/unifyweaver/targets/csharp_target'),
+%%             compile_predicate_to_csharp(category_ancestor/3,
+%%                 [target(csharp_query)], Code),
+%%             write(Code)" -t halt
 %% ==========================================================================
 
 :- discontiguous article_category/2.
 :- discontiguous category_parent/2.
 :- discontiguous root_category/1.
 
+%% Mode declarations for parameterized query engine
+:- dynamic user:mode/1.
+:- assert(user:mode(category_ancestor(+, -, -))).
+
 %% category_ancestor(+Cat, -Ancestor, -Hops)
-%% Transitive closure over category_parent/2.
-%% No Visited list needed — FixpointNode converges automatically.
-category_ancestor(Cat, Parent, 1) :-
-    category_parent(Cat, Parent).
+%% Transitive closure over category_parent/2 with hop counter.
+%% FixpointNode handles cycle detection automatically.
+%%
+%% Note: base case uses "Hops is 1" instead of head constant "1"
+%% because the C# query plan compiler requires variables in head args.
+category_ancestor(Cat, Parent, Hops) :-
+    category_parent(Cat, Parent),
+    Hops is 1.
 
 category_ancestor(Cat, Ancestor, Hops) :-
     category_parent(Cat, Mid),
@@ -24,10 +51,11 @@ category_ancestor(Cat, Ancestor, Hops) :-
     Hops is H1 + 1.
 
 %% path_to_root(+Article, -Root, -Hops)
-path_to_root(Article, Root, 1) :-
+path_to_root(Article, Root, Hops) :-
     article_category(Article, Cat),
     root_category(Cat),
-    Root = Cat.
+    Root = Cat,
+    Hops is 1.
 
 path_to_root(Article, Root, Hops) :-
     article_category(Article, Cat),

--- a/examples/benchmark/effective_distance_csharp.pl
+++ b/examples/benchmark/effective_distance_csharp.pl
@@ -9,11 +9,18 @@
 %%    automatically via delta-set convergence with HashSet deduplication.
 %%
 %% 2. Base case constant moved from head to body — the query plan
-%%    compiler requires variables in head positions, with binding
-%%    done via is/2 in the body. So instead of:
+%%    compiler currently requires variables in head positions, with
+%%    binding done via is/2 in the body. So instead of:
 %%      category_ancestor(Cat, Parent, 1) :- category_parent(Cat, Parent).
 %%    we write:
 %%      category_ancestor(Cat, Parent, Hops) :- category_parent(Cat, Parent), Hops is 1.
+%%
+%%    POTENTIAL BUG / FUTURE WORK: The plan compiler should ideally handle
+%%    constants in head positions of recursive predicates by implicitly
+%%    generating a SelectionNode (filtering on the constant column) or
+%%    inlining the value into the projection. This would allow the natural
+%%    Prolog idiom without the workaround. Filed as future enhancement for
+%%    the parameterized query engine's head-pattern compilation.
 %%
 %% 3. Mode declarations required — the parameterized query engine needs
 %%    user:mode/1 declarations to identify input (+) vs output (-) args.


### PR DESCRIPTION
  ## Summary

  - **C# query engine works**: The parameterized query engine already supports `is/2` arithmetic in recursive
  predicates. The earlier "variable not bound" error was due to predicate structuring, not a missing feature.
  - **Workaround documented**: Base case constants must be in body (`Hops is 1`) not head (`category_ancestor(Cat,
  Parent, 1)`) — documented as potential bug / future enhancement for the plan compiler's head-pattern compilation.
  - **Arity-N generalization noted**: Current Go/AWK/Python deepening is arity-specific (2 and 3). The C# parameterized
  engine handles arbitrary arity via IR. Other targets should converge toward arity-agnostic approach.

  ## Updated Gap Matrix

  All 5 targets now compile `category_ancestor/3`:

  | Target | Status | Approach |
  |---|---|---|
  | SWI-Prolog | ✅ | Native |
  | C# Query | ✅ (this PR) | Parameterized FixpointNode with `is/2` |
  | Go | ✅ (PR #1056) | Recursive function with visited map |
  | AWK | ✅ (PR #1056) | Semi-naive fixpoint iteration |
  | Python | ✅ (PR #1054) | Recursive generator with visited set |

  ## Future Work

  - Head-constant handling in recursive predicates (plan compiler should generate SelectionNode)
  - Generalize arity-specific deepening in Go/AWK/Python to arity-N

  ## Test plan

  - [x] C# parameterized query engine compiles `category_ancestor/3` with mode declaration and body-constant workaround
  - [x] Head-constant limitation documented as future enhancement

  🤖 Generated with [Claude Code](https://claude.com/claude-code)