### PR TITLE
feat(csharp-query): add min tabling for path-aware closure

### DIFF
--- a/examples/benchmark/benchmark_shortest_path_to_root.py
+++ b/examples/benchmark/benchmark_shortest_path_to_root.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+Benchmark shortest-path-to-root on the C# query engine with two runtime modes:
+
+  - all : path-aware counted closure preserving all simple paths
+  - min : mode-directed tabling with minimum-path pruning
+
+This isolates the benefit of the new min-tabling runtime support while
+keeping the aggregation workload identical. Both modes compute the same
+final shortest-path answers; they differ only in how much recursive work
+they retain before aggregation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+
+CSHARP_PROJECT = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+PROGRAM = """\
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{
+    const string ROOT_CATEGORY = "Physics";
+    const int MAX_DEPTH = 10;
+
+    static void Main(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: program <all|min> <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }
+
+        var modeName = args[0];
+        var mode = modeName switch
+        {
+            "all" => TableMode.All,
+            "min" => TableMode.Min,
+            _ => throw new ArgumentException($"Unknown mode: {modeName}")
+        };
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_ancestor", 3);
+        var articleCategories = new Dictionary<string, List<string>>();
+        var rootCategories = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }
+        }
+
+        foreach (var (line, i) in File.ReadLines(args[2]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }
+
+            categories.Add(parts[1]);
+        }
+
+        foreach (var categories in articleCategories.Values)
+        {
+            foreach (var category in categories)
+            {
+                if (category == ROOT_CATEGORY)
+                {
+                    rootCategories.Add(category);
+                }
+            }
+        }
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, mode),
+            true,
+            new int[] { 0 }
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {
+            foreach (var category in categories)
+            {
+                uniqueSeeds.Add(category);
+            }
+        }
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] { category })
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var hops = Convert.ToInt32(row[2]);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {
+                bucket = new List<(string, int)>();
+                ancestorIndex[source] = bucket;
+            }
+
+            bucket.Add((ancestor, hops));
+        }
+
+        var results = new List<(int Distance, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            int? best = null;
+            foreach (var category in articleCategories[article])
+            {
+                if (category == ROOT_CATEGORY)
+                {
+                    best = best is null ? 1 : Math.Min(best.Value, 1);
+                }
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {
+                    continue;
+                }
+
+                foreach (var (ancestor, hops) in ancestors)
+                {
+                    if (ancestor != ROOT_CATEGORY)
+                    {
+                        continue;
+                    }
+
+                    var dist = hops + 1;
+                    best = best is null ? dist : Math.Min(best.Value, dist);
+                }
+            }
+
+            if (best is not null)
+            {
+                results.Add((best.Value, article));
+            }
+        }
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        });
+
+        Console.WriteLine("article\\troot_category\\tshortest_path");
+        foreach (var (distance, article) in results)
+        {
+            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{distance}");
+        }
+
+        Console.Error.WriteLine($"mode={modeName}");
+        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"seed_count={seedParams.Count}");
+        Console.Error.WriteLine($"tuple_count={rows.Count}");
+        Console.Error.WriteLine($"article_count={results.Count}");
+    }
+}
+"""
+
+
+@dataclass
+class RunResult:
+    scale: str
+    mode: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if scale == "dev":
+        return (0, scale)
+    if not digits:
+        return (10**9, scale)
+    value = int(digits)
+    multiplier = 1000 if suffix.lower() == "k" else 1
+    return (value * multiplier, scale)
+
+
+def build_harness(root: Path) -> list[str]:
+    if shutil.which("dotnet") is None:
+        raise RuntimeError("dotnet not found")
+
+    project_dir = root / "shortest_path_to_root"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "Program.cs").write_text(PROGRAM, encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_shortest_path.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_shortest_path.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_shortest_path.dll")]
+
+
+def benchmark_mode(command: list[str], scale: str, mode: str, repetitions: int) -> RunResult:
+    scale_dir = BENCH_DIR / scale
+    edge_path = scale_dir / "category_parent.tsv"
+    article_path = scale_dir / "article_category.tsv"
+
+    times: list[float] = []
+    last_stdout = ""
+    last_stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [mode, str(edge_path), str(article_path)])
+        elapsed = time.perf_counter() - started
+        times.append(elapsed)
+        last_stdout = result.stdout
+        last_stderr = result.stderr
+
+    lines = last_stdout.splitlines()
+    header = lines[:1]
+    body = sorted(lines[1:])
+    normalized = "\n".join(header + body)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    rows = len(body)
+    return RunResult(scale=scale, mode=mode, times=times, stdout_sha256=digest, row_count=rows, stderr=last_stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    by_scale: dict[str, list[RunResult]] = {}
+    for result in results:
+        by_scale.setdefault(result.scale, []).append(result)
+
+    print("scale\tmode\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale in sorted(by_scale.keys(), key=scale_sort_key):
+        for result in sorted(by_scale[scale], key=lambda item: item.mode):
+            print(
+                f"{scale}\t{result.mode}\t{result.median:.3f}\t"
+                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+                f"{result.row_count}\t{result.stdout_sha256[:12]}"
+            )
+
+        all_mode = next((item for item in by_scale[scale] if item.mode == "all"), None)
+        min_mode = next((item for item in by_scale[scale] if item.mode == "min"), None)
+        if all_mode and min_mode:
+            status = "match" if all_mode.stdout_sha256 == min_mode.stdout_sha256 else "DIFFERENT"
+            print(f"{scale}\tall_vs_min\t{status}")
+            print(f"{scale}\tspeedup_min_vs_all\t{all_mode.median / min_mode.median:.2f}x")
+
+        if min_mode and min_mode.stderr:
+            phase_lines = [line.strip() for line in min_mode.stderr.splitlines() if "=" in line]
+            if phase_lines:
+                print(f"{scale}\tmin_metrics\t" + " ".join(phase_lines))
+        if all_mode and all_mode.stderr:
+            phase_lines = [line.strip() for line in all_mode.stderr.splitlines() if "=" in line]
+            if phase_lines:
+                print(f"{scale}\tall_metrics\t" + " ".join(phase_lines))
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-shortest-path-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-shortest-path-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        command = build_harness(temp_root)
+        results: list[RunResult] = []
+        for scale in scales:
+            for mode in ("all", "min"):
+                results.append(benchmark_mode(command, scale, mode, args.repetitions))
+        print_summary(results)
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}")
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unifyweaver/core/advanced/pattern_matchers.pl
+++ b/src/unifyweaver/core/advanced/pattern_matchers.pl
@@ -870,8 +870,8 @@ test_pattern_matchers :-
 %  TableModes is a list of atoms: lattice, min, max, first, sum, count.
 %  Fails if no table directive exists for this predicate.
 declared_table_modes(Pred, Arity, TableModes) :-
-    current_predicate(user:table/1),
-    user:table(TableSpec),
+    current_predicate(user:'table'/1),
+    user:'table'(TableSpec),
     compound(TableSpec),
     functor(TableSpec, Pred, Arity),
     parse_table_spec(TableSpec, TableModes).
@@ -887,13 +887,13 @@ parse_table_spec(TableSpec, TableModes) :-
 %% parse_table_arg(+Arg, -Mode) is det.
 %  Parses a single table argument.
 parse_table_arg(Arg, lattice) :- var(Arg), !.
-parse_table_arg(_, lattice) :- !.    % anonymous variable _
 parse_table_arg(min, min) :- !.
 parse_table_arg(max, max) :- !.
 parse_table_arg(first, first) :- !.
 parse_table_arg(sum, sum) :- !.
 parse_table_arg(count, count) :- !.
 parse_table_arg(lattice, lattice) :- !.
+parse_table_arg(_, lattice) :- !.    % anonymous variable _
 parse_table_arg(Arg, lattice) :-
     format(user_error,
            'Warning: unknown table mode ~w, defaulting to lattice~n',

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -240,7 +240,8 @@ namespace UnifyWeaver.QueryRuntime
         PredicateId Predicate,
         int BaseDepth,
         int DepthIncrement,
-        int MaxDepth = 0
+        int MaxDepth = 0,
+        TableMode AccumulatorMode = TableMode.All
     ) : PlanNode;
 
     /// <summary>
@@ -256,6 +257,16 @@ namespace UnifyWeaver.QueryRuntime
         ArithmeticExpression RecursiveExpression,
         int MaxDepth = 0
     ) : PlanNode;
