### PR TITLE
docs: transpilation audit + C# query engine fixpoint non-convergence

### DIFF
--- a/docs/design/FULL_TRANSPILATION_AUDIT.md
+++ b/docs/design/FULL_TRANSPILATION_AUDIT.md
@@ -87,12 +87,38 @@ these higher-order predicates.
 | `aggregate_all/3` compilation | Go, Python, AWK, Rust | High — requires collecting all solutions then aggregating |
 | Predicate-calls-predicate | All | Medium — compile multiple predicates and wire calls between them |
 
+## C# Query Plan Execution Test
+
+The C# parameterized query engine compiles `category_ancestor/3` to a
+query plan with `FixpointNode`, `ParamSeedNode`, `KeyJoinNode`, and
+`ArithmeticNode`. However, **execution hangs** on the dev dataset
+(198 edges) — the fixpoint does not converge.
+
+**Root cause**: Same as AWK's original fixpoint issue. With hop counting,
+each iteration produces tuples with new hop values:
+`(cat, ancestor, 3)` ≠ `(cat, ancestor, 7)`. In a cyclic graph, the
+fixpoint never converges because new tuples keep appearing.
+
+**Fix needed**: The `FixpointNode` needs a max-depth guard or the
+per-path visited pattern to prevent unbounded iteration with counters.
+This is the same issue solved differently per target:
+- Prolog: `max_depth/1` + `Visited` list
+- Go/Rust/Python: `depth` parameter in recursive function
+- AWK: `MAX_DEPTH` in DFS loop
+- C# Query Engine: **not yet solved** — FixpointNode has no depth bound
+
+This is a significant finding: the C# query engine's semi-naive
+evaluation does NOT handle cycle-bounded counters. The benchmark's
+DFS pipeline (which uses explicit visited sets) is algorithmically
+different from the query plan approach.
+
 ## What Works End-to-End Today
 
 Only the **C# Query Engine** can compile the combination of
 `category_ancestor/3` + `aggregate_all/3` in a single query plan.
-But it can't compile `path_to_root/3` or `effective_distance/3`
-because of the multi-clause and `setof/member` issues.
+But execution hangs due to fixpoint non-convergence on cyclic graphs
+with counters. It also can't compile `path_to_root/3` or
+`effective_distance/3` because of multi-clause and `setof/member` issues.
 
 **No target** can compile the full `effective_distance.pl` natively today.
 


### PR DESCRIPTION
  ## Summary

  Two findings from attempting full transpilation pipeline and C# query plan execution:

  ### 1. Full Transpilation Audit (updated)

  No target can compile the complete `effective_distance.pl` pipeline natively. The deepening work got
  `category_ancestor/3` compiling on all 5 targets, but:
  - `path_to_root/3` fails on C#/Go/Rust (multi-clause heterogeneous bodies)
  - `effective_distance/3` fails everywhere (`setof/3`, `member/2`, `aggregate_all/3` not compiled)

  ### 2. C# Query Plan Execution — Fixpoint Non-Convergence (new finding)

  Attempted running `category_ancestor/3` through the actual `QueryRuntime` (`FixpointNode` + `ParamSeedNode`).
  **Execution hangs and is eventually killed (exit 137 OOM).**

  **Root cause**: With hop counting, each fixpoint iteration produces tuples with new hop values — `(cat, ancestor, 3)`
  ≠ `(cat, ancestor, 7)`. On cyclic graphs, the fixpoint never converges because `HashSet<T>` deduplication treats
  different hop counts as different tuples.

  This is the same issue solved differently per target:

  | Target | Solution |
  |---|---|
  | Prolog | `max_depth/1` + `Visited` list |
  | Go/Rust/Python | `depth` parameter in recursive function |
  | AWK | `MAX_DEPTH` in DFS loop |
  | C# Query Engine | **Not yet solved** — FixpointNode has no depth bound |

  ### Implication

  The benchmark's DFS pipeline approach (which uses explicit visited sets and depth bounds) is **algorithmically
  correct** while the query plan approach is **not yet** — the `FixpointNode` needs a max-depth guard or per-path
  visited support to handle counter-bearing recursive predicates on cyclic graphs.

  This is an important distinction: the C# benchmark numbers (0.43s at 300, 9.48s at 10K) are from the DFS pipeline, not
   the query engine. Making the query engine handle this workload is future work.

  ## Test plan

  - [x] C# query plan generates successfully for `category_ancestor/3`
  - [x] C# query plan execution tested — confirmed non-convergence (OOM kill)
  - [x] Root cause documented — same as AWK fixpoint issue
  - [x] Updated audit doc with C# execution findings
  - [ ] Add max-depth to FixpointNode (future — for Codex/GPT)
  - [ ] Multi-clause heterogeneous body compilation (future)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)