### PR TITLE
perf(csharp-query): compact weighted min path state and propose SCC design

### DIFF
--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PHILOSOPHY.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PHILOSOPHY.md
@@ -1,0 +1,120 @@
+# SCC-Condensed Weighted Min: Philosophy
+
+## Why This Exists
+
+The current weighted `min` support for `PathAwareAccumulationNode` is
+correct, but not yet fast enough to justify its purpose.
+
+That is a different situation from counted shortest path:
+
+- counted `min` on `PathAwareTransitiveClosureNode` already delivers the
+  expected performance win
+- weighted `min` on `PathAwareAccumulationNode` still pays too much for
+  exact per-path state management
+
+So the next step should not be another local frontier tweak alone. It
+should be a change in the **graph model** that reduces how much
+path-specific state the runtime has to remember.
+
+## Core Intuition
+
+The expensive part of weighted `min` today is not arithmetic. It is the
+fact that correctness depends on more than:
+
+- current node
+- current accumulated cost
+
+It also depends on:
+
+- which nodes have already been used in the path
+
+That visited-set sensitivity is what prevents the simple "best cost per
+target" rule from being universally sound in cyclic graphs.
+
+The philosophical goal of SCC condensation is to move complexity out of
+the search state and into the graph representation:
+
+- collapse strongly connected regions into a single component graph
+- make the outer problem closer to dynamic programming on a DAG
+- reserve path-specific reasoning for the hard part only
+
+## Why SCC Condensation Fits This Problem
+
+Weighted minimum path is much easier on an acyclic graph than on a
+general graph:
+
+- no revisiting a component later through another cycle
+- no repeated global reconsideration of the same recursive region
+- much stronger pruning and dynamic-programming opportunities
+
+The Wikipedia-style category graph used in the benchmark is not fully
+acyclic, but its cycles are local rather than universal. That makes SCC
+condensation attractive because:
+
+- it removes global cyclic structure from the outer graph
+- it may sharply reduce the number of states that need exact visited-set
+  tracking
+- it gives us a path toward `min` actually beating `all`
+
+## What This Is Not
+
+This is not primarily a calculus-of-variations problem.
+
+The more relevant analogies are:
+
+- shortest path on weighted graphs
+- semiring / dynamic-programming evaluation
+- branch-and-bound with graph condensation
+- potential-guided search after structural reduction
+
+If we later add admissible lower bounds or node potentials, those should
+be treated as refinements on top of the condensed graph, not as the
+starting point.
+
+## Design Principle
+
+The runtime should prefer the **cheapest sound state model** available
+for a workload.
+
+That suggests the following hierarchy:
+
+1. Counted `min` on simple path-aware closure
+   Use scalar best-known pruning.
+
+2. Weighted `min` on an SCC-condensed component DAG
+   Use dynamic-programming or component-level best-known pruning where
+   possible.
+
+3. Weighted `min` inside cyclic SCCs
+   Use exact path-aware state only where condensation does not remove the
+   ambiguity.
+
+This keeps the hard machinery where it is truly needed instead of paying
+for it everywhere.
+
+## Cross-Target Importance
+
+This matters beyond the C# query engine.
+
+If the right abstraction is "weighted minimum path over an SCC-condensed
+graph", then that abstraction is portable:
+
+- C# query engine can specialize it in the runtime
+- Rust can lower to the same condensed-graph algorithm natively
+- other DFS-style targets can follow later
+
+That is better than teaching every target a fragile, path-frontier-heavy
+special case independently.
+
+## Evaluation Standard
+
+This proposal should only be considered successful if it achieves both:
+
+1. exact agreement with the current `All` semantics for the supported
+   weighted `min` workloads
+2. a clear runtime advantage over `All`, especially at larger scales
+
+The target is not just "less slow than before." The target is for
+weighted `min` to become meaningfully faster than full weighted path
+enumeration, even if the gain is smaller than the counted shortest-path
+case.

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -1,0 +1,166 @@
+# SCC-Condensed Weighted Min: Implementation Plan
+
+## Goal
+
+Make weighted `min` on `PathAwareAccumulationNode` meaningfully faster
+than `All` while preserving exact per-path semantics.
+
+Current status:
+
+- correctness is in place
+- local runtime optimizations reduced the cost of the exact frontier
+- weighted `min` is still slower than `All`
+
+So the next step must be algorithmic.
+
+## Phase 0: Baseline Preservation
+
+Before adding a new strategy:
+
+1. keep the current exact frontier implementation as the fallback
+2. preserve the existing benchmark script and output-comparison checks
+3. do not change user-facing syntax
+
+This gives us a known-correct baseline to compare against.
+
+## Phase 1: Graph Structure Measurement
+
+Add instrumentation to the weighted benchmark path to measure:
+
+- SCC count
+- SCC size distribution
+- largest SCC
+- condensation DAG size
+
+Deliverable:
+
+- a benchmark note or doc update summarizing whether the benchmark graph
+  is structurally favorable for SCC condensation
+
+Reason:
+
+- if SCCs are huge, condensation may not help much
+- if SCCs are mostly small with a sparse DAG between them, the approach
+  is promising
+
+## Phase 2: Internal Runtime Prototype
+
+Prototype a new internal runtime strategy for:
+
+- `PathAwareAccumulationNode`
+- `TableMode.Min`
+
+Algorithm sketch:
+
+1. build SCC ids for the edge relation
+2. build condensation DAG
+3. define component entry/exit boundary states
+4. compute exact local transfer costs inside SCCs
+5. compose those costs on the condensation DAG with DAG-style `min`
+   propagation
+
+Deliverable:
+
+- an internal C# runtime path behind the existing node
+- no planner change required yet
+
+## Phase 3: Strategy Selection
+
+Add a runtime applicability check:
+
+- use SCC-condensed strategy when safe
+- otherwise fall back to current exact frontier
+
+Possible early rule:
+
+- enable only for monotone additive `min`
+- disable for unsupported expression shapes
+
+Deliverable:
+
+- strategy split with explicit trace/debug labeling
+
+Examples:
+
+- `PathAwareAccumulation-Min-Frontier`
+- `PathAwareAccumulation-Min-SccCondensed`
+
+## Phase 4: Benchmark Loop
+
+Rerun:
+
+```bash
+python examples/benchmark/benchmark_weighted_shortest_path.py --scales 300,1k,5k,10k --repetitions 1
+```
+
+Track:
+
+- output match
+- total runtime
+- query time
+- SCC metrics
+- local state counts
+
+Success criteria:
+
+- exact output match at all scales
+- weighted `min` faster than `all` at larger scales
+- visible crossover toward a meaningful win, ideally around `2x`
+
+## Phase 5: Documentation and Rollout
+
+Once the runtime strategy is validated:
+
+1. update benchmark docs with the new results
+2. update mode-directed tabling docs to reflect the weighted `min` fast
+   path
+3. explicitly document the fallback boundary
+
+## Phase 6: Rust Follow-Up
+
+Only after the C# runtime strategy is stable:
+
+1. extend Rust native lowering for counted `min` if needed
+2. extend Rust native lowering for weighted `min`
+3. prefer the same condensed-graph abstraction rather than a
+   frontier-heavy path-state clone
+
+Reason:
+
+- Rust should inherit the better abstraction, not the current C#
+  exploratory intermediate form
+
+## Risks
+
+### Risk 1: SCCs are too large
+
+Mitigation:
+
+- keep the exact frontier fallback
+- use the SCC strategy only when condensation materially simplifies the
+  graph
+
+### Risk 2: Internal transfer summarization becomes lossy
+
+Mitigation:
+
+- compare against `All` benchmark outputs continuously
+- keep the prototype behind runtime strategy labeling until validated
+
+### Risk 3: SCC preprocessing overhead dominates
+
+Mitigation:
+
+- measure SCC construction separately
+- cache condensation structures per relation when feasible
+
+## Immediate Next Coding Step
+
+The first code step after this document set should be:
+
+1. add SCC measurement instrumentation to the weighted benchmark/runtime
+2. record actual SCC structure for `300/1k/5k/10k`
+3. decide whether the component-DAG strategy is justified by the data
+
+That keeps the next implementation grounded in the actual graph rather
+than intuition alone.

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md
@@ -1,0 +1,177 @@
+# SCC-Condensed Weighted Min: Specification
+
+## Scope
+
+This specification defines a candidate fast path for weighted `min`
+evaluation of `PathAwareAccumulationNode` workloads in the C# query
+engine.
+
+It is intended for recursive accumulation shapes that already match the
+current path-aware accumulation lowering:
+
+```prolog
+pred(X, Y, Acc) :-
+    edge(X, Y),
+    aux(X, V),
+    Acc is BaseExpr(V).
+
+pred(X, Z, Acc) :-
+    edge(X, Y),
+    aux(X, V),
+    pred(Y, Z, Acc1),
+    Acc is StepExpr(Acc1, V).
+```
+
+with:
+
+- `TableMode.Min`
+- per-path uniqueness
+- monotone positive accumulation
+
+## Supported Semantic Class
+
+The fast path is only sound when all of the following hold:
+
+1. The recursive accumulator is monotone increasing along a path.
+   Examples:
+   - `Acc is Acc1 + Cost`
+   - `Acc is Acc1 + log(Deg) / log(N)` with positive step
+
+2. The result contract is minimum accumulated cost per `(source,target)`.
+
+3. Paths are simple:
+   - no repeated nodes in a path
+
+4. The optimizer may transform the graph via SCC condensation, but may
+   not change the final result set.
+
+Out of scope initially:
+
+- negative increments
+- zero-cost cyclic edge systems where monotonicity gives no pruning
+- `max`, `first`, `sum`, `count`
+- multi-auxiliary or non-linear accumulation beyond the current path-aware
+  accumulation shape
+
+## High-Level Execution Model
+
+### Input
+
+- edge relation `edge(U, V)`
+- auxiliary relation `aux(U, Value)`
+- source seeds
+- weighted `min` accumulation expressions
+
+### Output
+
+For each seeded source `S` and reachable target `T`:
+
+- exactly one row `(S, T, MinAcc)`
+- where `MinAcc` equals the minimum accumulated cost over all valid
+  simple paths from `S` to `T`
+
+### Intermediate Graph Model
+
+The runtime may construct:
+
+1. SCC partition of the edge graph
+2. condensation DAG over SCC ids
+3. local entry/exit transfer structure for each SCC
+
+The runtime may then evaluate:
+
+- local exact weighted path costs inside SCCs
+- global `min` composition across the condensation DAG
+
+## Required Correctness Properties
+
+1. Exact agreement with current `TableMode.All` weighted results after
+   downstream `min` aggregation.
+
+2. No path may be accepted if it repeats a node.
+
+3. SCC condensation must not merge semantically distinct boundary costs.
+
+4. The fast path may use summaries, but only if they are lossless for the
+   supported workload class.
+
+## Runtime Shape
+
+Preferred runtime structure:
+
+- keep `PathAwareAccumulationNode`
+- add an internal execution strategy, not a new user-facing Prolog syntax
+
+Possible C# runtime strategies:
+
+- `PathAwareAccumulation-Min-Frontier` (current exact fallback)
+- `PathAwareAccumulation-Min-SccCondensed` (new fast path)
+
+The planner does not need a new source-level feature to select this.
+Selection may be runtime-internal as long as semantics are preserved.
+
+## Planner Contract
+
+No new Prolog syntax is required for the initial version.
+
+The planner already provides:
+
+- `path_aware_accumulation`
+- `table_modes:[..., ..., min]`
+- base and recursive arithmetic expressions
+
+The runtime may inspect the existing node and decide whether the SCC
+fast path is applicable.
+
+## Applicability Test
+
+The runtime fast path should only activate when:
+
+- `AccumulatorMode == TableMode.Min`
+- the accumulation expression is monotone additive in practice
+- graph condensation is available
+
+The runtime should fall back to the current exact frontier algorithm
+when:
+
+- applicability cannot be proven
+- SCC preprocessing fails
+- internal transfer summarization would be lossy
+
+## Instrumentation Requirements
+
+The implementation must report enough data to evaluate whether the new
+strategy is worth keeping.
+
+At minimum:
+
+- number of SCCs
+- largest SCC size
+- condensation DAG edge count
+- number of exact local states explored
+- number of outer DAG states explored
+- final output row count
+- total runtime
+
+These should be available to benchmark harnesses, at least through
+stderr metrics.
+
+## Benchmark Contract
+
+Primary benchmark:
+
+- `examples/benchmark/benchmark_weighted_shortest_path.py`
+
+Success criteria:
+
+1. `all_vs_min = match`
+2. `min` becomes faster than `all`
+3. the gain remains visible at `5k` and `10k`
+
+Target threshold:
+
+- weighted `min` should ideally approach at least `~2x` faster than
+  `all` on large-scale workloads
+
+That threshold is aspirational rather than a hard semantic requirement,
+but it is the practical bar for considering the fast path successful.

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_THEORY.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_THEORY.md
@@ -1,0 +1,171 @@
+# SCC-Condensed Weighted Min: Theory
+
+## Problem Statement
+
+Consider a recursive weighted path relation of the form:
+
+```prolog
+path(X, Y, Acc) :-
+    edge(X, Y),
+    weight(X, W),
+    Acc is W.
+
+path(X, Z, Acc) :-
+    edge(X, Y),
+    weight(X, W),
+    path(Y, Z, Acc1),
+    Acc is Acc1 + W.
+```
+
+with per-path uniqueness:
+
+- no node may repeat within a single path
+
+and `min` tabling semantics on the accumulator:
+
+- for each `(source, target)`, return only the minimum accumulated cost
+
+## Why Scalar Best-Known Pruning Fails in General
+
+In a cyclic graph, two distinct simple paths can reach the same
+intermediate node `N` with:
+
+- different accumulated costs
+- different visited sets
+
+The path with the better current cost is not always the one with the
+best continuation, because it may already have used a node that the
+other path still needs.
+
+So the implication
+
+```text
+best_cost_to(N) is enough state
+```
+
+is false in general under simple-path semantics.
+
+That is why exact weighted `min` requires more than a scalar table on the
+original graph.
+
+## SCC Condensation
+
+Given a directed graph `G = (V, E)`, compute its strongly connected
+components:
+
+```text
+SCC(G) = {C1, C2, ..., Ck}
+```
+
+and build the condensation graph:
+
+```text
+G* = (SCC(G), E*)
+```
+
+where there is an edge `Ci -> Cj` in `G*` iff there exists an edge in
+`G` from a node in `Ci` to a node in `Cj`, and `Ci != Cj`.
+
+Standard result:
+
+- `G*` is a DAG
+
+This matters because once a path leaves an SCC, it can never return to
+that SCC in the condensation graph.
+
+## Why Condensation Helps
+
+The difficult visited-set ambiguity is caused by cyclic revisitation
+possibility. SCC condensation limits that ambiguity:
+
+- between components, path order is acyclic
+- repeated reconsideration of the same global cyclic region disappears
+- dynamic programming becomes possible on the outer graph
+
+The remaining hard part is local:
+
+- inside an SCC, simple-path constraints still matter
+- but the scope of exact path-state reasoning is confined to the
+  component rather than the whole graph
+
+## Theoretical Decomposition
+
+Weighted `min` on the original graph can be decomposed into:
+
+1. local weighted simple-path transfer inside each SCC
+2. acyclic composition between SCCs on the condensation DAG
+
+Informally:
+
+```text
+global_min_path = DAG composition of local SCC transfer functions
+```
+
+The win comes from the fact that the second phase no longer needs
+visited-set-sensitive search over the whole graph.
+
+## Soundness Envelope
+
+Let a path in the original graph correspond to a sequence of SCCs:
+
+```text
+C0 -> C1 -> ... -> Cn
+```
+
+Because the condensation graph is acyclic, every valid path visits each
+component at most once.
+
+So if we summarize the minimal transfer cost from:
+
+- an SCC entry boundary
+- to an SCC exit boundary
+
+then the outer composition across SCCs can be treated as a DAG shortest
+path problem.
+
+This does not solve the internal SCC problem automatically, but it
+changes the asymptotic shape of the global problem:
+
+- expensive exact search is local
+- cheap DAG dynamic programming is global
+
+## Expected Runtime Consequence
+
+The current exact frontier algorithm pays path-state costs at every
+level of the graph. SCC condensation should reduce this by:
+
+- shrinking the search space seen by the global algorithm
+- reducing dominance comparisons across globally unrelated cycles
+- making the number of exact visited-state comparisons proportional more
+  to SCC size than to total graph size
+
+This is especially attractive when:
+
+- SCCs are small or moderate
+- the condensation DAG is much smaller than the raw graph
+- weighted `min` is asked over many seeds
+
+## Relationship to Potentials
+
+Potential functions or admissible lower bounds can still help, but they
+are best layered on top of the condensed graph:
+
+- SCC condensation removes structural cyclicity
+- potentials can then guide search or prune within the condensed model
+
+That is a cleaner path than applying heuristic pruning directly to the
+raw graph with full visited-state dependence.
+
+## What Must Be Proven Empirically
+
+The proposal rests on three empirical questions:
+
+1. Are benchmark SCCs small enough that local exact search is cheap?
+2. Does condensation materially reduce weighted `min` runtime relative to
+   the current frontier approach?
+3. Does the benefit hold at `5k` and `10k`, where weighted `min` should
+   become clearly faster than `All`?
+
+Those are benchmark questions, not just code questions, so the
+implementation plan must include SCC structure reporting as part of
+evaluation.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -7287,8 +7287,24 @@ namespace UnifyWeaver.QueryRuntime
             var frontier = useMinPruning
                 ? new Dictionary<object?, List<VisitedAccumulatorState>>()
                 : null;
