### PR TITLE
Document TypR unique-path per-path design

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ TypR annotation modes are regression-covered too:
 - current CLI validation boundary: `infer` and `off` are covered with
   `typr check`; the current `typr build` path still expects typed function
   signatures more often than the checker does
+- per-path unique-path work also has a dedicated TypR design note:
+  [docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md](docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md)
+  which records the next intended move: invariant-input helper/guard support
+  first, then path-aware aggregation slices
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md
+++ b/docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md
@@ -1,0 +1,210 @@
+# TypR Per-Path Unique-Path Design
+
+## Goal
+
+Define the next TypR design step for path-aware recursion where correctness
+depends on path-local visited state rather than endpoint memoization.
+
+This document is narrower than the cross-target plan in
+`PER_PATH_VISITED_IMPLEMENTATION_PLAN.md`. It focuses on:
+
+- what TypR already supports
+- what remains unsupported
+- what recent C#/Go/Rust path-aware aggregation work implies
+- what should be implemented next without adding another brittle matcher family
+
+## Core Semantic Distinction
+
+There are two materially different recursion models:
+
+1. Endpoint memoization
+   - caches results by input or endpoint tuple
+   - valid for ordinary transitive closure and DP-style recursion
+   - not sufficient for all-simple-path or path-sensitive semantics
+
+2. Per-path visited / unique-path semantics
+   - recursion state includes the current path's visited set
+   - sibling branches must not share visited state
+   - required for cycle-safe path enumeration and path-aware accumulation
+
+The second model is not "transitive closure with a different cache key". It is
+a different execution state model.
+
+## Current TypR Support
+
+TypR already supports a conservative native per-path slice with:
+
+- `VisitedPos`-driven detection
+- mode-driven input/output positions when `user:mode/1` is available
+- one recursion-driving input plus conservative invariant non-visited inputs
+- weighted outputs with additive numeric accumulation
+- seeded and `*_from_vectors` runtime helpers
+- `input(stdin|file|vfs|function)` wrappers
+- typed runtime parsing for:
+  - scalar nodes such as `integer` and `number`
+  - conservative pair-of-scalar nodes
+
+Primary implementation points:
+
+- [typr_target.pl](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/src/unifyweaver/targets/typr_target.pl)
+- [per_path_visited.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/per_path_visited.mustache)
+- [ppv_definitions.mustache](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/templates/targets/typr/ppv_definitions.mustache)
+
+## Current Boundary
+
+The next unsupported TypR slice is not loader-related. It is richer path-state
+control between the step relation and the recursive call.
+
+The first real missing cases are:
+
+- helper or guard goals over invariant inputs between step and recursive call
+- broader invariant-input threading beyond the current conservative shape
+- runtime-backed step relations that still preserve path-local uniqueness
+
+Examples:
+
+```prolog
+category_ancestor_limited(Cat, Ancestor, Hops, Limit, Visited) :-
+    category_parent(Cat, Mid),
+    Mid =< Limit,
+    \+ member(Mid, Visited),
+    category_ancestor_limited(Mid, Ancestor, H1, Limit, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+and:
+
+```prolog
+category_ancestor_guarded(Cat, Ancestor, Hops, Limit, Visited) :-
+    category_parent(Cat, Mid),
+    Allowed is Limit - 1,
+    Mid =< Allowed,
+    \+ member(Mid, Visited),
+    category_ancestor_guarded(Mid, Ancestor, H1, Limit, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+These are still structurally per-path, but they already want a more explicit
+internal model than the current narrow worker template.
+
+## Why Recent C#/Go/Rust Work Matters
+
+Recent target work in other backends points to the right abstraction.
+
+Relevant recent commits:
+
+- `bdaf9c1e` `feat(csharp-query): add min tabling for path-aware closure`
+- `bc89fb28` `feat(csharp-query): add path-aware accumulation node`
+- `c01d9c45` `feat(rust): add path-aware accumulation lowering`
+- `090bc667` `feat(rust): support recursive aggregate_all lowering`
+- `8c11f593` `feat(go): add aggregate_all subplan filters`
+- `ad355213` `feat(go): add native min recursion lowering`
+
+What they imply for TypR:
+
+1. Path-aware closure and path-aware accumulation are adjacent problems.
+2. Once path identity matters, aggregation is not just post-processing.
+3. Endpoint memoization is the wrong abstraction for unique-path work.
+
+So the next TypR step should be designed with path-state and future
+path-aware aggregation in mind, even if the immediate implementation remains
+conservative.
+
+## Proposed Internal Model
+
+Do not jump straight to a broad new IR. But do make the per-path worker model
+explicit enough that it can evolve into one.
+
+For TypR, the next implementation-friendly model should carry:
+
+- recursion-driving input
+- invariant inputs
+- current visited/path state
+- step-produced next node
+- local helper/guard values
+- yielded outputs
+
+Conceptually:
+
+```text
+worker(State, Invariants, Visited) ->
+    step(State, Next),
+    helper/guard checks,
+    not member(Next, Visited),
+    yield(BaseOrProjectedResult),
+    recurse(Next, Invariants, [Next|Visited])
+```
+
+That is enough to cover the next slice without committing yet to a full generic
+path-state IR.
+
+## Recommended Next Implementation Slice
+
+Recommended branch:
+
+- `feature/typr-per-path-invariant-guards-audit`
+
+Scope:
+
+- compile-time-seeded step relation first
+- scalar node IDs first
+- native TypR worker path only
+- one helper/guard segment between step and recursive call
+- no broader runtime loader expansion in the same branch
+
+That is the smallest slice that actually moves the boundary.
+
+## Aggregation-Oriented Follow-Up
+
+After invariant guards, the next high-signal per-path extension should not be
+more loader work. It should be the first path-aware aggregation shape.
+
+Conservative candidates:
+
+- counted unique-path reachability
+- min-cost unique-path reachability
+- grouped path-aware accumulation over a seeded relation
+
+If TypR can carry path-local state cleanly into one conservative aggregation
+slice, that will tell us whether the current worker model is enough or whether
+a broader IR is actually required.
+
+## Non-Goals
+
+Do not mix this design/implementation line with:
+
+- SCC generalization work
+- wrapped-R fallback reduction
+- unrelated generic producer-family audits
+- broader transitive-closure template cleanup
+
+## Recommended Probes
+
+Initial guarded probe:
+
+```prolog
+category_ancestor_limited(Cat, Ancestor, Hops, Limit, Visited) :-
+    category_parent(Cat, Ancestor),
+    Ancestor =< Limit,
+    \+ member(Ancestor, Visited),
+    Hops = 1.
+category_ancestor_limited(Cat, Ancestor, Hops, Limit, Visited) :-
+    category_parent(Cat, Mid),
+    Mid =< Limit,
+    \+ member(Mid, Visited),
+    category_ancestor_limited(Mid, Ancestor, H1, Limit, [Mid|Visited]),
+    Hops is H1 + 1.
+```
+
+Aggregation-oriented follow-up:
+
+```prolog
+category_ancestor_min_cost(Cat, Ancestor, Cost, Limit, Visited) :-
+    ...
+```
+
+## References
+
+- [typr-per-path-next-steps.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/handoff/typr-per-path-next-steps.md)
+- [PER_PATH_VISITED_IMPLEMENTATION_PLAN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/PER_PATH_VISITED_IMPLEMENTATION_PLAN.md)
+- [TYPR_TARGET_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_TARGET_DESIGN.md)

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -529,6 +529,10 @@ Current wrapped-fallback boundary note:
 - current CLI boundary: `infer` and `off` are validated with `typr check`;
   the current `typr build` path remains stricter about typed function
   signatures
+- per-path unique-path work has a dedicated TypR design note in
+  [TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md),
+  which defines the next TypR step as invariant-input helper/guard support
+  ahead of broader path-aware aggregation
 - the remaining wrapped fallback boundary is now beyond that first
   producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next


### PR DESCRIPTION
## Summary
This PR adds a dedicated TypR design note for per-path / unique-path recursion semantics.

The goal is to make the next TypR path-aware step explicit before more implementation work continues, especially now that path-aware accumulation work in other targets is making the right abstraction clearer.

## Why This PR
TypR already supports a conservative native per-path visited slice, but the remaining work is no longer just about loaders or another small matcher extension.

The real semantic boundary is the difference between:
- endpoint memoization
- path-local visited / unique-path semantics

That distinction matters for:
- cycle-safe all-simple-path traversal
- path-aware accumulation
- future min/count/aggregate-style path semantics

## What This Documents
The new design note records:
- the current TypR-supported per-path slice
- the next real missing TypR case:
  - invariant-input helper/guard goals between the step relation and the recursive call
- the recommended next implementation branch:
  - `feature/typr-per-path-invariant-guards-audit`
- the follow-up direction after that:
  - path-aware aggregation slices, not more loader variations

## Cross-Target Context
This PR also ties the TypR design direction to recent path-aware and aggregation work in other targets, including recent C#, Go, and Rust work on:
- path-aware closure
- path-aware accumulation
- recursive `aggregate_all`
- native min recursion lowering

That work suggests TypR should not model unique-path semantics as “ordinary memoized closure with a slightly different cache key.”

## Files Changed
- `docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md`
- `README.md`
- `docs/design/TYPR_TARGET_DESIGN.md`

## Validation
```sh
git diff --check
```

## Notes
This is a docs-only PR. It does not change TypR code generation behavior.