+
+    public enum TableMode
+    {
+        All,
+        Min,
+        Max,
+        First,
+        Sum,
+        Count
+    }
 
     /// <summary>
     /// Indicates which relation a recursive reference should read from.
@@ -969,7 +980,7 @@ namespace UnifyWeaver.QueryRuntime
                 OffsetNode offset => $"Offset count={offset.Count}",
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
-                PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth}",
+                PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
                 MutualFixpointNode mutual => $"MutualFixpoint head={mutual.Head} members={mutual.Members.Count}",
@@ -6995,7 +7006,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.MaxDepth);
+                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7050,7 +7061,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.MaxDepth);
+                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7067,8 +7078,11 @@ namespace UnifyWeaver.QueryRuntime
             int baseDepth,
             int depthIncrement,
             ICollection<object[]> output,
+            TableMode accumulatorMode,
             int maxDepth = 0)
         {
+            var preserveAllPaths = accumulatorMode is TableMode.All or TableMode.Sum or TableMode.Count;
+            var bestKnown = preserveAllPaths ? null : new Dictionary<object?, int>();
             var stack = new Stack<(object? Node, int Depth, HashSet<object?> Visited)>();
             stack.Push((seed, 0, new HashSet<object?> { seed }));
 
@@ -7104,10 +7118,48 @@ namespace UnifyWeaver.QueryRuntime
                         continue;
                     }
 
