### PR TITLE
perf(csharp-query): add positive min accumulation fast path

### DIFF
--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PHILOSOPHY.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PHILOSOPHY.md
@@ -3,23 +3,25 @@
 ## Why This Exists
 
 The current weighted `min` support for `PathAwareAccumulationNode` is
-correct, but not yet fast enough to justify its purpose.
+now split into two practical cases.
 
 That is a different situation from counted shortest path:
 
 - counted `min` on `PathAwareTransitiveClosureNode` already delivers the
   expected performance win
-- weighted `min` on `PathAwareAccumulationNode` still pays too much for
-  exact per-path state management
+- positive-additive weighted `min` on `PathAwareAccumulationNode` now
+  also has a fast runtime path based on layered dynamic programming
+- broader weighted `min` shapes with more path-sensitive continuation
+  still need a better structural solution than exact frontier tracking
 
-So the next step should not be another local frontier tweak alone. It
-should be a change in the **graph model** that reduces how much
-path-specific state the runtime has to remember.
+So the remaining next step is no longer "make weighted `min` fast at
+all." It is narrower: improve the cases that are not reducible to the
+current positive-additive fast path.
 
 ## Core Intuition
 
-The expensive part of weighted `min` today is not arithmetic. It is the
-fact that correctness depends on more than:
+For the remaining hard cases, the expensive part of weighted `min` is
+not arithmetic. It is the fact that correctness depends on more than:
 
 - current node
 - current accumulated cost
@@ -48,13 +50,15 @@ general graph:
 - much stronger pruning and dynamic-programming opportunities
 
 The Wikipedia-style category graph used in the benchmark is not fully
-acyclic, but its cycles are local rather than universal. That makes SCC
-condensation attractive because:
+acyclic, but the measured SCC structure is very favorable: only a small
+number of cyclic SCCs remain, and the largest cyclic SCC is small. That
+makes SCC condensation attractive because:
 
 - it removes global cyclic structure from the outer graph
 - it may sharply reduce the number of states that need exact visited-set
   tracking
-- it gives us a path toward `min` actually beating `all`
+- it gives us a path toward handling the broader weighted `min` cases
+  that are not already solved by the positive-additive fast path
 
 ## What This Is Not
 
@@ -81,11 +85,14 @@ That suggests the following hierarchy:
 1. Counted `min` on simple path-aware closure
    Use scalar best-known pruning.
 
-2. Weighted `min` on an SCC-condensed component DAG
+2. Weighted `min` on a positive-additive recurrence with hop bound
+   Use layered dynamic programming over `(node, depth)`.
+
+3. Weighted `min` on an SCC-condensed component DAG
    Use dynamic-programming or component-level best-known pruning where
    possible.
 
-3. Weighted `min` inside cyclic SCCs
+4. Weighted `min` inside cyclic SCCs
    Use exact path-aware state only where condensation does not remove the
    ambiguity.
 
@@ -114,7 +121,9 @@ This proposal should only be considered successful if it achieves both:
    weighted `min` workloads
 2. a clear runtime advantage over `All`, especially at larger scales
 
-The target is not just "less slow than before." The target is for
-weighted `min` to become meaningfully faster than full weighted path
-enumeration, even if the gain is smaller than the counted shortest-path
-case.
+That bar is now met for the positive-additive benchmarked case. The
+remaining success criterion for this SCC direction is narrower:
+
+1. preserve exact output agreement for the broader weighted `Min`
+   workload class
+2. beat the exact frontier fallback on those broader cases

--- a/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
+++ b/docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md
@@ -8,10 +8,14 @@ than `All` while preserving exact per-path semantics.
 Current status:
 
 - correctness is in place
-- local runtime optimizations reduced the cost of the exact frontier
-- weighted `min` is still slower than `All`
+- positive-additive weighted `min` now has a fast runtime path and
+  clearly beats `All`
+- SCC instrumentation is in place in the weighted benchmark harness
+- the remaining work is to broaden fast weighted `min` beyond the
+  positive-additive case
 
-So the next step must be algorithmic.
+So the next step remains algorithmic, but for a narrower class of
+workloads than when this plan was first drafted.
 
 ## Phase 0: Baseline Preservation
 
@@ -25,12 +29,21 @@ This gives us a known-correct baseline to compare against.
 
 ## Phase 1: Graph Structure Measurement
 
+Status: completed for the current benchmark harness.
+
 Add instrumentation to the weighted benchmark path to measure:
 
 - SCC count
 - SCC size distribution
 - largest SCC
 - condensation DAG size
