### PR TITLE
Keep native TypR per-path pair loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ includes:
   conservative pair-shaped runtime node parsing all stay in native TypR syntax
 - conservative per-path visited recursion like `category_ancestor/4`,
   moved-input variants, and `category_ancestor_weight/5`, where a compile-time-
-  seeded scalar step relation and detected `Visited` position lower to a
-  native TypR recursive worker that returns nested pair results with one
-  direct node output and one or more additive numeric outputs; this path still
-  assumes one recursion-driving scalar input, but it now also emits a native
-  `*_from_vectors` runtime helper, native
-  `input(stdin|file|vfs|function)` wrappers, and declared scalar runtime node
-  parsing such as `integer` and `number` over the same scalar step-relation
-  shape
+  seeded step relation and detected `Visited` position lower to a native TypR
+  recursive worker that returns nested pair results with one direct node
+  output and one or more additive numeric outputs; this path still assumes one
+  recursion-driving input, but it now also emits a native
+  `*_from_vectors` runtime helper, native `input(stdin|file|vfs|function)`
+  wrappers, and declared scalar or conservative pair-shaped runtime node
+  parsing such as `integer`, `number`, `pair(integer, integer)`, and
+  `pair(number, number)` over the same step-relation shape
 - accumulator-style tail-recursive predicates such as `factorial_acc/3`,
   lowered to TypR functions that use raw-expression loop bodies instead of
   relabeled standalone R scripts

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -146,13 +146,13 @@ bring-up.
   runtime node parsing
 - conservative per-path visited recursion for `category_ancestor/4`,
   moved-input variants, and weighted variants such as
-  `category_ancestor_weight/5`, with compile-time fact seeding, scalar node
-  IDs, a detected `Visited` position, one recursion-driving scalar input, and
-  native TypR nested pair results for the direct node output plus one or more
-  additive numeric outputs; the same slice now also emits a native
-  `*_from_vectors` runtime helper, native
-  `input(stdin|file|vfs|function)` wrappers, and declared scalar runtime node
-  parsing such as `integer` and `number`
+  `category_ancestor_weight/5`, with compile-time fact seeding, a detected
+  `Visited` position, one recursion-driving input, and native TypR nested pair
+  results for the direct node output plus one or more additive numeric
+  outputs; the same slice now also emits a native `*_from_vectors` runtime
+  helper, native `input(stdin|file|vfs|function)` wrappers, and declared
+  scalar or conservative pair-shaped runtime node parsing such as `integer`,
+  `number`, `pair(integer, integer)`, and `pair(number, number)`
 - `uw_return_type/2` support for TypR generic predicates so declared return
   types replace weak `Any` fallbacks where possible
 - `r`-target return-type constraints enabled by default when metadata exists,

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -332,15 +332,15 @@ Current TypR lowering policy is intentionally mixed:
   conservative pair-shaped runtime node parsing in native TypR when the base
   relation shape is known at compile time
 - conservative per-path visited recursion may also stay native in TypR when it
-  matches the currently supported mode-driven scalar-seeded shape: a compile-
-  time-seeded scalar step relation, a detected `Visited` position, one
-  recursion-driving scalar input, one direct node output, and one or more
-  additive numeric outputs returned as native nested pair results, including
-  `category_ancestor/4`, moved-input variants, and
-  `category_ancestor_weight/5`; the same slice now also emits a native
-  `*_from_vectors` runtime helper, native
-  `input(stdin|file|vfs|function)` wrappers, and declared scalar runtime node
-  parsing such as `integer` and `number`, without raw R
+  matches the currently supported mode-driven seeded shape: a compile-time-
+  seeded step relation, a detected `Visited` position, one recursion-driving
+  input, one direct node output, and one or more additive numeric outputs
+  returned as native nested pair results, including `category_ancestor/4`,
+  moved-input variants, and `category_ancestor_weight/5`; the same slice now
+  also emits a native `*_from_vectors` runtime helper, native
+  `input(stdin|file|vfs|function)` wrappers, and declared scalar or
+  conservative pair-shaped runtime node parsing such as `integer`, `number`,
+  `pair(integer, integer)`, and `pair(number, number)`, without raw R
 - multi-step native TypR control-flow chains may keep later guards and outputs
   in native TypR when those guards depend on earlier bound values
 - simple comparison and boolean guard expressions over already-bound

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -436,15 +436,16 @@ Current implementation note:
   conservative pair-shaped runtime node parsing in valid TypR syntax when the
   base relation is known at compile time
 - conservative per-path visited recursion now stays native in TypR for a