-            var initialVisited = new HashSet<object?> { seed };
-            var initialState = new VisitedAccumulatorState(0, initialVisited, initialVisited.Count, ComputeVisitedMaskA(seed), ComputeVisitedMaskB(seed));
+            var nodeIds = new Dictionary<object, int>();
+            var nextNodeId = 0;
+
+            int GetNodeId(object? value)
+            {
+                var key = value ?? NullFactIndexKey;
+                if (nodeIds.TryGetValue(key, out var existing))
+                {
+                    return existing;
+                }
+
+                var id = nextNodeId++;
+                nodeIds[key] = id;
+                return id;
+            }
+
+            var initialPath = CompactVisitedPath.Create(GetNodeId(seed));
+            var initialState = new VisitedAccumulatorState(0, initialPath);
             var stack = new Stack<(object? Node, VisitedAccumulatorState State, int Depth)>();
             stack.Push((seed, initialState, 0));
 
@@ -7301,7 +7317,7 @@ namespace UnifyWeaver.QueryRuntime
                 }
 
                 var accumulator = state.Accumulator;
-                var visited = state.Visited;
+                var visited = state.Path;
 
                 var currentKey = current ?? NullFactIndexKey;
                 if (!succIndex.TryGetValue(currentKey, out var edgeBucket) || !auxIndex.TryGetValue(currentKey, out var auxBucket))
