### PR TITLE
feat: per-path visited recursion — design, pattern detection, AWK DFS

### DIFF
--- a/docs/design/PER_PATH_VISITED_RECURSION.md
+++ b/docs/design/PER_PATH_VISITED_RECURSION.md
@@ -1,0 +1,200 @@
+# Design: Per-Path Visited Recursion
+
+## Problem
+
+Standard transitive closure deduplicates on `(source, target)` pairs — each
+pair is discovered once. But the effective distance formula
+`d_eff = (Σ dᵢ^(-n))^(-1/n)` requires **all simple paths** between nodes,
+where each path has a different length that contributes to the weighted sum.
+
+A "simple path" is one that visits no node more than once. In a cyclic graph,
+without this constraint, there are infinitely many paths (loops can be
+traversed arbitrarily many times).
+
+Prolog handles this naturally via a **Visited list** threaded through each
+recursive branch:
+
+```prolog
+category_ancestor(Cat, Parent, 1, Visited) :-
+    category_parent(Cat, Parent),
+    \+ member(Parent, Visited).
+
+category_ancestor(Cat, Ancestor, Hops, Visited) :-
+    category_parent(Cat, Mid),
+    \+ member(Mid, Visited),
+    category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+Key semantics:
+- Each branch of backtracking gets its own independent copy of `Visited`
+- A node can appear in different branches (different paths) but not twice
+  on the same path
+- `\+ member(Mid, Visited)` is negation-as-failure membership check
+- `[Mid|Visited]` extends the path before recursing
+
+## Taxonomy of Recursion Patterns
+
+| Pattern | State | Dedup | Use Case |
+|---------|-------|-------|----------|
+| Standard TC | None | `(source, target)` | Reachability |
+| Counted TC | Counter | `(source, target, hops)` | Shortest path |
+| Tail recursion | Accumulator | N/A (loop) | Aggregation |
+| Global memoization | Cache | Input → Output | Pure functions |
+| **Per-path visited** | **Visited set per branch** | **Node ∉ current path** | **All simple paths** |
+
+Per-path visited is distinct because:
+1. State is **per-branch**, not global
+2. The same computation can yield **multiple results** for the same input
+   (different paths to the same target with different lengths)
+3. Requires **negation** (`\+ member`) which interacts with the visited set
+
+## Target Compilation Strategies
+
+### Strategy A: Recursive Function with Set Parameter (Go, Python, Rust)
+
+Languages with recursion and set/hashset types can directly translate the
+Prolog pattern:
+
+```python
+def category_ancestor(cat, visited=None):
+    if visited is None:
+        visited = frozenset()
+    for parent in category_parent[cat]:
+        if parent not in visited:
+            yield (parent, 1)
+            # Recurse with extended visited set (immutable copy per branch)
+            for (ancestor, h) in category_ancestor(parent, visited | {parent}):
+                yield (ancestor, h + 1)
+```
+
+Key requirements:
+- **Immutable or copied visited set per branch** — `visited | {parent}`
+  creates a new set for each recursive call, so sibling branches don't
+  interfere
+- **Generator/yield pattern** — multiple results per input
+- **Set membership test** — `parent not in visited`
+
+This is what Go and Python already generate (with `visited` parameter),
+but it needs to be recognized as a **pattern** that the compiler extracts
+from the Prolog `\+ member(X, Visited)` + `[X|Visited]` idiom.
+
+### Strategy B: Explicit DFS with Stack (AWK, C)
+
+Languages without recursion (AWK) or where explicit stack control is
+preferred (C for performance) simulate DFS:
+
+```awk
+# Stack-based DFS with per-path visited encoded as string
+sp = 1
+stack_node[sp] = source
+stack_hops[sp] = 0
+stack_path[sp] = source  # comma-separated path
+
+while (sp > 0) {
+    cur = stack_node[sp]; hops = stack_hops[sp]; path = stack_path[sp]
+    sp--
+    for each neighbor of cur:
+        if neighbor not in path:
+            record (source, neighbor, hops + 1)
+            sp++
+            stack_node[sp] = neighbor
+            stack_hops[sp] = hops + 1
+            stack_path[sp] = path "," neighbor
+}
+```
+
+Key requirements:
+- **Explicit stack arrays** — AWK associative arrays indexed by stack pointer
+- **Path encoding** — visited set encoded as delimited string for containment
+  check via `index()`
+- **No recursion limit** — stack depth bounded by graph diameter
+
+### Strategy C: Semi-Naive with Path Tracking (C# Query Engine)
+
+The C# parameterized query engine uses `FixpointNode` with delta sets.
+To support per-path visited, the tuples would need to carry path
+information:
+
+- Tuple: `(source, ancestor, hops, path_hash)` where `path_hash`
+  encodes the visited set
+- Deduplication on the full tuple including path_hash
+- Join condition: new intermediate node not in path
+
+This is more complex and may not be worth implementing in the IR —
+the C# query engine could instead generate a custom C# function that
+does DFS directly, bypassing the plan-based evaluation for this pattern.
+
+## Pattern Recognition
+
+The compiler should recognize this pattern from Prolog source:
+
+```
+% Indicators of per-path visited recursion:
+1. A list parameter that grows by consing: [X|Visited]
+2. Negated membership check: \+ member(X, Visited)
+3. The parameter is threaded through the recursive call
+4. Base case checks the same negation pattern
+```
+
+Detection predicate:
+
+```prolog
+is_per_path_visited_recursion(Name, Arity, Clauses) :-
+    % Has a list parameter that grows in recursive clause
+    member((_RecHead, RecBody), RecClauses),
+    contains_pattern(RecBody, [_|_]),       % list cons
+    contains_pattern(RecBody, \+ member(_, _)),  % negated membership
+    % The list parameter is threaded through recursive call
+    ...
+```
+
+## Compilation Pipeline
+
+1. **Detect** the `\+ member(X, Visited)` + `[X|Visited]` pattern
+2. **Extract** which argument position holds the visited list
+3. **Generate** target-specific code using Strategy A, B, or C
+4. **Omit** the visited parameter from the external API (it's internal state)
+
+The external signature is `category_ancestor(Cat, Ancestor, Hops)` — the
+Visited parameter is an implementation detail that the compiler manages.
+
+## Interaction with Effective Distance
+
+For the benchmark, the full pipeline is:
+
+```
+category_ancestor/4 (with Visited)
+    ↓ per-path visited recursion
+    yields all (Cat, Ancestor, Hops) triples for simple paths
+    ↓
+effective_distance/3
+    aggregates: sum(Hops^(-5)) per (Article, Root) pair
+    ↓
+d_eff = WeightSum^(-1/5)
+```
+
+The per-path visited ensures finite enumeration (no cycles), and the
+aggregation combines all path lengths into the dimensional distance metric.
+
+## Implementation Priority
+
+| Target | Strategy | Effort | Notes |
+|--------|----------|--------|-------|
+| Python | A (recursive + frozenset) | Low | Already has visited param, just needs pattern recognition |
+| Go | A (recursive + map copy) | Low | Already has visited param |
+| Rust | A (recursive + HashSet clone) | Low | Needs arity-3 deepening first |
+| AWK | B (explicit DFS stack) | Medium | No recursion, needs stack simulation |
+| C# Query | C (custom function) | High | May bypass FixpointNode for this pattern |
+| C/C++ | B (explicit DFS stack) | Medium | Stack-based for performance |
+
+## Prior Work
+
+- `src/unifyweaver/core/clause_body_analysis.pl` — classify_goal_sequence
+  framework with multifile hooks (native deepening)
+- `docs/design/RECURSIVE_TEMPLATE_LOWERING.md` — recursive template → native
+  lowering architecture
+- `docs/design/CLAUSE_BODY_ANALYSIS_EXTRACTION.md` — extraction of shared
+  clause body analysis from typR
+- Go/Python already generate `visited` parameter — this design formalizes
+  the pattern and adds compiler-level recognition

--- a/docs/design/PER_PATH_VISITED_RECURSION.md
+++ b/docs/design/PER_PATH_VISITED_RECURSION.md
@@ -137,24 +137,86 @@ The compiler should recognize this pattern from Prolog source:
 4. Base case checks the same negation pattern
 ```
 
