### PR TITLE
bench: add cross-target min path benchmarks

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -182,8 +182,10 @@ Tables:
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
 | `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
+| `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
+| `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
 
@@ -214,6 +216,11 @@ python examples/benchmark/benchmark_effective_distance.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
 
+# Compare minimum-hop shortest path across query engine and DFS targets
+python examples/benchmark/benchmark_shortest_path_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
+
 # Measure overhead of the generalized path-aware accumulation runtime
 python examples/benchmark/benchmark_path_aware_accumulation.py \
     --scales 300,1k,5k,10k
@@ -221,6 +228,11 @@ python examples/benchmark/benchmark_path_aware_accumulation.py \
 # Measure directed-table pruning on weighted path-aware accumulation
 python examples/benchmark/benchmark_weighted_shortest_path.py \
     --scales 300,1k,5k,10k
+
+# Compare positive weighted minimum path distance across query engine and DFS targets
+python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
 ```
 
 The current native-lowering comparison surface across non-query targets is:
@@ -233,6 +245,16 @@ The current native-lowering comparison surface across non-query targets is:
   - all-path effective distance
   - minimum hop distance
   - positive weighted minimum path distance
+
+The benchmark split is now:
+
+- cross-target:
+  - `benchmark_effective_distance.py`
+  - `benchmark_shortest_path_cross_target.py`
+  - `benchmark_weighted_shortest_path_cross_target.py`
+- C# query-engine internal mode comparison:
+  - `benchmark_shortest_path_to_root.py`
+  - `benchmark_weighted_shortest_path.py`
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -256,6 +256,73 @@ The benchmark split is now:
   - `benchmark_shortest_path_to_root.py`
   - `benchmark_weighted_shortest_path.py`
 