-                    output.Add(new object[] { seed!, next!, nextDepth });
+                    if (bestKnown is not null)
+                    {
+                        if (bestKnown.TryGetValue(next, out var bestDepth))
+                        {
+                            switch (accumulatorMode)
+                            {
+                                case TableMode.Min:
+                                    if (nextDepth >= bestDepth)
+                                    {
+                                        continue;
+                                    }
+                                    break;
+                                case TableMode.Max:
+                                    if (nextDepth <= bestDepth)
+                                    {
+                                        continue;
+                                    }
+                                    break;
+                                case TableMode.First:
+                                    continue;
+                            }
+                        }
+
+                        bestKnown[next] = nextDepth;
+                    }
+                    else
+                    {
+                        output.Add(new object[] { seed!, next!, nextDepth });
+                    }
 
                     var nextVisited = new HashSet<object?>(visited) { next };
                     stack.Push((next, nextDepth, nextVisited));
+                }
+            }
+
+            if (bestKnown is not null)
+            {
+                var bestRows = new List<KeyValuePair<object?, int>>(bestKnown);
+                bestRows.Sort((left, right) => CompareCacheSeedValues(left.Key, right.Key));
+                foreach (var (target, depth) in bestRows)
+                {
+                    output.Add(new object[] { seed!, target!, depth });
                 }
             }
         }

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -36,6 +36,7 @@
 :- use_module(library(pairs), [pairs_values/2]).
 :- use_module(library(ugraphs), [vertices/2, vertices_edges_to_ugraph/3, transpose_ugraph/2, reachable/3, top_sort/2]).
 :- use_module('../core/dynamic_source_compiler', [is_dynamic_source/1, dynamic_source_metadata/2]).
