### PR TITLE
bench: add csharp query category influence benchmark

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -186,7 +186,7 @@ Tables:
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
-| `benchmark_category_influence_cross_target.py` | Compare category influence propagation across Rust DFS and Go DFS |
+| `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
 
@@ -235,13 +235,19 @@ python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
 
-# Compare category influence propagation across Rust and Go
+# Compare category influence propagation across the C# query engine, Rust, and Go
 python examples/benchmark/benchmark_category_influence_cross_target.py \
     --scales 300,1k,5k,10k \
-    --targets rust-dfs,go-dfs
+    --targets csharp-query,rust-dfs,go-dfs
 ```
 
-The current native-lowering comparison surface across non-query targets is:
+The current comparison surface across query and non-query targets is:
+
+- C# query:
+  - all-path effective distance
+  - minimum hop distance
+  - positive weighted minimum path distance
+  - category influence propagation
 
 - Rust DFS:
   - all-path effective distance
@@ -339,39 +345,38 @@ Command:
 ```bash
 python examples/benchmark/benchmark_category_influence_cross_target.py \
     --scales 300,1k,5k,10k \
-    --targets rust-dfs,go-dfs \
+    --targets csharp-query,rust-dfs,go-dfs \
     --repetitions 1
 ```
 
 Latest local results:
 
-| Scale | Rust DFS | Go DFS | Outputs |
-|-------|---------:|-------:|---------|
-| 300 | 0.356s | 0.487s | match |
-| 1k | 1.447s | 2.112s | match |
-| 5k | 7.860s | 12.857s | match |
-| 10k | 14.604s | 20.421s | match |
+| Scale | C# Query | Rust DFS | Go DFS | Outputs |
+|-------|---------:|---------:|-------:|---------|
+| 300 | 0.673s | 0.384s | 0.488s | match |
+| 1k | 0.484s | 1.500s | 2.022s | match |
+| 5k | 1.399s | 8.036s | 12.318s | match |
+| 10k | 3.861s | 14.450s | 19.990s | match |
 
-Rust speedup vs Go:
+Speedups of C# query engine:
 
-| Scale | Speedup |
-|-------|--------:|
-| 300 | 1.37x |
-| 1k | 1.46x |
-| 5k | 1.64x |
-| 10k | 1.40x |
+| Scale | vs Rust DFS | vs Go DFS |
+|-------|------------:|----------:|
+| 300 | 0.57x | 0.72x |
+| 1k | 3.10x | 4.18x |
+| 5k | 5.74x | 8.80x |
+| 10k | 3.74x | 5.18x |
 
 Comparison note:
 
-- this benchmark currently compares Rust and Go only
-- C# is intentionally not part of this runner yet
-- reason:
-  there is not yet a like-for-like `category_influence` benchmark path in
-  the C# query-engine harness, so including C# here would mix execution
-  models rather than isolating target-pipeline behavior
-- the current purpose of this runner is to validate the newly added
-  grouped/correlated aggregate compilation surface across non-query
-  targets before deciding how C# should join the same workload
+- the benchmark now includes a dedicated C# query-engine path
+- that path uses `QueryRuntime` for the recursive `category_ancestor`
+  expansion and performs the outer grouped sum in-process
+- Rust and Go remain generated DFS/pipeline binaries
+- so this runner is intentionally a mixed execution-model comparison:
+  query engine versus non-query target pipelines
+- the current C# path is weaker than Rust/Go at `300`, but clearly faster
+  from `1k` onward on the current workload
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 """
-Benchmark category influence propagation across generated Go and Rust binaries.
-
-This runner intentionally excludes the C# query engine for now. The current
-category-influence comparison is about cross-target aggregate/pipeline support,
-and there is not yet a directly comparable C# query-engine workload in the same
-benchmark harness.
+Benchmark category influence propagation across the C# query engine and
+generated Rust/Go binaries.
 """
 
 from __future__ import annotations
@@ -25,8 +21,20 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
+
+CSHARP_PROJECT = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
 
 
 @dataclass
@@ -43,13 +51,23 @@ class RunResult:
         return statistics.median(self.times)
 
 