@@ -7318,7 +7334,8 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     var next = edge[1];
-                    if (visited.Contains(next))
+                    var nextId = GetNodeId(next);
+                    if (visited.Contains(nextId))
                     {
                         continue;
                     }
@@ -7342,13 +7359,7 @@ namespace UnifyWeaver.QueryRuntime
                         var nextAccumulator = depth == 0
                             ? EvaluateArithmeticExpression(baseExpression, evalTuple)
                             : EvaluateArithmeticExpression(recursiveExpression, evalTuple);
-                        var nextVisited = new HashSet<object?>(visited) { next };
-                        var nextState = new VisitedAccumulatorState(
-                            nextAccumulator,
-                            nextVisited,
-                            state.VisitedCount + 1,
-                            state.MaskA | ComputeVisitedMaskA(next),
-                            state.MaskB | ComputeVisitedMaskB(next));
+                        var nextState = new VisitedAccumulatorState(nextAccumulator, visited.Extend(nextId));
 
                         if (preserveAllPaths)
                         {
@@ -7399,24 +7410,24 @@ namespace UnifyWeaver.QueryRuntime
 
             foreach (var candidate in states)
             {
-                var sameState = ReferenceEquals(candidate.Visited, state.Visited) && Equals(candidate.Accumulator, state.Accumulator);
+                var sameState = ReferenceEquals(candidate.Path, state.Path) && Equals(candidate.Accumulator, state.Accumulator);
                 if (sameState)
                 {
                     continue;
                 }
 
-                if (candidate.VisitedCount > state.VisitedCount)
+                if (candidate.Path.Count > state.Path.Count)
                 {
                     continue;
                 }
 
-                if ((candidate.MaskA & ~state.MaskA) != 0 || (candidate.MaskB & ~state.MaskB) != 0)
+                if ((candidate.Path.MaskA & ~state.Path.MaskA) != 0 || (candidate.Path.MaskB & ~state.Path.MaskB) != 0)
                 {
                     continue;
                 }
 
                 if (CompareValues(candidate.Accumulator, state.Accumulator) <= 0 &&
-                    candidate.Visited.IsSubsetOf(state.Visited))
+                    candidate.Path.IsSubsetOf(state.Path))
                 {
                     return true;
                 }
@@ -7439,18 +7450,18 @@ namespace UnifyWeaver.QueryRuntime
             for (var i = states.Count - 1; i >= 0; i--)
             {
                 var existing = states[i];
-                if (state.VisitedCount > existing.VisitedCount)
+                if (state.Path.Count > existing.Path.Count)
                 {
                     continue;
                 }
 
-                if ((state.MaskA & ~existing.MaskA) != 0 || (state.MaskB & ~existing.MaskB) != 0)
+                if ((state.Path.MaskA & ~existing.Path.MaskA) != 0 || (state.Path.MaskB & ~existing.Path.MaskB) != 0)
                 {
                     continue;
                 }
 
                 if (CompareValues(state.Accumulator, existing.Accumulator) <= 0 &&
-                    state.Visited.IsSubsetOf(existing.Visited))
+                    state.Path.IsSubsetOf(existing.Path))
                 {
                     states.RemoveAt(i);
                 }
@@ -7459,24 +7470,110 @@ namespace UnifyWeaver.QueryRuntime
             states.Add(state);
         }
 
