### PR TITLE
fix(kotlin): sequential if/return → idiomatic else if chain

### DIFF
--- a/src/unifyweaver/targets/kotlin_target.pl
+++ b/src/unifyweaver/targets/kotlin_target.pl
@@ -1756,25 +1756,36 @@ combine_kotlin_conditions([C|Rest], Combined) :-
     format(string(Combined), '~w && ~w', [C, RestCombined]).
 
 %% branches_to_kotlin_if_chain(+Branches, +PredSpec, -Code)
-branches_to_kotlin_if_chain([branch(Cond, ClauseCode)], PredSpec, Code) :-
-    !,
+%%   Uses if/else if/else pattern (not sequential if/return).
+branches_to_kotlin_if_chain([First|Rest], PredSpec, Code) :-
+    First = branch(Cond, ClauseCode),
     (   Cond == "true"
+    ->  format(string(Code), '    return ~w', [ClauseCode])
+    ;   Rest == []
     ->  format(string(Code),
-'    return ~w', [ClauseCode])
-    ;   format(string(Code),
 '    if (~w) {
         return ~w
-    }
-    throw RuntimeException("No matching clause for ~w")', [Cond, ClauseCode, PredSpec])
+    } else {
+        throw RuntimeException("No matching clause for ~w")
+    }', [Cond, ClauseCode, PredSpec])
+    ;   kotlin_elif_chain(Rest, PredSpec, ElifCode),
+        format(string(Code),
+'    if (~w) {
+        return ~w
+~w', [Cond, ClauseCode, ElifCode])
     ).
-branches_to_kotlin_if_chain([branch(Cond, ClauseCode)|Rest], PredSpec, Code) :-
-    (   Cond == "true"
-    ->  format(string(ThisBlock),
-'    return ~w', [ClauseCode])
-    ;   format(string(ThisBlock),
-'    if (~w) {
+
+kotlin_elif_chain([branch(Cond, ClauseCode)], PredSpec, Code) :-
+    !,
+    format(string(Code),
+'    } else if (~w) {
         return ~w
-    }', [Cond, ClauseCode])
-    ),
-    branches_to_kotlin_if_chain(Rest, PredSpec, RestCode),
-    format(string(Code), '~w~n~w', [ThisBlock, RestCode]).
+    } else {
+        throw RuntimeException("No matching clause for ~w")
+    }', [Cond, ClauseCode, PredSpec]).
+kotlin_elif_chain([branch(Cond, ClauseCode)|Rest], PredSpec, Code) :-
+    kotlin_elif_chain(Rest, PredSpec, RestCode),
+    format(string(Code),
+'    } else if (~w) {
+        return ~w
+~w', [Cond, ClauseCode, RestCode]).


### PR DESCRIPTION
## Summary

Fix the same codegen bug in Kotlin that was fixed for PowerShell and C# in PR #1123. The native clause lowering generated sequential `if` blocks with early `return` instead of idiomatic `if/else if/else` chains.

## Bug

**Before:**
```kotlin
fun classify(arg1: Long): String {
    if (arg1 > 0 && arg1 < 10) {
        return "small"
    }
    if (arg1 >= 10) {        // ← separate if, not else if
        return "large"
    }
    throw RuntimeException("No matching clause for classify/2")
}
```

**After:**
```kotlin
fun classify(arg1: Long): String {
    if (arg1 > 0 && arg1 < 10) {
        return "small"
    } else if (arg1 >= 10) {  // ← proper else if
        return "large"
    } else {
        throw RuntimeException("No matching clause for classify/2")
    }
}
```

## Root Cause

`branches_to_kotlin_if_chain` generated independent `if` blocks concatenated with newlines, relying on early `return` for flow control. While functionally correct, this is not idiomatic Kotlin and makes the generated code harder to read.

## Fix

Restructured into `branches_to_kotlin_if_chain` (first branch uses `if`) + `kotlin_elif_chain` helper (subsequent branches emit `} else if`). Same approach used for the PowerShell and C# fixes in PR #1123.

## Assembly/IR Target Status

Also investigated assembly/IR targets for native lowering status:

| Target | Native Lowering | Education Book | Notes |
|--------|:-:|:-:|-------|
| WAT | Yes | Book 7 Ch.25 | `if/else` with `i64.gt_s`/`i64.lt_s` |
| LLVM IR | Yes | Book 7 Ch.25 | `icmp`/`br` with SSA labels |
| Jamaica | Yes | Book 7 Ch.25 | `if_icmpgt`/`if_icmplt` JVM bytecode |
| Krakatau | Yes | Book 7 Ch.25 | Same JVM bytecode via shared `jvm_bytecode.pl` |
| ILAsm | Yes | Book 7 Ch.25 | `ble`/`bge` CIL instructions |
| WAM | N/A | Book 17 | Abstract machine bytecode, not source code |

All assembly/IR targets already have native lowering. They don't have dedicated education books but are covered in the cross-target reference (Book 7, Chapter 25).

## Tests

| Suite | Tests | Result |
|-------|-------|--------|
| Kotlin native lowering | 12 | Pass |

## Test plan

- [x] Kotlin generates `} else if (` instead of separate `if` blocks
- [x] Three-clause predicates generate `if/else if/else if/else` chain
- [x] Single-clause predicates still work correctly
- [x] 12/12 Kotlin native lowering tests pass
- [x] Scala already uses `else if` (verified, no fix needed)
- [x] VB.NET already uses `ElseIf` (verified, no fix needed)
