### PR TITLE
Keep native TypR cat bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ includes:
 
 - simple output-producing binding chains
 - guard-style command predicates such as `is_character/1`
+- unary TypR-safe I/O commands such as `cat/1` and `print/1`, emitted as
+  native fixed-arity TypR calls
 - multi-step native control-flow chains where an earlier output feeds a later
   guard and output
 - simple comparison and boolean guard expressions over already-bound

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -450,7 +450,9 @@ Current implementation note:
   same step-relation shape
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
-  predicates, sequential guard/output control-flow chains, simple comparison
+  predicates, including unary TypR-safe I/O commands such as `cat/1` and
+  `print/1` that emit native fixed-arity TypR calls, sequential guard/output
+  control-flow chains, simple comparison
   and boolean guard expressions over already-bound intermediates, structured
   fan-out chains where one earlier value feeds multiple later outputs or
   conditions, structured split-and-recombine chains where guarded derived

--- a/docs/suggestions/typr-target-improvements.md
+++ b/docs/suggestions/typr-target-improvements.md
@@ -24,7 +24,9 @@ Add regression tests for:
 - Compare TypR output vs R output for semantic equivalence
 
 ### 4. TypR upstream issues to track
-- **Variadic functions**: `cat("x =", x)` doesn't work, need `cat(paste("x =", x))`
+- **Variadic functions**: TypR-safe bindings should stay fixed-arity. Unary
+  `cat/1` and `print/1` are fine, but `cat("x =", x)` still needs
+  `cat(paste("x =", x))`
 - **Braceless function bodies**: `function(x) x * x` drops the body, must use braces
 - **`io.ty` not loadable**: New .ty files aren't picked up by the std generator parser
 - **`default.ty` skipped**: Contains syntax the parser rejects (`{}` record types, `let` definitions mixed with `@` declarations)

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -7677,6 +7677,9 @@ native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, _SeenOutput, _LastExpr0
 native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, _SeenOutput, _LastExpr0, Conditions, [Line|RestLines], TailCode, VarMapOut) :-
     native_typr_output_goal(Goal, VarMap0, PredName, VarMap1, Line, OutExpr),
     native_typr_prefix_goals(Rest, VarMap1, PredName, true, OutExpr, Conditions, RestLines, TailCode, VarMapOut).
+native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, SeenOutput, LastExpr, Conditions, [Line|RestLines], TailCode, VarMapOut) :-
+    native_typr_command_goal(Goal, VarMap0, Line),
+    native_typr_prefix_goals(Rest, VarMap0, PredName, SeenOutput, LastExpr, Conditions, RestLines, TailCode, VarMapOut).
 native_typr_prefix_goals([Goal|Rest], VarMap0, PredName, false, LastExpr, [GuardCondition|RestConditions], RestLines, TailCode, VarMapOut) :-
     native_typr_guard_goal(Goal, VarMap0, GuardCondition),
     native_typr_prefix_goals(Rest, VarMap0, PredName, false, LastExpr, RestConditions, RestLines, TailCode, VarMapOut).
@@ -7699,6 +7702,11 @@ native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, _LastExpr0, Pe
     guard_condition_expression(PendingGuards, GuardExpr),
     conditional_output_line(GuardExpr, PredName, IntroKind, OutVar, OutputExpr, Line),
     native_typr_guarded_tail_sequence(Rest, VarMap1, PredName, OutVar, [], RestLines, FinalExpr, VarMapOut).
+native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, LastExpr, PendingGuards, [Line|RestLines], FinalExpr, VarMapOut) :-
+    native_typr_command_goal(Goal, VarMap0, CommandLine),
+    guard_condition_expression(PendingGuards, GuardExpr),
+    conditional_command_line(GuardExpr, PredName, CommandLine, Line),
+    native_typr_guarded_tail_sequence(Rest, VarMap0, PredName, LastExpr, [], RestLines, FinalExpr, VarMapOut).
 native_typr_guarded_tail_sequence([Goal|Rest], VarMap0, PredName, LastExpr, PendingGuards0, Lines, FinalExpr, VarMapOut) :-
     native_typr_guard_goal(Goal, VarMap0, GuardCondition),
     append(PendingGuards0, [GuardCondition], PendingGuards),
