### PR TITLE
docs: WAM-to-Rust transpilation design (philosophy, spec, impl plan)

### DIFF
--- a/archive/pr_descriptions/PR_WAM_RESTORE_TESTS_PUTLIST_PEEPHOLE.md
+++ b/archive/pr_descriptions/PR_WAM_RESTORE_TESTS_PUTLIST_PEEPHOLE.md
@@ -1,0 +1,22 @@
+# PR: fix: restore dropped tests, add put_list E2E, fix peephole and heap deref
+
+**Title:** `fix: restore dropped tests, put_list E2E, peephole safety, heap deref`
+
+## Summary
+
+- Restore E2E tests dropped during prior merge: `get_list_match` (cons/3 head matching with execution) and `unify_value_unbound` (pair_first/2 with unbound sub-argument), plus test data for `e2e_cons/3` and `e2e_pair_first/2`
+- Add `put_list` body construction E2E test: `e2e_wrap_in_list(X)` constructs `[X]` via `put_list` + `set_value` + `set_constant []`, then passes the heap-constructed list to `member/2` — validates the full put_list -> builtin round-trip
+- Fix peephole optimizer safety: `match_get_put_passthrough` now verifies the register is not referenced by any subsequent instruction before eliminating the get/put pair, preventing removal of bindings needed by later `set_value`/`set_constant` instructions
+- Add `deref_heap/3` to reconstruct Prolog terms from `ref(Addr)` heap references, including list reconstruction (`./2` -> `[H|T]`). List builtins (`member/2`, `append/3`, `length/2`) now dereference heap refs before delegating to native Prolog operations
+
+## Test plan
+
+- [x] All 7 WAM target compiler tests pass
+- [x] All 21 E2E tests pass — including 3 restored/new tests
+- [x] Verified `e2e_cons(a, [b,c], [a,b,c])` succeeds via `get_list` decomposition
+- [x] Verified `e2e_pair_first(pair(hello, world), hello)` succeeds with unbound second sub-arg
+- [x] Verified `e2e_wrap_in_list(hello)` succeeds through full `put_list` -> heap -> `deref_heap` -> `member/2` pipeline
+- [x] Verified peephole no longer eliminates `get_variable X1, A1` when X1 is used by later `set_value X1`
+- [x] Exit code 0 on success, 1 on failure (CI-compatible)
+
+Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/design/WAM_RUST_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_RUST_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,245 @@
+# WAM-to-Rust Transpilation: Implementation Plan
+
+## Phase 0: Rust Binding Registry for Prolog Builtins (PREREQUISITE)
+
+**Goal:** Define Rust equivalents for the Prolog builtins used by
+`wam_runtime.pl`, so the native lowering pipeline can translate them.
+
+**Scope:**
+- Register bindings for `library(assoc)` operations → `HashMap`
+- Register bindings for list operations → `Vec`
+- Register bindings for arithmetic → native Rust operators
+- Register bindings for `format/2` → `format!()`
+- Register bindings for `=../2` → `Value` enum match/construct
+
+**Changes:**
+1. Create `src/unifyweaver/bindings/rust_wam_bindings.pl`:
+   ```prolog
+   :- module(rust_wam_bindings, [rust_wam_binding/5]).
+
+   % rust_wam_binding(+PrologPred/Arity, +RustExpr, +ArgMap, +ReturnMap, +Props)
+   rust_wam_binding(get_assoc/3, "~map.get(&~key).cloned()",
+       [key-string, map-hashmap], [value-value], [pure]).
+   rust_wam_binding(put_assoc/4, "{ let mut m = ~map.clone(); m.insert(~key, ~val); m }",
+       [key-string, map-hashmap, val-value], [result-hashmap], [pure]).
+   rust_wam_binding(empty_assoc/1, "HashMap::new()",
+       [], [result-hashmap], [pure]).
+   ```
+
+2. Register these bindings with the Rust target's `is_builtin_goal`
+   detection so they're recognized during native lowering.
+
+**Effort:** Medium — mechanical mapping work.
+
+**Risk:** Low — the mappings are straightforward.
+
+## Phase 1: Mustache Templates for Rust WAM Crate
+
+**Goal:** Define the Rust crate skeleton that the transpiled WAM runtime
+will live in.
+
+**Scope:**
+- `templates/targets/rust_wam/Cargo.toml.mustache`
+- `templates/targets/rust_wam/value.rs.mustache` — `Value` enum
+- `templates/targets/rust_wam/state.rs.mustache` — `WamState` struct
+- `templates/targets/rust_wam/instructions.rs.mustache` — `Instruction` enum
+- `templates/targets/rust_wam/lib.rs.mustache` — module layout
+
+**Changes:**
+1. Create template files in `templates/targets/rust_wam/`
+2. Register templates in `template_system.pl` via `template/2` facts
+3. Add `compile_wam_rust_crate/3` to `wam_target.pl` or a new
+   `wam_rust_target.pl` module that orchestrates template rendering
+   + code generation
+
+**Template composition strategy:**
+- Larger templates (value.rs, state.rs) use Mustache sections
+- Method bodies within templates are filled by native lowering
+- `{{step_wam_match_arms}}` placeholder is filled by compiling
+  `step_wam/3` clauses to Rust match arms
+
+**Effort:** Medium — template authoring + registration.
+
+**Risk:** Low — follows established template patterns.
+
+## Phase 2: Transpile `step_wam/3` to Rust `match`
+
+**Goal:** Compile the multi-clause `step_wam/3` predicate to a Rust
+`match` expression, producing the core instruction dispatcher.
+
+**Scope:**
+- Extend `rust_target.pl` to handle compound-head multi-clause dispatch
+  as Rust `match` on enum variants
+- Each `step_wam` clause body → one match arm body, lowered via
+  `clause_body_analysis` with Rust bindings
+- Handle state threading: `wam_state(PC, R, S, H, T, CP, CPS, Code, L)`
+  fields → `self.pc`, `self.regs`, `self.stack`, etc.
+
+**Changes:**
+1. Add `compile_match_dispatch_to_rust/4` in `rust_target.pl`:
+   ```prolog
+   compile_match_dispatch_to_rust(Pred, Arity, Clauses, RustCode) :-
+       Clauses are all compound-first-arg,
+       group by first-arg functor,
+       each group → one match arm,
+       each arm body → native_rust_clause_body.
+   ```
+
+2. Wire into `compile_predicate_to_rust_normal` as a new tier
+   (between recursive patterns and single rules).
+
+3. State field mapping:
+   ```prolog
+   wam_state_field(1, 'self.pc').
+   wam_state_field(2, 'self.regs').
+   wam_state_field(3, 'self.stack').
+   wam_state_field(4, 'self.heap').
+   wam_state_field(5, 'self.trail').
+   wam_state_field(6, 'self.cp').
+   wam_state_field(7, 'self.choice_points').
+   wam_state_field(8, 'self.code').
+   wam_state_field(9, 'self.labels').
+   ```
+
+**Effort:** High — this is the core compilation challenge.
+
+**Risk:** Medium — clause body analysis handles most patterns, but
+`step_wam` bodies use assoc operations that need the Phase 0 bindings.
+
+**Depends on:** Phase 0, Phase 1.
+
+## Phase 3: Transpile Helper Predicates
+
+**Goal:** Compile the remaining `wam_runtime.pl` predicates to Rust
+functions via native lowering.
+
+**Scope:**
+- `run_loop/2` → `fn run(&mut self) -> bool` (recursive loop)
+- `backtrack/2` → `fn backtrack(&mut self) -> bool`
+- `unwind_trail/4` → `fn unwind_trail(&mut self, saved: &[TrailEntry])`
+- `eval_arith/5` → `fn eval_arith(&self, expr: &Value) -> f64`
+- `deref_heap/3` → `fn deref_heap(&self, val: &Value) -> Value`
+- `is_unbound_var/1` → `fn is_unbound(&self) -> bool` (on Value)
+- `trail_binding/4` → `fn trail_binding(&mut self, key: &str)`
+- `get_reg/3`, `put_reg/6` → register access methods
+- `parse_instr/2` → instruction parser (if needed for string input)
+
+**Changes:**
+1. Each predicate → attempt native lowering first
+2. For predicates that resist → WAM-compile as fallback (but most
+   of these are simple enough for native lowering)
+3. Wire into the template's `{{helper_functions}}` placeholder
+
+**Effort:** Medium — most helpers are straightforward.
+
+**Risk:** Low — these are simpler than `step_wam/3`.
+
+**Depends on:** Phase 0.
+
+## Phase 4: WAM Fallback Integration in Rust Target
+
+**Goal:** When `compile_predicate_to_rust_normal` fails, fall back to
+WAM compilation + Rust codegen.
+
+**Scope:**
+- Add final clause to `compile_predicate_to_rust_normal`:
+  ```prolog
+  compile_predicate_to_rust_normal(Pred, Arity, Options, RustCode) :-
+      % All native tiers failed — fall back to WAM
+      wam_target:compile_predicate_to_wam(Pred/Arity, Options, WamCode),
+      compile_wam_instructions_to_rust(WamCode, RustCode).
+  ```
+- Generate Rust code that creates an `Instruction` array and calls
+  the transpiled WAM runtime to execute it
+- Register natively-lowered predicates as builtins so WAM-compiled
+  code can call them via `BuiltinCall`
+
+**Changes:**
+1. `compile_wam_instructions_to_rust/2` — parse WAM instruction
+   string → Rust `vec![Instruction::GetConstant(...), ...]` literal
+2. Wrapper function generation:
+   ```rust
+   fn predicate_name(vm: &mut WamState, a1: Value, a2: Value) -> bool {
+       static CODE: &[Instruction] = &[ ... ];
+       vm.load(CODE);
+       vm.set_reg("A1", a1);
+       vm.set_reg("A2", a2);
+       vm.run()
+   }
+   ```
+3. Builtin dispatch table for natively-lowered predicates
+
+**Effort:** Medium.
+
+**Risk:** Medium — interop calling convention needs careful design.
+
+**Depends on:** Phase 2, Phase 3.
+
+## Phase 5: End-to-End Testing & Validation
+
+**Goal:** Compile a mixed-complexity Prolog module to Rust, run it,
+verify correctness.
+
+**Scope:**
+- Test module with facts, rules, recursive predicates, and predicates
+  requiring WAM fallback
+- `cargo test` validation of generated code
+- Comparison of Prolog-runtime results vs Rust-compiled results
+
+**Changes:**
+1. Create `tests/test_wam_rust_transpilation.pl` — Prolog-side tests
+   that compile predicates and verify the generated Rust
+2. Create test Cargo project that exercises the generated code
+3. CI integration
+
+**Effort:** Medium.
+
+**Risk:** Low — validation is mechanical.
+
+**Depends on:** Phase 4.
+
+## Priority and Dependencies
+
+```
+Phase 0 (Rust bindings for Prolog builtins) ← independent
+  ↓
+Phase 1 (Mustache templates for crate structure) ← independent
+  ↓
+Phase 2 (step_wam/3 → Rust match) ← depends on Phase 0, 1
+  ↓
+Phase 3 (helper predicates → Rust functions) ← depends on Phase 0
+  ↓
+Phase 4 (WAM fallback in Rust target) ← depends on Phase 2, 3
+  ↓
+Phase 5 (E2E testing) ← depends on Phase 4
+```
+
+Phases 0 and 1 can proceed in parallel. Phase 3 can proceed in
+parallel with Phase 2 after Phase 0 is complete.
+
+## Metrics
+
+| Phase | Templates | Native Lowering | New Tests | Risk |
+|-------|-----------|-----------------|-----------|------|
+| 0 | 0 | 15+ bindings | 5 | Low |
+| 1 | 5 files | 0 | 2 | Low |
+| 2 | 0 | 1 major predicate | 5 | Medium |
+| 3 | 0 | 10+ predicates | 10 | Low |
+| 4 | 1 wrapper | 1 fallback path | 5 | Medium |
+| 5 | 0 | 0 | 10+ | Low |
+
+## Future Extensions
+
+Once the Rust pipeline works, the same architecture extends to:
+
+- **WAM → WAT (WebAssembly text)**: Replace Rust templates with WAT
+  templates, reuse the same instruction → target lowering pipeline.
+- **WAM → JVM (Jamaica/Krakatau)**: Replace with JVM bytecode
+  templates. The `shared_logic` pattern from agent-loop would let
+  instruction semantics be defined once and expanded per target.
+- **WAM → C**: For embedded/native targets. The `Value` enum becomes
+  a tagged union, `HashMap` becomes a hash table, etc.
+
+The binding registry (Phase 0) and instruction semantics (Phase 2) are
+the reusable core; only the templates and target-specific lowering rules
+change per downstream target.

