### PR TITLE
feat: list builtins, findall_wam, and structure/term indexing

### DIFF
--- a/archive/pr_descriptions/PR_WAM_BUILTINS_SOLVE_INDEXING.md
+++ b/archive/pr_descriptions/PR_WAM_BUILTINS_SOLVE_INDEXING.md
@@ -1,0 +1,28 @@
+# PR: feat: built-in predicates, solve_wam, first-arg indexing, and clause_body_analysis refactor
+
+**Title:** `feat: WAM builtins, solve_wam, indexing, and clause_body_analysis refactor`
+
+## Summary
+
+- Add `builtin_call` instruction for arithmetic (`is/2`, `+`, `-`, `*`, `/`, `//`, `mod`, `abs`), comparison (`>/2`, `</2`, `>=/2`, `=</2`, `=:=/2`, `=\=/2`), equality (`==/2`, `\==/2`, `\=/2`), type checks (`atom/1`, `number/1`, `integer/1`, `float/1`, `compound/1`, `var/1`, `nonvar/1`, `is_list/1`), and control (`true/0`, `fail/0`, `!/0`, `\+/1`)
+- Compiler recognizes builtins and emits `builtin_call` + `proceed` instead of `call`/`execute`
+- Arithmetic evaluation supports heap-ref dereferencing for `put_structure`-built expressions
+- Add `solve_wam/4` API: executes a query and extracts variable bindings as `Name=Value` pairs from the final register state — supports Prolog variables in queries
+- Add first-argument indexing via `switch_on_constant`: compiler generates index tables for multi-clause predicates with all-atomic first arguments; runtime dispatches directly to matching clause labels
+- Refactor `is_builtin_pred/2` to delegate to `clause_body_analysis:is_guard_goal/2` for guard detection instead of maintaining a hardcoded list — automatically picks up any predicate the shared analysis classifies as a guard (comparisons, type checks)
+
+## Test plan
+
+- [x] All 7 WAM target compiler tests pass
+- [x] All 12 E2E tests pass — including new tests for `>/2`, `is/2`, `atom/1`, `solve_wam`, and `switch_on_constant`
+- [x] Verified `e2e_double(3, 6)` succeeds via `is/2` with heap-ref arithmetic
+- [x] Verified `solve_wam` returns `['City'=paris]` for `e2e_capital(france, City)`
+- [x] Verified `switch_on_constant` appears in compiled output and execution still works
+- [x] Verified `e2e_is_atom(hello)` succeeds via delegated type check builtin
+- [x] Exit code 0 on success, 1 on failure (CI-compatible)
+
+## Companion PR
+
+- Education repo: `docs: add builtin_call, switch_on_constant to Book 17 ISA` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/archive/pr_descriptions/PR_WAM_BUILTINS_SOLVE_INDEXING_DOCS.md
+++ b/archive/pr_descriptions/PR_WAM_BUILTINS_SOLVE_INDEXING_DOCS.md
@@ -1,0 +1,19 @@
+# PR: docs: add builtin_call, switch_on_constant to Book 17 ISA
+
+**Title:** `docs: add builtin_call and switch_on_constant to Book 17 ISA`
+
+## Summary
+
+- Add `builtin_call(P/N, Arity)` to the Control section of Chapter 2 (ISA) — evaluates built-in predicates inline without jumping to compiled code
+- Add new "Indexing" section (section 5) documenting `switch_on_constant(Key1:Label1, ...)` — first-argument dispatch that skips inapplicable clauses
+
+## Test plan
+
+- [x] Documentation matches compiler emission and runtime `step_wam` clauses
+- [x] Instruction descriptions consistent with `is_builtin_pred` and `build_first_arg_index`
+
+## Companion PR
+
+- Main repo: `feat: WAM builtins, solve_wam, indexing, and clause_body_analysis refactor` (same branch name)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -8,6 +8,7 @@
 :- module(wam_runtime, [
     execute_wam/3,       % +InstructionsString, +Query, -Results
     solve_wam/4,         % +InstructionsString, +Query, +VarNames, -Bindings
+    findall_wam/4,       % +InstructionsString, +Query, +VarNames, -AllBindings
     test_wam_runtime/0
 ]).
 