+### Cross-Target Shortest-Path Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_shortest_path_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
+    --repetitions 1
+```
+
+Latest local results:
+
+| Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs DFS |
+|-------|---------:|--------:|---------:|-------:|--------------|
+| 300 | 0.142s | 0.424s | 0.361s | 0.472s | match |
+| 1k | 0.104s | 1.350s | 1.400s | 2.101s | match |
+| 5k | 0.202s | 5.697s | 7.445s | 12.323s | match |
+| 10k | 0.433s | 10.313s | 14.462s | 20.487s | match |
+
+Speedups of C# query engine:
+
+| Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
+|-------|----------:|------------:|----------:|
+| 300 | 3.00x | 2.55x | 3.33x |
+| 1k | 13.04x | 13.52x | 20.29x |
+| 5k | 28.15x | 36.79x | 60.89x |
+| 10k | 23.84x | 33.43x | 47.35x |
+
+### Cross-Target Weighted Shortest-Path Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
+    --repetitions 1
+```
+
+Latest local results:
+
+| Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
+|-------|---------:|--------:|---------:|-------:|-----------------|
+| 300 | 0.181s | 0.466s | 0.353s | 0.487s | match |
+| 1k | 0.142s | 1.409s | 1.447s | 2.206s | match |
+| 5k | 0.250s | 5.957s | 7.994s | 12.404s | match |
+| 10k | 0.460s | 10.845s | 15.198s | 20.549s | DIFFERENT |
+
+Speedups of C# query engine:
+
+| Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
+|-------|----------:|------------:|----------:|
+| 300 | 2.57x | 1.95x | 2.69x |
+| 1k | 9.91x | 10.18x | 15.51x |
+| 5k | 23.81x | 31.94x | 49.57x |
+| 10k | 23.57x | 33.02x | 44.65x |
+
+Current caveat:
+
+- at `300`, `1k`, and `5k`, all four weighted implementations matched
+- at `10k`, the DFS targets still matched each other, but `csharp-query`
+  diverged from the DFS result on this weighted workload
+- so the cross-target weighted benchmark is useful now, but the `10k`
+  C# query-engine result still needs investigation before it should be
+  treated as fully settled
+
 ### Weighted `Min` Results
 
 The current positive-additive weighted `Min` fast path in the C# query

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""
+Benchmark shortest-path-to-root across the C# query engine and generated
+DFS binaries for C#, Rust, and Go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
+
+CSHARP_PROJECT = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+QE_PROGRAM = """\
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{
+    const string ROOT_CATEGORY = "Physics";
+    const int MAX_DEPTH = 10;
+
+    static void Main(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_ancestor", 3);
+        var articleCategories = new Dictionary<string, List<string>>();
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }
+        }
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }
+
+            categories.Add(parts[1]);
+        }
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.Min),
+            true,
+            new int[] { 0 }
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {
+            foreach (var category in categories)
+            {
+                uniqueSeeds.Add(category);
+            }
+        }
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] { category })
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var hops = Convert.ToInt32(row[2]);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {
+                bucket = new List<(string, int)>();
+                ancestorIndex[source] = bucket;
+            }
+
+            bucket.Add((ancestor, hops));
+        }
+
+        var results = new List<(int Distance, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            int? best = null;
+            foreach (var category in articleCategories[article])
+            {
+                if (category == ROOT_CATEGORY)
+                {
+                    best = best is null ? 1 : Math.Min(best.Value, 1);
+                }
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {
+                    continue;
+                }
+
+                foreach (var (ancestor, hops) in ancestors)
+                {
+                    if (ancestor != ROOT_CATEGORY)
+                    {
+                        continue;
+                    }
+
+                    var dist = hops + 1;
+                    best = best is null ? dist : Math.Min(best.Value, dist);
+                }
+            }
+
+            if (best is not null)
+            {
+                results.Add((best.Value, article));
+            }
+        }
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        });
+
+        Console.WriteLine("article\\troot_category\\tshortest_path");
+        foreach (var (distance, article) in results)
+        {
+            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{distance}");
+        }
+
+        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"seed_count={seedParams.Count}");
+        Console.Error.WriteLine($"tuple_count={rows.Count}");
+        Console.Error.WriteLine($"article_count={results.Count}");
+    }
+}
+"""
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(
+    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env)
+
+
+def require_file(path: Path) -> Path:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return path
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    targets: list[str] = []
+    for target in requested:
+        if target == "rust-dfs" and shutil.which("rustc") is None:
+            print("skip rust-dfs: rustc not found", file=sys.stderr)
+            continue
+        if target == "go-dfs" and shutil.which("go") is None:
+            print("skip go-dfs: go not found", file=sys.stderr)
+            continue
+        if target.startswith("csharp-") and shutil.which("dotnet") is None:
+            print(f"skip {target}: dotnet not found", file=sys.stderr)
+            continue
+        targets.append(target)
+    return targets
+
+
+def generate_pipeline_source(root: Path, target: str) -> Path:
+    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go"}[target]
+    filename = "Program.cs" if target == "csharp" else f"shortest_path_to_root{ext}"
+    output = root / filename
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(FACTS_PATH),
+            "--root",
+            "Physics",
+            "--workload",
+            "shortest_path_to_root",
+            "--target",
+            target,
+            "--output",
+            str(output),
+        ]
+    )
+    return output
+
+
+def build_csharp_query(root: Path) -> list[str]:
+    project_dir = root / "csharp_query"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "Program.cs").write_text(QE_PROGRAM, encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_shortest_path_query.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_shortest_path_query.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_shortest_path_query.dll")]
+
+
+def build_csharp_dfs(root: Path) -> list[str]:
+    project_dir = root / "csharp_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    generate_pipeline_source(project_dir, "csharp")
+    (project_dir / "benchmark_shortest_path_dfs.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_shortest_path_dfs.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_shortest_path_dfs.dll")]
+
+
+def build_rust_dfs(root: Path) -> list[str]:
+    project_dir = root / "rust_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(project_dir, "rust")
+    binary = project_dir / "shortest_path_rust"
+    run(["rustc", "-O", str(source), "-o", str(binary)])
+    return [str(binary)]
+
+
+def build_go_dfs(root: Path) -> list[str]:
+    project_dir = root / "go_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(project_dir, "go")
+    binary = project_dir / "shortest_path_go"
+    go_cache = project_dir / ".gocache"
+    go_cache.mkdir(exist_ok=True)
+    env = dict(os.environ, GOCACHE=str(go_cache))
+    run(["go", "build", "-o", str(binary), str(source)], env=env)
+    return [str(binary)]
+
+
+def normalize_output(output: str) -> str:
+    lines = output.splitlines()
+    header = lines[:1]
+    body = sorted(lines[1:])
+    return "\n".join(header + body)
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+    edge_path = scale_dir / "category_parent.tsv"
+    article_path = scale_dir / "article_category.tsv"
+
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [str(edge_path), str(article_path)])
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_output(stdout)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    row_count = max(0, len(normalized.splitlines()) - 1)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    by_scale: dict[str, list[RunResult]] = {}
+    for result in results:
+        by_scale.setdefault(result.scale, []).append(result)
+
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale in sorted(by_scale.keys(), key=scale_sort_key):
+        entries = sorted(by_scale[scale], key=lambda item: item.target)
+        for result in entries:
+            print(
+                f"{scale}\t{result.target}\t{result.median:.3f}\t"
+                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+                f"{result.row_count}\t{result.stdout_sha256[:12]}"
+            )
+
+        qe = next((item for item in entries if item.target == "csharp-query"), None)
+        csharp_dfs = next((item for item in entries if item.target == "csharp-dfs"), None)
+        rust_dfs = next((item for item in entries if item.target == "rust-dfs"), None)
+        go_dfs = next((item for item in entries if item.target == "go-dfs"), None)
+        dfs_like = [item for item in entries if item.target != "csharp-query"]
+
+        if len(dfs_like) > 1:
+            dfs_hashes = {item.stdout_sha256 for item in dfs_like}
+            print(f"{scale}\tdfs_outputs\t{'match' if len(dfs_hashes) == 1 else 'MISMATCH'}")
+        if qe and csharp_dfs:
+            print(f"{scale}\tquery_vs_csharp_dfs\t{'match' if qe.stdout_sha256 == csharp_dfs.stdout_sha256 else 'DIFFERENT'}")
+            print(f"{scale}\tspeedup_vs_csharp_dfs\t{csharp_dfs.median / qe.median:.2f}x")
+        if qe and rust_dfs:
+            print(f"{scale}\tspeedup_vs_rust_dfs\t{rust_dfs.median / qe.median:.2f}x")
+        if qe and go_dfs:
+            print(f"{scale}\tspeedup_vs_go_dfs\t{go_dfs.median / qe.median:.2f}x")
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-shortest-cross-target-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-shortest-cross-target-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        commands: dict[str, list[str]] = {}
+        for target in targets:
+            if target == "csharp-query":
+                commands[target] = build_csharp_query(temp_root)
+            elif target == "csharp-dfs":
+                commands[target] = build_csharp_dfs(temp_root)
+            elif target == "rust-dfs":
+                commands[target] = build_rust_dfs(temp_root)
+            elif target == "go-dfs":
+                commands[target] = build_go_dfs(temp_root)
+            else:
+                raise ValueError(f"unsupported target: {target}")
+
+        results: list[RunResult] = []
+        for scale in scales:
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""
+Benchmark positive weighted shortest-path-to-root across the C# query engine
+and generated DFS binaries for C#, Rust, and Go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
+
+CSHARP_PROJECT = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+QE_PROGRAM = """\
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{
+    const string ROOT_CATEGORY = "Physics";
+    const int MAX_DEPTH = 10;
+
+    static void Main(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_weighted_shortest", 3);
+        var weightId = new PredicateId("category_weight", 2);
+        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+        var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            provider.AddFact(edgeId, parts[0], parts[1]);
+            sourceNodes.Add(parts[0]);
+            outDegree[parts[0]] = outDegree.TryGetValue(parts[0], out var degree) ? degree + 1 : 1;
+        }
+
+        foreach (var source in sourceNodes)
+        {
+            outDegree.TryGetValue(source, out var degree);
+            var weight = 1.0 + Math.Log(Math.Max(1, degree), 5.0);
+            provider.AddFact(weightId, source, weight);
+        }
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }
+
+            categories.Add(parts[1]);
+        }
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareAccumulationNode(
+                edgeId,
+                predId,
+                weightId,
+                new ColumnExpression(3),
+                new BinaryArithmeticExpression(
+                    ArithmeticBinaryOperator.Add,
+                    new ColumnExpression(2),
+                    new ColumnExpression(3)),
+                MAX_DEPTH,
+                TableMode.Min,
+                true),
+            true,
+            new int[] { 0 }
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {
+            foreach (var category in categories)
+            {
+                uniqueSeeds.Add(category);
+            }
+        }
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] { category })
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, double Weight)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var weight = Convert.ToDouble(row[2], CultureInfo.InvariantCulture);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {
+                bucket = new List<(string, double)>();
+                ancestorIndex[source] = bucket;
+            }
+
+            bucket.Add((ancestor, weight));
+        }
+
+        var results = new List<(double Distance, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            double? best = null;
+            foreach (var category in articleCategories[article])
+            {
+                if (category == ROOT_CATEGORY)
+                {
+                    best = best is null ? 0.0 : Math.Min(best.Value, 0.0);
+                }
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {
+                    continue;
+                }
+
+                foreach (var (ancestor, weight) in ancestors)
+                {
+                    if (ancestor != ROOT_CATEGORY)
+                    {
+                        continue;
+                    }
+
+                    best = best is null ? weight : Math.Min(best.Value, weight);
+                }
+            }
+
+            if (best is not null)
+            {
+                results.Add((best.Value, article));
+            }
+        }
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        });
+
+        Console.WriteLine("article\\troot_category\\tweighted_shortest_path");
+        foreach (var (distance, article) in results)
+        {
+            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{distance.ToString("F12", CultureInfo.InvariantCulture)}");
+        }
+
+        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"seed_count={seedParams.Count}");
+        Console.Error.WriteLine($"tuple_count={rows.Count}");
+        Console.Error.WriteLine($"article_count={results.Count}");
+    }
+}
+"""
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(
+    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env)
+
+
+def require_file(path: Path) -> Path:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return path
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    targets: list[str] = []
+    for target in requested:
+        if target == "rust-dfs" and shutil.which("rustc") is None:
+            print("skip rust-dfs: rustc not found", file=sys.stderr)
+            continue
+        if target == "go-dfs" and shutil.which("go") is None:
+            print("skip go-dfs: go not found", file=sys.stderr)
+            continue
+        if target.startswith("csharp-") and shutil.which("dotnet") is None:
+            print(f"skip {target}: dotnet not found", file=sys.stderr)
+            continue
+        targets.append(target)
+    return targets
+
+
+def generate_pipeline_source(root: Path, target: str) -> Path:
+    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go"}[target]
+    filename = "Program.cs" if target == "csharp" else f"weighted_shortest_path{ext}"
+    output = root / filename
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(FACTS_PATH),
+            "--root",
+            "Physics",
+            "--workload",
+            "weighted_shortest_path",
+            "--target",
+            target,
+            "--output",
+            str(output),
+        ]
+    )
+    return output
+
+
+def build_csharp_query(root: Path) -> list[str]:
+    project_dir = root / "csharp_query"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "Program.cs").write_text(QE_PROGRAM, encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_weighted_shortest_path_query.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_weighted_shortest_path_query.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path_query.dll")]
+
+
+def build_csharp_dfs(root: Path) -> list[str]:
+    project_dir = root / "csharp_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    generate_pipeline_source(project_dir, "csharp")
+    (project_dir / "benchmark_weighted_shortest_path_dfs.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_weighted_shortest_path_dfs.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path_dfs.dll")]
+
+
+def build_rust_dfs(root: Path) -> list[str]:
+    project_dir = root / "rust_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(project_dir, "rust")
+    binary = project_dir / "weighted_shortest_path_rust"
+    run(["rustc", "-O", str(source), "-o", str(binary)])
+    return [str(binary)]
+
+
+def build_go_dfs(root: Path) -> list[str]:
+    project_dir = root / "go_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(project_dir, "go")
+    binary = project_dir / "weighted_shortest_path_go"
+    go_cache = project_dir / ".gocache"
+    go_cache.mkdir(exist_ok=True)
+    env = dict(os.environ, GOCACHE=str(go_cache))
+    run(["go", "build", "-o", str(binary), str(source)], env=env)
+    return [str(binary)]
+
+
+def normalize_output(output: str) -> str:
+    lines = output.splitlines()
+    if not lines:
+        return ""
+    header = lines[0]
+    rows: list[tuple[str, str, float]] = []
+    for line in lines[1:]:
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        rows.append((parts[0], parts[1], round(float(parts[2]), 12)))
+    rows.sort(key=lambda item: (item[2], item[0], item[1]))
+    normalized = [header]
+    for article, root, value in rows:
+        normalized.append(f"{article}\t{root}\t{value:.12f}")
+    return "\n".join(normalized)
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+    edge_path = scale_dir / "category_parent.tsv"
+    article_path = scale_dir / "article_category.tsv"
+
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [str(edge_path), str(article_path)])
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_output(stdout)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    row_count = max(0, len(normalized.splitlines()) - 1)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    by_scale: dict[str, list[RunResult]] = {}
+    for result in results:
+        by_scale.setdefault(result.scale, []).append(result)
+
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale in sorted(by_scale.keys(), key=scale_sort_key):
+        entries = sorted(by_scale[scale], key=lambda item: item.target)
+        for result in entries:
+            print(
+                f"{scale}\t{result.target}\t{result.median:.3f}\t"
+                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+                f"{result.row_count}\t{result.stdout_sha256[:12]}"
+            )
+
+        qe = next((item for item in entries if item.target == "csharp-query"), None)
+        csharp_dfs = next((item for item in entries if item.target == "csharp-dfs"), None)
+        rust_dfs = next((item for item in entries if item.target == "rust-dfs"), None)
+        go_dfs = next((item for item in entries if item.target == "go-dfs"), None)
+        dfs_like = [item for item in entries if item.target != "csharp-query"]
+
+        if len(dfs_like) > 1:
+            dfs_hashes = {item.stdout_sha256 for item in dfs_like}
+            print(f"{scale}\tdfs_outputs\t{'match' if len(dfs_hashes) == 1 else 'MISMATCH'}")
+        if qe and csharp_dfs:
+            print(f"{scale}\tquery_vs_csharp_dfs\t{'match' if qe.stdout_sha256 == csharp_dfs.stdout_sha256 else 'DIFFERENT'}")
+            print(f"{scale}\tspeedup_vs_csharp_dfs\t{csharp_dfs.median / qe.median:.2f}x")
+        if qe and rust_dfs:
+            print(f"{scale}\tspeedup_vs_rust_dfs\t{rust_dfs.median / qe.median:.2f}x")
+        if qe and go_dfs:
+            print(f"{scale}\tspeedup_vs_go_dfs\t{go_dfs.median / qe.median:.2f}x")
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-weighted-cross-target-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-weighted-cross-target-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        commands: dict[str, list[str]] = {}
+        for target in targets:
+            if target == "csharp-query":
+                commands[target] = build_csharp_query(temp_root)
+            elif target == "csharp-dfs":
+                commands[target] = build_csharp_dfs(temp_root)
+            elif target == "rust-dfs":
+                commands[target] = build_rust_dfs(temp_root)
+            elif target == "go-dfs":
+                commands[target] = build_go_dfs(temp_root)
+            else:
+                raise ValueError(f"unsupported target: {target}")
+
+        results: list[RunResult] = []
+        for scale in scales:
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -318,7 +318,7 @@ if __name__ == "__main__":
 '''
 
 
-def generate_go(article_cats, category_parents, root_cats, n=5, max_depth=10):
+def generate_go_effective_distance(article_cats, category_parents, root_cats, n=5, max_depth=10):
     """Generate Go program that loads data from TSV files."""
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -462,7 +462,7 @@ func main() {{
 '''
 
 
