### PR TITLE
feat(csharp-query): add positive-step metadata constraints

### DIFF
--- a/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
+++ b/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
@@ -65,16 +65,19 @@ This keeps semantics explicit in the query itself and is easy to
 
 ## Mechanism 2: Declarative Positive-Step Metadata
 
-The longer-term mechanism should be a declarative compiler-visible
- contract, distinct from the query body.
-
-Possible shapes:
+The compiler-visible metadata mechanism is now implemented through the
+ existing constraint system:
 
 ```prolog
 :- constraint(path/3, [positive_step(3)]).
 ```
 
-or
+This proves that the accumulator-bearing position is driven by a
+ strictly positive recursive step for optimization purposes.
+
+The earlier alternative spellings remain historical design ideas:
+
+Possible shapes:
 
 ```prolog
 :- optimization_contract(path/3, [min_step_positive]).
@@ -82,7 +85,7 @@ or
 
 or a target-neutral metadata term attached to the accumulator position.
 
-The exact syntax is still open, but the design goal is:
+The chosen syntax keeps the design goal:
 
 - the user states positivity once
 - the compiler records it in plan metadata
@@ -92,8 +95,8 @@ The exact syntax is still open, but the design goal is:
 
 1. implement explicit guard recognition now
 2. keep runtime inference as a fallback for backwards compatibility
-3. design the declarative metadata mechanism next
-4. use one of these explicit contracts before extending Rust lowering
+3. keep runtime inference as a fallback for backwards compatibility
+4. use the declarative `constraint/2` contract before extending Rust lowering
 
 ## Why Rust Should Wait For This
 
@@ -114,6 +117,12 @@ That keeps the cross-target story coherent and avoids benchmark-specific
 The immediate explicit-guard mechanism is the minimum acceptable
  contract before moving to Rust on weighted `min`.
 
-The declarative metadata mechanism is still proposed work, but should be
- designed before we rely on weighted `min` native lowering broadly
- across targets.
+The declarative metadata mechanism is now available through
+ `constraint/2` with `positive_step(N)`.
+
+The remaining work before broad Rust adoption is not syntax design but
+ deciding how much Rust native lowering should rely on:
+
+- explicit positive guards
+- declarative `positive_step/1` metadata
+- or both

--- a/src/unifyweaver/core/constraint_analyzer.pl
+++ b/src/unifyweaver/core/constraint_analyzer.pl
@@ -116,7 +116,7 @@ normalize_constraints([unordered|Rest], [unordered(true)|NormRest]) :- !,
 normalize_constraints([ordered|Rest], [unordered(false)|NormRest]) :- !,
     normalize_constraints(Rest, NormRest).
 normalize_constraints([C|Rest], [C|NormRest]) :-
-    (C = unique(_) ; C = unordered(_)), !,
+    (C = unique(_) ; C = unordered(_) ; C = positive_step(_)), !,
     normalize_constraints(Rest, NormRest).
 normalize_constraints([Invalid|_], _) :-
     format('ERROR: Invalid constraint: ~w~n', [Invalid]),
@@ -147,7 +147,15 @@ get_constraints(Pred, Constraints) :-
 merge_constraints(Defaults, Declared, Merged) :-
     merge_constraint_list(Defaults, Declared, unique, MergedUnique),
     merge_constraint_list(Defaults, Declared, unordered, MergedOrdered),
-    append(MergedUnique, MergedOrdered, Merged).
+    findall(Constraint,
+        (   member(Constraint, Declared),
+            functor(Constraint, Functor, _),
+            Functor \= unique,
+            Functor \= unordered
+        ),
+        Extras),
+    append(MergedUnique, MergedOrdered, BaseMerged),
+    append(BaseMerged, Extras, Merged).
 
 merge_constraint_list(Defaults, Declared, Key, [Result]) :-
     Constraint =.. [Key, _],

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -35,6 +35,7 @@
 :- use_module(library(option)).
 :- use_module(library(pairs), [pairs_values/2]).
 :- use_module(library(ugraphs), [vertices/2, vertices_edges_to_ugraph/3, transpose_ugraph/2, reachable/3, top_sort/2]).
+:- use_module('../core/constraint_analyzer', [get_constraints/2]).
 :- use_module('../core/dynamic_source_compiler', [is_dynamic_source/1, dynamic_source_metadata/2]).
 :- use_module('../core/advanced/pattern_matchers', [declared_table_modes/3]).
 :- use_module('../core/binding_registry').
@@ -1155,8 +1156,8 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
     path_aware_transitive_closure_supported_modes(Modes),
     BaseClauses = [BaseClause],
     RecClauses = [RecClause],
-    path_aware_accumulation_base_clause(HeadSpec, BaseClause, EdgeSpec, AuxSpec, BaseExpression, PositiveStepProven),
-    path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, RecClause, RecursiveExpression, PositiveStepProven),
+    path_aware_accumulation_base_clause(HeadSpec, BaseClause, EdgeSpec, AuxSpec, BaseExpression, PositiveStepGuardProven),
+    path_aware_accumulation_recursive_rule_clause(HeadSpec, EdgeSpec, AuxSpec, RecClause, RecursiveExpression, PositiveStepGuardProven),
     get_dict(name, EdgeSpec, EdgePred),
     get_dict(arity, EdgeSpec, EdgeArity),
     get_dict(name, AuxSpec, AuxPred),
@@ -1168,6 +1169,14 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
     (   declared_table_modes(HeadName, 3, TableModes)
     ->  true
     ;   TableModes = [lattice, lattice, lattice]
+    ),
+    (   path_aware_accumulation_positive_step_metadata(HeadName/3, 3)
+    ->  PositiveStepMetadataProven = true
+    ;   PositiveStepMetadataProven = false
+    ),
+    (PositiveStepGuardProven == true ; PositiveStepMetadataProven == true
+    ->  PositiveStepProven = true
+    ;   PositiveStepProven = false
     ),
     Root = path_aware_accumulation{
         type:path_aware_accumulation,
@@ -1181,6 +1190,10 @@ maybe_path_aware_accumulation_plan(HeadSpec, GroupSpecs, BaseClauses, RecClauses
         table_modes:TableModes,
         width:3
     }.
+
+path_aware_accumulation_positive_step_metadata(Pred, Position) :-
+    get_constraints(Pred, Constraints),
+    member(positive_step(Position), Constraints).
 
 path_aware_accumulation_base_clause(HeadSpec, Head-Body, EdgeSpec, AuxSpec, BaseExpression, PositiveStepProven) :-
     get_dict(name, HeadSpec, Pred),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -13,6 +13,7 @@
 :- use_module(library(uuid)).
 :- use_module(library(csharp_query_target)).
 :- use_module(library(csharp_native_target)).
+:- use_module('src/unifyweaver/core/constraint_analyzer').
 :- use_module('src/unifyweaver/core/dynamic_source_compiler').
 :- use_module('src/unifyweaver/sources').
 :- use_module('src/unifyweaver/sources/csv_source').
@@ -160,6 +161,9 @@
 :- dynamic user:test_weighted_min_guarded_edge/2.
 :- dynamic user:test_weighted_min_guarded_cost/2.
 :- dynamic user:test_weighted_min_guarded_path/3.
+:- dynamic user:test_weighted_min_metadata_edge/2.
+:- dynamic user:test_weighted_min_metadata_cost/2.
+:- dynamic user:test_weighted_min_metadata_path/3.
 :- dynamic user:test_scanindex_allowed/1.
 :- dynamic user:test_scanindex_step/2.
 :- dynamic user:test_scanindex_reach_param/2.
@@ -316,6 +320,7 @@ test_csharp_query_target :-
         verify_path_aware_accumulation_preserves_path_multiplicity,
         verify_path_aware_accumulation_min_mode_plan,
         verify_path_aware_accumulation_positive_guard_plan,
+        verify_path_aware_accumulation_positive_metadata_plan,
         verify_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_plan,
         verify_parameterized_grouped_transitive_closure_pairs_strategy_runtime,
@@ -1212,6 +1217,26 @@ setup_test_data :-
         Acc is Acc1 + Cost
     )),
     assertz(user:'table'(test_weighted_min_guarded_path(_, _, min))),
+    assertz(user:test_weighted_min_metadata_edge(a, b)),
+    assertz(user:test_weighted_min_metadata_edge(a, c)),
+    assertz(user:test_weighted_min_metadata_edge(b, d)),
+    assertz(user:test_weighted_min_metadata_edge(c, d)),
+    assertz(user:test_weighted_min_metadata_cost(a, 1)),
+    assertz(user:test_weighted_min_metadata_cost(b, 5)),
+    assertz(user:test_weighted_min_metadata_cost(c, 2)),
+    assertz(user:(test_weighted_min_metadata_path(X, Y, Acc) :-
+        test_weighted_min_metadata_edge(X, Y),
+        test_weighted_min_metadata_cost(X, Cost),
+        Acc is Cost
+    )),
+    assertz(user:(test_weighted_min_metadata_path(X, Z, Acc) :-
+        test_weighted_min_metadata_edge(X, Y),
+        test_weighted_min_metadata_cost(X, Cost),
+        test_weighted_min_metadata_path(Y, Z, Acc1),
+        Acc is Acc1 + Cost
+    )),
+    assertz(user:'table'(test_weighted_min_metadata_path(_, _, min))),
+    declare_constraint(test_weighted_min_metadata_path/3, [positive_step(3)]),
     assert_binary_recursive_fixture(
         test_probe_dir_forward_edge,
         test_probe_dir_forward_reach,
@@ -1435,6 +1460,10 @@ cleanup_test_data :-
     retractall(user:test_weighted_min_guarded_edge(_, _)),
     retractall(user:test_weighted_min_guarded_cost(_, _)),
     retractall(user:test_weighted_min_guarded_path(_, _, _)),
+    retractall(user:test_weighted_min_metadata_edge(_, _)),
+    retractall(user:test_weighted_min_metadata_cost(_, _)),
+    retractall(user:test_weighted_min_metadata_path(_, _, _)),
+    clear_constraints(test_weighted_min_metadata_path/3),
     cleanup_recursive_fixture(test_probe_dir_forward_edge, test_probe_dir_forward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_backward_edge, test_probe_dir_backward_reach, 2),
     cleanup_recursive_fixture(test_probe_dir_mixed_edge, test_probe_dir_mixed_reach, 2),
@@ -3728,6 +3757,28 @@ verify_path_aware_accumulation_positive_guard_plan :-
     get_dict(root, Plan, Root),
     get_dict(type, Root, path_aware_accumulation),
     get_dict(head, Root, predicate{name:test_weighted_min_guarded_path, arity:3}),
+    get_dict(table_modes, Root, [lattice, lattice, min]),
+    get_dict(positive_step_proven, Root, true),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'PathAwareAccumulationNode'),
+    sub_string(Source, _, _, _, 'TableMode.Min'),
+    sub_string(Source, _, _, _, ', true)'),
+    maybe_run_query_runtime(Plan,
+        ['a,b,1',
+         'a,c,1',
+         'a,d,3'],
+        [[a]]).
+
+verify_path_aware_accumulation_positive_metadata_plan :-
+    csharp_target:build_query_plan(
+        test_weighted_min_metadata_path/3,
+        [target(csharp_query)],
+        [input, output, output],
+        Plan),
+    get_dict(is_recursive, Plan, true),
+    get_dict(root, Plan, Root),
+    get_dict(type, Root, path_aware_accumulation),
+    get_dict(head, Root, predicate{name:test_weighted_min_metadata_path, arity:3}),
     get_dict(table_modes, Root, [lattice, lattice, min]),
     get_dict(positive_step_proven, Root, true),
     csharp_query_target:render_plan_to_csharp(Plan, Source),


### PR DESCRIPTION
  ## Summary

  This PR finishes the planner-level contract for weighted `min`
  accumulation by adding declarative positive-step metadata through the
  existing constraint system.

  The C# query planner can now prove positive-step eligibility for the
  weighted `min` fast path in two ways:

  1. explicit guards in the query body, such as `Cost > 0`
  2. declarative metadata, such as:
     `:- constraint(path/3, [positive_step(3)]).`

  This makes the optimization contract explicit and reusable across
  targets, which is the missing piece we wanted before extending the same
  feature family in Rust.

  ## What Changed

  ### Constraint System

  In:

  - `src/unifyweaver/core/constraint_analyzer.pl`

  the existing constraint vocabulary now accepts and preserves:

  - `positive_step(N)`

  So predicate-level constraints can carry positive-step information
  without inventing a separate optimization-only directive path.

  ### C# Query Planner

  In:

  - `src/unifyweaver/targets/csharp_target.pl`

  the path-aware accumulation planner now treats either of these as proof:

  - a recognized positive guard in the clause body
  - a declared `positive_step(3)` constraint on the predicate

  That proof is propagated into the generated
  `path_aware_accumulation` plan as:

  - `positive_step_proven:true`

  This feeds the already-implemented weighted `min` fast path in the C#
  runtime.

  ### Tests

  In:

  - `tests/core/test_csharp_query_target.pl`

  add a metadata-driven weighted `min` regression that verifies:

  - declared `positive_step(3)` is picked up by the planner
  - generated C# still emits the expected `PathAwareAccumulationNode`
  - runtime output matches the guarded case

  ### Documentation

  Updated:

  - `docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md`

  The doc now reflects current reality:

  - explicit guards are implemented
  - declarative metadata is also implemented
  - the remaining question is how Rust lowering should consume these
    contracts, not whether the metadata syntax exists

  ## Why This Matters

  Before this PR, the minimum acceptable contract before Rust was only
  partially complete:

  - explicit positive guards were implemented
  - metadata was still only described in a proposal

  Now the planner contract is first-class and target-neutral.

  That means Rust can lower against explicit plan/source contracts rather
  than inheriting benchmark-specific runtime inference logic from the C#
  implementation.

  ## Example

  The new declarative form is:

  ```prolog
  :- constraint(path/3, [positive_step(3)]).

  For the weighted accumulation pattern, this lets the planner treat the
  accumulator position as positivity-proven without requiring the query
  body to repeat an explicit Cost > 0 guard.

  ## Verification

  ### C# query-target suite

  Passed locally:

  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl -g
  "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 232/232 tests passed

  ### Benchmark script syntax

  Passed locally:

  python -m py_compile examples/benchmark/benchmark_weighted_shortest_path.py

  ## Scope

  This PR does not change runtime semantics.

  It strengthens planner-visible optimization contracts so that the
  existing weighted min runtime fast path can be selected on explicit
  metadata, not just explicit guards or runtime inference.