@@ -400,6 +401,68 @@ lookup_index(Val, [Entry|Rest], Labels, TargetPC) :-
     ;   lookup_index(Val, Rest, Labels, TargetPC)
     ).
 
+%% switch_on_structure — indexes on compound first argument's functor/arity.
+step_wam(Instr, wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
+    Instr =.. [switch_on_structure|Entries],
+    Entries \= [],
+    (   get_assoc('A1', R, Val),
+        \+ is_unbound_var(Val),
+        compound(Val),
+        Val =.. [F|SubArgs],
+        length(SubArgs, SArity),
+        format(atom(FN), "~w/~w", [F, SArity]),
+        lookup_index(FN, Entries, L, TargetPC)
+    ->  NPC = TargetPC
+    ;   NPC is PC + 1
+    ).
+
+%% switch_on_term — type-based dispatch for mixed first arguments.
+%  Parsed as switch_on_term('constant:...', 'structure:...').
+step_wam(Instr, wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
+    Instr =.. [switch_on_term|Args],
+    Args \= [],
+    (   get_assoc('A1', R, Val),
+        \+ is_unbound_var(Val)
+    ->  (   atomic(Val)
+        ->  find_term_index_section('constant', Args, Entries),
+            (   lookup_index(Val, Entries, L, TargetPC)
+            ->  NPC = TargetPC
+            ;   NPC is PC + 1
+            )
+        ;   compound(Val)
+        ->  Val =.. [F|SubArgs],
+            length(SubArgs, SArity),
+            format(atom(FN), "~w/~w", [F, SArity]),
+            find_term_index_section('structure', Args, Entries),
+            (   lookup_index(FN, Entries, L, TargetPC)
+            ->  NPC = TargetPC
+            ;   NPC is PC + 1
+            )
+        ;   NPC is PC + 1
+        )
+    ;   NPC is PC + 1
+    ).
+
+find_term_index_section(Type, Args, Entries) :-
+    atom_string(Type, TypeStr),
+    member(Arg, Args),
+    atom_string(Arg, ArgStr),
+    atom_concat(TypeStr, ':', Prefix),
+    atom_string(Prefix, PrefixStr),
+    sub_string(ArgStr, 0, _, After, PrefixStr),
+    sub_string(ArgStr, _, After, 0, Rest),
+    (   Rest \= "none"
+    ->  split_string(Rest, ",", " ", Pairs),
+        maplist([PairStr, Entry]>>(
+            atom_string(PA, PairStr),
+            Entry = PA
+        ), Pairs, Entries)
+    ;   Entries = []
+    ), !.
+find_term_index_section(_, _, []).
+
 step_wam(try_me_else(NextL), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_state(NPC, R, S, H, T, CP, [cp(NextPC, R, S, CP, T)|CPS], Code, L)) :-
     get_assoc(NextL, L, NextPC),
     NPC is PC + 1.
@@ -578,6 +641,43 @@ step_wam(builtin_call('\\+/1', 1), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
     ;   fail
     ).
 
+%% List builtins — delegate to Prolog's native list operations.
+%% These are handled as runtime builtins since list operations involve
+%% recursive structure manipulation better done natively.
+step_wam(builtin_call('member/2', 2), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
+    get_assoc('A1', R, Elem),
+    get_assoc('A2', R, List),
+    member(Elem, List),
+    NPC is PC + 1.
+
+step_wam(builtin_call('append/3', 3), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
+    get_assoc('A1', R, L1),
+    get_assoc('A2', R, L2),
+    get_assoc('A3', R, L3),
+    (   is_unbound_var(L3)
+    ->  append(L1, L2, Result),
+        trail_binding('A3', R, T, NT),
+        put_assoc('A3', R, Result, NR)
+    ;   append(L1, L2, L3),
+        NR = R, NT = T
+    ),
+    NPC is PC + 1.
+
+step_wam(builtin_call('length/2', 2), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
+         wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
+    get_assoc('A1', R, List),
+    get_assoc('A2', R, Len),
+    (   is_unbound_var(Len)
+    ->  length(List, Result),
+        trail_binding('A2', R, T, NT),
+        put_assoc('A2', R, Result, NR)
+    ;   length(List, Len),
+        NR = R, NT = T
+    ),
+    NPC is PC + 1.
+
 %% eval_arith(+Expr, +Regs, +Stack, +Heap, -Result)
 %  Evaluates an arithmetic expression. Numbers pass through. Register
 %  names are dereferenced. Heap refs are reconstructed. Compounds are evaluated.
@@ -650,6 +750,38 @@ extract_bindings([Name=Var|Rest], Query, Regs, [Name=Value|RestBindings]) :-
     ;   Value = Var
     ),
     extract_bindings(Rest, Query, Regs, RestBindings).
+
+%% =====================================================
+%% findall_wam/4 — collect all solutions via backtracking
+%% =====================================================
+
+%% findall_wam(+Instructions, +Query, +VarNames, -AllBindings)
+%  Returns a list of binding sets, one per solution. Runs the WAM
+%  program and collects all successful execution paths by continuing
+%  to backtrack after each solution.
+findall_wam(Instructions, Query, VarNames, AllBindings) :-
+    prepare_code(Instructions, Code, Labels),
+    copy_term(Query-VarNames, QCopy-VNCopy),
+    init_state(QCopy, Code, Labels, S0),
+    run_all_solutions(S0, QCopy, VNCopy, AllBindings).
+
+run_all_solutions(S0, Query, VarNames, AllBindings) :-
+    run_all_acc(S0, Query, VarNames, [], RevBindings),
+    reverse(RevBindings, AllBindings).
+
+run_all_acc(State, Query, VarNames, Acc, AllBindings) :-
+    (   run_loop(State, Sf),
+        Sf = wam_state(_, FinalRegs, _, _, _, _, CPS, _, _)
+    ->  extract_bindings(VarNames, Query, FinalRegs, Bindings),
+        NewAcc = [Bindings|Acc],
+        % Try to backtrack for more solutions
+        (   CPS = [_|_],
+            backtrack(Sf, SBT)
+        ->  run_all_acc(SBT, Query, VarNames, NewAcc, AllBindings)
+        ;   AllBindings = NewAcc
+        )
+    ;   AllBindings = Acc
+    ).
 
 %% =====================================================
 %% Tests

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -100,28 +100,97 @@ compile_clauses_to_wam(Pred, Arity, Clauses, Options, Code) :-
     ).
 
 %% build_first_arg_index(+Pred, +Arity, +Clauses, -IndexCode)
-%  If all clauses have atomic first arguments, emit a switch_on_constant
-%  table that maps first-arg values directly to clause labels.
+%  Analyzes first arguments of all clauses and emits indexing instructions.
+%  - All atomic first args → switch_on_constant
+%  - All compound first args → switch_on_structure
+%  - Mixed types → switch_on_term (type-based dispatch)
+%  - Any variable first args → no indexing (variable matches anything)
 build_first_arg_index(Pred, Arity, Clauses, IndexCode) :-
-    length(Clauses, N),
-    build_index_entries(Clauses, 1, N, Pred, Arity, Entries),
-    Entries \= [],
-    format_index_entries(Entries, EntriesStr),
-    format(string(IndexCode), "    switch_on_constant ~w", [EntriesStr]).
-
-build_index_entries([], _, _, _, _, []).
-build_index_entries([Head-_|Rest], I, N, Pred, Arity, Entries) :-
-    Head =.. [_|[FirstArg|_]],
-    NextI is I + 1,
-    build_index_entries(Rest, NextI, N, Pred, Arity, RestEntries),
-    (   atomic(FirstArg)
-    ->  (   I == 1
-        ->  Label = default  % first clause is the default entry point
-        ;   format(atom(Label), "L_~w_~w_~w", [Pred, Arity, I])
-        ),
-        Entries = [FirstArg-Label|RestEntries]
-    ;   Entries = []  % non-constant first arg — can't index
+    classify_first_args(Clauses, Types),
+    \+ member(variable, Types),  % can't index if any clause has a variable first arg
+    (   forall(member(T, Types), T = constant)
+    ->  build_constant_index(Clauses, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode), "    switch_on_constant ~w", [EntriesStr])
+    ;   forall(member(T, Types), T = structure)
+    ->  build_structure_index(Clauses, 1, Pred, Arity, Entries),
+        Entries \= [],
+        format_index_entries(Entries, EntriesStr),
+        format(string(IndexCode), "    switch_on_structure ~w", [EntriesStr])
+    ;   % Mixed — emit switch_on_term with type-based dispatch
+        build_term_index(Clauses, 1, Pred, Arity, Types, ConstEntries, StructEntries),
+        format_switch_on_term(ConstEntries, StructEntries, IndexCode)
     ).
+
+classify_first_args([], []).
+classify_first_args([Head-_|Rest], [Type|RestTypes]) :-
+    Head =.. [_|[FirstArg|_]],
+    (   var(FirstArg) -> Type = variable
+    ;   atomic(FirstArg) -> Type = constant
+    ;   compound(FirstArg) -> Type = structure
+    ;   Type = variable
+    ),
+    classify_first_args(Rest, RestTypes).
+
+build_constant_index([], _, _, _, []).
+build_constant_index([Head-_|Rest], I, Pred, Arity, [FirstArg-Label|RestEntries]) :-
+    Head =.. [_|[FirstArg|_]],
+    (   I == 1 -> Label = default
+    ;   format(atom(Label), "L_~w_~w_~w", [Pred, Arity, I])
+    ),
+    NextI is I + 1,
+    build_constant_index(Rest, NextI, Pred, Arity, RestEntries).
+
+build_structure_index([], _, _, _, []).
+build_structure_index([Head-_|Rest], I, Pred, Arity, [FN-Label|RestEntries]) :-
+    Head =.. [_|[FirstArg|_]],
+    FirstArg =.. [F|SubArgs],
+    length(SubArgs, SArity),
+    format(atom(FN), "~w/~w", [F, SArity]),
+    (   I == 1 -> Label = default
+    ;   format(atom(Label), "L_~w_~w_~w", [Pred, Arity, I])
+    ),
+    NextI is I + 1,
+    build_structure_index(Rest, NextI, Pred, Arity, RestEntries).
+
+build_term_index([], _, _, _, _, [], []).
+build_term_index([Head-_|Rest], I, Pred, Arity, [Type|RestTypes],
+                 ConstEntries, StructEntries) :-
+    Head =.. [_|[FirstArg|_]],
+    (   I == 1 -> Label = default
+    ;   format(atom(Label), "L_~w_~w_~w", [Pred, Arity, I])
+    ),
+    NextI is I + 1,
+    build_term_index(Rest, NextI, Pred, Arity, RestTypes,
+                     RestConst, RestStruct),
+    (   Type = constant
+    ->  ConstEntries = [FirstArg-Label|RestConst],
+        StructEntries = RestStruct
+    ;   Type = structure
+    ->  FirstArg =.. [F|SubArgs],
+        length(SubArgs, SArity),
+        format(atom(FN), "~w/~w", [F, SArity]),
+        ConstEntries = RestConst,
+        StructEntries = [FN-Label|RestStruct]
+    ;   ConstEntries = RestConst,
+        StructEntries = RestStruct
+    ).
+
+format_switch_on_term(ConstEntries, StructEntries, IndexCode) :-
+    (   ConstEntries \= []
+    ->  format_index_entries(ConstEntries, CStr),
+        ConstPart = CStr
+    ;   ConstPart = "none"
+    ),
+    (   StructEntries \= []
+    ->  format_index_entries(StructEntries, SStr),
+        StructPart = SStr
+    ;   StructPart = "none"
+    ),
+    format(string(IndexCode),
+           "    switch_on_term constant:~w, structure:~w",
+           [ConstPart, StructPart]).
 
 format_index_entries(Entries, Str) :-
     maplist([K-V, S]>>format(atom(S), "~w:~w", [K, V]), Entries, Parts),
@@ -400,6 +469,9 @@ is_builtin_pred(true, 0).    % control
 is_builtin_pred(fail, 0).
 is_builtin_pred('!', 0).     % cut
 is_builtin_pred(\+, 1).      % negation-as-failure
+is_builtin_pred(member, 2).  % list operations
+is_builtin_pred(append, 3).
+is_builtin_pred(length, 2).
 
 compile_put_arguments([], _, V, V, "").
 compile_put_arguments([Arg|Rest], I, V0, Vf, Code) :-

--- a/tests/test_wam_e2e.pl
+++ b/tests/test_wam_e2e.pl
@@ -53,6 +53,15 @@ e2e_is_atom(X) :- atom(X).
 e2e_capital(france, paris).
 e2e_capital(germany, berlin).
 
+%% List builtin test data
+:- dynamic e2e_has_member/2.
+e2e_has_member(X, List) :- member(X, List).
+
+%% Structure-indexed predicate (compound first args)
+:- dynamic e2e_shape_area/2.
+e2e_shape_area(circle(R), A) :- A is 3 * R * R.
+e2e_shape_area(rect(W, H), A) :- A is W * H.
+
 :- dynamic test_failed/0.
 
 pass(Test) :-
@@ -187,6 +196,33 @@ test_wam_indexing :-
     ;   fail_test(Test, 'First-argument indexing failed')
     ).
 
+test_wam_findall :-
+    Test = 'WAM E2E: findall_wam multi-solution',
+    (   wam_target:compile_facts_to_wam(user:e2e_capital, 2, Code),
+        wam_runtime:findall_wam(Code, e2e_capital(Country, City),
+            ['Country'=Country, 'City'=City], AllBindings),
+        length(AllBindings, 2)
+    ->  pass(Test)
+    ;   fail_test(Test, 'findall_wam did not return 2 solutions')
+    ).
+
+test_wam_list_member :-
+    Test = 'WAM E2E: List builtin (member/2)',
+    (   wam_target:compile_predicate_to_wam(user:e2e_has_member/2, [], Code),
+        wam_runtime:execute_wam(Code, e2e_has_member(b, [a, b, c]), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'List member builtin failed')
+    ).
+
+test_wam_structure_index :-
+    Test = 'WAM E2E: Structure indexing (switch_on_structure)',
+    (   wam_target:compile_predicate_to_wam(user:e2e_shape_area/2, [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'switch_on_structure')
+    ->  pass(Test)
+    ;   fail_test(Test, 'switch_on_structure not emitted for compound heads')
+    ).
+
 run_tests :-
     format('~n========================================~n'),
     format('WAM Target E2E Test Suite~n'),
@@ -203,7 +239,10 @@ run_tests :-
     test_wam_builtin_is,
     test_wam_builtin_type_check,
     test_wam_solve,
+    test_wam_findall,
+    test_wam_list_member,
     test_wam_indexing,
+    test_wam_structure_index,
     
     format('~n========================================~n'),
     (   test_failed


### PR DESCRIPTION
## Summary

- Add list builtins `member/2`, `append/3`, `length/2` as native runtime operations that delegate to Prolog's list predicates; compiler recognizes them via `is_builtin_pred` and emits `builtin_call`
- Add `findall_wam/4` API that collects all solutions by iteratively running `run_loop`, extracting bindings, then backtracking via remaining choice points until exhausted
- Add `switch_on_structure` indexing for predicates with all-compound first arguments — indexes on functor/arity to jump directly to matching clauses
- Add `switch_on_term` for predicates with mixed constant/structure first arguments — type-based dispatch to the appropriate constant or structure index table
- Compiler `classify_first_args` analyzes first arguments across clauses and selects the optimal indexing strategy (constant, structure, or term-based)
- Archive PR descriptions for PR #1124

## Test plan

- [x] All 7 WAM target compiler tests pass
- [x] All 15 E2E tests pass — including new tests for `findall_wam` (2 solutions), `member/2`, and `switch_on_structure`
- [x] Verified `findall_wam` returns 2 binding sets for `e2e_capital/2` (france/paris + germany/berlin)
- [x] Verified `member(b, [a,b,c])` succeeds via list builtin
- [x] Verified `switch_on_structure` appears in compiled output for `e2e_shape_area/2` with compound heads `circle/1` and `rect/2`
- [x] Exit code 0 on success, 1 on failure (CI-compatible)

## Companion PR

- Education repo: `docs: add switch_on_structure and switch_on_term to Book 17 ISA` (same branch name)

Generated with [Claude Code](https://claude.com/claude-code)