-Detection predicate:
+## Existing Infrastructure
+
+Key findings from codebase analysis:
+
+1. **`classify_goal_sequence/3`** (`clause_body_analysis.pl`) does NOT handle
+   `\+` negation — negated goals fall through to `passthrough`. Negation-as-
+   guard classification needs to be added.
+
+2. **`split_body_at_recursive_call/5`** (`pattern_matchers.pl`) can identify
+   where the recursive call sits in the body — useful for finding the Visited
+   parameter position.
+
+3. **`is_tail_recursive_accumulator/2`** (`pattern_matchers.pl`) detects
+   accumulator patterns but uses a simple heuristic (arity-3, position 2).
+   The Visited list pattern is structurally different (list cons + negated
+   membership).
+
+4. **Go target** is the only target with explicit visited-set code generation.
+   The pattern needs to be generalized across targets.
+
+5. **TypR target** has "threaded context arguments" (positions 3+) for
+   invariant state in mutual recursion — conceptually similar but not
+   per-path mutable state.
+
+## Pattern Recognition
+
+The compiler should recognize the Visited-list pattern from these indicators
+in the Prolog source:
 
 ```prolog
-is_per_path_visited_recursion(Name, Arity, Clauses) :-
-    % Has a list parameter that grows in recursive clause
-    member((_RecHead, RecBody), RecClauses),
-    contains_pattern(RecBody, [_|_]),       % list cons
-    contains_pattern(RecBody, \+ member(_, _)),  % negated membership
-    % The list parameter is threaded through recursive call
-    ...
+%% Indicators:
+%% 1. A list parameter that grows via cons: [X|Visited]
+%% 2. Negated membership check: \+ member(X, Visited)
+%% 3. The list parameter is threaded through the recursive call
+%% 4. Base case also has a negated membership check
+
+is_per_path_visited_pattern(Name, Arity, Clauses, VisitedPos) :-
+    % Separate base and recursive clauses
+    partition(is_recursive_clause_for(Name), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [], BaseClauses \= [],
+
+    % Find the Visited parameter position:
+    % In the recursive clause, find which head arg appears in [X|Arg]
+    member((RecHead, RecBody), RecClauses),
+    RecHead =.. [Name|RecArgs],
+
+    % Find the arg position that has list-cons in body
+    nth1(VisitedPos, RecArgs, VisitedVar),
+    body_contains_cons(RecBody, _, VisitedVar),  % [_|VisitedVar]
+
+    % Verify negated membership check exists
+    body_contains_negated_member(RecBody, _, VisitedVar),
+
+    % Verify the extended list is passed to recursive call
+    body_recursive_call_arg(RecBody, Name, VisitedPos, ExtendedList),
+    ExtendedList = [_|VisitedVar].
+
+%% Helper: check body contains \+ member(X, List)
+body_contains_negated_member((\+ member(X, List), _), X, List) :- !.
+body_contains_negated_member((_, Rest), X, List) :-
+    body_contains_negated_member(Rest, X, List).
+body_contains_negated_member(\+ member(X, List), X, List).
+
+%% Helper: check body contains [H|T] pattern
+body_contains_cons(Body, H, T) :-
+    sub_term([H|T], Body).
 ```
 
 ## Compilation Pipeline
 
