### PR TITLE
feat(go): support correlated aggregate subplans

### DIFF
--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -4402,6 +4402,9 @@ compile_go_generator_rule(Index, Head, Body, Config, Code, RuleName) :-
         (   BeforeAgg == [],
             UnsupportedAfterAgg == []
         ->  compile_go_aggregate_rule(Index, HeadPred, HeadArgs, AggGoal, HavingFilters, Config, Code)
+        ;   BeforeAgg = [TriggerGoal],
+            UnsupportedAfterAgg == []
+        ->  compile_go_correlated_aggregate_rule(Index, HeadPred, HeadArgs, TriggerGoal, AggGoal, HavingFilters, Config, Code)
         ;   format(string(Code),
 "func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
     // Unsupported correlated aggregate form
@@ -4432,6 +4435,158 @@ compile_go_generator_rule(Index, Head, Body, Config, Code, RuleName) :-
     return results
 }", [RuleName, AllBlocks])
         )
+    ).
+
+compile_go_correlated_aggregate_rule(Index, HeadPred, HeadArgs, TriggerGoal, AggGoal0, HavingFilters, _Config, Code) :-
+    format(string(RuleName), "ApplyRule_~w", [Index]),
+    normalize_aggregate_goal_go(AggGoal0, AggGoal),
+    classify_aggregate(AggGoal, AggInfo),
+    get_dict(type, AggInfo, Type),
+    get_dict(goal_info, AggInfo, GoalInfo),
+    get_dict(group, AggInfo, GroupVar),
+    get_dict(op, AggInfo, Op),
+    get_dict(expr, AggInfo, Expr),
+    get_dict(result, AggInfo, Result),
+    TriggerGoal =.. [TriggerPred|TriggerArgs],
+    (   Type = all,
+        GoalInfo.relations = [RelGoal],
+        GoalInfo.other = []
+    ->  RelGoal =.. [Pred|Args],
+        build_go_correlation_conditions(TriggerArgs, Args, CorrelationCond),
+        build_go_aggregate_filter_conditions(GoalInfo, Args, FilterCond0),
+        combine_go_inline_conditions([CorrelationCond, FilterCond0], FilterCond),
+        go_correlated_output_args(HeadArgs, Result, TriggerArgs, ArgsStr),
+        (   HavingFilters \= []
+        ->  generate_having_conditions(HavingFilters, Result, HavingCond),
+            format(string(HavingIfStart), "
+        // HAVING clause filter
+        if ~w {", [HavingCond]),
+            HavingIfEnd = "
+        }"
+        ;   HavingIfStart = "",
+            HavingIfEnd = ""
+        ),
+        (   Op == count
+        ->  format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    count := 0.0
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            count += 1.0
+        }
+    }
+    if count > 0 {
+        agg := count~w
+            results = append(results, Fact{Relation: \"~w\", Args: map[string]interface{}{~w}})~w
+    }
+    return results
+}", [RuleName, TriggerPred, Pred, FilterCond, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd])
+        ;   find_var_index_go(Expr, Args, ValueIdx),
+            go_agg_code(Op, AggCode),
+            format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    var values []float64
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            val, ok := toFloat64(f.Args[\"arg~w\"])
+            if ok {
+                values = append(values, val)
+            }
+        }
+    }
+    if len(values) > 0 {
+        ~w~w
+            results = append(results, Fact{Relation: \"~w\", Args: map[string]interface{}{~w}})~w
+    }
+    return results
+}", [RuleName, TriggerPred, Pred, FilterCond, ValueIdx, AggCode, HavingIfStart, HeadPred, ArgsStr, HavingIfEnd])
+        )
+    ;   Type = group,
+        GoalInfo.relations = [RelGoal],
+        GoalInfo.other = []
+    ->  RelGoal =.. [Pred|Args],
+        build_go_correlation_conditions(TriggerArgs, Args, CorrelationCond),
+        build_go_aggregate_filter_conditions(GoalInfo, Args, FilterCond0),
+        combine_go_inline_conditions([CorrelationCond, FilterCond0], FilterCond),
+        find_var_index_go(GroupVar, Args, GroupIdx),
+        go_grouped_correlated_output_args(HeadArgs, GroupVar, Result, TriggerArgs, ArgsStr),
+        (   HavingFilters \= []
+        ->  generate_having_conditions(HavingFilters, Result, HavingCond),
+            format(string(HavingCode), "
+            // HAVING clause filter
+            if !(~w) {
+                continue
+            }", [HavingCond])
+        ;   HavingCode = ""
+        ),
+        (   Op == count
+        ->  format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    groups := make(map[interface{}]float64)
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            key := f.Args[\"arg~w\"]
+            groups[key] += 1.0
+        }
+    }
+    for key, agg := range groups {
+        if agg > 0 {
+            ~w
+            results = append(results, Fact{
+                Relation: \"~w\",
+                Args: map[string]interface{}{~w},
+            })
+        }
+    }
+    return results
+}", [RuleName, TriggerPred, Pred, FilterCond, GroupIdx, HavingCode, HeadPred, ArgsStr])
+        ;   find_var_index_go(Expr, Args, ValueIdx),
+            go_agg_code(Op, AggCode),
+            format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    var results []Fact
+    if fact.Relation != \"~w\" {
+        return results
+    }
+    groups := make(map[interface{}][]float64)
+    for _, f := range total {
+        if f.Relation == \"~w\" && (~w) {
+            key := f.Args[\"arg~w\"]
+            val, ok := toFloat64(f.Args[\"arg~w\"])
+            if ok {
+                groups[key] = append(groups[key], val)
+            }
+        }
+    }
+    for key, values := range groups {
+        if len(values) > 0 {
+            ~w~w
+            results = append(results, Fact{
+                Relation: \"~w\",
+                Args: map[string]interface{}{~w},
+            })
+        }
+    }
+    return results
+}", [RuleName, TriggerPred, Pred, FilterCond, GroupIdx, ValueIdx, AggCode, HavingCode, HeadPred, ArgsStr])
+        )
+    ;   format(string(Code),
+"func ~w(fact Fact, total map[string]Fact, idx *Index) []Fact {
+    // Unsupported correlated aggregate form
+    return nil
+}", [RuleName])
     ).
 
 %% compile_go_trigger_block(+TriggerGoal, +OtherGoals, +Builtins, +HeadPred, +HeadArgs, +Config, -BlockCode)
