### PR TITLE
feat(go): add aggregate_all subplan filters

### DIFF
--- a/src/unifyweaver/core/advanced/pattern_matchers.pl
+++ b/src/unifyweaver/core/advanced/pattern_matchers.pl
@@ -34,6 +34,7 @@
     % Aggregate classification
     classify_aggregate/2,                  % +AggTerm, -AggInfo
     parse_aggregate_template/3,            % +Template, -Op, -Expr
+    classify_aggregate_goal/2,             % +Goal, -GoalInfo
     test_pattern_matchers/0         % Test predicate
 ]).
 
@@ -58,11 +59,13 @@ classify_aggregate(Term0, AggInfo) :-
     ),
     nonvar(Goal),
     parse_aggregate_template(Template, Op, Expr),
+    classify_aggregate_goal(Goal, GoalInfo),
     AggInfo = agg_info{
         type: Type,
         op: Op,
         expr: Expr,
         goal: Goal,
+        goal_info: GoalInfo,
         group: Group,
         result: Result
     }.
@@ -74,6 +77,53 @@ parse_aggregate_template(max(Expr), max, Expr).
 parse_aggregate_template(avg(Expr), avg, Expr).
 parse_aggregate_template(set(Expr), set, Expr).
 parse_aggregate_template(bag(Expr), bag, Expr).
+
+classify_aggregate_goal(Goal0, GoalInfo) :-
+    strip_module(Goal0, _, Goal),
+    aggregate_goal_terms(Goal, Terms),
+    include(aggregate_relation_term, Terms, RelationTerms),
+    include(aggregate_arithmetic_term, Terms, ArithmeticTerms),
+    include(aggregate_constraint_term, Terms, ConstraintTerms),
+    subtract(Terms, RelationTerms, NonRelationTerms0),
+    subtract(NonRelationTerms0, ArithmeticTerms, NonRelationTerms1),
+    subtract(NonRelationTerms1, ConstraintTerms, OtherTerms),
+    GoalInfo = agg_goal{
+        terms: Terms,
+        relations: RelationTerms,
+        arithmetic: ArithmeticTerms,
+        constraints: ConstraintTerms,
+        other: OtherTerms
+    }.
+
+aggregate_goal_terms(true, []) :- !.
+aggregate_goal_terms((A, B), Terms) :- !,
+    aggregate_goal_terms(A, TermsA),
+    aggregate_goal_terms(B, TermsB),
+    append(TermsA, TermsB, Terms).
+aggregate_goal_terms(Goal, [Goal]).
+
+aggregate_arithmetic_term(Term0) :-
+    strip_module(Term0, _, Term),
+    nonvar(Term),
+    Term = (_ is _).
+
+aggregate_constraint_term(Term0) :-
+    strip_module(Term0, _, Term),
+    nonvar(Term),
+    compound(Term),
+    functor(Term, Fun, Arity),
+    member(Fun/Arity,
+        ['>'/2, '<'/2, '>='/2, '=<'/2, '=:='/2, '=\\='/2, '=='/2, '\\=='/2]).
+
+aggregate_relation_term(Term0) :-
+    strip_module(Term0, _, Term),
+    nonvar(Term),
+    compound(Term),
+    \+ aggregate_arithmetic_term(Term),
+    \+ aggregate_constraint_term(Term),
+    \+ (Term = (_,_)),
+    \+ (Term = (_;_)),
+    \+ (Term = (_->_)).
 
 %% is_tail_recursive_accumulator(+Pred/Arity, -AccInfo)
 %  Detect tail recursion with accumulator pattern

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -92,6 +92,7 @@
 :- use_module('../core/service_validation').
 :- use_module('../core/optimizer').
 :- use_module('../core/constraint_analyzer').
+:- use_module('../core/advanced/pattern_matchers', [classify_aggregate/2]).
 :- use_module('../core/index_analyzer').
 :- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4, parse_table_spec/2]).
 
@@ -4281,6 +4282,14 @@ func toFloat64(v interface{}) (float64, bool) {
     }
 }
 
