### PR TITLE
feat(csharp-query): add positive-step contracts for weighted min

### DIFF
--- a/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
+++ b/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
@@ -1,0 +1,119 @@
+# Positive Step Optimization Contracts
+
+## Problem
+
+The C# query engine now has a fast path for weighted `min` accumulation
+ when the recursive step is:
+
+- additive
+- strictly positive
+- depth bounded
+
+Today the runtime can prove this by inspecting the generated arithmetic
+ expression and, if needed, sampling the auxiliary relation values at
+ runtime.
+
+That is useful, but it is not the ideal long-term contract for native
+ lowering across targets.
+
+We want two stronger mechanisms:
+
+1. an explicit Prolog-side guard that proves positivity in the query
+2. a declarative metadata mechanism the compiler can consume directly
+
+## Mechanism 1: Explicit Positivity Guards
+
+The immediate mechanism is an ordinary Prolog guard in the recursive
+ definition:
+
+```prolog
+path(X, Y, Acc) :-
+    edge(X, Y),
+    weight(X, Cost),
+    Cost > 0,
+    Acc is Cost.
+
+path(X, Z, Acc) :-
+    edge(X, Y),
+    weight(X, Cost),
+    Cost > 0,
+    path(Y, Z, Acc1),
+    Acc is Acc1 + Cost.
+```
+
+The compiler can recognize this as an optimization contract:
+
+- `Cost > 0`
+- `0 < Cost`
+- `Cost >= 1`
+- `1 =< Cost`
+
+This keeps semantics explicit in the query itself and is easy to
+ implement immediately.
+
+### Pros
+
+- clear and local to the predicate definition
+- target-independent at the source level
+- no new syntax required
+
+### Cons
+
+- mixes optimization-relevant facts with query logic
+- not ideal when positivity is already known structurally elsewhere
+- still narrower than a full declarative constraint system
+
+## Mechanism 2: Declarative Positive-Step Metadata
+
+The longer-term mechanism should be a declarative compiler-visible
+ contract, distinct from the query body.
+
+Possible shapes:
+
+```prolog
+:- constraint(path/3, [positive_step(3)]).
+```
+
+or
+
+```prolog
+:- optimization_contract(path/3, [min_step_positive]).
+```
+
+or a target-neutral metadata term attached to the accumulator position.
+
+The exact syntax is still open, but the design goal is:
+
+- the user states positivity once
+- the compiler records it in plan metadata
+- C#, Rust, and other targets can lower against the same contract
+
+## Recommended Sequencing
+
+1. implement explicit guard recognition now
+2. keep runtime inference as a fallback for backwards compatibility
+3. design the declarative metadata mechanism next
+4. use one of these explicit contracts before extending Rust lowering
+
+## Why Rust Should Wait For This
+
+Rust should not depend purely on runtime inference copied from the C#
+ path.
+
+It should lower against an explicit source-level or plan-level contract
+ such as:
+
+- positive guard recognized by the compiler
+- positive-step metadata declared by the user
+
+That keeps the cross-target story coherent and avoids benchmark-specific
+ magic.
+
+## Current Status
+
+The immediate explicit-guard mechanism is the minimum acceptable
+ contract before moving to Rust on weighted `min`.
+
+The declarative metadata mechanism is still proposed work, but should be
+ designed before we rely on weighted `min` native lowering broadly
+ across targets.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -256,7 +256,8 @@ namespace UnifyWeaver.QueryRuntime
         ArithmeticExpression BaseExpression,
         ArithmeticExpression RecursiveExpression,
         int MaxDepth = 0,
-        TableMode AccumulatorMode = TableMode.All
+        TableMode AccumulatorMode = TableMode.All,
+        bool PositiveStepProven = false
     ) : PlanNode;
 
     public enum TableMode
@@ -982,7 +983,7 @@ namespace UnifyWeaver.QueryRuntime
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
-                PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
+                PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode} positiveStep={closure.PositiveStepProven}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
                 MutualFixpointNode mutual => $"MutualFixpoint head={mutual.Head} members={mutual.Members.Count}",
                 RecursiveRefNode recursiveRef => $"RecursiveRef predicate={recursiveRef.Predicate} kind={recursiveRef.Kind}",
@@ -7184,7 +7185,7 @@ namespace UnifyWeaver.QueryRuntime
                 var seenSeeds = new HashSet<object?>();
                 PositiveStepEvaluator? stepEvaluator = null;
                 var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
