### PR TITLE
Keep native TypR transitive closure pair loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ includes:
   subsequent native steps
 - transitive-closure generation where BFS control flow, seeded adjacency
   storage, vector-parameter runtime query helpers, explicit
-  `input(stdin|file|vfs|function)` loader wrappers, and declared integer or
-  numeric runtime node parsing all stay in native TypR syntax
+  `input(stdin|file|vfs|function)` loader wrappers, and declared scalar or
+  conservative pair-shaped runtime node parsing all stay in native TypR syntax
 - accumulator-style tail-recursive predicates such as `factorial_acc/3`,
   lowered to TypR functions that use raw-expression loop bodies instead of
   relabeled standalone R scripts

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -142,7 +142,8 @@ bring-up.
 - transitive-closure generation with compile-time fact seeding, native TypR BFS
   control flow, native TypR adjacency-vector storage, native vector-based
   runtime query helpers, native explicit `input(stdin|file|vfs|function)`
-  loader wrappers, and native declared integer or numeric runtime node parsing
+  loader wrappers, and native declared scalar or conservative pair-shaped
+  runtime node parsing
 - `uw_return_type/2` support for TypR generic predicates so declared return
   types replace weak `Any` fallbacks where possible
 - `r`-target return-type constraints enabled by default when metadata exists,

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -328,9 +328,9 @@ Current TypR lowering policy is intentionally mixed:
   conditions
 - transitive-closure generation may keep BFS control flow, seeded adjacency
   storage, vector-parameter runtime query helpers, explicit
-  `input(stdin|file|vfs|function)` loader wrappers, and declared integer or
-  numeric runtime node parsing in native TypR when the base relation shape is
-  known at compile time
+  `input(stdin|file|vfs|function)` loader wrappers, and declared scalar or
+  conservative pair-shaped runtime node parsing in native TypR when the base
+  relation shape is known at compile time
 - multi-step native TypR control-flow chains may keep later guards and outputs
   in native TypR when those guards depend on earlier bound values
 - simple comparison and boolean guard expressions over already-bound

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -432,9 +432,9 @@ Current implementation note:
 
 - transitive closure now keeps BFS control flow, seeded adjacency storage,
   vector-parameter runtime query helpers, explicit