@@ -4871,6 +5026,88 @@ go_aggregate_operand(Term, _Args, Expr) :-
     number(Term),
     !,
     format(string(Expr), "~w", [Term]).
+
+build_go_correlation_conditions(TriggerArgs, AggArgs, Condition) :-
+    findall(Part,
+        go_correlation_condition(TriggerArgs, AggArgs, Part),
+        Parts),
+    combine_go_inline_conditions(Parts, Condition).
+
+go_correlation_condition(TriggerArgs, AggArgs, Cond) :-
+    nth0(TriggerIndex, TriggerArgs, TriggerArg),
+    var(TriggerArg),
+    nth0(AggIndex, AggArgs, AggArg),
+    var(AggArg),
+    TriggerArg == AggArg,
+    format(string(Cond), 'f.Args["arg~w"] == fact.Args["arg~w"]', [AggIndex, TriggerIndex]).
+
+combine_go_inline_conditions(Parts0, Condition) :-
+    exclude(=("true"), Parts0, Parts),
+    (   Parts == []
+    ->  Condition = "true"
+    ;   atomic_list_concat(Parts, " && ", Condition)
+    ).
+
+go_correlated_output_args(HeadArgs, ResultVar, TriggerArgs, ArgsStr) :-
+    findall(Part,
+        (   nth0(Index, HeadArgs, Arg),
+            go_correlated_output_arg(Index, Arg, ResultVar, TriggerArgs, Part)
+        ),
+        Parts),
+    atomic_list_concat(Parts, ", ", ArgsStr).
+
+go_correlated_output_arg(Index, Arg, ResultVar, _TriggerArgs, Part) :-
+    var(Arg),
+    Arg == ResultVar,
+    !,
+    format(string(Part), '"arg~w": agg', [Index]).
+go_correlated_output_arg(Index, Arg, _ResultVar, TriggerArgs, Part) :-
+    var(Arg),
+    nth0(TriggerIndex, TriggerArgs, TriggerArg),
+    TriggerArg == Arg,
+    !,
+    format(string(Part), '"arg~w": fact.Args["arg~w"]', [Index, TriggerIndex]).
+go_correlated_output_arg(Index, Arg, _ResultVar, _TriggerArgs, Part) :-
+    number(Arg),
+    !,
+    format(string(Part), '"arg~w": ~w', [Index, Arg]).
+go_correlated_output_arg(Index, Arg, _ResultVar, _TriggerArgs, Part) :-
+    atom(Arg),
+    !,
+    format(string(Part), '"arg~w": "~w"', [Index, Arg]).
+
+go_grouped_correlated_output_args(HeadArgs, GroupVar, ResultVar, TriggerArgs, ArgsStr) :-
+    findall(Part,
+        (   nth0(Index, HeadArgs, Arg),
+            go_grouped_correlated_output_arg(Index, Arg, GroupVar, ResultVar, TriggerArgs, Part)
+        ),
+        Parts),
+    atomic_list_concat(Parts, ", ", ArgsStr).
+
+go_grouped_correlated_output_arg(Index, Arg, GroupVar, _ResultVar, _TriggerArgs, Part) :-
+    var(Arg),
+    Arg == GroupVar,
+    !,
+    format(string(Part), '"arg~w": key', [Index]).
+go_grouped_correlated_output_arg(Index, Arg, _GroupVar, ResultVar, _TriggerArgs, Part) :-
+    var(Arg),
+    Arg == ResultVar,
+    !,
+    format(string(Part), '"arg~w": agg', [Index]).
+go_grouped_correlated_output_arg(Index, Arg, _GroupVar, _ResultVar, TriggerArgs, Part) :-
+    var(Arg),
+    nth0(TriggerIndex, TriggerArgs, TriggerArg),
+    TriggerArg == Arg,
+    !,
+    format(string(Part), '"arg~w": fact.Args["arg~w"]', [Index, TriggerIndex]).
+go_grouped_correlated_output_arg(Index, Arg, _GroupVar, _ResultVar, _TriggerArgs, Part) :-
+    number(Arg),
+    !,
+    format(string(Part), '"arg~w": ~w', [Index, Arg]).
+go_grouped_correlated_output_arg(Index, Arg, _GroupVar, _ResultVar, _TriggerArgs, Part) :-
+    atom(Arg),
+    !,
+    format(string(Part), '"arg~w": "~w"', [Index, Arg]).
 
 %% generate_having_conditions(+HavingFilters, +ResultVar, -GoCondition)
 %  Translate HAVING filter builtins to Go conditions