+
+Current measured shape is favorable:
+
+- `10k`: `8247` nodes, `25227` edges
+- `8204` SCCs total
+- `17` cyclic SCCs
+- largest cyclic SCC size `35`
 
 Deliverable:
 
@@ -45,7 +58,8 @@ Reason:
 
 ## Phase 2: Internal Runtime Prototype
 
-Prototype a new internal runtime strategy for:
+Prototype a new internal runtime strategy for the remaining weighted
+`min` cases not already handled by the positive-additive fast path:
 
 - `PathAwareAccumulationNode`
 - `TableMode.Min`
@@ -71,10 +85,16 @@ Add a runtime applicability check:
 - use SCC-condensed strategy when safe
 - otherwise fall back to current exact frontier
 
-Possible early rule:
+Current selection boundary:
 
-- enable only for monotone additive `min`
-- disable for unsupported expression shapes
+- use the layered dynamic-programming fast path for strictly positive
+  additive `min`
+- use the exact frontier fallback otherwise
+
+Next selection work:
+
+- determine where SCC-condensed evaluation can replace the frontier
+  fallback safely
 
 Deliverable:
 
@@ -101,11 +121,17 @@ Track:
 - SCC metrics
 - local state counts
 
-Success criteria:
+Current positive-additive benchmark results already satisfy the intended
+performance goal:
 
-- exact output match at all scales
-- weighted `min` faster than `all` at larger scales
-- visible crossover toward a meaningful win, ideally around `2x`
+- `300`: `3.41x`
+- `1k`: `3.17x`
+- `5k`: `5.03x`
+- `10k`: `6.98x`
+
+So for the SCC work, success criteria should be read as applying to the
+broader remaining weighted `min` cases that still fall back to the exact
+frontier algorithm.
 
 ## Phase 5: Documentation and Rollout
 
@@ -156,11 +182,17 @@ Mitigation:
 
 ## Immediate Next Coding Step
 
-The first code step after this document set should be:
+The original first code step after this document set was:
 
 1. add SCC measurement instrumentation to the weighted benchmark/runtime
 2. record actual SCC structure for `300/1k/5k/10k`
 3. decide whether the component-DAG strategy is justified by the data
 
-That keeps the next implementation grounded in the actual graph rather
-than intuition alone.
+That step is now complete.
+
+The next coding step should be:
+
+1. identify weighted `Min` recurrence shapes not covered by the current
+   positive-additive fast path
+2. prototype SCC-condensed evaluation for one of those broader cases
+3. benchmark it against the exact frontier fallback

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -223,6 +223,41 @@ python examples/benchmark/benchmark_weighted_shortest_path.py \
     --scales 300,1k,5k,10k
 ```
 
+### Weighted `Min` Results
+
+The current positive-additive weighted `Min` fast path in the C# query
+engine is now materially faster than `All` while preserving exact output
+agreement on the benchmarked workload.
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_weighted_shortest_path.py \
+    --scales 300,1k,5k,10k --repetitions 1
+```
+
+Latest local results:
+
+| Scale | All | Min | Speedup | Output Match |
+|-------|-----|-----|---------|--------------|
+| 300 | 0.627s | 0.184s | 3.41x | match |
+| 1k | 0.440s | 0.139s | 3.17x | match |
+| 5k | 1.188s | 0.236s | 5.03x | match |
+| 10k | 2.930s | 0.419s | 6.98x | match |
+
+The same run also reports SCC metrics for the category graph. At `10k`
+the graph has:
+
+- `8247` nodes
+- `25227` edges
+- `8204` SCCs
+- `17` cyclic SCCs
+- largest cyclic SCC size `35`
+
+That matters because it suggests the remaining hard cyclic structure is
+small and localized, which is favorable for future SCC-condensed
+strategies on broader weighted `Min` workloads.
+
 ### Available Targets
 
 | Target | Flag | Run Command |

--- a/examples/benchmark/benchmark_weighted_shortest_path.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path.py
@@ -78,6 +78,9 @@ class Program
         var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
         var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
