### PR TITLE
Document native TypR extra-parameter string producer tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ includes:
   string-transform or length-producing step
 - simple alias tails after native conversion, list, and path producers such as
   `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, narrowed
-  `sub_atom/5`, and `string_substr/4`
+  `sub_atom/5`, `string_substr/4`, and representative extra-parameter string
+  producers such as `string_replace/4`, `string_sub/4`, `string_format/3`,
+  and `string_grepl/3`
 - guard-style command predicates such as `is_character/1`
 - unary TypR-safe I/O commands such as `cat/1` and `print/1`, emitted as
   native fixed-arity TypR calls
@@ -387,8 +389,10 @@ string-transform/output-tail slice; if this area is extended further, the next
 real audit target is the producer-goal family after the currently supported
 `string_lower/2`, `string_upper/2`, `string_length/2`, `to_numeric/2`,
 `reverse/2`, `dirname/2`, `atom_string/2`, broader constant-parameter
-substring slices such as `sub_atom/5`, and `string_substr/4` follow-on alias
-or arithmetic tails.
+substring slices such as `sub_atom/5` and `string_substr/4`, and
+representative extra-parameter string producers such as `string_replace/4`,
+`string_sub/4`, `string_format/3`, and `string_grepl/3` follow-on alias or
+arithmetic tails.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -171,7 +171,9 @@ bring-up.
     string-transform or length-producing step
   - simple alias tails after native conversion, list, and path producers such
     as `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, narrowed
-    `sub_atom/5`, and `string_substr/4`
+    `sub_atom/5`, `string_substr/4`, and representative extra-parameter
+    string producers such as `string_replace/4`, `string_sub/4`,
+    `string_format/3`, and `string_grepl/3`
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -518,6 +518,9 @@ Current wrapped-fallback boundary note:
 - the next narrowed substring-style slice is also native when it stays within
   constant-parameter substring producers such as `sub_atom/5` and
   `string_substr/4`, followed by a simple alias tail
+- the next audited extra-parameter string producer family is also native for
+  simple alias tails, including representative `string_replace/4`,
+  `string_sub/4`, `string_format/3`, and `string_grepl/3`
 - the remaining wrapped fallback boundary is now beyond that first
   producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2231,6 +2231,58 @@ test(string_substr_alias_after_native_outputs_stays_native) :-
     \+ sub_string(Code, _, _, _, "Unknown predicate"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(string_replace_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(string_replace_alias(A, Out) :- string_replace(A, 'a', 'b', Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_replace_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_replace_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_replace_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let string_replace_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ gsub(arg1, \"a\", \"b\") }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(string_sub_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(string_sub_alias(A, Out) :- string_sub(A, 'a', 'b', Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_sub_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_sub_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_sub_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let string_sub_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ sub(arg1, \"a\", \"b\") }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(string_format_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(string_format_alias(A, Out) :- string_format('x=%s', A, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_format_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_format_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_format_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let string_format_alias <- fn(arg1: char, arg2: char): char")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ sprintf(\"x=%s\", arg1) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
+test(string_grepl_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(string_grepl_alias(A, Out) :- string_grepl('a', A, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_grepl_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_grepl_alias/2, 2, boolean)),
+    once(compile_predicate_to_typr(string_grepl_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let string_grepl_alias <- fn(arg1: char, arg2: bool): bool")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ grepl(\"a\", arg1) }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(multi_decision_guard_chains_use_let_for_new_intermediates) :-
     clear_type_declarations,
     assertz(user:(multi_guard_chain(Name, Out) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Upper), is_character(Upper), string_concat(Upper, '!', Out))),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -194,6 +194,74 @@ test(string_substr_alias_after_native_outputs_check_with_typr, [condition(typr_c
     ),
     retractall(user:string_substr_alias(_, _)).
 
+test(string_replace_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(string_replace_alias(A, Out) :- string_replace(A, 'a', 'b', Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_replace_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_replace_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_replace_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:string_replace_alias(_, _)).
+
+test(string_sub_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(string_sub_alias(A, Out) :- string_sub(A, 'a', 'b', Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_sub_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_sub_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_sub_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:string_sub_alias(_, _)).
+
+test(string_format_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(string_format_alias(A, Out) :- string_format('x=%s', A, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_format_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_format_alias/2, 2, atom)),
+    once(compile_predicate_to_typr(string_format_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:string_format_alias(_, _)).
+
+test(string_grepl_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(string_grepl_alias(A, Out) :- string_grepl('a', A, Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(string_grepl_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(string_grepl_alias/2, 2, boolean)),
+    once(compile_predicate_to_typr(string_grepl_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:string_grepl_alias(_, _)).
+
 test(cat_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:(say_cat(Msg) :- cat(Msg))),


### PR DESCRIPTION
## Summary
This PR documents and regression-covers the next audited generic TypR producer family beyond the constant-parameter substring slice.

The audit found that these producer-follow-on shapes were already lowering natively, so this PR adds tests and docs rather than changing `typr_target.pl`.

Covered producer families:
- `string_replace/4`
- `string_sub/4`
- `string_format/3`
- `string_grepl/3`

## What changed
- added target-level regression coverage for native TypR alias tails after these producer steps
- added real `typr check` coverage for the same shapes
- updated TypR docs to record that these representative extra-parameter string producers are already native in the simple producer-plus-alias-tail path

## Why this matters
The wrapped-fallback boundary is narrower than it looked. These string producer families do not require another emitter change or another fallback carveout.

That lets the next audit move past representative string cases and focus on a genuinely unsupported producer family.

## Validation
```sh
swipl -q -g "run_tests([typr_target:string_replace_alias_after_native_outputs_stays_native,typr_target:string_sub_alias_after_native_outputs_stays_native,typr_target:string_format_alias_after_native_outputs_stays_native,typr_target:string_grepl_alias_after_native_outputs_stays_native])" -t halt tests/test_typr_target.pl
swipl -q -g "run_tests([typr_toolchain:string_replace_alias_after_native_outputs_check_with_typr,typr_toolchain:string_sub_alias_after_native_outputs_check_with_typr,typr_toolchain:string_format_alias_after_native_outputs_check_with_typr,typr_toolchain:string_grepl_alias_after_native_outputs_check_with_typr])" -t halt tests/test_typr_toolchain.pl
git diff --check
```
