### PR TITLE
Keep native TypR split_string/4 producer tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,9 @@ real audit target is the producer-goal family after the currently supported
 substring slices such as `sub_atom/5` and `string_substr/4`, and
 representative extra-parameter string producers such as `string_replace/4`,
 `string_sub/4`, `string_format/3`, and `string_grepl/3` follow-on alias or
-arithmetic tails.
+arithmetic tails, and the first list-producing Prolog string helper slice
+`split_string/4` with a constant separator and empty pad chars followed by a
+simple alias tail.
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -173,7 +173,9 @@ bring-up.
     as `to_numeric/2`, `reverse/2`, `dirname/2`, `atom_string/2`, narrowed
     `sub_atom/5`, `string_substr/4`, and representative extra-parameter
     string producers such as `string_replace/4`, `string_sub/4`,
-    `string_format/3`, and `string_grepl/3`
+    `string_format/3`, and `string_grepl/3`, plus the first conservative
+    list-producing `split_string/4` slice with a constant separator and empty
+    pad chars
   - guard-style command predicates lowered into clause conditions
   - sequential native control-flow chains where earlier outputs feed later
     guards and outputs

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -521,6 +521,8 @@ Current wrapped-fallback boundary note:
 - the next audited extra-parameter string producer family is also native for
   simple alias tails, including representative `string_replace/4`,
   `string_sub/4`, `string_format/3`, and `string_grepl/3`
+- the first list-producing Prolog string helper slice is now native for simple
+  alias tails: `split_string/4` with a constant separator and empty pad chars
 - the remaining wrapped fallback boundary is now beyond that first
   producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -7800,6 +7800,15 @@ native_typr_output_expr(sub_atom(InValue, Before, Length, After, OutVar), VarMap
     Start is Before + 1,
     End is Before + Length,
     format(string(OutputExpr), '@{ substr(~w, ~w, ~w) }@', [InExpr, Start, End]).
+native_typr_output_expr(split_string(InValue, Separator, PadChars, OutVar), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
+    var(OutVar),
+    atomic(Separator),
+    typr_split_string_empty_pad(PadChars),
+    !,
+    ensure_typr_var(VarMap0, OutVar, FinalExpr, VarMap, IntroKind),
+    typr_resolve_value(VarMap0, InValue, InExpr),
+    typr_resolve_value(VarMap0, Separator, SepExpr),
+    format(string(OutputExpr), '@{ strsplit(~w, ~w) }@', [InExpr, SepExpr]).
 native_typr_output_expr(sort_by(DF, Col, Out), VarMap0, _PredName, VarMap, FinalExpr, OutputExpr, IntroKind) :-
     !,
     ensure_typr_var(VarMap0, Out, FinalExpr, VarMap, IntroKind),
@@ -8599,6 +8608,9 @@ typr_name_index(Name, Index) :-
         sub_string(Name, 1, _, 0, Digits)
     ),
     number_string(Index, Digits).
+
+typr_split_string_empty_pad('').
+typr_split_string_empty_pad("").
 
 lookup_typr_var(Var, [StoredVar-Name|_], Name) :-
     Var == StoredVar,

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -2283,6 +2283,19 @@ test(string_grepl_alias_after_native_outputs_stays_native) :-
     \+ sub_string(Code, _, _, _, "Unknown predicate"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(split_string_alias_after_native_outputs_stays_native) :-
+    clear_type_declarations,
+    assertz(user:(split_string_alias(A, Out) :- split_string(A, ',', '', Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(split_string_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(split_string_alias/2, 2, list(string))),
+    once(compile_predicate_to_typr(split_string_alias/2, [typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let split_string_alias <- fn(arg1: char, arg2: [#N, char]): [#N, char]")),
+    once(sub_string(Code, _, _, _, "let v3 <- @{ strsplit(arg1, \",\") }@;")),
+    once(sub_string(Code, _, _, _, "arg2 <- v3;")),
+    \+ sub_string(Code, _, _, _, "(function("),
+    \+ sub_string(Code, _, _, _, "Unknown predicate"),
+    generated_typr_is_valid(Code, exit(0)).
+
 test(multi_decision_guard_chains_use_let_for_new_intermediates) :-
     clear_type_declarations,
     assertz(user:(multi_guard_chain(Name, Out) :- string_lower(Name, Lower), is_character(Lower), string_length(Lower, Len), is_numeric(Len), string_upper(Lower, Upper), is_character(Upper), string_concat(Upper, '!', Out))),

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -262,6 +262,23 @@ test(string_grepl_alias_after_native_outputs_check_with_typr, [condition(typr_cl
     ),
     retractall(user:string_grepl_alias(_, _)).
 
+test(split_string_alias_after_native_outputs_check_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    assertz(user:(split_string_alias(A, Out) :- split_string(A, ',', '', Tmp), Out = Tmp)),
+    assertz(type_declarations:uw_type(split_string_alias/2, 1, atom)),
+    assertz(type_declarations:uw_type(split_string_alias/2, 2, list(string))),
+    once(compile_predicate_to_typr(split_string_alias/2, [typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:split_string_alias(_, _)).
+
 test(cat_command_output_checks_with_typr, [condition(typr_cli_available)]) :-
     clear_type_declarations,
     assertz(user:(say_cat(Msg) :- cat(Msg))),


### PR DESCRIPTION
## Summary
This PR closes the first real collection-producing generic producer gap in the TypR target.

TypR already handled several single-output producer-follow-on cases natively, but a conservative `split_string/4` shape was still falling through to the wrapped fallback path.

That slice now stays native.

## Supported slice
This PR adds native TypR lowering for:
- `split_string(Input, Separator, '', Tmp), Out = Tmp`

Current scope is intentionally narrow:
- constant separator
- empty pad chars
- simple alias tail

## What changed
- added a native TypR output path for conservative `split_string/4`
- added target-level regression coverage for the new native output shape
- added real `typr check` coverage for the same slice
- updated TypR docs to record that this first collection-producing producer slice is now native

## Why this matters
This is the first audited producer family after the earlier string/conversion/path/substring audits that was not already native.

It also confirms that the next generic TypR frontier is collection-producing producer families, not more single-output string helpers.

## Validation
```sh
swipl -q -g "run_tests([typr_target:split_string_alias_after_native_outputs_stays_native])" -t halt tests/test_typr_target.pl
swipl -q -g "run_tests([typr_toolchain:split_string_alias_after_native_outputs_check_with_typr])" -t halt tests/test_typr_toolchain.pl
git diff --check
```
