### PR TITLE
feat(rust): add native min recursion lowering

### DIFF
--- a/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
+++ b/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
@@ -121,8 +121,15 @@ The declarative metadata mechanism is now available through
  `constraint/2` with `positive_step(N)`.
 
 The remaining work before broad Rust adoption is not syntax design but
- deciding how much Rust native lowering should rely on:
+ deciding how broadly targets should rely on:
 
 - explicit positive guards
 - declarative `positive_step/1` metadata
 - or both
+
+Current implementation status:
+
+- C# weighted `Min` lowering consumes both explicit guards and
+  `positive_step/1` metadata
+- Rust native lowering for counted and positive-additive weighted `Min`
+  now consumes the same contracts during native emission

--- a/src/unifyweaver/targets/rust_target.pl
+++ b/src/unifyweaver/targets/rust_target.pl
@@ -71,6 +71,7 @@
 :- use_module('../core/service_validation').
 :- use_module('../core/optimizer').
 :- use_module('../core/template_system', [render_template/3]).
+:- use_module('../core/constraint_analyzer', [get_constraints/2]).
 
 % Component system integration (ported from Go target)
 :- use_module('../core/component_registry').
@@ -80,7 +81,7 @@
 :- use_module('../core/clause_body_analysis', except([translate_expr/3])).
 
 % Per-path visited pattern detection
-:- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4]).
+:- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4, parse_table_spec/2]).
 
 % Track collected components for code generation
 :- dynamic collected_component/2.
@@ -3372,8 +3373,8 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
         compile_facts_to_rust(Pred, Arity, Clauses, FieldDelim, RustCode)
     ;   is_general_recursive_pattern_rust(Pred, Arity, Clauses) ->
         format('Type: general_recursion_arity_~w~n', [Arity]),
-        (   rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr)
-        ->  compile_general_recursive_accumulation_to_rust(Pred, Arity, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, RustCode)
+        (   rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepGuardProven)
+        ->  compile_general_recursive_accumulation_to_rust(Pred, Arity, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepGuardProven, RustCode)
         %% Check for per-path visited pattern and branch code generation
         ;   rust_clauses_to_ppv_pairs(Clauses, PPVPairs),
             is_per_path_visited_pattern(Pred, Arity, PPVPairs, VisitedPos)
@@ -3392,6 +3393,19 @@ compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
 %%
 %% Handles transitive closure with counter patterns.
 %% Generates recursive Rust function with HashSet<String> visited parameter.
+
+rust_declared_table_mode(Pred/Arity, Mode) :-
+    clause(user:'table'(TableSpec), true),
+    compound(TableSpec),
+    functor(TableSpec, Pred, Arity),
+    parse_table_spec(TableSpec, Modes),
+    nth1(Arity, Modes, Mode),
+    !.
+rust_declared_table_mode(_, all).
+
+rust_positive_step_metadata(Pred/Arity, Position) :-
+    get_constraints(Pred/Arity, Constraints),
+    member(positive_step(Position), Constraints).
 
 is_general_recursive_pattern_rust(Pred, Arity, Clauses) :-
     Arity >= 2,
@@ -3418,6 +3432,7 @@ rust_clauses_to_ppv_pairs([Head-Body|Rest], [(Head, Body)|RestPairs]) :-
 %  Plain recursive Rust function without HashSet<String> visited parameter.
 compile_general_recursive_to_rust_no_visited(Pred, Arity, Clauses, RustCode) :-
     atom_string(Pred, PredStr),
+    rust_declared_table_mode(Pred/Arity, TableMode),
     % Partition clauses
     partition(is_rec_clause_rust(Pred), Clauses, RecClauses, BaseClauses),
     % Extract step relation from base case
@@ -3464,7 +3479,17 @@ compile_general_recursive_to_rust_no_visited(Pred, Arity, Clauses, RustCode) :-
         ),
         FactLines),
     atomic_list_concat(FactLines, '\n', FactBlock),
