### PR TITLE
feat: recursive E2E, nested compound unification, and write mode

### DIFF
--- a/archive/pr_descriptions/PR_WAM_PUT_STRUCTURE.md
+++ b/archive/pr_descriptions/PR_WAM_PUT_STRUCTURE.md
@@ -1,0 +1,23 @@
+# PR: feat: add put_structure compound term support and document CP safety
+
+**Title:** `feat: add put_structure compound term support and CP safety docs`
+
+## Summary
+
+- Implement `put_structure`/`set_variable`/`set_value`/`set_constant` in the WAM compiler and runtime, enabling compound term construction in body goals (e.g., `foo(pair(X, done))`)
+- Add `compile_set_arguments/4` helper to emit `set_*` sequences for compound sub-arguments
+- Document the CP (Continuation Pointer) safety invariant: `call` safely overwrites CP because `allocate` always precedes it in multi-goal bodies, and single-goal bodies use `execute` instead
+- Add `test_wam_put_structure` test covering compound body argument compilation
+
+## Test plan
+
+- [x] All 5 existing WAM target tests pass
+- [x] Both E2E tests pass (fact execution + backtracking)
+- [x] New `test_wam_put_structure` verifies `put_structure pair/2` appears in compiled output for `test_wrap/1`
+- [x] Verified compiled output manually: `put_structure pair/2, A1` / `set_value X1` / `set_constant done` sequence is correct
+
+## Companion PR
+
+- Education repo: `docs: document put_structure and set_* instructions in Book 17` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/archive/pr_descriptions/PR_WAM_PUT_STRUCTURE_DOCS.md
+++ b/archive/pr_descriptions/PR_WAM_PUT_STRUCTURE_DOCS.md
@@ -1,0 +1,20 @@
+# PR: docs: document put_structure and set_* instructions in Book 17
+
+**Title:** `docs: document put_structure and set_* instructions in Book 17`
+
+## Summary
+
+- Add `put_structure`, `set_variable`, `set_value`, `set_constant` documentation to Chapter 2 (ISA) with descriptions of heap construction semantics
+- Add compound body argument compilation example (`wrap/1 :- check(pair(X, done))`) to Chapter 3 with annotated WAM output
+- Update README instruction table to include `set_*` instructions under Body Construction
+
+## Test plan
+
+- [x] Documentation matches actual compiler output (verified against `wam_target.pl`)
+- [x] Examples are consistent with the ISA definitions
+
+## Companion PR
+
+- Main repo: `feat: add put_structure compound term support and CP safety docs` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/archive/pr_descriptions/PR_WAM_TRAIL_TESTS.md
+++ b/archive/pr_descriptions/PR_WAM_TRAIL_TESTS.md
@@ -1,0 +1,24 @@
+# PR: feat: add trail unwinding on backtrack and harden test harness
+
+**Title:** `feat: add WAM trail unwinding and CI-compatible test harness`
+
+## Summary
+
+- Implement trail-based register unwinding in the WAM runtime so backtracking correctly restores register state instead of carrying stale bindings
+- Register-mutating instructions (`get_variable`, `put_variable`, `put_value`, `put_constant`) now record `trail(Key, OldValue)` entries before mutation
+- `backtrack/2` diffs the current trail against the saved trail from the choice point and undoes bindings in reverse order
+- Harden both `test_wam_target.pl` and `test_wam_e2e.pl` to exit with `halt(1)` on any test failure, making them CI-compatible (previously printed `[FAIL]` but exited 0)
+
+## Test plan
+
+- [x] All 5 WAM target compiler tests pass
+- [x] Both E2E tests pass (fact execution + backtracking to second fact)
+- [x] Verified exit code is 0 on success
+- [x] Verified `halt(1)` path is wired correctly via `test_failed/0` dynamic predicate
+- [x] No warnings (renamed `del_assoc/4` to `remove_assoc_key/4` to avoid assoc library conflict)
+
+## Companion PR
+
+- Education repo: `docs: document unify_* instructions in Book 17 ISA` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/archive/pr_descriptions/PR_WAM_TRAIL_TESTS_DOCS.md
+++ b/archive/pr_descriptions/PR_WAM_TRAIL_TESTS_DOCS.md
@@ -1,0 +1,20 @@
+# PR: docs: document unify_* instructions in Book 17 ISA
+
+**Title:** `docs: document unify_variable, unify_value, unify_constant in Book 17`
+
+## Summary
+
+- Add `unify_variable(Xn)`, `unify_value(Xn)`, and `unify_constant(C)` to the head unification section of Chapter 2 (ISA)
+- These instructions are emitted by the compiler inside `get_structure` sequences but were previously undocumented
+- Clarify that `get_structure(F/N, Ai)` must be followed by N `unify_*` instructions for sub-argument matching
+
+## Test plan
+
+- [x] Documentation matches compiler implementation in `compile_unify_arguments/4`
+- [x] Instruction descriptions are consistent with runtime `step_wam` clauses
+
+## Companion PR
+
+- Main repo: `feat: add WAM trail unwinding and CI-compatible test harness` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/archive/pr_descriptions/PR_WAM_YI_UNIFY_E2E.md
+++ b/archive/pr_descriptions/PR_WAM_YI_UNIFY_E2E.md
@@ -1,0 +1,26 @@
+# PR: feat: Yi permanent variables, unify_* runtime, and E2E rule test
+
+**Title:** `feat: Yi permanent variables, unify_* runtime, and E2E rule test`
+
+## Summary
+
+- Implement automatic permanent variable (Yi) allocation in the WAM compiler — variables that survive across `call` boundaries are detected and assigned Yi registers stored in the environment frame, while temporaries remain in Xi registers
+- Emit `allocate` before head instructions so `get_variable Yi, Ai` can write directly to the environment frame; place `deallocate` after `put_value Yi` reads but before `execute` for correct TCO
+- Add runtime `step_wam` clauses for `get_structure`, `unify_variable`, `unify_value`, and `unify_constant` enabling compound head term matching via a `unify_ctx` stack mechanism
+- Add Yi register support in the runtime via `get_reg`/`put_reg` helpers that dispatch to the environment frame for Y-prefixed registers
+- Extend `get_constant` and `get_value` to perform unification with unbound variables (not just strict equality), enabling rule execution with variable arguments
+- Add E2E test that compiles `parent/2` facts + `grandparent/2` rule into WAM and executes `grandparent(alice, charlie)` through the full pipeline
+
+## Test plan
+
+- [x] All 5 WAM target compiler tests pass (facts, single clause, recursion, put_structure, module)
+- [x] All 3 E2E tests pass — including new `test_wam_rule_execution` for grandparent
+- [x] Verified compiled output shows correct Yi allocation: `get_variable Y2, A2` in head, `put_variable Y1, A2` / `put_value Y1, A1` / `put_value Y2, A2` in body
+- [x] Verified `deallocate` appears after Yi reads, before `execute`
+- [x] Exit code 0 on success, 1 on failure (CI-compatible)
+
+## Companion PR
+
+- Education repo: `docs: update Book 17 for Yi permanent variables and correct WAM output` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/archive/pr_descriptions/PR_WAM_YI_UNIFY_E2E_DOCS.md
+++ b/archive/pr_descriptions/PR_WAM_YI_UNIFY_E2E_DOCS.md
@@ -1,0 +1,20 @@
+# PR: docs: update Book 17 for Yi permanent variables and correct WAM output
+
+**Title:** `docs: update Book 17 for Yi permanent variables and correct WAM output`
+
+## Summary
+
+- Update Yi register documentation in Chapter 2 (ISA) from "planned enhancement" to fully implemented, with explanation of automatic permanent variable detection and environment frame storage
+- Update `grandparent/2` and `ancestor/2` compilation examples in Chapter 3 to show correct Yi register allocation with annotated WAM output
+- Document the `allocate`-before-head and `deallocate`-after-Yi-reads placement rationale
+
+## Test plan
+
+- [x] Documentation examples match actual compiler output
+- [x] Yi register descriptions consistent with runtime `get_reg`/`put_reg` behavior
+
+## Companion PR
+
+- Main repo: `feat: Yi permanent variables, unify_* runtime, and E2E rule test` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -76,9 +76,17 @@ parse_instr(Str, Term) :-
         sub_string(Str, _, After, 0, ArgsStr),
         atom_string(Op, OpStr),
         split_string(ArgsStr, ",", " \t", ArgList),