-                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, out stepEvaluator);
+                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
 
                 foreach (var edge in edges)
                 {
@@ -7247,7 +7248,7 @@ namespace UnifyWeaver.QueryRuntime
                 var seenSeeds = new HashSet<object?>();
                 PositiveStepEvaluator? stepEvaluator = null;
                 var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
-                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, out stepEvaluator);
+                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
 
                 foreach (var paramTuple in parameters)
                 {
@@ -7385,12 +7386,24 @@ namespace UnifyWeaver.QueryRuntime
             ArithmeticExpression recursiveExpression,
             IReadOnlyDictionary<object, List<object[]>> succIndex,
             IReadOnlyDictionary<object, List<object[]>> auxIndex,
+            bool positiveStepProven,
             out PositiveStepEvaluator? evaluator)
         {
             evaluator = null;
             if (!TryExtractMinStepExpression(baseExpression, recursiveExpression, out var stepExpression))
             {
                 return false;
+            }
+
+            if (positiveStepProven)
+            {
+                evaluator = (current, next, auxValue) =>
+                {
+                    var evalTuple = new object[] { current, next, 0, auxValue };
+                    var stepObject = EvaluateArithmeticExpression(stepExpression, evalTuple);
+                    return Convert.ToDouble(stepObject, CultureInfo.InvariantCulture);
+                };
+                return true;
             }
 
             foreach (var (currentKey, edgeBucket) in succIndex)

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -1155,8 +1155,8 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
     path_aware_transitive_closure_supported_modes(Modes),
     BaseClauses = [BaseClause],
     RecClauses = [RecClause],
-    path_aware_accumulation_base_clause(HeadSpec, BaseClause, EdgeSpec, AuxSpec, BaseExpression),
-    path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, RecClause, RecursiveExpression),
+    path_aware_accumulation_base_clause(HeadSpec, BaseClause, EdgeSpec, AuxSpec, BaseExpression, PositiveStepProven),
+    path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, RecClause, RecursiveExpression, PositiveStepProven),
     get_dict(name, EdgeSpec, EdgePred),
     get_dict(arity, EdgeSpec, EdgeArity),
     get_dict(name, AuxSpec, AuxPred),
@@ -1176,12 +1176,13 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
         auxiliary:AuxSpec,
         base_expression:BaseExpression,
         recursive_expression:RecursiveExpression,
+        positive_step_proven:PositiveStepProven,
         max_depth:10,
         table_modes:TableModes,
         width:3
     }.
 
-path_aware_accumulation_base_clause(HeadSpec, Head-Body, EdgeSpec, AuxSpec, BaseExpression) :-
+path_aware_accumulation_base_clause(HeadSpec, Head-Body, EdgeSpec, AuxSpec, BaseExpression, PositiveStepProven) :-
     get_dict(name, HeadSpec, Pred),
     Head =.. [Pred, From, To, Acc],
     var(From),
@@ -1189,13 +1190,14 @@ path_aware_accumulation_base_clause(HeadSpec, Head-Body, EdgeSpec, AuxSpec, Base
     var(Acc),
     body_to_list(Body, Terms),
     select(ArithTerm0, Terms, Terms1),
-    Terms1 = [TermA0, TermB0],
+    maybe_extract_positive_step_guard(Terms1, AuxValue, RelationTerms, PositiveStepProven),
+    RelationTerms = [TermA0, TermB0],
     path_aware_accumulation_edge_aux_terms(From, To, AuxValue, TermA0, TermB0, EdgeTerm0, AuxTerm0),
     transitive_closure_edge_term(EdgeSpec, From, To, EdgeTerm0),
     path_aware_auxiliary_term(AuxSpec, From, AuxValue, AuxTerm0),
     arithmetic_assignment_expression(ArithTerm0, Acc, [From-0, To-1, AuxValue-3], BaseExpression).
 
-path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, Head-Body, RecursiveExpression) :-
+path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, Head-Body, RecursiveExpression, PositiveStepProven) :-
     get_dict(name, HeadSpec, Pred),
     Head =.. [Pred, From, To, Acc],
     var(From),
@@ -1203,12 +1205,35 @@ path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, Head-
     var(Acc),
     body_to_list(Body, Terms),
     select(ArithTerm0, Terms, Terms1),
-    select(AuxTerm0, Terms1, Terms2),
+    maybe_extract_positive_step_guard(Terms1, AuxValue, TermsNoGuard, PositiveStepProven),
+    select(AuxTerm0, TermsNoGuard, Terms2),
     select(EdgeTerm0, Terms2, [RecTerm0]),
     transitive_closure_edge_term(EdgeSpec, From, Mid, EdgeTerm0),
     path_aware_auxiliary_term(AuxSpec, From, AuxValue, AuxTerm0),
     path_aware_transitive_recursive_term(Pred, Mid, To, PrevAcc, RecTerm0),
     arithmetic_assignment_expression(ArithTerm0, Acc, [From-0, To-1, PrevAcc-2, AuxValue-3], RecursiveExpression).
