### PR TITLE
feat: Yi permanent variables, unify_* runtime, and E2E rule test

### DIFF
--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -153,38 +153,100 @@ remove_assoc_key(Key, Assoc, Value, NewAssoc) :-
     ).
 
 %% step_wam(+Instruction, +StateIn, -StateOut)
-step_wam(get_constant(C, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
-    (   get_assoc(Ai, R, Val)
-    ->  (Val == C -> NPC is PC + 1 ; fail)
+step_wam(get_constant(C, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
+    get_assoc(Ai, R, Val),
+    (   Val == C
+    ->  NR = R, NT = T, NPC is PC + 1
+    ;   is_unbound_var(Val)
+    ->  % Unify: bind the variable to the constant
+        trail_binding(Ai, R, T, NT),
+        put_assoc(Ai, R, C, NR),
+        NPC is PC + 1
     ;   fail
     ).
 
-step_wam(get_variable(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
+step_wam(get_variable(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, NS, H, NT, CP, CPS, Code, L)) :-
     get_assoc(Ai, R, Val),
     trail_binding(Xn, R, T, NT),
-    put_assoc(Xn, R, Val, NR),
+    put_reg(Xn, Val, R, NR, S, NS),
     NPC is PC + 1.
 
-step_wam(get_value(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
+step_wam(get_value(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, NS, H, NT, CP, CPS, Code, L)) :-
     get_assoc(Ai, R, ValA),
-    get_assoc(Xn, R, ValX),
-    (ValA == ValX -> NPC is PC + 1 ; fail).
+    get_reg(Xn, R, S, ValX),
+    (   ValA == ValX
+    ->  NR = R, NS = S, NT = T, NPC is PC + 1
+    ;   is_unbound_var(ValA)
+    ->  trail_binding(Ai, R, T, NT),
+        put_assoc(Ai, R, ValX, NR), NS = S,
+        NPC is PC + 1
+    ;   is_unbound_var(ValX)
+    ->  trail_binding(Xn, R, T, NT),
+        put_reg(Xn, ValA, R, NR, S, NS),
+        NPC is PC + 1
+    ;   fail
+    ).
+
+%% get_structure F/N, Ai — checks that Ai holds a compound term with functor F
+%  and arity N. On success, pushes the sub-arguments as a unify context onto
+%  the stack so that subsequent unify_* instructions can consume them.
+step_wam(get_structure(FN, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, [unify_ctx(SubArgs)|S], H, T, CP, CPS, Code, L)) :-
+    get_assoc(Ai, R, Val),
+    Val =.. [F|SubArgs],
+    length(SubArgs, Arity),
+    format(atom(FN_check), "~w/~w", [F, Arity]),
+    FN_check == FN,
+    NPC is PC + 1.
+
+%% unify_variable Xn — in read mode, binds the next sub-argument to Xn.
+step_wam(unify_variable(Xn), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, CP, CPS, Code, L),
+         wam_state(NPC, NR, NewS, H, NT, CP, CPS, Code, L)) :-
+    trail_binding(Xn, R, T, NT),
+    (   RestArgs == []
+    ->  BaseS = S
+    ;   BaseS = [unify_ctx(RestArgs)|S]
+    ),
+    put_reg(Xn, Arg, R, NR, BaseS, NewS),
+    NPC is PC + 1.
+
+%% unify_value Xn — in read mode, checks that the next sub-argument matches Xn.
+step_wam(unify_value(Xn), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, NewS, H, T, CP, CPS, Code, L)) :-
+    get_reg(Xn, R, S, Val),
+    Val == Arg,
+    (   RestArgs == []
+    ->  NewS = S
+    ;   NewS = [unify_ctx(RestArgs)|S]
+    ),
+    NPC is PC + 1.
+
+%% unify_constant C — in read mode, checks that the next sub-argument is constant C.
+step_wam(unify_constant(C), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, NewS, H, T, CP, CPS, Code, L)) :-
+    Arg == C,
+    (   RestArgs == []
+    ->  NewS = S
+    ;   NewS = [unify_ctx(RestArgs)|S]
+    ),
+    NPC is PC + 1.
 
 step_wam(put_constant(C, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
     trail_binding(Ai, R, T, NT),
     put_assoc(Ai, R, C, NR),
     NPC is PC + 1.
 
-step_wam(put_variable(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
+step_wam(put_variable(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, NS, H, NT, CP, CPS, Code, L)) :-
     format(atom(NewVar), "_V~w", [PC]),
     trail_binding(Xn, R, T, T1),
     trail_binding(Ai, R, T1, NT),
-    put_assoc(Xn, R, NewVar, R1),
+    put_reg(Xn, NewVar, R, R1, S, S1),
     put_assoc(Ai, R1, NewVar, NR),
+    (   is_y_reg(Xn) -> NS = S1 ; NS = S
+    ),
     NPC is PC + 1.
 
 step_wam(put_value(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
-    get_assoc(Xn, R, Val),
+    get_reg(Xn, R, S, Val),
     trail_binding(Ai, R, T, NT),
     put_assoc(Ai, R, Val, NR),
     NPC is PC + 1.
@@ -199,16 +261,16 @@ step_wam(put_structure(FN, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam
     NPC is PC + 1.
 
 %% set_variable Xn — pushes a new unbound variable onto the heap and binds Xn to it.
-step_wam(set_variable(Xn), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, NH, T, CP, CPS, Code, L)) :-
+step_wam(set_variable(Xn), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, NS, NH, T, CP, CPS, Code, L)) :-
     length(H, Addr),
     format(atom(Var), "_H~w", [Addr]),
     append(H, [Var], NH),
-    put_assoc(Xn, R, Var, NR),
+    put_reg(Xn, Var, R, NR, S, NS),
     NPC is PC + 1.
 
 %% set_value Xn — pushes the value of Xn onto the heap.
 step_wam(set_value(Xn), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, NH, T, CP, CPS, Code, L)) :-
-    get_assoc(Xn, R, Val),
+    get_reg(Xn, R, S, Val),
     append(H, [Val], NH),
     NPC is PC + 1.
 
@@ -231,10 +293,13 @@ step_wam(execute(P), wam_state(_, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, 
 
 step_wam(proceed, wam_state(_, R, S, H, T, CP, CPS, Code, L), wam_state(CP, R, S, H, T, halt, CPS, Code, L)).
 
-step_wam(allocate, wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, [env(CP)|S], H, T, CP, CPS, Code, L)) :-
+%% allocate — creates an environment frame with saved CP and empty Yi storage.
+step_wam(allocate, wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, [env(CP, YRegs)|S], H, T, CP, CPS, Code, L)) :-
+    empty_assoc(YRegs),
     NPC is PC + 1.
 
-step_wam(deallocate, wam_state(PC, R, [env(OldCP)|S], H, T, _, CPS, Code, L), wam_state(NPC, R, S, H, T, OldCP, CPS, Code, L)) :-
+%% deallocate — restores CP from the environment frame.
+step_wam(deallocate, wam_state(PC, R, [env(OldCP, _)|S], H, T, _, CPS, Code, L), wam_state(NPC, R, S, H, T, OldCP, CPS, Code, L)) :-
     NPC is PC + 1.
 
 step_wam(try_me_else(NextL), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, [cp(NextPC, R, S, CP, T)|CPS], Code, L)) :-
@@ -250,12 +315,43 @@ step_wam(retry_me_else(NextL), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_
     (CPS = [_|Rest] -> NCPS = [cp(NextPC, R, S, CP, T)|Rest] ; NCPS = [cp(NextPC, R, S, CP, T)]),
     NPC is PC + 1.
 
+%% is_unbound_var(+Val)
+%  Checks if a value represents a WAM unbound variable (generated by put_variable).
+is_unbound_var(Val) :-
+    atom(Val),
+    sub_atom(Val, 0, 2, _, '_V').
+
 %% trail_binding(+Key, +Regs, +TrailIn, -TrailOut)
 %  Records the old value of Key (or 'unbound' if absent) on the trail.
 trail_binding(Key, Regs, Trail, [trail(Key, OldValue)|Trail]) :-
     (   get_assoc(Key, Regs, OldValue) -> true
     ;   OldValue = unbound
     ).
+
+%% Yi register helpers — read/write permanent variables in the environment frame.
+is_y_reg(Reg) :-
+    atom(Reg),
+    sub_atom(Reg, 0, 1, _, 'Y').
+
+%% get_reg(+Reg, +Regs, +Stack, -Value)
+%  Gets a register value. Yi registers are read from the top environment frame.
+get_reg(Reg, _R, Stack, Val) :-
+    is_y_reg(Reg), !,
+    member(env(_, YRegs), Stack), !,
+    get_assoc(Reg, YRegs, Val).
+get_reg(Reg, R, _, Val) :-
+    get_assoc(Reg, R, Val).
+
+%% put_reg(+Reg, +Val, +Regs, -NewRegs, +Stack, -NewStack)
+%  Sets a register value. Yi registers are written to the top environment frame.
+put_reg(Reg, Val, R, R, Stack, NewStack) :-
+    is_y_reg(Reg), !,
+    update_top_env(Stack, Reg, Val, NewStack).
+put_reg(Reg, Val, R, NR, Stack, Stack) :-
+    put_assoc(Reg, R, Val, NR).
+
+update_top_env([env(CP, YRegs)|Rest], Reg, Val, [env(CP, NewYRegs)|Rest]) :-
+    put_assoc(Reg, YRegs, Val, NewYRegs).
 
 test_wam_runtime :-
     Code = [

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -96,17 +96,23 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
 
 %% compile_single_clause_wam(+Clause, +Options, -Code)
 compile_single_clause_wam(Head-Body, Options, Code) :-
-    % Head unification
     Head =.. [_|Args],
-    empty_varmap(V0),
-    compile_head_arguments(Args, 1, V0, V1, HeadCode),
-    % Body execution
     normalize_goals(Body, Goals),
-    (   Goals == []
-    ->  BodyCode = "    proceed"
-    ;   compile_body_goals(Goals, V1, Options, BodyCode)
-    ),
-    format(string(Code), "~w~n~w", [HeadCode, BodyCode]).
+    empty_varmap(V0),
+    (   length(Goals, N), N > 1
+    ->  % Pre-assign Yi registers, emit allocate before head so Yi
+        % registers can be stored in the environment frame immediately.
+        pre_assign_permanent_vars(Goals, V0, V0a),
+        compile_head_arguments(Args, 1, V0a, V1, HeadCode),
+        compile_goals(Goals, V1, yes, _, GoalsCode),
+        format(string(Code), "    allocate~n~w~n~w", [HeadCode, GoalsCode])
+    ;   compile_head_arguments(Args, 1, V0, V1, HeadCode),
+        (   Goals == []
+        ->  BodyCode = "    proceed"
+        ;   compile_body_goals(Goals, V1, Options, BodyCode)
+        ),
+        format(string(Code), "~w~n~w", [HeadCode, BodyCode])
+    ).
 
 %% compile_multi_clause_wam(+Pred, +Arity, +Clauses, +Options, -Code)
 compile_multi_clause_wam(Pred, Arity, Clauses, Options, Code) :-
@@ -122,14 +128,21 @@ compile_clauses_with_choice_points([Head-Body|Rest], I, N, Pred, Arity, Options,
     ;   Next is I + 1,
         format(string(Choice), "L_~w_~w_~w:~n    retry_me_else L_~w_~w_~w", [Pred, Arity, I, Pred, Arity, Next])
     ),
-    % Compile clause body
+    % Compile clause body — pre-assign Yi for permanent vars before head
     Head =.. [_|Args],
-    empty_varmap(V0),
-    compile_head_arguments(Args, 1, V0, V1, HeadCode),
     normalize_goals(Body, Goals),
-    (   Goals == []
-    ->  BodyCode = "    proceed"
-    ;   compile_body_goals(Goals, V1, Options, BodyCode)
+    empty_varmap(V0),
+    (   length(Goals, NG), NG > 1
+    ->  pre_assign_permanent_vars(Goals, V0, V0a),
+        compile_head_arguments(Args, 1, V0a, V1, HeadCode0),
+        compile_goals(Goals, V1, yes, _, GoalsCode),
+        format(string(HeadCode), "    allocate~n~w", [HeadCode0]),
+        BodyCode = GoalsCode
+    ;   compile_head_arguments(Args, 1, V0, V1, HeadCode),
+        (   Goals == []
+        ->  BodyCode = "    proceed"
+        ;   compile_body_goals(Goals, V1, Options, BodyCode)
+        )
     ),
     NextI is I + 1,
     compile_clauses_with_choice_points(Rest, NextI, N, Pred, Arity, Options, RestCode),
@@ -154,6 +167,8 @@ compile_head_argument(Arg, I, V0, V1, Code) :-
     ->  (   get_var_reg(Arg, V0, Reg)
         ->  format(string(Code), "    get_value ~w, A~w", [Reg, I]),
             V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  format(string(Code), "    get_variable ~w, A~w", [YReg, I])
         ;   next_x_reg(V0, XReg, V_temp),
             bind_var(Arg, XReg, V_temp, V1),
             format(string(Code), "    get_variable ~w, A~w", [XReg, I])
@@ -175,6 +190,8 @@ compile_unify_arguments([Arg|Rest], V0, Vf, Code) :-
     ->  (   get_var_reg(Arg, V0, Reg)
         ->  format(string(ArgCode), "    unify_value ~w", [Reg]),
             V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  format(string(ArgCode), "    unify_variable ~w", [YReg])
         ;   next_x_reg(V0, XReg, V_temp),
             bind_var(Arg, XReg, V_temp, V1),
             format(string(ArgCode), "    unify_variable ~w", [XReg])
@@ -196,11 +213,79 @@ compile_unify_arguments([Arg|Rest], V0, Vf, Code) :-
 %% compile_body_goals(+Goals, +VarMap, +Options, -Code)
 compile_body_goals(Goals, V, _Options, Code) :-
     length(Goals, N),
-    % Safe allocation guard for Phase 1
     (   N > 1
-    ->  compile_goals(Goals, V, yes, _, GoalsCode),
+    ->  % allocate + Yi promotion handled by the clause compiler.
+        compile_goals(Goals, V, yes, _, GoalsCode),
         format(string(Code), "    allocate~n~w", [GoalsCode])
     ;   compile_goals(Goals, V, no, _, Code)
+    ).
+
+%% pre_assign_permanent_vars(+Goals, +VarMapIn, -VarMapOut)
+%  Identifies permanent variables and pre-assigns them Yi registers.
+%  A variable is permanent if it is used in any non-first goal (i.e., it
+%  must survive across at least one call instruction). This includes
+%  head-bound variables referenced after the first call.
+pre_assign_permanent_vars(Goals, vmap(Bindings, X), vmap(NewBindings, X)) :-
+    collect_goal_vars(Goals, GoalVarSets),
+    find_permanent_vars(GoalVarSets, PermVars),
+    reassign_to_yi(Bindings, PermVars, 1, ReassignedBindings, NextY),
+    pre_bind_unbound_yi(PermVars, ReassignedBindings, NextY, NewBindings).
+
+collect_goal_vars([], []).
+collect_goal_vars([Goal|Rest], [Vars|RestVars]) :-
+    term_variables(Goal, Vars),
+    collect_goal_vars(Rest, RestVars).
+
+%% find_permanent_vars(+GoalVarSets, -PermVars)
+%  A variable is permanent if it appears in any non-first goal, since the
+%  first goal's call instruction may clobber Xi registers. This captures
+%  both cross-goal variables and head-bound variables used after a call.
+find_permanent_vars(GoalVarSets, PermVars) :-
+    (   GoalVarSets = [_|RestGoalSets]
+    ->  append(RestGoalSets, AllLaterVars),
+        unique_vars(AllLaterVars, PermVars)
+    ;   PermVars = []
+    ).
+
+unique_vars([], []).
+unique_vars([V|Rest], Result) :-
+    unique_vars(Rest, Acc),
+    (   member(A, Acc), A == V
+    ->  Result = Acc
+    ;   Result = [V|Acc]
+    ).
+
+var_in_list(List, Var) :-
+    member(V, List), V == Var, !.
+
+union_vars([], Acc, Acc).
+union_vars([V|Rest], Acc, Result) :-
+    (   member(A, Acc), A == V
+    ->  union_vars(Rest, Acc, Result)
+    ;   union_vars(Rest, [V|Acc], Result)
+    ).
+
+%% reassign_to_yi(+Bindings, +PermVars, +YI, -NewBindings, -NextY)
+%  Reassigns already-bound permanent variables from Xi to Yi.
+reassign_to_yi([], _, YI, [], YI).
+reassign_to_yi([b(Var, _Reg)|Rest], PermVars, YI, [b(Var, YReg)|NewRest], NextY) :-
+    member(PV, PermVars), PV == Var, !,
+    format(atom(YReg), "Y~w", [YI]),
+    NYI is YI + 1,
+    reassign_to_yi(Rest, PermVars, NYI, NewRest, NextY).
+reassign_to_yi([B|Rest], PermVars, YI, [B|NewRest], NextY) :-
+    reassign_to_yi(Rest, PermVars, YI, NewRest, NextY).
+
+%% pre_bind_unbound_yi(+PermVars, +Bindings, +YI, -NewBindings)
+%  For permanent variables not yet in the varmap, pre-allocate a Yi register
+%  using y_alloc (not yet seen — will be promoted to b() on first use).
+pre_bind_unbound_yi([], Bindings, _, Bindings).
+pre_bind_unbound_yi([Var|Rest], Bindings, YI, NewBindings) :-
+    (   (member(b(V, _), Bindings), V == Var ; member(y_alloc(V, _), Bindings), V == Var)
+    ->  pre_bind_unbound_yi(Rest, Bindings, YI, NewBindings)
+    ;   format(atom(YReg), "Y~w", [YI]),
+        NYI is YI + 1,
+        pre_bind_unbound_yi(Rest, [y_alloc(Var, YReg)|Bindings], NYI, NewBindings)
     ).
 
 %% compile_goals(+Goals, +VarMap, +HasEnv, -Vf, -Code)
@@ -208,9 +293,17 @@ compile_goals([], V, _, V, "").
 compile_goals([Goal|Rest], V0, HasEnv, Vf, Code) :-
     (   Rest == []
     ->  % Last goal: execute (Tail Call Optimization)
+        % For TCO with environments, put arguments BEFORE deallocate
+        % so that Yi registers are still accessible.
         (   HasEnv == yes
-        ->  compile_goal_execute(Goal, V0, Vf, ExecCode),
-            format(string(Code), "    deallocate~n~w", [ExecCode])
+        ->  Goal =.. [Pred|Args],
+            length(Args, Arity),
+            compile_put_arguments(Args, 1, V0, Vf, PutCode),
+            format(string(ExecCode), "    execute ~w/~w", [Pred, Arity]),
+            (   PutCode == ""
+            ->  format(string(Code), "    deallocate~n~w", [ExecCode])
+            ;   format(string(Code), "~w~n    deallocate~n~w", [PutCode, ExecCode])
+            )
         ;   compile_goal_execute(Goal, V0, Vf, Code)
         )
     ;   compile_goal_call(Goal, V0, V1, GoalCode),
@@ -253,6 +346,8 @@ compile_put_argument(Arg, I, V0, V1, Code) :-
     ->  (   get_var_reg(Arg, V0, Reg)
         ->  format(string(Code), "    put_value ~w, A~w", [Reg, I]),
             V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  format(string(Code), "    put_variable ~w, A~w", [YReg, I])
         ;   next_x_reg(V0, XReg, V_temp),
             bind_var(Arg, XReg, V_temp, V1),
             format(string(Code), "    put_variable ~w, A~w", [XReg, I])
@@ -285,6 +380,8 @@ compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
     ->  (   get_var_reg(Arg, V0, Reg)
         ->  format(string(ArgCode), "    set_value ~w", [Reg]),
             V1 = V0
+        ;   get_yi_alloc(Arg, V0, YReg, V1)
+        ->  format(string(ArgCode), "    set_variable ~w", [YReg])
         ;   next_x_reg(V0, XReg, V_temp),
             bind_var(Arg, XReg, V_temp, V1),
             format(string(ArgCode), "    set_variable ~w", [XReg])
@@ -305,11 +402,20 @@ compile_set_arguments([Arg|Rest], V0, Vf, Code) :-
     ).
 
 %% Variable Mapping Helpers
+%  Bindings use b(Var, Reg) for seen variables, and
+%  y_alloc(Var, Reg) for pre-allocated Yi registers not yet seen.
 empty_varmap(vmap([], 1)).
 
 get_var_reg(Var, vmap(Bindings, _), Reg) :-
     member(b(V, Reg), Bindings),
     V == Var, !.
+
+%% get_yi_alloc(+Var, +VarMap, -YReg, -VarMapOut)
+%  If Var has a pre-allocated Yi register, return it and promote to seen.
+get_yi_alloc(Var, vmap(Bindings, X), YReg, vmap(NewBindings, X)) :-
+    select(y_alloc(V, YReg), Bindings, Rest),
+    V == Var, !,
+    NewBindings = [b(Var, YReg)|Rest].
 
 bind_var(Var, Reg, vmap(Bs, X), vmap([b(Var, Reg)|Bs], X)).
 

--- a/tests/test_wam_e2e.pl
+++ b/tests/test_wam_e2e.pl
@@ -9,6 +9,10 @@
 e2e_parent(alice, bob).
 e2e_parent(bob, charlie).
 
+%% Rule — exercises allocate/deallocate, call/execute, Yi registers
+:- dynamic e2e_grandparent/2.
+e2e_grandparent(X, Z) :- e2e_parent(X, Y), e2e_parent(Y, Z).
+
 :- dynamic test_failed/0.
 
 pass(Test) :-
@@ -40,6 +44,18 @@ test_wam_backtracking_simple :-
     ;   fail_test(Test, 'E2E execution failed for second fact')
     ).
 
+test_wam_rule_execution :-
+    Test = 'WAM E2E: Rule compilation and execution (grandparent)',
+    (   % 1. Compile both parent facts and grandparent rule
+        wam_target:compile_wam_module(
+            [user:e2e_parent/2, user:e2e_grandparent/2], [], Code),
+        % 2. Execute: grandparent(alice, charlie)? should succeed
+        %    (alice->bob via parent, bob->charlie via parent)
+        wam_runtime:execute_wam(Code, e2e_grandparent(alice, charlie), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'E2E rule execution failed for grandparent')
+    ).
+
 run_tests :-
     format('~n========================================~n'),
     format('WAM Target E2E Test Suite~n'),
@@ -47,6 +63,7 @@ run_tests :-
     
     test_wam_compilation_and_execution,
     test_wam_backtracking_simple,
+    test_wam_rule_execution,
     
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

- Implement automatic permanent variable (Yi) allocation in the WAM compiler — variables that survive across `call` boundaries are detected and assigned Yi registers stored in the environment frame, while temporaries remain in Xi registers
- Emit `allocate` before head instructions so `get_variable Yi, Ai` can write directly to the environment frame; place `deallocate` after `put_value Yi` reads but before `execute` for correct TCO
- Add runtime `step_wam` clauses for `get_structure`, `unify_variable`, `unify_value`, and `unify_constant` enabling compound head term matching via a `unify_ctx` stack mechanism
- Add Yi register support in the runtime via `get_reg`/`put_reg` helpers that dispatch to the environment frame for Y-prefixed registers
- Extend `get_constant` and `get_value` to perform unification with unbound variables (not just strict equality), enabling rule execution with variable arguments
- Add E2E test that compiles `parent/2` facts + `grandparent/2` rule into WAM and executes `grandparent(alice, charlie)` through the full pipeline

## Test plan

- [x] All 5 WAM target compiler tests pass (facts, single clause, recursion, put_structure, module)
- [x] All 3 E2E tests pass — including new `test_wam_rule_execution` for grandparent
- [x] Verified compiled output shows correct Yi allocation: `get_variable Y2, A2` in head, `put_variable Y1, A2` / `put_value Y1, A1` / `put_value Y2, A2` in body
- [x] Verified `deallocate` appears after Yi reads, before `execute`
- [x] Exit code 0 on success, 1 on failure (CI-compatible)

## Companion PR

- Education repo: `docs: update Book 17 for Yi permanent variables and correct WAM output` (same branch name)

Generated with [Claude Code](https://claude.com/claude-code)
