### PR TITLE
Keep native TypR transitive closure typed loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ includes:
   intermediate, the final output directly, or the later result set needed by
   subsequent native steps
 - transitive-closure generation where BFS control flow, seeded adjacency
-  storage, vector-parameter runtime query helpers, and explicit
-  `input(stdin|file|vfs|function)` loader wrappers all stay in native TypR
-  syntax
+  storage, vector-parameter runtime query helpers, explicit
+  `input(stdin|file|vfs|function)` loader wrappers, and declared integer or
+  numeric runtime node parsing all stay in native TypR syntax
 - accumulator-style tail-recursive predicates such as `factorial_acc/3`,
   lowered to TypR functions that use raw-expression loop bodies instead of
   relabeled standalone R scripts

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -141,8 +141,8 @@ bring-up.
 - simple fact predicate lowering
 - transitive-closure generation with compile-time fact seeding, native TypR BFS
   control flow, native TypR adjacency-vector storage, native vector-based
-  runtime query helpers, and native explicit `input(stdin|file|vfs|function)`
-  loader wrappers
+  runtime query helpers, native explicit `input(stdin|file|vfs|function)`
+  loader wrappers, and native declared integer or numeric runtime node parsing
 - `uw_return_type/2` support for TypR generic predicates so declared return
   types replace weak `Any` fallbacks where possible
 - `r`-target return-type constraints enabled by default when metadata exists,

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -327,9 +327,10 @@ Current TypR lowering policy is intentionally mixed:
 - guard-style zero-output command bindings may be folded into TypR clause
   conditions
 - transitive-closure generation may keep BFS control flow, seeded adjacency
-  storage, vector-parameter runtime query helpers, and explicit
-  `input(stdin|file|vfs|function)` loader wrappers in native TypR when the
-  base relation shape is known at compile time
+  storage, vector-parameter runtime query helpers, explicit
+  `input(stdin|file|vfs|function)` loader wrappers, and declared integer or
+  numeric runtime node parsing in native TypR when the base relation shape is
+  known at compile time
 - multi-step native TypR control-flow chains may keep later guards and outputs
   in native TypR when those guards depend on earlier bound values
 - simple comparison and boolean guard expressions over already-bound

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -431,9 +431,10 @@ Inference note:
 Current implementation note:
 
 - transitive closure now keeps BFS control flow, seeded adjacency storage,