-        maplist(atom_string, ArgAtoms, ArgList),
+        maplist(parse_arg, ArgList, ArgAtoms),
         Term =.. [Op|ArgAtoms]
     ;   atom_string(Term, Str)
+    ).
+
+%% parse_arg(+String, -Value)
+%  Converts a string argument to an atom, or a number if it looks numeric.
+parse_arg(Str, Val) :-
+    (   number_string(Num, Str)
+    ->  Val = Num
+    ;   atom_string(Val, Str)
     ).
 
 init_state(Goal, Code, Labels, wam_state(PC, Regs, [], [], [], halt, [], Code, Labels)) :-
@@ -120,8 +128,10 @@ fetch_instr(wam_state(PC, _, _, _, _, _, _, Code, _), Instr) :-
 %  choice point was created. On backtrack, we restore registers to their
 %  saved state from the choice point, then apply trail entries to undo any
 %  bindings that leaked into the saved register set.
+%% backtrack restores state from the top choice point but does NOT pop it.
+%% The choice point is removed by trust_me, or updated by retry_me_else.
 backtrack(wam_state(_, _, _, _, Trail, _, [cp(NextPC, R, S, CP, SavedTrail)|CPs], Code, L),
-          wam_state(NextPC, RestoredR, S, [], SavedTrail, CP, CPs, Code, L)) :-
+          wam_state(NextPC, RestoredR, S, [], SavedTrail, CP, [cp(NextPC, R, S, CP, SavedTrail)|CPs], Code, L)) :-
     unwind_trail(Trail, SavedTrail, R, RestoredR).
 
 %% unwind_trail(+CurrentTrail, +SavedTrail, +Regs, -RestoredRegs)
