### PR TITLE
feat: add put_structure compound term support and document CP safety …

### DIFF
--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -151,6 +151,39 @@ step_wam(put_value(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_sta
     put_assoc(Ai, R, Val, NR),
     NPC is PC + 1.
 
+%% put_structure F/N, Ai — begins constructing a compound term on the heap.
+%  Allocates a structure cell str(F/N) on the heap, stores the heap address
+%  in Ai, and enters "write mode" for subsequent set_variable/set_value.
+step_wam(put_structure(FN, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, NH, T, CP, CPS, Code, L)) :-
+    length(H, Addr),
+    append(H, [str(FN)], NH),
+    put_assoc(Ai, R, ref(Addr), NR),
+    NPC is PC + 1.
+
+%% set_variable Xn — pushes a new unbound variable onto the heap and binds Xn to it.
+step_wam(set_variable(Xn), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, NH, T, CP, CPS, Code, L)) :-
+    length(H, Addr),
+    format(atom(Var), "_H~w", [Addr]),
+    append(H, [Var], NH),
+    put_assoc(Xn, R, Var, NR),
+    NPC is PC + 1.
+
+%% set_value Xn — pushes the value of Xn onto the heap.
+step_wam(set_value(Xn), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, NH, T, CP, CPS, Code, L)) :-
+    get_assoc(Xn, R, Val),
+    append(H, [Val], NH),
+    NPC is PC + 1.
+
+%% set_constant C — pushes a constant value onto the heap.
+step_wam(set_constant(C), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, NH, T, CP, CPS, Code, L)) :-
+    append(H, [C], NH),
+    NPC is PC + 1.
+
+% NOTE: call/2 overwrites CP with the return address (PC+1). This is safe
+% because the compiler emits allocate (which saves CP to the environment
+% stack) before any call instruction in multi-goal bodies (N > 1 guard in
+% compile_body_goals). Single-goal bodies use execute instead of call,
+% so the outer CP is never lost.
 step_wam(call(P, _), wam_state(PC, R, S, H, T, _, CPS, Code, L), wam_state(NPC, R, S, H, T, NCP, CPS, Code, L)) :-
     get_assoc(P, L, NPC),
     NCP is PC + 1.

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -260,10 +260,48 @@ compile_put_argument(Arg, I, V0, V1, Code) :-
     ;   atomic(Arg)
     ->  format(string(Code), "    put_constant ~w, A~w", [Arg, I]),
         V1 = V0
-    ;   % TODO: put_structure
+    ;   compound(Arg)
+    ->  Arg =.. [F|SubArgs],
+        length(SubArgs, SArity),
+        next_x_reg(V0, XReg, V_temp),
+        bind_var(Arg, XReg, V_temp, V2),
+        format(string(StructCode), "    put_structure ~w/~w, A~w", [F, SArity, I]),
+        compile_set_arguments(SubArgs, V2, V1, SetCode),
+        (   SetCode == ""
+        ->  Code = StructCode
+        ;   format(string(Code), "~w~n~w", [StructCode, SetCode])
+        )
+    ;   % Fallback for unknown terms — allocate a fresh variable
         next_x_reg(V0, XReg, V_temp),
         bind_var(Arg, XReg, V_temp, V1),
         format(string(Code), "    put_variable ~w, A~w", [XReg, I])
