### PR TITLE
feat(go): add grouped recursive aggregate wrappers

### DIFF
--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -4396,8 +4396,18 @@ compile_go_generator_rule(Index, Head, Body, Config, Code, RuleName) :-
     (   member(AggGoal, Goals),
         is_aggregate_goal_go(AggGoal)
     ->  % Aggregate rule - extract HAVING filters (builtins after aggregate)
-        extract_having_filters(Goals, AggGoal, HavingFilters),
-        compile_go_aggregate_rule(Index, HeadPred, HeadArgs, AggGoal, HavingFilters, Config, Code)
+        append(BeforeAgg, [AggGoal|AfterAgg], Goals),
+        include(is_builtin_goal_go, AfterAgg, HavingFilters),
+        exclude(is_builtin_goal_go, AfterAgg, UnsupportedAfterAgg),
+        (   BeforeAgg == [],
+            UnsupportedAfterAgg == []
+        ->  compile_go_aggregate_rule(Index, HeadPred, HeadArgs, AggGoal, HavingFilters, Config, Code)
+        ;   format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    // Unsupported correlated aggregate form
+    return nil
+}", [RuleName])
+        )
     ;   % Normal rule (joins, negation, etc.)
         partition(is_builtin_goal_go, Goals, Builtins, RelGoals),
         
@@ -4541,7 +4551,31 @@ compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, InnerGoal
         HavingIfEnd = ""
     ),
     
-    format(string(Code),
+    (   Op == count
+    ->  format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    
+    // Skip if not triggered by this relation
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    
+    count := 0.0
+    for _, f := range total {
+        if f.Relation == \"~w\" {
+            count += 1.0
+        }
+    }
+    
+    if count > 0 {
+        agg := count~w
+            results = append(results, Fact{Relation: \"~w\", Args: map[string]interface{}{~w}})~w
+    }
+    
+    return results
+}", [RuleName, Pred, Pred, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd])
+    ;   format(string(Code),
 "func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
     var results []Fact
     
@@ -4568,7 +4602,8 @@ compile_go_ungrouped_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, InnerGoal
     }
     
     return results
-}", [RuleName, Pred, Pred, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd]).
+}", [RuleName, Pred, Pred, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd])
+    ).
 
 %% compile_go_grouped_aggregate(+RuleName, +HeadPred, +HeadArgs, +Op, +Expr, +InnerGoal, +GroupVar, +Result, +HavingFilters, +Config, -Code)
 compile_go_grouped_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, InnerGoal, GroupVar, Result, HavingFilters, _Config, Code) :-
@@ -4595,7 +4630,37 @@ compile_go_grouped_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, InnerGoal,
     ;   HavingCode = ""
     ),
     
-    format(string(Code),
+    (   Op == count
+    ->  format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    
+    // Skip if not triggered by this relation
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    
+    groups := make(map[interface{}]float64)
+    for _, f := range total {
+        if f.Relation == \"~w\" {
+            key := f.Args[\"arg~w\"]
+            groups[key] += 1.0
+        }
+    }
+    
+    for key, agg := range groups {
+        if agg > 0 {
+            ~w
+            results = append(results, Fact{
+                Relation: \"~w\",
+                Args: map[string]interface{}{\"arg0\": key, \"arg1\": agg},
+            })
+        }
+    }
+    
+    return results
+}", [RuleName, Pred, Pred, GroupIdx, HavingCode, HeadPred])
+    ;   format(string(Code),
 "func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
     var results []Fact
     
@@ -4628,7 +4693,8 @@ compile_go_grouped_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, InnerGoal,
     }
     
     return results
-}", [RuleName, Pred, Pred, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred]).
+}", [RuleName, Pred, Pred, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred])
+    ).
 
 compile_go_ungrouped_subplan_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, RelGoal, GoalInfo, Result, HavingFilters, _Config, Code) :-
     RelGoal =.. [Pred|Args],
@@ -4650,7 +4716,26 @@ compile_go_ungrouped_subplan_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, R
     ;   HavingIfStart = "",
         HavingIfEnd = ""
     ),
-    format(string(Code),
+    (   Op == count
+    ->  format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    count := 0.0
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            count += 1.0
+        }
+    }
+    if count > 0 {
+        agg := count~w
+            results = append(results, Fact{Relation: \"~w\", Args: map[string]interface{}{~w}})~w
+    }
+    return results
+}", [RuleName, Pred, Pred, FilterCond, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd])
+    ;   format(string(Code),
 "func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
     var results []Fact
     if fact.Relation != \"~w\" {
@@ -4670,7 +4755,8 @@ compile_go_ungrouped_subplan_aggregate(RuleName, HeadPred, HeadArgs, Op, Expr, R
             results = append(results, Fact{Relation: \"~w\", Args: map[string]interface{}{~w}})~w
     }
     return results
-}", [RuleName, Pred, Pred, FilterCond, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd]).
+}", [RuleName, Pred, Pred, FilterCond, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd])
+    ).
 
 compile_go_grouped_subplan_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, RelGoal, GoalInfo, GroupVar, Result, HavingFilters, _Config, Code) :-
     RelGoal =.. [Pred|Args],
