### PR TITLE
fix(csharp-query): dedup + max depth for PathAwareTransitiveClosureNode

### DIFF
--- a/docs/proposals/CSHARP_QUERY_ENGINE_PER_PATH_VISITED.md
+++ b/docs/proposals/CSHARP_QUERY_ENGINE_PER_PATH_VISITED.md
@@ -82,45 +82,72 @@ The runtime:
 3. Runs DFS from each seed
 4. Copies the visited set on each branch so sibling paths do not
    interfere
-5. Emits `(source, target, hops)` rows with the configured base depth
+5. Deduplicates output by `(target, depth)` per seed — multiple simple
+   paths reaching the same node at the same hop count produce one row
+6. Enforces `MaxDepth` to match Prolog's `max_depth/1` semantics
+7. Emits `(source, target, hops)` rows with the configured base depth
    and increment
+
+#### Bugs Fixed (2026-03-30)
+
+Codex's initial implementation (commit `08df76b`) had two issues:
+
+1. **No output deduplication**: Multiple distinct simple paths to the
+   same `(target, hops)` produced duplicate rows. E.g., 56 paths from
+   Relativity to Container_categories at hops=20 → 56 identical output
+   rows. Fix: `emitted` HashSet keyed on `(target, depth)` per seed.
+
+2. **No max depth**: Without a depth limit, the DFS explores all simple
+   paths of arbitrary length. With per-path visited, simple paths in a
+   cyclic graph can be very long (hops 19-24+). Fix: `MaxDepth` field
+   on the record, enforced in `AppendPathAwareRowsForSeed`.
+
+Results on dev dataset (198 edges), querying "Relativity":
+
+| Version | Total rows | Unique pairs | Physics hops |
+|---------|-----------|-------------|-------------|
+| Before fix | 3930 | 522 | [2, 19, 20, 21, 22, 23, 24] |
+| Dedup only | 522 | 522 | [2, 19, 20, 21, 22, 23, 24] |
+| Dedup + MaxDepth=10 | 71 | 71 | [2] |
+| Prolog reference | 115* | 71 | [2] |
+
+*Prolog reports 115 derivations but 71 unique `(ancestor, hops)` pairs.
 
 #### Implementation Sketch
 
 ```csharp
-private IEnumerable<object[]> ExecutePathAwareTransitiveClosure(
-    PathAwareTransitiveClosureNode closure, EvaluationContext? context)
+private static void AppendPathAwareRowsForSeed(
+    object? seed,
+    IReadOnlyDictionary<object, List<object[]>> succIndex,
+    int baseDepth, int depthIncrement,
+    ICollection<object[]> output, int maxDepth = 0)
 {
-    var adj = BuildAdjacencyFromRelation(closure.EdgeRelation, context);
-    var results = new List<object[]>();
+    var emitted = new HashSet<(object?, int)>();
+    var stack = new Stack<(object? Node, int Depth, HashSet<object?> Visited)>();
+    stack.Push((seed, 0, new HashSet<object?> { seed }));
 
-    foreach (var seed in GetSeeds(closure, context))
+    while (stack.Count > 0)
     {
-        var stack = new Stack<(string node, int hops, HashSet<string> visited)>();
-        stack.Push((seed, 0, new HashSet<string> { seed }));
-
-        while (stack.Count > 0)
+        var (current, depth, visited) = stack.Pop();
+        foreach (var neighbor in GetNeighbors(current, succIndex))
         {
-            var (cur, hops, visited) = stack.Pop();
-            foreach (var neighbor in adj.GetValueOrDefault(cur, Array.Empty<string>()))
-            {
-                if (visited.Contains(neighbor)) continue;
-                results.Add(new object[] { seed, neighbor, hops + 1 });
-
-                var newVisited = new HashSet<string>(visited) { neighbor };
-                stack.Push((neighbor, hops + 1, newVisited));
-            }
+            if (visited.Contains(neighbor)) continue;
+            var nextDepth = depth == 0 ? baseDepth : depth + depthIncrement;
+            if (maxDepth > 0 && nextDepth > maxDepth) continue;
+            if (emitted.Add((neighbor, nextDepth)))
+                output.Add(new object[] { seed!, neighbor!, nextDepth });
+            var nextVisited = new HashSet<object?>(visited) { neighbor };
+            stack.Push((neighbor, nextDepth, nextVisited));
         }
     }
-
-    return results;
 }
 ```
 
 #### When to Use
 
 The compiler now emits `PathAwareTransitiveClosureNode` when it detects
-the counted transitive-closure shape above.
+the counted transitive-closure shape above. The `MaxDepth` defaults to
+10 (matching Prolog's `max_depth/1`).
 
 For standard Datalog predicates without counters, the existing
 `TransitiveClosureNode`, `GroupedTransitiveClosureNode`, or generic

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -239,7 +239,8 @@ namespace UnifyWeaver.QueryRuntime
         PredicateId EdgeRelation,
         PredicateId Predicate,
         int BaseDepth,
-        int DepthIncrement
+        int DepthIncrement,
+        int MaxDepth = 0
     ) : PlanNode;
 
     /// <summary>