+def load_root_categories(facts_path: Path) -> list[str]:
+    roots: set[str] = set()
+    for line in facts_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith("root_category("):
+            inner = line[len("root_category("):-2]
+            roots.add(inner.strip("'"))
+    return sorted(roots) or ["Physics"]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scales", default="300,1k,5k,10k")
     parser.add_argument(
         "--targets",
-        default="rust-dfs,go-dfs",
-        help="Comma-separated targets: rust-dfs,go-dfs",
+        default="csharp-query,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-query,rust-dfs,go-dfs",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -82,6 +100,9 @@ def scale_sort_key(scale: str) -> tuple[int, str]:
 def available_targets(requested: list[str]) -> list[str]:
     targets: list[str] = []
     for target in requested:
+        if target == "csharp-query" and shutil.which("dotnet") is None:
+            print("skip csharp-query: dotnet not found", file=sys.stderr)
+            continue
         if target == "rust-dfs" and shutil.which("rustc") is None:
             print("skip rust-dfs: rustc not found", file=sys.stderr)
             continue
@@ -111,6 +132,188 @@ def generate_pipeline_source(root: Path, target: str) -> Path:
         ]
     )
     return output
+
+
+def generate_csharp_query_program(root_categories: list[str]) -> str:
+    root_entries = ", ".join(f'"{root}"' for root in root_categories)
+    return f"""// Category influence benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const double N = 5.0;
+    const int MAX_DEPTH = 10;
+    static readonly HashSet<string> ROOTS = new(new[] {{ {root_entries} }}, StringComparer.Ordinal);
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_ancestor", 3);
+        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }}
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {{
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }}
+
+            categories.Add(parts[1]);
+        }}
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.All),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {{
+            foreach (var category in categories)
+            {{
+                uniqueSeeds.Add(category);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] {{ category }})
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var hops = Convert.ToInt32(row[2], CultureInfo.InvariantCulture);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {{
+                bucket = new List<(string, int)>();
+                ancestorIndex[source] = bucket;
+            }}
+
+            bucket.Add((ancestor, hops));
+        }}
+
+        var influence = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var (_, categories) in articleCategories.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+        {{
+            foreach (var category in categories)
+            {{
+                if (ROOTS.Contains(category))
+                {{
+                    influence[category] = influence.TryGetValue(category, out var score) ? score + 1.0 : 1.0;
+                }}
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {{
+                    continue;
+                }}
+
+                foreach (var (ancestor, hops) in ancestors)
+                {{
+                    if (!ROOTS.Contains(ancestor))
+                    {{
+                        continue;
+                    }}
+
+                    var distance = hops + 1;
+                    var weight = Math.Pow(distance, -N);
+                    influence[ancestor] = influence.TryGetValue(ancestor, out var score) ? score + weight : weight;
+                }}
+            }}
+        }}
+        swAgg.Stop();
+        swTotal.Stop();
+
+        var results = influence
+            .Where(kvp => kvp.Value > 0.0)
+            .OrderByDescending(kvp => kvp.Value)
+            .ThenBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .ToList();
+
+        Console.WriteLine("root_category\\tinfluence_score");
+        foreach (var (root, score) in results)
+        {{
+            Console.WriteLine($"{{root}}\\t{{score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
+        }}
+
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"root_count={{results.Count}}");
+    }}
+}}
+"""
+
+
+def build_csharp_query(root: Path) -> list[str]:
+    project_dir = root / "csharp_query"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    roots = load_root_categories(FACTS_PATH)
+    (project_dir / "Program.cs").write_text(generate_csharp_query_program(roots), encoding="utf-8")
+    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+    (project_dir / "benchmark_qe.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
+    run(["dotnet", "build", "benchmark_qe.csproj", "-c", "Release"], cwd=project_dir)
+    return [
+        "dotnet",
+        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_qe.dll"),
+    ]
 
 
 def build_rust_dfs(root: Path) -> list[str]:
@@ -191,13 +394,22 @@ def print_summary(results: list[RunResult]) -> None:
         if len(entries) > 1:
             hashes = {item.stdout_sha256 for item in entries}
             print(f"{scale}\toutputs\t{'match' if len(hashes) == 1 else 'MISMATCH'}")
+            csharp = next((item for item in entries if item.target == "csharp-query"), None)
             rust = next((item for item in entries if item.target == "rust-dfs"), None)
             go = next((item for item in entries if item.target == "go-dfs"), None)
+            if csharp and rust:
+                print(f"{scale}\tspeedup_vs_rust_dfs\t{rust.median / csharp.median:.2f}x")
+            if csharp and go:
+                print(f"{scale}\tspeedup_vs_go_dfs\t{go.median / csharp.median:.2f}x")
             if rust and go:
                 faster = "rust-dfs" if rust.median < go.median else "go-dfs"
                 speedup = (go.median / rust.median) if faster == "rust-dfs" else (rust.median / go.median)
                 print(f"{scale}\tfaster_target\t{faster}")
                 print(f"{scale}\tspeedup\t{speedup:.2f}x")
+            if csharp and csharp.stderr:
+                phase_lines = [line.strip() for line in csharp.stderr.splitlines() if "=" in line]
+                if phase_lines:
+                    print(f"{scale}\tcsharp-query-metrics\t" + " ".join(phase_lines))
 
 
 def main() -> int:
@@ -218,7 +430,9 @@ def main() -> int:
     try:
         commands: dict[str, list[str]] = {}
         for target in targets:
-            if target == "rust-dfs":
+            if target == "csharp-query":
+                commands[target] = build_csharp_query(temp_root)
+            elif target == "rust-dfs":
                 commands[target] = build_rust_dfs(temp_root)
             elif target == "go-dfs":
                 commands[target] = build_go_dfs(temp_root)


### PR DESCRIPTION
  ## Summary

  This PR brings `category_influence` into the C# query-engine benchmark
  surface.

  The existing cross-target runner for category influence previously
  compared only:

  - `rust-dfs`
  - `go-dfs`

  This PR adds:

  - `csharp-query`

  using a dedicated query-engine benchmark path that keeps the recursive
  work in `QueryRuntime` and performs only the outer grouped influence
  aggregation in-process.

  ## What Changed

  ### Category-Influence Cross-Target Runner

  Extended:

  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  The runner now supports:

  - `csharp-query`
  - `rust-dfs`
  - `go-dfs`

  It builds a small C# query-engine benchmark binary on demand and reports:

  - timing
  - normalized output hashes
  - row counts
  - C# query-engine phase metrics
  - speedups of C# query vs Rust/Go DFS

  ### C# Query-Engine Benchmark Path

  The new C# benchmark path is implemented directly in the benchmark runner
  as a generated `Program.cs` plus the existing `QueryRuntime.cs`.

  It:

  1. loads `category_parent.tsv` and `article_category.tsv`
  2. runs `PathAwareTransitiveClosureNode(..., TableMode.All)` over
     `category_parent/2`
  3. uses the resulting `category_ancestor` rows to compute the weighted
     category influence sum for each root

  This keeps the expensive recursive enumeration inside the query engine
  instead of degrading to a plain C# DFS pipeline.

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now documents:

  - the new `csharp-query` category-influence target
  - updated command examples
  - current local `300/1k/5k/10k` results
  - the fact that this runner is now intentionally a mixed execution-model
    comparison:
    - C# query engine
    - Rust/Go generated DFS/pipeline binaries

  ## Why This Matters

  If `category_influence` is an important grouped/correlated aggregate
  pattern for Rust and Go, it should also be represented on the C# side.

  This PR does that without abandoning the query engine.

  Instead of treating C# as “not comparable yet,” the benchmark now
  includes a C# query-engine implementation of the same workload family so
  we can see how the recursive query runtime behaves against the current
  non-query target pipelines.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile examples/benchmark/benchmark_category_influence_cross_target.py

  Benchmarks run locally:

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 1k,5k,10k \
      --repetitions 1

  ## Results

  | Scale | C# Query | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---|
  | 300 | 0.673s | 0.384s | 0.488s | match |
  | 1k | 0.484s | 1.500s | 2.022s | match |
  | 5k | 1.399s | 8.036s | 12.318s | match |
  | 10k | 3.861s | 14.450s | 19.990s | match |

  Speedups of C# query engine:

  | Scale | vs Rust DFS | vs Go DFS |
  |---|---:|---:|
  | 300 | 0.57x | 0.72x |
  | 1k | 3.10x | 4.18x |
  | 5k | 5.74x | 8.80x |
  | 10k | 3.74x | 5.18x |

  ## Interpretation

  The new C# category-influence benchmark path is:

  - correct
  - output-matching
  - weaker than Rust/Go at 300
  - clearly faster from 1k onward

  So the query engine does recover a meaningful advantage at larger scales,
  even for this grouped/correlated aggregate workload.

  ## Scope

  This PR adds benchmark coverage, not a new general-purpose compiler path
  for category_influence/2 in C# query mode.

  The benchmarked C# implementation uses:

  - query-engine recursion for category_ancestor
  - in-process aggregation for the final root influence totals

  That is a deliberate benchmarking bridge so we can compare this workload
  now while broader aggregate/query integration continues to evolve.