### PR TITLE
Keep native TypR recursive loop bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,16 +243,16 @@ includes:
   parsing such as `integer`, `number`, `pair(integer, integer)`, and
   `pair(number, number)` over the same step-relation shape
 - accumulator-style tail-recursive predicates such as `factorial_acc/3`,
-  lowered to TypR functions that use raw-expression loop bodies instead of
+  lowered to TypR functions that use native TypR loop bodies instead of
   relabeled standalone R scripts
 - conservative single-recursive-call numeric linear-recursive predicates with
   one recursion-driving argument and invariant context args, such as
   `factorial_linear/2` and `power/3`, lowered to TypR functions that use
-  raw-expression fold/loop bodies instead of wrapped-R fallback
+  native TypR fold/loop bodies instead of wrapped-R fallback
 - conservative single-recursive-call list linear-recursive predicates with
   one recursion-driving list argument and invariant context args, such as
   `list_length/2` and `list_length_from/3`, lowered to TypR functions that
-  use raw-expression fold/loop bodies instead of wrapped-R fallback
+  use native TypR fold/loop bodies instead of wrapped-R fallback
 - conservative arity-2 numeric multi-call tree-recursive predicates such as
   `fib/2`, lowered to TypR functions that use raw-expression memoized helper
   bodies inside TypR instead of wrapped-R fallback

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -199,14 +199,14 @@ bring-up.
     intermediate, the final output directly, or the later result set needed
     by subsequent native steps
   - accumulator-style tail-recursive predicates lowered to TypR-valid
-    functions with raw-expression loop bodies for the currently supported
+    functions with native TypR loop bodies for the currently supported
     tail-recursion shape
   - conservative single-recursive-call numeric linear-recursive predicates
-    lowered to TypR-valid functions with raw-expression fold/loop bodies for
+    lowered to TypR-valid functions with native TypR fold/loop bodies for
     the currently supported single-base shape with one recursion-driving
     argument and invariant context args
   - conservative single-recursive-call list linear-recursive predicates
-    lowered to TypR-valid functions with raw-expression fold/loop bodies for
+    lowered to TypR-valid functions with native TypR fold/loop bodies for
     the currently supported empty-list shape with one recursion-driving list
     argument and invariant context args
   - conservative arity-2 numeric multi-call tree-recursive predicates

--- a/docs/design/TYPE_SYSTEM_SPEC.md
+++ b/docs/design/TYPE_SYSTEM_SPEC.md
@@ -376,17 +376,17 @@ Current TypR lowering policy is intentionally mixed:
   subsequent native steps
 - accumulator-style tail-recursive predicates may also lower to TypR-valid
   functions when they match the conservative tail-recursion shape currently
-  supported by the shared recursion compiler, using raw-expression loop bodies
+  supported by the shared recursion compiler, using native TypR loop bodies
   inside TypR rather than relabeled standalone R output
 - conservative single-recursive-call numeric linear-recursive predicates may
   also lower to TypR-valid functions when they match the currently supported
   single-base, single-recursive-clause fold shape with one recursion-driving
-  argument and invariant context args, using raw-expression fold/loop bodies
+  argument and invariant context args, using native TypR fold/loop bodies
   inside TypR rather than wrapped-R fallback
 - conservative single-recursive-call list linear-recursive predicates may
   also lower to TypR-valid functions when they match the currently supported
   empty-list base-case fold shape with one recursion-driving list argument
-  and invariant context args, using raw-expression fold/loop bodies inside
+  and invariant context args, using native TypR fold/loop bodies inside
   TypR rather than wrapped-R fallback
 - conservative arity-2 numeric multi-call tree-recursive predicates may also
   lower to TypR-valid functions when they match the currently supported

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -56,15 +56,15 @@ This document focuses on architecture and rollout choices specific to TypR.
      by subsequent native steps
    - accumulator-style tail-recursive predicates that match the currently
      supported shared tail-recursion shape, emitted as TypR functions with
-     raw-expression loop bodies
+     native TypR loop bodies
    - conservative single-recursive-call numeric linear-recursive predicates
      that match the currently supported single-base fold shape with one
      recursion-driving argument and invariant context args, emitted as TypR