-  mode-driven `VisitedPos`-driven scalar-seeded slice: `category_ancestor/4`,
+  mode-driven `VisitedPos`-driven seeded slice: `category_ancestor/4`,
   moved-input variants, and weighted variants such as
-  `category_ancestor_weight/5`, with a compile-time-seeded scalar step
-  relation, one recursion-driving scalar input, one direct node output, one
-  or more additive numeric outputs, a native recursive worker that returns
-  nested pair results without raw R, a native `*_from_vectors` runtime
-  helper, native `input(stdin|file|vfs|function)` wrappers, and declared
-  scalar runtime node parsing such as `integer` and `number` over the same
-  scalar step-relation shape
+  `category_ancestor_weight/5`, with a compile-time-seeded step relation, one
+  recursion-driving input, one direct node output, one or more additive
+  numeric outputs, a native recursive worker that returns nested pair results
+  without raw R, a native `*_from_vectors` runtime helper, native
+  `input(stdin|file|vfs|function)` wrappers, and declared scalar or
+  conservative pair-shaped runtime node parsing such as `integer`, `number`,
+  `pair(integer, integer)`, and `pair(number, number)` over the same
+  step-relation shape
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
   predicates, sequential guard/output control-flow chains, simple comparison

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -5062,7 +5062,7 @@ typr_per_path_visited_spec(
         RecursiveAccumulatorPairs
     ),
     resolve_node_type(Pred/Arity, BasePred/2, NodeTypeTerm),
-    typr_per_path_visited_scalar_node_type(NodeTypeTerm),
+    typr_per_path_visited_supported_node_type(NodeTypeTerm),
     atom_string(Pred, PredStr),
     atom_string(BasePred, BaseStr),
     empty_collection_expr(NodeTypeTerm, EmptyNodesExpr),
@@ -5125,6 +5125,13 @@ typr_per_path_visited_scalar_node_type(string).
 typr_per_path_visited_scalar_node_type(integer).
 typr_per_path_visited_scalar_node_type(float).
 typr_per_path_visited_scalar_node_type(number).
+
+typr_per_path_visited_supported_node_type(NodeTypeTerm) :-
+    typr_per_path_visited_scalar_node_type(NodeTypeTerm),
+    !.
+typr_per_path_visited_supported_node_type(pair(LeftType, RightType)) :-
+    typr_per_path_visited_scalar_node_type(LeftType),
+    typr_per_path_visited_scalar_node_type(RightType).
 
 typr_per_path_visited_base_clause(Head-Body0, Pred, InputPos, VisitedPos, OutputPositions, BasePred, NodeOutputPos, BaseAccumulatorPairs) :-
     Head =.. [Pred|HeadArgs],

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -5302,4 +5302,58 @@ test(recursive_compiler_supports_typr_per_path_visited_number_stdin_loader) :-
     \+ sub_string(Code, _, _, _, "@{"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_per_path_visited_pair_integer_stdin_loader) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor(_, _, _, _)),
