### PR TITLE
fix: restore dropped tests, add put_list E2E, fix peephole and heap deref

### DIFF
--- a/archive/pr_descriptions/PR_WAM_LIST_REF_YI_PEEPHOLE_UNIFY.md
+++ b/archive/pr_descriptions/PR_WAM_LIST_REF_YI_PEEPHOLE_UNIFY.md
@@ -1,0 +1,21 @@
+# PR: feat: get_list heap-ref support, Yi peephole rules, and unify_value unification
+
+**Title:** `feat: get_list heap-ref, Yi peephole, and unify_value unification`
+
+## Summary
+
+- Add `ref(Addr)` handling to `get_list` read mode — when a register holds a heap reference to a `./2` structure (from `put_list`), look up head and tail on the heap via `heap_subargs`, completing the `put_list` -> `get_list` round-trip through the heap
+- Extend `unify_value` from strict `==` equality to full unification: if `Xn` is unbound, bind it to the sub-argument; if the sub-argument is unbound, succeed unconditionally
+- Extend `unify_constant` to accept unbound sub-arguments (unifies with any constant)
+- Add `match_put_variable_put_value` peephole rule to eliminate redundant `put_variable Xn, Ai` + `put_value Xn, Ai` identity pairs (works for both Xi and Yi registers)
+- Archive PR descriptions for PR #1144
+
+## Test plan
+
+- [x] All 7 WAM target compiler tests pass
+- [x] All 20 E2E tests pass — including new tests for `get_list` head matching (`e2e_cons/3`) and `unify_value` with unbound variables (`e2e_pair_first/2`)
+- [x] Verified `e2e_cons(a, [b,c], [a,b,c])` succeeds via `get_list` decomposition + `unify_value`
+- [x] Verified `e2e_pair_first(pair(hello, world), hello)` succeeds with unbound second sub-arg
+- [x] Exit code 0 on success, 1 on failure (CI-compatible)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/src/unifyweaver/runtime/wam_runtime.pl
+++ b/src/unifyweaver/runtime/wam_runtime.pl
@@ -516,6 +516,26 @@ step_wam(retry_me_else(NextL), wam_state(PC, R, S, H, T, CP, CPS, Code, L), wam_
     (CPS = [_|Rest] -> NCPS = [cp(NextPC, R, S, CP, T)|Rest] ; NCPS = [cp(NextPC, R, S, CP, T)]),
     NPC is PC + 1.
 
+%% deref_heap(+Value, +Heap, -DereferencedValue)
+%  Reconstructs a Prolog term from a heap reference. If Value is ref(Addr),
+%  looks up the structure on the heap and recursively dereferences sub-args.
+%  Non-ref values pass through unchanged.
+deref_heap(ref(Addr), Heap, Term) :- !,
+    nth0(Addr, Heap, str(FN)),
+    atom_string(FN, FNStr),
+    split_string(FNStr, "/", "", [FStr, ArStr]),
+    atom_string(F, FStr),
+    number_string(HArity, ArStr),
+    StartIdx is Addr + 1,
+    heap_subargs(Heap, StartIdx, HArity, SubArgs),
+    maplist({Heap}/[A, D]>>deref_heap(A, Heap, D), SubArgs, DerefArgs),
+    (   F == '.'
+    ->  DerefArgs = [Head, Tail],
+        Term = [Head|Tail]
+    ;   Term =.. [F|DerefArgs]
+    ).
+deref_heap(Val, _, Val).
+
 %% heap_subargs(+Heap, +StartIdx, +Count, -SubArgs)
 %  Extracts Count elements from the heap starting at StartIdx.
 heap_subargs(_, _, 0, []) :- !.
@@ -686,29 +706,35 @@ step_wam(builtin_call('\\+/1', 1), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
 %% recursive structure manipulation better done natively.
 step_wam(builtin_call('member/2', 2), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
          wam_state(NPC, R, S, H, T, CP, CPS, Code, L)) :-
-    get_assoc('A1', R, Elem),
-    get_assoc('A2', R, List),
+    get_assoc('A1', R, ElemRaw),
+    get_assoc('A2', R, ListRaw),
+    deref_heap(ElemRaw, H, Elem),
+    deref_heap(ListRaw, H, List),
     member(Elem, List),
     NPC is PC + 1.
 
 step_wam(builtin_call('append/3', 3), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
          wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
-    get_assoc('A1', R, L1),
-    get_assoc('A2', R, L2),
+    get_assoc('A1', R, L1Raw),
+    get_assoc('A2', R, L2Raw),
     get_assoc('A3', R, L3),
+    deref_heap(L1Raw, H, L1),
+    deref_heap(L2Raw, H, L2),
     (   is_unbound_var(L3)
     ->  append(L1, L2, Result),
         trail_binding('A3', R, T, NT),
         put_assoc('A3', R, Result, NR)
-    ;   append(L1, L2, L3),
+    ;   deref_heap(L3, H, L3D),
+        append(L1, L2, L3D),
         NR = R, NT = T
     ),
     NPC is PC + 1.
 
 step_wam(builtin_call('length/2', 2), wam_state(PC, R, S, H, T, CP, CPS, Code, L),
          wam_state(NPC, NR, S, H, NT, CP, CPS, Code, L)) :-
-    get_assoc('A1', R, List),
+    get_assoc('A1', R, ListRaw),
     get_assoc('A2', R, Len),
+    deref_heap(ListRaw, H, List),
     (   is_unbound_var(Len)
     ->  length(List, Result),
         trail_binding('A2', R, T, NT),

--- a/src/unifyweaver/targets/wam_target.pl
+++ b/src/unifyweaver/targets/wam_target.pl
@@ -679,11 +679,13 @@ peephole_lines([L1, L2|Rest], [L1|Result]) :-
     sub_string(S1, 0, _, _, "put_"), !,
     peephole_lines(Rest, Result).
 % Eliminate get_variable Xn, Ai followed by put_value Xn, Ai (pass-through)
+% Only safe if Xn is not referenced by any later instruction.
 peephole_lines([L1, L2|Rest], Result) :-
     normalize_ws(L1, N1),
     normalize_ws(L2, N2),
     atom_string(N1, S1), atom_string(N2, S2),
-    match_get_put_passthrough(S1, S2), !,
+    match_get_put_passthrough(S1, S2, Reg),
+    \+ reg_used_in_rest(Reg, Rest), !,
     peephole_lines(Rest, Result).
 peephole_lines([L|Rest], [L|Result]) :-
     peephole_lines(Rest, Result).
@@ -702,9 +704,16 @@ match_put_get_identity(Put, Get) :-
 %% match_get_put_passthrough(+GetStr, +PutStr)
 %  get_variable X1, A1 followed by put_value X1, A1 — both redundant
 %  (the value is already in Ai and doesn't need round-tripping through Xn).
-match_get_put_passthrough(Get, Put) :-
+match_get_put_passthrough(Get, Put, Reg) :-
     split_string(Get, " ,", " ,", ["get_variable", Reg, Ai]),
     split_string(Put, " ,", " ,", ["put_value", Reg, Ai]).
+
+%% reg_used_in_rest(+Reg, +Lines)
+%  True if the register name appears in any subsequent line.
+reg_used_in_rest(Reg, Lines) :-
+    member(Line, Lines),
+    atom_string(Line, LineStr),
+    sub_string(LineStr, _, _, _, Reg), !.
 
 %% write_wam_program(+Code, +Filename)
 write_wam_program(Code, Filename) :-

--- a/tests/test_wam_e2e.pl
+++ b/tests/test_wam_e2e.pl
@@ -66,10 +66,23 @@ e2e_shape_area(rect(W, H), A) :- A is W * H.
 :- dynamic e2e_head/2.
 e2e_head([H|_], H).
 
+%% List in head (third arg) — exercises get_list for matching
+:- dynamic e2e_cons/3.
+e2e_cons(H, T, [H|T]).
+
+%% Compound head with variable sub-args — exercises unify_value with unbound
+:- dynamic e2e_pair_first/2.
+e2e_pair_first(pair(X, _), X).
+
 %% Second-arg indexed predicate (variable first arg, constant second)
 :- dynamic e2e_greet/2.
 e2e_greet(X, hello) :- X = world.
 e2e_greet(X, goodbye) :- X = moon.
+
+%% Body list construction — exercises put_list + set_*
+%  e2e_wrap_in_list/2 calls e2e_has_member with a constructed [X] list.
+:- dynamic e2e_wrap_in_list/1.
+e2e_wrap_in_list(X) :- e2e_has_member(X, [X]).
 
 :- dynamic test_failed/0.
 
@@ -242,6 +255,35 @@ test_wam_get_list :-
     ;   fail_test(Test, 'get_list decomposition failed')
     ).
 
+test_wam_get_list_match :-
+    Test = 'WAM E2E: get_list head matching (cons)',
+    (   wam_target:compile_predicate_to_wam(user:e2e_cons/3, [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'get_list'),
+        wam_runtime:execute_wam(Code, e2e_cons(a, [b, c], [a, b, c]), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'get_list head matching failed')
+    ).
+
+test_wam_unify_value_unbound :-
+    Test = 'WAM E2E: unify_value with unbound variable',
+    (   wam_target:compile_predicate_to_wam(user:e2e_pair_first/2, [], Code),
+        wam_runtime:execute_wam(Code, e2e_pair_first(pair(hello, world), hello), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'unify_value with unbound variable failed')
+    ).
+
+test_wam_put_list_body :-
+    Test = 'WAM E2E: put_list body construction',
+    (   wam_target:compile_wam_module(
+            [user:e2e_has_member/2, user:e2e_wrap_in_list/1], [], Code),
+        atom_string(Code, S),
+        sub_string(S, _, _, _, 'put_list'),
+        wam_runtime:execute_wam(Code, e2e_wrap_in_list(hello), _)
+    ->  pass(Test)
+    ;   fail_test(Test, 'put_list body construction failed')
+    ).
+
 test_wam_peephole :-
     Test = 'WAM E2E: Peephole optimization (no redundant get/put pairs)',
     (   % ancestor clause 1 does get_variable X1,A1 then put_value X1,A1
@@ -287,6 +329,9 @@ run_tests :-
     test_wam_indexing,
     test_wam_structure_index,
     test_wam_get_list,
+    test_wam_get_list_match,
+    test_wam_unify_value_unbound,
+    test_wam_put_list_body,
     test_wam_peephole,
     test_wam_second_arg_index,
     


### PR DESCRIPTION
## Summary

- Restore E2E tests dropped during prior merge: `get_list_match` (cons/3 head matching with execution) and `unify_value_unbound` (pair_first/2 with unbound sub-argument), plus test data for `e2e_cons/3` and `e2e_pair_first/2`
- Add `put_list` body construction E2E test: `e2e_wrap_in_list(X)` constructs `[X]` via `put_list` + `set_value` + `set_constant []`, then passes the heap-constructed list to `member/2` — validates the full put_list -> builtin round-trip
- Fix peephole optimizer safety: `match_get_put_passthrough` now verifies the register is not referenced by any subsequent instruction before eliminating the get/put pair, preventing removal of bindings needed by later `set_value`/`set_constant` instructions
- Add `deref_heap/3` to reconstruct Prolog terms from `ref(Addr)` heap references, including list reconstruction (`./2` -> `[H|T]`). List builtins (`member/2`, `append/3`, `length/2`) now dereference heap refs before delegating to native Prolog operations

## Test plan

- [x] All 7 WAM target compiler tests pass
- [x] All 21 E2E tests pass — including 3 restored/new tests
- [x] Verified `e2e_cons(a, [b,c], [a,b,c])` succeeds via `get_list` decomposition
- [x] Verified `e2e_pair_first(pair(hello, world), hello)` succeeds with unbound second sub-arg
- [x] Verified `e2e_wrap_in_list(hello)` succeeds through full `put_list` -> heap -> `deref_heap` -> `member/2` pipeline
- [x] Verified peephole no longer eliminates `get_variable X1, A1` when X1 is used by later `set_value X1`
- [x] Exit code 0 on success, 1 on failure (CI-compatible)

Generated with [Claude Code](https://claude.com/claude-code)