@@ -187,18 +197,35 @@ step_wam(get_value(Xn, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_sta
     ;   fail
     ).
 
-%% get_structure F/N, Ai — checks that Ai holds a compound term with functor F
-%  and arity N. On success, pushes the sub-arguments as a unify context onto
-%  the stack so that subsequent unify_* instructions can consume them.
-step_wam(get_structure(FN, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, [unify_ctx(SubArgs)|S], H, T, CP, CPS, Code, L)) :-
+%% get_structure F/N, Ai — two modes:
+%  Read mode: Ai holds a compound term — verify functor/arity and push sub-args
+%  as unify_ctx for subsequent unify_* instructions to match.
+%  Write mode: Ai holds an unbound variable — allocate a structure on the heap,
+%  bind Ai to it, and push write_ctx so unify_* instructions build sub-args.
+step_wam(get_structure(FN, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), StateOut) :-
     get_assoc(Ai, R, Val),
-    Val =.. [F|SubArgs],
-    length(SubArgs, Arity),
-    format(atom(FN_check), "~w/~w", [F, Arity]),
-    FN_check == FN,
-    NPC is PC + 1.
+    (   is_unbound_var(Val)
+    ->  % Write mode: construct structure on heap
+        length(H, Addr),
+        append(H, [str(FN)], NH),
+        trail_binding(Ai, R, T, NT),
+        put_assoc(Ai, R, ref(Addr), NR),
+        atom_string(FN, FNStr),
+        split_string(FNStr, "/", "", [_, ArStr]),
+        number_string(WriteArity, ArStr),
+        NPC is PC + 1,
+        StateOut = wam_state(NPC, NR, [write_ctx(WriteArity)|S], NH, NT, CP, CPS, Code, L)
+    ;   % Read mode: match existing structure
+        Val =.. [F|SubArgs],
+        length(SubArgs, Arity),
+        format(atom(FN_check), "~w/~w", [F, Arity]),
+        FN_check == FN,
+        NPC is PC + 1,
+        StateOut = wam_state(NPC, R, [unify_ctx(SubArgs)|S], H, T, CP, CPS, Code, L)
+    ).
 
-%% unify_variable Xn — in read mode, binds the next sub-argument to Xn.
+%% unify_variable Xn — read mode: bind next sub-arg to Xn.
+%%                     write mode: create new var on heap and bind Xn to it.
 step_wam(unify_variable(Xn), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, CP, CPS, Code, L),
          wam_state(NPC, NR, NewS, H, NT, CP, CPS, Code, L)) :-
     trail_binding(Xn, R, T, NT),
@@ -208,8 +235,19 @@ step_wam(unify_variable(Xn), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, 
     ),
     put_reg(Xn, Arg, R, NR, BaseS, NewS),
     NPC is PC + 1.
+step_wam(unify_variable(Xn), wam_state(PC, R, [write_ctx(N)|S], H, T, CP, CPS, Code, L),
+         wam_state(NPC, NR, NewS, NH, T, CP, CPS, Code, L)) :-
+    N > 0,
+    length(H, Addr),
+    format(atom(Var), "_H~w", [Addr]),
+    append(H, [Var], NH),
+    N1 is N - 1,
+    (   N1 == 0 -> BaseS = S ; BaseS = [write_ctx(N1)|S] ),
+    put_reg(Xn, Var, R, NR, BaseS, NewS),
+    NPC is PC + 1.
 
