### PR TITLE
Document native TypR constant-parameter substring producer tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ includes:
 - simple alias or arithmetic assignment tails after an earlier native
   string-transform or length-producing step
 - simple alias tails after native conversion, list, and path producers such as
-  `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, and narrowed
-  `sub_atom/5`
+  `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, narrowed
+  `sub_atom/5`, and `string_substr/4`
 - guard-style command predicates such as `is_character/1`
 - unary TypR-safe I/O commands such as `cat/1` and `print/1`, emitted as
   native fixed-arity TypR calls
@@ -386,8 +386,9 @@ The wrapped fallback boundary is now beyond the first native
 string-transform/output-tail slice; if this area is extended further, the next
 real audit target is the producer-goal family after the currently supported
 `string_lower/2`, `string_upper/2`, `string_length/2`, `to_numeric/2`,
-`reverse/2`, `dirname/2`, `atom_string/2`, and narrowed `sub_atom/5`
-follow-on alias or arithmetic tails.
+`reverse/2`, `dirname/2`, `atom_string/2`, broader constant-parameter
+substring slices such as `sub_atom/5`, and `string_substr/4` follow-on alias
+or arithmetic tails.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -170,8 +170,8 @@ bring-up.
   - simple alias or arithmetic assignment tails after an earlier native
     string-transform or length-producing step
   - simple alias tails after native conversion, list, and path producers such
-    as `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, and
-    narrowed `sub_atom/5`
+    as `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, narrowed
+    `sub_atom/5`, and `string_substr/4`
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -516,7 +516,8 @@ Current wrapped-fallback boundary note:
   producers such as `to_numeric/2`, `reverse/2`, `dirname/2`, and
   `atom_string/2`
 - the next narrowed substring-style slice is also native when it stays within
-  constant-offset/constant-length `sub_atom/5` followed by a simple alias tail
+  constant-parameter substring producers such as `sub_atom/5` and
+  `string_substr/4`, followed by a simple alias tail
 - the remaining wrapped fallback boundary is now beyond that first
   producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2205,6 +2205,32 @@ test(sub_atom_alias_after_native_outputs_stays_native) :-
     \+ sub_string(Code, _, _, _, "Unknown predicate"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(sub_atom_offset_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(sub_atom_offset_alias(A, Out) :- sub_atom(A, 2, 3, _, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(sub_atom_offset_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(sub_atom_offset_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(sub_atom_offset_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let sub_atom_offset_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ substr(arg1, 3, 5) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(string_substr_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(string_substr_alias(A, Out) :- string_substr(A, 2, 4, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_substr_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_substr_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_substr_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let string_substr_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ substr(arg1, 2, 4) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(multi_decision_guard_chains_use_let_for_new_intermediates) :-
     clear_type_declarations,
     assertz(user:(multi_guard_chain(Name, Out) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Upper), is_character(Upper), string_concat(Upper, '!', Out))),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -160,6 +160,40 @@ test(sub_atom_alias_after_native_outputs_check_with_typr, [condition(typr_cli_av
     ),
     retractall(user:sub_atom_alias(_, _)).
 
+test(sub_atom_offset_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(sub_atom_offset_alias(A, Out) :- sub_atom(A, 2, 3, _, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(sub_atom_offset_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(sub_atom_offset_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(sub_atom_offset_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:sub_atom_offset_alias(_, _)).
+
+test(string_substr_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(string_substr_alias(A, Out) :- string_substr(A, 2, 4, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_substr_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_substr_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_substr_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:string_substr_alias(_, _)).
+
 test(cat_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:(say_cat(Msg) :- cat(Msg))),


### PR DESCRIPTION
## Summary
- keep a conservative narrowed `sub_atom/5` producer-follow-on slice native in the TypR target
- add target-level and real `typr check` regression coverage for that slice
- update docs to reflect the narrower remaining wrapped-fallback boundary

## What changed
- added a conservative native TypR output path for `sub_atom/5` when it is used as a producer followed by a simple alias tail
- supported slice is intentionally narrow:
  - constant `Before`
  - constant `Length`
  - ignored variable `After`
  - simple alias tail
- added regression coverage in:
  - `tests/test_typr_target.pl`
  - `tests/test_typr_toolchain.pl`
- updated TypR docs in:
  - `README.md`
  - `docs/design/TYPE_SYSTEM_IMPL_PLAN.md`
  - `docs/design/TYPR_TARGET_DESIGN.md`

## Important result
The next real unsupported typed producer family after `atom_string/2` was a narrowed substring-style `sub_atom/5` slice.

A shape like:

```prolog
sub_atom(A, 0, 2, _, Tmp), Out = Tmp
```

was still falling through to wrapped fallback.

It now stays native in TypR.

## Example generated shape
```typr
let sub_atom_alias <- fn(arg1: char, arg2: char): char {
	let v3 <- @{ substr(arg1, 1, 2) }@;
	arg2 <- v3;
	arg2
};
```

## Why this matters
This narrows the remaining wrapped-fallback boundary again without reopening the broader generic-body design question.

The support is intentionally conservative. This branch does not claim full native coverage for all `sub_atom/5` shapes.

## Validation
```sh
swipl -q -g "run_tests([typr_target:sub_atom_alias_after_native_outputs_stays_native])" -t halt tests/test_typr_target.pl
swipl -q -g "run_tests([typr_toolchain:sub_atom_alias_after_native_outputs_check_with_typr])" -t halt tests/test_typr_toolchain.pl
git diff --check
```