-  `input(stdin|file|vfs|function)` loader wrappers, and declared integer or
-  numeric runtime node parsing in valid TypR syntax when the base relation is
-  known at compile time
+  `input(stdin|file|vfs|function)` loader wrappers, and declared scalar or
+  conservative pair-shaped runtime node parsing in valid TypR syntax when the
+  base relation is known at compile time
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
   predicates, sequential guard/output control-flow chains, simple comparison

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -6651,8 +6651,9 @@ compile_typr_transitive_closure(Module, Pred/Arity, BasePred, TypedMode, Options
     annotation_suffix(TypedMode, list(NodeTypeTerm), AllReturnAnnotation),
     annotation_suffix(TypedMode, boolean, CheckReturnAnnotation),
     empty_collection_expr(NodeTypeTerm, EmptyNodesExpr),
-    typr_tc_line_part_expr(NodeTypeTerm, 1, FromLineExpr),
-    typr_tc_line_part_expr(NodeTypeTerm, 2, ToLineExpr),
+    typr_tc_node_parse_helper(BaseStr, NodeTypeTerm, NodeParseHelperCode),
+    typr_tc_line_part_expr(BaseStr, NodeTypeTerm, 1, FromLineExpr),
+    typr_tc_line_part_expr(BaseStr, NodeTypeTerm, 2, ToLineExpr),
     base_pair_vectors(Module, BasePred, NodeTypeTerm, FromNodesExpr, ToNodesExpr),
     Dict = [
         pred=PredStr,
@@ -6663,6 +6664,7 @@ compile_typr_transitive_closure(Module, Pred/Arity, BasePred, TypedMode, Options
         all_return_annotation=AllReturnAnnotation,
         check_return_annotation=CheckReturnAnnotation,
         empty_nodes_expr=EmptyNodesExpr,
+        node_parse_helper_code=NodeParseHelperCode,
         from_line_expr=FromLineExpr,
         to_line_expr=ToLineExpr,
         from_nodes_expr=FromNodesExpr,
@@ -6716,20 +6718,51 @@ typr_tc_string_value(Value, String) :-
     ;   format(string(String), '~w', [Value])
     ).
 
-typr_tc_line_part_expr(NodeTypeTerm, PartIndex, Expr) :-
-    format(string(PartExpr), 'trimws(parts[~w])', [PartIndex]),
-    typr_tc_parse_node_expr(NodeTypeTerm, PartExpr, Expr).
+typr_tc_line_part_expr(BaseName, NodeTypeTerm, PartIndex, Expr) :-
+    format(string(PartExpr), 'parts[~w]', [PartIndex]),
+    typr_tc_parse_node_expr(BaseName, NodeTypeTerm, PartExpr, Expr).
 
-typr_tc_parse_node_expr(atom, Expr, Expr).
-typr_tc_parse_node_expr(string, Expr, Expr).
-typr_tc_parse_node_expr(integer, Expr, ParsedExpr) :-
-    format(string(ParsedExpr), 'as__integer(~w)', [Expr]).
-typr_tc_parse_node_expr(float, Expr, ParsedExpr) :-
-    format(string(ParsedExpr), 'as__numeric(~w)', [Expr]).
-typr_tc_parse_node_expr(number, Expr, ParsedExpr) :-
-    format(string(ParsedExpr), 'as__numeric(~w)', [Expr]).
-typr_tc_parse_node_expr(any, Expr, Expr).
-typr_tc_parse_node_expr(_, Expr, Expr).
+typr_tc_node_parse_helper(_BaseName, NodeTypeTerm, "") :-
+    \+ typr_tc_requires_parse_helper(NodeTypeTerm),
+    !.
+typr_tc_node_parse_helper(BaseName, pair(LeftType, RightType), Code) :-
+    !,
+    typr_tc_pair_component_expr(LeftType, "pair_parts[1]", LeftExpr),
+    typr_tc_pair_component_expr(RightType, "pair_parts[2]", RightExpr),
+    format(string(Code),
+'let ~w_parse_node <- function(text) {
+\tpair_parts <- strsplit(trimws(text), ",");
+\tpair(~w, ~w)
+};
+
+', [BaseName, LeftExpr, RightExpr]).
+
+typr_tc_requires_parse_helper(pair(_, _)).
+
+typr_tc_pair_component_expr(TypeTerm, Expr, ParsedExpr) :-
+    typr_tc_scalar_parse_node_expr(TypeTerm, Expr, ParsedExpr).
+
+typr_tc_parse_node_expr(BaseName, NodeTypeTerm, Expr, ParsedExpr) :-
+    typr_tc_requires_parse_helper(NodeTypeTerm),
+    !,
+    format(string(ParsedExpr), '~w_parse_node(~w)', [BaseName, Expr]).
+typr_tc_parse_node_expr(_BaseName, NodeTypeTerm, Expr, ParsedExpr) :-
+    typr_tc_scalar_parse_node_expr(NodeTypeTerm, Expr, ParsedExpr).
+
+typr_tc_scalar_parse_node_expr(atom, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'trimws(~w)', [Expr]).
+typr_tc_scalar_parse_node_expr(string, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'trimws(~w)', [Expr]).
+typr_tc_scalar_parse_node_expr(integer, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'as__integer(trimws(~w))', [Expr]).
+typr_tc_scalar_parse_node_expr(float, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'as__numeric(trimws(~w))', [Expr]).
+typr_tc_scalar_parse_node_expr(number, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'as__numeric(trimws(~w))', [Expr]).
+typr_tc_scalar_parse_node_expr(any, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'trimws(~w)', [Expr]).
+typr_tc_scalar_parse_node_expr(_, Expr, ParsedExpr) :-
+    format(string(ParsedExpr), 'trimws(~w)', [Expr]).
 
 load_typr_transitive_closure_template(Template) :-
     (   exists_file('templates/targets/typr/transitive_closure.mustache')

--- a/templates/targets/typr/tc_definitions.mustache
+++ b/templates/targets/typr/tc_definitions.mustache
@@ -16,7 +16,7 @@ let {{base}}_neighbors <- function(current, from_nodes, to_nodes) {
 	results
 };
 
-let {{base}}_from_lines <- function(lines) {
+{{node_parse_helper_code}}let {{base}}_from_lines <- function(lines) {
 	results <- {{empty_nodes_expr}};
 
 	for (line in lines) {

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -331,6 +331,34 @@ test(transitive_closure_numeric_runtime_loader_parses_declared_node_type) :-
     \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[2]));"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(transitive_closure_pair_integer_runtime_loader_parses_declared_node_shape) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, pair(integer, integer))),
+    assertz(type_declarations:uw_type(edge/2, 2, pair(integer, integer))),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(stdin)], Code)),
+    once(sub_string(Code, _, _, _, "let edge_parse_node <- function(text)")),
+    once(sub_string(Code, _, _, _, "pair_parts <- strsplit(trimws(text), \",\");")),
+    once(sub_string(Code, _, _, _, "pair(as__integer(trimws(pair_parts[1])), as__integer(trimws(pair_parts[2])))")),
+    once(sub_string(Code, _, _, _, "results <- c(results, edge_parse_node(parts[1]));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, edge_parse_node(parts[2]));")),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[1]));"),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[2]));"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(transitive_closure_pair_numeric_runtime_loader_parses_declared_node_shape) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, pair(number, number))),
+    assertz(type_declarations:uw_type(edge/2, 2, pair(number, number))),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(vfs("family_tree"))], Code)),
+    once(sub_string(Code, _, _, _, "let edge_parse_node <- function(text)")),
+    once(sub_string(Code, _, _, _, "pair_parts <- strsplit(trimws(text), \",\");")),
+    once(sub_string(Code, _, _, _, "pair(as__numeric(trimws(pair_parts[1])), as__numeric(trimws(pair_parts[2])))")),
+    once(sub_string(Code, _, _, _, "results <- c(results, edge_parse_node(parts[1]));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, edge_parse_node(parts[2]));")),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[1]));"),
+    \+ sub_string(Code, _, _, _, "results <- c(results, trimws(parts[2]));"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(per_predicate_typed_mode_overrides_call_option) :-
     clear_type_declarations,
     assertz(type_declarations:uw_type(edge/2, 1, atom)),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -162,6 +162,34 @@ test(transitive_closure_numeric_runtime_loader_checks_with_typr, [condition(typr
         delete_directory_and_contents(ProjectDir)
     ).
 
+test(transitive_closure_pair_integer_runtime_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, pair(integer, integer))),
+    assertz(type_declarations:uw_type(edge/2, 2, pair(integer, integer))),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(stdin)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check'])
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ).
+
+test(transitive_closure_pair_numeric_runtime_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(type_declarations:uw_type(edge/2, 1, pair(number, number))),
+    assertz(type_declarations:uw_type(edge/2, 2, pair(number, number))),
+    once(compile_predicate_to_typr(tc/2, [base_pred(edge), typed_mode(explicit), input(vfs("family_tree"))], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check'])
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ).
+
 test(tail_recursive_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:factorial_acc(0, Acc, Acc)),


### PR DESCRIPTION
## Summary
This PR keeps TypR transitive-closure runtime loaders native for conservative pair-shaped node values.

Previously, runtime transitive-closure loaders only handled scalar node parsing cleanly. Declared pair node types still fell through to string-biased line parsing even though compile-time seeded pair facts already emitted valid native TypR values.

This change adds a narrow native parser path for pair nodes in the loader layer without changing the native BFS traversal path or reintroducing raw R.

## What changed
- added native pair-node runtime parsing in the TypR transitive-closure backend
- refactored scalar loader parsing so pair parsing can reuse the same path cleanly
- injected optional `*_parse_node` helpers into the shared TypR transitive-closure definitions template
- added regression coverage for:
  - `pair(integer, integer)` runtime loaders
  - `pair(number, number)` runtime loaders
- added real `typr check` coverage for the same shapes
- updated TypR docs to clarify that runtime transitive-closure loaders now support scalar and conservative pair-shaped node parsing natively

## Why this matters
This keeps the generated TypR output closer to actual TypR instead of treating richer runtime node values as strings and hoping later code happens to tolerate that.

It also keeps the remaining boundary explicit:
- supported natively now: scalar nodes and pair-of-scalar nodes
- still out of scope here: broader nested runtime node-shape parsing

## Validation
```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_r_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```
