### PR TITLE
fix(python,jamaica,krakatau): missing imports + response parser chains

### DIFF
--- a/src/unifyweaver/targets/jamaica_target.pl
+++ b/src/unifyweaver/targets/jamaica_target.pl
@@ -18,7 +18,7 @@
     compile_tree_recursion_jamaica/3,
     compile_multicall_recursion_jamaica/3,
     compile_direct_multicall_jamaica/3,
-    compile_mutual_recursion_jamaica/2,
+    compile_mutual_recursion_jamaica/3,
     % Component system
     jamaica_type_info/1,
     jamaica_validate_config/1,

--- a/src/unifyweaver/targets/krakatau_target.pl
+++ b/src/unifyweaver/targets/krakatau_target.pl
@@ -18,7 +18,7 @@
     compile_tree_recursion_krakatau/3,
     compile_multicall_recursion_krakatau/3,
     compile_direct_multicall_krakatau/3,
-    compile_mutual_recursion_krakatau/2,
+    compile_mutual_recursion_krakatau/3,
     krakatau_type_info/1,
     krakatau_validate_config/1,
     krakatau_compile_component/4,

--- a/src/unifyweaver/targets/python_target.pl
+++ b/src/unifyweaver/targets/python_target.pl
@@ -98,6 +98,7 @@
 
 % Native clause body lowering (shared analysis infrastructure)
 :- use_module('../core/clause_body_analysis', except([translate_expr/3])).
+:- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4]).
 
 % Service validation (Client-Server Phase 2)
 :- use_module('../core/service_validation').

--- a/tools/agent-loop/agent_loop_module.pl
+++ b/tools/agent-loop/agent_loop_module.pl
@@ -45,7 +45,11 @@
     component_in_layer/2,
     should_emit_component/1,
     core_components/1,
-    host_components/1
+    host_components/1,
+    %% Response parser chains
+    response_parser_chain/2,
+    response_parser/3,
+    resolve_parser_chain/2
 ]).
 
 :- discontiguous generate_backend_full/3.
@@ -239,6 +243,82 @@ host_components(Components) :-
 %%   Convenience check — true if feature is explicitly enabled.
 feature_enabled(Target, Feature) :-
     agent_target_feature(Target, Feature, true).
+
+%% =============================================================================
+%% Response Parser Chains
+%% =============================================================================
+%%
+%% response_parser_chain(+BackendName, +ParserList)
+%%   Defines the cascade of response formats to try when parsing API responses.
+%%   Each parser is tried in order; first successful parse wins.
+%%
+%% Parser types:
+%%   anthropic       — content[].type=="tool_use" format
+%%   openai          — choices[0].message.tool_calls format
+%%   openai_stream   — streaming delta chunks
+%%   raw_json        — bare JSON extraction fallback
+%%
+%% Used by backends that proxy multiple providers (e.g. OpenRouter)
+%% where the response format depends on the underlying model.
+
+:- discontiguous response_parser_chain/2.
+:- discontiguous response_parser/3.
+
+%% --- Per-backend parser chains ---
+response_parser_chain(claude_api,    [anthropic]).
+response_parser_chain(openai_api,    [openai]).
+response_parser_chain(gemini,        [openai]).         % Gemini uses OpenAI-compatible format
+response_parser_chain(ollama_api,    [openai]).
+response_parser_chain(ollama_cli,    [raw_json]).
+response_parser_chain(coro,          [raw_json]).
+response_parser_chain(claude_code,   [raw_json]).
+response_parser_chain(openrouter_api,[openai, anthropic, raw_json]).  % proxy: try all
+
+%% --- Parser definitions ---
+%% response_parser(+ParserName, +Description, +DetectionRule)
+%%   DetectionRule describes how to detect if a response matches this format.
+
+response_parser(anthropic, 'Anthropic Messages API format', [
+    detection(has_field("content"), content_is_array, has_type_field("tool_use")),
+    extract_text(content_blocks_text),
+    extract_tools(content_blocks_tool_use)
+]).
+
+response_parser(openai, 'OpenAI Chat Completions format', [
+    detection(has_field("choices"), has_message_field, has_tool_calls_field),
+    extract_text(choices_message_content),
+    extract_tools(choices_message_tool_calls)
+]).
+
+response_parser(openai_stream, 'OpenAI streaming delta format', [
+    detection(has_field("choices"), has_delta_field),
+    extract_text(delta_content),
+    extract_tools(delta_tool_calls)
+]).
+
+response_parser(raw_json, 'Raw JSON extraction fallback', [
+    detection(always),
+    extract_text(full_text_content),
+    extract_tools(extract_json_blocks)
+]).
+
+%% resolve_parser_chain(+BackendName, -Parsers)
+%%   Get the parser chain for a backend, defaulting to [openai, raw_json].
+resolve_parser_chain(Backend, Parsers) :-
+    (   response_parser_chain(Backend, Parsers)
+    ->  true
+    ;   Parsers = [openai, raw_json]  % sensible default
+    ).
+
+%% parser_detection_rule(+ParserName, -Rule)
+parser_detection_rule(Parser, Rule) :-
+    response_parser(Parser, _, Props),
+    member(detection(Rule), Props).
+
+%% parser_count(-Count)
+parser_count(Count) :-
+    findall(P, response_parser(P, _, _), Ps),
+    length(Ps, Count).
 
 %% =============================================================================
 %% Interop Stub Framework


### PR DESCRIPTION
## Summary

Fix three pre-existing test failures across Python, Jamaica, and Krakatau targets, and add response parser chains to the agent loop emitter for multi-format API response handling.