+func toFloat64Must(v interface{}) float64 {
+    f, ok := toFloat64(v)
+    if !ok {
+        return 0
+    }
+    return f
+}
+
 // Index provides O(1) lookup by relation and argument value
 type Index struct {
     // byArg[relation][argN][value] -> []*Fact
@@ -4466,16 +4475,33 @@ extract_having_filters(_, _, []).
 compile_go_aggregate_rule(Index, HeadPred, HeadArgs, AggGoal0, HavingFilters, Config, Code) :-
     format(string(RuleName), "ApplyRule_~w", [Index]),
     
-    % Normalize aggregate/3 -> aggregate_all/3
     normalize_aggregate_goal_go(AggGoal0, AggGoal),
-    
-    % Decompose aggregate goal
-    (   AggGoal = aggregate_all(OpTerm, InnerGoal, GroupVar, Result)
-    ->  % Grouped aggregation (aggregate_all/4)
-        compile_go_grouped_aggregate(RuleName, HeadPred, HeadArgs, OpTerm, InnerGoal, GroupVar, Result, HavingFilters, Config, Code)
-    ;   AggGoal = aggregate_all(OpTerm, InnerGoal, Result)
-    ->  % Ungrouped aggregation (aggregate_all/3)
-        compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, OpTerm, InnerGoal, Result, HavingFilters, Config, Code)
+    classify_aggregate(AggGoal, AggInfo),
+    get_dict(type, AggInfo, Type),
+    get_dict(goal, AggInfo, InnerGoal),
+    get_dict(goal_info, AggInfo, GoalInfo),
+    get_dict(group, AggInfo, GroupVar),
+    get_dict(result, AggInfo, Result),
+    get_dict(op, AggInfo, Op),
+    get_dict(expr, AggInfo, Expr),
+    (   Type = all,
+        GoalInfo.relations = [RelGoal],
+        GoalInfo.other = [],
+        InnerGoal == RelGoal
+    ->  compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, RelGoal, Result, HavingFilters, Config, Code)
+    ;   Type = group,
+        GoalInfo.relations = [RelGoal],
+        GoalInfo.other = [],
+        InnerGoal == RelGoal
+    ->  compile_go_grouped_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, RelGoal, GroupVar, Result, HavingFilters, Config, Code)
+    ;   Type = all,
+        GoalInfo.relations = [RelGoal],
+        GoalInfo.other = []
+    ->  compile_go_ungrouped_subplan_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, RelGoal, GoalInfo, Result, HavingFilters, Config, Code)
+    ;   Type = group,
+        GoalInfo.relations = [RelGoal],
+        GoalInfo.other = []
+    ->  compile_go_grouped_subplan_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, RelGoal, GoalInfo, GroupVar, Result, HavingFilters, Config, Code)
     ;   format(string(Code),
 "func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
     // Unsupported aggregate form
@@ -4483,16 +4509,13 @@ compile_go_aggregate_rule(Index, HeadPred, HeadArgs, AggGoal0, HavingFilters, Co
 }", [RuleName])
     ).
 
-%% compile_go_ungrouped_aggregate(+RuleName, +HeadPred, +HeadArgs, +OpTerm, +InnerGoal, +Result, +HavingFilters, +Config, -Code)
-compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, OpTerm, InnerGoal, Result, HavingFilters, _Config, Code) :-
+%% compile_go_ungrouped_aggregate(+RuleName, +HeadPred, +HeadArgs, +Op, +Expr, +InnerGoal, +Result, +HavingFilters, +Config, -Code)
+compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, InnerGoal, Result, HavingFilters, _Config, Code) :-
     InnerGoal =.. [Pred|Args],
     
-    % Determine the aggregate operation and value variable
-    decompose_agg_op(OpTerm, Op, ValueVar),
-    
     % Find value variable index in inner goal args
-    (   var(ValueVar)
-    ->  find_var_index_go(ValueVar, Args, ValueIdx)
+    (   var(Expr)
+    ->  find_var_index_go(Expr, Args, ValueIdx)
     ;   ValueIdx = -1  % count doesn't need a value index
     ),
     
@@ -4547,17 +4570,14 @@ compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, OpTerm, InnerGoal, 
     return results
 }", [RuleName, Pred, Pred, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd]).
 