--- a/tests/core/test_go_generator_aggregate_subplans.pl
+++ b/tests/core/test_go_generator_aggregate_subplans.pl
@@ -26,6 +26,13 @@ setup_correlated_aggregate_example :-
     assertz(user:rel(x, 1)),
     assertz(user:(outer_sum(X, S) :- base(X), aggregate_all(sum(V), rel(X, V), S))).
 
+setup_grouped_correlated_aggregate_example :-
+    cleanup_all,
+    assertz(user:base(x)),
+    assertz(user:rel(x, tag_a, 1)),
+    assertz(user:rel(x, tag_b, 2)),
+    assertz(user:(outer_group_sum(X, Tag, S) :- base(X), aggregate_all(sum(V), rel(X, Tag, V), Tag, S))).
+
 cleanup_all :-
     catch(abolish(user:sale/2), _, true),
     catch(abolish(user:high_sale_count/1), _, true),
@@ -33,7 +40,9 @@ cleanup_all :-
     catch(abolish(user:dept_big_total/2), _, true),
     catch(abolish(user:base/1), _, true),
     catch(abolish(user:rel/2), _, true),
-    catch(abolish(user:outer_sum/2), _, true).
+    catch(abolish(user:rel/3), _, true),
+    catch(abolish(user:outer_sum/2), _, true),
+    catch(abolish(user:outer_group_sum/3), _, true).
 
 :- begin_tests(go_generator_aggregate_subplans).
 
