### PR TITLE
Generalize native TypR per-path invariant inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ includes:
   moved-input variants, and `category_ancestor_weight/5`, where a compile-time-
   seeded step relation and detected `Visited` position lower to a native TypR
   recursive worker that returns nested pair results with one direct node
-  output and one or more additive numeric outputs; this path still assumes one
-  recursion-driving input, but it now also emits a native
+  output and one or more additive numeric outputs; this path now supports one
+  recursion-driving input plus conservative invariant non-visited inputs, and
+  it also emits a native
   `*_from_vectors` runtime helper, native `input(stdin|file|vfs|function)`
   wrappers, and declared scalar or conservative pair-shaped runtime node
   parsing such as `integer`, `number`, `pair(integer, integer)`, and

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -147,12 +147,13 @@ bring-up.
 - conservative per-path visited recursion for `category_ancestor/4`,
   moved-input variants, and weighted variants such as
   `category_ancestor_weight/5`, with compile-time fact seeding, a detected
-  `Visited` position, one recursion-driving input, and native TypR nested pair
-  results for the direct node output plus one or more additive numeric
-  outputs; the same slice now also emits a native `*_from_vectors` runtime
-  helper, native `input(stdin|file|vfs|function)` wrappers, and declared
-  scalar or conservative pair-shaped runtime node parsing such as `integer`,
-  `number`, `pair(integer, integer)`, and `pair(number, number)`
+  `Visited` position, one recursion-driving input plus conservative invariant
+  non-visited inputs, and native TypR nested pair results for the direct node
+  output plus one or more additive numeric outputs; the same slice now also
+  emits a native `*_from_vectors` runtime helper, native
+  `input(stdin|file|vfs|function)` wrappers, and declared scalar or
+  conservative pair-shaped runtime node parsing such as `integer`, `number`,
+  `pair(integer, integer)`, and `pair(number, number)`
 - `uw_return_type/2` support for TypR generic predicates so declared return
   types replace weak `Any` fallbacks where possible
 - `r`-target return-type constraints enabled by default when metadata exists,

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -334,10 +334,11 @@ Current TypR lowering policy is intentionally mixed:
 - conservative per-path visited recursion may also stay native in TypR when it
   matches the currently supported mode-driven seeded shape: a compile-time-
   seeded step relation, a detected `Visited` position, one recursion-driving
-  input, one direct node output, and one or more additive numeric outputs
-  returned as native nested pair results, including `category_ancestor/4`,
-  moved-input variants, and `category_ancestor_weight/5`; the same slice now
-  also emits a native `*_from_vectors` runtime helper, native
+  input plus conservative invariant non-visited inputs, one direct node
+  output, and one or more additive numeric outputs returned as native nested
+  pair results, including `category_ancestor/4`, moved-input variants,
+  `category_ancestor_weight/5`, and conservative invariant-input variants; the
+  same slice now also emits a native `*_from_vectors` runtime helper, native
   `input(stdin|file|vfs|function)` wrappers, and declared scalar or
   conservative pair-shaped runtime node parsing such as `integer`, `number`,
   `pair(integer, integer)`, and `pair(number, number)`, without raw R

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -437,15 +437,16 @@ Current implementation note:
   base relation is known at compile time
 - conservative per-path visited recursion now stays native in TypR for a
   mode-driven `VisitedPos`-driven seeded slice: `category_ancestor/4`,
-  moved-input variants, and weighted variants such as
-  `category_ancestor_weight/5`, with a compile-time-seeded step relation, one
-  recursion-driving input, one direct node output, one or more additive
-  numeric outputs, a native recursive worker that returns nested pair results
-  without raw R, a native `*_from_vectors` runtime helper, native
-  `input(stdin|file|vfs|function)` wrappers, and declared scalar or
-  conservative pair-shaped runtime node parsing such as `integer`, `number`,
-  `pair(integer, integer)`, and `pair(number, number)` over the same
-  step-relation shape
+  moved-input variants, weighted variants such as
+  `category_ancestor_weight/5`, and conservative invariant-input variants,
+  with a compile-time-seeded step relation, one recursion-driving input plus
+  conservative invariant non-visited inputs, one direct node output, one or
+  more additive numeric outputs, a native recursive worker that returns
+  nested pair results without raw R, a native `*_from_vectors` runtime
+  helper, native `input(stdin|file|vfs|function)` wrappers, and declared
+  scalar or conservative pair-shaped runtime node parsing such as `integer`,
+  `number`, `pair(integer, integer)`, and `pair(number, number)` over the
+  same step-relation shape
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
   predicates, sequential guard/output control-flow chains, simple comparison

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -5035,19 +5035,22 @@ typr_per_path_visited_spec(
         to_line_expr=ToLineExpr,
         from_nodes_expr=FromNodesExpr,
         to_nodes_expr=ToNodesExpr,
+        invariant_param_suffix=InvariantParamSuffix,
         base_result_expr=BaseResultExpr,
         recursive_result_expr=RecursiveResultExpr
     ]
 ) :-
     single_linear_recursive_clause_pair(Pred, Arity, Clauses, BaseClause, RecClause),