+        var adjacency = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var allNodes = new HashSet<string>(StringComparer.Ordinal);
+        var edgeCount = 0;
 
         foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
         {
@@ -95,6 +98,22 @@ class Program
             provider.AddFact(edgeId, parts[0], parts[1]);
             sourceNodes.Add(parts[0]);
             outDegree[parts[0]] = outDegree.TryGetValue(parts[0], out var degree) ? degree + 1 : 1;
+            allNodes.Add(parts[0]);
+            allNodes.Add(parts[1]);
+            edgeCount++;
+
+            if (!adjacency.TryGetValue(parts[0], out var neighbors))
+            {
+                neighbors = new List<string>();
+                adjacency[parts[0]] = neighbors;
+            }
+
+            neighbors.Add(parts[1]);
+        }
+
+        foreach (var node in allNodes)
+        {
+            adjacency.TryAdd(node, new List<string>());
         }
 
         foreach (var source in sourceNodes)
@@ -126,6 +145,7 @@ class Program
             categories.Add(parts[1]);
         }
 
+        var sccStats = ComputeSccStats(adjacency);
         swLoad.Stop();
 
         var plan = new QueryPlan(
@@ -235,7 +255,126 @@ class Program
         Console.Error.WriteLine($"seed_count={seedParams.Count}");
         Console.Error.WriteLine($"tuple_count={rows.Count}");
         Console.Error.WriteLine($"article_count={results.Count}");
+        Console.Error.WriteLine($"graph_nodes={allNodes.Count}");
+        Console.Error.WriteLine($"graph_edges={edgeCount}");
+        Console.Error.WriteLine($"scc_count={sccStats.SccCount}");
+        Console.Error.WriteLine($"cyclic_scc_count={sccStats.CyclicSccCount}");
+        Console.Error.WriteLine($"largest_scc={sccStats.LargestScc}");
+        Console.Error.WriteLine($"largest_cyclic_scc={sccStats.LargestCyclicScc}");
+        Console.Error.WriteLine($"condensed_edges={sccStats.CondensedEdgeCount}");
     }