@@ -953,7 +954,7 @@ namespace UnifyWeaver.QueryRuntime
                 OffsetNode offset => $"Offset count={offset.Count}",
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
-                PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement}",
+                PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
                 MutualFixpointNode mutual => $"MutualFixpoint head={mutual.Head} members={mutual.Members.Count}",
                 RecursiveRefNode recursiveRef => $"RecursiveRef predicate={recursiveRef.Predicate} kind={recursiveRef.Kind}",
@@ -6942,7 +6943,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows);
+                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -6997,7 +6998,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows);
+                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7013,8 +7014,10 @@ namespace UnifyWeaver.QueryRuntime
             IReadOnlyDictionary<object, List<object[]>> succIndex,
             int baseDepth,
             int depthIncrement,
-            ICollection<object[]> output)
+            ICollection<object[]> output,
+            int maxDepth = 0)
         {
+            var emitted = new HashSet<(object?, int)>();
             var stack = new Stack<(object? Node, int Depth, HashSet<object?> Visited)>();
             stack.Push((seed, 0, new HashSet<object?> { seed }));
 
@@ -7044,7 +7047,16 @@ namespace UnifyWeaver.QueryRuntime
                     var nextDepth = depth == 0
                         ? baseDepth
                         : checked(depth + depthIncrement);
-                    output.Add(new object[] { seed!, next!, nextDepth });
+
+                    if (maxDepth > 0 && nextDepth > maxDepth)
+                    {
+                        continue;
+                    }
+
+                    if (emitted.Add((next, nextDepth)))
+                    {
+                        output.Add(new object[] { seed!, next!, nextDepth });
+                    }
 
                     var nextVisited = new HashSet<object?>(visited) { next };
                     stack.Push((next, nextDepth, nextVisited));

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1069,6 +1069,7 @@ maybe_path_aware_transitive_closure_plan(HeadSpec, GroupSpecs, BaseClauses, RecC
         edge:EdgeSpec,
         base_depth:BaseDepth,
         depth_increment:DepthIncrement,
+        max_depth:10,
         width:3
     }.
 
@@ -3577,10 +3578,11 @@ emit_plan_expression(Node, Expr) :-
     get_dict(head, Node, predicate{name:Name, arity:Arity}),
     get_dict(base_depth, Node, BaseDepth),
     get_dict(depth_increment, Node, DepthIncrement),
+    (get_dict(max_depth, Node, MaxDepth) -> true ; MaxDepth = 0),
     atom_string(EdgeName, EdgeNameStr),
     atom_string(Name, NameStr),
-    format(atom(Expr), 'new PathAwareTransitiveClosureNode(new PredicateId("~w", ~w), new PredicateId("~w", ~w), ~w, ~w)',
-        [EdgeNameStr, EdgeArity, NameStr, Arity, BaseDepth, DepthIncrement]).
+    format(atom(Expr), 'new PathAwareTransitiveClosureNode(new PredicateId("~w", ~w), new PredicateId("~w", ~w), ~w, ~w, ~w)',
+        [EdgeNameStr, EdgeArity, NameStr, Arity, BaseDepth, DepthIncrement, MaxDepth]).
 emit_plan_expression(Node, Expr) :-
     is_dict(Node, fixpoint), !,
     get_dict(base, Node, BaseNode),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -3401,6 +3401,7 @@ verify_path_aware_transitive_closure_plan :-
         edge:predicate{name:test_pathaware_edge, arity:2},
         base_depth:1,
         depth_increment:1,
+        max_depth:10,
         width:3
     }),
     csharp_query_target:render_plan_to_csharp(Plan, Source),
@@ -3427,6 +3428,7 @@ verify_parameterized_path_aware_transitive_closure_plan :-
         edge:predicate{name:test_pathaware_edge, arity:2},
         base_depth:1,
         depth_increment:1,
+        max_depth:10,
         width:3
     }),
     csharp_query_target:render_plan_to_csharp(Plan, Source),


### PR DESCRIPTION
  ## Summary
  - Fix output deduplication in `PathAwareTransitiveClosureNode` — multiple simple paths reaching the same `(target,
  hops)` no longer produce duplicate rows
  - Add `MaxDepth` parameter to bound DFS exploration, matching Prolog's `max_depth/1` semantics
  - Update compiler (`csharp_target.pl`) to emit `MaxDepth=10` by default

  ## Context

  Codex's initial implementation (commit `08df76b`) had correct per-path visited structure but missed two things:
  1. No dedup on output — 56 distinct simple paths to `Container_categories` at hops=20 all emitted as separate rows
  2. No depth limit — paths up to hops 24 explored through indirect cycles in the category graph

  | Version | Total rows | Unique pairs | Physics hops |
  |---------|-----------|-------------|-------------|
  | Before fix | 3930 | 522 | [2, 19-24] |
  | After fix (MaxDepth=10) | 71 | 71 | [2] |
  | Prolog reference | 71 | 71 | [2] |

  ## Test plan
  - [x] Dev dataset (198 edges): Relativity query produces 71 results matching Prolog
  - [x] Physics appears only at hops=2
  - [ ] Benchmark query engine vs DFS pipeline at 300/1K/5K/10K scale
  - [ ] Verify compiler emits MaxDepth correctly via full transpilation

  🤖 Generated with [Claude Code](https://claude.com/claude-code)