-        private static ulong ComputeVisitedMaskA(object? value)
-        {
-            var hash = value?.GetHashCode() ?? 0;
-            return 1UL << (hash & 63);
-        }
-
-        private static ulong ComputeVisitedMaskB(object? value)
-        {
-            var hash = value?.GetHashCode() ?? 0;
-            return 1UL << ((int)((uint)hash >> 6) & 63);
-        }
-
         private sealed record VisitedAccumulatorState(
             object Accumulator,
-            HashSet<object?> Visited,
-            int VisitedCount,
-            ulong MaskA,
-            ulong MaskB);
+            CompactVisitedPath Path);
+
+        private sealed class CompactVisitedPath
+        {
+            private readonly int[] _nodeIds;
+
+            private CompactVisitedPath(int[] nodeIds, int count, ulong maskA, ulong maskB)
+            {
+                _nodeIds = nodeIds;
+                Count = count;
+                MaskA = maskA;
+                MaskB = maskB;
+            }
+
+            public int Count { get; }
+
+            public ulong MaskA { get; }
+
+            public ulong MaskB { get; }
+
+            public static CompactVisitedPath Create(int nodeId)
+            {
+                return new CompactVisitedPath(new[] { nodeId }, 1, ComputeVisitedMaskA(nodeId), ComputeVisitedMaskB(nodeId));
+            }
+
+            public bool Contains(int nodeId)
+            {
+                var maskA = ComputeVisitedMaskA(nodeId);
+                if ((MaskA & maskA) == 0)
+                {
+                    return false;
+                }
+
+                var maskB = ComputeVisitedMaskB(nodeId);
+                if ((MaskB & maskB) == 0)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < Count; i++)
+                {
+                    if (_nodeIds[i] == nodeId)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public CompactVisitedPath Extend(int nodeId)
+            {
+                var nodeIds = new int[Count + 1];
+                Array.Copy(_nodeIds, nodeIds, Count);
+                nodeIds[Count] = nodeId;
+                return new CompactVisitedPath(nodeIds, Count + 1, MaskA | ComputeVisitedMaskA(nodeId), MaskB | ComputeVisitedMaskB(nodeId));
+            }
+
+            public bool IsSubsetOf(CompactVisitedPath other)
+            {
+                if (Count > other.Count)
+                {
+                    return false;
+                }
+
+                if ((MaskA & ~other.MaskA) != 0 || (MaskB & ~other.MaskB) != 0)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < Count; i++)
+                {
+                    var found = false;
+                    var value = _nodeIds[i];
+                    for (var j = 0; j < other.Count; j++)
+                    {
+                        if (value == other._nodeIds[j])
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        private static ulong ComputeVisitedMaskA(int value)
+        {
+            return 1UL << (value & 63);
+        }
+
+        private static ulong ComputeVisitedMaskB(int value)
+        {
+            return 1UL << ((value >> 6) & 63);
+        }
 
         private IEnumerable<object[]> ExecuteGroupedTransitiveClosure(GroupedTransitiveClosureNode closure, EvaluationContext? parentContext)
         {


### PR DESCRIPTION
  ## Summary

  This PR does two related things for weighted `min` tabling on
  `PathAwareAccumulationNode`:

  1. it lands another runtime optimization pass in the C# query engine
  2. it adds the design-doc set for the next larger optimization step:
     SCC-condensed weighted `min`

  So this is not docs-only. It is an incremental runtime improvement plus
  the proposal for the next structural optimization.

  ## What Changed

  ### Runtime

  - compact the weighted `min` frontier's visited-state representation in:
    - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  This keeps exact per-path semantics unchanged, but replaces the heavier
  visited-state handling with a more compact path representation over
  integer node ids inside the accumulation `Min` runtime path.

  ### Docs

  Add the proposal set for the next step:

  - `docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PHILOSOPHY.md`
  - `docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_THEORY.md`
  - `docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_SPEC.md`
  - `docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md`

  ## Why This PR Exists

  Weighted `min` is in an awkward middle state right now:

  - correctness is already in place
  - earlier frontier optimizations improved the runtime
  - but weighted `Min` is still slower than `All`

  This PR improves the current implementation again, while also documenting
  the next intended move so follow-up work is grounded in a concrete design.

  ## Runtime Semantics

  Unchanged:

  - per-path visited semantics are preserved
  - no duplicate nodes within a path
  - `Min` still matches `All` after downstream min aggregation
  - this is still exact weighted `min`, not an approximation

  The runtime change is a performance optimization only.

  ## Local Verification

  ### C# query-target suite

  Passed locally:

  ```bash
  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 230/230 tests passed

  ### Weighted benchmark

  Used:

  python examples/benchmark/benchmark_weighted_shortest_path.py --scales 300,1k,5k,10k --repetitions 1

  All scales still reported:

  - all_vs_min = match

  ## Benchmark Results After This Runtime Change

  | Scale | All | Min | Output Match |
  |---|---:|---:|---|
  | 300 | 0.666s | 0.786s | match |
  | 1k | 0.440s | 0.822s | match |
  | 5k | 1.220s | 2.852s | match |
  | 10k | 2.979s | 5.182s | match |

  ## Interpretation

  This runtime change is real, but still incremental:

  - weighted Min is materially better than the earlier merged baseline
  - weighted Min is still slower than All
  - the remaining problem looks algorithmic rather than purely
    data-structure-level

  That is why this PR also includes the SCC-condensed design docs.

  ## Design Direction Included in This PR

  The proposal set argues that the next meaningful improvement should be
  graph-structural:

  - compute SCCs
  - condense the graph to a DAG
  - use weighted min composition on the condensed graph
  - reserve exact path-aware reasoning for SCC interiors
  - keep the current exact frontier algorithm as fallback

  This is intended to reduce where we pay the expensive path-sensitive
  state cost.

  ## Proposed Next Step

  From the new implementation plan:

  1. add SCC measurement/instrumentation to the weighted benchmark/runtime
  2. record SCC structure for 300, 1k, 5k, and 10k
  3. use that data to decide how aggressively to pursue the condensed-graph
     runtime path

  ## Cross-Target Note

  The docs also make the sequencing explicit:

  - first improve the abstraction in the C# query engine
  - then extend Rust native lowering for:
      - counted closure Min
      - weighted accumulation Min

  The intent is for Rust to inherit the better abstraction rather than
  copying the current frontier-heavy intermediate form.