### PR TITLE
bench: add category influence cross-target benchmark

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -186,6 +186,7 @@ Tables:
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
+| `benchmark_category_influence_cross_target.py` | Compare category influence propagation across Rust DFS and Go DFS |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
 
@@ -233,6 +234,11 @@ python examples/benchmark/benchmark_weighted_shortest_path.py \
 python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
+
+# Compare category influence propagation across Rust and Go
+python examples/benchmark/benchmark_category_influence_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets rust-dfs,go-dfs
 ```
 
 The current native-lowering comparison surface across non-query targets is:
@@ -241,10 +247,12 @@ The current native-lowering comparison surface across non-query targets is:
   - all-path effective distance
   - minimum hop distance
   - positive weighted minimum path distance
+  - category influence propagation
 - Go DFS:
   - all-path effective distance
   - minimum hop distance
   - positive weighted minimum path distance
+  - category influence propagation
 
 The benchmark split is now:
 
@@ -252,6 +260,7 @@ The benchmark split is now:
   - `benchmark_effective_distance.py`
   - `benchmark_shortest_path_cross_target.py`
   - `benchmark_weighted_shortest_path_cross_target.py`
+  - `benchmark_category_influence_cross_target.py`
 - C# query-engine internal mode comparison:
   - `benchmark_shortest_path_to_root.py`
   - `benchmark_weighted_shortest_path.py`
@@ -322,6 +331,47 @@ Comparison note:
 - the cross-target weighted benchmark now normalizes floating-point
   outputs with a tolerance appropriate for cross-language evaluation
   order differences
+
+### Cross-Target Category Influence Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_category_influence_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets rust-dfs,go-dfs \
+    --repetitions 1
+```
+
+Latest local results:
+
+| Scale | Rust DFS | Go DFS | Outputs |
+|-------|---------:|-------:|---------|
+| 300 | 0.356s | 0.487s | match |
+| 1k | 1.447s | 2.112s | match |
+| 5k | 7.860s | 12.857s | match |
+| 10k | 14.604s | 20.421s | match |
+
+Rust speedup vs Go:
+
+| Scale | Speedup |
+|-------|--------:|
+| 300 | 1.37x |
+| 1k | 1.46x |
+| 5k | 1.64x |
+| 10k | 1.40x |
+
+Comparison note:
+
+- this benchmark currently compares Rust and Go only
+- C# is intentionally not part of this runner yet
+- reason:
+  there is not yet a like-for-like `category_influence` benchmark path in
+  the C# query-engine harness, so including C# here would mix execution
+  models rather than isolating target-pipeline behavior
+- the current purpose of this runner is to validate the newly added
+  grouped/correlated aggregate compilation surface across non-query
+  targets before deciding how C# should join the same workload
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Benchmark category influence propagation across generated Go and Rust binaries.
+
+This runner intentionally excludes the C# query engine for now. The current
+category-influence comparison is about cross-target aggregate/pipeline support,
+and there is not yet a directly comparable C# query-engine workload in the same
+benchmark harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="rust-dfs,go-dfs",
+        help="Comma-separated targets: rust-dfs,go-dfs",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def run(
+    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env)
+
+
+def require_file(path: Path) -> Path:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return path
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    targets: list[str] = []
+    for target in requested:
+        if target == "rust-dfs" and shutil.which("rustc") is None:
+            print("skip rust-dfs: rustc not found", file=sys.stderr)
+            continue
+        if target == "go-dfs" and shutil.which("go") is None:
+            print("skip go-dfs: go not found", file=sys.stderr)
+            continue
+        targets.append(target)
+    return targets
+
+
+def generate_pipeline_source(root: Path, target: str) -> Path:
+    ext = {"rust": ".rs", "go": ".go"}[target]
+    filename = f"category_influence{ext}"
+    output = root / filename
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(FACTS_PATH),
+            "--workload",
+            "category_influence",
+            "--target",
+            target,
+            "--output",
+            str(output),
+        ]
+    )
+    return output
+
+
+def build_rust_dfs(root: Path) -> list[str]:
+    project_dir = root / "rust_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(project_dir, "rust")
+    binary = project_dir / "category_influence_rust"
+    run(["rustc", "-O", str(source), "-o", str(binary)])
+    return [str(binary)]
+
+
+def build_go_dfs(root: Path) -> list[str]:
+    project_dir = root / "go_dfs"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(project_dir, "go")
+    binary = project_dir / "category_influence_go"
+    go_cache = project_dir / ".gocache"
+    go_cache.mkdir(exist_ok=True)
+    env = dict(os.environ, GOCACHE=str(go_cache))
+    run(["go", "build", "-o", str(binary), str(source)], env=env)
+    return [str(binary)]
+
+
+def normalize_output(output: str) -> str:
+    lines = output.splitlines()
+    if not lines:
+        return ""
+    header = lines[0]
+    rows: list[tuple[str, float]] = []
+    for line in lines[1:]:
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        rows.append((parts[0], round(float(parts[1]), 9)))
+    rows.sort(key=lambda item: (-item[1], item[0]))
+    normalized = [header]
+    for root, score in rows:
+        normalized.append(f"{root}\t{score:.9f}")
+    return "\n".join(normalized)
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+    edge_path = scale_dir / "category_parent.tsv"
+    article_path = scale_dir / "article_category.tsv"
+
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run(command + [str(edge_path), str(article_path)])
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_output(stdout)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    row_count = max(0, len(normalized.splitlines()) - 1)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    by_scale: dict[str, list[RunResult]] = {}
+    for result in results:
+        by_scale.setdefault(result.scale, []).append(result)
+
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale in sorted(by_scale.keys(), key=scale_sort_key):
+        entries = sorted(by_scale[scale], key=lambda item: item.target)
+        for result in entries:
+            print(
+                f"{scale}\t{result.target}\t{result.median:.3f}\t"
+                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+                f"{result.row_count}\t{result.stdout_sha256[:12]}"
+            )
+
+        if len(entries) > 1:
+            hashes = {item.stdout_sha256 for item in entries}
+            print(f"{scale}\toutputs\t{'match' if len(hashes) == 1 else 'MISMATCH'}")
+            rust = next((item for item in entries if item.target == "rust-dfs"), None)
+            go = next((item for item in entries if item.target == "go-dfs"), None)
+            if rust and go:
+                faster = "rust-dfs" if rust.median < go.median else "go-dfs"
+                speedup = (go.median / rust.median) if faster == "rust-dfs" else (rust.median / go.median)
+                print(f"{scale}\tfaster_target\t{faster}")
+                print(f"{scale}\tspeedup\t{speedup:.2f}x")
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-category-influence-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-category-influence-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        commands: dict[str, list[str]] = {}
+        for target in targets:
+            if target == "rust-dfs":
+                commands[target] = build_rust_dfs(temp_root)
+            elif target == "go-dfs":
+                commands[target] = build_go_dfs(temp_root)
+            else:
+                raise ValueError(f"unsupported target: {target}")
+
+        results: list[RunResult] = []
+        for scale in scales:
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1398,6 +1398,230 @@ fn main() {{
 '''
 
 
+def generate_go_category_influence(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    roots = sorted(root_cats) if root_cats else ["Physics"]
+    root_entries = ", ".join(f'"{root}": true' for root in roots)
+
+    return f'''// Category influence benchmark (Go)
+package main
+
+import (
+\t"bufio"
+\t"fmt"
+\t"math"
+\t"os"
+\t"sort"
+\t"strings"
+)
+
+const N = {float(n)}
+const MAX_DEPTH = {max_depth}
+
+var ROOTS = map[string]bool{{{root_entries}}}
+
+func loadTSVPairs(path string) map[string][]string {{
+\tm := make(map[string][]string)
+\tf, err := os.Open(path)
+\tif err != nil {{
+\t\tfmt.Fprintf(os.Stderr, "Cannot open %s: %v\\n", path, err)
+\t\tos.Exit(1)
+\t}}
+\tdefer f.Close()
+\tscanner := bufio.NewScanner(f)
+\tfirst := true
+\tfor scanner.Scan() {{
+\t\tline := scanner.Text()
+\t\tif first {{
+\t\t\tfirst = false
+\t\t\tif strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {{
+\t\t\t\tcontinue
+\t\t\t}}
+\t\t}}
+\t\tparts := strings.SplitN(line, "\\t", 2)
+\t\tif len(parts) == 2 {{
+\t\t\tm[parts[0]] = append(m[parts[0]], parts[1])
+\t\t}}
+\t}}
+\treturn m
+}}
+
+type pathResult struct {{
+\tancestor string
+\thops int
+}}
+
+func categoryAncestorPaths(cat string, visited map[string]bool, adj map[string][]string, depth int) []pathResult {{
+\tif visited[cat] || depth >= MAX_DEPTH {{
+\t\treturn nil
+\t}}
+\tnewVisited := make(map[string]bool, len(visited)+1)
+\tfor k, v := range visited {{
+\t\tnewVisited[k] = v
+\t}}
+\tnewVisited[cat] = true
+
+\tvar results []pathResult
+\tfor _, parent := range adj[cat] {{
+\t\tif !newVisited[parent] {{
+\t\t\tresults = append(results, pathResult{{parent, 1}})
+\t\t\tfor _, sub := range categoryAncestorPaths(parent, newVisited, adj, depth+1) {{
+\t\t\t\tresults = append(results, pathResult{{sub.ancestor, sub.hops + 1}})
+\t\t\t}}
+\t\t}}
+\t}}
+\treturn results
+}}
+
+type rootScore struct {{
+\troot string
+\tscore float64
+}}
+
+func main() {{
+\tif len(os.Args) < 3 {{
+\t\tfmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\\n", os.Args[0])
+\t\tos.Exit(1)
+\t}}
+
+\tadj := loadTSVPairs(os.Args[1])
+\tartCats := loadTSVPairs(os.Args[2])
+\tinfluence := make(map[string]float64)
+
+\tfor article, cats := range artCats {{
+\t\t_ = article
+\t\tfor _, cat := range cats {{
+\t\t\tif ROOTS[cat] {{
+\t\t\t\tinfluence[cat] += 1.0
+\t\t\t}}
+\t\t\tfor _, pr := range categoryAncestorPaths(cat, map[string]bool{{}}, adj, 0) {{
+\t\t\t\tif ROOTS[pr.ancestor] {{
+\t\t\t\t\tdistance := float64(pr.hops + 1)
+\t\t\t\t\tinfluence[pr.ancestor] += math.Pow(distance, -N)
+\t\t\t\t}}
+\t\t\t}}
+\t\t}}
+\t}}
+
+\tvar results []rootScore
+\tfor root, score := range influence {{
+\t\tif score > 0 {{
+\t\t\tresults = append(results, rootScore{{root, score}})
+\t\t}}
+\t}}
+
+\tsort.Slice(results, func(i, j int) bool {{
+\t\tif results[i].score != results[j].score {{
+\t\t\treturn results[i].score > results[j].score
+\t\t}}
+\t\treturn results[i].root < results[j].root
+\t}})
+
+\tfmt.Println("root_category\\tinfluence_score")
+\tfor _, r := range results {{
+\t\tfmt.Printf("%s\\t%.12f\\n", r.root, r.score)
+\t}}
+}}
+'''
+
+
+def generate_rust_category_influence(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    roots = sorted(root_cats) if root_cats else ["Physics"]
+    root_lines = "\n".join(f'    roots.insert("{root}".to_string());' for root in roots)
+
+    return f'''// Category influence benchmark (Rust)
+use std::collections::{{HashMap, HashSet}};
+use std::env;
+use std::fs;
+use std::io::{{BufRead, BufReader}};
+
+const N: f64 = {float(n)};
+const MAX_DEPTH: usize = {max_depth};
+
+fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {{
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let file = fs::File::open(path).unwrap_or_else(|e| panic!("Cannot open {{}}: {{}}", path, e));
+    let reader = BufReader::new(file);
+    for (i, line) in reader.lines().enumerate() {{
+        let line = line.unwrap();
+        if (i == 0) && (line.starts_with("article") || line.starts_with("child")) {{
+            continue;
+        }}
+        let parts: Vec<&str> = line.splitn(2, '\\t').collect();
+        if parts.len() == 2 {{
+            map.entry(parts[0].to_string()).or_insert_with(Vec::new).push(parts[1].to_string());
+        }}
+    }}
+    map
+}}
+
+fn category_ancestor_paths(
+    cat: &str,
+    visited: &HashSet<String>,
+    adj: &HashMap<String, Vec<String>>,
+    depth: usize,
+) -> Vec<(String, i32)> {{
+    if visited.contains(cat) || depth >= MAX_DEPTH {{
+        return Vec::new();
+    }}
+    let mut new_visited = visited.clone();
+    new_visited.insert(cat.to_string());
+
+    let mut results = Vec::new();
+    if let Some(neighbors) = adj.get(cat) {{
+        for nb in neighbors {{
+            if !new_visited.contains(nb.as_str()) {{
+                results.push((nb.clone(), 1));
+                for (ancestor, h) in category_ancestor_paths(nb, &new_visited, adj, depth + 1) {{
+                    results.push((ancestor, h + 1));
+                }}
+            }}
+        }}
+    }}
+    results
+}}
+
+fn main() {{
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {{
+        eprintln!("Usage: {{}} <category_parent.tsv> <article_category.tsv>", args[0]);
+        std::process::exit(1);
+    }}
+
+    let adj = load_tsv_pairs(&args[1]);
+    let art_cats = load_tsv_pairs(&args[2]);
+    let mut roots: HashSet<String> = HashSet::new();
+{root_lines}
+    let mut influence: HashMap<String, f64> = HashMap::new();
+
+    for (_article, cats) in &art_cats {{
+        for cat in cats {{
+            if roots.contains(cat) {{
+                *influence.entry(cat.clone()).or_insert(0.0) += 1.0;
+            }}
+            let visited = HashSet::new();
+            for (ancestor, h) in category_ancestor_paths(cat, &visited, &adj, 0) {{
+                if roots.contains(&ancestor) {{
+                    let distance = (h + 1) as f64;
+                    *influence.entry(ancestor).or_insert(0.0) += distance.powf(-N);
+                }}
+            }}
+        }}
+    }}
+
+    let mut results: Vec<(String, f64)> = influence
+        .into_iter()
+        .filter(|(_, score)| *score > 0.0)
+        .collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap().then(a.0.cmp(&b.0)));
+
+    println!("root_category\\tinfluence_score");
+    for (root, score) in results {{
+        println!("{{}}\\t{{:.12}}", root, score);
+    }}
+}}
+'''
+
+
 def generate_csharp_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -1532,6 +1756,10 @@ GENERATORS = {
         'go': generate_go_weighted_shortest_path,
         'rust': generate_rust_weighted_shortest_path,
         'csharp': generate_csharp_weighted_shortest_path,
+    },
+    'category_influence': {
+        'go': generate_go_category_influence,
+        'rust': generate_rust_category_influence,
     },
 }
 


### PR DESCRIPTION
  ## Summary

  This PR adds the first real cross-target benchmark runner for
  `category_influence`.

  It extends the benchmark pipeline so the normalized category-influence
  workload can be generated and compared across:

  - `rust-dfs`
  - `go-dfs`

  It also records the first local `300/1k/5k/10k` results in the benchmark
  README.

  ## What Changed

  ### Workload Generation

  Extended:

  - `examples/benchmark/generate_pipeline.py`

  The benchmark generator now supports:

  - `category_influence`

  for:

  - `rust`
  - `go`

  The generated programs:

  - read `category_parent.tsv` and `article_category.tsv`
  - use the root-category set from benchmark facts
  - compute weighted root influence using the same normalized benchmark
    semantics
  - emit sorted `root_category\tinfluence_score` output

  ### New Cross-Target Runner

  Added:

  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  This runner:

  - builds Rust and Go binaries from generated benchmark sources
  - runs them across selected benchmark scales
  - normalizes and hashes outputs
  - reports output agreement and wall-clock timing
  - reports which target is faster and by how much

  It currently compares:

  - `rust-dfs`
  - `go-dfs`

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now documents:

  - the new benchmark script
  - the command used to run it
  - current native-lowering comparison coverage for category influence
  - the latest local results at `300`, `1k`, `5k`, and `10k`

  ## Why This Matters

  We had already done the compiler work needed to normalize and compile the
  category-influence helper pipeline in Go and Rust.

  What was still missing was the benchmark layer:

  - a real workload generator
  - a real comparison runner
  - recorded results

  This PR closes that gap.

  It gives us the first cross-target performance baseline for
  category-influence-style grouped/correlated aggregate compilation outside
  the C# query engine.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_category_influence_cross_target.py

  ### Benchmark commands run

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 1k,5k,10k \
      --repetitions 1

  ## Results

  | Scale | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---|
  | 300 | 0.356s | 0.487s | match |
  | 1k | 1.447s | 2.112s | match |
  | 5k | 7.860s | 12.857s | match |
  | 10k | 14.604s | 20.421s | match |

  Rust speedup vs Go:

  | Scale | Speedup |
  |---|---:|
  | 300 | 1.37x |
  | 1k | 1.46x |
  | 5k | 1.64x |
  | 10k | 1.40x |

  ## Scope

  This PR is intentionally focused on Rust and Go.

  C# is not part of this runner yet.

  Reason:

  - there is not yet a like-for-like category_influence benchmark path in
    the C# query-engine harness
  - including C# here right now would mix execution models instead of
    isolating target-pipeline behavior