-    (   Arity =:= 3
+    (   Arity =:= 3,
+        TableMode == min
+    ->  load_rust_template('path_aware_transitive_closure_min', Template),
+        render_template(Template, [
+            pred=PredStr,
+            step_rel=StepRelStr,
+            base_const=BaseConstStr,
+            recursive_increment=IncrStr,
+            step_block=FactBlock
+        ], RustCode)
+    ;   Arity =:= 3
     ->  format(string(RustCode),
 '// Transitive closure with counter: ~w/3 (no visited pattern)
 // Step relation: ~w/2
@@ -3525,6 +3550,7 @@ fn main() {{
 
 compile_general_recursive_to_rust(Pred, Arity, Clauses, RustCode) :-
     atom_string(Pred, PredStr),
+    rust_declared_table_mode(Pred/Arity, TableMode),
     % Partition clauses
     partition(is_rec_clause_rust(Pred), Clauses, RecClauses, BaseClauses),
     % Extract step relation from base case
@@ -3572,7 +3598,17 @@ compile_general_recursive_to_rust(Pred, Arity, Clauses, RustCode) :-
         ),
         FactLines),
     atomic_list_concat(FactLines, '\n', FactBlock),
-    (   Arity =:= 3
+    (   Arity =:= 3,
+        TableMode == min
+    ->  load_rust_template('path_aware_transitive_closure_min', Template),
+        render_template(Template, [
+            pred=PredStr,
+            step_rel=StepRelStr,
+            base_const=BaseConstStr,
+            recursive_increment=IncrStr,
+            step_block=FactBlock
+        ], RustCode)
+    ;   Arity =:= 3
     ->  format(string(RustCode),
 '// Transitive closure with counter: ~w/3
 // Step relation: ~w/2
@@ -3656,7 +3692,7 @@ extract_goals_list_rust((A, B), [A|Rest]) :- !,
     extract_goals_list_rust(B, Rest).
 extract_goals_list_rust(Goal, [Goal]).
 
-rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr) :-
+rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepProven) :-
     partition(is_rec_clause_rust(Pred), Clauses, RecClauses, BaseClauses),
     BaseClauses = [BaseHead-BaseBody|_],
     RecClauses = [_RecHead-RecBody|_],
@@ -3665,7 +3701,8 @@ rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAc
     var(To),
     var(Acc),
     extract_goals_list_rust(BaseBody, BaseGoals),
-    select(BaseArith, BaseGoals, BaseTerms),
+    select(BaseArith, BaseGoals, BaseTerms0),
+    rust_extract_positive_step_guard(BaseTerms0, AuxValue, BaseTerms, BasePositiveStep),
     BaseTerms = [BaseGoalA, BaseGoalB],
     rust_edge_aux_terms(From, To, AuxValue, BaseGoalA, BaseGoalB, EdgeGoal, AuxGoal),
     EdgeGoal =.. [StepRel, From, To],
@@ -3674,7 +3711,8 @@ rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAc
     term_variables(BaseExpr, BaseVars),
     subset_vars(BaseVars, [AuxValue]),
     extract_goals_list_rust(RecBody, RecGoals),
-    select(RecArith, RecGoals, RecTerms0),
+    select(RecArith, RecGoals, RecTermsWithGuard),
+    rust_extract_positive_step_guard(RecTermsWithGuard, AuxValue, RecTerms0, RecPositiveStep),
     select(RecAuxGoal, RecTerms0, RecTerms1),
     select(RecEdgeGoal, RecTerms1, [RecCall]),
     RecEdgeGoal =.. [StepRel, From, Mid],
@@ -3683,7 +3721,33 @@ rust_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAc
     RecArith = (Acc is RecExpr),
     term_variables(RecExpr, RecVars),
     member_var_eq(PrevAcc, RecVars),
-    subset_vars(RecVars, [PrevAcc, AuxValue]).
+    subset_vars(RecVars, [PrevAcc, AuxValue]),
+    (   (BasePositiveStep == true ; RecPositiveStep == true)
+    ->  PositiveStepProven = true
+    ;   PositiveStepProven = false
+    ).
+
+rust_extract_positive_step_guard(Terms, AuxValue, RemainingTerms, true) :-
+    select(Guard0, Terms, RemainingTerms),
+    rust_positive_step_guard(Guard0, AuxValue),
+    !.
+rust_extract_positive_step_guard(Terms, _AuxValue, Terms, false).
+
+rust_positive_step_guard(Goal0, AuxValue) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [>, AuxValue, Value],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [<, Value, AuxValue],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [>=, AuxValue, Value],
+        number(Value),
+        Value > 0
+    ;   Goal =.. [=<, Value, AuxValue],
+        number(Value),
+        Value > 0
+    ).
 
 rust_edge_aux_terms(From, To, AuxValue, GoalA, GoalB, EdgeGoal, AuxGoal) :-
     (   rust_binary_relation_term(From, To, GoalA),
@@ -3708,14 +3772,20 @@ rust_aux_relation_term(Key, Value, Goal0) :-
     arg(1, Goal, Key),
     arg(2, Goal, Value).
 
-compile_general_recursive_accumulation_to_rust(Pred, Arity, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, RustCode) :-
+compile_general_recursive_accumulation_to_rust(Pred, Arity, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepGuardProven, RustCode) :-
     Arity =:= 3,
     atom_string(Pred, PredStr),
     atom_string(StepRel, StepRelStr),
     atom_string(AuxRel, AuxRelStr),
+    rust_declared_table_mode(Pred/Arity, TableMode),
+    (   (PositiveStepGuardProven == true ; rust_positive_step_metadata(Pred/Arity, Arity))
+    ->  PositiveStepProven = true
+    ;   PositiveStepProven = false
+    ),
     rust_accumulation_numeric_type(BaseExpr, RecExpr, AccType),
     rust_accumulation_expr(BaseExpr, [AuxValue-'*step_cost'], AccType, BaseExprCode),
     rust_accumulation_expr(RecExpr, [PrevAcc-acc, AuxValue-'*step_cost'], AccType, RecExprCode),
+    rust_accumulation_expr(RecExpr, [PrevAcc-cost, AuxValue-'*step_cost'], AccType, MinRecExprCode),
     functor(StepHead, StepRel, 2),
     findall(A-B, (user:clause(StepHead, true), StepHead =.. [_, A, B]), StepFacts),
     findall(StepLine,
@@ -3737,7 +3807,11 @@ compile_general_recursive_accumulation_to_rust(Pred, Arity, StepRel, AuxRel, Aux
         ),
         AuxLines),
     atomic_list_concat(AuxLines, '\n', AuxBlock),
-    load_rust_template('path_aware_accumulation', Template),
+    (   TableMode == min,
+        PositiveStepProven == true
+    ->  load_rust_template('path_aware_accumulation_min', Template)
+    ;   load_rust_template('path_aware_accumulation', Template)
+    ),
     render_template(Template, [
         pred=PredStr,
         step_rel=StepRelStr,
@@ -3746,7 +3820,8 @@ compile_general_recursive_accumulation_to_rust(Pred, Arity, StepRel, AuxRel, Aux
         step_block=StepBlock,
         aux_block=AuxBlock,
         base_expr=BaseExprCode,
-        recursive_expr=RecExprCode
+        recursive_expr=RecExprCode,
+        min_recursive_expr=MinRecExprCode
     ], RustCode).
 
 member_var_eq(Var, [Candidate|_]) :-

--- a/templates/targets/rust/path_aware_accumulation_min.mustache
+++ b/templates/targets/rust/path_aware_accumulation_min.mustache
@@ -1,0 +1,87 @@
+// Path-aware positive weighted minimum accumulation: {{pred}}/3
+// Edge relation: {{step_rel}}/2
+// Auxiliary relation: {{aux_rel}}/2
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+
+#[derive(Clone, Debug)]
+struct State {
+    cost: {{acc_type}},
+    node: String,
+}
+
+impl PartialEq for State {
+    fn eq(&self, other: &Self) -> bool {
+        self.node == other.node && self.cost == other.cost
+    }
+}
+
+impl Eq for State {}
+
+impl Ord for State {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .cost
+            .partial_cmp(&self.cost)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| self.node.cmp(&other.node))
+    }
+}
+
+impl PartialOrd for State {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn {{pred}}_min(
+    start: &str,
+    adj: &HashMap<String, Vec<String>>,
+    aux: &HashMap<String, {{acc_type}}>
+) -> Vec<(String, {{acc_type}})> {
+    let mut best: HashMap<String, {{acc_type}}> = HashMap::new();
+    let mut heap: BinaryHeap<State> = BinaryHeap::new();
+
+    if let (Some(neighbors), Some(step_cost)) = (adj.get(start), aux.get(start)) {
+        for nb in neighbors {
+            heap.push(State {
+                cost: {{base_expr}},
+                node: nb.clone(),
+            });
+        }
+    }
+
+    while let Some(State { cost, node }) = heap.pop() {
+        if let Some(existing) = best.get(&node) {
+            if cost >= *existing {
+                continue;
+            }
+        }
+        best.insert(node.clone(), cost);
+
+        if let (Some(neighbors), Some(step_cost)) = (adj.get(&node), aux.get(&node)) {
+            for nb in neighbors {
+                heap.push(State {
+                    cost: {{min_recursive_expr}},
+                    node: nb.clone(),
+                });
+            }
+        }
+    }
+
+    let mut results: Vec<(String, {{acc_type}})> = best.into_iter().collect();
+    results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal)));
+    results
+}
+
+fn main() {
+    let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+{{step_block}}
+    let mut aux: HashMap<String, {{acc_type}}> = HashMap::new();
+{{aux_block}}
+
+    let results = {{pred}}_min("test", &adj, &aux);
+    for (ancestor, acc) in &results {
+        println!("{}\t{}", ancestor, acc);
+    }
+}

--- a/templates/targets/rust/path_aware_transitive_closure_min.mustache
+++ b/templates/targets/rust/path_aware_transitive_closure_min.mustache
@@ -1,0 +1,43 @@
+// Path-aware minimum-hop transitive closure: {{pred}}/3
+// Step relation: {{step_rel}}/2
+use std::collections::{HashMap, VecDeque};
+
+fn {{pred}}_min(start: &str, adj: &HashMap<String, Vec<String>>) -> Vec<(String, i32)> {
+    let mut best: HashMap<String, i32> = HashMap::new();
+    let mut queue: VecDeque<(String, i32)> = VecDeque::new();
+
+    if let Some(neighbors) = adj.get(start) {
+        for nb in neighbors {
+            queue.push_back((nb.clone(), {{base_const}}));
+        }
+    }
+
+    while let Some((node, depth)) = queue.pop_front() {
+        if let Some(existing) = best.get(&node) {
+            if depth >= *existing {
+                continue;
+            }
+        }
+        best.insert(node.clone(), depth);
+
+        if let Some(neighbors) = adj.get(&node) {
+            for nb in neighbors {
+                queue.push_back((nb.clone(), depth + {{recursive_increment}}));
+            }
+        }
+    }
+
+    let mut results: Vec<(String, i32)> = best.into_iter().collect();
+    results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    results
+}
+
+fn main() {
+    let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+{{step_block}}
+
+    let results = {{pred}}_min("test", &adj);
+    for (ancestor, hops) in &results {
+        println!("{}\t{}", ancestor, hops);
+    }
+}

--- a/tests/core/test_rust_native_lowering.pl
+++ b/tests/core/test_rust_native_lowering.pl
@@ -1,6 +1,9 @@
 :- module(test_rust_native_lowering, [test_rust_native_lowering/0]).
 :- use_module(library(plunit)).
 :- use_module('../../src/unifyweaver/targets/rust_target').
+:- use_module('../../src/unifyweaver/core/constraint_analyzer').
+
+:- dynamic user:'table'/1.
 
 test_rust_native_lowering :-
     run_tests([rust_native_lowering]).
@@ -197,6 +200,81 @@ test(weighted_recursive_accumulation_lowering) :-
     retractall(user:weighted_edge(_, _)),
     retractall(user:weighted_cost(_, _)),
     retractall(user:weighted_path(_, _, _)).
+
+test(min_counted_recursive_lowering) :-
+    assert(user:(min_edge(a, b))),
+    assert(user:(min_edge(b, c))),
+    assert(user:(min_reach(X, Y, H) :-
+        min_edge(X, Y),
+        H is 1)),
+    assert(user:(min_reach(X, Z, H) :-
+        min_edge(X, Y),
+        min_reach(Y, Z, H1),
+        H is H1 + 1)),
+    assert(user:'table'(min_reach(_, _, min))),
+    compile_rs(min_reach/3, Code),
+    has(Code, "Path-aware minimum-hop transitive closure"),
+    has(Code, "VecDeque"),
+    has(Code, "fn min_reach_min"),
+    has(Code, "let mut best: HashMap<String, i32> = HashMap::new();"),
+    retractall(user:min_edge(_, _)),
+    retractall(user:min_reach(_, _, _)),
+    retractall(user:'table'(min_reach(_, _, min))).
+
+test(weighted_min_recursive_accumulation_lowering) :-
+    assert(user:(weighted_min_edge(a, b))),
+    assert(user:(weighted_min_edge(b, c))),
+    assert(user:(weighted_min_cost(a, 2))),
+    assert(user:(weighted_min_cost(b, 5))),
+    assert(user:(weighted_min_path(X, Y, Acc) :-
+        weighted_min_edge(X, Y),
+        weighted_min_cost(X, Cost),
+        Acc is Cost)),
+    assert(user:(weighted_min_path(X, Z, Acc) :-
+        weighted_min_edge(X, Y),
+        weighted_min_cost(X, Cost),
+        weighted_min_path(Y, Z, PrevAcc),
+        Acc is PrevAcc + Cost)),
+    assert(user:'table'(weighted_min_path(_, _, min))),
+    declare_constraint(weighted_min_path/3, [positive_step(3)]),
+    compile_rs(weighted_min_path/3, Code),
+    has(Code, "Path-aware positive weighted minimum accumulation"),
+    has(Code, "BinaryHeap"),
+    has(Code, "fn weighted_min_path_min"),
+    has(Code, "let mut best: HashMap<String, i64> = HashMap::new();"),
+    has(Code, "cost: *step_cost"),
+    has(Code, "cost: (cost + *step_cost)"),
+    retractall(user:weighted_min_edge(_, _)),
+    retractall(user:weighted_min_cost(_, _)),
+    retractall(user:weighted_min_path(_, _, _)),
+    clear_constraints(weighted_min_path/3),
+    retractall(user:'table'(weighted_min_path(_, _, min))).
+
+test(weighted_min_guarded_recursive_accumulation_lowering) :-
+    assert(user:(weighted_guard_edge(a, b))),
+    assert(user:(weighted_guard_edge(b, c))),
+    assert(user:(weighted_guard_cost(a, 2))),
+    assert(user:(weighted_guard_cost(b, 5))),
+    assert(user:(weighted_guard_path(X, Y, Acc) :-
+        weighted_guard_edge(X, Y),
+        weighted_guard_cost(X, Cost),
+        Cost > 0,
+        Acc is Cost)),
+    assert(user:(weighted_guard_path(X, Z, Acc) :-
+        weighted_guard_edge(X, Y),
+        weighted_guard_cost(X, Cost),
+        Cost > 0,
+        weighted_guard_path(Y, Z, PrevAcc),
+        Acc is PrevAcc + Cost)),
+    assertz(user:'table'(weighted_guard_path(_, _, min))),
+    compile_rs(weighted_guard_path/3, Code),
+    has(Code, "Path-aware positive weighted minimum accumulation"),
+    has(Code, "fn weighted_guard_path_min"),
+    has(Code, "BinaryHeap"),
+    retractall(user:weighted_guard_edge(_, _)),
+    retractall(user:weighted_guard_cost(_, _)),
+    retractall(user:weighted_guard_path(_, _, _)),
+    retractall(user:'table'(weighted_guard_path(_, _, min))).
 
 test(log_recursive_accumulation_lowering) :-
     assert(user:(semantic_edge(a, b))),


### PR DESCRIPTION
  ## Summary

  This PR brings Rust native lowering up to the same new recursion feature
  surface we recently added on the C# side.

  It adds native Rust lowering for:

  - counted recursive `Min` from `:- table pred(_, _, min).`
  - positive-additive weighted recursive `Min`
  - positivity proven either by:
    - explicit guards such as `Cost > 0`
    - declarative metadata such as:
      `:- constraint(path/3, [positive_step(3)]).`

  The goal is to keep Rust aligned with the same planner/source contracts
  now used by the C# query engine, rather than relying on Rust-specific
  handwritten benchmark paths.

  ## What Changed

  ### Rust Lowering

  In:

  - `src/unifyweaver/targets/rust_target.pl`

  the native recursive lowering path now recognizes:

  1. counted shortest-path style recursion with `table(..., min)`
  2. weighted positive-additive recursive accumulation with `table(..., min)`

  The Rust target now consumes:

  - table mode information from `table/1`
  - positive-step metadata from `constraint/2`
  - explicit positive guards in the recursive clauses

  ### New Rust Templates

  Added:

  - `templates/targets/rust/path_aware_transitive_closure_min.mustache`
  - `templates/targets/rust/path_aware_accumulation_min.mustache`

  These cover:

  - minimum-hop counted recursion
  - positive weighted minimum accumulation

  ### Tests

  Extended:

  - `tests/core/test_rust_native_lowering.pl`

  New regression coverage verifies native-lowered Rust emission for:

  - counted `Min`
  - weighted `Min` with `positive_step(3)` metadata
  - weighted `Min` with explicit `Cost > 0` guards

  ### Docs

  Updated:

  - `docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md`

  The doc now reflects that Rust, not just C#, consumes the same explicit
  positivity contracts.

  ## Why This Matters

  We had already generalized the C# query engine to support:

  - counted `Min`
  - weighted `Min`
  - explicit positivity contracts

  Rust was behind that work.

  This PR closes that gap for native lowering, so the two targets now
  share the same contract model for these recursive `Min` cases.

  That keeps the long-term direction consistent:

  - generalize the lowering
  - do not handcraft benchmark-only Rust paths
  - rely on explicit planner/source contracts where possible

  ## Supported Shapes

  ### Counted `Min`

  Example shape:

  ```prolog
  path(X, Y, H) :-
      edge(X, Y),
      H is 1.

  path(X, Z, H) :-
      edge(X, Y),
      path(Y, Z, H1),
      H is H1 + 1.

  :- table path(_, _, min).

  ### Weighted Positive Min

  Example shape:

  path(X, Y, Acc) :-
      edge(X, Y),
      weight(X, Cost),
      Acc is Cost.

  path(X, Z, Acc) :-
      edge(X, Y),
      weight(X, Cost),
      path(Y, Z, Acc1),
      Acc is Acc1 + Cost.

  :- table path(_, _, min).
  :- constraint(path/3, [positive_step(3)]).

  or equivalently with explicit guards:

  Cost > 0

  in both base and recursive clauses.

  ## Verification

  Passed locally:

  swipl -q -g "use_module(tests/core/test_rust_native_lowering), test_rust_native_lowering, halt"
  python -m py_compile examples/benchmark/benchmark_shortest_path_to_root.py examples/benchmark/
  benchmark_weighted_shortest_path.py

  ## Notes

  This PR is intentionally scoped to native lowering and emitted-code
  coverage.

  It does not yet add a full Rust benchmark comparison against the new
  C# Min paths. The focus here is closing the lowering gap first.

  ## Follow-Up

  Likely next steps:

  - add Rust-side benchmark scripts or extend the existing benchmark suite
    to compare the new Min lowerings directly
  - broaden Rust support beyond the current positive-additive weighted Min
    class if we decide to mirror more of the C# fallback behavior