+    ).
+
+%% compile_set_arguments(+Args, +VIn, -VOut, -Code)
+%  Emits set_value/set_variable instructions for put_structure sub-arguments.
+compile_set_arguments([], V, V, "").
+compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
+    (   var(Arg)
+    ->  (   get_var_reg(Arg, V0, Reg)
+        ->  format(string(ArgCode), "    set_value ~w", [Reg]),
+            V1 = V0
+        ;   next_x_reg(V0, XReg, V_temp),
+            bind_var(Arg, XReg, V_temp, V1),
+            format(string(ArgCode), "    set_variable ~w", [XReg])
+        )
+    ;   atomic(Arg)
+    ->  % For atomic sub-args, emit set_constant directly
+        V1 = V0,
+        format(string(ArgCode), "    set_constant ~w", [Arg])
+    ;   % Nested compound — allocate a register for the sub-structure
+        next_x_reg(V0, XReg, V_temp),
+        bind_var(Arg, XReg, V_temp, V1),
+        format(string(ArgCode), "    set_variable ~w", [XReg])
+    ),
+    compile_set_arguments(Rest, V1, Vf, RestCode),
+    (   RestCode == ""
+    ->  Code = ArgCode
+    ;   format(string(Code), "~w~n~w", [ArgCode, RestCode])
     ).
 
 %% Variable Mapping Helpers

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -5,7 +5,7 @@
 :- use_module('../src/unifyweaver/targets/wam_target').
 
 %% Test data (facts) - MUST BE DYNAMIC for clause/2 to work across modules
-:- dynamic test_parent/2, test_grandparent/2, test_ancestor/2.
+:- dynamic test_parent/2, test_grandparent/2, test_ancestor/2, test_wrap/2.
 
 test_parent(alice, bob).
 test_parent(bob, charlie).
@@ -16,6 +16,12 @@ test_grandparent(X, Z) :- test_parent(X, Y), test_parent(Y, Z).
 %% Recursive ancestor rule
 test_ancestor(X, Y) :- test_parent(X, Y).
 test_ancestor(X, Y) :- test_parent(X, Z), test_ancestor(Z, Y).
+
+%% Rule with compound body argument — exercises put_structure
+%  The body goal `test_check(pair(X, done))` has a compound argument.
+:- dynamic test_check/1.
+test_check(pair(_, _)).
+test_wrap(X) :- test_check(pair(X, done)).
 
 pass(Test) :-
     format('[PASS] ~w~n', [Test]).
@@ -85,6 +91,19 @@ test_wam_module :-
         fail_test(Test, 'Incorrect WAM module output from template')
     ).
 
+test_wam_put_structure :-
+    Test = 'WAM: put_structure for compound body args',
+    (   wam_target:compile_predicate_to_wam(user:test_wrap/1, [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'put_structure pair/2')
+    ->  pass(Test)
+    ;   (   wam_target:compile_predicate_to_wam(user:test_wrap/1, [], Code2)
+        ->  format(user_error, 'DEBUG: put_structure output:~n~w~n', [Code2])
+        ;   format(user_error, 'DEBUG: compile_predicate_to_wam failed~n', [])
+        ),
+        fail_test(Test, 'Missing put_structure in compound body arg output')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -94,6 +113,7 @@ run_tests :-
     test_wam_facts,
     test_wam_single_clause,
     test_wam_recursion,
+    test_wam_put_structure,
     test_wam_module,
     
     format('~n========================================~n'),


### PR DESCRIPTION
## Summary

- Implement `put_structure`/`set_variable`/`set_value`/`set_constant` in the WAM compiler and runtime, enabling compound term construction in body goals (e.g., `foo(pair(X, done))`)
- Add `compile_set_arguments/4` helper to emit `set_*` sequences for compound sub-arguments
- Document the CP (Continuation Pointer) safety invariant: `call` safely overwrites CP because `allocate` always precedes it in multi-goal bodies, and single-goal bodies use `execute` instead
- Add `test_wam_put_structure` test covering compound body argument compilation

## Test plan

- [x] All 5 existing WAM target tests pass
- [x] Both E2E tests pass (fact execution + backtracking)
- [x] New `test_wam_put_structure` verifies `put_structure pair/2` appears in compiled output for `test_wrap/1`
- [x] Verified compiled output manually: `put_structure pair/2, A1` / `set_value X1` / `set_constant done` sequence is correct

## Companion PR

- Education repo: `docs: document put_structure and set_* instructions in Book 17` (same branch name)

Generated with [Claude Code](https://claude.com/claude-code)
