### PR TITLE
Keep native TypR fact-only fallbacks

### DIFF
--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -363,8 +363,9 @@ Completed:
 9. Extended the native generic path further so sequential guard/output control
    flow can stay in TypR when a later guard depends on an earlier bound value.
 10. Extended native multi-clause TypR lowering so supported branch bodies stay
-    native and introduce new branch-local intermediates with `let` rather than
-    raw `local({ ... })` wrappers.
+    native, fact-only predicates emit direct native boolean matches, and
+    branch-local intermediates use `let` rather than raw `local({ ... })`
+    wrappers.
 11. Extended the native guard path again so simple comparison and boolean
     expressions over already-bound intermediates can stay native in both
     top-level control-flow chains and supported branch bodies.

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -7324,7 +7324,7 @@ typr_function_body(PredSpec, _Options, _TypedMode, Clauses, "bool", Body) :-
     all_fact_clauses(Clauses),
     fact_match_expression(PredSpec, Clauses, MatchExpr),
     !,
-    format(string(Body), 'result <- ~w;\nresult', [MatchExpr]).
+    format(string(Body), 'let result <- ~w;\nresult', [MatchExpr]).
 typr_function_body(PredSpec, Options, _TypedMode, Clauses, ReturnType, Body) :-
     generic_typr_return_type(PredSpec, Clauses, ReturnType),
     (   cba_typr_clause_body(PredSpec, Clauses, Body)

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -7324,7 +7324,7 @@ typr_function_body(PredSpec, _Options, _TypedMode, Clauses, "bool", Body) :-
     all_fact_clauses(Clauses),
     fact_match_expression(PredSpec, Clauses, MatchExpr),
     !,
-    format(string(Body), 'result <- @{ local({ ~w }) }@;\nresult', [MatchExpr]).
+    format(string(Body), 'result <- ~w;\nresult', [MatchExpr]).
 typr_function_body(PredSpec, Options, _TypedMode, Clauses, ReturnType, Body) :-
     generic_typr_return_type(PredSpec, Clauses, ReturnType),
     (   cba_typr_clause_body(PredSpec, Clauses, Body)

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -394,7 +394,7 @@ test(generic_predicates_receive_typed_signature) :-
     once(compile_predicate_to_typr(simple_fact/1, [typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let simple_fact <- fn(arg1: char): bool")),
     once(sub_string(Code, _, _, _, "identical(arg1, \"hello\")")),
-    once(sub_string(Code, _, _, _, "result <- identical(arg1, \"hello\");")),
+    once(sub_string(Code, _, _, _, "let result <- identical(arg1, \"hello\");")),
     \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -394,6 +394,8 @@ test(generic_predicates_receive_typed_signature) :-
     once(compile_predicate_to_typr(simple_fact/1, [typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let simple_fact <- fn(arg1: char): bool")),
     once(sub_string(Code, _, _, _, "identical(arg1, \"hello\")")),
+    once(sub_string(Code, _, _, _, "result <- identical(arg1, \"hello\");")),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_non_recursive_path) :-
@@ -402,6 +404,7 @@ test(recursive_compiler_supports_typr_non_recursive_path) :-
     assertz(type_declarations:uw_type(simple_fact/1, 1, atom)),
     once(recursive_compiler:compile_recursive(simple_fact/1, [target(typr), typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let simple_fact <- fn(arg1: char): bool")),
+    \+ sub_string(Code, _, _, _, "local({"),
     generated_typr_is_valid(Code, exit(0)).
 
 test(recursive_compiler_supports_typr_tail_recursion_path) :-


### PR DESCRIPTION
# PR Title

Keep native TypR fact-only fallbacks

# PR Description

## Summary

This PR removes the remaining unnecessary raw `@{ local({ ... }) }@` wrapper from the fact-only boolean path in the TypR target.

Fact-only predicates now emit direct native TypR boolean matches, with `let` used for the initial `result` binding.

## What changed

- nativeized the fact-only boolean path in `src/unifyweaver/targets/typr_target.pl`
- changed the initial fact-only `result` binding to `let result <- ...` instead of plain reassignment
- added and updated regression checks in `tests/test_typr_target.pl` to ensure direct fact-only TypR output stays native and does not regress to `local({ ... })`
- updated `docs/design/TYPR_TARGET_DESIGN.md` to record that fact-only predicates now emit direct native boolean matches

## Result

Fact-only predicates such as a simple single-clause fact now emit native TypR like:

```typr
let result <- identical(arg1, "hello");
result
```

instead of:

```typr
result <- @{ local({ identical(arg1, "hello") }) }@;
result
```

## Scope boundary

This PR intentionally does not change the generic wrapped-R fallback path.

That remaining path is still the real fallback boundary for more complex generic non-recursive bodies and should be handled as a separate design/audit step rather than treated as another trivial wrapper cleanup.

## Validation

Ran:

```sh
swipl -q -g "run_tests([typr_target:generic_predicates_receive_typed_signature,typr_target:recursive_compiler_supports_typr_non_recursive_path])" -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```