@@ -56,12 +65,29 @@ test(compile_grouped_filtered_sum_aggregate, [
     sub_string(Code, _, _, _, "groups := make(map[interface{}][]float64)"),
     sub_string(Code, _, _, _, "dept_big_total").
 
-test(reject_correlated_aggregate, [
+test(compile_correlated_aggregate, [
     setup(setup_correlated_aggregate_example),
     cleanup(cleanup_all)
 ]) :-
     compile_predicate_to_go(outer_sum/2, [mode(generator)], Code),
-    sub_string(Code, _, _, _, "Unsupported correlated aggregate form").
+    \+ sub_string(Code, _, _, _, "Unsupported correlated aggregate form"),
+    sub_string(Code, _, _, _, "if fact.Relation != \"base\""),
+    sub_string(Code, _, _, _, "if f.Relation == \"rel\" && (f.Args[\"arg0\"] == fact.Args[\"arg0\"])"),
+    sub_string(Code, _, _, _, "\"arg0\": fact.Args[\"arg0\"]"),
+    sub_string(Code, _, _, _, "\"arg1\": agg").
+
+test(compile_grouped_correlated_aggregate, [
+    setup(setup_grouped_correlated_aggregate_example),
+    cleanup(cleanup_all)
+]) :-
+    compile_predicate_to_go(outer_group_sum/3, [mode(generator)], Code),
+    \+ sub_string(Code, _, _, _, "Unsupported correlated aggregate form"),
+    sub_string(Code, _, _, _, "if fact.Relation != \"base\""),
+    sub_string(Code, _, _, _, "groups := make(map[interface{}][]float64)"),
+    sub_string(Code, _, _, _, "if f.Relation == \"rel\" && (f.Args[\"arg0\"] == fact.Args[\"arg0\"])"),
+    sub_string(Code, _, _, _, "\"arg0\": fact.Args[\"arg0\"]"),
+    sub_string(Code, _, _, _, "\"arg1\": key"),
+    sub_string(Code, _, _, _, "\"arg2\": agg").
 
 :- end_tests(go_generator_aggregate_subplans).
 


### PR DESCRIPTION
  ## Summary

  This PR extends Go generator-mode aggregate lowering to support a narrow
  but important correlated aggregate subplan shape.

  It adds support for:

  - ungrouped correlated aggregates
  - grouped correlated aggregates

  where an outer trigger relation binds variables that constrain a single
  inner aggregate relation.

  This closes the specific gap that was still blocking simple
  category-influence-style aggregate patterns in Go.

  ## What Changed

  ### Correlated Aggregate Subplans in Go

  Extended:

  - `src/unifyweaver/targets/go_target.pl`

  Go generator-mode `aggregate_all` lowering now supports rules of the form:

  ```prolog
  outer_sum(X, S) :-
      base(X),
      aggregate_all(sum(V), rel(X, V), S).

  and grouped variants such as:

  outer_group_sum(X, Tag, S) :-
      base(X),
      aggregate_all(sum(V), rel(X, Tag, V), Tag, S).

  Supported shape:

  - exactly one relation before the aggregate
  - exactly one relation inside the aggregate goal
  - optional inline numeric filters inside the aggregate goal
  - optional grouping with aggregate_all/4

  This is implemented by:

  - triggering on the outer relation
  - scanning the inner relation in total
  - generating explicit correlation conditions between shared variables
  - preserving outer-bound variables in emitted result rows

  ### Grouped Correlated Support

  This PR does not stop at ungrouped correlation.

  It also supports grouped correlated aggregates for the same narrow shape,
  for example:

  outer_group_sum(X, Tag, S) :-
      base(X),
      aggregate_all(sum(V), rel(X, Tag, V), Tag, S).

  The generated Go code now:

  - builds per-group value collections or counts
  - preserves the correlated outer key
  - emits the grouped key and aggregate result together

  ### Behavior Change

  Previously, Go could silently miscompile correlated aggregates by dropping
  the outer binding when compiling the aggregate goal.

  This PR replaces that behavior for the supported slice with correct
  correlated lowering.

  ## Files

  - src/unifyweaver/targets/go_target.pl
  - tests/core/test_go_generator_aggregate_subplans.pl

  ## Tests

  Extended:

  - tests/core/test_go_generator_aggregate_subplans.pl

  New regression coverage verifies:

  - filtered ungrouped aggregate subplans
  - filtered grouped aggregate subplans
  - correlated ungrouped aggregate support
  - correlated grouped aggregate support

  ## Verification

  Passed locally:

  swipl -q -g "use_module(tests/core/test_go_generator_aggregate_subplans), test_go_generator_aggregate_subplans, halt"
  swipl -q -g "use_module(tests/core/test_go_generator_aggregates), run_tests, halt"
  swipl -q -g "use_module(tests/core/test_rust_generator_aggregates), test_rust_generator_aggregates, halt"

  ## Why This Matters

  Before this PR:

  - Go already had:
      - basic aggregate_all
      - filtered one-relation subplans
      - grouped recursive aggregate wrappers
  - but it still did not preserve outer correlation in aggregate subplans

  That meant category-influence-style aggregate composition was still
  blocked, even though the surrounding recursive machinery had improved.

  This PR closes that next gap for the simplest correlated case.

  ## Scope

  Included:

  - one-trigger correlated aggregates
  - one-inner-relation aggregate goals
  - grouped and ungrouped correlated aggregate support
  - inline numeric filtering inside the aggregate goal

  Not included yet:

  - multi-relation correlated aggregate subplans
  - joins inside the aggregate goal
  - fully general correlated recursive aggregate pipelines
  - full category influence compilation end to end

  ## Remaining Gap

  The category-influence blocker is now narrower.

  It is no longer “Go cannot do correlated aggregates.”

  The remaining missing surface is the richer forms beyond this slice, most
  likely:

  - multi-relation correlated aggregate subplans
  - correlated recursive aggregate pipelines with joined inner goals