-def generate_rust(article_cats, category_parents, root_cats, n=5, max_depth=10):
+def generate_rust_effective_distance(article_cats, category_parents, root_cats, n=5, max_depth=10):
     """Generate Rust program that loads data from TSV files."""
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -579,7 +579,7 @@ fn main() {{
 '''
 
 
-def generate_csharp(article_cats, category_parents, root_cats, n=5, max_depth=10):
+def generate_csharp_effective_distance(article_cats, category_parents, root_cats, n=5, max_depth=10):
     """Generate C# program that loads data from TSV files."""
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -795,13 +795,744 @@ main()
 '''
 
 
+def generate_go_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = list(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Shortest path to root benchmark (Go)
+// Usage: ./shortest_path_to_root <category_parent.tsv> <article_category.tsv>
+package main
+
+import (
+\t"bufio"
+\t"fmt"
+\t"os"
+\t"sort"
+\t"strings"
+)
+
+const ROOT = "{root}"
+const MAX_DEPTH = {max_depth}
+
+func loadTSVPairs(path string) map[string][]string {{
+\tm := make(map[string][]string)
+\tf, err := os.Open(path)
+\tif err != nil {{
+\t\tfmt.Fprintf(os.Stderr, "Cannot open %s: %v\\n", path, err)
+\t\tos.Exit(1)
+\t}}
+\tdefer f.Close()
+\tscanner := bufio.NewScanner(f)
+\tfirst := true
+\tfor scanner.Scan() {{
+\t\tline := scanner.Text()
+\t\tif first {{
+\t\t\tfirst = false
+\t\t\tif strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {{
+\t\t\t\tcontinue
+\t\t\t}}
+\t\t}}
+\t\tparts := strings.SplitN(line, "\\t", 2)
+\t\tif len(parts) == 2 {{
+\t\t\tm[parts[0]] = append(m[parts[0]], parts[1])
+\t\t}}
+\t}}
+\treturn m
+}}
+
+func categoryAncestorDFS(cat string, visited map[string]bool, adj map[string][]string, depth int) [][2]int {{
+\tif visited[cat] || depth >= MAX_DEPTH {{
+\t\treturn nil
+\t}}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {{
+\t\tnewVisited[k] = v
+\t}}
+\tnewVisited[cat] = true
+
+\tvar results [][2]int
+\tfor _, parent := range adj[cat] {{
+\t\tif !newVisited[parent] {{
+\t\t\tresults = append(results, [2]int{{0, 1}})
+\t\t\tfor _, sub := range categoryAncestorDFS(parent, newVisited, adj, depth+1) {{
+\t\t\t\tresults = append(results, [2]int{{0, sub[1] + 1}})
+\t\t\t}}
+\t\t}}
+\t}}
+\treturn results
+}}
+
+type pathResult struct {{
+\tancestor string
+\thops int
+}}
+
+func categoryAncestorPaths(cat string, visited map[string]bool, adj map[string][]string, depth int) []pathResult {{
+\tif visited[cat] || depth >= MAX_DEPTH {{
+\t\treturn nil
+\t}}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {{
+\t\tnewVisited[k] = v
+\t}}
+\tnewVisited[cat] = true
+
+\tvar results []pathResult
+\tfor _, parent := range adj[cat] {{
+\t\tif !newVisited[parent] {{
+\t\t\tresults = append(results, pathResult{{parent, 1}})
+\t\t\tfor _, sub := range categoryAncestorPaths(parent, newVisited, adj, depth+1) {{
+\t\t\t\tresults = append(results, pathResult{{sub.ancestor, sub.hops + 1}})
+\t\t\t}}
+\t\t}}
+\t}}
+\treturn results
+}}
+
+type articleResult struct {{
+\tarticle string
+\tdistance int
+}}
+
+func main() {{
+\tif len(os.Args) < 3 {{
+\t\tfmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\\n", os.Args[0])
+\t\tos.Exit(1)
+\t}}
+
+\tadj := loadTSVPairs(os.Args[1])
+\tartCats := loadTSVPairs(os.Args[2])
+
+\tvar arts []string
+\tfor art := range artCats {{
+\t\tarts = append(arts, art)
+\t}}
+\tsort.Strings(arts)
+
+\tvar results []articleResult
+\tfor _, art := range arts {{
+\t\tbest := -1
+\t\tfor _, cat := range artCats[art] {{
+\t\t\tif cat == ROOT {{
+\t\t\t\tif best == -1 || 1 < best {{
+\t\t\t\t\tbest = 1
+\t\t\t\t}}
+\t\t\t}}
+\t\t\tfor _, pr := range categoryAncestorPaths(cat, map[string]bool{{}}, adj, 0) {{
+\t\t\t\tif pr.ancestor == ROOT {{
+\t\t\t\t\tdist := pr.hops + 1
+\t\t\t\t\tif best == -1 || dist < best {{
+\t\t\t\t\t\tbest = dist
+\t\t\t\t\t}}
+\t\t\t\t}}
+\t\t\t}}
+\t\t}}
+\t\tif best != -1 {{
+\t\t\tresults = append(results, articleResult{{art, best}})
+\t\t}}
+\t}}
+
+\tsort.Slice(results, func(i, j int) bool {{
+\t\tif results[i].distance != results[j].distance {{
+\t\t\treturn results[i].distance < results[j].distance
+\t\t}}
+\t\treturn results[i].article < results[j].article
+\t}})
+
+\tfmt.Println("article\\troot_category\\tshortest_path")
+\tfor _, r := range results {{
+\t\tfmt.Printf("%s\\t%s\\t%d\\n", r.article, ROOT, r.distance)
+\t}}
+}}
+'''
+
+
+def generate_rust_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = list(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Shortest path to root benchmark (Rust)
+use std::collections::{{HashMap, HashSet}};
+use std::env;
+use std::fs;
+use std::io::{{BufRead, BufReader}};
+
+const ROOT: &str = "{root}";
+const MAX_DEPTH: usize = {max_depth};
+
+fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {{
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let file = fs::File::open(path).unwrap_or_else(|e| panic!("Cannot open {{}}: {{}}", path, e));
+    let reader = BufReader::new(file);
+    for (i, line) in reader.lines().enumerate() {{
+        let line = line.unwrap();
+        if (i == 0) && (line.starts_with("article") || line.starts_with("child")) {{
+            continue;
+        }}
+        let parts: Vec<&str> = line.splitn(2, '\\t').collect();
+        if parts.len() == 2 {{
+            map.entry(parts[0].to_string()).or_insert_with(Vec::new).push(parts[1].to_string());
+        }}
+    }}
+    map
+}}
+
+fn category_ancestor_paths(
+    cat: &str,
+    visited: &HashSet<String>,
+    adj: &HashMap<String, Vec<String>>,
+    depth: usize,
+) -> Vec<(String, i32)> {{
+    if visited.contains(cat) || depth >= MAX_DEPTH {{
+        return Vec::new();
+    }}
+    let mut new_visited = visited.clone();
+    new_visited.insert(cat.to_string());
+
+    let mut results = Vec::new();
+    if let Some(neighbors) = adj.get(cat) {{
+        for nb in neighbors {{
+            if !new_visited.contains(nb.as_str()) {{
+                results.push((nb.clone(), 1));
+                for (ancestor, h) in category_ancestor_paths(nb, &new_visited, adj, depth + 1) {{
+                    results.push((ancestor, h + 1));
+                }}
+            }}
+        }}
+    }}
+    results
+}}
+
+fn main() {{
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {{
+        eprintln!("Usage: {{}} <category_parent.tsv> <article_category.tsv>", args[0]);
+        std::process::exit(1);
+    }}
+
+    let adj = load_tsv_pairs(&args[1]);
+    let art_cats = load_tsv_pairs(&args[2]);
+    let mut arts: Vec<&String> = art_cats.keys().collect();
+    arts.sort();
+
+    let mut results: Vec<(i32, String)> = Vec::new();
+    for art in arts {{
+        let mut best: Option<i32> = None;
+        if let Some(cats) = art_cats.get(art) {{
+            for cat in cats {{
+                if cat == ROOT {{
+                    best = Some(best.map_or(1, |b| b.min(1)));
+                }}
+                let visited = HashSet::new();
+                for (ancestor, h) in category_ancestor_paths(cat, &visited, &adj, 0) {{
+                    if ancestor == ROOT {{
+                        let dist = h + 1;
+                        best = Some(best.map_or(dist, |b| b.min(dist)));
+                    }}
+                }}
+            }}
+        }}
+        if let Some(best_dist) = best {{
+            results.push((best_dist, art.to_string()));
+        }}
+    }}
+
+    results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    println!("article\\troot_category\\tshortest_path");
+    for (dist, art) in results {{
+        println!("{{}}\\t{{}}\\t{{}}", art, ROOT, dist);
+    }}
+}}
+'''
+
+
+def generate_csharp_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = list(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Shortest path to root benchmark (C#)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+class ShortestPathBenchmark
+{{
+    const string ROOT = "{root}";
+    const int MAX_DEPTH = {max_depth};
+
+    static Dictionary<string, List<string>> LoadTsvPairs(string path)
+    {{
+        var map = new Dictionary<string, List<string>>();
+        foreach (var (line, i) in File.ReadLines(path).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child"))) continue;
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                if (!map.ContainsKey(parts[0])) map[parts[0]] = new List<string>();
+                map[parts[0]].Add(parts[1]);
+            }}
+        }}
+        return map;
+    }}
+
+    static List<(string ancestor, int hops)> CategoryAncestorDFS(
+        string cat, HashSet<string> visited,
+        Dictionary<string, List<string>> adj, int depth)
+    {{
+        var results = new List<(string, int)>();
+        if (visited.Contains(cat) || depth >= MAX_DEPTH) return results;
+
+        var newVisited = new HashSet<string>(visited) {{ cat }};
+        if (adj.TryGetValue(cat, out var neighbors))
+        {{
+            foreach (var nb in neighbors)
+            {{
+                if (!newVisited.Contains(nb))
+                {{
+                    results.Add((nb, 1));
+                    foreach (var (ancestor, h) in CategoryAncestorDFS(nb, newVisited, adj, depth + 1))
+                    {{
+                        results.Add((ancestor, h + 1));
+                    }}
+                }}
+            }}
+        }}
+        return results;
+    }}
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var adj = LoadTsvPairs(args[0]);
+        var artCats = LoadTsvPairs(args[1]);
+        var results = new List<(int Distance, string Article)>();
+
+        foreach (var art in artCats.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            int? best = null;
+            foreach (var cat in artCats[art])
+            {{
+                if (cat == ROOT)
+                {{
+                    best = best is null ? 1 : Math.Min(best.Value, 1);
+                }}
+                foreach (var (ancestor, hops) in CategoryAncestorDFS(cat, new HashSet<string>(), adj, 0))
+                {{
+                    if (ancestor == ROOT)
+                    {{
+                        var dist = hops + 1;
+                        best = best is null ? dist : Math.Min(best.Value, dist);
+                    }}
+                }}
+            }}
+            if (best is not null)
+            {{
+                results.Add((best.Value, art));
+            }}
+        }}
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("article\\troot_category\\tshortest_path");
+        foreach (var (distance, art) in results)
+        {{
+            Console.WriteLine($"{{art}}\\t{{ROOT}}\\t{{distance}}");
+        }}
+    }}
+}}
+'''
+
+
+def generate_go_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = list(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Weighted shortest path to root benchmark (Go)
+package main
+
+import (
+\t"bufio"
+\t"fmt"
+\t"math"
+\t"os"
+\t"sort"
+\t"strings"
+)
+
+const ROOT = "{root}"
+const MAX_DEPTH = {max_depth}
+
+func loadTSVPairs(path string) map[string][]string {{
+\tm := make(map[string][]string)
+\tf, err := os.Open(path)
+\tif err != nil {{
+\t\tfmt.Fprintf(os.Stderr, "Cannot open %s: %v\\n", path, err)
+\t\tos.Exit(1)
+\t}}
+\tdefer f.Close()
+\tscanner := bufio.NewScanner(f)
+\tfirst := true
+\tfor scanner.Scan() {{
+\t\tline := scanner.Text()
+\t\tif first {{
+\t\t\tfirst = false
+\t\t\tif strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {{
+\t\t\t\tcontinue
+\t\t\t}}
+\t\t}}
+\t\tparts := strings.SplitN(line, "\\t", 2)
+\t\tif len(parts) == 2 {{
+\t\t\tm[parts[0]] = append(m[parts[0]], parts[1])
+\t\t}}
+\t}}
+\treturn m
+}}
+
+type pathResultWeighted struct {{
+\tancestor string
+\tweight float64
+}}
+
+func categoryWeightedDFS(
+\tcat string,
+\tvisited map[string]bool,
+\tadj map[string][]string,
+\tweights map[string]float64,
+\tdepth int,
+) []pathResultWeighted {{
+\tif visited[cat] || depth >= MAX_DEPTH {{
+\t\treturn nil
+\t}}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {{
+\t\tnewVisited[k] = v
+\t}}
+\tnewVisited[cat] = true
+
+\tstepCost := weights[cat]
+\tvar results []pathResultWeighted
+\tfor _, parent := range adj[cat] {{
+\t\tif !newVisited[parent] {{
+\t\t\tresults = append(results, pathResultWeighted{{parent, stepCost}})
+\t\t\tfor _, sub := range categoryWeightedDFS(parent, newVisited, adj, weights, depth+1) {{
+\t\t\t\tresults = append(results, pathResultWeighted{{sub.ancestor, sub.weight + stepCost}})
+\t\t\t}}
+\t\t}}
+\t}}
+\treturn results
+}}
+
+type articleWeightedResult struct {{
+\tarticle string
+\tdistance float64
+}}
+
+func main() {{
+\tif len(os.Args) < 3 {{
+\t\tfmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\\n", os.Args[0])
+\t\tos.Exit(1)
+\t}}
+
+\tadj := loadTSVPairs(os.Args[1])
+\tartCats := loadTSVPairs(os.Args[2])
+\tweights := make(map[string]float64)
+\tfor child, parents := range adj {{
+\t\tdegree := len(parents)
+\t\tweights[child] = 1.0 + math.Log(math.Max(1.0, float64(degree)))/math.Log(5.0)
+\t}}
+
+\tvar arts []string
+\tfor art := range artCats {{
+\t\tarts = append(arts, art)
+\t}}
+\tsort.Strings(arts)
+
+\tvar results []articleWeightedResult
+\tfor _, art := range arts {{
+\t\tvar best *float64
+\t\tfor _, cat := range artCats[art] {{
+\t\t\tif cat == ROOT {{
+\t\t\t\tzero := 0.0
+\t\t\t\tif best == nil || zero < *best {{
+\t\t\t\t\tbest = &zero
+\t\t\t\t}}
+\t\t\t}}
+\t\t\tfor _, pr := range categoryWeightedDFS(cat, map[string]bool{{}}, adj, weights, 0) {{
+\t\t\t\tif pr.ancestor == ROOT {{
+\t\t\t\t\tvalue := pr.weight
+\t\t\t\t\tif best == nil || value < *best {{
+\t\t\t\t\t\tbest = &value
+\t\t\t\t\t}}
+\t\t\t\t}}
+\t\t\t}}
+\t\t}}
+\t\tif best != nil {{
+\t\t\tresults = append(results, articleWeightedResult{{art, *best}})
+\t\t}}
+\t}}
+
+\tsort.Slice(results, func(i, j int) bool {{
+\t\tif results[i].distance != results[j].distance {{
+\t\t\treturn results[i].distance < results[j].distance
+\t\t}}
+\t\treturn results[i].article < results[j].article
+\t}})
+
+\tfmt.Println("article\\troot_category\\tweighted_shortest_path")
+\tfor _, r := range results {{
+\t\tfmt.Printf("%s\\t%s\\t%.12f\\n", r.article, ROOT, r.distance)
+\t}}
+}}
+'''
+
+
+def generate_rust_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = list(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Weighted shortest path to root benchmark (Rust)
+use std::collections::{{HashMap, HashSet}};
+use std::env;
+use std::fs;
+use std::io::{{BufRead, BufReader}};
+
+const ROOT: &str = "{root}";
+const MAX_DEPTH: usize = {max_depth};
+
+fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {{
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let file = fs::File::open(path).unwrap_or_else(|e| panic!("Cannot open {{}}: {{}}", path, e));
+    let reader = BufReader::new(file);
+    for (i, line) in reader.lines().enumerate() {{
+        let line = line.unwrap();
+        if (i == 0) && (line.starts_with("article") || line.starts_with("child")) {{
+            continue;
+        }}
+        let parts: Vec<&str> = line.splitn(2, '\\t').collect();
+        if parts.len() == 2 {{
+            map.entry(parts[0].to_string()).or_insert_with(Vec::new).push(parts[1].to_string());
+        }}
+    }}
+    map
+}}
+
+fn category_weighted_dfs(
+    cat: &str,
+    visited: &HashSet<String>,
+    adj: &HashMap<String, Vec<String>>,
+    weights: &HashMap<String, f64>,
+    depth: usize,
+) -> Vec<(String, f64)> {{
+    if visited.contains(cat) || depth >= MAX_DEPTH {{
+        return Vec::new();
+    }}
+    let mut new_visited = visited.clone();
+    new_visited.insert(cat.to_string());
+
+    let step_cost = *weights.get(cat).unwrap_or(&1.0);
+    let mut results = Vec::new();
+    if let Some(neighbors) = adj.get(cat) {{
+        for nb in neighbors {{
+            if !new_visited.contains(nb.as_str()) {{
+                results.push((nb.clone(), step_cost));
+                for (ancestor, w) in category_weighted_dfs(nb, &new_visited, adj, weights, depth + 1) {{
+                    results.push((ancestor, w + step_cost));
+                }}
+            }}
+        }}
+    }}
+    results
+}}
+
+fn main() {{
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {{
+        eprintln!("Usage: {{}} <category_parent.tsv> <article_category.tsv>", args[0]);
+        std::process::exit(1);
+    }}
+
+    let adj = load_tsv_pairs(&args[1]);
+    let art_cats = load_tsv_pairs(&args[2]);
+    let mut weights: HashMap<String, f64> = HashMap::new();
+    for (child, parents) in &adj {{
+        let degree = parents.len().max(1) as f64;
+        weights.insert(child.clone(), 1.0 + degree.log(5.0));
+    }}
+
+    let mut arts: Vec<&String> = art_cats.keys().collect();
+    arts.sort();
+
+    let mut results: Vec<(f64, String)> = Vec::new();
+    for art in arts {{
+        let mut best: Option<f64> = None;
+        if let Some(cats) = art_cats.get(art) {{
+            for cat in cats {{
+                if cat == ROOT {{
+                    best = Some(best.map_or(0.0, |b| b.min(0.0)));
+                }}
+                let visited = HashSet::new();
+                for (ancestor, weight) in category_weighted_dfs(cat, &visited, &adj, &weights, 0) {{
+                    if ancestor == ROOT {{
+                        best = Some(best.map_or(weight, |b| b.min(weight)));
+                    }}
+                }}
+            }}
+        }}
+        if let Some(best_dist) = best {{
+            results.push((best_dist, art.to_string()));
+        }}
+    }}
+
+    results.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap().then(a.1.cmp(&b.1)));
+    println!("article\\troot_category\\tweighted_shortest_path");
+    for (dist, art) in results {{
+        println!("{{}}\\t{{}}\\t{{:.12}}", art, ROOT, dist);
+    }}
+}}
+'''
+
+
+def generate_csharp_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = list(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Weighted shortest path to root benchmark (C#)
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+class WeightedShortestPathBenchmark
+{{
+    const string ROOT = "{root}";
+    const int MAX_DEPTH = {max_depth};
+
+    static Dictionary<string, List<string>> LoadTsvPairs(string path)
+    {{
+        var map = new Dictionary<string, List<string>>();
+        foreach (var (line, i) in File.ReadLines(path).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child"))) continue;
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                if (!map.ContainsKey(parts[0])) map[parts[0]] = new List<string>();
+                map[parts[0]].Add(parts[1]);
+            }}
+        }}
+        return map;
+    }}
+
+    static List<(string ancestor, double weight)> CategoryWeightedDFS(
+        string cat, HashSet<string> visited,
+        Dictionary<string, List<string>> adj,
+        Dictionary<string, double> weights,
+        int depth)
+    {{
+        var results = new List<(string, double)>();
+        if (visited.Contains(cat) || depth >= MAX_DEPTH) return results;
+
+        var newVisited = new HashSet<string>(visited) {{ cat }};
+        var stepCost = weights.TryGetValue(cat, out var cost) ? cost : 1.0;
+        if (adj.TryGetValue(cat, out var neighbors))
+        {{
+            foreach (var nb in neighbors)
+            {{
+                if (!newVisited.Contains(nb))
+                {{
+                    results.Add((nb, stepCost));
+                    foreach (var (ancestor, subWeight) in CategoryWeightedDFS(nb, newVisited, adj, weights, depth + 1))
+                    {{
+                        results.Add((ancestor, subWeight + stepCost));
+                    }}
+                }}
+            }}
+        }}
+        return results;
+    }}
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var adj = LoadTsvPairs(args[0]);
+        var artCats = LoadTsvPairs(args[1]);
+        var weights = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var (child, parents) in adj)
+        {{
+            var degree = Math.Max(1, parents.Count);
+            weights[child] = 1.0 + Math.Log(degree, 5.0);
+        }}
+
+        var results = new List<(double Distance, string Article)>();
+        foreach (var art in artCats.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            double? best = null;
+            foreach (var cat in artCats[art])
+            {{
+                if (cat == ROOT)
+                {{
+                    best = best is null ? 0.0 : Math.Min(best.Value, 0.0);
+                }}
+                foreach (var (ancestor, weight) in CategoryWeightedDFS(cat, new HashSet<string>(), adj, weights, 0))
+                {{
+                    if (ancestor == ROOT)
+                    {{
+                        best = best is null ? weight : Math.Min(best.Value, weight);
+                    }}
+                }}
+            }}
+            if (best is not null)
+            {{
+                results.Add((best.Value, art));
+            }}
+        }}
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("article\\troot_category\\tweighted_shortest_path");
+        foreach (var (distance, art) in results)
+        {{
+            Console.WriteLine($"{{art}}\\t{{ROOT}}\\t{{distance.ToString("F12", CultureInfo.InvariantCulture)}}");
+        }}
+    }}
+}}
+'''
+
+
 GENERATORS = {
-    'awk': generate_awk,
-    'python': generate_python,
-    'codon': generate_codon,
-    'go': generate_go,
-    'rust': generate_rust,
-    'csharp': generate_csharp,
+    'effective_distance': {
+        'awk': generate_awk,
+        'python': generate_python,
+        'codon': generate_codon,
+        'go': generate_go_effective_distance,
+        'rust': generate_rust_effective_distance,
+        'csharp': generate_csharp_effective_distance,
+    },
+    'shortest_path_to_root': {
+        'go': generate_go_shortest_path,
+        'rust': generate_rust_shortest_path,
+        'csharp': generate_csharp_shortest_path,
+    },
+    'weighted_shortest_path': {
+        'go': generate_go_weighted_shortest_path,
+        'rust': generate_rust_weighted_shortest_path,
+        'csharp': generate_csharp_weighted_shortest_path,
+    },
 }
 
 
