### PR TITLE
docs: WAM-to-Go transpilation design (philosophy, spec, impl plan)

### DIFF
--- a/docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,328 @@
+# WAM-to-Go Transpilation: Implementation Plan
+
+## Phase 0: Go Binding Registry for Prolog Builtins (PREREQUISITE)
+
+**Goal:** Define Go equivalents for the Prolog builtins used by
+`wam_runtime.pl`, so the native lowering pipeline can translate them.
+
+**Scope:**
+- Register bindings for `library(assoc)` operations → `map[string]Value`
+- Register bindings for list operations → `[]Value` slices
+- Register bindings for arithmetic → native Go operators
+- Register bindings for `format/2` → `fmt.Sprintf()`
+- Register bindings for `=../2` → `Compound` construction/destructure
+
+**Changes:**
+1. Create `src/unifyweaver/bindings/go_wam_bindings.pl`:
+   ```prolog
+   :- module(go_wam_bindings, [go_wam_binding/5]).
+
+   go_wam_binding(get_assoc/3, "~map[~key]",
+       [key-string, map-gomap], [value-value], [pure]).
+   go_wam_binding(put_assoc/4, "~map[~key] = ~val",
+       [key-string, map-gomap, val-value], [result-gomap], [mutating]).
+   go_wam_binding(empty_assoc/1, "make(map[string]Value)",
+       [], [result-gomap], [pure]).
+   ```
+
+2. Register these bindings with the Go target's `is_builtin_goal`
+   detection so they're recognized during native lowering.
+
+**Effort:** Medium — mechanical mapping work, parallel to Rust Phase 0.
+
+## Phase 1: Mustache Templates for Go WAM Package
+
+**Goal:** Define the Go package skeleton.
+
+**Scope:**
+- `templates/targets/go_wam/go.mod.mustache`
+- `templates/targets/go_wam/value.go.mustache` — `Value` interface + types
+- `templates/targets/go_wam/state.go.mustache` — `WamState` struct
+- `templates/targets/go_wam/instructions.go.mustache` — `Instruction` interface + types
+- `templates/targets/go_wam/runtime.go.mustache` — `Step` + `Run`
+
+**Changes:**
+1. Create template files in `templates/targets/go_wam/`
+2. Register templates in `template_system.pl`
+3. Add `compile_wam_go_package/3` to `go_target.pl` or a new
+   `wam_go_target.pl` module
+
+**Template composition strategy:**
+- Larger templates (value.go, state.go) use Mustache sections
+- Method bodies are filled by native lowering
+- `{{step_switch_cases}}` placeholder filled by compiling `step_wam/3`
+  clauses to Go type switch cases
+
+**Go-specific template considerations:**
+- Go requires all types in a package to be in `.go` files (no headers)
+- Interface methods need marker methods (`valueTag()`, `instrTag()`)
+- `go.mod` defines module path and Go version
+- No generics needed (interface-based polymorphism sufficient)
+
+**Effort:** Medium — more boilerplate than Rust (Go has no enums).
+
+## Phase 2: WAM Instruction Lowering to Go
+
+**Goal:** Compile WAM instructions from `compile_predicate_to_wam/3`
+output into Go struct literals.
+
+**Changes:**
+1. Add `wam_to_go_instruction/2` to translate each WAM instruction:
+   ```prolog
+   wam_to_go_instruction(get_constant(C, Ai), GoCode) :-
+       go_value_literal(C, GoVal),
+       format(string(GoCode), '&GetConstant{C: ~w, Ai: "~w"}', [GoVal, Ai]).
+   ```
+
+2. Add `wam_to_go_code_array/2` to produce a Go slice literal:
+   ```go
+   var ancestorCode = []Instruction{
+       &GetConstant{C: &Atom{"parent"}, Ai: "A1"},
+       &Call{Pred: "parent/2", Arity: 2},
+       ...
+   }
+   ```
+
+3. Add `wam_to_go_labels/2` to produce label map:
+   ```go
+   var ancestorLabels = map[string]int{
+       "clause_1": 0,
+       "clause_2": 5,
+   }
+   ```
+
+**Effort:** Low — mechanical translation of instruction terms.
+
+## Phase 3: step_wam/3 Transpilation via Type Switch
+
+**Goal:** Transpile `step_wam/3` from `wam_runtime.pl` to a Go
+`Step` method using type switch dispatch.
+
+**Strategy:**
+1. Load `wam_runtime.pl` clauses for `step_wam/3`
+2. Group by first-argument functor (instruction type)
+3. For each group, compile the clause body via `clause_body_analysis`
+4. Emit as a `case *InstructionType:` block in the type switch
+
+**Go-specific lowering rules:**
+- `get_assoc(Key, Map, Val)` → `val, ok := regs[key]; if !ok { return false }`
+- `put_assoc(Key, Map, Val, NewMap)` → `regs[key] = val`
+- `Val == C` → `equals(val, c)`
+- `is_unbound_var(Val)` → `isUnbound(val)`
+- `NPC is PC + 1` → `vm.PC++`
+- `nth0(Idx, List, Elem)` → `list[idx]`
+- `append(A, B, C)` → `c = append(a, b...)`
+
+**Effort:** High — requires extending Go native lowering to handle
+compound first-argument dispatch (type switch pattern). This is the
+key engineering challenge.
+
+## Phase 4: Hybrid Module Assembly
+
+**Goal:** Produce a Go package that mixes native and WAM-compiled code.
+
+**Changes:**
+1. Add `compile_hybrid_go_package/3`:
+   ```prolog
+   compile_hybrid_go_package(Predicates, Options, Files) :-
+       classify_predicates(Predicates, Native, WamRequired, Builtins),
+       compile_native_predicates(go, Native, NativeCode),
+       compile_wam_predicates(WamRequired, WamCode),
+       render_go_wam_templates(Options, TemplateFiles),
+       assemble_package(NativeCode, WamCode, TemplateFiles, Files).
+   ```
+
+2. Generate the entry point that routes to native or WAM:
+   ```go
+   func Query(pred string, args ...Value) ([]Value, bool) {
+       switch pred {
+       case "factorial/2":
+           // Native path
+           n := args[0].(*Integer).Val
+           return []Value{&Integer{factorial(n)}}, true
+       default:
+           // WAM fallback
+           vm := NewWamState(codeFor(pred), labelsFor(pred))
+           for i, arg := range args {
+               vm.SetReg(fmt.Sprintf("A%d", i+1), arg)
+           }
+           return vm.RunAndCollect(), vm.Run()
+       }
+   }
+   ```
+
+**Effort:** Medium — assembly and routing logic.
+
+## Phase 5: Goroutine-Based Parallel Search (Optional)
+
+**Goal:** Use Go's concurrency for parallel choice point exploration.
+
+**Design:**
+```go
+func (vm *WamState) RunParallel(maxWorkers int) <-chan []Value {
+    results := make(chan []Value, 100)
+    sem := make(chan struct{}, maxWorkers)
+
+    var explore func(state WamState)
+    explore = func(state WamState) {
+        sem <- struct{}{} // acquire
+        defer func() { <-sem }() // release
+
+        for {
+            if !state.Step(state.Code[state.PC]) {
+                return // this branch failed
+            }
+            if state.IsProceeded() {
+                results <- state.CollectResults()
+                return
+            }
+            if state.HasChoicePoint() {
+                // Fork: explore alternative in goroutine
+                alt := state.ForkAtChoicePoint()
+                go explore(alt)
+            }
+        }
+    }
+
+    go func() {
+        explore(*vm)
+        close(results)
+    }()
+
+    return results
+}
+```
+
+**This is a Go-unique feature** — not available in the Rust design.
+It leverages Go's lightweight goroutines to explore the search tree
+concurrently.
+
+**Effort:** High — requires careful state cloning and synchronization.
+**Priority:** Low — implement after sequential WAM works correctly.
+
+## Phase 5b: Order-Independent Goal Parallelism
+
+**Goal:** Parallelize body goals of predicates declared or proven
+order-independent. This is **separate from WAM choice point
+parallelism** — it applies to natively-lowered deterministic predicates
+whose subgoals happen to be independent.
+
+**Declarations:**
+```prolog
+%% User declaration — promise that clause order doesn't matter
+:- order_independent(node_score/2).
+:- parallel_safe(feature_lookup/2).
+
+%% Compiler can also prove independence via static analysis:
+%% - All goals are pure (no I/O, no assert/retract)
+%% - Goals bind disjoint variable sets
+%% - No shared mutable state
+```
+
+**Changes:**
+1. Add `order_independent/1` and `parallel_safe/1` as recognized
+   directives in the clause body analysis pipeline.
+
+2. Add `classify_parallelism/2` to determine the parallelism strategy:
+   ```prolog
+   classify_parallelism(Pred/Arity, goal_parallel(Goals)) :-
+       single_clause_with_independent_goals(Pred/Arity, Goals), !.
+   classify_parallelism(Pred/Arity, clause_parallel) :-
+       is_order_independent(Pred/Arity, _), !.
+   classify_parallelism(_, sequential).
+   ```
+
+3. Add `is_order_independent/2` that checks declarations first, then
+   attempts static proof:
+   ```prolog
+   is_order_independent(Pred/Arity, declared) :-
+       order_independent(Pred/Arity), !.
+   is_order_independent(Pred/Arity, proven(Reasons)) :-
+       all_clauses_pure(Pred/Arity),
+       all_goals_bind_disjoint_vars(Pred/Arity),
+       Reasons = [pure_goals, disjoint_bindings].
+   ```
+
+4. Update Go native lowering to emit `sync.WaitGroup` + goroutines
+   when `classify_parallelism` returns `goal_parallel` or
+   `clause_parallel`.
+
+**Go code generation:**
+```go
+// goal_parallel: independent body goals run concurrently
+func nodeScore(x Value) Value {
+    var a, b Value
+    var wg sync.WaitGroup
+    wg.Add(2)
+    go func() { defer wg.Done(); a = featureA(x) }()
+    go func() { defer wg.Done(); b = featureB(x) }()
+    wg.Wait()
+    return &Integer{a.(*Integer).Val + b.(*Integer).Val}
+}
+```
+
+**Interaction with Phase 5a (WAM parallel search):**
+- Phase 5a: parallelizes WAM **choice point exploration** (non-determinism)
+- Phase 5b: parallelizes **independent subgoals** (deterministic concurrency)
+- Both use goroutines but for different purposes
+- A predicate can use 5b for its body AND 5a for its choice points
+
+**Static analysis rules for proving independence:**
+- Goal `G` is **pure** if it doesn't call assert/retract, I/O predicates,
+  or global state modifiers
+- Goals `G1, G2` have **disjoint bindings** if the output variables of
+  `G1` don't appear in the input variables of `G2` and vice versa
+- A clause is **order-independent** if all its clauses produce the same
+  result set regardless of evaluation order (true for set-producing
+  predicates like `findall`, TC, aggregations)
+
+**Effort:** Medium — static analysis is the hard part; code generation
+is straightforward (WaitGroup + goroutines).
+**Priority:** Medium — valuable without WAM, applies to many predicates.
+
+## Phase Summary
+
+| Phase | Description | Effort | Depends On |
+|-------|------------|--------|------------|
+| 0 | Go WAM bindings registry | Medium | — |
+| 1 | Mustache templates for Go package | Medium | — |
+| 2 | WAM instruction → Go literals | Low | Phase 0 |
+| 3 | step_wam/3 → Go type switch | High | Phase 0, 1 |
+| 4 | Hybrid module assembly | Medium | Phase 2, 3 |
+| 5a | Goroutine WAM parallel search | High | Phase 4 |
+| 5b | Order-independent goal parallelism | Medium | Phase 0 (no WAM needed) |
+
+## Differences from Rust Implementation Plan
+
+| Aspect | Rust (PR #1153) | Go (this plan) |
+|--------|----------------|----------------|
+| Value type | `enum Value` | `interface Value` + structs |
+| Dispatch | `match` expression | `switch i := instr.(type)` |
+| Memory | Ownership/borrowing | GC, pointer semantics |
+| Package | Cargo crate | Go module |
+| Template files | `.rs.mustache` | `.go.mustache` |
+| Concurrency | Not planned | Phase 5 (goroutines) |
+| Bindings file | `rust_wam_bindings.pl` | `go_wam_bindings.pl` |
+| Trail simplification | Need lifetime mgmt | GC handles it |
+| Build validation | `cargo check` | `go build` |
+
+## Success Criteria
+
+A Prolog program with mixed predicate types:
+
+```prolog
+factorial(0, 1).
+factorial(N, F) :- N > 0, N1 is N - 1, factorial(N1, F1), F is N * F1.
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).
+unify_complex(f(X, g(Y)), f(a, g(b))) :- X = a, Y = b.
+```
+
+Produces a Go package that:
+
+1. `go build` compiles without errors
+2. `go test` passes for all three predicates
+3. `factorial` uses native Go (direct recursion)
+4. `ancestor` uses native Go (TC pattern) or WAM (if not detected)
+5. `unify_complex` uses WAM (deep unification)
+6. Cross-calls between native and WAM work seamlessly

--- a/docs/design/WAM_GO_TRANSPILATION_PHILOSOPHY.md
+++ b/docs/design/WAM_GO_TRANSPILATION_PHILOSOPHY.md
@@ -1,0 +1,258 @@
+# WAM-to-Go Transpilation: Philosophy
+
+## The Problem
+
+UnifyWeaver's Go target handles arithmetic, guards, facts, recursive
+patterns, transitive closure, and if-then-else natively. It also has
+substantial pipeline, aggregation, and database modes. But some Prolog
+predicates resist native lowering: genuine unification with nested
+structures, non-deterministic choice points, mutual recursion with
+backtracking. Today, when the Go target encounters such predicates,
+compilation either falls back to a comment or fails silently.
+
+The WAM target (Phase 1, PRs #1086–#1152) provides the missing layer.
+The next step — as with Rust (PR #1153) — is connecting these, using
+WAM as a fallback for predicates that resist native lowering, producing
+a Go module that mixes natively-lowered functions with WAM-compiled ones.
+
+## Design Principle: Transpile, Don't Rewrite
+
+Rather than manually writing a WAM runtime in Go, UnifyWeaver should
+**transpile its own WAM runtime** (`wam_runtime.pl`) to Go using its
+compilation infrastructure. This achieves:
+
+- **Single source of truth** — improvements to the Prolog WAM runtime
+  automatically propagate to the Go version
+- **Dog-fooding** — proves the compiler handles its own code
+- **Correctness by construction** — the transpiled runtime inherits the
+  tested semantics of the Prolog version
+
+This is the same principle as the Rust design (PR #1153). The Go
+implementation differs in idiom but shares the same compilation pipeline.
+
+## The Compilation Spectrum
+
+```
+Most Idiomatic                              Most Coverage
+─────────────────────────────────────────────────────────
+Templates    Native Lowering    WAM-Compiled    Interpreted
+(Mustache)   (clause_body)      (transpiled)    (runtime)
+```
+
+For a single Go output package:
+
+```
+factorial/2    → native lowering → func factorial(n int) int { ... }
+grandparent/2  → WAM-compiled    → func grandparent(vm *WamState, ...)
+step_wam/3     → native lowering → switch instr.(type) { case *GetConstant: ... }
+eval_arith/4   → native lowering → func evalArith(expr Value) float64
+backtrack/2    → WAM-compiled    → func backtrack(state *WamState) bool
+```
+
+## Go vs Rust: Key Design Differences
+
+The WAM-to-Rust design (PR #1153) uses Rust's `enum` + `match` for
+instruction dispatch. Go requires a different approach:
+
+### Instruction Dispatch
+
+**Rust:** Single enum with exhaustive match
+```rust
+match instr {
+    Instruction::GetConstant(c, ai) => { ... }
+    Instruction::GetVariable(xn, ai) => { ... }
+}
+```
+
+**Go:** Interface type + type switch
+```go
+switch i := instr.(type) {
+case *GetConstant:
+    // i.C, i.Ai available
+case *GetVariable:
+    // i.Xn, i.Ai available
+}
+```
+
+Go's type switch on interface values is the natural analog of Rust's
+pattern matching on enums. Both provide exhaustive dispatch over a
+closed set of variants.
+
+### Memory Model
+
+**Rust:** Ownership + borrowing, zero-copy where possible
+```rust
+fn step(&mut self, instr: &Instruction) -> bool
+```
+
+**Go:** Garbage collected, pointer semantics
+```go
+func (vm *WamState) Step(instr Instruction) bool
+```
+
+Go's GC simplifies the WAM heap — no manual deallocation needed. The
+trail/backtracking mechanism is simpler because Go doesn't need to
+reason about lifetimes of trail entries.
+
+### Value Type
+
+**Rust:** `enum Value { Atom(String), Integer(i64), ... }` with pattern matching
+
+**Go:** Interface-based with type assertions
+```go
+type Value interface{ valueTag() }
+type Atom struct{ Name string }
+type Integer struct{ Val int64 }
+type Compound struct{ Functor string; Args []Value }
+type Ref struct{ Addr int }
+type Unbound struct{ Name string }
+```
+
+Go's `interface{}` (or `any`) could also work, but a sealed interface
+with a marker method provides type safety without generics.
+
+### Concurrency: A Go Advantage
+
+Go has first-class concurrency via goroutines and channels. This opens
+a design path not available in single-threaded Rust:
+
+- **Parallel choice exploration**: Each choice point spawns a goroutine
+  that explores one alternative. Solutions are sent back on a channel.
+- **Bounded parallelism**: A worker pool limits concurrent explorations.
+- **First-solution optimization**: Cancel remaining goroutines once the
+  first solution is found.
+
+This is optional and orthogonal to the core transpilation — the initial
+implementation should use sequential backtracking (matching Rust). But
+Go's goroutine model makes parallel search a natural extension.
+
+### Order-Independent Parallelism
+
+Not all parallelism requires WAM choice points. Predicates that are
+**order-independent** — where clause order doesn't affect the result
+set — can parallelize at the goal level without backtracking machinery:
+
+```prolog
+:- order_independent(node_score/2).
+node_score(X, S) :- feature_a(X, A), feature_b(X, B), S is A + B.
+```
+
+When a predicate is declared `order_independent` (or proven so by
+static analysis), its body goals can execute concurrently:
+
+```go
+func nodeScore(x Value) Value {
+    var a, b Value
+    var wg sync.WaitGroup
+    wg.Add(2)
+    go func() { defer wg.Done(); a = featureA(x) }()
+    go func() { defer wg.Done(); b = featureB(x) }()
+    wg.Wait()
+    return &Integer{a.(*Integer).Val + b.(*Integer).Val}
+}
+```
+
+**When parallelism is safe:**
+
+- **Declared**: User annotates with `:- order_independent(pred/arity)`
+  or `:- parallel_safe(pred/arity)`. This is a promise that clause
+  order doesn't matter and goals have no observable side effects on
+  each other.
+
+- **Proven**: Static analysis detects independence:
+  - All body goals are pure (no I/O, no assert/retract)
+  - No shared mutable state between goals
+  - Goals bind disjoint variable sets
+  - Commutative operations (e.g. set union, bag collection)
+
+**Granularity levels:**
+
+1. **Goal-level**: Independent body goals in a single clause run
+   concurrently (as above). Safe when goals bind disjoint variables.
+
+2. **Clause-level**: Multiple clauses of the same predicate run
+   concurrently, collecting all solutions. Safe when clause order
+   doesn't affect the result set (true for all `findall`-like usage).
+
+3. **Predicate-level**: Independent predicate calls in a pipeline
+   run concurrently. Safe when predicates don't share mutable state.
+
+**Interaction with WAM:**
+
+Order-independent predicates don't need WAM at all — they can be
+natively lowered with goroutine parallelism. This means parallelism
+applies even to predicates that are too simple for WAM but complex
+enough to benefit from concurrent execution (e.g. multi-feature
+scoring, independent constraint checks, parallel data lookups).
+
+The key insight: **parallelism and backtracking are orthogonal**.
+Goroutine parallelism applies to deterministic predicates that happen
+to have independent subgoals. WAM backtracking applies to non-
+deterministic predicates with choice points. Go can do both.
+
+## Templates vs Native Lowering: Both, Applied Recursively
+
+As with Rust, UnifyWeaver applies both templates and native lowering
+at every nesting level:
+
+1. **Mustache templates** define the Go package structure: `go.mod`,
+   `value.go`, `state.go`, `instructions.go`, `runtime.go`
+2. **Native lowering** compiles `step_wam/3` clauses to `switch` cases,
+   `eval_arith/4` to recursive expression evaluation
+3. **Nested control flow** recursively dispatches back through the same
+   pipeline via `compile_expression/6`
+
+## Interop Between Native and WAM-Compiled Predicates
+
+The same calling convention as Rust, adapted to Go idioms:
+
+- **Native → WAM**: The caller constructs a `WamState`, sets argument
+  registers, and calls `vm.Run()`. The WAM executor runs until
+  `Proceed` or failure.
+- **WAM → Native**: When WAM encounters a `BuiltinCall` instruction
+  for a natively-lowered predicate, it reads arguments from registers,
+  calls the native Go function, and stores results back.
+
+```go
+// Native calls WAM-compiled predicate:
+func queryAncestor(a, b string) bool {
+    vm := NewWamState(ancestorCode, ancestorLabels)
+    vm.SetReg("A1", &Atom{a})
+    vm.SetReg("A2", &Atom{b})
+    return vm.Run()
+}
+
+// WAM calls native predicate:
+case *BuiltinCall:
+    switch i.Op {
+    case "factorial/2":
+        n := vm.GetRegInt("A1")
+        result := factorial(n)  // call native func
+        vm.SetReg("A2", &Integer{result})
+        vm.PC++
+    }
+```
+
+## What Success Looks Like
+
+A Prolog module with mixed complexity:
+
+```prolog
+factorial(0, 1).
+factorial(N, F) :- N > 0, N1 is N - 1, factorial(N1, F1), F is N * F1.
+
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y).
+
+unify_complex(f(X, g(Y)), f(a, g(b))) :- X = a, Y = b.
+```
+
+Compiles to a single Go package where:
+
+- `factorial` is natively lowered (recursive arithmetic)
+- `ancestor` might be natively lowered (transitive closure) or
+  WAM-compiled (if the pattern detector doesn't recognize it)
+- `unify_complex` is WAM-compiled (deep structure unification)
+- The WAM runtime was itself transpiled from `wam_runtime.pl`
+
+All three functions interoperate seamlessly within the same Go binary.

--- a/docs/design/WAM_GO_TRANSPILATION_SPECIFICATION.md
+++ b/docs/design/WAM_GO_TRANSPILATION_SPECIFICATION.md
@@ -1,0 +1,395 @@
+# WAM-to-Go Transpilation: Specification
+
+## Overview
+
+This document specifies the hybrid compilation strategy that produces
+Go packages containing a mix of natively-lowered functions and WAM-
+compiled functions, with a transpiled WAM runtime providing backtracking
+and unification support.
+
+## Architecture Layers
+
+```
+Layer 1: Predicate Classification
+    → native_lowerable | wam_required | builtin
+
+Layer 2: Compilation Strategy Selection
+    → native_lowering(go) | wam_compile_then_lower(go) | builtin_binding(go)
+
+Layer 3: Code Generation
+    → Mustache templates (package structure) + native lowering (bodies)
+
+Layer 4: WAM Runtime Transpilation
+    → wam_runtime.pl → Go via same pipeline (self-application)
+
+Layer 5: Assembly & Validation
+    → go build, go test
+```
+
+## Go Value System
+
+The WAM operates on a universal `Value` type. In Go, using a sealed
+interface:
+
+```go
+// Value is the universal Prolog term type.
+type Value interface {
+    valueTag()  // sealed marker
+    String() string
+}
+
+type Atom struct{ Name string }
+type Integer struct{ Val int64 }
+type Float struct{ Val float64 }
+type Compound struct{ Functor string; Args []Value }
+type List struct{ Elements []Value }
+type Ref struct{ Addr int }
+type Unbound struct{ Name string }
+type Bool struct{ Val bool }
+
+func (Atom) valueTag()     {}
+func (Integer) valueTag()  {}
+func (Float) valueTag()    {}
+func (Compound) valueTag() {}
+func (List) valueTag()     {}
+func (Ref) valueTag()      {}
+func (Unbound) valueTag()  {}
+func (Bool) valueTag()     {}
+```
+
+## WAM State Structure
+
+Mirrors the 9-field `wam_state` tuple from `wam_runtime.pl`:
+
+```go
+type WamState struct {
+    PC           int                    // program counter
+    Regs         map[string]Value       // registers (Ai, Xi)
+    Stack        []StackEntry           // env frames + unify contexts
+    Heap         []Value                // term construction heap
+    Trail        []TrailEntry           // binding trail for backtrack
+    CP           int                    // continuation pointer
+    ChoicePoints []ChoicePoint          // backtracking stack
+    Code         []Instruction          // compiled instructions
+    Labels       map[string]int         // label → PC mapping
+}
+
+type StackEntry struct {
+    Type    string // "env" or "unify_context"
+    Env     *Environment
+    Context *UnifyContext
+}
+
+type ChoicePoint struct {
+    PC    int
+    Regs  map[string]Value  // saved registers
+    Trail int               // trail mark
+    CP    int               // saved continuation
+}
+
+type TrailEntry struct {
+    Var   string
+    Value Value
+}
+```
+
+## Instruction Interface
+
+Each WAM instruction is a Go struct implementing the `Instruction`
+interface. Dispatch uses type switch:
+
+```go
+type Instruction interface {
+    instrTag()
+}
+
+// Head unification
+type GetConstant struct{ C Value; Ai string }
+type GetVariable struct{ Xn, Ai string }
+type GetValue struct{ Xn, Ai string }
+type GetStructure struct{ Functor string; Ai string }
+type GetList struct{ Ai string }
+type UnifyVariable struct{ Xn string }
+type UnifyValue struct{ Xn string }
+type UnifyConstant struct{ C Value }
+
+// Body construction
+type PutConstant struct{ C Value; Ai string }
+type PutVariable struct{ Xn, Ai string }
+type PutValue struct{ Xn, Ai string }
+type PutStructure struct{ Functor string; Ai string }
+type PutList struct{ Ai string }
+type SetVariable struct{ Xn string }
+type SetValue struct{ Xn string }
+type SetConstant struct{ C Value }
+
+// Control
+type Allocate struct{}
+type Deallocate struct{}
+type Call struct{ Pred string; Arity int }
+type Execute struct{ Pred string }
+type Proceed struct{}
+type BuiltinCall struct{ Op string; Arity int }
+
+// Choice points
+type TryMeElse struct{ Label string }
+type RetryMeElse struct{ Label string }
+type TrustMe struct{}
+
+// Indexing
+type SwitchOnConstant struct{ Cases []ConstCase }
+type SwitchOnStructure struct{ Cases []StructCase }
+type SwitchOnConstantA2 struct{ Cases []ConstCase }
+
+type ConstCase struct{ Val Value; Label string }
+type StructCase struct{ Functor, Label string }
+
+func (GetConstant) instrTag()       {}
+func (GetVariable) instrTag()       {}
+// ... (all instruction types)
+```
+
+## Predicate Classification
+
+```prolog
+%% classify_for_go(+Pred/Arity, -Strategy)
+classify_for_go(Pred/Arity, native) :-
+    compile_predicate_to_go_normal(Pred, Arity, _, _), !.
+classify_for_go(Pred/Arity, wam) :-
+    compile_predicate_to_wam(Pred/Arity, [], _), !.
+classify_for_go(Pred/Arity, builtin) :-
+    is_builtin_pred(Pred, Arity).
+```
+
+## Compilation Pipeline
+
+### For natively-lowered predicates (no change):
+
+```
+Prolog clause → clause_body_analysis → Go function
+```
+
+### For WAM-compiled predicates:
+
+```
+Prolog clause → wam_target:compile_predicate_to_wam → WAM instructions
+    → wam_to_go_instructions → Go Instruction struct literals
+    → wrapped in func predicate(vm *WamState) → Go function
+```
+
+### For the WAM runtime itself:
+
+```
+wam_runtime.pl predicates
+    → clause_body_analysis + Go native lowering
+    → func (vm *WamState) Step(instr Instruction) bool { switch ... }
+```
+
+## `step_wam/3` Lowering Strategy
+
+The `step_wam/3` predicate maps to a Go type switch:
+
+```prolog
+% Prolog (wam_runtime.pl):
+step_wam(get_constant(C, Ai), State0, State1) :- ...
+step_wam(get_variable(Xn, Ai), State0, State1) :- ...
+```
+
+```go
+// Go (transpiled):
+func (vm *WamState) Step(instr Instruction) bool {
+    switch i := instr.(type) {
+    case *GetConstant:
+        val := vm.Regs[i.Ai]
+        if isUnbound(val) {
+            vm.Regs[i.Ai] = i.C
+            vm.PC++
+            return true
+        }
+        if equals(val, i.C) {
+            vm.PC++
+            return true
+        }
+        return false
+    case *GetVariable:
+        vm.Regs[i.Xn] = vm.Regs[i.Ai]
+        vm.PC++
+        return true
+    // ...
+    default:
+        return false
+    }
+}
+```
+
+## Builtin Mapping Table
+
+| Prolog builtin | Go equivalent |
+|----------------|---------------|
+| `get_assoc/3` | `regs[key]` (map lookup) |
+| `put_assoc/4` | `regs[key] = val` (map insert) |
+| `nth0/3` | `slice[i]` |
+| `nth1/3` | `slice[i-1]` |
+| `append/3` | `append(a, b...)` |
+| `length/2` | `len(slice)` |
+| `member/2` | `slices.Contains()` or loop |
+| `format/2` | `fmt.Sprintf()` |
+| `=../2` (univ) | `Compound` construction/destructure |
+| `atom/1` | `_, ok := val.(*Atom)` |
+| `number/1` | type switch `*Integer \| *Float` |
+| `compound/1` | `_, ok := val.(*Compound)` |
+| `is_list/1` | `_, ok := val.(*List)` |
+| `empty_assoc/1` | `make(map[string]Value)` |
+| `sub_atom/5` | `strings.Contains` / `strings.Index` |
+
+## Mustache Templates
+
+### Package structure: `templates/targets/go_wam/`
+
+**`go.mod.mustache`:**
+```
+module {{module_name}}
+
+go 1.21
+```
+
+**`value.go.mustache`:** The `Value` interface and concrete types.
+
+**`state.go.mustache`:** The `WamState` struct with register/stack/heap
+management methods.
+
+**`instructions.go.mustache`:** The `Instruction` interface and all
+instruction struct types.
+
+**`runtime.go.mustache`:** The `Step` method (transpiled from
+`step_wam/3`) and `Run` loop (transpiled from `run_loop/2`).
+
+## Interop Calling Convention
+
+### Native calls WAM-compiled predicate:
+
+```go
+func queryAncestor(a, b string) bool {
+    vm := NewWamState(ancestorCode, ancestorLabels)
+    vm.SetReg("A1", &Atom{a})
+    vm.SetReg("A2", &Atom{b})
+    return vm.Run()
+}
+```
+
+### WAM-compiled calls native predicate:
+
+```go
+case *BuiltinCall:
+    switch i.Op {
+    case "is/2":
+        vm.builtinIs()
+    case ">/2":
+        vm.builtinGt()
+    case "factorial/2":
+        n := vm.GetRegInt("A1")
+        result := factorial(n)
+        vm.SetReg("A2", &Integer{result})
+        vm.PC++
+    default:
+        return false
+    }
+```
+
+## Order-Independence Declarations
+
+Predicates can be marked order-independent to enable safe parallelism:
+
+```prolog
+%% User declaration — a promise that clause order doesn't matter
+:- order_independent(node_score/2).
+:- parallel_safe(feature_a/2).
+
+%% Or: proven by static analysis (no side effects, disjoint bindings)
+```
+
+### Analysis Predicate
+
+```prolog
+%% is_order_independent(+Pred/Arity, -Evidence)
+%%   Evidence: declared | proven(Reasons)
+is_order_independent(Pred/Arity, declared) :-
+    order_independent(Pred/Arity), !.
+is_order_independent(Pred/Arity, proven(Reasons)) :-
+    functor(Head, Pred, Arity),
+    findall(Head-Body, clause(user:Head, Body), Clauses),
+    all_clauses_pure(Clauses, R1),      % no I/O, no assert/retract
+    all_goals_independent(Clauses, R2),  % disjoint variable sets
+    append(R1, R2, Reasons),
+    Reasons \= [].
+```
+
+### Parallelism Classification
+
+```prolog
+%% classify_parallelism(+Pred/Arity, -Strategy)
+classify_parallelism(Pred/Arity, goal_parallel(Goals)) :-
+    %% Body goals bind disjoint variables — run concurrently
+    single_clause_with_independent_goals(Pred/Arity, Goals), !.
+classify_parallelism(Pred/Arity, clause_parallel) :-
+    %% All clauses are order-independent — collect solutions concurrently
+    is_order_independent(Pred/Arity, _), !.
+classify_parallelism(_, sequential).
+```
+
+### Go Code Generation for Order-Independent Goals
+
+Goal-level parallelism (independent body goals in one clause):
+
+```go
+// From: score(X, S) :- feature_a(X, A), feature_b(X, B), S is A + B.
+// With: :- order_independent(score/2).
+func score(x Value) Value {
+    var a, b Value
+    var wg sync.WaitGroup
+    wg.Add(2)
+    go func() { defer wg.Done(); a = featureA(x) }()
+    go func() { defer wg.Done(); b = featureB(x) }()
+    wg.Wait()
+    return &Integer{a.(*Integer).Val + b.(*Integer).Val}
+}
+```
+
+Clause-level parallelism (multiple clauses, all solutions):
+
+```go
+// From: reachable(X, Y) :- edge(X, Y).
+//       reachable(X, Y) :- edge(X, Z), reachable(Z, Y).
+// With: :- order_independent(reachable/2).
+func reachableAll(x Value) <-chan Value {
+    results := make(chan Value, 100)
+    go func() {
+        defer close(results)
+        var wg sync.WaitGroup
+        // Each clause explores independently
+        wg.Add(2)
+        go func() { defer wg.Done(); /* clause 1 */ }()
+        go func() { defer wg.Done(); /* clause 2 */ }()
+        wg.Wait()
+    }()
+    return results
+}
+```
+
+## Target Capability Matrix
+
+| Capability | Native Go | WAM-Compiled | Both |
+|------------|-----------|-------------|------|
+| Arithmetic | yes | yes | native preferred |
+| Guards/comparisons | yes | yes | native preferred |
+| Facts (lookup) | yes | yes | native preferred |
+| Tail recursion | yes | yes | native preferred |
+| Transitive closure | yes | yes | native preferred |
+| If-then-else | yes | yes | native preferred |
+| Pipeline/streaming | yes | no | native only |
+| Choice points | no | yes | WAM only |
+| Deep unification | no | yes | WAM only |
+| Mutual recursion | partial | yes | WAM fallback |
+| Meta-predicates | no | yes | WAM only |
+| Goroutine search | planned | no | native extension |
+| Order-independent parallel | yes | no | native (goroutines) |


### PR DESCRIPTION
## Summary

Add three design documents for WAM-to-Go transpilation, following the same three-document pattern as the WAM-to-Rust design (PR #1153). Covers Go-specific idioms (interfaces, type switches, goroutines) and introduces order-independent parallelism as a Go-unique feature.

## Documents

### Philosophy (194 → 260 lines)

`docs/design/WAM_GO_TRANSPILATION_PHILOSOPHY.md`

Core principles:
- **Transpile, don't rewrite** — same as Rust: compile `wam_runtime.pl` to Go using UnifyWeaver's own pipeline
- **Compilation spectrum** — Templates → Native Lowering → WAM-Compiled → Interpreted
- **Go vs Rust differences** — interface types (not enums), type switch (not match), GC (not ownership)
- **Two forms of parallelism** — orthogonal, both using goroutines:
  - **WAM parallel search**: choice point exploration (non-deterministic)
  - **Order-independent parallelism**: independent subgoals run concurrently (deterministic)

Key insight from the philosophy:
> Parallelism and backtracking are orthogonal. Goroutine parallelism applies to deterministic predicates that happen to have independent subgoals. WAM backtracking applies to non-deterministic predicates with choice points. Go can do both.

### Specification (314 → 395 lines)

`docs/design/WAM_GO_TRANSPILATION_SPECIFICATION.md`

Technical specification covering:

**Value System:**
```go
type Value interface{ valueTag() }  // sealed interface
type Atom struct{ Name string }
type Integer struct{ Val int64 }
type Compound struct{ Functor string; Args []Value }
// ... 8 types total
```

**Instruction Dispatch:**
```go
switch i := instr.(type) {
case *GetConstant:  // ...
case *GetVariable:  // ...
}
```

**Order-Independence Declarations:**
```prolog
:- order_independent(node_score/2).  % user declaration
:- parallel_safe(feature_a/2).       % user promise
```

**Parallelism Classification:**
```prolog
classify_parallelism(Pred/Arity, goal_parallel(Goals)).   % independent body goals
classify_parallelism(Pred/Arity, clause_parallel).         % order-independent clauses
classify_parallelism(_, sequential).                       % default
```

**Static Analysis for Proving Independence:**
- All goals are pure (no I/O, no assert/retract)
- Goals bind disjoint variable sets
- No shared mutable state between goals

**Go Codegen for Parallel Goals:**
```go
func nodeScore(x Value) Value {
    var a, b Value
    var wg sync.WaitGroup
    wg.Add(2)
    go func() { defer wg.Done(); a = featureA(x) }()
    go func() { defer wg.Done(); b = featureB(x) }()
    wg.Wait()
    return &Integer{a.(*Integer).Val + b.(*Integer).Val}
}
```

**Capability Matrix** (12 capabilities including order-independent parallel).

### Implementation Plan (247 → 326 lines)

`docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md`

| Phase | Description | Effort | Depends On |
|-------|------------|--------|------------|
| 0 | Go WAM bindings registry | Medium | — |
| 1 | Mustache templates for Go package | Medium | — |
| 2 | WAM instruction → Go struct literals | Low | Phase 0 |
| 3 | step_wam/3 → Go type switch | High | Phase 0, 1 |
| 4 | Hybrid module assembly | Medium | Phase 2, 3 |
| 5a | Goroutine WAM parallel search | High | Phase 4 |
| **5b** | **Order-independent goal parallelism** | **Medium** | **Phase 0 (no WAM needed)** |

Phase 5b is notable because it **doesn't require WAM** — it applies to natively-lowered predicates whose subgoals happen to be independent. This makes it independently valuable even before WAM-to-Go is complete.

## Differences from Rust Design (PR #1153)

| Aspect | Rust | Go |
|--------|------|-----|
| Value type | `enum Value` + pattern match | `interface Value` + type switch |
| Instruction dispatch | `match instr { ... }` | `switch i := instr.(type) { ... }` |
| Memory model | Ownership, borrowing, lifetimes | GC, pointer semantics |
| Package system | Cargo crate | Go module |
| Trail cleanup | Manual lifetime management | GC handles it |
| Concurrency | Not planned | Phase 5a (WAM) + 5b (order-independent) |
| Order-independent parallel | Not planned | Declared or proven, uses goroutines |
| Build validation | `cargo check` | `go build` |

## Order-Independent Parallelism: The Key Addition

This is the novel contribution beyond the Rust design. Three granularity levels:

1. **Goal-level**: Independent body goals in a single clause run concurrently (WaitGroup + goroutines). Safe when goals bind disjoint variables.

2. **Clause-level**: Multiple clauses of the same predicate run concurrently, collecting all solutions. Safe when clause order doesn't affect the result set.

3. **Predicate-level**: Independent predicate calls in a pipeline run concurrently. Safe when predicates don't share mutable state.

Safety determined by:
- **Declaration**: `:- order_independent(pred/arity)` — user promise
- **Proof**: Static analysis detects pure goals + disjoint bindings

## Test plan

- [x] All three documents follow the Rust design pattern structure
- [x] Go-specific idioms used throughout (interfaces, type switch, goroutines)
- [x] Value system uses sealed interface pattern (not `any`)
- [x] Instruction dispatch uses type switch (not reflection)
- [x] Builtin mapping table covers 15 Prolog→Go equivalents
- [x] Order-independence section covers declarations, static analysis, and codegen
- [x] Phase 5 split into 5a (WAM search) and 5b (order-independent goals)
- [x] Differences from Rust design documented explicitly
