### PR TITLE
Document native TypR broader producer tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ includes:
 - simple output-producing binding chains
 - simple alias or arithmetic assignment tails after an earlier native
   string-transform or length-producing step
+- simple alias tails after native conversion, list, and path producers such as
+  `to_numeric/2`, `reverse/2`, and `dirname/2`
 - guard-style command predicates such as `is_character/1`
 - unary TypR-safe I/O commands such as `cat/1` and `print/1`, emitted as
   native fixed-arity TypR calls
@@ -382,8 +384,8 @@ More complex generic bodies still fall back to the wrapped R path.
 The wrapped fallback boundary is now beyond the first native
 string-transform/output-tail slice; if this area is extended further, the next
 real audit target is the producer-goal family after the currently supported
-`string_lower/2`, `string_upper/2`, and `string_length/2` follow-on alias or
-arithmetic tails.
+`string_lower/2`, `string_upper/2`, `string_length/2`, `to_numeric/2`,
+`reverse/2`, and `dirname/2` follow-on alias or arithmetic tails.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -169,6 +169,8 @@ bring-up.
   - simple output-producing binding chains
   - simple alias or arithmetic assignment tails after an earlier native
     string-transform or length-producing step
+  - simple alias tails after native conversion, list, and path producers such
+    as `to_numeric/2`, `reverse/2`, and `dirname/2`
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -511,8 +511,11 @@ Current wrapped-fallback boundary note:
   `string_lower/2`, `string_upper/2`, and `string_length/2` may feed a simple
   alias or arithmetic assignment tail such as `Out = Lower` or
   `Out is Len + 1`
+- the next audited producer families also stay native for simple alias tails,
+  including representative conversion, list, and path producers such as
+  `to_numeric/2`, `reverse/2`, and `dirname/2`
 - the remaining wrapped fallback boundary is now beyond that first
-  string-transform/output-tail slice
+  producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next
   unsupported producer-goal family rather than the final assignment tail
 - fixed-arity unary I/O stays native (`cat/1`, `print/1`), but variadic-style

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2140,6 +2140,45 @@ test(arithmetic_assignments_after_native_outputs_stay_native) :-
     \+ sub_string(Code, _, _, _, "Unknown predicate"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(conversion_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(to_numeric_alias(Value, Out) :- to_numeric(Value, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(to_numeric_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(to_numeric_alias/2, 2, number)),
+    once(compile_predicate_to_typr(to_numeric_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let to_numeric_alias <- fn(arg1: char, arg2: num): num")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ as.numeric(arg1) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(list_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(reverse_alias(Xs, Out) :- reverse(Xs, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(reverse_alias/2, 1, list(string))),
+    assertz(type_declarations:uw_type(reverse_alias/2, 2, list(string))),
+    once(compile_predicate_to_typr(reverse_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let reverse_alias <- fn(arg1: [#N, char], arg2: [#N, char]): [#N, char]")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ rev(arg1) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(path_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(dirname_alias(Path, Out) :- dirname(Path, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(dirname_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(dirname_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(dirname_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let dirname_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ dirname(arg1) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(multi_decision_guard_chains_use_let_for_new_intermediates) :-
     clear_type_declarations,
     assertz(user:(multi_guard_chain(Name, Out) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Upper), is_character(Upper), string_concat(Upper, '!', Out))),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -75,6 +75,57 @@ test(arithmetic_assignments_after_native_outputs_check_with_typr, [condition(typ
     ),
     retractall(user:arith_after_output(_, _)).
 
+test(conversion_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(to_numeric_alias(Value, Out) :- to_numeric(Value, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(to_numeric_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(to_numeric_alias/2, 2, number)),
+    once(compile_predicate_to_typr(to_numeric_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:to_numeric_alias(_, _)).
+
+test(list_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(reverse_alias(Xs, Out) :- reverse(Xs, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(reverse_alias/2, 1, list(string))),
+    assertz(type_declarations:uw_type(reverse_alias/2, 2, list(string))),
+    once(compile_predicate_to_typr(reverse_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:reverse_alias(_, _)).
+
+test(path_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(dirname_alias(Path, Out) :- dirname(Path, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(dirname_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(dirname_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(dirname_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:dirname_alias(_, _)).
+
 test(cat_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:(say_cat(Msg) :- cat(Msg))),


### PR DESCRIPTION
## Summary
- document that additional TypR producer-follow-on cases already lower natively
- add regression coverage for simple alias tails after native producer steps
- clarify that this branch is an audit-and-coverage pass, not a new `typr_target.pl` lowering change

## What changed
- added target-level regression coverage for native follow-on alias tails after:
  - `to_numeric/2`
  - `reverse/2`
  - `dirname/2`
- added real `typr check` coverage for the same shapes
- updated TypR docs to reflect that these producer families are already native in the generic TypR path

## Important result
The audit did not find a new TypR emitter gap here.

These producer-family cases were already native on `main`; the missing work was to make that boundary explicit and regression-covered.

## Why this matters
This narrows the remaining wrapped-fallback boundary.

The next producer-family audit should move past the string/conversion/list/path follow-on slice and target the next genuinely unsupported generic producer family instead of reworking already-native cases.

## Validation
```sh
swipl -q -g "run_tests([typr_target:conversion_alias_after_native_outputs_stays_native,typr_target:list_alias_after_native_outputs_stays_native,typr_target:path_alias_after_native_outputs_stays_native])" -t halt tests/test_typr_target.pl
swipl -q -g "run_tests([typr_toolchain:conversion_alias_after_native_outputs_check_with_typr,typr_toolchain:list_alias_after_native_outputs_check_with_typr,typr_toolchain:path_alias_after_native_outputs_check_with_typr])" -t halt tests/test_typr_toolchain.pl
git diff --check
```