+
+maybe_extract_positive_step_guard(Terms, AuxValue, RemainingTerms, true) :-
+    select(Guard0, Terms, RemainingTerms),
+    positive_step_guard(Guard0, AuxValue),
+    !.
+maybe_extract_positive_step_guard(Terms, _AuxValue, Terms, false).
+
+positive_step_guard(Goal0, AuxValue) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [>, AuxValue, Value],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [<, Value, AuxValue],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [>=, AuxValue, Value],
+        number(Value),
+        Value > 0
+    ;   Goal =.. [=<, Value, AuxValue],
+        number(Value),
+        Value > 0
+    ).
 
 path_aware_accumulation_edge_aux_terms(From, To, AuxValue, TermA0, TermB0, EdgeTerm0, AuxTerm0) :-
     (   binary_relation_term(From, To, TermA0),
@@ -3724,6 +3749,7 @@ emit_plan_expression(Node, Expr) :-
     get_dict(base_expression, Node, BaseExpression),
     get_dict(recursive_expression, Node, RecursiveExpression),
     (get_dict(max_depth, Node, MaxDepth) -> true ; MaxDepth = 0),
+    (get_dict(positive_step_proven, Node, PositiveStepProven) -> true ; PositiveStepProven = false),
     (   get_dict(table_modes, Node, TableModes),
         nth0(2, TableModes, AccTableMode),
         AccTableMode \= lattice
@@ -3732,11 +3758,12 @@ emit_plan_expression(Node, Expr) :-
     ),
     emit_arithmetic_expression(BaseExpression, BaseExprCode),
     emit_arithmetic_expression(RecursiveExpression, RecExprCode),
+    (PositiveStepProven == true -> PositiveStepStr = "true" ; PositiveStepStr = "false"),
     atom_string(EdgeName, EdgeNameStr),
     atom_string(AuxName, AuxNameStr),
     atom_string(Name, NameStr),
-    format(atom(Expr), 'new PathAwareAccumulationNode(new PredicateId("~w", ~w), new PredicateId("~w", ~w), new PredicateId("~w", ~w), ~w, ~w, ~w, ~w)',
-        [EdgeNameStr, EdgeArity, NameStr, Arity, AuxNameStr, AuxArity, BaseExprCode, RecExprCode, MaxDepth, TableModeStr]).
+    format(atom(Expr), 'new PathAwareAccumulationNode(new PredicateId("~w", ~w), new PredicateId("~w", ~w), new PredicateId("~w", ~w), ~w, ~w, ~w, ~w, ~w)',
+        [EdgeNameStr, EdgeArity, NameStr, Arity, AuxNameStr, AuxArity, BaseExprCode, RecExprCode, MaxDepth, TableModeStr, PositiveStepStr]).
 emit_plan_expression(Node, Expr) :-
     is_dict(Node, fixpoint), !,
     get_dict(base, Node, BaseNode),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -157,6 +157,9 @@
 :- dynamic user:test_weighted_min_edge/2.
 :- dynamic user:test_weighted_min_cost/2.
 :- dynamic user:test_weighted_min_path/3.
+:- dynamic user:test_weighted_min_guarded_edge/2.
+:- dynamic user:test_weighted_min_guarded_cost/2.
+:- dynamic user:test_weighted_min_guarded_path/3.
 :- dynamic user:test_scanindex_allowed/1.
 :- dynamic user:test_scanindex_step/2.
 :- dynamic user:test_scanindex_reach_param/2.
@@ -312,6 +315,7 @@ test_csharp_query_target :-
         verify_parameterized_path_aware_accumulation_plan,
         verify_path_aware_accumulation_preserves_path_multiplicity,
         verify_path_aware_accumulation_min_mode_plan,
+        verify_path_aware_accumulation_positive_guard_plan,
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
@@ -1187,6 +1191,27 @@ setup_test_data :-
         Acc is Acc1 + Cost
     )),
     assertz(user:'table'(test_weighted_min_path(_, _, min))),