## Test Fixes

### Python: Missing `is_per_path_visited_pattern/4` Import

**Symptom:** `test python_native_lowering:fallback_for_recursive` failed with `Unknown procedure: python_target:is_per_path_visited_pattern/4`

**Root cause:** `compile_recursive_predicate` in python_target.pl called `is_per_path_visited_pattern/4` (defined in `pattern_matchers.pl`) but never imported it. Other targets (C, C++, Clojure) import it correctly.

**Fix:** Added `use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4])`.

**Result:** 12/12 Python native lowering tests pass (was 11/12).

### Jamaica/Krakatau: Export Arity Mismatch

**Symptom:** Startup error `Exported procedure jamaica_target:compile_mutual_recursion_jamaica/2 is not defined` (same for Krakatau). This affected all tests loading `recursive_compiler.pl`.

**Root cause:** Module exports declared `compile_mutual_recursion_jamaica/2` but the predicate is defined with 3 arguments (Predicates, Options, Code).

**Fix:** Changed export from `/2` to `/3` in both `jamaica_target.pl` and `krakatau_target.pl`.

### TypR Test Status

Investigated the 208 TypR test failures:
- **193 failures**: `Could not find executable file "typr" in $PATH` — runtime validation tests requiring the TypR toolchain (not installable on Termux)
- **15 failures**: Code generation tests with output format mismatches — require TypR-specific investigation
- **8 passing**: Type annotation, target registry, and per-path-visited tests

These are **not addressed** in this PR as they require either the TypR toolchain or detailed format investigation.

## Response Parser Chains

Inspired by sci-repl's 3-format cascade (OpenAI → Anthropic → WASM fallback), this adds a declarative system for configuring how each backend parses API responses.

### New Fact Types

#### `response_parser_chain/2` — Per-Backend Parser Ordering

```prolog
response_parser_chain(claude_api,     [anthropic]).
response_parser_chain(openai_api,     [openai]).
response_parser_chain(gemini,         [openai]).
response_parser_chain(ollama_api,     [openai]).
response_parser_chain(ollama_cli,     [raw_json]).
response_parser_chain(coro,           [raw_json]).
response_parser_chain(claude_code,    [raw_json]).
response_parser_chain(openrouter_api, [openai, anthropic, raw_json]).
```

OpenRouter uses a 3-format cascade because it proxies multiple providers — the response format depends on the underlying model.

#### `response_parser/3` — Parser Metadata

```prolog
response_parser(anthropic, 'Anthropic Messages API format', [
    detection(has_field("content"), content_is_array, has_type_field("tool_use")),
    extract_text(content_blocks_text),
    extract_tools(content_blocks_tool_use)
]).

response_parser(openai, 'OpenAI Chat Completions format', [
    detection(has_field("choices"), has_message_field, has_tool_calls_field),
    extract_text(choices_message_content),
    extract_tools(choices_message_tool_calls)
]).

response_parser(openai_stream, 'OpenAI streaming delta format', [
    detection(has_field("choices"), has_delta_field),
    extract_text(delta_content),
    extract_tools(delta_tool_calls)
]).

response_parser(raw_json, 'Raw JSON extraction fallback', [
    detection(always),
    extract_text(full_text_content),
    extract_tools(extract_json_blocks)
]).
```

Each parser declares:
- **Detection rule**: How to identify if a response matches this format
- **Text extraction**: How to get the assistant's text content
- **Tool extraction**: How to get tool call objects

#### `resolve_parser_chain/2` — Lookup with Default

```prolog
resolve_parser_chain(Backend, Parsers) :-
    (   response_parser_chain(Backend, Parsers) -> true
    ;   Parsers = [openai, raw_json]   % sensible default
    ).
```

### Parser Types

| Parser | Format | Detection |
|--------|--------|-----------|
| `anthropic` | `content[].type=="tool_use"` | `has_field("content")` + type check |
| `openai` | `choices[0].message.tool_calls` | `has_field("choices")` + message field |
| `openai_stream` | Streaming delta chunks | `has_field("choices")` + delta field |
| `raw_json` | Bare JSON extraction | Always matches (fallback) |

### Backend Configurations

| Backend | Chain | Reason |
|---------|-------|--------|
| `claude_api` | `[anthropic]` | Native Anthropic format |
| `openai_api` | `[openai]` | Native OpenAI format |
| `gemini` | `[openai]` | Uses OpenAI-compatible API |
| `ollama_api` | `[openai]` | Uses OpenAI-compatible API |
| `ollama_cli` | `[raw_json]` | CLI output, extract JSON |
| `coro` | `[raw_json]` | CLI output, extract JSON |
| `claude_code` | `[raw_json]` | CLI output, extract JSON |
| `openrouter_api` | `[openai, anthropic, raw_json]` | Proxy — format varies by model |
| Unknown | `[openai, raw_json]` | Sensible default |

## Verified Behavior

```
claude_api: [anthropic]
openrouter: [openai,anthropic,raw_json]
unknown: [openai,raw_json]
anthropic: Anthropic Messages API format
Total parsers: 4
```

## Test plan

- [x] Python 12/12 native lowering tests pass (was 11/12)
- [x] Jamaica/Krakatau startup errors eliminated
- [x] Kotlin 12/12 tests still pass
- [x] Response parser chains load and query correctly
- [x] OpenRouter cascade includes all 3 formats
- [x] Unknown backends get sensible default `[openai, raw_json]`
- [x] Parser metadata queryable (description, detection rules)