+:- use_module('../core/advanced/pattern_matchers', [declared_table_modes/3]).
 :- use_module('../core/binding_registry').
 :- use_module('../bindings/csharp_bindings').
 :- use_module('../core/pipeline_validation').
@@ -1072,8 +1073,7 @@ maybe_path_aware_transitive_closure_plan(HeadSpec, GroupSpecs, BaseClauses, RecC
     ensure_relation(EdgePred, EdgeArity, [], Relations0),
     dedup_relations(Relations0, Relations),
     get_dict(name, HeadSpec, HeadName),
-    (   current_predicate(pattern_matchers:declared_table_modes/3),
-        pattern_matchers:declared_table_modes(HeadName, 3, TableModes)
+    (   declared_table_modes(HeadName, 3, TableModes)
     ->  true
     ;   TableModes = [lattice, lattice, lattice]
     ),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -146,6 +146,8 @@
 :- dynamic user:test_pathaware_reach/3.
 :- dynamic user:test_pathaware_multi_edge/2.
 :- dynamic user:test_pathaware_multi_reach/3.
+:- dynamic user:test_pathaware_min_edge/2.
+:- dynamic user:test_pathaware_min_reach/3.
 :- dynamic user:test_weighted_edge/2.
 :- dynamic user:test_weighted_cost/2.
 :- dynamic user:test_weighted_path/3.
@@ -157,6 +159,7 @@
 :- dynamic user:test_scanindex_reach_param/2.
 :- dynamic user:test_scanindex_reach_filtered/2.
 :- dynamic user:mode/1.
+:- dynamic user:'table'/1.
 :- dynamic user:test_negation_cycle_root/1.
 :- dynamic user:test_negation_cycle_p/1.
 :- dynamic user:test_negation_cycle_q/1.
@@ -301,6 +304,7 @@ test_csharp_query_target :-
         verify_path_aware_transitive_closure_plan,
         verify_parameterized_path_aware_transitive_closure_plan,
         verify_path_aware_transitive_closure_preserves_path_multiplicity,
+        verify_path_aware_transitive_closure_min_mode_plan,
         verify_path_aware_accumulation_plan,
         verify_parameterized_path_aware_accumulation_plan,
         verify_path_aware_accumulation_preserves_path_multiplicity,
@@ -1117,6 +1121,14 @@ setup_test_data :-
         1,
         [[a, b], [a, c], [b, d], [c, d]]
     ),
+    assert_counted_recursive_fixture(
+        test_pathaware_min_edge,
+        test_pathaware_min_reach,
+        1,
+        1,
+        [[a, b], [a, c], [b, d], [c, e], [e, d]]
+    ),
+    assertz(user:'table'(test_pathaware_min_reach(_, _, min))),
     assertz(user:test_weighted_edge(a, b)),
     assertz(user:test_weighted_edge(b, a)),
     assertz(user:test_weighted_edge(b, c)),
@@ -1361,6 +1373,8 @@ cleanup_test_data :-
     retractall(user:mode(test_reachable_param_both(_, _))),
     cleanup_counted_recursive_fixture(test_pathaware_edge, test_pathaware_reach),
     cleanup_counted_recursive_fixture(test_pathaware_multi_edge, test_pathaware_multi_reach),
+    cleanup_counted_recursive_fixture(test_pathaware_min_edge, test_pathaware_min_reach),
+    retractall(user:'table'(_)),
     retractall(user:test_weighted_edge(_, _)),
     retractall(user:test_weighted_cost(_, _)),
     retractall(user:test_weighted_path(_, _, _)),
@@ -3522,6 +3536,32 @@ verify_path_aware_transitive_closure_preserves_path_multiplicity :-
         ['MATCH_COUNT:2'],
         [[a]],
         HarnessSource).