@@ -4690,7 +4776,32 @@ compile_go_grouped_subplan_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, Re
             }", [HavingCond])
     ;   HavingCode = ""
     ),
-    format(string(Code),
+    (   Op == count
+    ->  format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    groups := make(map[interface{}]float64)
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            key := f.Args[\"arg~w\"]
+            groups[key] += 1.0
+        }
+    }
+    for key, agg := range groups {
+        if agg > 0 {
+            ~w
+            results = append(results, Fact{
+                Relation: \"~w\",
+                Args: map[string]interface{}{\"arg0\": key, \"arg1\": agg},
+            })
+        }
+    }
+    return results
+}", [RuleName, Pred, Pred, FilterCond, GroupIdx, HavingCode, HeadPred])
+    ;   format(string(Code),
 "func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
     var results []Fact
     if fact.Relation != \"~w\" {
@@ -4716,7 +4827,8 @@ compile_go_grouped_subplan_aggregate(RuleName, HeadPred, _HeadArgs, Op, Expr, Re
         }
     }
     return results
-}", [RuleName, Pred, Pred, FilterCond, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred]).
+}", [RuleName, Pred, Pred, FilterCond, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred])
+    ).
 
 %% decompose_agg_op(+OpTerm, -Op, -ValueVar)
 decompose_agg_op(count, count, _).

--- a/tests/core/test_go_generator_aggregate_subplans.pl
+++ b/tests/core/test_go_generator_aggregate_subplans.pl
@@ -20,11 +20,20 @@ setup_grouped_filtered_sum_example :-
     assertz(user:salary(sales, 2000)),
     assertz(user:(dept_big_total(Dept, Total) :- aggregate_all(sum(S), (salary(Dept, S), S > 1000), Dept, Total))).
 
+setup_correlated_aggregate_example :-
+    cleanup_all,
+    assertz(user:base(x)),
+    assertz(user:rel(x, 1)),
+    assertz(user:(outer_sum(X, S) :- base(X), aggregate_all(sum(V), rel(X, V), S))).
+
 cleanup_all :-
     catch(abolish(user:sale/2), _, true),
     catch(abolish(user:high_sale_count/1), _, true),
     catch(abolish(user:salary/2), _, true),
-    catch(abolish(user:dept_big_total/2), _, true).
+    catch(abolish(user:dept_big_total/2), _, true),
+    catch(abolish(user:base/1), _, true),
+    catch(abolish(user:rel/2), _, true),
+    catch(abolish(user:outer_sum/2), _, true).
 
 :- begin_tests(go_generator_aggregate_subplans).
 
@@ -34,7 +43,8 @@ test(compile_filtered_count_aggregate, [
 ]) :-
     compile_predicate_to_go(high_sale_count/1, [mode(generator)], Code),
     sub_string(Code, _, _, _, "toFloat64Must(f.Args[\"arg1\"]) > 150"),
