### PR TITLE
Document TypR wrapped fallback boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ includes:
 - guard-style command predicates such as `is_character/1`
 - unary TypR-safe I/O commands such as `cat/1` and `print/1`, emitted as
   native fixed-arity TypR calls
+- multi-argument output should still be composed explicitly, e.g.
+  `cat(paste("x =", x))`
 - multi-step native control-flow chains where an earlier output feeds a later
   guard and output
 - simple comparison and boolean guard expressions over already-bound
@@ -375,6 +377,10 @@ includes:
 - dataframe helpers such as `filter/3`, `sort_by/3`, and `group_by/3`
 
 More complex generic bodies still fall back to the wrapped R path.
+That currently includes generic string-transform/output-tail shapes such as
+`string_lower(Name, Lower), Out = Lower` or
+`string_length(Name, Len), Out is Len + 1`; the limiting step is the earlier
+producer goal, not the final assignment tail.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -505,6 +505,20 @@ Current implementation note:
   dataframe helper calls, and literal-guarded branch selection; more complex
   bodies still fall back to wrapped R
 
+Current wrapped-fallback boundary note:
+
+- simple assignment tails such as `Out = Lower` or `Out is Len + 1` do not by
+  themselves qualify a generic body for native TypR lowering when the earlier
+  producer goals still come from the R-backed generic path
+- representative cases are string-transform/output-tail bodies such as
+  `string_lower(Name, Lower), Out = Lower` and
+  `string_length(Name, Len), Out is Len + 1`
+- treat those as wrapped-fallback cases until the producer-goal layer itself
+  has a clean native TypR lowering
+- fixed-arity unary I/O stays native (`cat/1`, `print/1`), but variadic-style
+  output should still be composed with `paste` first, e.g.
+  `cat(paste("x =", x))`
+
 Follow-on work:
 
 1. Extend TypR beyond the current conservative native generic subset.

--- a/docs/handoff/typr-wrapped-fallback-boundary.md
+++ b/docs/handoff/typr-wrapped-fallback-boundary.md
@@ -1,0 +1,72 @@
+# TypR Wrapped Fallback Boundary
+
+## Current State
+
+Most high-traffic raw-R seams in the TypR target have already been reduced:
+
+- transitive closure control flow and loaders
+- recursive loop bodies
+- single-predicate helper bodies
+- mutual wrapper/helper bodies
+- fact-only boolean paths
+- fixed-arity unary I/O commands such as `cat/1` and `print/1`
+
+The main remaining generic raw-R seam is now the wrapped fallback path in:
+
+- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl:7334)
+- [src/unifyweaver/targets/typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl:8610)
+
+That seam is no longer “template noise.” It is the boundary for generic bodies
+that still rely on the R backend to express their body semantics.
+
+## Audit Result
+
+The first plausible promotion candidates were generic bodies shaped like:
+
+- `string_lower(Name, Lower), Out = Lower`
+- `string_length(Name, Len), Out is Len + 1`
+- `string_lower(Name, Lower), string_upper(Lower, Upper), Out = Upper`
+
+Those look close to the existing native assignment-tail logic, but they do not
+currently enter the native generic path for the right reason:
+
+- the assignment tail itself is simple
+- the earlier producer goals such as `string_lower/2` and `string_length/2`
+  are not on the native generic TypR binding path
+
+So promoting only the tail assignment is the wrong abstraction. The controlling
+boundary is the earlier generic producer step, not the final `=` or `is/2`.
+
+## Practical Boundary
+
+For now, treat the wrapped fallback as intentional for generic bodies whose
+main value-producing steps are only available through the R-backed lowering.
+
+That includes the current string-transform/output-tail shapes above.
+
+## Cat / Print Binding Constraint
+
+TypR-safe I/O bindings should remain explicit about fixed arity:
+
+- `cat/1` is fine
+- `print/1` is fine
+- variadic-style `cat("x =", x)` should not be modeled as a native TypR
+  variadic binding
+
+Preferred shape:
+
+```typr
+let x <- 42;
+cat(paste("x =", x));
+```
+
+## Recommended Next Step
+
+If this fallback seam is revisited, start by auditing the producer-goal layer,
+not the assignment tail:
+
+1. classify wrapped generic bodies by the first non-native producer goal
+2. promote only the first producer family that can be expressed cleanly in
+   native TypR
+3. if the producer remains fundamentally R-shaped, keep the wrapped fallback
+   and document it instead of forcing fake-native output

--- a/docs/suggestions/typr-target-improvements.md
+++ b/docs/suggestions/typr-target-improvements.md
@@ -9,6 +9,14 @@ type-checked. As TypR matures (especially variadic function support and
 environment/hash types), these blocks should be progressively replaced with
 native TypR constructs.
 
+Important current boundary:
+- the remaining generic wrapped fallback is not just an unnecessary wrapper
+- generic bodies like `string_lower(Name, Lower), Out = Lower` still depend on
+  the R-backed producer step, so promoting only the final assignment tail is
+  the wrong abstraction
+- if this area is revisited, start with the producer-goal family, not the
+  final `=` or `is/2` tail
+
 **Example:** `parent_graph <- @{ new.env(hash = TRUE, parent = emptyenv()) }@;`
 could become native when TypR supports environment types.
 


### PR DESCRIPTION
## Summary

This PR records the current TypR wrapped-fallback boundary instead of pretending the next remaining generic raw-R seam can be removed with another narrow codegen patch.

The audit showed that the remaining wrapped fallback is no longer just an unnecessary wrapper. The real boundary is earlier in the generic producer-goal layer.

## What This PR Does

- adds a handoff/design note for the remaining wrapped fallback seam
- updates TypR target docs to state the current boundary explicitly
- clarifies that fixed-arity TypR-safe I/O bindings such as `cat/1` and `print/1` remain native
- clarifies that multi-argument output should still be composed explicitly, for example:
  - `cat(paste("x =", x))`

## Audit Result

The first plausible promotion candidates were generic bodies shaped like:

- `string_lower(Name, Lower), Out = Lower`
- `string_length(Name, Len), Out is Len + 1`
- `string_lower(Name, Lower), string_upper(Lower, Upper), Out = Upper`

Those look close to the existing native assignment-tail logic, but they do not currently become native for the right reason:

- the final assignment tail is simple
- the earlier producer goals such as `string_lower/2` and `string_length/2` are still coming from the R-backed generic path

So promoting only the final `=` or `is/2` tail would be the wrong abstraction.

## Files Updated

- `docs/handoff/typr-wrapped-fallback-boundary.md`
- `README.md`
- `docs/design/TYPR_TARGET_DESIGN.md`
- `docs/suggestions/typr-target-improvements.md`

## Why This Is Better Than Another Small Patch

At this point, the high-value raw-R cleanup has already landed for:

- transitive closure control flow and loaders
- recursive loop bodies
- single-predicate helper bodies
- mutual wrapper/helper bodies
- fact-only boolean paths
- fixed-arity unary I/O commands like `cat/1` and `print/1`

What remains is a real design boundary. This PR makes that explicit so future work can target the producer-goal families directly instead of layering another partial nativeization on top of a still-R-backed body.

## Validation

- `git diff --check`