+
+verify_path_aware_transitive_closure_min_mode_plan :-
+    csharp_target:build_query_plan(
+        test_pathaware_min_reach/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, path_aware_transitive_closure{type:path_aware_transitive_closure,
+        head:predicate{name:test_pathaware_min_reach, arity:3},
+        edge:predicate{name:test_pathaware_min_edge, arity:2},
+        base_depth:1,
+        depth_increment:1,
+        max_depth:10,
+        table_modes:[lattice, lattice, min],
+        width:3
+    }),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareTransitiveClosureNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    maybe_run_query_runtime(Plan,
+        ['a,b,1',
+         'a,c,1',
+         'a,d,2',
+         'a,e,2'],
+        [[a]]).
 
 verify_path_aware_accumulation_plan :-
     csharp_query_target:build_query_plan(test_weighted_path/3, [target(csharp_query)], Plan),


### PR DESCRIPTION
  ## Summary

  This PR adds the first runtime phase of mode-directed tabling to the C# query engine for path-aware counted transitive
  closure.

  The new `Min` mode enables shortest-path-style pruning while preserving the existing `All`-mode semantics for workloads that
  need full path multiplicity.

  ## What Changed

  - add `TableMode` support to the C# query runtime
  - extend `PathAwareTransitiveClosureNode` to carry an accumulator mode
  - implement `Min` pruning for counted path-aware closure in the runtime
  - keep `All` mode fully multiplicity-preserving
  - fix compiler-side table mode detection so quoted `user:'table'/1` declarations are recognized
  - add a shortest-path regression in the C# query-target test suite
  - add a dedicated shortest-path benchmark script for `All` vs `Min`

  ## Files

  - `src/unifyweaver/core/advanced/pattern_matchers.pl`
  - `src/unifyweaver/targets/csharp_target.pl`
  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`
  - `tests/core/test_csharp_query_target.pl`
  - `examples/benchmark/benchmark_shortest_path_to_root.py`

  ## Semantics

  This PR preserves the semantic distinction established in the earlier path-multiplicity fix:

  - `TableMode.All`
    - preserves all simple paths
    - prevents cycles per path
    - does not deduplicate by `(target, depth)`

  - `TableMode.Min`
    - keeps only the shortest path per key
    - prunes branches once they cannot improve the current best-known depth

  This means shortest-path workloads can now use the same path-aware closure machinery without paying the cost of retaining all
  longer derivations.

  ## Verification

  ### C# query-target tests

  Passed:

  ```bash
  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 229/229 tests passed

  ### Direct runtime verification

  Passed:

  - targeted dotnet harness execution for the new verify_path_aware_transitive_closure_min_mode_plan case

  ## Benchmark Procedure

  python examples/benchmark/benchmark_shortest_path_to_root.py --scales 300 --repetitions 1
  python examples/benchmark/benchmark_shortest_path_to_root.py --scales 1k,5k,10k --repetitions 1

  The benchmark compares two C# query-engine modes on the same shortest-path-to-root workload:

  - all = full path-aware enumeration
  - min = directed-table shortest-path pruning

  ## Benchmark Results

  | Scale | All | Min | Speedup | All Tuples | Min Tuples | Output Match |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.596s | 0.139s | 4.29x | 602,808 | 30,968 | yes |
  | 1k | 0.418s | 0.101s | 4.15x | 352,522 | 10,328 | yes |
  | 5k | 1.300s | 0.170s | 7.63x | 1,343,900 | 33,054 | yes |
  | 10k | 3.692s | 0.428s | 8.63x | 3,616,699 | 102,067 | yes |

  ## Interpretation

  The result is not a small constant-factor improvement. Min tabling reduces recursive work by more than an order of magnitude
  at larger scales while preserving identical shortest-path outputs.

  This validates the next-stage query-engine direction:

  - All mode for semantics that truly need all paths
  - Min mode for shortest-path semantics
  - same recursive runtime family, different accumulator behavior

  ## Not Included

  This PR does not add directed-table pruning to PathAwareAccumulationNode yet.