-%% compile_go_grouped_aggregate(+RuleName, +HeadPred, +HeadArgs, +OpTerm, +InnerGoal, +GroupVar, +Result, +HavingFilters, +Config, -Code)
-compile_go_grouped_aggregate(RuleName, HeadPred, _HeadArgs, OpTerm, InnerGoal, GroupVar, Result, HavingFilters, _Config, Code) :-
+%% compile_go_grouped_aggregate(+RuleName, +HeadPred, +HeadArgs, +Op, +Expr, +InnerGoal, +GroupVar, +Result, +HavingFilters, +Config, -Code)
+compile_go_grouped_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, InnerGoal, GroupVar, Result, HavingFilters, _Config, Code) :-
     InnerGoal =.. [Pred|Args],
-    
-    % Determine the aggregate operation and value variable
-    decompose_agg_op(OpTerm, Op, ValueVar),
     
     % Find group key and value indices
     find_var_index_go(GroupVar, Args, GroupIdx),
-    (   var(ValueVar)
-    ->  find_var_index_go(ValueVar, Args, ValueIdx)
+    (   var(Expr)
+    ->  find_var_index_go(Expr, Args, ValueIdx)
     ;   ValueIdx = -1
     ),
     
@@ -4610,6 +4630,94 @@ compile_go_grouped_aggregate(RuleName, HeadPred, _HeadArgs, OpTerm, InnerGoal, G
     return results
 }", [RuleName, Pred, Pred, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred]).
 
+compile_go_ungrouped_subplan_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, RelGoal, GoalInfo, Result, HavingFilters, _Config, Code) :-
+    RelGoal =.. [Pred|Args],
+    build_go_aggregate_filter_conditions(GoalInfo, Args, FilterCond),
+    (   var(Expr)
+    ->  find_var_index_go(Expr, Args, ValueIdx)
+    ;   ValueIdx = -1
+    ),
+    go_agg_code(Op, AggCode),
+    length(HeadArgs, NumArgs),
+    (   NumArgs == 1 -> ArgsStr = "\"arg0\": agg" ; ArgsStr = "\"arg0\": agg" ),
+    (   HavingFilters \= []
+    ->  generate_having_conditions(HavingFilters, Result, HavingCond),
+        format(string(HavingIfStart), "
+        // HAVING clause filter
+        if ~w {", [HavingCond]),
+        HavingIfEnd = "
+        }"
+    ;   HavingIfStart = "",
+        HavingIfEnd = ""
+    ),
+    format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    var values []float64
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            val, ok := toFloat64(f.Args[\"arg~w\"])
+            if ok {
+                values = append(values, val)
+            }
+        }
+    }
+    if len(values) > 0 {
+        ~w~w
+            results = append(results, Fact{Relation: \"~w\", Args: map[string]interface{}{~w}})~w
+    }
+    return results
+}", [RuleName, Pred, Pred, FilterCond, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd]).
+
+compile_go_grouped_subplan_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, RelGoal, GoalInfo, GroupVar, Result, HavingFilters, _Config, Code) :-
+    RelGoal =.. [Pred|Args],
+    build_go_aggregate_filter_conditions(GoalInfo, Args, FilterCond),
+    find_var_index_go(GroupVar, Args, GroupIdx),
+    (   var(Expr)
+    ->  find_var_index_go(Expr, Args, ValueIdx)
+    ;   ValueIdx = -1
+    ),
+    go_agg_code(Op, AggCode),
+    (   HavingFilters \= []
+    ->  generate_having_conditions(HavingFilters, Result, HavingCond),
+        format(string(HavingCode), "
+            // HAVING clause filter
+            if !(~w) {
+                continue
+            }", [HavingCond])
+    ;   HavingCode = ""
+    ),
+    format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    groups := make(map[interface{}][]float64)
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            key := f.Args[\"arg~w\"]
+            val, ok := toFloat64(f.Args[\"arg~w\"])
+            if ok {
+                groups[key] = append(groups[key], val)
+            }
+        }
+    }
+    for key, values := range groups {
+        if len(values) > 0 {
+            ~w~w
+            results = append(results, Fact{
+                Relation: \"~w\",
+                Args: map[string]interface{}{\"arg0\": key, \"arg1\": agg},
+            })
+        }
+    }
+    return results
+}", [RuleName, Pred, Pred, FilterCond, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred]).
+
 %% decompose_agg_op(+OpTerm, -Op, -ValueVar)
 decompose_agg_op(count, count, _).
 decompose_agg_op(sum(V), sum, V).
@@ -4618,6 +4726,39 @@ decompose_agg_op(max(V), max, V).
 decompose_agg_op(avg(V), avg, V).
 decompose_agg_op(set(V), set, V).
 decompose_agg_op(bag(V), bag, V).
+
+build_go_aggregate_filter_conditions(GoalInfo, Args, Condition) :-
+    get_dict(constraints, GoalInfo, Constraints),
+    build_go_aggregate_filter_conditions_(Constraints, Args, Parts),
+    (   Parts == []
+    ->  Condition = "true"
+    ;   atomic_list_concat(Parts, " && ", Condition)
+    ).
+
+build_go_aggregate_filter_conditions_([], _Args, []).
+build_go_aggregate_filter_conditions_([Constraint|Rest], Args, [Part|Parts]) :-
+    go_aggregate_constraint_condition(Constraint, Args, Part),
+    !,
+    build_go_aggregate_filter_conditions_(Rest, Args, Parts).
+build_go_aggregate_filter_conditions_([_|Rest], Args, Parts) :-
+    build_go_aggregate_filter_conditions_(Rest, Args, Parts).
+
+go_aggregate_constraint_condition(Constraint, Args, Cond) :-
+    Constraint =.. [Op, Left, Right],
+    member(Op-GoOp, [(>)-">", (<)-"<", (>=)-">=", (=<)-"<=", (=:=)-"==", (=\=)-"!="]),
+    go_aggregate_operand(Left, Args, LeftExpr),
+    go_aggregate_operand(Right, Args, RightExpr),
+    format(string(Cond), "~w ~w ~w", [LeftExpr, GoOp, RightExpr]).
+
+go_aggregate_operand(Term, Args, Expr) :-
+    var(Term),
+    !,
+    find_var_index_go(Term, Args, Index),
+    format(string(Expr), "toFloat64Must(f.Args[\"arg~w\"])", [Index]).
+go_aggregate_operand(Term, _Args, Expr) :-
+    number(Term),
+    !,
+    format(string(Expr), "~w", [Term]).
 
 %% generate_having_conditions(+HavingFilters, +ResultVar, -GoCondition)
 %  Translate HAVING filter builtins to Go conditions

--- a/tests/core/test_go_generator_aggregate_subplans.pl
+++ b/tests/core/test_go_generator_aggregate_subplans.pl
@@ -1,0 +1,52 @@
+:- module(test_go_generator_aggregate_subplans, [
+    test_go_generator_aggregate_subplans/0
+]).
+
+:- use_module(library(plunit)).
+:- use_module('../../src/unifyweaver/targets/go_target.pl').
+
+setup_filtered_count_example :-
+    cleanup_all,
+    assertz(user:sale(alice, 100)),
+    assertz(user:sale(bob, 250)),
+    assertz(user:sale(carol, 175)),
+    assertz(user:(high_sale_count(C) :- aggregate_all(count, (sale(_, A), A > 150), C))).
+
+setup_grouped_filtered_sum_example :-
+    cleanup_all,
+    assertz(user:salary(eng, 1000)),
+    assertz(user:salary(eng, 1500)),
+    assertz(user:salary(sales, 500)),
+    assertz(user:salary(sales, 2000)),
+    assertz(user:(dept_big_total(Dept, Total) :- aggregate_all(sum(S), (salary(Dept, S), S > 1000), Dept, Total))).
+
+cleanup_all :-
+    catch(abolish(user:sale/2), _, true),
+    catch(abolish(user:high_sale_count/1), _, true),
+    catch(abolish(user:salary/2), _, true),
+    catch(abolish(user:dept_big_total/2), _, true).
+
+:- begin_tests(go_generator_aggregate_subplans).
+
+test(compile_filtered_count_aggregate, [
+    setup(setup_filtered_count_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(high_sale_count/1, [mode(generator)], Code),
+    sub_string(Code, _, _, _, "toFloat64Must(f.Args[\"arg1\"]) > 150"),
+    sub_string(Code, _, _, _, "len(values)"),
+    sub_string(Code, _, _, _, "high_sale_count").
+
+test(compile_grouped_filtered_sum_aggregate, [
+    setup(setup_grouped_filtered_sum_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(dept_big_total/2, [mode(generator)], Code),
+    sub_string(Code, _, _, _, "toFloat64Must(f.Args[\"arg1\"]) > 1000"),
+    sub_string(Code, _, _, _, "groups := make(map[interface{}][]float64)"),
+    sub_string(Code, _, _, _, "dept_big_total").
+
+:- end_tests(go_generator_aggregate_subplans).
+
+test_go_generator_aggregate_subplans :-
+    run_tests([go_generator_aggregate_subplans]).


### PR DESCRIPTION
  ## Summary

  This PR starts the next `aggregate_all` implementation layer after the
  initial Phase 1 work.

  It does two related things:

  1. broadens the shared aggregate classifier so targets can reason about
     conjunction/subplan aggregate goals in a normalized way
  2. adds the first non-C# aggregate-subplan lowering path by teaching Go
     to compile a narrow class of conjunction-based `aggregate_all` goals

  This is still an incremental step. It does **not** yet implement full
  grouped recursive aggregation.

  ## What Changed

  ### Shared Aggregate Goal Classification

  Extended:

  - `src/unifyweaver/core/advanced/pattern_matchers.pl`

  The shared aggregate support now includes a goal classifier that splits
  an aggregate goal into:

  - relation terms
  - arithmetic terms
  - constraint terms
  - other terms

  This lets targets distinguish between:

  - plain aggregate wrappers
  - subplan-style aggregate goals with inline filters
  - more complex aggregate bodies that are still out of scope

  The shared `classify_aggregate/2` output now includes `goal_info`.

  ### Go Subplan-Filter Lowering

  Extended:

  - `src/unifyweaver/targets/go_target.pl`

  Go generator-mode aggregate lowering now supports a narrow but useful
  subplan shape:

  - one relation goal
  - optional inline numeric constraints
  - scalar or grouped aggregation over the filtered rows

  Examples of the new supported shape:

  ```prolog
  high_sale_count(C) :-
      aggregate_all(count, (sale(_, A), A > 150), C).

  dept_big_total(Dept, Total) :-
      aggregate_all(sum(S), (salary(Dept, S), S > 1000), Dept, Total).

  This is implemented by generating aggregate loops over the relation with
  an additional compiled filter condition.

  It also adds a small helper in the generated Go runtime support:

  - toFloat64Must

  used for inline numeric predicate checks on row arguments.

  ## Tests

  Added:

  - tests/core/test_go_generator_aggregate_subplans.pl

  New regression coverage verifies Go code generation for:

  - filtered ungrouped count aggregate
  - filtered grouped sum aggregate

  Existing aggregate and Rust generator aggregate tests were also rerun to
  check that the new shared classifier did not regress the earlier paths.

  ## Verification

  Passed locally:

  swipl -q -g "use_module(tests/core/test_go_generator_aggregate_subplans), test_go_generator_aggregate_subplans, halt"
  swipl -q -g "use_module(tests/core/test_go_generator_aggregates), run_tests, halt"
  swipl -q -g "use_module(tests/core/test_rust_generator_aggregates), test_rust_generator_aggregates, halt"

  ## Why This Matters

  The current aggregate implementation surface was uneven:

  - C# already had real aggregate subplan support
  - Go and Rust only handled the simpler wrapper-style aggregate cases

  This PR begins closing that gap by:

  - moving more aggregate-body understanding into a shared classifier
  - giving Go the first subplan-style aggregate lowering outside C#

  That makes the next steps toward grouped recursive aggregation more
  grounded and less target-specific.

  ## Scope

  This PR is intentionally narrow.

  Included:

  - shared aggregate goal classification
  - Go aggregate_all lowering for one-relation conjunctions with filters

  Not included yet:

  - multi-relation aggregate subplans
  - arithmetic projection terms inside aggregate subplans
  - recursive aggregate subplans
  - grouped recursive aggregation
  - Rust aggregate-subplan parity

  ## Follow-Up

  The next logical step is the larger one:

  - grouped recursive aggregation on top of the new subplan substrate

  Before that, there is still room for a smaller parity step if desired:

  - extend Rust with the same one-relation filtered aggregate-subplan shape

  But the main remaining compiler-generality gap is now the grouped
  recursive aggregation layer rather than this initial filter-only
  subplan case.