### PR TITLE
feat(csharp-query): add min tabling for path-aware accumulation

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -183,6 +183,7 @@ Tables:
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
 | `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs DFS binaries |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
+| `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
 
@@ -215,6 +216,10 @@ python examples/benchmark/benchmark_effective_distance.py \
 
 # Measure overhead of the generalized path-aware accumulation runtime
 python examples/benchmark/benchmark_path_aware_accumulation.py \
+    --scales 300,1k,5k,10k
+
+# Measure directed-table pruning on weighted path-aware accumulation
+python examples/benchmark/benchmark_weighted_shortest_path.py \
     --scales 300,1k,5k,10k
 ```
 

--- a/examples/benchmark/benchmark_weighted_shortest_path.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Benchmark weighted shortest-path-to-root on the C# query engine with two
+PathAwareAccumulationNode runtime modes:
+
+  - all : preserve all simple weighted paths
+  - min : mode-directed pruning on the accumulator
+
+The harness derives a positive source weight from category out-degree so the
+recursive increment remains monotone and min-pruning is sound.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+
+CSHARP_PROJECT = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+PROGRAM = """\
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{
+    const string ROOT_CATEGORY = "Physics";
+    const int MAX_DEPTH = 10;
+
+    static void Main(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: program <all|min> <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }
+
+        var modeName = args[0];
+        var mode = modeName switch
+        {
+            "all" => TableMode.All,
+            "min" => TableMode.Min,
+            _ => throw new ArgumentException($"Unknown mode: {modeName}")
+        };
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_weighted_shortest", 3);
+        var weightId = new PredicateId("category_weight", 2);
+        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+        var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            provider.AddFact(edgeId, parts[0], parts[1]);
+            sourceNodes.Add(parts[0]);
+            outDegree[parts[0]] = outDegree.TryGetValue(parts[0], out var degree) ? degree + 1 : 1;
+        }
+
+        foreach (var source in sourceNodes)
+        {
+            outDegree.TryGetValue(source, out var degree);
+            var weight = 1.0 + Math.Log(Math.Max(1, degree), 5.0);
+            provider.AddFact(weightId, source, weight);
+        }
+
+        foreach (var (line, i) in File.ReadLines(args[2]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }
+
+            categories.Add(parts[1]);
+        }
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareAccumulationNode(
+                edgeId,
+                predId,
+                weightId,
+                new ColumnExpression(3),
+                new BinaryArithmeticExpression(
+                    ArithmeticBinaryOperator.Add,
+                    new ColumnExpression(2),
+                    new ColumnExpression(3)),
+                MAX_DEPTH,
+                mode),
+            true,
+            new int[] { 0 }
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {
+            foreach (var category in categories)
+            {
+                uniqueSeeds.Add(category);
+            }
+        }
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] { category })
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, double Weight)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var weight = Convert.ToDouble(row[2], CultureInfo.InvariantCulture);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {
+                bucket = new List<(string, double)>();
+                ancestorIndex[source] = bucket;
+            }
+
+            bucket.Add((ancestor, weight));
+        }
+
+        var results = new List<(double Distance, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            double? best = null;
+            foreach (var category in articleCategories[article])
+            {
+                if (category == ROOT_CATEGORY)
+                {
+                    best = best is null ? 0.0 : Math.Min(best.Value, 0.0);
+                }
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {
+                    continue;
+                }
+
+                foreach (var (ancestor, weight) in ancestors)
+                {
+                    if (ancestor != ROOT_CATEGORY)
+                    {
+                        continue;
+                    }
+
+                    best = best is null ? weight : Math.Min(best.Value, weight);
+                }
+            }
+
+            if (best is not null)
+            {
+                results.Add((best.Value, article));
+            }
+        }
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        });
+
+        Console.WriteLine("article\\troot_category\\tweighted_shortest_path");
+        foreach (var (distance, article) in results)
+        {
+            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{distance.ToString("G17", CultureInfo.InvariantCulture)}");
+        }
+
+        Console.Error.WriteLine($"mode={modeName}");
+        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"seed_count={seedParams.Count}");
+        Console.Error.WriteLine($"tuple_count={rows.Count}");
+        Console.Error.WriteLine($"article_count={results.Count}");
+    }
+}
+"""
+
+
+@dataclass
+class RunResult:
+    scale: str
+    mode: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def build_harness(root: Path) -> list[str]:
+    if shutil.which("dotnet") is None:
+        raise RuntimeError("dotnet not found")
+
+    project_dir = root / "weighted_shortest_path"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "Program.cs").write_text(PROGRAM, encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_weighted_shortest_path.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_weighted_shortest_path.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path.dll")]
+
+
+def benchmark_mode(command: list[str], scale: str, mode: str, repetitions: int) -> RunResult:
+    scale_dir = BENCH_DIR / scale
+    edge_path = scale_dir / "category_parent.tsv"
+    article_path = scale_dir / "article_category.tsv"
+
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [mode, str(edge_path), str(article_path)])
+        elapsed = time.perf_counter() - started
+        times.append(elapsed)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    row_count = max(0, len(stdout.splitlines()) - 1)
+    digest = hashlib.sha256(stdout.encode("utf-8")).hexdigest()
+    return RunResult(scale, mode, times, digest, row_count, stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-weighted-shortest-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-weighted-shortest-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        command = build_harness(temp_root)
+        results: list[RunResult] = []
+        for scale in scales:
+            results.append(benchmark_mode(command, scale, "all", args.repetitions))
+            results.append(benchmark_mode(command, scale, "min", args.repetitions))
+
+        print("scale\tmode\tmedian_s\tmin_s\tmax_s\trows")
+        grouped: dict[str, dict[str, RunResult]] = {}
+        for result in results:
+            grouped.setdefault(result.scale, {})[result.mode] = result
+            print(
+                f"{result.scale}\t{result.mode}\t{result.median:.3f}\t"
+                f"{min(result.times):.3f}\t{max(result.times):.3f}\t{result.row_count}"
+            )
+
+        for scale in sorted(grouped.keys(), key=scale_sort_key):
+            all_result = grouped[scale]["all"]
+            min_result = grouped[scale]["min"]
+            outputs_match = "match" if all_result.stdout_sha256 == min_result.stdout_sha256 else "DIFFERENT"
+            speedup = all_result.median / min_result.median if min_result.median else float("inf")
+            print(f"{scale}\tall_vs_min\t{outputs_match}")
+            print(f"{scale}\tspeedup_min_vs_all\t{speedup:.2f}x")
+            if all_result.stderr:
+                print(f"{scale}\tall_metrics\t{' '.join(line.strip() for line in all_result.stderr.splitlines())}")
+            if min_result.stderr:
+                print(f"{scale}\tmin_metrics\t{' '.join(line.strip() for line in min_result.stderr.splitlines())}")
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -255,7 +255,8 @@ namespace UnifyWeaver.QueryRuntime
         PredicateId AuxiliaryRelation,
         ArithmeticExpression BaseExpression,
         ArithmeticExpression RecursiveExpression,
-        int MaxDepth = 0
+        int MaxDepth = 0,
+        TableMode AccumulatorMode = TableMode.All
     ) : PlanNode;
 
     public enum TableMode
@@ -981,7 +982,7 @@ namespace UnifyWeaver.QueryRuntime
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
-                PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth}",
+                PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
                 MutualFixpointNode mutual => $"MutualFixpoint head={mutual.Head} members={mutual.Members.Count}",
                 RecursiveRefNode recursiveRef => $"RecursiveRef predicate={recursiveRef.Predicate} kind={recursiveRef.Kind}",
@@ -7200,7 +7201,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.MaxDepth);
+                    AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7257,7 +7258,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.MaxDepth);
+                    AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7275,14 +7276,28 @@ namespace UnifyWeaver.QueryRuntime
             ArithmeticExpression baseExpression,
             ArithmeticExpression recursiveExpression,
             ICollection<object[]> output,
+            TableMode accumulatorMode,
             int maxDepth = 0)
         {
+            var useMinPruning = accumulatorMode == TableMode.Min;
+            var preserveAllPaths = !useMinPruning;
+            var bestKnown = useMinPruning
+                ? new Dictionary<object?, object>()
+                : null;
+            var frontier = useMinPruning
+                ? new Dictionary<object?, List<(object Accumulator, HashSet<object?> Visited)>>()
+                : null;
             var stack = new Stack<(object? Node, object Accumulator, int Depth, HashSet<object?> Visited)>();
             stack.Push((seed, 0, 0, new HashSet<object?> { seed }));
 
             while (stack.Count > 0)
             {
                 var (current, accumulator, depth, visited) = stack.Pop();
+                if (useMinPruning && current is not null && IsDominatedMinState(frontier!, current, accumulator, visited))
+                {
+                    continue;
+                }
+
                 var currentKey = current ?? NullFactIndexKey;
                 if (!succIndex.TryGetValue(currentKey, out var edgeBucket) || !auxIndex.TryGetValue(currentKey, out var auxBucket))
                 {
@@ -7322,14 +7337,95 @@ namespace UnifyWeaver.QueryRuntime
                         var nextAccumulator = depth == 0
                             ? EvaluateArithmeticExpression(baseExpression, evalTuple)
                             : EvaluateArithmeticExpression(recursiveExpression, evalTuple);
-
-                        output.Add(new object[] { seed!, next!, nextAccumulator });
-
                         var nextVisited = new HashSet<object?>(visited) { next };
+
+                        if (preserveAllPaths)
+                        {
+                            output.Add(new object[] { seed!, next!, nextAccumulator });
+                        }
+                        else
+                        {
+                            if (IsDominatedMinState(frontier!, next, nextAccumulator, nextVisited))
+                            {
+                                continue;
+                            }
+
+                            RecordMinState(frontier!, next, nextAccumulator, nextVisited);
+                            if (!bestKnown!.TryGetValue(next, out var bestAccumulator) ||
+                                CompareValues(nextAccumulator, bestAccumulator) < 0)
+                            {
+                                bestKnown[next] = nextAccumulator;
+                            }
+                        }
+
                         stack.Push((next, nextAccumulator, nextDepth, nextVisited));
                     }
                 }
             }
+
+            if (!preserveAllPaths && bestKnown is not null)
+            {
+                var bestRows = bestKnown
+                    .OrderBy(kvp => kvp.Key, Comparer<object?>.Create(CompareCacheSeedValues))
+                    .ToList();
+
+                foreach (var (target, accumulator) in bestRows)
+                {
+                    output.Add(new object[] { seed!, target!, accumulator });
+                }
+            }
+        }
+
+        private static bool IsDominatedMinState(
+            IReadOnlyDictionary<object?, List<(object Accumulator, HashSet<object?> Visited)>> frontier,
+            object? node,
+            object accumulator,
+            HashSet<object?> visited)
+        {
+            if (!frontier.TryGetValue(node, out var states))
+            {
+                return false;
+            }
+
+            foreach (var (bestAccumulator, bestVisited) in states)
+            {
+                var sameState = ReferenceEquals(bestVisited, visited) && Equals(bestAccumulator, accumulator);
+                if (sameState)
+                {
+                    continue;
+                }
+
+                if (CompareValues(bestAccumulator, accumulator) <= 0 && bestVisited.IsSubsetOf(visited))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void RecordMinState(
+            IDictionary<object?, List<(object Accumulator, HashSet<object?> Visited)>> frontier,
+            object? node,
+            object accumulator,
+            HashSet<object?> visited)
+        {
+            if (!frontier.TryGetValue(node, out var states))
+            {
+                states = new List<(object Accumulator, HashSet<object?> Visited)>();
+                frontier[node] = states;
+            }
+
+            for (var i = states.Count - 1; i >= 0; i--)
+            {
+                var (existingAccumulator, existingVisited) = states[i];
+                if (CompareValues(accumulator, existingAccumulator) <= 0 && visited.IsSubsetOf(existingVisited))
+                {
+                    states.RemoveAt(i);
+                }
+            }
+
+            states.Add((accumulator, visited));
         }
 
         private IEnumerable<object[]> ExecuteGroupedTransitiveClosure(GroupedTransitiveClosureNode closure, EvaluationContext? parentContext)

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -48,6 +48,7 @@
 :- use_module('csharp_runtime/custom_csharp', []).
 
 :- dynamic query_materialized_relation/1.
+:- discontiguous emit_plan_expression/2.
 
 % Track collected components for code generation
 :- dynamic collected_component/2.
@@ -1163,6 +1164,11 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
     ensure_relation(EdgePred, EdgeArity, [], Relations0),
     ensure_relation(AuxPred, AuxArity, Relations0, Relations1),
     dedup_relations(Relations1, Relations),
+    get_dict(name, HeadSpec, HeadName),
+    (   declared_table_modes(HeadName, 3, TableModes)
+    ->  true
+    ;   TableModes = [lattice, lattice, lattice]
+    ),
     Root = path_aware_accumulation{
         type:path_aware_accumulation,
         head:HeadSpec,
@@ -1171,6 +1177,7 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
         base_expression:BaseExpression,
         recursive_expression:RecursiveExpression,
         max_depth:10,
+        table_modes:TableModes,
         width:3
     }.
 
@@ -3717,13 +3724,19 @@ emit_plan_expression(Node, Expr) :-
     get_dict(base_expression, Node, BaseExpression),
     get_dict(recursive_expression, Node, RecursiveExpression),
     (get_dict(max_depth, Node, MaxDepth) -> true ; MaxDepth = 0),
+    (   get_dict(table_modes, Node, TableModes),
+        nth0(2, TableModes, AccTableMode),
+        AccTableMode \= lattice
+    ->  table_mode_csharp_enum(AccTableMode, TableModeStr)
+    ;   TableModeStr = "TableMode.All"
+    ),
     emit_arithmetic_expression(BaseExpression, BaseExprCode),
     emit_arithmetic_expression(RecursiveExpression, RecExprCode),
     atom_string(EdgeName, EdgeNameStr),
     atom_string(AuxName, AuxNameStr),
     atom_string(Name, NameStr),
-    format(atom(Expr), 'new PathAwareAccumulationNode(new PredicateId("~w", ~w), new PredicateId("~w", ~w), new PredicateId("~w", ~w), ~w, ~w, ~w)',
-        [EdgeNameStr, EdgeArity, NameStr, Arity, AuxNameStr, AuxArity, BaseExprCode, RecExprCode, MaxDepth]).
+    format(atom(Expr), 'new PathAwareAccumulationNode(new PredicateId("~w", ~w), new PredicateId("~w", ~w), new PredicateId("~w", ~w), ~w, ~w, ~w, ~w)',
+        [EdgeNameStr, EdgeArity, NameStr, Arity, AuxNameStr, AuxArity, BaseExprCode, RecExprCode, MaxDepth, TableModeStr]).
 emit_plan_expression(Node, Expr) :-
     is_dict(Node, fixpoint), !,
     get_dict(base, Node, BaseNode),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -154,6 +154,9 @@
 :- dynamic user:test_weighted_multi_edge/2.
 :- dynamic user:test_weighted_multi_cost/2.
 :- dynamic user:test_weighted_multi_path/3.
+:- dynamic user:test_weighted_min_edge/2.
+:- dynamic user:test_weighted_min_cost/2.
+:- dynamic user:test_weighted_min_path/3.
 :- dynamic user:test_scanindex_allowed/1.
 :- dynamic user:test_scanindex_step/2.
 :- dynamic user:test_scanindex_reach_param/2.
@@ -308,6 +311,7 @@ test_csharp_query_target :-
         verify_path_aware_accumulation_plan,
         verify_parameterized_path_aware_accumulation_plan,
         verify_path_aware_accumulation_preserves_path_multiplicity,
+        verify_path_aware_accumulation_min_mode_plan,
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
@@ -1164,6 +1168,25 @@ setup_test_data :-
         test_weighted_multi_path(Y, Z, Acc1),
         Acc is Acc1 + Cost
     )),
+    assertz(user:test_weighted_min_edge(a, b)),
+    assertz(user:test_weighted_min_edge(a, c)),
+    assertz(user:test_weighted_min_edge(b, d)),
+    assertz(user:test_weighted_min_edge(c, d)),
+    assertz(user:test_weighted_min_cost(a, 1)),
+    assertz(user:test_weighted_min_cost(b, 5)),
+    assertz(user:test_weighted_min_cost(c, 2)),
+    assertz(user:(test_weighted_min_path(X, Y, Acc) :-
+        test_weighted_min_edge(X, Y),
+        test_weighted_min_cost(X, Cost),
+        Acc is Cost
+    )),
+    assertz(user:(test_weighted_min_path(X, Z, Acc) :-
+        test_weighted_min_edge(X, Y),
+        test_weighted_min_cost(X, Cost),
+        test_weighted_min_path(Y, Z, Acc1),
+        Acc is Acc1 + Cost
+    )),
+    assertz(user:'table'(test_weighted_min_path(_, _, min))),
     assert_binary_recursive_fixture(
         test_probe_dir_forward_edge,
         test_probe_dir_forward_reach,
@@ -1381,6 +1404,9 @@ cleanup_test_data :-
     retractall(user:test_weighted_multi_edge(_, _)),
     retractall(user:test_weighted_multi_cost(_, _)),
     retractall(user:test_weighted_multi_path(_, _, _)),
+    retractall(user:test_weighted_min_edge(_, _)),
+    retractall(user:test_weighted_min_cost(_, _)),
+    retractall(user:test_weighted_min_path(_, _, _)),
     cleanup_recursive_fixture(test_probe_dir_forward_edge, test_probe_dir_forward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_backward_edge, test_probe_dir_backward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_mixed_edge, test_probe_dir_mixed_reach, 2),
@@ -3638,6 +3664,31 @@ verify_path_aware_accumulation_preserves_path_multiplicity :-
         ['MATCH_COUNT:2'],
         [[a]],
         HarnessSource).
+
+verify_path_aware_accumulation_min_mode_plan :-
+    csharp_target:build_query_plan(
+        test_weighted_min_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(metadata, Plan, Meta),
+    get_dict(modes, Meta, Modes),
+    Modes == [input, output, output],
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_min_path, arity:3}),
+    get_dict(edge, Root, predicate{name:test_weighted_min_edge, arity:2}),
+    get_dict(auxiliary, Root, predicate{name:test_weighted_min_cost, arity:2}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    maybe_run_query_runtime(Plan,
+        ['a,b,1',
+         'a,c,1',
+         'a,d,3'],
+        [[a]]).
 
 verify_grouped_transitive_closure_plan :-
     csharp_query_target:build_query_plan(test_label_cat_reach/4, [target(csharp_query)], Plan),


### PR DESCRIPTION
  ## Summary

  This PR extends mode-directed tabling in the C# query engine from counted
  path-aware closure to `PathAwareAccumulationNode`.

  It adds `TableMode` plumbing for path-aware weighted accumulation, a new
  regression for weighted `min` mode, and a dedicated benchmark for weighted
  shortest-path style workloads.

  This is a correctness-first increment. It preserves per-path semantics, but
  the current exact pruning strategy is slower than `All` mode and still needs
  optimization.

  ## What Changed

  - add `TableMode` support to `PathAwareAccumulationNode`
  - carry `:- table ... min` declarations into `path_aware_accumulation` plans
  - emit `TableMode.Min` in generated C# for accumulation plans
  - add weighted-accumulation `min` regression coverage in the C# query-target suite
  - add a dedicated weighted shortest-path benchmark script
  - document the new benchmark in the benchmark README
  - clean up the `emit_plan_expression/2` warning by marking it `discontiguous`

  ## Files

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`
  - `src/unifyweaver/targets/csharp_target.pl`
  - `tests/core/test_csharp_query_target.pl`
  - `examples/benchmark/benchmark_weighted_shortest_path.py`
  - `examples/benchmark/README.md`

  ## Semantics

  This PR is specifically about weighted `min` tabling for recursive accumulation.

  Example shape:

  ```prolog
  path(X, Y, Acc) :-
      edge(X, Y),
      weight(X, Cost),
      Acc is Cost.

  path(X, Z, Acc) :-
      edge(X, Y),
      weight(X, Cost),
      path(Y, Z, Acc1),
      Acc is Acc1 + Cost.

  The important constraint is that semantics remain:

  - per-path visited
  - no repeated nodes within a path
  - no collapsing of distinct simple paths unless pruning is sound

  ## Correctness Note

  A naive weighted min implementation that keeps only one best accumulator
  per target is not sound under per-path visited semantics.

  Why:

  - two paths can reach the same node with different visited sets
  - the path with the smaller current accumulator may have already consumed a
    node that the other path still needs for the best completion
  - so continuation depends on more than (target, accumulator)

  This PR uses a stricter dominance frontier so that Min stays correct for
  the current weighted path-aware setting.

  ## Verification

  ### C# query-target suite

  Passed locally:

  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 230/230 tests passed

  ### Benchmark script syntax

  Passed locally:

  python -m py_compile examples/benchmark/benchmark_weighted_shortest_path.py

  ## Benchmark Procedure

  python examples/benchmark/benchmark_weighted_shortest_path.py --scales 300 --repetitions 1
  python examples/benchmark/benchmark_weighted_shortest_path.py --scales 1k --repetitions 1

  The benchmark compares two modes of the same weighted path-aware accumulation workload:

  - all = preserve all simple weighted paths
  - min = mode-directed pruning with a correctness-preserving dominance frontier

  The harness derives positive source weights from category out-degree so the
  recursive increment remains monotone.

  ## Benchmark Results

  | Scale | All | Min | Output Match |
  |---|---:|---:|---|
  | 300 | 0.802s | 4.028s | match |
  | 1k | 0.573s | 4.573s | match |

  Additional metrics:

  - 300
      - all tuple_count = 602,808
      - min tuple_count = 30,968
  - 1k
      - all tuple_count = 352,522
      - min tuple_count = 10,328

  ## Interpretation

  This is a correctness success, not yet a performance success.

  The runtime is clearly pruning rows, but the exact dominance-frontier tracking
  needed to preserve per-path semantics currently costs more than the work it saves.

  That does not affect the previously landed counted-closure Min path:

  - shortest path by hop count on PathAwareTransitiveClosureNode remains fast
  - the large speedups from the earlier shortest-path benchmark still stand

  The slowdown is specific to the new weighted accumulation Min implementation.

  ## Follow-Up

  Likely follow-up work:

  - optimize the dominance frontier representation for weighted Min
  - restrict pruning to provably safe monotone weighted cases where a cheaper summary is possible
  - benchmark larger scales once the pruning representation is improved

  ## Scope

  This PR should be read as:

  - extending the query-engine machinery to weighted min accumulation
  - proving correctness under per-path semantics
  - exposing the performance gap that still remains to be solved