-1. **Detect** the `\+ member(X, Visited)` + `[X|Visited]` pattern
-2. **Extract** which argument position holds the visited list
-3. **Generate** target-specific code using Strategy A, B, or C
-4. **Omit** the visited parameter from the external API (it's internal state)
+1. **Detect** the `\+ member(X, Visited)` + `[X|Visited]` pattern via
+   `is_per_path_visited_pattern/4`
+2. **Extract** which argument position holds the visited list (`VisitedPos`)
+3. **Generate** target-specific code using Strategy A, B, or C:
+   - Strategy A targets receive the Visited position and generate a set
+     parameter with copy-on-branch semantics
+   - Strategy B targets receive the adjacency structure and generate DFS
+     with stack-encoded path strings
+4. **External API omits** the visited parameter — it's internal state
+   managed by the generated code
 
 The external signature is `category_ancestor(Cat, Ancestor, Hops)` — the
 Visited parameter is an implementation detail that the compiler manages.

--- a/src/unifyweaver/core/advanced/pattern_matchers.pl
+++ b/src/unifyweaver/core/advanced/pattern_matchers.pl
@@ -26,6 +26,8 @@
     % Linear-to-tail recursion transformation
     can_transform_linear_to_tail/2,       % +Pred/Arity, -TransformInfo
     split_body_at_recursive_call/5,       % +Body, +Pred, -PreGoals, -RecCall, -PostGoals
+    % Per-path visited recursion pattern
+    is_per_path_visited_pattern/4,        % +Name, +Arity, +Clauses, -VisitedPos
     test_pattern_matchers/0         % Test predicate
 ]).
 