@@ -811,7 +1542,13 @@ def main():
     )
     parser.add_argument("--facts", required=True, help="Prolog facts file")
     parser.add_argument("--root", default="Physics", help="Root category")
-    parser.add_argument("--target", required=True, choices=list(GENERATORS.keys()))
+    parser.add_argument(
+        "--workload",
+        default="effective_distance",
+        choices=list(GENERATORS.keys()),
+        help="Benchmark workload to generate",
+    )
+    parser.add_argument("--target", required=True, help="Target language")
     parser.add_argument("--output", required=True, help="Output file path")
     parser.add_argument("--n", type=float, default=5, help="Dimensionality parameter")
     parser.add_argument("--max-depth", type=int, default=10,
@@ -824,7 +1561,13 @@ def main():
     if args.root:
         root_cats = {args.root}
 
-    generator = GENERATORS[args.target]
+    workload_generators = GENERATORS[args.workload]
+    if args.target not in workload_generators:
+        supported = ", ".join(sorted(workload_generators.keys()))
+        print(f"Unsupported target '{args.target}' for workload '{args.workload}'. Supported: {supported}", file=sys.stderr)
+        sys.exit(2)
+
+    generator = workload_generators[args.target]
     code = generator(article_cats, category_parents, root_cats,
                      n=int(args.n), max_depth=args.max_depth)
 


### PR DESCRIPTION
  ## Summary

  This PR extends the benchmark pipeline so the newer `Min` workloads can
  be compared across the same target set as effective distance:

  - `csharp-query`
  - `csharp-dfs`
  - `rust-dfs`
  - `go-dfs`

  It adds cross-target benchmark runners for:

  - minimum-hop shortest path to root
  - positive weighted minimum path to root

  and updates the benchmark generator so those workloads can be emitted for
  C#, Rust, and Go from the same benchmark definitions instead of relying
  on handwritten one-off binaries.

  ## What Changed

  ### Benchmark Generator

  In:

  - `examples/benchmark/generate_pipeline.py`

  the generator now supports explicit workloads:

  - `effective_distance`
  - `shortest_path_to_root`
  - `weighted_shortest_path`

  This lets the benchmark scripts generate target-specific binaries for the
  same workload family instead of only supporting effective distance.

  ### New Cross-Target Benchmark Scripts

  Added:

  - `examples/benchmark/benchmark_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_weighted_shortest_path_cross_target.py`

  These compare:

  - `csharp-query`
  - `csharp-dfs`
  - `rust-dfs`
  - `go-dfs`

  and report:

  - median/min/max wall-clock time
  - row counts
  - normalized output hashes
  - DFS-vs-DFS agreement
  - `csharp-query` vs `csharp-dfs` agreement
  - speedups of the query engine against each DFS target

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now documents:

  - the new cross-target benchmark scripts
  - how they relate to the existing C#-only `All` vs `Min` scripts
  - the latest local `300/1k/5k/10k` results

  ## Why This Matters

  We had already brought Rust and then Go up to parity for the same recent
  recursive features:

  - all-path effective distance
  - minimum hop distance
  - minimum weighted path distance

  But the benchmark tooling had not caught up. The newer shortest-path
  benchmarks were still C#-only.

  This PR closes that tooling gap so the comparison surface matches the
  target feature surface.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py

  ### Cross-target shortest path smoke test

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Result:

  - all four targets matched
  - C# query engine was fastest

  ### Cross-target weighted shortest path smoke test

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Result:

  - all four targets matched
  - C# query engine was fastest

  ## Documented Results

  ### Minimum-Hop Shortest Path

  Latest local results:

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.142s | 0.424s | 0.361s | 0.472s | match |
  | 1k | 0.104s | 1.350s | 1.400s | 2.101s | match |
  | 5k | 0.202s | 5.697s | 7.445s | 12.323s | match |
  | 10k | 0.433s | 10.313s | 14.462s | 20.487s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 3.00x | 2.55x | 3.33x |
  | 1k | 13.04x | 13.52x | 20.29x |
  | 5k | 28.15x | 36.79x | 60.89x |
  | 10k | 23.84x | 33.43x | 47.35x |

  ### Positive Weighted Minimum Path

  Latest local results:

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.181s | 0.466s | 0.353s | 0.487s | match |
  | 1k | 0.142s | 1.409s | 1.447s | 2.206s | match |
  | 5k | 0.250s | 5.957s | 7.994s | 12.404s | match |
  | 10k | 0.460s | 10.845s | 15.198s | 20.549s | DIFFERENT |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 2.57x | 1.95x | 2.69x |
  | 1k | 9.91x | 10.18x | 15.51x |
  | 5k | 23.81x | 31.94x | 49.57x |
  | 10k | 23.57x | 33.02x | 44.65x |

  ## Important Caveat

  The minimum-hop benchmark is clean across all tested scales.

  The weighted minimum benchmark is not fully settled yet:

  - at 300, 1k, and 5k, all four targets matched
  - at 10k, the DFS targets still matched each other
  - but csharp-query diverged from the DFS result

  So this PR should be read as:

  - a benchmark infrastructure win
  - a clear performance win for minimum-hop shortest path
  - and a useful diagnostic for weighted Min, where the 10k C# query
    result still needs follow-up investigation

  ## Implementation Note

  The new benchmark scripts localize GOCACHE into their temp build
  directories so go build works cleanly in restricted environments
  instead of depending on a writable global Go cache.

  ## Follow-Up

  Likely next work:

  - investigate the weighted 10k C# query-engine mismatch
  - decide whether that is:
      - a query-engine semantic bug
      - a benchmark harness normalization issue
      - or a workload mismatch
  - once resolved, refresh the weighted cross-target benchmark tables