-     functions with raw-expression fold/loop bodies
+     functions with native TypR fold/loop bodies
    - conservative single-recursive-call list linear-recursive predicates
      that match the currently supported empty-list fold shape with one
      recursion-driving list argument and invariant context args, emitted as
-     TypR functions with raw-expression fold/loop bodies
+     TypR functions with native TypR fold/loop bodies
    - conservative arity-2 numeric multi-call tree-recursive predicates that
      match the currently supported memoized helper shape for `fib/2`-style
      recursion, emitted as TypR functions with raw-expression helper bodies
@@ -473,11 +473,11 @@ Current implementation note:
   later state before later native steps expand it, two-level nested guarded
   alternatives inside supported semicolon branches where each nested branch
   still selects the same later result set, accumulator-style tail-recursive
-  predicates compiled to raw-expression loop bodies inside TypR functions,
+  predicates compiled to native TypR loop bodies inside TypR functions,
   conservative single-recursive-call numeric linear-recursive predicates
-  compiled to raw-expression fold/loop bodies inside TypR functions,
+  compiled to native TypR fold/loop bodies inside TypR functions,
   conservative single-recursive-call list linear-recursive predicates
-  compiled to raw-expression fold/loop bodies inside TypR functions,
+  compiled to native TypR fold/loop bodies inside TypR functions,
   conservative arity-2 numeric multi-call tree-recursive predicates
   compiled to raw-expression memoized helper bodies inside TypR functions,
   conservative `N`-ary structural tree-recursive predicates compiled to