-    typr_per_path_visited_io_positions(Pred/Arity, VisitedPos, InputPos, OutputPositions),
+    typr_per_path_visited_io_positions(Pred/Arity, VisitedPos, InputPositions, OutputPositions),
     typr_per_path_visited_base_clause(
         BaseClause,
         Pred,
-        InputPos,
+        InputPositions,
         VisitedPos,
         OutputPositions,
         BasePred,
+        DriverPos,
+        InvariantPositions,
         NodeOutputPos,
         BaseAccumulatorPairs
     ),
@@ -5055,7 +5058,8 @@ typr_per_path_visited_spec(
         RecClause,
         Pred,
         BasePred,
-        InputPos,
+        DriverPos,
+        InvariantPositions,
         VisitedPos,
         OutputPositions,
         NodeOutputPos,
@@ -5070,21 +5074,23 @@ typr_per_path_visited_spec(
     typr_tc_line_part_expr(BaseStr, NodeTypeTerm, 1, FromLineExpr),
     typr_tc_line_part_expr(BaseStr, NodeTypeTerm, 2, ToLineExpr),
     base_pair_vectors(Module, BasePred, NodeTypeTerm, FromNodesExpr, ToNodesExpr),
+    typr_per_path_visited_invariant_arg_names(InvariantPositions, InvariantArgNames),
+    typr_per_path_visited_param_suffix(InvariantArgNames, InvariantParamSuffix),
     typr_per_path_visited_base_output_exprs(OutputPositions, NodeOutputPos, BaseAccumulatorPairs, BaseOutputExprs),
     typr_per_path_visited_recursive_output_exprs(OutputPositions, NodeOutputPos, RecursiveAccumulatorPairs, RecursiveOutputExprs),
     typr_per_path_visited_result_expr(BaseOutputExprs, BaseResultExpr),
     typr_per_path_visited_result_expr(RecursiveOutputExprs, RecursiveResultExpr).
 
-typr_per_path_visited_io_positions(Pred/Arity, VisitedPos, InputPos, OutputPositions) :-
+typr_per_path_visited_io_positions(Pred/Arity, VisitedPos, InputPositions, OutputPositions) :-
     typr_per_path_visited_mode_variants(Pred/Arity, ModeVariants),
     (   ModeVariants == []
-    ->  typr_per_path_visited_default_io_positions(Arity, VisitedPos, InputPos, OutputPositions)
+    ->  typr_per_path_visited_default_io_positions(Arity, VisitedPos, InputPositions, OutputPositions)
     ;   member(Modes, ModeVariants),
-        typr_per_path_visited_supported_mode_vector(Modes, VisitedPos, InputPos, OutputPositions),
+        typr_per_path_visited_supported_mode_vector(Modes, VisitedPos, InputPositions, OutputPositions),
         !
     ).
 
-typr_per_path_visited_default_io_positions(Arity, VisitedPos, 1, OutputPositions) :-
+typr_per_path_visited_default_io_positions(Arity, VisitedPos, [1], OutputPositions) :-
     findall(Pos, (between(2, Arity, Pos), Pos =\= VisitedPos), OutputPositions),
     OutputPositions \= [].
 
@@ -5112,11 +5118,11 @@ typr_per_path_visited_mode_symbol(+, input) :- !.
 typr_per_path_visited_mode_symbol(-, output) :- !.
 typr_per_path_visited_mode_symbol(?, any) :- !.
 
-typr_per_path_visited_supported_mode_vector(Modes, VisitedPos, InputPos, OutputPositions) :-
+typr_per_path_visited_supported_mode_vector(Modes, VisitedPos, InputPositions, OutputPositions) :-
     \+ member(any, Modes),
     nth1(VisitedPos, Modes, input),
     findall(Pos, (nth1(Pos, Modes, input), Pos =\= VisitedPos), InputPositions),
-    InputPositions = [InputPos],
+    InputPositions \= [],
     findall(Pos, (nth1(Pos, Modes, output), Pos =\= VisitedPos), OutputPositions),
     OutputPositions \= [].
 
@@ -5133,15 +5139,25 @@ typr_per_path_visited_supported_node_type(pair(LeftType, RightType)) :-
     typr_per_path_visited_scalar_node_type(LeftType),
     typr_per_path_visited_scalar_node_type(RightType).
 
-typr_per_path_visited_base_clause(Head-Body0, Pred, InputPos, VisitedPos, OutputPositions, BasePred, NodeOutputPos, BaseAccumulatorPairs) :-
+typr_per_path_visited_base_clause(
+    Head-Body0,
+    Pred,
+    InputPositions,
+    VisitedPos,
+    OutputPositions,
+    BasePred,
+    DriverPos,
+    InvariantPositions,
+    NodeOutputPos,
+    BaseAccumulatorPairs
+) :-
     Head =.. [Pred|HeadArgs],
-    nth1(InputPos, HeadArgs, InputVar),
     nth1(VisitedPos, HeadArgs, VisitedVar),
-    var(InputVar),
     var(VisitedVar),
     typr_mutual_goal_list(Body0, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
-    typr_per_path_visited_base_goals(Goals, InputVar, VisitedVar, BasePred, StepOutputVar),
+    typr_per_path_visited_base_goals(Goals, StepInputVar, VisitedVar, BasePred, StepOutputVar),
+    typr_per_path_visited_driver_and_invariants(InputPositions, HeadArgs, StepInputVar, DriverPos, InvariantPositions),
     typr_per_path_visited_node_output_position(HeadArgs, OutputPositions, StepOutputVar, NodeOutputPos),
     typr_per_path_visited_base_accumulator_pairs(HeadArgs, OutputPositions, NodeOutputPos, BaseAccumulatorPairs).
 
@@ -5155,14 +5171,15 @@ typr_per_path_visited_recursive_clause(
     Head-Body0,
     Pred,
     BasePred,
-    InputPos,
+    DriverPos,
+    InvariantPositions,
     VisitedPos,
     OutputPositions,
     NodeOutputPos,
     RecursiveAccumulatorPairs
 ) :-
     Head =.. [Pred|HeadArgs],
-    nth1(InputPos, HeadArgs, InputVar),
+    nth1(DriverPos, HeadArgs, InputVar),
     nth1(VisitedPos, HeadArgs, VisitedVar),
     var(InputVar),
     var(VisitedVar),
@@ -5175,7 +5192,8 @@ typr_per_path_visited_recursive_clause(
     typr_per_path_visited_recursive_call(
         RecCallGoal,
         Pred,
-        InputPos,
+        DriverPos,
+        InvariantPositions,
         VisitedPos,
         MidVar,
         HeadArgs,
@@ -5193,6 +5211,19 @@ typr_per_path_visited_recursive_clause(
         AccumulatorGoals,
         RecursiveAccumulatorPairs
     ).
+
+typr_per_path_visited_driver_and_invariants(InputPositions, HeadArgs, StepInputVar, DriverPos, InvariantPositions) :-
+    findall(
+        Pos,
+        (
+            member(Pos, InputPositions),
+            nth1(Pos, HeadArgs, HeadInputVar),
+            HeadInputVar == StepInputVar
+        ),
+        DriverPositions
+    ),
+    DriverPositions = [DriverPos],
+    exclude(=(DriverPos), InputPositions, InvariantPositions).
 
 typr_per_path_visited_node_output_position(HeadArgs, OutputPositions, StepOutputVar, NodeOutputPos) :-
     member(NodeOutputPos, OutputPositions),
@@ -5246,7 +5277,7 @@ typr_per_path_visited_recursive_accumulator_pairs_1(
 typr_per_path_visited_step_goal(Goal, InputVar, OutputVar, BasePred) :-
     Goal =.. [BasePred, StepInputVar, StepOutputVar],
     BasePred \= member,
-    StepInputVar == InputVar,
+    InputVar = StepInputVar,
     OutputVar = StepOutputVar.
 
 typr_per_path_visited_mid_step_goal(Goal, InputVar, MidVar, BasePred) :-
@@ -5257,16 +5288,24 @@ typr_per_path_visited_mid_step_goal(Goal, InputVar, MidVar, BasePred) :-
 typr_per_path_visited_negated_member_goal(\+ member(MemberVar, VisitedVar0), MemberVar, VisitedVar) :-
     VisitedVar0 == VisitedVar.
 
-typr_per_path_visited_recursive_call(Goal, Pred, InputPos, VisitedPos, MidVar, HeadArgs, RecArgs, VisitedVar) :-
+typr_per_path_visited_recursive_call(Goal, Pred, DriverPos, InvariantPositions, VisitedPos, MidVar, HeadArgs, RecArgs, VisitedVar) :-
     Goal =.. [Pred|RecArgs],
     same_length(HeadArgs, RecArgs),
-    nth1(InputPos, RecArgs, RecInputVar),
+    nth1(DriverPos, RecArgs, RecInputVar),
     nth1(VisitedPos, RecArgs, ConsVisited),
     RecInputVar == MidVar,
     nonvar(ConsVisited),
     ConsVisited = [VisitedHead|VisitedTail],
     VisitedHead == MidVar,
-    VisitedTail == VisitedVar.
+    VisitedTail == VisitedVar,
+    typr_per_path_visited_invariants_static(InvariantPositions, HeadArgs, RecArgs).
+
+typr_per_path_visited_invariants_static([], _HeadArgs, _RecArgs).
+typr_per_path_visited_invariants_static([Pos|Rest], HeadArgs, RecArgs) :-
+    nth1(Pos, HeadArgs, HeadInvariantVar),
+    nth1(Pos, RecArgs, RecInvariantVar),
+    HeadInvariantVar == RecInvariantVar,
+    typr_per_path_visited_invariants_static(Rest, HeadArgs, RecArgs).
 
 typr_per_path_visited_hops_goal(HopsVar is Expr, HopsVar, PrevHopsVar, HopIncrement) :-
     typr_per_path_visited_hops_expr(Expr, PrevHopsVar, HopIncrement).
@@ -5312,6 +5351,16 @@ typr_per_path_visited_result_expr([Expr], Expr) :- !.
 typr_per_path_visited_result_expr([Expr|Rest], ResultExpr) :-
     typr_per_path_visited_result_expr(Rest, RestExpr),
     format(string(ResultExpr), 'pair(~w, ~w)', [Expr, RestExpr]).
+
+typr_per_path_visited_invariant_arg_names([], []).
+typr_per_path_visited_invariant_arg_names([Pos|Rest], [Name|RestNames]) :-
+    format(string(Name), 'arg~w', [Pos]),
+    typr_per_path_visited_invariant_arg_names(Rest, RestNames).
+
+typr_per_path_visited_param_suffix([], '').
+typr_per_path_visited_param_suffix(Names, Suffix) :-
+    atomic_list_concat(Names, ', ', Inner),
+    format(string(Suffix), ', ~w', [Inner]).
 
 typr_per_path_visited_result_extract_expr(ResultExpr, 1, 1, ResultExpr) :- !.
 typr_per_path_visited_result_extract_expr(ResultExpr, 1, _OutputCount, ExtractExpr) :-

--- a/templates/targets/typr/per_path_visited.mustache
+++ b/templates/targets/typr/per_path_visited.mustache
@@ -20,14 +20,14 @@ let {{base}}_neighbors <- function(current, from_nodes, to_nodes) {
 let {{base}}_from <- {{from_nodes_expr}};
 let {{base}}_to <- {{to_nodes_expr}};
 
-let {{pred}}_worker <- function(current, visited, from_nodes, to_nodes) {
+let {{pred}}_worker <- function(current, visited{{invariant_param_suffix}}, from_nodes, to_nodes) {
 	results <- c();
 	neighbors <- {{base}}_neighbors(current, from_nodes, to_nodes);
 
 	for (next_node in neighbors) {
 		if (!any(visited == next_node)) {
 			results <- c(results, {{base_result_expr}});
-			sub_results <- {{pred}}_worker(next_node, c(visited, next_node), from_nodes, to_nodes);
+			sub_results <- {{pred}}_worker(next_node, c(visited, next_node){{invariant_param_suffix}}, from_nodes, to_nodes);
 
 			for (sub_result in sub_results) {
 				results <- c(results, {{recursive_result_expr}});
@@ -38,10 +38,10 @@ let {{pred}}_worker <- function(current, visited, from_nodes, to_nodes) {
 	results
 };
 
-let {{pred}}_from_vectors <- function(start, from_nodes, to_nodes) {
-	{{pred}}_worker(start, start, from_nodes, to_nodes)
+let {{pred}}_from_vectors <- function(start{{invariant_param_suffix}}, from_nodes, to_nodes) {
+	{{pred}}_worker(start, start{{invariant_param_suffix}}, from_nodes, to_nodes)
 };
 
-let {{pred}} <- function(start) {
-	{{pred}}_from_vectors(start, {{base}}_from, {{base}}_to)
+let {{pred}} <- function(start{{invariant_param_suffix}}) {
+	{{pred}}_from_vectors(start{{invariant_param_suffix}}, {{base}}_from, {{base}}_to)
 };

--- a/templates/targets/typr/ppv_definitions.mustache
+++ b/templates/targets/typr/ppv_definitions.mustache
@@ -43,14 +43,14 @@ let {{base}}_to_lines <- function(lines) {
 	results
 };
 
-let {{pred}}_worker <- function(current, visited, from_nodes, to_nodes) {
+let {{pred}}_worker <- function(current, visited{{invariant_param_suffix}}, from_nodes, to_nodes) {
 	results <- c();
 	neighbors <- {{base}}_neighbors(current, from_nodes, to_nodes);
 
 	for (next_node in neighbors) {
 		if (!any(visited == next_node)) {
 			results <- c(results, {{base_result_expr}});
-			sub_results <- {{pred}}_worker(next_node, c(visited, next_node), from_nodes, to_nodes);
+			sub_results <- {{pred}}_worker(next_node, c(visited, next_node){{invariant_param_suffix}}, from_nodes, to_nodes);
 
 			for (sub_result in sub_results) {
 				results <- c(results, {{recursive_result_expr}});
@@ -61,6 +61,6 @@ let {{pred}}_worker <- function(current, visited, from_nodes, to_nodes) {
 	results
 };
 
-let {{pred}}_from_vectors <- function(start, from_nodes, to_nodes) {
-	{{pred}}_worker(start, start, from_nodes, to_nodes)
+let {{pred}}_from_vectors <- function(start{{invariant_param_suffix}}, from_nodes, to_nodes) {
+	{{pred}}_worker(start, start{{invariant_param_suffix}}, from_nodes, to_nodes)
 };

--- a/templates/targets/typr/ppv_input_file.mustache
+++ b/templates/targets/typr/ppv_input_file.mustache
@@ -3,7 +3,7 @@ let {{base}}_lines_from_file <- function() {
 	readLines("{{input_path}}")
 };
 
-let {{pred}} <- function(start) {
+let {{pred}} <- function(start{{invariant_param_suffix}}) {
 	lines <- {{base}}_lines_from_file();
-	{{pred}}_from_vectors(start, {{base}}_from_lines(lines), {{base}}_to_lines(lines))
+	{{pred}}_from_vectors(start{{invariant_param_suffix}}, {{base}}_from_lines(lines), {{base}}_to_lines(lines))
 };

--- a/templates/targets/typr/ppv_input_function.mustache
+++ b/templates/targets/typr/ppv_input_function.mustache
@@ -1,4 +1,4 @@
 
-let {{pred}} <- function(start, from_nodes, to_nodes) {
-	{{pred}}_from_vectors(start, from_nodes, to_nodes)
+let {{pred}} <- function(start{{invariant_param_suffix}}, from_nodes, to_nodes) {
+	{{pred}}_from_vectors(start{{invariant_param_suffix}}, from_nodes, to_nodes)
 };

--- a/templates/targets/typr/ppv_input_stdin.mustache
+++ b/templates/targets/typr/ppv_input_stdin.mustache
@@ -3,7 +3,7 @@ let {{base}}_lines_from_stdin <- function() {
 	readLines(file("stdin"))
 };
 
-let {{pred}} <- function(start) {
+let {{pred}} <- function(start{{invariant_param_suffix}}) {
 	lines <- {{base}}_lines_from_stdin();
-	{{pred}}_from_vectors(start, {{base}}_from_lines(lines), {{base}}_to_lines(lines))
+	{{pred}}_from_vectors(start{{invariant_param_suffix}}, {{base}}_from_lines(lines), {{base}}_to_lines(lines))
 };

--- a/templates/targets/typr/ppv_input_vfs.mustache
+++ b/templates/targets/typr/ppv_input_vfs.mustache
@@ -8,7 +8,7 @@ let {{base}}_lines_from_vfs <- function() {
 	}
 };
 
-let {{pred}} <- function(start) {
+let {{pred}} <- function(start{{invariant_param_suffix}}) {
 	lines <- {{base}}_lines_from_vfs();
-	{{pred}}_from_vectors(start, {{base}}_from_lines(lines), {{base}}_to_lines(lines))
+	{{pred}}_from_vectors(start{{invariant_param_suffix}}, {{base}}_from_lines(lines), {{base}}_to_lines(lines))
 };

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -5356,4 +5356,88 @@ test(recursive_compiler_supports_typr_per_path_visited_pair_number_vfs_loader) :
     \+ sub_string(Code, _, _, _, "@{"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_invariant_per_path_visited_recursion) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limited(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limited(_, _, _, _, _))),
+    assertz(user:category_parent(a, b)),
+    assertz(user:category_parent(b, c)),
+    assertz(user:mode(category_ancestor_limited(+, +, -, -, +))),
+    assertz(user:(category_ancestor_limited(Cat, Limit, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_limited(Cat, Limit, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor_limited(Mid, Limit, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_limited/5, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limited_worker <- function(current, visited, arg2, from_nodes, to_nodes)")),
+    once(sub_string(Code, _, _, _, "sub_results <- category_ancestor_limited_worker(next_node, c(visited, next_node), arg2, from_nodes, to_nodes);")),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limited_from_vectors <- function(start, arg2, from_nodes, to_nodes)")),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limited <- function(start, arg2)")),
+    once(sub_string(Code, _, _, _, "category_ancestor_limited_from_vectors(start, arg2, category_parent_from, category_parent_to)")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_weighted_invariant_per_path_visited_recursion) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limit_weight(_, _, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limit_weight(_, _, _, _, _, _))),
+    assertz(user:category_parent(a, b)),
+    assertz(user:category_parent(b, c)),
+    assertz(user:mode(category_ancestor_limit_weight(+, +, -, -, -, +))),
+    assertz(user:(category_ancestor_limit_weight(Cat, Limit, Parent, 1, 10, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_limit_weight(Cat, Limit, Ancestor, Hops, Cost, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor_limit_weight(Mid, Limit, Ancestor, H1, Cost1, [Mid|Visited]),
+        Hops is H1 + 1,
+        Cost is Cost1 + 10
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_limit_weight/6, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limit_weight_worker <- function(current, visited, arg2, from_nodes, to_nodes)")),
+    once(sub_string(Code, _, _, _, "results <- c(results, pair(next_node, pair(1, 10)));")),
+    once(sub_string(Code, _, _, _, "sub_results <- category_ancestor_limit_weight_worker(next_node, c(visited, next_node), arg2, from_nodes, to_nodes);")),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limit_weight <- function(start, arg2)")),
+    once(sub_string(Code, _, _, _, "category_ancestor_limit_weight_from_vectors(start, arg2, category_parent_from, category_parent_to)")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(recursive_compiler_supports_typr_invariant_per_path_visited_function_input_mode) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limited_fn(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limited_fn(_, _, _, _, _))),
+    assertz(user:mode(category_ancestor_limited_fn(+, +, -, -, +))),
+    assertz(user:(category_ancestor_limited_fn(Cat, Limit, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_limited_fn(Cat, Limit, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor_limited_fn(Mid, Limit, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_limited_fn/5, [target(typr), typed_mode(explicit), input(function)], Code)),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limited_fn_from_vectors <- function(start, arg2, from_nodes, to_nodes)")),
+    once(sub_string(Code, _, _, _, "let category_ancestor_limited_fn <- function(start, arg2, from_nodes, to_nodes)")),
+    once(sub_string(Code, _, _, _, "category_ancestor_limited_fn_from_vectors(start, arg2, from_nodes, to_nodes)")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -4321,6 +4321,107 @@ test(per_path_visited_pair_number_vfs_loader_checks_with_typr, [condition(typr_c
     retractall(user:category_ancestor(_, _, _, _)),
     retractall(user:category_parent(_, _)).
 
+test(invariant_per_path_visited_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limited(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limited(_, _, _, _, _))),
+    assertz(user:category_parent(a, b)),
+    assertz(user:category_parent(b, c)),
+    assertz(user:mode(category_ancestor_limited(+, +, -, -, +))),
+    assertz(user:(category_ancestor_limited(Cat, Limit, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_limited(Cat, Limit, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor_limited(Mid, Limit, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_limited/5, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limited(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limited(_, _, _, _, _))).
+
+test(weighted_invariant_per_path_visited_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limit_weight(_, _, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limit_weight(_, _, _, _, _, _))),
+    assertz(user:category_parent(a, b)),
+    assertz(user:category_parent(b, c)),
+    assertz(user:mode(category_ancestor_limit_weight(+, +, -, -, -, +))),
+    assertz(user:(category_ancestor_limit_weight(Cat, Limit, Parent, 1, 10, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_limit_weight(Cat, Limit, Ancestor, Hops, Cost, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor_limit_weight(Mid, Limit, Ancestor, H1, Cost1, [Mid|Visited]),
+        Hops is H1 + 1,
+        Cost is Cost1 + 10
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_limit_weight/6, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limit_weight(_, _, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limit_weight(_, _, _, _, _, _))).
+
+test(invariant_per_path_visited_function_input_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limited_fn(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limited_fn(_, _, _, _, _))),
+    assertz(user:mode(category_ancestor_limited_fn(+, +, -, -, +))),
+    assertz(user:(category_ancestor_limited_fn(Cat, Limit, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_limited_fn(Cat, Limit, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        \+ member(Mid, Visited),
+        category_ancestor_limited_fn(Mid, Limit, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_limited_fn/5, [target(typr), typed_mode(explicit), input(function)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_limited_fn(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_limited_fn(_, _, _, _, _))).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary

This PR generalizes the native TypR per-path visited path beyond a single fixed recursion-driving input.

TypR per-path visited lowering now supports:

- one recursion-driving input
- conservative invariant non-visited inputs threaded unchanged through recursion
- weighted variants over the same native worker path
- native `input(function)` and existing vector/input-mode wrappers over that same path

This also fixes a real matcher bug in the TypR per-path base-step path, so the native TypR lowering is actually selected for the supported invariant-input slice.

## What changed

- generalized per-path visited input/output analysis in `typr_target.pl`
  - uses detected `VisitedPos`
  - derives the recursion-driving input from the step relation
  - threads remaining input-mode positions as invariant inputs
- updated TypR per-path templates to carry invariant inputs through:
  - seeded wrappers
  - `*_from_vectors`
  - composable input-mode wrappers
  - recursive worker calls
- added regression coverage for:
  - invariant-input per-path visited recursion
  - weighted invariant-input per-path visited recursion
  - invariant-input `input(function)` codegen and `typr check`
- updated docs to reflect the new native TypR boundary

## Scope and boundary

This PR is intentionally conservative.

It supports invariant inputs that are threaded unchanged through recursion.

It does not yet add native lowering for new helper or guard goals over those invariant inputs between the step relation and the recursive call. That remains the next frontier.

## Validation

```sh
swipl -q -g "run_tests([typr_target:recursive_compiler_supports_typr_invariant_per_path_visited_recursion,typr_target:recursive_compiler_supports_typr_weighted_invariant_per_path_visited_recursion,typr_target:recursive_compiler_supports_typr_invariant_per_path_visited_function_input_mode])" -t halt tests/test_typr_target.pl
swipl -q -g "run_tests([typr_toolchain:invariant_per_path_visited_output_checks_with_typr,typr_toolchain:weighted_invariant_per_path_visited_output_checks_with_typr,typr_toolchain:invariant_per_path_visited_function_input_checks_with_typr])" -t halt tests/test_typr_toolchain.pl
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```