--- a/docs/design/WAM_RUST_TRANSPILATION_PHILOSOPHY.md
+++ b/docs/design/WAM_RUST_TRANSPILATION_PHILOSOPHY.md
@@ -1,0 +1,136 @@
+# WAM-to-Rust Transpilation: Philosophy
+
+## The Problem
+
+UnifyWeaver's Rust target handles arithmetic, guards, facts, recursive
+patterns, and if-then-else natively. But some Prolog predicates resist
+native lowering: genuine unification with nested structures, non-
+deterministic choice points, mutual recursion with backtracking. Today,
+when the Rust target encounters such predicates, compilation simply
+fails.
+
+The WAM target (Phase 1, PRs #1086–#1152) provides the missing layer:
+a symbolic compiler and runtime that preserves full Prolog semantics.
+The next step is connecting these — using WAM as a fallback for
+predicates that resist native lowering, producing a Rust module that
+mixes natively-lowered functions with WAM-compiled ones.
+
+## Design Principle: Transpile, Don't Rewrite
+
+Rather than manually writing a WAM runtime in Rust, UnifyWeaver should
+**transpile its own WAM runtime** (`wam_runtime.pl`) to Rust using its
+compilation infrastructure. This achieves:
+
+- **Single source of truth** — improvements to the Prolog WAM runtime
+  automatically propagate to the Rust version
+- **Dog-fooding** — proves the compiler handles its own code
+- **Correctness by construction** — the transpiled runtime inherits the
+  tested semantics of the Prolog version (28 tests, CI-verified)
+
+## The Compilation Spectrum for WAM Predicates
+
+UnifyWeaver's philosophy is a spectrum from maximum idiom to maximum
+coverage:
+
+```
+Most Idiomatic                              Most Coverage
+─────────────────────────────────────────────────────────
+Templates    Native Lowering    WAM-Compiled    Interpreted
+(Mustache)   (clause_body)      (transpiled)    (runtime)
+```
+
+For a single Rust output module, this means:
+
+```
+factorial/2    → native lowering → fn factorial(n: i64) -> i64 { ... }
+grandparent/2  → WAM-compiled    → fn grandparent(vm: &mut WamState, ...)
+step_wam/3     → native lowering → match instr { GetConstant(..) => ... }
+eval_arith/4   → native lowering → fn eval_arith(expr: &Value) -> f64
+backtrack/2    → WAM-compiled    → fn backtrack(state: &mut WamState) -> bool
+```
+
+The key insight: **the WAM runtime itself is a Prolog program**, and
+most of its predicates (arithmetic, type checks, register helpers) are
+simple enough for native lowering. Only the most complex predicates
+(if any) would need the WAM fallback — a form of recursive self-
+application.
+
+## Templates vs Native Lowering: Both, Applied Recursively
+
+UnifyWeaver's architecture does not choose between templates and native
+lowering — it applies both recursively at every nesting level:
+
+1. **Template** provides the idiomatic Rust skeleton (struct definitions,
+   enum declarations, trait implementations, module layout)
+2. **Native lowering** fills in the function bodies via clause body
+   analysis and expression translation
+3. **Nested control flow** recursively dispatches back through the same
+   pipeline via `compile_expression/6`
+
+For the WAM runtime transpilation:
+
+- **Mustache templates** define the Rust crate structure:
+  `Cargo.toml`, `lib.rs`, `value.rs`, `state.rs`, `instructions.rs`
+- **Native lowering** compiles `step_wam/3` clauses to `match` arms,
+  `eval_arith/4` to recursive expression evaluation, `is_unbound_var/1`
+  to a simple `matches!()` check
+- **`shared_logic` pattern** (from agent-loop) could define WAM
+  instruction semantics once, expand to Rust/WAT/JVM differently
+
+## AST Analysis Drives the Pipeline
+
+UnifyWeaver's `clause_body_analysis.pl` provides the structural analysis
+that makes this possible:
+
+- **`classify_goal/3`** determines whether a goal is a guard, output, or
+  control flow — this drives how `step_wam` clauses get lowered
+- **`translate_expr/3`** normalizes Prolog expressions to a target-
+  independent AST (`op(+, var(x), literal(2))`) that Rust can consume
+- **`compile_expression/6`** is the recursive entry point where templates
+  and native lowering compose at every level
+
+The `step_wam/3` predicate is a multi-clause dispatch on compound first
+arguments — exactly the pattern that `switch_on_structure` indexing
+handles. The Rust target's `match` expression is the natural lowering
+for this pattern.
+
+## Interop Between Native and WAM-Compiled Predicates
+
+A critical requirement: natively-lowered Rust functions must be callable
+from WAM-compiled code and vice versa. The calling convention:
+
+- **Native → WAM**: The caller constructs a `WamState`, sets argument
+  registers, and calls the WAM entry point. The WAM executor runs until
+  `proceed` or failure.
+- **WAM → Native**: When WAM encounters a `builtin_call` or `call` to a
+  natively-lowered predicate, it reads arguments from registers, calls
+  the native Rust function, and stores results back.
+
+This is the same pattern as the existing `builtin_call` mechanism in the
+WAM runtime — builtins like `is/2`, `member/2`, `>/2` already bridge
+between WAM execution and native Prolog evaluation. The Rust version
+extends this to natively-lowered user predicates.
+
+## What Success Looks Like
+
+A Prolog module with mixed complexity:
+
+```prolog
+factorial(0, 1).
+factorial(N, F) :- N > 0, N1 is N - 1, factorial(N1, F1), F is N * F1.
+
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).
+
+unify_complex(f(X, g(Y)), f(a, g(b))) :- X = a, Y = b.
+```
+
+Compiles to a single Rust crate where:
+
+- `factorial` is natively lowered (recursive arithmetic)
+- `ancestor` might be natively lowered (transitive closure pattern) or
+  WAM-compiled (if the pattern detector doesn't recognize it)
+- `unify_complex` is WAM-compiled (deep structure unification)
+- The WAM runtime support code was itself transpiled from `wam_runtime.pl`
+
+All three functions interoperate seamlessly within the same Rust binary.

--- a/docs/design/WAM_RUST_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/WAM_RUST_TRANSPILATION_SPECIFICATION.md
@@ -1,0 +1,279 @@
+# WAM-to-Rust Transpilation: Specification
+
+## Overview
+
+This document specifies the hybrid compilation strategy that produces
+Rust modules containing a mix of natively-lowered functions and WAM-
+compiled functions, with a transpiled WAM runtime providing backtracking
+and unification support.
+
+## Architecture Layers
+
+```
+Layer 1: Predicate Classification
+    → native_lowerable | wam_required | builtin
+
+Layer 2: Compilation Strategy Selection
+    → native_lowering(rust) | wam_compile_then_lower(rust) | builtin_binding(rust)
+
+Layer 3: Code Generation
+    → Mustache templates (crate structure) + native lowering (bodies)
+
+Layer 4: WAM Runtime Transpilation
+    → wam_runtime.pl → Rust via same pipeline (self-application)
+
+Layer 5: Assembly & Validation
+    → cargo check, test execution
+```
+
+## Rust Value System
+
+The WAM operates on a universal `Value` type. In Rust:
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    Atom(String),
+    Integer(i64),
+    Float(f64),
+    Str(String, Vec<Value>),  // compound: functor + args
+    List(Vec<Value>),
+    Ref(usize),               // heap reference
+    Unbound(String),           // unbound variable (_V5, _H3)
+    Bool(bool),
+}
+```
+
+## WAM State Structure
+
+Mirrors the 9-field `wam_state` tuple from `wam_runtime.pl`:
+
+```rust
+pub struct WamState {
+    pub pc: usize,                          // program counter
+    pub regs: HashMap<String, Value>,       // registers (Ai, Xi)
+    pub stack: Vec<StackEntry>,             // env frames + unify contexts
+    pub heap: Vec<Value>,                   // term construction heap
+    pub trail: Vec<TrailEntry>,             // binding trail for backtrack
+    pub cp: usize,                          // continuation pointer
+    pub choice_points: Vec<ChoicePoint>,    // backtracking stack
+    pub code: Vec<Instruction>,             // compiled instructions
+    pub labels: HashMap<String, usize>,     // label → PC mapping
+}
+```
+
+## Instruction Enum
+
+Each WAM instruction maps to a Rust enum variant:
+
+```rust
+pub enum Instruction {
+    // Head unification
+    GetConstant(Value, String),          // get_constant C, Ai
+    GetVariable(String, String),         // get_variable Xn, Ai
+    GetValue(String, String),            // get_value Xn, Ai
+    GetStructure(String, String),        // get_structure F/N, Ai
+    GetList(String),                     // get_list Ai
+    UnifyVariable(String),              // unify_variable Xn
+    UnifyValue(String),                 // unify_value Xn
+    UnifyConstant(Value),               // unify_constant C
+
+    // Body construction
+    PutConstant(Value, String),         // put_constant C, Ai
+    PutVariable(String, String),        // put_variable Xn, Ai
+    PutValue(String, String),           // put_value Xn, Ai
+    PutStructure(String, String),       // put_structure F/N, Ai
+    PutList(String),                    // put_list Ai
+    SetVariable(String),               // set_variable Xn
+    SetValue(String),                   // set_value Xn
+    SetConstant(Value),                 // set_constant C
+
+    // Control
+    Allocate,
+    Deallocate,
+    Call(String, usize),                // call P/N, Arity
+    Execute(String),                    // execute P/N
+    Proceed,
+    BuiltinCall(String, usize),         // builtin_call Op, Arity
+
+    // Choice points
+    TryMeElse(String),                  // try_me_else Label
+    RetryMeElse(String),               // retry_me_else Label
+    TrustMe,
+
+    // Indexing
+    SwitchOnConstant(Vec<(Value, String)>),
+    SwitchOnStructure(Vec<(String, String)>),
+    SwitchOnConstantA2(Vec<(Value, String)>),
+}
+```
+
+## Predicate Classification
+
+```prolog
+%% classify_for_rust(+Pred/Arity, -Strategy)
+classify_for_rust(Pred/Arity, native) :-
+    compile_predicate_to_rust_normal(Pred, Arity, _, _), !.
+classify_for_rust(Pred/Arity, wam) :-
+    compile_predicate_to_wam(Pred/Arity, [], _), !.
+classify_for_rust(Pred/Arity, builtin) :-
+    is_builtin_pred(Pred, Arity).
+```
+
+## Compilation Pipeline
+
+### For natively-lowered predicates (no change):
+
+```
+Prolog clause → clause_body_analysis → Rust function
+```
+
+### For WAM-compiled predicates:
+
+```
+Prolog clause → wam_target:compile_predicate_to_wam → WAM instructions
+    → wam_to_rust_instructions → Rust Instruction enum literals
+    → wrapped in fn predicate(vm: &mut WamState) → Rust function
+```
+
+### For the WAM runtime itself:
+
+```
+wam_runtime.pl predicates
+    → clause_body_analysis + Rust native lowering
+    → Rust impl WamState { fn step(&mut self) → match ... }
+```
+
+## Mustache Templates
+
+### Crate structure: `templates/targets/rust_wam/`
+
+**`Cargo.toml.mustache`:**
+```toml
+[package]
+name = "{{module_name}}"
+version = "0.1.0"
+edition = "2021"
+```
+
+**`lib.rs.mustache`:**
+```rust
+mod value;
+mod state;
+mod instructions;
+mod runtime;
+{{#native_predicates}}
+mod {{module_name}};
+{{/native_predicates}}
+
+{{predicates_code}}
+```
+
+**`value.rs.mustache`:** The `Value` enum and helper methods.
+
+**`state.rs.mustache`:** The `WamState` struct with register/stack/heap
+management methods.
+
+**`runtime.rs.mustache`:** The `step` method (transpiled from
+`step_wam/3`) and `run_loop` (transpiled from `run_loop/2`).
+
+## `step_wam/3` Lowering Strategy
+
+The `step_wam/3` predicate is a multi-clause dispatch on the first
+argument (instruction type). This maps directly to a Rust `match`:
+
+```prolog
+% Prolog (wam_runtime.pl):
+step_wam(get_constant(C, Ai), State0, State1) :- ...
+step_wam(get_variable(Xn, Ai), State0, State1) :- ...
+```
+
+```rust
+// Rust (transpiled):
+impl WamState {
+    fn step(&mut self, instr: &Instruction) -> bool {
+        match instr {
+            Instruction::GetConstant(c, ai) => { ... }
+            Instruction::GetVariable(xn, ai) => { ... }
+            ...
+        }
+    }
+}
+```
+
+Each clause body is lowered via `clause_body_analysis`:
+- `get_assoc(Ai, R, Val)` → `self.regs.get(ai)`
+- `put_assoc(Ai, R, C, NR)` → `self.regs.insert(ai, c)`
+- `Val == C` → `val == c`
+- `is_unbound_var(Val)` → `val.is_unbound()`
+- `NPC is PC + 1` → `self.pc += 1`
+
+## Builtin Mapping Table
+
+| Prolog builtin | Rust equivalent |
+|----------------|-----------------|
+| `get_assoc/3` | `HashMap::get` |
+| `put_assoc/4` | `HashMap::insert` |
+| `nth0/3` | `Vec` indexing `[]` |
+| `nth1/3` | `Vec` indexing `[i-1]` |
+| `append/3` | `Vec::extend` / `[a, b].concat()` |
+| `length/2` | `Vec::len()` |
+| `member/2` | `.contains()` / `.iter().any()` |
+| `format/2` | `format!()` |
+| `=../2` (univ) | `Value::Str` construction/destructure |
+| `atom/1` | `matches!(val, Value::Atom(_))` |
+| `number/1` | `matches!(val, Value::Integer(_) \| Value::Float(_))` |
+| `compound/1` | `matches!(val, Value::Str(_, _))` |
+| `is_list/1` | `matches!(val, Value::List(_))` |
+| `empty_assoc/1` | `HashMap::new()` |
+| `assoc_to_list/2` | `.iter().collect()` |
+| `sub_atom/5` | `str::contains` / `str::find` |
+
+## Interop Calling Convention
+
+### Native calls WAM-compiled predicate:
+
+```rust
+fn query_ancestor(a: &str, b: &str) -> bool {
+    let mut vm = WamState::new(&ANCESTOR_CODE, &ANCESTOR_LABELS);
+    vm.set_reg("A1", Value::Atom(a.into()));
+    vm.set_reg("A2", Value::Atom(b.into()));
+    vm.run()
+}
+```
+
+### WAM-compiled calls native predicate:
+
+The `BuiltinCall` instruction dispatches to native Rust:
+
+```rust
+Instruction::BuiltinCall(op, _arity) => {
+    match op.as_str() {
+        "is/2" => self.builtin_is(),
+        ">/2"  => self.builtin_gt(),
+        "factorial/2" => {  // natively-lowered predicate
+            let n = self.get_reg_int("A1");
+            let result = factorial(n);  // call native fn
+            self.set_reg("A2", Value::Integer(result));
+            self.pc += 1;
+            true
+        }
+        _ => false
+    }
+}
+```
+
+## Target Capability Matrix
+
+| Capability | Native Lowering | WAM-Compiled | Both |
+|------------|----------------|-------------|------|
+| Arithmetic | yes | yes | native preferred |
+| Guards/comparisons | yes | yes | native preferred |
+| Facts (lookup) | yes | yes | native preferred |
+| Tail recursion | yes | yes | native preferred |
+| Transitive closure | yes | yes | native preferred |
+| If-then-else | yes | yes | native preferred |
+| Choice points | no | yes | WAM only |
+| Deep unification | no | yes | WAM only |
+| Mutual recursion | partial | yes | WAM fallback |
+| Meta-predicates | no | yes | WAM only |


### PR DESCRIPTION
## Summary

- Add **Philosophy** document establishing the "transpile, don't rewrite" principle — UnifyWeaver compiles its own `wam_runtime.pl` to Rust using its existing compilation pipeline, maintaining a single source of truth. Templates provide idiomatic Rust crate structure, native lowering fills function bodies, both applied recursively via `compile_expression/6`. The WAM runtime's predicates are themselves mostly native-lowerable.
- Add **Specification** defining concrete Rust types (`Value` enum, `WamState` struct, `Instruction` enum with 25+ variants), predicate classification strategy (native vs WAM vs builtin), interop calling convention (native ↔ WAM-compiled), builtin mapping table (16 Prolog builtins → Rust equivalents), and target capability matrix
- Add **Implementation Plan** with 6 phases: binding registry (Phase 0), Mustache templates (Phase 1), `step_wam/3` → Rust `match` transpilation (Phase 2), helper predicate lowering (Phase 3), WAM fallback integration in Rust target (Phase 4), E2E testing (Phase 5). Includes dependency graph, effort/risk per phase, and metrics table. Architecture extends to WAT/JVM/C downstream targets.
- Archive PR description for PR #1152

## Test plan

- [x] Documents follow established design doc style (philosophy → specification → implementation plan)
- [x] Cross-references existing architecture (clause_body_analysis, template_system, compile_expression/6, fallback_chain)
- [x] Phase dependencies are consistent and parallelizable where noted
- [x] Implementation plan references existing code paths (`compile_predicate_to_rust_normal`, `is_builtin_pred`, `switch_on_structure`)

Generated with [Claude Code](https://claude.com/claude-code)