--- a/docs/handoff/typr-per-path-next-steps.md
+++ b/docs/handoff/typr-per-path-next-steps.md
@@ -1,0 +1,138 @@
+# Handoff: Remaining TypR Per-Path Visited Work
+
+## Goal
+Hand off the next TypR per-path visited slice cleanly so another agent can
+ continue from `main` without re-discovering the current boundary.
+
+## Current Supported TypR Slice
+
+`main` now supports conservative native TypR lowering for per-path visited
+recursion with:
+
+- detected `VisitedPos` rather than a fixed visited argument
+- mode-driven input/output positions when `user:mode/1` is available
+- one recursion-driving input plus conservative invariant non-visited inputs
+- weighted variants with one direct node output plus additive numeric outputs
+- native `*_from_vectors` runtime helpers
+- native `input(stdin|file|vfs|function)` wrappers
+- declared scalar runtime node parsing such as `integer` and `number`
+- conservative pair-shaped runtime node parsing such as
+  `pair(integer, integer)` and `pair(number, number)`
+
+Primary implementation points:
+
+- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)
+- [templates/targets/typr/per_path_visited.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/per_path_visited.mustache)
+- [templates/targets/typr/ppv_definitions.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_definitions.mustache)
+- [templates/targets/typr/ppv_input_stdin.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_input_stdin.mustache)
+- [templates/targets/typr/ppv_input_file.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_input_file.mustache)
+- [templates/targets/typr/ppv_input_vfs.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_input_vfs.mustache)
+- [templates/targets/typr/ppv_input_function.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_input_function.mustache)
+
+Relevant design references:
+
+- [docs/design/PER_PATH_VISITED_IMPLEMENTATION_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/PER_PATH_VISITED_IMPLEMENTATION_PLAN.md)
+- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)
+- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
+
+## Confirmed Next Gap
+
+The next real TypR gap is not another loader variation. It is helper or guard
+goals over invariant inputs between the step relation and the recursive call.
+
+Concretely, the current supported path assumes the recursive body is still
+close to:
+
+```prolog
+step(Current, Next),
+\+ member(Next, Visited),
+pred(Next, ..., [Next|Visited])
+```
+
+The next failing slice is:
+
+```prolog
+step(Current, Next),
+Next =< Limit,
+\+ member(Next, Visited),
+pred(Next, Limit, ..., [Next|Visited])
+```
+
+or an equivalent helper-goal form such as:
+
+```prolog
+step(Current, Next),
+Allowed is Limit - 1,
+Next =< Allowed,
+\+ member(Next, Visited),
+pred(Next, Limit, ..., [Next|Visited])
+```
+
+This should stay on the existing native TypR worker path. It should not fall
+back to raw R or to an unrelated general-recursion matcher.
+
+## Recommended Next Branch
+
+- `feature/typr-per-path-invariant-guards-audit`
+
+## Recommended Scope
+
+Keep the next branch narrow:
+
+- compile-time-seeded step relation first
+- scalar node IDs first
+- native TypR worker path only
+- preserve existing `VisitedPos` and mode-driven input/output handling
+- no broader runtime loader expansion in the same branch
+
+## Proving Predicates
+
+Use one or two tight probes:
+
+```prolog
+category_ancestor_limited(Cat, Ancestor, Hops, Limit, Visited) :-
+    category_parent(Cat, Ancestor),
+    Ancestor =< Limit,
+    \+ member(Ancestor, Visited),
+    Hops = 1.
+category_ancestor_limited(Cat, Ancestor, Hops, Limit, Visited) :-
+    category_parent(Cat, Mid),
+    Mid =< Limit,
+    \+ member(Mid, Visited),
+    category_ancestor_limited(Mid, Ancestor, H1, Limit, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+Weighted follow-up:
+
+```prolog
+category_ancestor_weight_limited(Cat, Ancestor, Hops, Cost, Limit, Visited) :-
+    ...
+```
+
+## Files Most Likely to Change
+
+- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)
+- [templates/targets/typr/per_path_visited.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/per_path_visited.mustache)
+- [templates/targets/typr/ppv_definitions.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_definitions.mustache)
+- [tests/test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)
+- [tests/test_typr_toolchain.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_toolchain.pl)
+- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
+- [docs/design/TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
+- [docs/design/TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
+- [docs/design/TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)
+
+## Non-Goals for That Branch
+
+Do not mix in:
+
+- broader generic recursion lowering
+- SCC work
+- transitive-closure raw-R reduction
+- richer runtime node-shape parsing beyond the current scalar and pair slices
+
+## Do Not Touch
+
+- [examples/sci-repl/prototype](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/examples/sci-repl/prototype)
+- existing untracked `PR_DESCRIPTION_*` files
+- [std.ty](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/std.ty)

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -6533,23 +6533,22 @@ build_typr_linear_recursive_body(
     },
     Body
 ) :-
-    linear_recursive_guard_lines(RecursiveGuardExpr, Pred, GuardLines),
-    format(string(BaseLine), '        ~w', [BaseOutputExpr]),
-    format(string(AccInitLine), '        acc = ~w;', [BaseOutputExpr]),
+    linear_recursive_guard_lines(RecursiveGuardExpr, Pred, RawGuardLines),
+    typr_nativeize_statement_lines(RawGuardLines, GuardLines),
+    format(string(ResultInitLine), '    ~w <- ~w;', [ResultName, BaseOutputExpr]),
+    format(string(AccInitLine), '    acc <- ~w;', [BaseOutputExpr]),
     format(string(LoopLine), '        for (current in ~w) {', [SeqExpr]),
-    format(string(AccStepLine), '            acc = ~w;', [FoldExpr]),
-    format(string(BaseCaseIfLine), '    if (identical(current_input, ~w)) {', [BaseInputLiteral]),
-    format(string(ResultIntroLine), 'let ~w <- @{', [ResultName]),
-    format(string(CurrentInputLine), '    current_input = ~w;', [InputArgName]),
+    format(string(AccStepLine), '            acc <- ~w;', [FoldExpr]),
+    format(string(ResultLine), '        ~w <- acc;', [ResultName]),
+    format(string(LoopIfLine), '    if (!identical(current_input, ~w)) {', [BaseInputLiteral]),
+    format(string(CurrentInputLine), '    current_input <- ~w;', [InputArgName]),
     format(string(AssignResultLine), '~w <- ~w;', [OutputArgName, ResultName]),
     atomic_list_concat(
         [
-            ResultIntroLine,
-            'local({',
             CurrentInputLine,
-            BaseCaseIfLine,
-            BaseLine,
-            '    } else {'
+            ResultInitLine,
+            AccInitLine,
+            LoopIfLine
         ],
         '\n',
         Prefix
@@ -6564,14 +6563,11 @@ build_typr_linear_recursive_body(
     append(
         RawLines0,
         [
-            AccInitLine,
             LoopLine,
             AccStepLine,
-            '        };',
-            '        acc',
+            '        }',
+            ResultLine,
             '    }',
-            '})',
-            '}@;',
             AssignResultLine,
             OutputArgName
         ],
@@ -6589,28 +6585,23 @@ build_typr_linear_recursive_list_body(
     },
     Body
 ) :-
-    format(string(BaseLine), '        ~w', [BaseOutputExpr]),
-    format(string(AccInitLine), '        acc = ~w;', [BaseOutputExpr]),
-    format(string(AccStepLine), '            acc = ~w;', [FoldExpr]),
-    format(string(ResultIntroLine), 'let ~w <- @{', [ResultName]),
-    format(string(CurrentInputLine), '    current_input = ~w;', [InputArgName]),
+    format(string(ResultInitLine), '    ~w <- ~w;', [ResultName, BaseOutputExpr]),
+    format(string(AccInitLine), '    acc <- ~w;', [BaseOutputExpr]),
+    format(string(AccStepLine), '            acc <- ~w;', [FoldExpr]),
+    format(string(ResultLine), '        ~w <- acc;', [ResultName]),
+    format(string(CurrentInputLine), '    current_input <- ~w;', [InputArgName]),
     format(string(AssignResultLine), '~w <- ~w;', [OutputArgName, ResultName]),
     atomic_list_concat(
         [
-            ResultIntroLine,
-            'local({',
             CurrentInputLine,
-            '    if (length(current_input) == 0) {',
-            BaseLine,
-            '    } else {',
+            ResultInitLine,
             AccInitLine,
+            '    if (length(current_input) > 0) {',
             '        for (current in rev(current_input)) {',
             AccStepLine,
-            '        };',
-            '        acc',
+            '        }',
+            ResultLine,
             '    }',
-            '})',
-            '}@;',
             AssignResultLine,
             OutputArgName
         ],
@@ -6979,6 +6970,25 @@ raw_guard_expr(GuardConditions, GuardExpr) :-
     combine_typr_conditions(GuardConditions, CombinedCondition),
     typr_condition_expr_text(CombinedCondition, GuardExpr).
 
+typr_nativeize_statement_lines([], []).
+typr_nativeize_statement_lines([Line0|Rest0], [Line|Rest]) :-
+    typr_nativeize_statement_line(Line0, Line),
+    typr_nativeize_statement_lines(Rest0, Rest).
+
+typr_nativeize_statement_line(Line0, Line) :-
+    (   sub_string(Line0, Before, 3, After, " = "),
+        sub_string(Line0, _, 1, 0, ";")
+    ->  sub_string(Line0, 0, Before, _, Left),
+        Start is Before + 3,
+        sub_string(Line0, Start, After, 0, Right),
+        string_concat(Left, " <- ", Prefix),
+        string_concat(Prefix, Right, Line)
+    ;   sub_string(Line0, Before, 2, 0, "};")
+    ->  sub_string(Line0, 0, Before, 2, Prefix),
+        string_concat(Prefix, "}", Line)
+    ;   Line = Line0
+    ).
+
 build_typr_tail_recursive_body(
     RecHead-_RecBody,
     loop_spec{
@@ -6995,15 +7005,18 @@ build_typr_tail_recursive_body(
     build_head_varmap([HeadInputVar, HeadAccVar, HeadOutVar], 1, HeadVarMap0),
     reserve_typr_internal_var(HeadVarMap0, _ResultToken, ResultName, _HeadVarMap, new),
     lookup_typr_var(HeadOutVar, HeadVarMap0, OutputName),
-    tail_recursive_guard_lines(GuardExpr, PredName, GuardLines),
+    tail_recursive_guard_lines(GuardExpr, PredName, RawGuardLines),
+    typr_nativeize_statement_lines(RawGuardLines, GuardLines),
+    typr_nativeize_statement_lines(StepLines, NativeStepLines),
     format_string('    while (!identical(current_input, ~w)) {', [BaseInputLiteral], WhileLine),
-    format_string('        current_input = ~w;', [NextInputExpr], NextInputLine),
-    format_string('        current_acc = ~w;', [NextAccExpr], NextAccLine),
+    format_string('        current_input <- ~w;', [NextInputExpr], NextInputLine),
+    format_string('        current_acc <- ~w;', [NextAccExpr], NextAccLine),
+    format_string('    ~w <- current_acc;', [ResultName], ResultLine),
+    format_string('~w <- ~w;', [OutputName, ResultName], AssignResultLine),
     append(
         [
-            'local({',
-            '    current_input = arg1;',
-            '    current_acc = arg2;',
+            '    current_input <- arg1;',
+            '    current_acc <- arg2;',
             WhileLine
         ],
         GuardLines,
@@ -7011,7 +7024,7 @@ build_typr_tail_recursive_body(
     ),
     append(
         RawLines0,
-        StepLines,
+        NativeStepLines,
         RawLines1
     ),
     append(
@@ -7019,19 +7032,14 @@ build_typr_tail_recursive_body(
         [
             NextInputLine,
             NextAccLine,
-            '    };',
-            '    current_acc',
-            '})'
+            '    }',
+            ResultLine,
+            AssignResultLine,
+            OutputName
         ],
         RawLines
     ),
-    atomic_list_concat(RawLines, '\n', RawExpr),
-    format(string(Body),
-'let ~w <- @{
-~w
-}@;
-~w <- ~w;
-~w', [ResultName, RawExpr, OutputName, ResultName, OutputName]).
+    atomic_list_concat(RawLines, '\n', Body).
 
 tail_recursive_guard_lines('TRUE', _PredName, []) :-
     !.

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -420,8 +420,9 @@ test(recursive_compiler_supports_typr_tail_recursion_path) :-
     once(recursive_compiler:compile_recursive(factorial_acc/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let factorial_acc <- fn(arg1: int, arg2: int, arg3: int): int")),
     once(sub_string(Code, _, _, _, "while (!identical(current_input, 0))")),
-    once(sub_string(Code, _, _, _, "current_acc = step_2;")),
+    once(sub_string(Code, _, _, _, "current_acc <- step_2;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_linear_recursion_path) :-
@@ -439,9 +440,10 @@ test(recursive_compiler_supports_typr_linear_recursion_path) :-
     once(recursive_compiler:compile_recursive(factorial_linear/2, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let factorial_linear <- fn(arg1: int, arg2: int): int")),
     once(sub_string(Code, _, _, _, "for (current in seq(current_input, 1))")),
-    once(sub_string(Code, _, _, _, "acc = (current * acc);")),
+    once(sub_string(Code, _, _, _, "acc <- (current * acc);")),
     once(sub_string(Code, _, _, _, "stop(\"No matching recursive clause for factorial_linear\")")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_list_linear_recursion_path) :-
@@ -456,10 +458,11 @@ test(recursive_compiler_supports_typr_list_linear_recursion_path) :-
     assertz(type_declarations:uw_return_type(list_length/2, integer)),
     once(recursive_compiler:compile_recursive(list_length/2, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let list_length <- fn(arg1: [#N, Any], arg2: int): int")),
-    once(sub_string(Code, _, _, _, "if (length(current_input) == 0)")),
+    once(sub_string(Code, _, _, _, "if (length(current_input) > 0)")),
     once(sub_string(Code, _, _, _, "for (current in rev(current_input))")),
-    once(sub_string(Code, _, _, _, "acc = (acc + 1);")),
+    once(sub_string(Code, _, _, _, "acc <- (acc + 1);")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_tree_recursion_path) :-
@@ -1800,11 +1803,12 @@ test(recursive_compiler_supports_typr_nary_linear_recursion_path) :-
     assertz(type_declarations:uw_return_type(power/3, integer)),
     once(recursive_compiler:compile_recursive(power/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let power <- fn(arg1: int, arg2: int, arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
     once(sub_string(Code, _, _, _, "for (current in seq(current_input, 1))")),
-    once(sub_string(Code, _, _, _, "acc = (arg1 * acc);")),
+    once(sub_string(Code, _, _, _, "acc <- (arg1 * acc);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_nary_list_linear_recursion_path) :-
@@ -1820,11 +1824,12 @@ test(recursive_compiler_supports_typr_nary_list_linear_recursion_path) :-
     assertz(type_declarations:uw_return_type(list_length_from/3, integer)),
     once(recursive_compiler:compile_recursive(list_length_from/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let list_length_from <- fn(arg1: int, arg2: [#N, Any], arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
-    once(sub_string(Code, _, _, _, "if (length(current_input) == 0)")),
-    once(sub_string(Code, _, _, _, "acc = (acc + 1);")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
+    once(sub_string(Code, _, _, _, "if (length(current_input) > 0)")),
+    once(sub_string(Code, _, _, _, "acc <- (acc + 1);")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_guarded_nary_linear_recursion_path) :-
@@ -1842,10 +1847,11 @@ test(recursive_compiler_supports_typr_guarded_nary_linear_recursion_path) :-
     assertz(type_declarations:uw_return_type(power_if/3, integer)),
     once(recursive_compiler:compile_recursive(power_if/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let power_if <- fn(arg1: int, arg2: int, arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
-    once(sub_string(Code, _, _, _, "acc = if (@{ arg1 > 1 }@) { (arg1 * acc) } else { acc };")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
+    once(sub_string(Code, _, _, _, "acc <- if (@{ arg1 > 1 }@) { (arg1 * acc) } else { acc };")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_guarded_nary_list_linear_recursion_path) :-
@@ -1861,10 +1867,11 @@ test(recursive_compiler_supports_typr_guarded_nary_list_linear_recursion_path) :
     assertz(type_declarations:uw_return_type(count_occ/3, integer)),
     once(recursive_compiler:compile_recursive(count_occ/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let count_occ <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
-    once(sub_string(Code, _, _, _, "acc = if (@{ arg1 == current }@) { (acc + 1) } else { acc };")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
+    once(sub_string(Code, _, _, _, "acc <- if (@{ arg1 == current }@) { (acc + 1) } else { acc };")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_multistate_nary_linear_recursion_path) :-
@@ -1888,11 +1895,12 @@ test(recursive_compiler_supports_typr_multistate_nary_linear_recursion_path) :-
     assertz(type_declarations:uw_return_type(power_multistate/3, integer)),
     once(recursive_compiler:compile_recursive(power_multistate/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let power_multistate <- fn(arg1: int, arg2: int, arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 > 1 }@) { (arg1 * acc) } else { acc }")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 > 1 }@) { ((arg1 * acc) + 1) } else { (acc + 2) }")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_multistate_nary_list_linear_recursion_path) :-
@@ -1914,11 +1922,12 @@ test(recursive_compiler_supports_typr_multistate_nary_list_linear_recursion_path
     assertz(type_declarations:uw_return_type(count_weighted/3, integer)),
     once(recursive_compiler:compile_recursive(count_weighted/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let count_weighted <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { (acc + 1) } else { acc }")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { ((acc + 1) + 1) } else { (acc + 2) }")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_asymmetric_nary_linear_recursion_path) :-
@@ -1941,10 +1950,11 @@ test(recursive_compiler_supports_typr_asymmetric_nary_linear_recursion_path) :-
     assertz(type_declarations:uw_return_type(asym_rec_a/3, integer)),
     once(recursive_compiler:compile_recursive(asym_rec_a/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let asym_rec_a <- fn(arg1: int, arg2: int, arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 > 1 }@) { ((arg1 * acc) + 1) } else { ((acc + 2) + acc) }")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_asymmetric_nary_list_linear_recursion_path) :-
@@ -1965,10 +1975,11 @@ test(recursive_compiler_supports_typr_asymmetric_nary_list_linear_recursion_path
     assertz(type_declarations:uw_return_type(asym_rec_c/3, integer)),
     once(recursive_compiler:compile_recursive(asym_rec_c/3, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let asym_rec_c <- fn(arg1: int, arg2: [#N, int], arg3: int): int")),
-    once(sub_string(Code, _, _, _, "current_input = arg2;")),
+    once(sub_string(Code, _, _, _, "current_input <- arg2;")),
     once(sub_string(Code, _, _, _, "if (@{ arg1 == current }@) { ((acc + 1) + 1) } else { ((acc + 2) + acc) }")),
     once(sub_string(Code, _, _, _, "arg3 <- v4;")),
     \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(generic_body_predicates_reuse_r_backend) :-


### PR DESCRIPTION
## Summary

This PR reduces the remaining raw-R surface in generic TypR recursive lowering.

The branch converts the currently supported TypR loop-based recursion paths from
raw-expression wrappers like `@{ local({ ... }) }@` into native TypR statement
bodies.

Concretely, the following paths now stay native inside TypR functions:

- accumulator-style tail recursion
- conservative numeric linear recursion
- conservative list linear recursion

This PR also adds a handoff doc for the remaining TypR per-path visited work so
that effort can continue independently while raw-R reduction moves forward.

## Why This PR Exists

Recent work removed most of the raw R from TypR transitive-closure output, but
large parts of the generic recursive path still emitted loop bodies through raw
R wrappers.

That left an important inconsistency in the TypR backend:

- the compiler claimed native TypR support for several conservative recursive
  shapes
- but the emitted loop bodies for those shapes were still effectively R blocks
  inside TypR functions

This PR fixes the next highest-leverage part of that problem without trying to
rewrite every remaining recursive path at once.

## Main Changes

### 1. Native TypR loop bodies for supported recursive loop emitters

Updated [typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl).

The TypR target now emits native TypR assignment and loop statements for the
currently supported loop-based recursion shapes instead of wrapping the body in
raw-expression `local({ ... })` code.

This affects:

- tail recursion
- numeric linear recursion
- list linear recursion

The emitter changes include:

- native `<-` assignment generation in recursive loop bodies
- native guard/body statement normalization
- native result binding inside the TypR function body instead of through a raw
  expression wrapper

### 2. Regression coverage for the new native loop output

Updated [test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl).

The target-level tests now assert that these recursive loop paths no longer
fall back to the old raw-expression wrapper shape.

### 3. Per-path visited handoff doc

Added [typr-per-path-next-steps.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/handoff/typr-per-path-next-steps.md).

This documents the remaining TypR per-path visited boundary so another agent
can continue that line of work without having to reconstruct the current state
from recent commits.

### 4. Docs updated to reflect the native loop change

Updated:

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

The docs now describe these supported loop-based recursive shapes as using
native TypR loop bodies rather than raw-expression loop bodies.

## Files Changed

### Implementation

- [typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)

### Tests

- [test_typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/tests/test_typr_target.pl)

### Documentation

- [README.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/README.md)
- [TYPE_SYSTEM_SPEC.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_SPEC.md)
- [TYPE_SYSTEM_IMPL_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPE_SYSTEM_IMPL_PLAN.md)
- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)
- [typr-per-path-next-steps.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/handoff/typr-per-path-next-steps.md)

## Validation Performed

Verified locally with:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

All of the above passed.

Known unrelated baseline:

```sh
swipl -q -g run_tests -t halt tests/test_r_target.pl
```

This still fails in the pre-existing R-target return-type diagnostics area and
was not changed by this branch.

## Scope And Remaining Gaps

Implemented now:

- native TypR loop bodies for the currently supported tail-recursive path
- native TypR loop bodies for the currently supported numeric linear-recursive
  path
- native TypR loop bodies for the currently supported list linear-recursive
  path
- explicit handoff documentation for remaining TypR per-path visited work

Still remaining:

- tree-recursive helper bodies still use raw-expression helper paths
- memoized recursive helper bodies still use raw-expression helper paths
- broader recursive-body raw-R reduction is still ahead

## Why This PR Is Worth Merging

This PR moves the TypR backend closer to being meaningfully native rather than
native only at the outer syntax level.

It removes raw R from a high-traffic part of recursive TypR output, keeps the
supported recursive subset working, and documents the parallel per-path frontier
cleanly.

That is a better next step than chasing another isolated recursion shape while
leaving the common loop emitters wrapped in raw R.