+    assertz(user:test_weighted_min_guarded_edge(a, b)),
+    assertz(user:test_weighted_min_guarded_edge(a, c)),
+    assertz(user:test_weighted_min_guarded_edge(b, d)),
+    assertz(user:test_weighted_min_guarded_edge(c, d)),
+    assertz(user:test_weighted_min_guarded_cost(a, 1)),
+    assertz(user:test_weighted_min_guarded_cost(b, 5)),
+    assertz(user:test_weighted_min_guarded_cost(c, 2)),
+    assertz(user:(test_weighted_min_guarded_path(X, Y, Acc) :-
+        test_weighted_min_guarded_edge(X, Y),
+        test_weighted_min_guarded_cost(X, Cost),
+        Cost > 0,
+        Acc is Cost
+    )),
+    assertz(user:(test_weighted_min_guarded_path(X, Z, Acc) :-
+        test_weighted_min_guarded_edge(X, Y),
+        test_weighted_min_guarded_cost(X, Cost),
+        Cost > 0,
+        test_weighted_min_guarded_path(Y, Z, Acc1),
+        Acc is Acc1 + Cost
+    )),
+    assertz(user:'table'(test_weighted_min_guarded_path(_, _, min))),
     assert_binary_recursive_fixture(
         test_probe_dir_forward_edge,
         test_probe_dir_forward_reach,
@@ -1407,6 +1432,9 @@ cleanup_test_data :-
     retractall(user:test_weighted_min_edge(_, _)),
     retractall(user:test_weighted_min_cost(_, _)),
     retractall(user:test_weighted_min_path(_, _, _)),
+    retractall(user:test_weighted_min_guarded_edge(_, _)),
+    retractall(user:test_weighted_min_guarded_cost(_, _)),
+    retractall(user:test_weighted_min_guarded_path(_, _, _)),
     cleanup_recursive_fixture(test_probe_dir_forward_edge, test_probe_dir_forward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_backward_edge, test_probe_dir_backward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_mixed_edge, test_probe_dir_mixed_reach, 2),
@@ -3684,6 +3712,28 @@ verify_path_aware_accumulation_min_mode_plan :-
     csharp_query_target:render_plan_to_csharp(Plan, Source),
     sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
     sub_string(Source, _, _, _, 'TableMode.Min'),
+    maybe_run_query_runtime(Plan,
+        ['a,b,1',
+         'a,c,1',
+         'a,d,3'],
+        [[a]]).
+
+verify_path_aware_accumulation_positive_guard_plan :-
+    csharp_target:build_query_plan(
+        test_weighted_min_guarded_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_min_guarded_path, arity:3}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    get_dict(positive_step_proven, Root, true),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    sub_string(Source, _, _, _, ', true)'),
     maybe_run_query_runtime(Plan,
         ['a,b,1',
          'a,c,1',


### PR DESCRIPTION
  ## Summary

  This PR adds an explicit optimization contract for the C# query engine's
  weighted `min` accumulation fast path.

  The compiler now recognizes positive-step guards written directly in the
  Prolog query, carries that proof into the generated plan/runtime, and
  uses it to enable the weighted `min` fast path without relying on runtime
  positivity sampling.

  This is the minimum contract needed before extending the same feature
  family to other targets such as Rust.

  ## What Changed

  ### Compiler

  In:

  - `src/unifyweaver/targets/csharp_target.pl`

  the path-aware accumulation planner now detects explicit positive-step
  guards in recursive accumulation clauses.

  Currently recognized forms include:

  - `Cost > 0`
  - `0 < Cost`
  - `Cost >= 1`
  - `1 =< Cost`

  When found, the generated `path_aware_accumulation` plan includes:

  - `positive_step_proven:true`

  ### Runtime

  In:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  `PathAwareAccumulationNode` now carries a `PositiveStepProven` flag.

  When weighted `Min` pruning is considered:

  - if positivity is explicitly proven by the Prolog source, the runtime
    uses that proof directly
  - otherwise it falls back to the existing runtime positivity inference

  So this PR improves the contract between source, planner, and runtime,
  without removing the current fallback behavior.

  ### Tests

  In:

  - `tests/core/test_csharp_query_target.pl`

  add a guarded weighted `min` regression that verifies:

  - the planner recognizes the positive-step proof
  - generated C# includes the expected `PathAwareAccumulationNode` fields
  - the runtime still produces the expected rows

  ### Proposal Doc

  Add:

  - `docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md`

  This documents the two intended mechanisms:

  1. explicit positivity guards in query bodies
  2. a future declarative metadata/constraint mechanism

  ## Why This Matters

  The weighted `min` fast path currently depends on positivity.

  Before this PR, that was inferred dynamically by the runtime.

  That worked, but it was not a strong enough contract to build on across
  targets. Rust and future target generalization should not depend only on
  runtime sampling to justify a lowering decision.

  This PR makes positivity visible at the source/planner boundary.

  ## Verification

  ### C# query-target suite

  Passed locally:

  ```bash
  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 231/231 tests passed

  ### Weighted benchmark spot check

  Weighted min remains correct and fast:

  - 300
      - all=0.647s
      - min=0.184s
  - 1k
      - all=0.407s
      - min=0.145s

  Outputs still matched between All and Min.

  ## Semantics

  This PR does not change query semantics.

  It only strengthens fast-path eligibility by recognizing explicit source
  evidence that the recursive step is strictly positive.

  If no explicit proof is present:

  - the query still works
  - the planner/runtime still fall back to the existing behavior

  ## Follow-Up

  This PR is intended as the minimum source-level contract before broader
  cross-target work.

  Likely next steps:

  - add a declarative metadata mechanism for positive-step constraints
  - then extend Rust native lowering for:
      - counted closure Min
      - weighted accumulation Min

  The long-term goal is for target lowering decisions to rely on explicit
  contracts rather than benchmark-specific runtime inference alone.