### PR TITLE
  feat(go): add native min recursion lowering

### DIFF
--- a/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
+++ b/docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md
@@ -120,8 +120,8 @@ The immediate explicit-guard mechanism is the minimum acceptable
 The declarative metadata mechanism is now available through
  `constraint/2` with `positive_step(N)`.
 
-The remaining work before broad Rust adoption is not syntax design but
- deciding how broadly targets should rely on:
+The remaining work before broader cross-target adoption is not syntax
+ design but deciding how broadly targets should rely on:
 
 - explicit positive guards
 - declarative `positive_step/1` metadata
@@ -132,4 +132,6 @@ Current implementation status:
 - C# weighted `Min` lowering consumes both explicit guards and
   `positive_step/1` metadata
 - Rust native lowering for counted and positive-additive weighted `Min`
+  now consumes the same contracts during native emission
+- Go native lowering for counted and positive-additive weighted `Min`
   now consumes the same contracts during native emission

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -181,7 +181,7 @@ Tables:
 | `generate_facts.py` | Alternative: fetch from Wikipedia API (for small datasets) |
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
-| `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs DFS binaries |
+| `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `effective_distance.pl` | Benchmark Prolog program |
@@ -212,7 +212,7 @@ go build -o bench pipelines/effective_distance.go
 # Re-run the current non-regression benchmark
 python examples/benchmark/benchmark_effective_distance.py \
     --scales 300,1k,5k,10k \
-    --targets csharp-query,csharp-dfs,rust-dfs
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
 
 # Measure overhead of the generalized path-aware accumulation runtime
 python examples/benchmark/benchmark_path_aware_accumulation.py \