@@ -7765,9 +7773,8 @@ native_typr_output_expr(group_by(DF, Col, Out), VarMap0, _PredName, VarMap, Fina
     format(string(OutputExpr), '@{ aggregate(. ~~ ~w, data=~w, FUN=list) }@', [RCol, RDF]).
 native_typr_output_expr(Goal, VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     functor(Goal, Pred, Arity),
-    binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
+    typr_simple_binding(Pred/Arity, TargetName, Inputs, Outputs, _Options),
     Outputs = [_],
-    simple_r_binding_target(TargetName),
     Goal =.. [_|Args],
     length(Inputs, InCount),
     length(InArgs, InCount),
@@ -8102,9 +8109,8 @@ typr_goal_output_var_simple(sort_by(_, _, OutputVar), OutputVar).
 typr_goal_output_var_simple(group_by(_, _, OutputVar), OutputVar).
 typr_goal_output_var_simple(Goal, OutputVar) :-
     functor(Goal, Pred, Arity),
-    binding(r, Pred/Arity, TargetName, Inputs, Outputs, _Options),
+    typr_simple_binding(Pred/Arity, _TargetName, Inputs, Outputs, _Options),
     Outputs = [_],
-    simple_r_binding_target(TargetName),
     Goal =.. [_|Args],
     length(Inputs, InCount),
     length(Outputs, OutCount),
@@ -8269,9 +8275,8 @@ native_typr_guard_goal(Goal, VarMap, GuardCondition) :-
     !.
 native_typr_guard_goal(Goal, VarMap, GuardCondition) :-
     functor(Goal, Pred, Arity),
-    binding(r, Pred/Arity, TargetName, Inputs, [], Options),
+    typr_simple_binding(Pred/Arity, TargetName, Inputs, [], Options),
     member(pattern(command), Options),
-    simple_r_binding_target(TargetName),
     Goal =.. [_|Args],
     length(Inputs, InCount),
     length(InArgs, InCount),
@@ -8293,6 +8298,43 @@ simple_r_binding_target(TargetName) :-
 simple_r_binding_target(TargetName) :-
     string(TargetName),
     \+ sub_string(TargetName, _, _, _, "~").
+
+typr_simple_binding(PredSpec, TargetName, Inputs, Outputs, Options) :-
+    binding(r, PredSpec, TargetName, Inputs, Outputs, Options),
+    typr_simple_binding_target(PredSpec, TargetName, Inputs, Outputs, Options).
+
+typr_simple_binding_target(cat/1, TargetName, Inputs, [], Options) :-
+    member(effect(io), Options),
+    simple_r_binding_target(TargetName),
+    Inputs = [_].
+typr_simple_binding_target(print/1, TargetName, Inputs, [], Options) :-
+    member(effect(io), Options),
+    simple_r_binding_target(TargetName),
+    Inputs = [_].
+typr_simple_binding_target(_PredSpec, TargetName, _Inputs, _Outputs, Options) :-
+    simple_r_binding_target(TargetName),
+    \+ member(effect(io), Options).
+
+native_typr_command_goal(_Module:Goal, VarMap, Line) :-
+    !,
+    native_typr_command_goal(Goal, VarMap, Line).
+native_typr_command_goal(Goal, VarMap, Line) :-
+    functor(Goal, Pred, Arity),
+    typr_simple_binding(Pred/Arity, TargetName, Inputs, [], Options),
+    member(effect(io), Options),
+    Goal =.. [_|Args],
+    length(Inputs, InCount),
+    length(InArgs, InCount),
+    append(InArgs, [], Args),
+    maplist(typr_resolve_value(VarMap), InArgs, ResolvedInArgs),
+    typr_native_call_expression(TargetName, ResolvedInArgs, CommandExpr),
+    format(string(Line), '~w;', [CommandExpr]).
+
+typr_native_call_expression(TargetName, [], Expr) :-
+    format(string(Expr), '~w', [TargetName]).
+typr_native_call_expression(TargetName, ResolvedInArgs, Expr) :-
+    atomic_list_concat(ResolvedInArgs, ', ', ArgText),
+    format(string(Expr), '~w(~w)', [TargetName, ArgText]).
 
 typr_resolve_value(VarMap, Var, Value) :-
     var(Var),
@@ -8351,6 +8393,15 @@ conditional_output_line(GuardExpr, PredName, IntroKind, OutVar, OutputExpr, Line
 } else {
 	stop("No matching clause for ~w")
 };', [Prefix, OutVar, GuardExpr, OutputExpr, PredName]).
+
+conditional_command_line(none, _PredName, CommandLine, CommandLine).
+conditional_command_line(GuardExpr, PredName, CommandLine, Line) :-
+    format(string(Line),
+'if (~w) {
+	~w
+} else {
+	stop("No matching clause for ~w")
+}', [GuardExpr, CommandLine, PredName]).
 
 guard_tail_final_expression([], _PredName, none, 'true').
 guard_tail_final_expression([], _PredName, LastExpr, LastExpr) :-

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -18,6 +18,8 @@ cleanup_typr_test :-
     retractall(user:tc(_, _)),
     retractall(user:simple_fact(_)),
     retractall(user:lower_name(_, _)),
+    retractall(user:say_cat(_)),
+    retractall(user:say_print(_)),
     retractall(user:classify_name(_, _)),
     retractall(user:inferred_lower(_, _)),
     retractall(user:classify_name_guarded(_, _)),
@@ -2023,6 +2025,28 @@ test(generic_body_predicates_reuse_r_backend) :-
     once(compile_predicate_to_typr(lower_name/2, [typed_mode(explicit)], Code)),
     once(sub_string(Code, _, _, _, "let lower_name <- fn(arg1: char, arg2: char): char")),
     once(sub_string(Code, _, _, _, "tolower(arg1)")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(generic_cat_command_predicates_emit_native_typr) :-
+    clear_type_declarations,
+    assertz(user:(say_cat(Msg) :- cat(Msg))),
+    assertz(type_declarations:uw_type(say_cat/1, 1, atom)),
+    once(compile_predicate_to_typr(say_cat/1, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let say_cat <- fn(arg1: char): bool")),
+    once(sub_string(Code, _, _, _, "cat(arg1);")),
+    \+ sub_string(Code, _, _, _, "local({"),
+    \+ sub_string(Code, _, _, _, "(function("),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(generic_print_command_predicates_emit_native_typr) :-
+    clear_type_declarations,
+    assertz(user:(say_print(Msg) :- print(Msg))),
+    assertz(type_declarations:uw_type(say_print/1, 1, atom)),
+    once(compile_predicate_to_typr(say_print/1, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let say_print <- fn(arg1: char): bool")),
+    once(sub_string(Code, _, _, _, "print(arg1);")),
+    \+ sub_string(Code, _, _, _, "local({"),
     \+ sub_string(Code, _, _, _, "(function("),
     generated_typr_is_valid(Code, exit(0)).
 

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -41,6 +41,38 @@ test(generated_output_checks_with_typr, [condition(typr_cli_available)]) :-
     ),
     retractall(user:simple_fact(_)).
 
+test(cat_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(say_cat(Msg) :- cat(Msg))),
+    assertz(type_declarations:uw_type(say_cat/1, 1, atom)),
+    once(compile_predicate_to_typr(say_cat/1, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:say_cat(_)).
+
+test(print_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(say_print(Msg) :- print(Msg))),
+    assertz(type_declarations:uw_type(say_print/1, 1, atom)),
+    once(compile_predicate_to_typr(say_print/1, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:say_print(_)).
+
 test(transitive_closure_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:edge(a, b)),


### PR DESCRIPTION
# PR Title

Keep native TypR cat bindings

# PR Description

## Summary

Fix the TypR target so unary output bindings like `cat/1` and `print/1` compile as native fixed-arity TypR calls, while making the fixed-arity TypR boundary explicit.

## Problem

The issue is not that `cat` is missing from TypR.
The issue is that TypR should not inherit R-style variadic assumptions from the generic R binding path.

In TypR, code like this is the right shape:

```typr
let x <- 42;
cat(paste("x =", x));
```

not a variadic-style call such as:

```typr
cat("x =", x)
```

So the target must not treat arbitrary simple R bindings as automatically safe for TypR just because the R binding name is simple.

## What Was Going Wrong

The TypR target was reusing the generic simple-R-binding path too broadly.
That caused unary I/O predicates such as:

```prolog
say_cat(Msg) :- cat(Msg).
```

to fall through to wrapped fallback code instead of emitting a native fixed-arity TypR command.

## What Changed

- added a TypR-specific safe-binding gate in `typr_target.pl`
- explicitly allowed unary TypR-safe I/O bindings such as `cat/1` and `print/1`
- added native command emission for those bindings
- kept broader effectful R bindings out of the TypR simple-binding path unless they are explicitly safe
- added target-level regression coverage for `cat/1` and `print/1`
- added real `typr check` coverage for the same cases
- updated TypR docs to clarify that the output binding boundary is fixed-arity, not variadic-R-compatible

## Result

Predicates like:

```prolog
say_cat(Msg) :- cat(Msg).
say_print(Msg) :- print(Msg).
```

now emit native TypR like:

```typr
let say_cat <- fn(arg1: char): bool {
    cat(arg1);
    true
};
```

instead of wrapped fallback code.

## Boundary After This PR

This PR does **not** make TypR variadic `cat` work.
It makes the TypR target honest about the language boundary:

- `cat/1` is safe
- `print/1` is safe
- multi-argument output should still be composed explicitly, e.g. `cat(paste("x =", x))`
- the TypR target should not pretend R-style variadic output helpers are generically available

## Validation

Ran:

```sh
swipl -q -g run_tests -t halt tests/type_declarations_test.pl
swipl -q -g run_tests -t halt tests/test_typr_target.pl
swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl
git diff --check
```

## Notes

- `tests/test_r_target.pl` was not rerun because of the existing unrelated R-target baseline issue
- the intentional modified submodule `examples/sci-repl/prototype` was left untouched