-%% unify_value Xn — in read mode, checks that the next sub-argument matches Xn.
+%% unify_value Xn — read mode: check next sub-arg matches Xn.
+%%                   write mode: push value of Xn onto heap.
 step_wam(unify_value(Xn), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, CP, CPS, Code, L),
          wam_state(NPC, R, NewS, H, T, CP, CPS, Code, L)) :-
     get_reg(Xn, R, S, Val),
@@ -219,8 +257,17 @@ step_wam(unify_value(Xn), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, 
     ;   NewS = [unify_ctx(RestArgs)|S]
     ),
     NPC is PC + 1.
+step_wam(unify_value(Xn), wam_state(PC, R, [write_ctx(N)|S], H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, NewS, NH, T, CP, CPS, Code, L)) :-
+    N > 0,
+    get_reg(Xn, R, S, Val),
+    append(H, [Val], NH),
+    N1 is N - 1,
+    (   N1 == 0 -> NewS = S ; NewS = [write_ctx(N1)|S] ),
+    NPC is PC + 1.
 
-%% unify_constant C — in read mode, checks that the next sub-argument is constant C.
+%% unify_constant C — read mode: check next sub-arg equals C.
+%%                     write mode: push C onto heap.
 step_wam(unify_constant(C), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T, CP, CPS, Code, L),
          wam_state(NPC, R, NewS, H, T, CP, CPS, Code, L)) :-
     Arg == C,
