### PR TITLE
Document native TypR per-path typed loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ includes:
   native TypR recursive worker that returns nested pair results with one
   direct node output and one or more additive numeric outputs; this path still
   assumes one recursion-driving scalar input, but it now also emits a native
-  `*_from_vectors` runtime helper and native
-  `input(stdin|file|vfs|function)` wrappers over the same scalar step-relation
+  `*_from_vectors` runtime helper, native
+  `input(stdin|file|vfs|function)` wrappers, and declared scalar runtime node
+  parsing such as `integer` and `number` over the same scalar step-relation
   shape
 - accumulator-style tail-recursive predicates such as `factorial_acc/3`,
   lowered to TypR functions that use raw-expression loop bodies instead of

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -150,8 +150,9 @@ bring-up.
   IDs, a detected `Visited` position, one recursion-driving scalar input, and
   native TypR nested pair results for the direct node output plus one or more
   additive numeric outputs; the same slice now also emits a native
-  `*_from_vectors` runtime helper and native
-  `input(stdin|file|vfs|function)` wrappers
+  `*_from_vectors` runtime helper, native
+  `input(stdin|file|vfs|function)` wrappers, and declared scalar runtime node
+  parsing such as `integer` and `number`
 - `uw_return_type/2` support for TypR generic predicates so declared return
   types replace weak `Any` fallbacks where possible
 - `r`-target return-type constraints enabled by default when metadata exists,

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -338,8 +338,9 @@ Current TypR lowering policy is intentionally mixed:
   additive numeric outputs returned as native nested pair results, including
   `category_ancestor/4`, moved-input variants, and
   `category_ancestor_weight/5`; the same slice now also emits a native
-  `*_from_vectors` runtime helper and native
-  `input(stdin|file|vfs|function)` wrappers without raw R
+  `*_from_vectors` runtime helper, native
+  `input(stdin|file|vfs|function)` wrappers, and declared scalar runtime node
+  parsing such as `integer` and `number`, without raw R
 - multi-step native TypR control-flow chains may keep later guards and outputs
   in native TypR when those guards depend on earlier bound values
 - simple comparison and boolean guard expressions over already-bound

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -442,7 +442,8 @@ Current implementation note:
   relation, one recursion-driving scalar input, one direct node output, one
   or more additive numeric outputs, a native recursive worker that returns
   nested pair results without raw R, a native `*_from_vectors` runtime
-  helper, and native `input(stdin|file|vfs|function)` wrappers over the same
+  helper, native `input(stdin|file|vfs|function)` wrappers, and declared
+  scalar runtime node parsing such as `integer` and `number` over the same
   scalar step-relation shape
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -5252,4 +5252,54 @@ test(recursive_compiler_supports_typr_per_path_visited_function_input_mode) :-
     \+ sub_string(Code, _, _, _, "@{"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_per_path_visited_integer_stdin_loader) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor(_, _, _, _)),
+    assertz(user:category_parent(1, 2)),
+    assertz(user:category_parent(2, 3)),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, integer)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, integer)),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(stdin)], Code)),
+    once(sub_string(Code, _, _, _, "results <- integer();")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__integer(trimws(parts[1])));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__integer(trimws(parts[2])));")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_per_path_visited_number_stdin_loader) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor(_, _, _, _)),
+    assertz(user:category_parent(1.5, 2.5)),
+    assertz(user:category_parent(2.5, 3.5)),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, number)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, number)),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(stdin)], Code)),
+    once(sub_string(Code, _, _, _, "results <- numeric();")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__numeric(trimws(parts[1])));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, as__numeric(trimws(parts[2])));")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -4209,6 +4209,62 @@ test(per_path_visited_function_input_checks_with_typr, [condition(typr_cli_avail
     ),
     retractall(user:category_ancestor(_, _, _, _)).
 
+test(per_path_visited_integer_stdin_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, integer)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, integer)),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(stdin)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_ancestor(_, _, _, _)),
+    retractall(user:category_parent(_, _)).
+
+test(per_path_visited_number_stdin_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, number)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, number)),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(stdin)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_ancestor(_, _, _, _)),
+    retractall(user:category_parent(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR makes the existing native TypR support for typed per-path visited runtime loaders explicit and regression-covered.

The audit target was conservative scalar runtime parsing for the per-path visited path, starting with declared `integer` and `number` node types.

The key result is that this support was already present on `main` because the per-path loader path reuses the transitive-closure typed parse helpers.

So this PR does not change the TypR emitter. It adds the missing coverage and updates the docs to match the actual current boundary.

## What Changed

- updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
  - added target-level regression coverage for per-path visited `input(stdin)` loaders with declared:
    - `integer` nodes
    - `number` nodes
  - asserts the generated TypR uses:
    - `as__integer(...)`
    - `as__numeric(...)`
  - asserts the generated code stays native TypR without raw-R blocks
- updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)
  - added real `typr check` coverage for the same integer and number per-path loader shapes
- updated docs in:
  - [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
  - [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
  - [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
  - [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)
  - docs now state that per-path visited runtime loaders support declared scalar runtime parsing such as `integer` and `number`

## Why This Matters

This closes a documentation and regression gap in a part of the TypR target that had already become more native:

- traversal is native TypR
- runtime vector helpers are native TypR
- explicit input-mode wrappers are native TypR

Without this branch, the typed scalar loader support was real but implicit.

That is a weak boundary. It is easy to regress if it is neither documented nor tested directly.

## Audit Result

The audit did not expose a new emitter gap.

Instead, it showed that the current per-path visited loader path already reuses the same typed parse helpers as the transitive-closure path, so declared scalar runtime parsing was already working for:

- `integer`
- `number`

This PR records that fact in tests and docs rather than pretending another codegen change was necessary.

## Proving Cases

The proving cases are per-path visited predicates compiled with:

- `target(typr)`
- `typed_mode(explicit)`
- `input(stdin)`

for declared scalar node types:

- `integer`
- `number`

The generated TypR now has explicit regression coverage for:

- integer parsing through `as__integer(...)`
- numeric parsing through `as__numeric(...)`

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not expand the supported recursion shape.

It does not add:

- richer runtime node shapes
- extra invariant non-visited inputs
- non-scalar step relations

It only makes the existing typed scalar loader support explicit for the current native per-path visited slice.

## Current Tip

- `e8530859` `Document native TypR per-path typed loaders`