+
+    static SccStats ComputeSccStats(Dictionary<string, List<string>> adjacency)
+    {
+        var index = 0;
+        var indexMap = new Dictionary<string, int>(StringComparer.Ordinal);
+        var lowLink = new Dictionary<string, int>(StringComparer.Ordinal);
+        var onStack = new HashSet<string>(StringComparer.Ordinal);
+        var stack = new Stack<string>();
+        var componentByNode = new Dictionary<string, int>(StringComparer.Ordinal);
+        var componentSizes = new List<int>();
+        var componentHasSelfLoop = new List<bool>();
+
+        void StrongConnect(string node)
+        {
+            indexMap[node] = index;
+            lowLink[node] = index;
+            index++;
+            stack.Push(node);
+            onStack.Add(node);
+
+            foreach (var next in adjacency[node])
+            {
+                if (!indexMap.ContainsKey(next))
+                {
+                    StrongConnect(next);
+                    lowLink[node] = Math.Min(lowLink[node], lowLink[next]);
+                }
+                else if (onStack.Contains(next))
+                {
+                    lowLink[node] = Math.Min(lowLink[node], indexMap[next]);
+                }
+            }
+
+            if (lowLink[node] == indexMap[node])
+            {
+                var componentId = componentSizes.Count;
+                var size = 0;
+                var hasSelfLoop = false;
+
+                while (true)
+                {
+                    var member = stack.Pop();
+                    onStack.Remove(member);
+                    componentByNode[member] = componentId;
+                    size++;
+                    if (adjacency[member].Contains(member, StringComparer.Ordinal))
+                    {
+                        hasSelfLoop = true;
+                    }
+
+                    if (member == node)
+                    {
+                        break;
+                    }
+                }
+
+                componentSizes.Add(size);
+                componentHasSelfLoop.Add(hasSelfLoop);
+            }
+        }
+
+        foreach (var node in adjacency.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            if (!indexMap.ContainsKey(node))
+            {
+                StrongConnect(node);
+            }
+        }
+
+        var condensedEdges = new HashSet<(int From, int To)>();
+        foreach (var (from, neighbors) in adjacency)
+        {
+            var fromComponent = componentByNode[from];
+            foreach (var to in neighbors)
+            {
+                var toComponent = componentByNode[to];
+                if (fromComponent != toComponent)
+                {
+                    condensedEdges.Add((fromComponent, toComponent));
+                }
+            }
+        }
+
+        var cyclicSccCount = 0;
+        var largestScc = 0;
+        var largestCyclicScc = 0;
+        for (var i = 0; i < componentSizes.Count; i++)
+        {
+            var size = componentSizes[i];
+            largestScc = Math.Max(largestScc, size);
+            var isCyclic = size > 1 || componentHasSelfLoop[i];
+            if (isCyclic)
+            {
+                cyclicSccCount++;
+                largestCyclicScc = Math.Max(largestCyclicScc, size);
+            }
+        }
+
+        return new SccStats(
+            componentSizes.Count,
+            cyclicSccCount,
+            largestScc,
+            largestCyclicScc,
+            condensedEdges.Count);
+    }
+
+    readonly record struct SccStats(
+        int SccCount,
+        int CyclicSccCount,
+        int LargestScc,
+        int LargestCyclicScc,
+        int CondensedEdgeCount);
 }
 """
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -7182,6 +7182,9 @@ namespace UnifyWeaver.QueryRuntime
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
                 var seeds = new List<object?>();
                 var seenSeeds = new HashSet<object?>();
+                PositiveStepEvaluator? stepEvaluator = null;
+                var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
+                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, out stepEvaluator);
 
                 foreach (var edge in edges)
                 {
@@ -7201,7 +7204,14 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    if (usePositiveMinFastPath)
+                    {
+                        AppendPositiveMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
+                    }
+                    else
+                    {
+                        AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    }
                 }
 
                 return totalRows;
@@ -7235,6 +7245,9 @@ namespace UnifyWeaver.QueryRuntime
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
                 var seeds = new List<object?>();
                 var seenSeeds = new HashSet<object?>();
+                PositiveStepEvaluator? stepEvaluator = null;
+                var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
+                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, out stepEvaluator);
 
                 foreach (var paramTuple in parameters)
                 {
@@ -7258,7 +7271,14 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    if (usePositiveMinFastPath)
+                    {
+                        AppendPositiveMinAccumulationRowsForSeed(seed, succIndex, auxIndex, stepEvaluator!, totalRows, closure.MaxDepth);
+                    }
+                    else
+                    {
+                        AppendPathAwareAccumulationRowsForSeed(seed, succIndex, auxIndex, closure.BaseExpression, closure.RecursiveExpression, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    }
                 }
 
                 return totalRows;
@@ -7268,6 +7288,216 @@ namespace UnifyWeaver.QueryRuntime
                 context.FixpointDepth--;
             }
         }
+
+        private delegate double PositiveStepEvaluator(object current, object next, object auxValue);
+
+        // For strictly positive additive steps, the minimum-cost walk within a hop
+        // budget is simple automatically. That lets us replace the expensive
+        // visited-state frontier with dynamic programming over (node, depth).
+        private void AppendPositiveMinAccumulationRowsForSeed(
+            object? seed,
+            IReadOnlyDictionary<object, List<object[]>> succIndex,
+            IReadOnlyDictionary<object, List<object[]>> auxIndex,
+            PositiveStepEvaluator stepEvaluator,
+            ICollection<object[]> output,
+            int maxDepth = 0)
+        {
+            var effectiveMaxDepth = maxDepth > 0 ? maxDepth : int.MaxValue;
+            var depthCosts = new List<Dictionary<object?, double>>(effectiveMaxDepth == int.MaxValue ? 16 : effectiveMaxDepth + 1)
+            {
+                new Dictionary<object?, double> { [seed] = 0d }
+            };
+            var bestKnown = new Dictionary<object?, double>();
+
+            for (var depth = 0; depth < effectiveMaxDepth && depth < depthCosts.Count; depth++)
+            {
+                var currentLayer = depthCosts[depth];
+                if (currentLayer.Count == 0)
+                {
+                    continue;
+                }
+
+                foreach (var (current, currentCost) in currentLayer)
+                {
+                    var currentKey = current ?? NullFactIndexKey;
+                    if (!succIndex.TryGetValue(currentKey, out var edgeBucket) || !auxIndex.TryGetValue(currentKey, out var auxBucket))
+                    {
+                        continue;
+                    }
+
+                    var nextDepth = depth + 1;
+                    if (nextDepth > effectiveMaxDepth)
+                    {
+                        continue;
+                    }
+
+                    while (depthCosts.Count <= nextDepth)
+                    {
+                        depthCosts.Add(new Dictionary<object?, double>());
+                    }
+
+                    var nextLayer = depthCosts[nextDepth];
+                    for (var edgeIndex = edgeBucket.Count - 1; edgeIndex >= 0; edgeIndex--)
+                    {
+                        var edge = edgeBucket[edgeIndex];
+                        if (edge is null || edge.Length < 2)
+                        {
+                            continue;
+                        }
+
+                        var next = edge[1];
+                        for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
+                        {
+                            var auxRow = auxBucket[auxIndexPos];
+                            if (auxRow is null || auxRow.Length < 2)
+                            {
+                                continue;
+                            }
+
+                            var step = stepEvaluator(current!, next!, auxRow[1]!);
+                            var nextCost = currentCost + step;
+
+                            if (!nextLayer.TryGetValue(next, out var existingCost) || nextCost < existingCost)
+                            {
+                                nextLayer[next] = nextCost;
+                            }
+
+                            if (!bestKnown.TryGetValue(next, out var bestCost) || nextCost < bestCost)
+                            {
+                                bestKnown[next] = nextCost;
+                            }
+                        }
+                    }
+                }
+            }
+
+            var bestRows = bestKnown
+                .OrderBy(kvp => kvp.Key, Comparer<object?>.Create(CompareCacheSeedValues))
+                .ToList();
+            foreach (var (target, cost) in bestRows)
+            {
+                output.Add(new object[] { seed!, target!, cost });
+            }
+        }
+
+        private bool TryCreatePositiveAdditiveStepEvaluator(
+            ArithmeticExpression baseExpression,
+            ArithmeticExpression recursiveExpression,
+            IReadOnlyDictionary<object, List<object[]>> succIndex,
+            IReadOnlyDictionary<object, List<object[]>> auxIndex,
+            out PositiveStepEvaluator? evaluator)
+        {
+            evaluator = null;
+            if (!TryExtractMinStepExpression(baseExpression, recursiveExpression, out var stepExpression))
+            {
+                return false;
+            }
+
+            foreach (var (currentKey, edgeBucket) in succIndex)
+            {
+                if (!auxIndex.TryGetValue(currentKey, out var auxBucket))
+                {
+                    continue;
+                }
+
+                foreach (var edge in edgeBucket)
+                {
+                    if (edge is null || edge.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    foreach (var auxRow in auxBucket)
+                    {
+                        if (auxRow is null || auxRow.Length < 2)
+                        {
+                            continue;
+                        }
+
+                        var evalTuple = new object[] { edge[0]!, edge[1]!, 0, auxRow[1]! };
+                        var stepObject = EvaluateArithmeticExpression(stepExpression, evalTuple);
+                        double step;
+                        try
+                        {
+                            step = Convert.ToDouble(stepObject, CultureInfo.InvariantCulture);
+                        }
+                        catch
+                        {
+                            return false;
+                        }
+
+                        if (!(step > 0d))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            evaluator = (current, next, auxValue) =>
+            {
+                var evalTuple = new object[] { current, next, 0, auxValue };
+                var stepObject = EvaluateArithmeticExpression(stepExpression, evalTuple);
+                return Convert.ToDouble(stepObject, CultureInfo.InvariantCulture);
+            };
+            return true;
+        }
+
+        private static bool TryExtractMinStepExpression(
+            ArithmeticExpression baseExpression,
+            ArithmeticExpression recursiveExpression,
+            out ArithmeticExpression stepExpression)
+        {
+            stepExpression = baseExpression;
+            if (ReferencesAccumulator(baseExpression))
+            {
+                return false;
+            }
+
+            if (recursiveExpression is not BinaryArithmeticExpression { Operator: ArithmeticBinaryOperator.Add } add)
+            {
+                return false;
+            }
+
+            if (add.Left is ColumnExpression { Index: 2 } && ArithmeticExpressionStructuralEquals(baseExpression, add.Right))
+            {
+                stepExpression = add.Right;
+                return true;
+            }
+
+            if (add.Right is ColumnExpression { Index: 2 } && ArithmeticExpressionStructuralEquals(baseExpression, add.Left))
+            {
+                stepExpression = add.Left;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool ReferencesAccumulator(ArithmeticExpression expression) =>
+            expression switch
+            {
+                ColumnExpression { Index: 2 } => true,
+                ColumnExpression => false,
+                ConstantExpression => false,
+                UnaryArithmeticExpression unary => ReferencesAccumulator(unary.Operand),
+                BinaryArithmeticExpression binary => ReferencesAccumulator(binary.Left) || ReferencesAccumulator(binary.Right),
+                _ => true
+            };
+
+        private static bool ArithmeticExpressionStructuralEquals(ArithmeticExpression left, ArithmeticExpression right) =>
+            (left, right) switch
+            {
+                (ColumnExpression l, ColumnExpression r) => l.Index == r.Index,
+                (ConstantExpression l, ConstantExpression r) => Equals(l.Value, r.Value),
+                (UnaryArithmeticExpression l, UnaryArithmeticExpression r) =>
+                    l.Operator == r.Operator && ArithmeticExpressionStructuralEquals(l.Operand, r.Operand),
+                (BinaryArithmeticExpression l, BinaryArithmeticExpression r) =>
+                    l.Operator == r.Operator &&
+                    ArithmeticExpressionStructuralEquals(l.Left, r.Left) &&
+                    ArithmeticExpressionStructuralEquals(l.Right, r.Right),
+                _ => false
+            };
 
         private void AppendPathAwareAccumulationRowsForSeed(
             object? seed,


### PR DESCRIPTION
  ## Summary

  This PR makes weighted `min` tabling on `PathAwareAccumulationNode`
  actually fast for the current positive-additive benchmark class.

  It does two things:

  1. add a new C# query-runtime fast path for weighted `min` when the
     recurrence is strictly positive and additive
  2. update benchmark/docs material to reflect the new results and the
     narrower remaining scope for SCC-condensed follow-up work

  ## What Changed

  ### Runtime

  In:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  the C# query engine now recognizes a safe weighted `min` fast path for
  `PathAwareAccumulationNode` when:

  - `AccumulatorMode == TableMode.Min`
  - the recurrence is additive
  - the step does not depend on the previous accumulator except through
    `prev + step`
  - the evaluated step is strictly positive on the workload

  For that case, the runtime uses layered dynamic programming over
  `(node, depth)` instead of the more expensive exact visited-state
  frontier.

  This keeps exact answers while removing most of the cost that made the
  previous weighted `min` implementation slower than `All`.

  ### Benchmarking

  In:

  - `examples/benchmark/benchmark_weighted_shortest_path.py`

  the weighted shortest-path benchmark now also reports graph structure:

  - node count
  - edge count
  - SCC count
  - cyclic SCC count
  - largest SCC
  - largest cyclic SCC
  - condensation edge count

  This was added to ground the SCC-condensed design work in actual graph
  data rather than intuition.

  ### Documentation

  Updated:

  - `examples/benchmark/README.md`
  - `docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PHILOSOPHY.md`
  - `docs/proposals/SCC_CONDENSED_WEIGHTED_MIN_PLAN.md`

  The docs now reflect that:

  - positive-additive weighted `min` is no longer the unsolved case
  - the current benchmarked weighted `min` path is fast and exact
  - the SCC-condensed work is now aimed at broader fallback cases beyond
    the new fast path

  ## Why This Matters

  Before this PR, weighted `min` on `PathAwareAccumulationNode` was
  correct, but still slower than `All`, even after multiple runtime
  optimizations.

  After this PR, the benchmarked positive-additive weighted `min` case is
  clearly faster than `All` at every tested scale while still producing
  matching outputs.

  That means the weighted `min` feature is now practically useful, not
  just semantically correct.

  ## Verification

  ### C# query-target suite

  Passed locally:

  ```bash
  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 230/230 tests passed

  ### Weighted benchmark

  Used:

  python examples/benchmark/benchmark_weighted_shortest_path.py --scales 300,1k,5k,10k --repetitions 1

  All scales reported:

  - all_vs_min = match

  ## Benchmark Results

  | Scale | All | Min | Speedup | Output Match |
  |---|---:|---:|---:|---|
  | 300 | 0.627s | 0.184s | 3.41x | match |
  | 1k | 0.440s | 0.139s | 3.17x | match |
  | 5k | 1.188s | 0.236s | 5.03x | match |
  | 10k | 2.930s | 0.419s | 6.98x | match |

  ## Graph Structure Metrics

  The same benchmark now reports SCC structure for the category graph.

  At 10k:

  - 8247 graph nodes
  - 25227 graph edges
  - 8204 SCCs
  - 17 cyclic SCCs
  - largest cyclic SCC size 35
  - 25118 condensation edges

  This is useful because it shows the remaining cyclic structure is small
  and localized, which is favorable for the broader SCC-condensed follow-up
  design.

  ## Semantics

  This PR does not relax correctness.

  The weighted min fast path is only used when the runtime can prove the
  recurrence matches the safe positive-additive shape.

  Otherwise, the runtime still falls back to the exact frontier-based
  implementation.

  So the semantics remain:

  - exact weighted min
  - per-path correctness preserved
  - no output changes relative to All + downstream min

  ## Follow-Up

  This PR substantially solves the current benchmarked weighted min
  performance problem.

  The remaining follow-up work is narrower:

  - broaden fast weighted min beyond the current positive-additive case
  - use the SCC metrics and design docs to target fallback cases that
    still need structural optimization
  - extend Rust native lowering for the new min features once the C#
    runtime abstraction is stable enough to mirror