### PR TITLE
fix(awk): cycle detection + benchmark runner cleanup

### DIFF
--- a/examples/benchmark/run_benchmark.sh
+++ b/examples/benchmark/run_benchmark.sh
@@ -76,6 +76,9 @@ echo "=== Step 2: Compile category_ancestor/3 ==="
 # Note: C# parameterized query engine requires:
 #   1. mode/1 declaration for input/output args
 #   2. Constants in body (Hops is 1) not head (category_ancestor(_, _, 1))
+# Helper: strip debug lines from swipl compilation output
+strip_debug() { grep -v '^===\|^Checking\|^Type:\|^Defined\|^Registered\|^  All\|^  Combined'; }
+
 echo -n "  Compiling C# ... "
 CSHARP_CODE=$(swipl -q -g "
     ['$FACTS_FILE'],
@@ -85,7 +88,7 @@ CSHARP_CODE=$(swipl -q -g "
     use_module('src/unifyweaver/targets/csharp_target'),
     compile_predicate_to_csharp(category_ancestor/3, [target(csharp_query)], Code),
     write(Code)
-" -t halt 2>/dev/null) && echo "OK" || echo "FAILED"
+" -t halt 2>/dev/null | strip_debug) && echo "OK" || echo "FAILED"
 
 if [ -n "$CSHARP_CODE" ]; then
     echo "$CSHARP_CODE" > "$OUTPUT_DIR/category_ancestor.cs"
@@ -103,7 +106,7 @@ GO_CODE=$(swipl -q -g "
     use_module('src/unifyweaver/targets/go_target'),
     compile_predicate_to_go(category_ancestor/3, [], Code),
     write(Code)
-" -t halt 2>/dev/null) && echo "OK" || echo "FAILED"
+" -t halt 2>/dev/null | strip_debug) && echo "OK" || echo "FAILED"
 
 if [ -n "$GO_CODE" ]; then
     echo "$GO_CODE" > "$OUTPUT_DIR/category_ancestor.go"
@@ -121,7 +124,7 @@ AWK_CODE=$(swipl -q -g "
     use_module('src/unifyweaver/targets/awk_target'),
     compile_predicate_to_awk(category_ancestor/3, [], Code),
     write(Code)
-" -t halt 2>/dev/null) && echo "OK" || echo "FAILED"
+" -t halt 2>/dev/null | strip_debug) && echo "OK" || echo "FAILED"
 
 if [ -n "$AWK_CODE" ]; then
     echo "$AWK_CODE" > "$OUTPUT_DIR/category_ancestor.awk"
@@ -139,7 +142,7 @@ PY_CODE=$(swipl -q -g "
     use_module('src/unifyweaver/targets/python_target'),
     compile_predicate_to_python(category_ancestor/3, [], Code),
     write(Code)
-" -t halt 2>/dev/null) && echo "OK" || echo "FAILED"
+" -t halt 2>/dev/null | strip_debug) && echo "OK" || echo "FAILED"
 
 if [ -n "$PY_CODE" ]; then
     echo "$PY_CODE" > "$OUTPUT_DIR/category_ancestor.py"

--- a/src/unifyweaver/targets/awk_target.pl
+++ b/src/unifyweaver/targets/awk_target.pl
@@ -198,7 +198,14 @@ BEGIN {
         }
     }
 
-    # Fixpoint: expand until no new tuples
+    # Cycle-aware fixpoint: track (source, ancestor) pairs.
+    # Only store shortest hops per pair — this matches the Prolog Visited
+    # semantics where each node is visited at most once per path.
+    # The effective distance formula uses ALL distinct paths, but in a
+    # cycle-free traversal each (source, ancestor) pair has one shortest path.
+    MAX_DEPTH = 50
+
+    # Fixpoint: expand delta set, deduplicate on (source, ancestor) pairs
     while (ndelta > 0) {
         ndelta = 0
         for (d in delta) {
@@ -206,12 +213,18 @@ BEGIN {
             cat = parts[1]
             ancestor = parts[2]
             hops = parts[3] + 0
+            if (hops + 1 > MAX_DEPTH) continue
             # Join: step(X, cat) => ancestor(X, ancestor, hops+1)
             for (i = 1; i <= ~w; i++) {
                 split(edges[i], e, FS)
                 if (e[2] == cat) {
-                    newkey = e[1] FS ancestor FS (hops + 1)
-                    if (!(newkey in result)) {
+                    pair = e[1] SUBSEP ancestor
+                    newhops = hops + 1
+                    # Only add if this (source, ancestor) pair is new
+                    # or we found a shorter path
+                    if (!(pair in best_hops) || newhops < best_hops[pair]) {
+                        best_hops[pair] = newhops
+                        newkey = e[1] FS ancestor FS newhops
                         result[newkey] = 1
                         new_delta[newkey] = 1
                         ndelta++


### PR DESCRIPTION
 ## Summary

  - **AWK fixpoint cycle detection**: Add shortest-path memoization via associative array (`best_hops[pair]`) to prevent
   non-termination in cyclic category graphs. Uses `MAX_DEPTH=50` safety bound.
  - **Benchmark runner fix**: Strip debug output (`=== Compiling ...`, `Type:`, etc.) from target compilation, which was
   polluting generated source files.

  ## AWK Cycle Detection

  The AWK fixpoint was non-terminating because different hop counts created distinct `(source, ancestor, hops)` tuples
  in cyclic graphs, preventing convergence. Fix: memoize shortest hops per `(source, ancestor)` pair — AWK's associative
   arrays serve as the memoization table (equivalent of Prolog's Visited list).

  **Known limitation**: Current AWK approach tracks shortest paths only, not all simple paths. The effective distance
  formula `d_eff = (Σ dᵢ^(-n))^(-1/n)` ideally needs all path lengths. This requires a new recursion pattern — **DFS
  with per-path visited tracking** — which is distinct from standard transitive closure or global memoization. This
  should be designed as a proper cross-target feature rather than hacked into templates.

  ## New Recursion Pattern Identified

  All-simple-paths traversal (per-path visited set) is a new recursion type that none of the targets currently support
  natively:

  | Pattern | Dedup Strategy | Targets |
  |---|---|---|
  | Standard TC | `(source, target)` pairs | All |
  | Tail recursion | Loop conversion | All |
  | Global memoization | `@cache` / `map` | Python, Go |
  | **Per-path visited** | **Visited set threaded per branch** | **Prolog only (native)** |

  Designing this as a cross-target feature is future work.

  ## Test plan

  - [x] AWK fixpoint terminates on cyclic dev dataset (5,146 results)
  - [x] Benchmark runner generates clean source files for all 5 targets
  - [ ] Full all-simple-paths support (future: new recursion pattern)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)