-  vector-parameter runtime query helpers, and explicit
-  `input(stdin|file|vfs|function)` loader wrappers in valid TypR syntax when
-  the base relation is known at compile time
+  vector-parameter runtime query helpers, explicit
+  `input(stdin|file|vfs|function)` loader wrappers, and declared integer or
+  numeric runtime node parsing in valid TypR syntax when the base relation is
+  known at compile time
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
   predicates, sequential guard/output control-flow chains, simple comparison

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -6651,6 +6651,8 @@ compile_typr_transitive_closure(Module, Pred/Arity, BasePred, TypedMode, Options
     annotation_suffix(TypedMode, list(NodeTypeTerm), AllReturnAnnotation),
     annotation_suffix(TypedMode, boolean, CheckReturnAnnotation),
     empty_collection_expr(NodeTypeTerm, EmptyNodesExpr),
+    typr_tc_line_part_expr(NodeTypeTerm, 1, FromLineExpr),
+    typr_tc_line_part_expr(NodeTypeTerm, 2, ToLineExpr),
     base_pair_vectors(Module, BasePred, NodeTypeTerm, FromNodesExpr, ToNodesExpr),
     Dict = [
         pred=PredStr,
@@ -6661,6 +6663,8 @@ compile_typr_transitive_closure(Module, Pred/Arity, BasePred, TypedMode, Options
         all_return_annotation=AllReturnAnnotation,
         check_return_annotation=CheckReturnAnnotation,
         empty_nodes_expr=EmptyNodesExpr,
+        from_line_expr=FromLineExpr,
+        to_line_expr=ToLineExpr,
         from_nodes_expr=FromNodesExpr,
         to_nodes_expr=ToNodesExpr
     ],
@@ -6711,6 +6715,21 @@ typr_tc_string_value(Value, String) :-
     ->  atom_string(Value, String)
     ;   format(string(String), '~w', [Value])
     ).
+
+typr_tc_line_part_expr(NodeTypeTerm, PartIndex, Expr) :-
+    format(string(PartExpr), 'trimws(parts[~w])', [PartIndex]),
+    typr_tc_parse_node_expr(NodeTypeTerm, PartExpr, Expr).
+
+typr_tc_parse_node_expr(atom, Expr, Expr).
+typr_tc_parse_node_expr(string, Expr, Expr).
+typr_tc_parse_node_expr(integer, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'as__integer(~w)', [Expr]).
+typr_tc_parse_node_expr(float, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'as__numeric(~w)', [Expr]).
+typr_tc_parse_node_expr(number, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'as__numeric(~w)', [Expr]).
+typr_tc_parse_node_expr(any, Expr, Expr).
+typr_tc_parse_node_expr(_, Expr, Expr).
 
 load_typr_transitive_closure_template(Template) :-
     (   exists_file('templates/targets/typr/transitive_closure.mustache')

--- a/templates/targets/typr/tc_definitions.mustache
+++ b/templates/targets/typr/tc_definitions.mustache
@@ -22,7 +22,7 @@ let {{base}}_from_lines <- function(lines) {
 	for (line in lines) {
 		parts <- strsplit(trimws(line), ":");
 		if (length(parts) >= 2) {
-			results <- c(results, trimws(parts[1]));
+			results <- c(results, {{from_line_expr}});
 		}
 	}
 
@@ -35,7 +35,7 @@ let {{base}}_to_lines <- function(lines) {
 	for (line in lines) {
 		parts <- strsplit(trimws(line), ":");
 		if (length(parts) >= 2) {
-			results <- c(results, trimws(parts[2]));
+			results <- c(results, {{to_line_expr}});
 		}
 	}
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -307,6 +307,30 @@ test(transitive_closure_function_input_mode_emits_vector_wrappers) :-
     \+ sub_string(Code, _, _, _, "@{"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(transitive_closure_integer_runtime_loader_parses_declared_node_type) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, integer)),
+    assertz(type_declarations:uw_type(edge/2, 2, integer)),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(stdin)], Code)),
+    once(sub_string(Code, _, _, _, "results <- integer()")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__integer(trimws(parts[1])));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__integer(trimws(parts[2])));")),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[1]));"),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[2]));"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(transitive_closure_numeric_runtime_loader_parses_declared_node_type) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, number)),
+    assertz(type_declarations:uw_type(edge/2, 2, number)),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(vfs("family_tree"))], Code)),
+    once(sub_string(Code, _, _, _, "results <- numeric()")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__numeric(trimws(parts[1])));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__numeric(trimws(parts[2])));")),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[1]));"),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[2]));"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(per_predicate_typed_mode_overrides_call_option) :-
     clear_type_declarations,
     assertz(type_declarations:uw_type(edge/2, 1, atom)),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -133,6 +133,35 @@ test(transitive_closure_function_input_checks_with_typr, [condition(typr_cli_ava
         delete_directory_and_contents(ProjectDir)
     ).
 
+test(transitive_closure_integer_runtime_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, integer)),
+    assertz(type_declarations:uw_type(edge/2, 2, integer)),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(stdin)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ).
+
+test(transitive_closure_numeric_runtime_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, number)),
+    assertz(type_declarations:uw_type(edge/2, 2, number)),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(vfs("family_tree"))], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check'])
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ).
+
 test(tail_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:factorial_acc(0, Acc, Acc)),


### PR DESCRIPTION
## Summary
- make TypR transitive-closure runtime loaders respect declared node types
- keep runtime parsing native in TypR for `integer` and `number` / `float` nodes
- add regression coverage for typed runtime loader generation and `typr check`

## What changed
- added node-type-aware parse generation in [src/unifyweaver/targets/typr_target.pl](src/unifyweaver/targets/typr_target.pl)
  - `integer` nodes now parse with `as__integer(...)`
  - `float` and `number` nodes now parse with `as__numeric(...)`
- updated [templates/targets/typr/tc_definitions.mustache](templates/targets/typr/tc_definitions.mustache)
  - `*_from_lines` and `*_to_lines` no longer always append trimmed char values
  - the emitted parse expression now depends on the declared transitive-closure node type
- added regression coverage in:
  - [tests/test_typr_target.pl](tests/test_typr_target.pl)
  - [tests/test_typr_toolchain.pl](tests/test_typr_toolchain.pl)
- updated docs in:
  - [README.md](README.md)
  - [docs/design/TYPE_SYSTEM_SPEC.md](docs/design/TYPE_SYSTEM_SPEC.md)
  - [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
  - [docs/design/TYPR_TARGET_DESIGN.md](docs/design/TYPR_TARGET_DESIGN.md)

## Why
Before this change, the native TypR transitive-closure runtime loaders still parsed line-based input as character data even when the declared node type was numeric. That meant the generated code was native TypR syntactically, but it did not preserve the declared runtime node type at the loader boundary.

This branch closes that gap without reintroducing raw R.

## Validation
```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Notes
- this change is intentionally narrow: it fixes native loader typing for the current runtime transitive-closure path
- it does not add new raw-R fallback
- the remaining frontier is richer runtime node typing beyond the current `integer` / `number` / `float` parsing slice
