### PR TITLE
Keep native TypR atom string tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ includes:
 - simple alias or arithmetic assignment tails after an earlier native
   string-transform or length-producing step
 - simple alias tails after native conversion, list, and path producers such as
-  `to_numeric/2`, `reverse/2`, and `dirname/2`
+  `to_numeric/2`, `reverse/2`, `dirname/2`, and `atom_string/2`
 - guard-style command predicates such as `is_character/1`
 - unary TypR-safe I/O commands such as `cat/1` and `print/1`, emitted as
   native fixed-arity TypR calls
@@ -385,7 +385,8 @@ The wrapped fallback boundary is now beyond the first native
 string-transform/output-tail slice; if this area is extended further, the next
 real audit target is the producer-goal family after the currently supported
 `string_lower/2`, `string_upper/2`, `string_length/2`, `to_numeric/2`,
-`reverse/2`, and `dirname/2` follow-on alias or arithmetic tails.
+`reverse/2`, `dirname/2`, and `atom_string/2` follow-on alias or arithmetic
+tails.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -170,7 +170,7 @@ bring-up.
   - simple alias or arithmetic assignment tails after an earlier native
     string-transform or length-producing step
   - simple alias tails after native conversion, list, and path producers such
-    as `to_numeric/2`, `reverse/2`, and `dirname/2`
+    as `to_numeric/2`, `reverse/2`, `dirname/2`, and `atom_string/2`
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -512,8 +512,9 @@ Current wrapped-fallback boundary note:
   alias or arithmetic assignment tail such as `Out = Lower` or
   `Out is Len + 1`
 - the next audited producer families also stay native for simple alias tails,
-  including representative conversion, list, and path producers such as
-  `to_numeric/2`, `reverse/2`, and `dirname/2`
+  including representative conversion, list, path, and atom/string bridge
+  producers such as `to_numeric/2`, `reverse/2`, `dirname/2`, and
+  `atom_string/2`
 - the remaining wrapped fallback boundary is now beyond that first
   producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -7782,6 +7782,11 @@ native_typr_output_expr(filter(DF, Expr, Out), VarMap0, _PredName, VarMap, Final
     typr_resolve_value(VarMap0, DF, RDF),
     typr_translate_r_expr(Expr, VarMap0, RExpr),
     format(string(OutputExpr), '@{ subset(~w, ~w) }@', [RDF, RExpr]).
+native_typr_output_expr(atom_string(InValue, OutVar), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+    var(OutVar),
+    !,
+    ensure_typr_var(VarMap0, OutVar, FinalExpr, VarMap, IntroKind),
+    typr_resolve_value(VarMap0, InValue, OutputExpr).
 native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2179,6 +2179,19 @@ test(path_alias_after_native_outputs_stays_native) :-
     \+ sub_string(Code, _, _, _, "Unknown predicate"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(atom_string_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(atom_string_alias(A, Out) :- atom_string(A, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(atom_string_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(atom_string_alias/2, 2, string)),
+    once(compile_predicate_to_typr(atom_string_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let atom_string_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- arg1;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(multi_decision_guard_chains_use_let_for_new_intermediates) :-
     clear_type_declarations,
     assertz(user:(multi_guard_chain(Name, Out) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Upper), is_character(Upper), string_concat(Upper, '!', Out))),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -126,6 +126,23 @@ test(path_alias_after_native_outputs_check_with_typr, [condition(typr_cli_availa
     ),
     retractall(user:dirname_alias(_, _)).
 
+test(atom_string_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(atom_string_alias(A, Out) :- atom_string(A, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(atom_string_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(atom_string_alias/2, 2, string)),
+    once(compile_predicate_to_typr(atom_string_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:atom_string_alias(_, _)).
+
 test(cat_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:(say_cat(Msg) :- cat(Msg))),


### PR DESCRIPTION
## Summary
- keep `atom_string/2` producer-follow-on alias tails native in the TypR target
- add target-level and real `typr check` regression coverage for that slice
- update docs to reflect the narrower remaining wrapped-fallback boundary

## What changed
- added a conservative native TypR output path for `atom_string/2` when it is used as a producer followed by a simple alias tail
- added regression coverage in:
  - `tests/test_typr_target.pl`
  - `tests/test_typr_toolchain.pl`
- updated TypR docs in:
  - `README.md`
  - `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
  - `docs/design/TYPR_TARGET_DESIGN.md`

## Important result
The next real unsupported producer family after the already-native string/conversion/list/path slice was `atom_string/2`.

A shape like:

```prolog
atom_string(A, Tmp), Out = Tmp
```

was still falling through to wrapped fallback.

It now stays native in TypR.

## Example generated shape
```typr
let atom_string_alias <- fn(arg1: char, arg2: char): char {
	let v3 <- arg1;
	arg2 <- v3;
	arg2
};
```

## Why this matters
This narrows the remaining wrapped-fallback boundary again without reopening the broader generic-body design question.

The next producer-family audit should move to the next genuinely unsupported typed producer family, likely a narrowed `sub_atom`/substring-style slice rather than revisiting already-native conversions.

## Validation
```sh
swipl -q -g "run_tests([typr_target:atom_string_alias_after_native_outputs_stays_native])" -t halt tests/test_typr_target.pl
swipl -q -g "run_tests([typr_toolchain:atom_string_alias_after_native_outputs_check_with_typr])" -t halt tests/test_typr_toolchain.pl
git diff --check
```