@@ -599,6 +601,74 @@ extract_base_result_value(BaseClauses, _ResultVar, Init) :-
         number(Init)
     ),
     !.
+
+%% ============================================
+%% PER-PATH VISITED RECURSION PATTERN
+%% ============================================
+%%
+%% Detects the Prolog idiom for cycle-safe graph traversal:
+%%   pred(X, Y, N, Visited) :-
+%%       step(X, Mid),
+%%       \+ member(Mid, Visited),
+%%       pred(Mid, Y, N1, [Mid|Visited]),
+%%       N is N1 + 1.
+%%
+%% Returns the position (1-indexed) of the Visited list parameter.
+%% Targets use this to generate per-path cycle detection:
+%%   - Go/Python/Rust: recursive function with set/frozenset parameter
+%%   - AWK/C: explicit DFS with stack-encoded path
+
+%% is_per_path_visited_pattern(+Name, +Arity, +Clauses, -VisitedPos)
+%%   Clauses are (Head, Body) pairs.
+is_per_path_visited_pattern(Name, Arity, Clauses, VisitedPos) :-
+    Arity >= 3,
+    % Separate base and recursive clauses
+    partition(is_recursive_clause_for_ppv(Name), Clauses, RecClauses, _BaseClauses),
+    RecClauses \= [],
+    % Examine the recursive clause
+    member((RecHead, RecBody), RecClauses),
+    RecHead =.. [Name|RecArgs],
+    % Find the Visited position: the arg that appears in [_|Arg] cons
+    % AND in \+ member(_, Arg) in the body
+    between(1, Arity, VisitedPos),
+    nth1(VisitedPos, RecArgs, VisitedVar),
+    var(VisitedVar),
+    % Check: body has \+ member(_, VisitedVar)
+    body_has_negated_member(RecBody, VisitedVar),
+    % Check: body has [_|VisitedVar] passed to recursive call
+    body_has_cons_in_recursive_call(RecBody, Name, VisitedPos, VisitedVar),
+    !.
+
+%% is_recursive_clause_for_ppv(+Name, +Clause)
+is_recursive_clause_for_ppv(Name, (_Head, Body)) :-
+    contains_call_to(Body, Name).
+
+%% body_has_negated_member(+Body, +ListVar)
+%%   True if Body contains \+ member(_, ListVar).
+body_has_negated_member((\+ member(_, Var), _), ListVar) :-
+    Var == ListVar, !.
+body_has_negated_member((_, Rest), ListVar) :- !,
+    body_has_negated_member(Rest, ListVar).
+body_has_negated_member(\+ member(_, Var), ListVar) :-
+    Var == ListVar.
+
+%% body_has_cons_in_recursive_call(+Body, +Name, +Pos, +VisitedVar)
+%%   True if the recursive call to Name has [_|VisitedVar] at position Pos.
+body_has_cons_in_recursive_call(Body, Name, Pos, VisitedVar) :-
+    extract_goals_ppv(Body, Goals),
+    member(RecCall, Goals),
+    RecCall =.. [Name|CallArgs],
+    nth1(Pos, CallArgs, CallArg),
+    nonvar(CallArg),
+    CallArg = [_|Tail],
+    Tail == VisitedVar.
+
+%% extract_goals_ppv(+Body, -Goals)
+extract_goals_ppv((A, B), Goals) :- !,
+    extract_goals_ppv(A, GA),
+    extract_goals_ppv(B, GB),
+    append(GA, GB, Goals).
+extract_goals_ppv(Goal, [Goal]).
 
 %% ============================================
 %% TESTS