-    sub_string(Code, _, _, _, "len(values)"),
+    sub_string(Code, _, _, _, "count := 0.0"),
+    sub_string(Code, _, _, _, "count += 1.0"),
     sub_string(Code, _, _, _, "high_sale_count").
 
 test(compile_grouped_filtered_sum_aggregate, [
@@ -45,6 +55,13 @@ test(compile_grouped_filtered_sum_aggregate, [
     sub_string(Code, _, _, _, "toFloat64Must(f.Args[\"arg1\"]) > 1000"),
     sub_string(Code, _, _, _, "groups := make(map[interface{}][]float64)"),
     sub_string(Code, _, _, _, "dept_big_total").
+
+test(reject_correlated_aggregate, [
+    setup(setup_correlated_aggregate_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(outer_sum/2, [mode(generator)], Code),
+    sub_string(Code, _, _, _, "Unsupported correlated aggregate form").
 
 :- end_tests(go_generator_aggregate_subplans).
 

--- a/tests/core/test_go_generator_aggregates.pl
+++ b/tests/core/test_go_generator_aggregates.pl
@@ -30,13 +30,49 @@ setup_grouped_sum_example :-
     assertz(user:salary(sales, 500)),
     assertz(user:(dept_total(Dept, Total) :- aggregate_all(sum(S), salary(Dept, S), Dept, Total))).
 
+setup_grouped_count_example :-
+    cleanup_all,
+    assertz(user:salary(eng, 1000)),
+    assertz(user:salary(sales, 2000)),
+    assertz(user:salary(eng, 1500)),
+    assertz(user:(dept_count(Dept, Count) :- aggregate_all(count, salary(Dept, _), Dept, Count))).
+
+setup_grouped_recursive_count_example :-
+    cleanup_all,
+    assertz(user:r_edge(a, b)),
+    assertz(user:r_edge(a, c)),
+    assertz(user:r_edge(b, c)),
+    assertz(user:(r_reach(X, Y, H) :- r_edge(X, Y), H is 1)),
+    assertz(user:(r_reach(X, Z, H) :- r_edge(X, Y), r_reach(Y, Z, H1), H is H1 + 1)),
+    assertz(user:(r_count_by_target(X, Y, N) :- aggregate_all(count, r_reach(X, Y, _), Y, N))).
+
+setup_grouped_recursive_weighted_sum_example :-
+    cleanup_all,
+    assertz(user:wa_edge(a, b)),
+    assertz(user:wa_edge(a, c)),
+    assertz(user:wa_edge(b, c)),
+    assertz(user:wa_cost(a, 2)),
+    assertz(user:wa_cost(b, 5)),
+    assertz(user:wa_cost(c, 7)),
+    assertz(user:(wa_path(X, Y, Acc) :- wa_edge(X, Y), wa_cost(X, Cost), Acc is Cost)),
+    assertz(user:(wa_path(X, Z, Acc) :- wa_edge(X, Y), wa_cost(X, Cost), wa_path(Y, Z, PrevAcc), Acc is PrevAcc + Cost)),
+    assertz(user:(wa_sum_by_target(X, Y, Total) :- aggregate_all(sum(Acc), wa_path(X, Y, Acc), Y, Total))).
+
 cleanup_all :-
     catch(abolish(user:item/2), _, true),
     catch(abolish(user:item_count/1), _, true),
     catch(abolish(user:sale/1), _, true),
     catch(abolish(user:total_sales/1), _, true),
     catch(abolish(user:salary/2), _, true),
-    catch(abolish(user:dept_total/2), _, true).
+    catch(abolish(user:dept_total/2), _, true),
+    catch(abolish(user:dept_count/2), _, true),
+    catch(abolish(user:r_edge/2), _, true),
+    catch(abolish(user:r_reach/3), _, true),
+    catch(abolish(user:r_count_by_target/3), _, true),
+    catch(abolish(user:wa_edge/2), _, true),
+    catch(abolish(user:wa_cost/2), _, true),
+    catch(abolish(user:wa_path/3), _, true),
+    catch(abolish(user:wa_sum_by_target/3), _, true).
 
 :- begin_tests(go_generator_aggregates).
 
@@ -45,11 +81,9 @@ test(compile_count_aggregate, [
     cleanup(cleanup_all)
 ]) :-
     compile_predicate_to_go(item_count/1, [mode(generator)], Code),
-    % Check that code contains aggregate elements
-    sub_string(Code, _, _, _, "values []float64"),
-    sub_string(Code, _, _, _, "len(values)"),
-    sub_string(Code, _, _, _, "toFloat64"),
-    format('~n=== Count Aggregate Code ===~n~w~n', [Code]).
+    sub_string(Code, _, _, _, "count := 0.0"),
+    sub_string(Code, _, _, _, "if f.Relation == \"item\""),
+    sub_string(Code, _, _, _, "count += 1.0").
 
 test(compile_sum_aggregate, [
     setup(setup_sum_example),
@@ -69,6 +103,35 @@ test(compile_grouped_aggregate, [
     sub_string(Code, _, _, _, "groups := make(map[interface{}][]float64)"),
     sub_string(Code, _, _, _, "for key, values := range groups"),
     format('~n=== Grouped Aggregate Code ===~n~w~n', [Code]).
+
+test(compile_grouped_count_aggregate, [
+    setup(setup_grouped_count_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(dept_count/2, [mode(generator)], Code),
+    sub_string(Code, _, _, _, "groups := make(map[interface{}]float64)"),
+    sub_string(Code, _, _, _, "groups[key] += 1.0"),
+    sub_string(Code, _, _, _, "\"arg1\": agg").
+
+test(compile_grouped_recursive_count_aggregate, [
+    setup(setup_grouped_recursive_count_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(r_count_by_target/3, [mode(generator)], Code),
+    sub_string(Code, _, _, _, "groups := make(map[interface{}]float64)"),
+    sub_string(Code, _, _, _, "if f.Relation == \"r_reach\""),
+    sub_string(Code, _, _, _, "groups[key] += 1.0"),
+    sub_string(Code, _, _, _, "r_count_by_target").
+
+test(compile_grouped_recursive_weighted_sum_aggregate, [
+    setup(setup_grouped_recursive_weighted_sum_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(wa_sum_by_target/3, [mode(generator)], Code),
+    sub_string(Code, _, _, _, "groups := make(map[interface{}][]float64)"),
+    sub_string(Code, _, _, _, "if f.Relation == \"wa_path\""),
+    sub_string(Code, _, _, _, "val, ok := toFloat64(f.Args[\"arg2\"])"),
+    sub_string(Code, _, _, _, "wa_sum_by_target").
 
 :- end_tests(go_generator_aggregates).
 


### PR DESCRIPTION
  ## Summary

  This PR brings Go one step closer to the current aggregate surface of the
  other targets by adding grouped recursive aggregate wrappers in generator
  mode.

  It also fixes incorrect count-aggregate lowering in Go and makes one
  important boundary explicit:

  - grouped recursive aggregation over a single recursive predicate is now supported
  - correlated aggregates with outer bindings are still not supported, and
    are now rejected explicitly instead of being compiled incorrectly

  ## What Changed

  ### Go Grouped Recursive Aggregate Wrappers

  Extended:

  - `src/unifyweaver/targets/go_target.pl`

  Go generator-mode aggregate lowering now supports a narrow grouped
  recursive wrapper shape over a single recursive predicate result stream.

  Supported examples include:

  #### Grouped recursive count

  ```prolog
  r_count_by_target(X, Y, N) :-
      aggregate_all(count, r_reach(X, Y, _), Y, N).

  #### Grouped recursive weighted sum

  wa_sum_by_target(X, Y, Total) :-
      aggregate_all(sum(Acc), wa_path(X, Y, Acc), Y, Total).

  This builds on the existing recursive lowering already present in Go for:

  - counted closure
  - weighted recursive accumulation

  The new grouped wrapper lives at the aggregate layer rather than requiring
  a separate recursive executor just for grouping.

  ### Go Count Aggregate Fixes

  While implementing this, I fixed a real bug in Go aggregate generation:

  - ungrouped count
  - grouped count
  - filtered count
  - grouped filtered count

  were still using the old value-column style path as if count required a
  numeric value argument.

  That was wrong.

  They now use explicit count accumulation instead, e.g.:

  - count := 0.0
  - count += 1.0
  - groups[key] += 1.0

  ### Explicit Rejection of Correlated Aggregates

  Also in:

  - src/unifyweaver/targets/go_target.pl

  Go now explicitly rejects correlated aggregate forms where outer-bound
  variables must flow into the aggregate goal.

  Example of the still-unsupported shape:

  outer_sum(X, S) :-
      base(X),
      aggregate_all(sum(V), rel(X, V), S).

  Before this PR, Go could silently compile such a rule incorrectly by
  dropping the outer correlation.

  After this PR, it emits an explicit unsupported stub instead:

  - Unsupported correlated aggregate form

  This is important because it makes the remaining category-influence gap
  honest and localized.

  ## Files

  - src/unifyweaver/targets/go_target.pl
  - tests/core/test_go_generator_aggregates.pl
  - tests/core/test_go_generator_aggregate_subplans.pl

  ## Tests

  ### Added / Expanded

  In test_go_generator_aggregates.pl:

  - grouped count aggregate
  - grouped recursive count aggregate
  - grouped recursive weighted sum aggregate

  In test_go_generator_aggregate_subplans.pl:

  - updated filtered count expectations for the corrected count path
  - added explicit regression for rejecting correlated aggregates

  ## Verification

  Passed locally:

  swipl -q -g "use_module(tests/core/test_go_generator_aggregates), run_tests, halt"
  swipl -q -g "use_module(tests/core/test_go_generator_aggregate_subplans), test_go_generator_aggregate_subplans, halt"
  swipl -q -g "use_module(tests/core/test_rust_generator_aggregates), test_rust_generator_aggregates, halt"

  ## Why This Matters

  Before this PR:

  - Rust had the new grouped recursive aggregate slice
  - Go had filtered aggregate subplans
  - but Go did not yet have grouped recursive aggregate wrappers

  That made the aggregate story uneven across non-C# targets.

  This PR closes that specific Go parity gap.

  At the same time, it also clarifies the real next missing feature for
  category-influence-style workloads:

  - not grouped recursive aggregation itself
  - but correlated aggregate subplans where an outer variable constrains the
    inner aggregate goal

  ## Scope

  Included:

  - grouped recursive aggregate wrappers in Go
  - correct count aggregate lowering in Go
  - explicit rejection of correlated aggregates

  Not included yet:

  - correlated aggregate subplans
  - full category-influence compilation
  - richer multi-relation aggregate subplans with outer binding propagation