@@ -228,6 +275,13 @@ step_wam(unify_constant(C), wam_state(PC, R, [unify_ctx([Arg|RestArgs])|S], H, T
     ->  NewS = S
     ;   NewS = [unify_ctx(RestArgs)|S]
     ),
+    NPC is PC + 1.
+step_wam(unify_constant(C), wam_state(PC, R, [write_ctx(N)|S], H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, NewS, NH, T, CP, CPS, Code, L)) :-
+    N > 0,
+    append(H, [C], NH),
+    N1 is N - 1,
+    (   N1 == 0 -> NewS = S ; NewS = [write_ctx(N1)|S] ),
     NPC is PC + 1.
 
 step_wam(put_constant(C, Ai), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -199,7 +199,18 @@ compile_unify_arguments([Arg|Rest], V0, Vf, Code) :-
     ;   atomic(Arg)
     ->  format(string(ArgCode), "    unify_constant ~w", [Arg]),
         V1 = V0
-    ;   % Nested structure
+    ;   % Nested structure — emit unify_variable for a temp register,
+        % then get_structure + unify_* for the nested sub-arguments.
+        compound(Arg)
+    ->  Arg =.. [F|NestedArgs],
+        length(NestedArgs, NArity),
+        next_x_reg(V0, XReg, V_temp),
+        bind_var(Arg, XReg, V_temp, V1a),
+        format(string(UnifyCode), "    unify_variable ~w", [XReg]),
+        format(string(GetCode), "    get_structure ~w/~w, ~w", [F, NArity, XReg]),
+        compile_unify_arguments(NestedArgs, V1a, V1, NestedCode),
+        format(string(ArgCode), "~w~n~w~n~w", [UnifyCode, GetCode, NestedCode])
+    ;   % Fallback
         next_x_reg(V0, XReg, V_temp),
         bind_var(Arg, XReg, V_temp, V1),
         format(string(ArgCode), "    unify_variable ~w", [XReg])

--- a/tests/test_wam_e2e.pl
+++ b/tests/test_wam_e2e.pl
@@ -13,6 +13,16 @@ e2e_parent(bob, charlie).
 :- dynamic e2e_grandparent/2.
 e2e_grandparent(X, Z) :- e2e_parent(X, Y), e2e_parent(Y, Z).
 
+%% Recursive rule — multi-clause, backtracking, recursive calls
+:- dynamic e2e_ancestor/2.
+e2e_ancestor(X, Y) :- e2e_parent(X, Y).
+e2e_ancestor(X, Y) :- e2e_parent(X, Z), e2e_ancestor(Z, Y).
+
+%% Compound head facts — exercises get_structure + unify_* in the runtime
+:- dynamic e2e_color/2.
+e2e_color(rgb(255, 0, 0), red).
+e2e_color(rgb(0, 255, 0), green).
+
 :- dynamic test_failed/0.
 
 pass(Test) :-
@@ -56,6 +66,26 @@ test_wam_rule_execution :-
     ;   fail_test(Test, 'E2E rule execution failed for grandparent')
     ).
 
+test_wam_recursive_execution :-
+    Test = 'WAM E2E: Recursive rule (ancestor)',
+    (   % Compile parent + ancestor, execute ancestor(alice, charlie)
+        % Path: alice->bob (parent), bob->charlie (parent) via recursive clause
+        wam_target:compile_wam_module(
+            [user:e2e_parent/2, user:e2e_ancestor/2], [], Code),
+        wam_runtime:execute_wam(Code, e2e_ancestor(alice, charlie), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Recursive ancestor execution failed')
+    ).
+
+test_wam_compound_head :-
+    Test = 'WAM E2E: Compound head unification (get_structure)',
+    (   % Compile color/2 with compound first arg, query rgb(255,0,0) -> red
+        wam_target:compile_predicate_to_wam(user:e2e_color/2, [], Code),
+        wam_runtime:execute_wam(Code, e2e_color(rgb(255, 0, 0), red), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'Compound head unification failed')
+    ).
+
 run_tests :-
     format('~n========================================~n'),
     format('WAM Target E2E Test Suite~n'),
@@ -64,6 +94,8 @@ run_tests :-
     test_wam_compilation_and_execution,
     test_wam_backtracking_simple,
     test_wam_rule_execution,
+    test_wam_recursive_execution,
+    test_wam_compound_head,
     
     format('~n========================================~n'),
     (   test_failed

--- a/tests/test_wam_target.pl
+++ b/tests/test_wam_target.pl
@@ -23,6 +23,10 @@ test_ancestor(X, Y) :- test_parent(X, Z), test_ancestor(Z, Y).
 test_check(pair(_, _)).
 test_wrap(X) :- test_check(pair(X, done)).
 
+%% Compound head — exercises get_structure + unify_constant
+:- dynamic test_color/2.
+test_color(rgb(255, 0, 0), red).
+
 :- dynamic test_failed/0.
 
 pass(Test) :-
@@ -107,6 +111,21 @@ test_wam_put_structure :-
         fail_test(Test, 'Missing put_structure in compound body arg output')
     ).
 
+test_wam_compound_head :-
+    Test = 'WAM: compound head (get_structure)',
+    (   wam_target:compile_predicate_to_wam(user:test_color/2, [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'get_structure rgb/3'),
+        sub_string(S, _, _, _, 'unify_constant 255'),
+        sub_string(S, _, _, _, 'get_constant red')
+    ->  pass(Test)
+    ;   (   wam_target:compile_predicate_to_wam(user:test_color/2, [], Code2)
+        ->  format(user_error, 'DEBUG: compound head output:~n~w~n', [Code2])
+        ;   format(user_error, 'DEBUG: compile failed~n', [])
+        ),
+        fail_test(Test, 'Missing get_structure in compound head output')
+    ).
+
 %% Run all tests
 run_tests :-
     format('~n========================================~n'),
@@ -117,6 +136,7 @@ run_tests :-
     test_wam_single_clause,
     test_wam_recursion,
     test_wam_put_structure,
+    test_wam_compound_head,
     test_wam_module,
     
     format('~n========================================~n'),


### PR DESCRIPTION
## Summary

- Add E2E test for recursive `ancestor/2` — exercises multi-clause backtracking, recursive calls, and Yi registers through the full compile-then-execute pipeline
- Add E2E and compiler tests for compound head unification (`get_structure` + `unify_constant`)
- Compiler now emits recursive `get_structure` + `unify_*` sequences for nested compound sub-arguments in head matching (previously emitted bare `unify_variable` placeholder)
- Runtime `get_structure` now operates in dual mode: **read mode** (matches existing compound terms) and **write mode** (constructs structures on the heap when the register is unbound)
- `unify_variable`, `unify_value`, `unify_constant` all handle both read mode (match from `unify_ctx`) and write mode (push to heap via `write_ctx`)
- Fix `backtrack` to preserve choice points on the stack — `trust_me`/`retry_me_else` handle popping, not backtrack itself (was causing nested backtracking across predicates to fail)
- Fix `parse_arg` to convert numeric strings to numbers so `unify_constant 255` correctly matches integer `255`
- Archive PR descriptions for PRs #1105, #1111, #1113

## Test plan

- [x] All 6 WAM target compiler tests pass (facts, single clause, recursion, put_structure, compound head, module)
- [x] All 5 E2E tests pass (fact execution, backtracking, grandparent rule, recursive ancestor, compound head)
- [x] Verified `ancestor(alice, charlie)` succeeds via recursive path: alice→bob (parent), bob→charlie (parent)
- [x] Verified `color(rgb(255,0,0), red)` succeeds via compound head matching with `get_structure rgb/3` + `unify_constant`
- [x] Exit code 0 on success, 1 on failure (CI-compatible)

## Companion PR

- Education repo: `docs: document read/write mode for get_structure and unify_* in Book 17` (same branch name)

Generated with [Claude Code](https://claude.com/claude-code)