+    assertz(user:category_parent(pair(1, 2), pair(3, 4))),
+    assertz(user:category_parent(pair(3, 4), pair(5, 6))),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, pair(integer, integer))),
+    assertz(type_declarations:uw_type(category_parent/2, 2, pair(integer, integer))),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(stdin)], Code)),
+    once(sub_string(Code, _, _, _, "let category_parent_parse_node <- function(text)")),
+    once(sub_string(Code, _, _, _, "pair_parts <- strsplit(trimws(text), \",\");")),
+    once(sub_string(Code, _, _, _, "pair(as__integer(trimws(pair_parts[1])), as__integer(trimws(pair_parts[2])))")),
+    once(sub_string(Code, _, _, _, "results <- c(results, category_parent_parse_node(parts[1]));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, category_parent_parse_node(parts[2]));")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_per_path_visited_pair_number_vfs_loader) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor(_, _, _, _)),
+    assertz(user:category_parent(pair(1.5, 2.5), pair(3.5, 4.5))),
+    assertz(user:category_parent(pair(3.5, 4.5), pair(5.5, 6.5))),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, pair(number, number))),
+    assertz(type_declarations:uw_type(category_parent/2, 2, pair(number, number))),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(vfs("family_tree"))], Code)),
+    once(sub_string(Code, _, _, _, "let category_parent_parse_node <- function(text)")),
+    once(sub_string(Code, _, _, _, "pair_parts <- strsplit(trimws(text), \",\");")),
+    once(sub_string(Code, _, _, _, "pair(as__numeric(trimws(pair_parts[1])), as__numeric(trimws(pair_parts[2])))")),
+    once(sub_string(Code, _, _, _, "results <- c(results, category_parent_parse_node(parts[1]));")),
+    once(sub_string(Code, _, _, _, "results <- c(results, category_parent_parse_node(parts[2]));")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -4265,6 +4265,62 @@ test(per_path_visited_number_stdin_loader_checks_with_typr, [condition(typr_cli_
     retractall(user:category_ancestor(_, _, _, _)),
     retractall(user:category_parent(_, _)).
 
+test(per_path_visited_pair_integer_stdin_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, pair(integer, integer))),
+    assertz(type_declarations:uw_type(category_parent/2, 2, pair(integer, integer))),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(stdin)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_ancestor(_, _, _, _)),
+    retractall(user:category_parent(_, _)).
+
+test(per_path_visited_pair_number_vfs_loader_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    assertz(user:(category_ancestor(Cat, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor(Cat, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, pair(number, number))),
+    assertz(type_declarations:uw_type(category_parent/2, 2, pair(number, number))),
+    once(recursive_compiler:compile_recursive(category_ancestor/4, [target(typr), typed_mode(explicit), input(vfs("family_tree"))], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_ancestor(_, _, _, _)),
+    retractall(user:category_parent(_, _)).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
# PR Description

## Summary

This PR extends the native TypR per-path visited loader path from scalar-only runtime node parsing to the same conservative pair-of-scalars subset already supported by the TypR transitive-closure path.

Before this branch, per-path visited runtime loaders accepted declared scalar node types such as `integer` and `number`, but pair-shaped node types still fell out before code generation and dropped to generic memoization.

This PR keeps those pair-shaped runtime loader cases native.

## What Changed

- updated [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)
  - replaced the per-path visited scalar-only node-type gate with a supported-node-type gate
  - the per-path path now accepts:
    - scalar node types
    - conservative pair-shaped node types whose components are supported scalars
  - this reuses the existing native parse-helper path instead of adding another recursion matcher family
- updated [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
  - added target-level regression coverage for:
    - `pair(integer, integer)` with `input(stdin)`
    - `pair(number, number)` with `input(vfs(...))`
  - asserts the generated TypR emits the native pair parse helper and stays free of raw-R blocks
- updated [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)
  - added real `typr check` coverage for the same pair-shaped per-path loader cases
- updated docs in:
  - [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
  - [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
  - [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
  - [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)
  - docs now state that the current native per-path path supports declared scalar or conservative pair-shaped runtime node parsing

## Why This Matters

This brings the native per-path visited runtime loader path closer to parity with the transitive-closure path.

The important part is that the change is not another one-off recursion matcher. The existing native per-path worker and input-mode path were already correct. The gap was the node-type gate in front of them.

With this branch:

- traversal remains native TypR
- `*_from_vectors` helpers remain native TypR
- `input(stdin|file|vfs|function)` wrappers remain native TypR
- pair-shaped runtime nodes no longer force a fallback out of the native path

## Proving Cases

The proving cases are per-path visited predicates compiled with:

- `target(typr)`
- `typed_mode(explicit)`
- runtime input loaders

for declared pair-shaped node types:

- `pair(integer, integer)`
- `pair(number, number)`

Before this branch, those cases failed by dropping out of the supported per-path path and into generic memoization.

After this branch, they emit the native pair parse helper and validate through `typr check`.

## Validation

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Scope Boundary

This PR does not broaden the supported recursion shape itself.

It does not add:

- richer runtime node shapes beyond conservative scalar pairs
- extra invariant non-visited inputs
- non-pair structured node parsing

It specifically closes the pair-shaped runtime loader gap for the current native per-path visited slice.

## Notes

`tests/test_r_target.pl` currently has unrelated baseline failures in this repo and was not changed by this branch.

## Current Tip

- `fc0072a1` `Keep native TypR per-path pair loaders`