@@ -222,6 +222,17 @@ python examples/benchmark/benchmark_path_aware_accumulation.py \
 python examples/benchmark/benchmark_weighted_shortest_path.py \
     --scales 300,1k,5k,10k
 ```
+
+The current native-lowering comparison surface across non-query targets is:
+
+- Rust DFS:
+  - all-path effective distance
+  - minimum hop distance
+  - positive weighted minimum path distance
+- Go DFS:
+  - all-path effective distance
+  - minimum hop distance
+  - positive weighted minimum path distance
 
 ### Weighted `Min` Results
 

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -93,6 +93,7 @@
 :- use_module('../core/optimizer').
 :- use_module('../core/constraint_analyzer').
 :- use_module('../core/index_analyzer').
+:- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4, parse_table_spec/2]).
 
 % Track required imports from bindings
 :- dynamic required_binding_import/1.
@@ -6535,6 +6536,19 @@ count_recursive_calls_go_(_, _, Acc, Acc).
 %%
 %% Generates a recursive Go function with visited-set cycle detection.
 
+go_declared_table_mode(Pred/Arity, Mode) :-
+    clause(user:'table'(TableSpec), true),
+    compound(TableSpec),
+    functor(TableSpec, Pred, Arity),
+    parse_table_spec(TableSpec, Modes),
+    nth1(Arity, Modes, Mode),
+    !.
+go_declared_table_mode(_, all).
+
+go_positive_step_metadata(Pred/Arity, Position) :-
+    get_constraints(Pred/Arity, Constraints),
+    member(positive_step(Position), Constraints).
+
 %% is_general_recursive_pattern_go(+Pred, +Arity, +Clauses)
 %  Detect non-tail general recursion (has base + recursive clauses,
 %  recursive call is NOT in tail position).
@@ -6560,8 +6574,12 @@ contains_call_to((_, B), Pred) :-
 %% compile_general_recursive_to_go(+Pred, +Arity, +Clauses, -GoCode)
 compile_general_recursive_to_go(Pred, Arity, Clauses, GoCode) :-
     atom_string(Pred, PredStr),
+    go_declared_table_mode(Pred/Arity, TableMode),
     partition(is_recursive_clause_go(Pred), Clauses, RecClauses, BaseClauses),
     (   Arity =:= 3,
+        go_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepGuardProven)
+    ->  compile_general_recursive_accumulation_to_go(Pred, Arity, TableMode, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepGuardProven, GoCode)
+    ;   Arity =:= 3,
         %% Check if per-path visited pattern detected
         go_clauses_to_ppv_pairs(Clauses, PPVPairs),
         is_per_path_visited_pattern(Pred, Arity, PPVPairs, VisitedPos)
@@ -6577,17 +6595,69 @@ compile_general_recursive_to_go(Pred, Arity, Clauses, GoCode) :-
 
 %% go_clauses_to_ppv_pairs(+Clauses, -Pairs)
 go_clauses_to_ppv_pairs([], []).
-go_clauses_to_ppv_pairs([(Head, Body)|Rest], [(Head, Body)|RestPairs]) :-
+go_clauses_to_ppv_pairs([Head-Body|Rest], [(Head, Body)|RestPairs]) :-
     go_clauses_to_ppv_pairs(Rest, RestPairs).
 
 %% compile_ternary_recursive_go_no_visited(+PredStr, +BaseClauses, +RecClauses, -GoCode)
 %  Arity-3 recursive without visited-set (no \+ member pattern detected).
 compile_ternary_recursive_go_no_visited(PredStr, BaseClauses, RecClauses, GoCode) :-
+    atom_string(Pred, PredStr),
+    go_declared_table_mode(Pred/3, TableMode),
     %% Extract base case
     go_extract_ternary_base(BaseClauses, PredStr, BaseCode),
     %% Extract recursive case
     go_extract_ternary_rec(RecClauses, PredStr, RecCode),
-    format(string(GoCode),
+    (   TableMode == min
+    ->  go_extract_ternary_base_const(BaseClauses, BaseConstStr),
+        go_extract_ternary_increment(RecClauses, IncrStr),
+        format(string(GoCode),
+'// Path-aware minimum-hop transitive closure: ~w/3
+package main
+
+import (
+\t"container/list"
+\t"fmt"
+)
+
+type ~wState struct {
+\tNode string
+\tDepth int
+}
+
+var ~wData [][]string
+
+func ~wMin(start string) map[string]int {
+\tbest := map[string]int{}
+\tqueue := list.New()
+\tfor _, row := range ~wData {
+\t\tif len(row) >= 2 && row[0] == start {
+\t\t\tqueue.PushBack(~wState{Node: row[1], Depth: ~w})
+\t\t}
+\t}
+\tfor queue.Len() > 0 {
+\t\tfront := queue.Front()
+\t\tqueue.Remove(front)
+\t\tstate := front.Value.(~wState)
+\t\tif existing, ok := best[state.Node]; ok && state.Depth >= existing {
+\t\t\tcontinue
+\t\t}
+\t\tbest[state.Node] = state.Depth
+\t\tfor _, row := range ~wData {
+\t\t\tif len(row) >= 2 && row[0] == state.Node {
+\t\t\t\tqueue.PushBack(~wState{Node: row[1], Depth: state.Depth + ~w})
+\t\t\t}
+\t\t}
+\t}
+\treturn best
+}
+
+func main() {
+\tfor node, depth := range ~wMin("test") {
+\t\tfmt.Printf("%%s\\t%%d\\n", node, depth)
+\t}
+}
+', [PredStr, PredStr, PredStr, PredStr, PredStr, PredStr, BaseConstStr, PredStr, PredStr, PredStr, IncrStr, PredStr])
+    ;   format(string(GoCode),
 'package main
 
 import (
@@ -6614,10 +6684,11 @@ func main() {
 \t\t}
 \t}
 }
-', [PredStr, PredStr, PredStr, PredStr, BaseCode, RecCode, PredStr]).
+', [PredStr, PredStr, PredStr, PredStr, BaseCode, RecCode, PredStr])
+    ).
 
 go_extract_ternary_base([], _, '\t// No base case').
-go_extract_ternary_base([(BaseHead, _BaseBody)|_], PredStr, BaseCode) :-
+go_extract_ternary_base([BaseHead-_BaseBody|_], PredStr, BaseCode) :-
     BaseHead =.. [_, _Arg1, _Arg2, Arg3],
     (integer(Arg3) -> format(string(Val), '~w', [Arg3]) ; Val = "1"),
     format(string(BaseCode),
@@ -6629,7 +6700,7 @@ go_extract_ternary_base([(BaseHead, _BaseBody)|_], PredStr, BaseCode) :-
 \t}', [PredStr, PredStr, Val]).
 
 go_extract_ternary_rec([], _, '\t// No recursive case').
-go_extract_ternary_rec([(_, _RecBody)|_], PredStr, RecCode) :-
+go_extract_ternary_rec([_RecHead-RecBody|_], PredStr, RecCode) :-
     format(string(RecCode),
 '\t// Recursive case
 \tfor _, row := range ~w_data {
@@ -6646,6 +6717,8 @@ go_extract_ternary_rec([(_, _RecBody)|_], PredStr, RecCode) :-
 %% - Base case: lookup step relation, yield (result, constant)
 %% - Recursive: step through intermediate, recurse, compute counter
 compile_ternary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode) :-
+    atom_string(Pred, PredStr),
+    go_declared_table_mode(Pred/3, TableMode),
     % Extract base case info
     (   BaseClauses = [BaseHead-BaseBody|_]
     ->  BaseHead =.. [_|BaseArgs],
@@ -6680,7 +6753,55 @@ compile_ternary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode) :-
     ;   IncrStr = "1"
     ),
     % Generate Go code
-    format(string(GoCode),
+    (   TableMode == min
+    ->  format(string(GoCode),
+'// Path-aware minimum-hop transitive closure: ~w/3
+package main
+
+import (
+\t"container/list"
+\t"fmt"
+)
+
+type ~wState struct {
+\tNode string
+\tDepth int
+}
+
+var ~wData [][]string // populated from facts
+
+func ~wMin(start string) map[string]int {
+\tbest := map[string]int{}
+\tqueue := list.New()
+\tfor _, row := range ~wData {
+\t\tif len(row) >= 2 && row[0] == start {
+\t\t\tqueue.PushBack(~wState{Node: row[1], Depth: ~s})
+\t\t}
+\t}
+\tfor queue.Len() > 0 {
+\t\tfront := queue.Front()
+\t\tqueue.Remove(front)
+\t\tstate := front.Value.(~wState)
+\t\tif existing, ok := best[state.Node]; ok && state.Depth >= existing {
+\t\t\tcontinue
+\t\t}
+\t\tbest[state.Node] = state.Depth
+\t\tfor _, row := range ~wData {
+\t\t\tif len(row) >= 2 && row[0] == state.Node {
+\t\t\t\tqueue.PushBack(~wState{Node: row[1], Depth: state.Depth + ~s})
+\t\t\t}
+\t\t}
+\t}
+\treturn best
+}
+
+func main() {
+\tfor node, depth := range ~wMin("test") {
+\t\tfmt.Printf("%%s\\t%%d\\n", node, depth)
+\t}
+}
+', [PredStr, PredStr, StepRelStr, PredStr, StepRelStr, PredStr, BaseConstStr, StepRelStr, PredStr, IncrStr, PredStr])
+    ;   format(string(GoCode),
 '// Transitive closure with counter: ~w/3
 // Step relation: ~w/2
 type ~wResult struct {
@@ -6723,7 +6844,28 @@ func ~w(arg1 string, visited map[string]bool) []~wResult {
     StepRelStr,
     PredStr, BaseConstStr,
     PredStr,
-    PredStr, IncrStr]).
+    PredStr, IncrStr])
+    ).
+
+go_extract_ternary_base_const(BaseClauses, BaseConstStr) :-
+    (   BaseClauses = [BaseHead-_|_],
+        BaseHead =.. [_|BaseArgs],
+        length(BaseArgs, 3),
+        nth1(3, BaseArgs, BaseConst),
+        number(BaseConst)
+    ->  format(string(BaseConstStr), "~w", [BaseConst])
+    ;   BaseConstStr = "1"
+    ).
+
+go_extract_ternary_increment(RecClauses, IncrStr) :-
+    (   RecClauses = [_RecHead-RecBody|_],
+        extract_goals_list_go(RecBody, RecGoals),
+        member((_ is ArithExpr), RecGoals),
+        ArithExpr = (_ + Incr),
+        number(Incr)
+    ->  format(string(IncrStr), "~w", [Incr])
+    ;   IncrStr = "1"
+    ).
 
 %% compile_binary_recursive_go(+PredStr, +BaseClauses, +RecClauses, -GoCode)
 compile_binary_recursive_go(PredStr, BaseClauses, RecClauses, GoCode) :-
@@ -6769,6 +6911,373 @@ func ~w(arg1 string, visited map[string]bool) []string {
 extract_goals_list_go((A, B), [A|Rest]) :- !,
     extract_goals_list_go(B, Rest).
 extract_goals_list_go(Goal, [Goal]).
+
+go_computed_increment_pattern(Pred, Clauses, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepProven) :-
+    partition(is_recursive_clause_go(Pred), Clauses, RecClauses, BaseClauses),
+    BaseClauses = [BaseHead-BaseBody|_],
+    RecClauses = [_RecHead-RecBody|_],
+    BaseHead =.. [Pred, From, To, Acc],
+    var(From),
+    var(To),
+    var(Acc),
+    extract_goals_list_go(BaseBody, BaseGoals),
+    select(BaseArith, BaseGoals, BaseTerms0),
+    go_extract_positive_step_guard(BaseTerms0, AuxValue, BaseTerms, BasePositiveStep),
+    BaseTerms = [BaseGoalA, BaseGoalB],
+    go_edge_aux_terms(From, To, AuxValue, BaseGoalA, BaseGoalB, EdgeGoal, AuxGoal),
+    EdgeGoal =.. [StepRel, From, To],
+    AuxGoal =.. [AuxRel, From, AuxValue],
+    BaseArith = (Acc is BaseExpr),
+    term_variables(BaseExpr, BaseVars),
+    subset_go_vars(BaseVars, [AuxValue]),
+    extract_goals_list_go(RecBody, RecGoals),
+    select(RecArith, RecGoals, RecTermsWithGuard),
+    go_extract_positive_step_guard(RecTermsWithGuard, AuxValue, RecTerms0, RecPositiveStep),
+    select(RecAuxGoal, RecTerms0, RecTerms1),
+    select(RecEdgeGoal, RecTerms1, [RecCall]),
+    RecEdgeGoal =.. [StepRel, From, Mid],
+    RecAuxGoal =.. [AuxRel, From, AuxValue],
+    RecCall =.. [Pred, Mid, To, PrevAcc],
+    RecArith = (Acc is RecExpr),
+    term_variables(RecExpr, RecVars),
+    member_var_eq_go(PrevAcc, RecVars),
+    subset_go_vars(RecVars, [PrevAcc, AuxValue]),
+    (   (BasePositiveStep == true ; RecPositiveStep == true)
+    ->  PositiveStepProven = true
+    ;   PositiveStepProven = false
+    ).
+
+go_extract_positive_step_guard(Terms, AuxValue, RemainingTerms, true) :-
+    select(Guard0, Terms, RemainingTerms),
+    go_positive_step_guard(Guard0, AuxValue),
+    !.
+go_extract_positive_step_guard(Terms, _AuxValue, Terms, false).
+
+go_positive_step_guard(Goal0, AuxValue) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [>, AuxValue, Value],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [<, Value, AuxValue],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [>=, AuxValue, Value],
+        number(Value),
+        Value > 0
+    ;   Goal =.. [=<, Value, AuxValue],
+        number(Value),
+        Value > 0
+    ).
+
+go_edge_aux_terms(From, To, AuxValue, GoalA0, GoalB0, EdgeGoal, AuxGoal) :-
+    strip_module(GoalA0, _, GoalA),
+    strip_module(GoalB0, _, GoalB),
+    (   functor(GoalA, _, 2),
+        arg(1, GoalA, From),
+        arg(2, GoalA, To),
+        functor(GoalB, _, 2),
+        arg(1, GoalB, From),
+        arg(2, GoalB, AuxValue)
+    ->  EdgeGoal = GoalA,
+        AuxGoal = GoalB
+    ;   functor(GoalB, _, 2),
+        arg(1, GoalB, From),
+        arg(2, GoalB, To),
+        functor(GoalA, _, 2),
+        arg(1, GoalA, From),
+        arg(2, GoalA, AuxValue)
+    ->  EdgeGoal = GoalB,
+        AuxGoal = GoalA
+    ).
+
+member_var_eq_go(Var, [Candidate|_]) :-
+    Var == Candidate, !.
+member_var_eq_go(Var, [_|Rest]) :-
+    member_var_eq_go(Var, Rest).
+
+subset_go_vars([], _).
+subset_go_vars([Var|Rest], Allowed) :-
+    member_var_eq_go(Var, Allowed),
+    subset_go_vars(Rest, Allowed).
+
+go_accumulation_numeric_type(BaseExpr, RecExpr, "float64") :-
+    (   go_expr_requires_float(BaseExpr)
+    ;   go_expr_requires_float(RecExpr)
+    ),
+    !.
+go_accumulation_numeric_type(_, _, "int").
+
+go_expr_requires_float(Expr) :-
+    number(Expr),
+    \+ integer(Expr),
+    !.
+go_expr_requires_float(Expr) :-
+    compound(Expr),
+    (   Expr = (_ / _)
+    ;   Expr = (_ ** _)
+    ;   Expr =.. [log, _]
+    ;   Expr =.. [ln, _]
+    ),
+    !.
+go_expr_requires_float(Expr) :-
+    compound(Expr),
+    Expr =.. [_|Args],
+    member(Arg, Args),
+    go_expr_requires_float(Arg),
+    !.
+
+go_numeric_literal("float64", Number, Literal) :-
+    number(Number),
+    !,
+    (   integer(Number)
+    ->  format(string(Literal), '~w.0', [Number])
+    ;   format(string(Literal), '~w', [Number])
+    ).
+go_numeric_literal("int", Number, Literal) :-
+    format(string(Literal), '~w', [Number]).
+
+go_accumulation_expr(Expr, VarBindings, _Type, GoExpr) :-
+    var(Expr),
+    !,
+    lookup_go_var(Expr, VarBindings, GoExpr).
+go_accumulation_expr(Number, _, Type, GoExpr) :-
+    number(Number),
+    !,
+    go_numeric_literal(Type, Number, GoExpr).
+go_accumulation_expr(-Expr, VarBindings, Type, GoExpr) :-
+    !,
+    go_accumulation_expr(Expr, VarBindings, Type, Inner),
+    format(string(GoExpr), '(-~w)', [Inner]).
+go_accumulation_expr(log(Expr), VarBindings, _Type, GoExpr) :-
+    !,
+    go_accumulation_expr(Expr, VarBindings, "float64", Inner),
+    format(string(GoExpr), 'math.Log(~w)', [Inner]).
+go_accumulation_expr(ln(Expr), VarBindings, _Type, GoExpr) :-
+    !,
+    go_accumulation_expr(Expr, VarBindings, "float64", Inner),
+    format(string(GoExpr), 'math.Log(~w)', [Inner]).
+go_accumulation_expr(min(Left, Right), VarBindings, Type, GoExpr) :-
+    !,
+    go_accumulation_expr(Left, VarBindings, Type, LeftExpr),
+    go_accumulation_expr(Right, VarBindings, Type, RightExpr),
+    format(string(GoExpr), 'min(~w, ~w)', [LeftExpr, RightExpr]).
+go_accumulation_expr(max(Left, Right), VarBindings, Type, GoExpr) :-
+    !,
+    go_accumulation_expr(Left, VarBindings, Type, LeftExpr),
+    go_accumulation_expr(Right, VarBindings, Type, RightExpr),
+    format(string(GoExpr), 'max(~w, ~w)', [LeftExpr, RightExpr]).
+go_accumulation_expr(Expr, VarBindings, Type, GoExpr) :-
+    compound(Expr),
+    Expr =.. [Op, Left, Right],
+    expr_op(Op, StdOp),
+    !,
+    go_accumulation_expr(Left, VarBindings, Type, LeftExpr),
+    go_accumulation_expr(Right, VarBindings, Type, RightExpr),
+    go_op(StdOp, GoOp),
+    format(string(GoExpr), '(~w ~w ~w)', [LeftExpr, GoOp, RightExpr]).
+go_accumulation_expr(Atom, _, _, GoExpr) :-
+    atom(Atom),
+    format(string(GoExpr), '"~w"', [Atom]).
+
+lookup_go_var(Var, [BindingVar-Expr|_], Expr) :-
+    Var == BindingVar,
+    !.
+lookup_go_var(Var, [_|Rest], Expr) :-
+    lookup_go_var(Var, Rest, Expr).
+
+compile_general_recursive_accumulation_to_go(Pred, Arity, TableMode, StepRel, AuxRel, AuxValue, PrevAcc, BaseExpr, RecExpr, PositiveStepGuardProven, GoCode) :-
+    Arity =:= 3,
+    atom_string(Pred, PredStr),
+    atom_string(StepRel, StepRelStr),
+    atom_string(AuxRel, AuxRelStr),
+    (   (PositiveStepGuardProven == true ; go_positive_step_metadata(Pred/Arity, Arity))
+    ->  PositiveStepProven = true
+    ;   PositiveStepProven = false
+    ),
+    go_accumulation_numeric_type(BaseExpr, RecExpr, AccType),
+    go_accumulation_expr(BaseExpr, [AuxValue-'stepCost'], AccType, BaseExprCode),
+    go_accumulation_expr(RecExpr, [PrevAcc-'sub.Acc', AuxValue-'stepCost'], AccType, RecExprCode),
+    go_accumulation_expr(RecExpr, [PrevAcc-'cost', AuxValue-'stepCost'], AccType, MinRecExprCode),
+    functor(StepHead, StepRel, 2),
+    findall(A-B, (module_clause(StepHead, true), StepHead =.. [_, A, B]), StepFacts),
+    findall(StepLine,
+        (   member(K-V, StepFacts),
+            format(string(StepLine), '\t~wData = append(~wData, []string{"~w", "~w"})', [StepRelStr, StepRelStr, K, V])
+        ),
+        StepLines),
+    atomic_list_concat(StepLines, '\n', StepBlock),
+    functor(AuxHead, AuxRel, 2),
+    findall(AuxLine,
+        (   module_clause(AuxHead, true),
+            AuxHead =.. [_, K, V],
+            go_numeric_literal(AccType, V, AuxLiteral),
+            format(string(AuxLine), '\t~wAux["~w"] = ~w', [PredStr, K, AuxLiteral])
+        ),
+        AuxLines),
+    atomic_list_concat(AuxLines, '\n', AuxBlock),
+    (   TableMode == min,
+        PositiveStepProven == true
+    ->  compile_go_min_accumulation(PredStr, StepRelStr, AuxRelStr, AccType, StepBlock, AuxBlock, BaseExprCode, MinRecExprCode, GoCode)
+    ;   compile_go_all_accumulation(PredStr, StepRelStr, AuxRelStr, AccType, StepBlock, AuxBlock, BaseExprCode, RecExprCode, GoCode)
+    ).
+
+go_math_import(ExprCode, '\t"math"\n') :-
+    sub_string(ExprCode, _, _, _, 'math.'),
+    !.
+go_math_import(_, '').
+
+compile_go_all_accumulation(PredStr, StepRelStr, AuxRelStr, AccType, StepBlock, AuxBlock, BaseExprCode, RecExprCode, GoCode) :-
+    go_math_import(BaseExprCode, BaseMathImport),
+    go_math_import(RecExprCode, RecMathImport),
+    atomic_list_concat([BaseMathImport, RecMathImport], '', MathImports0),
+    (MathImports0 = "" -> MathImports = "" ; sort(["\t\"math\"\n"], Sorted), atomic_list_concat(Sorted, '', MathImports)),
+    format(string(GoCode),
+'// Path-aware recursive accumulation: ~w/3
+// Edge relation: ~w/2
+// Auxiliary relation: ~w/2
+package main
+
+import (
+\t"fmt"
+~s)
+
+type ~wResult struct {
+\tValue string
+\tAcc   ~w
+}
+
+var ~wData [][]string
+var ~wAux = map[string]~w{}
+
+func ~w(arg1 string, visited map[string]bool) []~wResult {
+\tif visited[arg1] {
+\t\treturn nil
+\t}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {
+\t\tnewVisited[k] = v
+\t}
+\tnewVisited[arg1] = true
+
+\tvar results []~wResult
+\tfor _, row := range ~wData {
+\t\tif len(row) >= 2 && row[0] == arg1 {
+\t\t\tnb := row[1]
+\t\t\tif !newVisited[nb] {
+\t\t\t\tstepCost := ~wAux[arg1]
+\t\t\t\tresults = append(results, ~wResult{nb, ~w})
+\t\t\t\tfor _, sub := range ~w(nb, newVisited) {
+\t\t\t\t\tresults = append(results, ~wResult{sub.Value, ~w})
+\t\t\t\t}
+\t\t\t}
+\t\t}
+\t}
+\treturn results
+}
+
+func main() {
+~w
+~w
+\tvisited := map[string]bool{}
+\tfor _, result := range ~w("test", visited) {
+\t\tfmt.Printf("%%s\\t%%v\\n", result.Value, result.Acc)
+\t}
+}
+', [PredStr, StepRelStr, AuxRelStr, MathImports,
+    PredStr, AccType,
+    StepRelStr, PredStr, AccType,
+    PredStr, PredStr,
+    PredStr,
+    StepRelStr,
+    PredStr,
+    PredStr, BaseExprCode,
+    PredStr,
+    PredStr, RecExprCode,
+    StepBlock, AuxBlock,
+    PredStr]).
+
+compile_go_min_accumulation(PredStr, StepRelStr, AuxRelStr, AccType, StepBlock, AuxBlock, BaseExprCode, MinRecExprCode, GoCode) :-
+    go_math_import(BaseExprCode, BaseMathImport),
+    go_math_import(MinRecExprCode, RecMathImport),
+    atomic_list_concat([BaseMathImport, RecMathImport], '', MathImports0),
+    (MathImports0 = "" -> MathImports = "" ; sort(["\t\"math\"\n"], Sorted), atomic_list_concat(Sorted, '', MathImports)),
+    format(string(StateType), '~wState', [PredStr]),
+    format(string(HeapType), '~wHeap', [PredStr]),
+    format(string(DataName), '~wData', [StepRelStr]),
+    format(string(AuxName), '~wAux', [PredStr]),
+    format(string(MinFunc), '~wMin', [PredStr]),
+    format(string(Header), '// Path-aware positive weighted minimum accumulation: ~w/3\n// Edge relation: ~w/2\n// Auxiliary relation: ~w/2\npackage main\n\nimport (\n\t"container/heap"\n\t"fmt"\n~s)\n', [PredStr, StepRelStr, AuxRelStr, MathImports]),
+    format(string(Types),
+'type ~w struct {
+\tNode string
+\tCost ~w
+\tIndex int
+}
+
+type ~w []~w
+
+func (h ~w) Len() int { return len(h) }
+func (h ~w) Less(i, j int) bool { return h[i].Cost < h[j].Cost }
+func (h ~w) Swap(i, j int) { h[i], h[j] = h[j], h[i]; h[i].Index = i; h[j].Index = j }
+func (h *~w) Push(x interface{}) { *h = append(*h, x.(~w)) }
+func (h *~w) Pop() interface{} {
+\told := *h
+\tn := len(old)
+\titem := old[n-1]
+\t*h = old[:n-1]
+\treturn item
+}
+
+var ~w [][]string
+var ~w = map[string]~w{}
+', [StateType, AccType, HeapType, StateType, HeapType, HeapType, HeapType, HeapType, StateType, HeapType, DataName, AuxName, AccType]),
+    format(string(FuncCode),
+'func ~w(start string) map[string]~w {
+\tbest := map[string]~w{}
+\tpq := &~w{}
+\theap.Init(pq)
+
+\tstepCost, ok := ~w[start]
+\tif ok {
+\t\tfor _, row := range ~w {
+\t\t\tif len(row) >= 2 && row[0] == start {
+\t\t\t\tstate := ~w{Node: row[1], Cost: ~w}
+\t\t\t\theap.Push(pq, state)
+\t\t\t}
+\t\t}
+\t}
+
+\tfor pq.Len() > 0 {
+\t\tstate := heap.Pop(pq).(~w)
+\t\tcost := state.Cost
+\t\tnode := state.Node
+\t\tif existing, ok := best[node]; ok && cost >= existing {
+\t\t\tcontinue
+\t\t}
+\t\tbest[node] = cost
+\t\tstepCost, ok := ~w[node]
+\t\tif !ok {
+\t\t\tcontinue
+\t\t}
+\t\tfor _, row := range ~w {
+\t\t\tif len(row) >= 2 && row[0] == node {
+\t\t\t\theap.Push(pq, ~w{Node: row[1], Cost: ~w})
+\t\t\t}
+\t\t}
+\t}
+\treturn best
+}
+', [MinFunc, AccType, AccType, HeapType, AuxName, DataName, StateType, BaseExprCode, StateType, AuxName, DataName, StateType, MinRecExprCode]),
+    format(string(MainCode),
+'func main() {
+~w
+~w
+\tfor node, cost := range ~w("test") {
+\t\tfmt.Printf("%%s\\t%%v\\n", node, cost)
+\t}
+}
+', [StepBlock, AuxBlock, MinFunc]),
+    atomic_list_concat([Header, Types, FuncCode, MainCode], '\n', GoCode).
 
 %% ============================================
 %% MUTUAL RECURSION

--- a/tests/core/test_go_native_lowering.pl
+++ b/tests/core/test_go_native_lowering.pl
@@ -1,6 +1,9 @@
 :- module(test_go_native_lowering, [test_go_native_lowering/0]).
 :- use_module(library(plunit)).
 :- use_module('../../src/unifyweaver/targets/go_target').
+:- use_module('../../src/unifyweaver/core/constraint_analyzer').
+
+:- dynamic user:'table'/1.
 
 test_go_native_lowering :-
     run_tests([go_native_lowering]).
@@ -137,5 +140,125 @@ test(uses_shared_analysis_module) :-
     current_predicate(clause_body_analysis:normalize_goals/2),
     current_predicate(clause_body_analysis:if_then_else_goal/4),
     current_predicate(clause_body_analysis:build_head_varmap/3).
+
+test(weighted_recursive_accumulation_lowering) :-
+    assert(user:(weighted_edge(a, b))),
+    assert(user:(weighted_edge(b, c))),
+    assert(user:(weighted_cost(a, 2))),
+    assert(user:(weighted_cost(b, 5))),
+    assert(user:(weighted_path(X, Y, Acc) :-
+        weighted_edge(X, Y),
+        weighted_cost(X, Cost),
+        Acc is Cost)),
+    assert(user:(weighted_path(X, Z, Acc) :-
+        weighted_edge(X, Y),
+        weighted_cost(X, Cost),
+        weighted_path(Y, Z, PrevAcc),
+        Acc is PrevAcc + Cost)),
+    compile_go(weighted_path/3, Code),
+    has(Code, "Path-aware recursive accumulation"),
+    has(Code, "var weighted_pathAux = map[string]int{}"),
+    has(Code, "results = append(results, weighted_pathResult{nb, stepCost})"),
+    has(Code, "results = append(results, weighted_pathResult{sub.Value, (sub.Acc + stepCost)})"),
+    retractall(user:weighted_edge(_, _)),
+    retractall(user:weighted_cost(_, _)),
+    retractall(user:weighted_path(_, _, _)).
+
+test(log_recursive_accumulation_lowering) :-
+    assert(user:(semantic_edge(a, b))),
+    assert(user:(semantic_edge(b, c))),
+    assert(user:(semantic_degree(a, 2))),
+    assert(user:(semantic_degree(b, 5))),
+    assert(user:(semantic_path(X, Y, Acc) :-
+        semantic_edge(X, Y),
+        semantic_degree(X, Deg),
+        Acc is log(Deg) / log(5))),
+    assert(user:(semantic_path(X, Z, Acc) :-
+        semantic_edge(X, Y),
+        semantic_degree(X, Deg),
+        semantic_path(Y, Z, PrevAcc),
+        Acc is PrevAcc + (log(Deg) / log(5)))),
+    compile_go(semantic_path/3, Code),
+    has(Code, "var semantic_pathAux = map[string]float64{}"),
+    has(Code, "\"math\""),
+    has(Code, "math.Log(stepCost) / math.Log(5.0)"),
+    retractall(user:semantic_edge(_, _)),
+    retractall(user:semantic_degree(_, _)),
+    retractall(user:semantic_path(_, _, _)).
+
+test(min_counted_recursive_lowering) :-
+    assert(user:(min_edge(a, b))),
+    assert(user:(min_edge(b, c))),
+    assert(user:(min_reach(X, Y, H) :-
+        min_edge(X, Y),
+        H is 1)),
+    assert(user:(min_reach(X, Z, H) :-
+        min_edge(X, Y),
+        min_reach(Y, Z, H1),
+        H is H1 + 1)),
+    assertz(user:'table'(min_reach(_, _, min))),
+    compile_go(min_reach/3, Code),
+    has(Code, "minimum-hop transitive closure"),
+    has(Code, "container/list"),
+    has(Code, "func min_reachMin"),
+    has(Code, "best := map[string]int{}"),
+    retractall(user:min_edge(_, _)),
+    retractall(user:min_reach(_, _, _)),
+    retractall(user:'table'(min_reach(_, _, min))).
+
+test(weighted_min_recursive_accumulation_lowering) :-
+    assert(user:(weighted_min_edge(a, b))),
+    assert(user:(weighted_min_edge(b, c))),
+    assert(user:(weighted_min_cost(a, 2))),
+    assert(user:(weighted_min_cost(b, 5))),
+    assert(user:(weighted_min_path(X, Y, Acc) :-
+        weighted_min_edge(X, Y),
+        weighted_min_cost(X, Cost),
+        Acc is Cost)),
+    assert(user:(weighted_min_path(X, Z, Acc) :-
+        weighted_min_edge(X, Y),
+        weighted_min_cost(X, Cost),
+        weighted_min_path(Y, Z, PrevAcc),
+        Acc is PrevAcc + Cost)),
+    assertz(user:'table'(weighted_min_path(_, _, min))),
+    declare_constraint(weighted_min_path/3, [positive_step(3)]),
+    compile_go(weighted_min_path/3, Code),
+    has(Code, "positive weighted minimum accumulation"),
+    has(Code, "\"container/heap\""),
+    has(Code, "func weighted_min_pathMin"),
+    has(Code, "best := map[string]int{}"),
+    has(Code, "Cost: stepCost"),
+    has(Code, "Cost: (cost + stepCost)"),
+    retractall(user:weighted_min_edge(_, _)),
+    retractall(user:weighted_min_cost(_, _)),
+    retractall(user:weighted_min_path(_, _, _)),
+    clear_constraints(weighted_min_path/3),
+    retractall(user:'table'(weighted_min_path(_, _, min))).
+
+test(weighted_min_guarded_recursive_accumulation_lowering) :-
+    assert(user:(weighted_guard_edge(a, b))),
+    assert(user:(weighted_guard_edge(b, c))),
+    assert(user:(weighted_guard_cost(a, 2))),
+    assert(user:(weighted_guard_cost(b, 5))),
+    assert(user:(weighted_guard_path(X, Y, Acc) :-
+        weighted_guard_edge(X, Y),
+        weighted_guard_cost(X, Cost),
+        Cost > 0,
+        Acc is Cost)),
+    assert(user:(weighted_guard_path(X, Z, Acc) :-
+        weighted_guard_edge(X, Y),
+        weighted_guard_cost(X, Cost),
+        Cost > 0,
+        weighted_guard_path(Y, Z, PrevAcc),
+        Acc is PrevAcc + Cost)),
+    assertz(user:'table'(weighted_guard_path(_, _, min))),
+    compile_go(weighted_guard_path/3, Code),
+    has(Code, "positive weighted minimum accumulation"),
+    has(Code, "func weighted_guard_pathMin"),
+    has(Code, "\"container/heap\""),
+    retractall(user:weighted_guard_edge(_, _)),
+    retractall(user:weighted_guard_cost(_, _)),
+    retractall(user:weighted_guard_path(_, _, _)),
+    retractall(user:'table'(weighted_guard_path(_, _, min))).
 
 :- end_tests(go_native_lowering).


### PR DESCRIPTION
  ## Summary

  This PR brings Go native recursive lowering up to the same new feature
  surface we recently added for Rust.

  Go now supports native lowering for the same three recursive benchmark
  shapes:

  - all-path effective-distance-style accumulation
  - minimum hop distance
  - minimum weighted path distance

  It also consumes the same explicit optimization contracts already used by
  the C# query engine and Rust:

  - `:- table pred(_, _, min).`
  - explicit positive guards such as `Cost > 0`
  - declarative metadata such as:
    `:- constraint(path/3, [positive_step(3)]).`

  ## What Changed

  ### Go Lowering

  In:

  - `src/unifyweaver/targets/go_target.pl`

  the Go target now recognizes and lowers:

  1. counted shortest-path recursion with `table(..., min)`
  2. positive-additive weighted recursive accumulation with `table(..., min)`
  3. all-path recursive accumulation for effective-distance-style workloads

  This keeps Go aligned with the current recursive feature surface of the
  other comparison targets.

  ### Tests

  Extended:

  - `tests/core/test_go_native_lowering.pl`

  New regression coverage verifies emitted Go code for:

  - weighted recursive accumulation
  - logarithmic recursive accumulation
  - counted `Min`
  - weighted `Min` with `positive_step(3)` metadata
  - weighted `Min` with explicit `Cost > 0` guards

  ### Docs

  Updated:

  - `examples/benchmark/README.md`
  - `docs/proposals/POSITIVE_STEP_OPTIMIZATION_CONTRACTS.md`

  The docs now reflect that Go, like Rust, consumes the same planner/source
  contracts for recursive `Min` lowering.

  ## Why This Matters

  Before this PR:

  - C# query engine had the most advanced support
  - Rust had already caught up for the recent `Min` features
  - Go still lagged, despite being one of the more aggregation-capable targets

  That left a gap in both:
  - cross-target generality
  - benchmark comparison value

  This PR closes that gap for Go.

  ## Supported Shapes

  ### All-Path Effective-Distance-Style Accumulation

  Example shape:

  ```prolog
  path(X, Y, Acc) :-
      edge(X, Y),
      aux(X, Cost),
      Acc is Cost.

  path(X, Z, Acc) :-
      edge(X, Y),
      aux(X, Cost),
      path(Y, Z, PrevAcc),
      Acc is PrevAcc + Cost.

  This is the recursive accumulation family we used for effective-distance
  style workloads, including logarithmic weighting.

  ### Counted Min

  Example shape:

  path(X, Y, H) :-
      edge(X, Y),
      H is 1.

  path(X, Z, H) :-
      edge(X, Y),
      path(Y, Z, H1),
      H is H1 + 1.

  :- table path(_, _, min).

  ### Weighted Positive Min

  Example shape:

  path(X, Y, Acc) :-
      edge(X, Y),
      weight(X, Cost),
      Acc is Cost.

  path(X, Z, Acc) :-
      edge(X, Y),
      weight(X, Cost),
      path(Y, Z, Acc1),
      Acc is Acc1 + Cost.

  :- table path(_, _, min).
  :- constraint(path/3, [positive_step(3)]).

  or equivalently with explicit positive guards in the clauses.

  ## Verification

  Passed locally:

  swipl -q -g "use_module(tests/core/test_go_native_lowering), test_go_native_lowering, halt"
  python -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/benchmark_shortest_path_to_root.py
  examples/benchmark/benchmark_weighted_shortest_path.py

  ## Notable Fix

  During the work, one concrete emitter bug was fixed:

  - the counted Go recursion path still expected (Head, Body) clause pairs
  - the compiler actually passes Head-Body
  - that mismatch caused counted Min lowering to fail before emission

  Fixing that was necessary to make counted Min native lowering work.

  ## Scope

  This PR is about native lowering parity and emitted-code coverage.

  It does not yet add Go into the dedicated shortest-path and
  weighted-shortest-path benchmark runners. Go is already included in the
  effective-distance benchmark path, but the newer Min benchmark scripts
  should be extended in a follow-up so C#, Rust, and Go can be compared
  across all three workload families.