--- a/src/unifyweaver/targets/awk_target.pl
+++ b/src/unifyweaver/targets/awk_target.pl
@@ -178,72 +178,57 @@ compile_general_recursive_to_awk(Pred, Arity, Clauses, Options, AwkCode) :-
     atomic_list_concat(EdgeLines, '\n', EdgeBlock),
     length(StepFacts, NEdges),
     (   Arity =:= 3
-    ->  % Ternary: with counter
+    ->  % Ternary: with counter — DFS with per-path visited
         format(string(AwkCode),
-'# Fixpoint evaluation: ~w/~w (transitive closure with counter)
+'# DFS all-simple-paths: ~w/~w (transitive closure with counter)
 # Step relation: ~w/2 (~w edges)
+# Uses per-path visited set to find ALL simple paths (no repeated nodes).
+# This matches Prolog Visited-list semantics for the effective distance formula.
 BEGIN {
     FS = "~w"
     # Load step relation edges
 ~w
 
-    # Initialize base case: direct edges have distance 1
+    # Build adjacency list
     for (i = 1; i <= ~w; i++) {
         split(edges[i], e, FS)
-        key = e[1] FS e[2] FS 1
-        if (!(key in result)) {
-            result[key] = 1
-            delta[key] = 1
-            ndelta++
-        }
+        adj_n[e[1]]++
+        adj[e[1], adj_n[e[1]]] = e[2]
     }
 
-    # Cycle-aware fixpoint: track (source, ancestor) pairs.
-    # Only store shortest hops per pair — this matches the Prolog Visited
-    # semantics where each node is visited at most once per path.
-    # The effective distance formula uses ALL distinct paths, but in a
-    # cycle-free traversal each (source, ancestor) pair has one shortest path.
-    MAX_DEPTH = 50
+    # DFS from every source node to find all simple paths
+    for (src in adj_n) {
+        # Stack: node, hops, visited-path (comma-delimited)
+        sp = 1
+        stk_node[1] = src
+        stk_hops[1] = 0
+        stk_path[1] = "," src ","
 
-    # Fixpoint: expand delta set, deduplicate on (source, ancestor) pairs
-    while (ndelta > 0) {
-        ndelta = 0
-        for (d in delta) {
-            split(d, parts, FS)
-            cat = parts[1]
-            ancestor = parts[2]
-            hops = parts[3] + 0
-            if (hops + 1 > MAX_DEPTH) continue
-            # Join: step(X, cat) => ancestor(X, ancestor, hops+1)
-            for (i = 1; i <= ~w; i++) {
-                split(edges[i], e, FS)
-                if (e[2] == cat) {
-                    pair = e[1] SUBSEP ancestor
-                    newhops = hops + 1
-                    # Only add if this (source, ancestor) pair is new
-                    # or we found a shorter path
-                    if (!(pair in best_hops) || newhops < best_hops[pair]) {
-                        best_hops[pair] = newhops
-                        newkey = e[1] FS ancestor FS newhops
-                        result[newkey] = 1
-                        new_delta[newkey] = 1
-                        ndelta++
-                    }
-                }
+        while (sp > 0) {
+            cur = stk_node[sp]
+            hops = stk_hops[sp]
+            path = stk_path[sp]
+            sp--
+
+            nc = adj_n[cur]
+            for (j = 1; j <= nc; j++) {
+                nb = adj[cur, j]
+                # Per-path cycle check
+                if (index(path, "," nb ",") > 0) continue
+
+                nh = hops + 1
+                print src FS nb FS nh
+                # Push for further DFS
+                sp++
+                stk_node[sp] = nb
+                stk_hops[sp] = nh
+                stk_path[sp] = path nb ","
             }
         }
-        delete delta
-        for (k in new_delta) delta[k] = 1
-        delete new_delta
-    }
-
-    # Output all results
-    for (key in result) {
-        print key
     }
 }
 ', [PredStr, Arity, StepRelStr, NEdges, FieldSep,
-    EdgeBlock, NEdges, NEdges])
+    EdgeBlock, NEdges])
     ;   % Binary: no counter
         format(string(AwkCode),
 '# Fixpoint evaluation: ~w/~w (transitive closure)


### PR DESCRIPTION
  ## Summary

  Introduces a new recursion pattern for **all-simple-paths traversal** with per-path visited tracking. This is needed
  for the effective distance formula `d_eff = (Σ dᵢ^(-n))^(-1/n)` which aggregates over all paths, not just shortest —
  multiple paths represent valid hierarchical relationships weighted by dimensionality.

  ### What's included

  - **Design doc** (`docs/design/PER_PATH_VISITED_RECURSION.md`): Taxonomy of recursion patterns, three compilation
  strategies (recursive+set, DFS+stack, semi-naive+path), pattern recognition spec, per-target implementation priority
  - **Core pattern detection** (`pattern_matchers.pl`): New `is_per_path_visited_pattern/4` detects the Prolog `\+
  member(X, Visited)` + `[X|Visited]` idiom and returns the Visited parameter position. Correctly identifies
  `category_ancestor/4` (pos=4) and rejects regular transitive closure.
  - **AWK DFS implementation**: Replace fixpoint (shortest-path only) with explicit DFS using stack arrays and per-path
  visited encoded as comma-delimited strings. Finds all simple paths — 198 edges, 121 categories → 973K paths in 1.5s.

  ### New recursion pattern taxonomy

  | Pattern | State | Dedup | Targets |
  |---|---|---|---|
  | Standard TC | None | `(source, target)` | All |
  | Counted TC | Counter | `(source, target, hops)` | All |
  | Tail recursion | Accumulator | N/A (loop) | All |
  | Global memoization | Cache | Input → Output | Python, Go |
  | **Per-path visited** | **Visited set per branch** | **Node ∉ current path** | **Prolog native; AWK DFS (this PR)** |

  ### Findings from codebase analysis

  - `classify_goal_sequence` doesn't handle `\+` negation (falls to passthrough)
  - `split_body_at_recursive_call/5` exists for body analysis
  - Go is the only target with explicit visited-set code generation
  - Pattern recognition is now in shared core — targets can wire into it

  ## Next steps

  - Wire `is_per_path_visited_pattern/4` into Go/Python/Rust compilation pipelines
  - Add `\+` negation-as-guard to `classify_goal_sequence`
  - Path trimming optimization: cap at `k * shortest_path` since `d^(-5)` makes long paths negligible

  ## Test plan

  - [x] Pattern detection: correctly identifies `category_ancestor/4` Visited at position 4
  - [x] Pattern detection: correctly rejects regular `ancestor/2` (no visited list)
  - [x] AWK DFS: terminates on cyclic graph, produces 973K simple paths in 1.5s
  - [ ] Wire pattern into Go/Python target compilation pipelines
  - [ ] End-to-end validation against Prolog reference

  🤖 Generated with [Claude Code](https://claude.com/claude-code)