### PR TITLE
Document native TypR per-path invariant guard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,9 @@ includes:
   seeded step relation and detected `Visited` position lower to a native TypR
   recursive worker that returns nested pair results with one direct node
   output and one or more additive numeric outputs; this path now supports one
-  recursion-driving input plus conservative invariant non-visited inputs, and
-  it also emits a native
+  recursion-driving input plus conservative invariant non-visited inputs,
+  including one helper/guard segment between the step relation and recursive
+  call, and it also emits a native
   `*_from_vectors` runtime helper, native `input(stdin|file|vfs|function)`
   wrappers, and declared scalar or conservative pair-shaped runtime node
   parsing such as `integer`, `number`, `pair(integer, integer)`, and
@@ -406,8 +407,7 @@ TypR annotation modes are regression-covered too:
   signatures more often than the checker does
 - per-path unique-path work also has a dedicated TypR design note:
   [docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md](docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md)
-  which records the next intended move: invariant-input helper/guard support
-  first, then path-aware aggregation slices
+  which now records path-aware aggregation as the next intended TypR move
 
 Worked example:
 - [Typed R/TypR Return Types](docs/examples/typed_r_typr_return_types.md)

--- a/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
+++ b/docs/design/TYPE_SYSTEM_IMPL_PLAN.md
@@ -148,9 +148,10 @@ bring-up.
   moved-input variants, and weighted variants such as
   `category_ancestor_weight/5`, with compile-time fact seeding, a detected
   `Visited` position, one recursion-driving input plus conservative invariant
-  non-visited inputs, and native TypR nested pair results for the direct node
-  output plus one or more additive numeric outputs; the same slice now also
-  emits a native `*_from_vectors` runtime helper, native
+  non-visited inputs, including one helper/guard segment between the step
+  relation and recursive call, and native TypR nested pair results for the
+  direct node output plus one or more additive numeric outputs; the same
+  slice now also emits a native `*_from_vectors` runtime helper, native
   `input(stdin|file|vfs|function)` wrappers, and declared scalar or
   conservative pair-shaped runtime node parsing such as `integer`, `number`,
   `pair(integer, integer)`, and `pair(number, number)`

--- a/docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md
+++ b/docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md
@@ -52,13 +52,13 @@ Primary implementation points:
 
 ## Current Boundary
 
-The next unsupported TypR slice is not loader-related. It is richer path-state
-control between the step relation and the recursive call.
+The first helper/guard slice between the step relation and the recursive call
+now stays native in TypR.
 
-The first real missing cases are:
+The next real missing cases are:
 
-- helper or guard goals over invariant inputs between step and recursive call
 - broader invariant-input threading beyond the current conservative shape
+- multiple helper/guard stages or richer branch-local path-state control
 - runtime-backed step relations that still preserve path-local uniqueness
 
 Examples:
@@ -138,26 +138,10 @@ worker(State, Invariants, Visited) ->
 That is enough to cover the next slice without committing yet to a full generic
 path-state IR.
 
-## Recommended Next Implementation Slice
-
-Recommended branch:
-
-- `feature/typr-per-path-invariant-guards-audit`
-
-Scope:
-
-- compile-time-seeded step relation first
-- scalar node IDs first
-- native TypR worker path only
-- one helper/guard segment between step and recursive call
-- no broader runtime loader expansion in the same branch
-
-That is the smallest slice that actually moves the boundary.
-
 ## Aggregation-Oriented Follow-Up
 
-After invariant guards, the next high-signal per-path extension should not be
-more loader work. It should be the first path-aware aggregation shape.
+With invariant guards in place, the next high-signal per-path extension should
+not be more loader work. It should be the first path-aware aggregation shape.
 
 Conservative candidates:
 

--- a/docs/design/TYPR_TARGET_DESIGN.md
+++ b/docs/design/TYPR_TARGET_DESIGN.md
@@ -441,13 +441,14 @@ Current implementation note:
   moved-input variants, weighted variants such as
   `category_ancestor_weight/5`, and conservative invariant-input variants,
   with a compile-time-seeded step relation, one recursion-driving input plus
-  conservative invariant non-visited inputs, one direct node output, one or
-  more additive numeric outputs, a native recursive worker that returns
-  nested pair results without raw R, a native `*_from_vectors` runtime
-  helper, native `input(stdin|file|vfs|function)` wrappers, and declared
-  scalar or conservative pair-shaped runtime node parsing such as `integer`,
-  `number`, `pair(integer, integer)`, and `pair(number, number)` over the
-  same step-relation shape
+  conservative invariant non-visited inputs, including one helper/guard
+  segment between the step relation and recursive call, one direct node
+  output, one or more additive numeric outputs, a native recursive worker
+  that returns nested pair results without raw R, a native `*_from_vectors`
+  runtime helper, native `input(stdin|file|vfs|function)` wrappers, and
+  declared scalar or conservative pair-shaped runtime node parsing such as
+  `integer`, `number`, `pair(integer, integer)`, and
+  `pair(number, number)` over the same step-relation shape
 - the native generic TypR path is intentionally conservative and currently
   targets simple output-producing binding chains, guard-style command
   predicates, including unary TypR-safe I/O commands such as `cat/1` and
@@ -531,8 +532,7 @@ Current wrapped-fallback boundary note:
   signatures
 - per-path unique-path work has a dedicated TypR design note in
   [TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md](/home/s243a/Projects/UnifyWeaver/context/antigravity/UnifyWeaver/docs/design/TYPR_PER_PATH_UNIQUE_PATH_DESIGN.md),
-  which defines the next TypR step as invariant-input helper/guard support
-  ahead of broader path-aware aggregation
+  which now defines path-aware aggregation as the next TypR step
 - the remaining wrapped fallback boundary is now beyond that first
   producer-follow-on slice
 - if this area is revisited again, the next real audit target is the next

--- a/src/unifyweaver/core/advanced/pattern_matchers.pl
+++ b/src/unifyweaver/core/advanced/pattern_matchers.pl
@@ -724,10 +724,12 @@ is_per_path_visited_pattern(Name, Arity, Clauses, VisitedPos) :-
     between(1, Arity, VisitedPos),
     nth1(VisitedPos, RecArgs, VisitedVar),
     var(VisitedVar),
-    % Check: body has \+ member(_, VisitedVar)
-    body_has_negated_member(RecBody, VisitedVar),
-    % Check: body has [_|VisitedVar] passed to recursive call
-    body_has_cons_in_recursive_call(RecBody, Name, VisitedPos, VisitedVar),
+    % Check: body has the ordered unique-path shape
+    %   StepGoal,
+    %   PreGoals...,
+    %   \+ member(_, Visited),
+    %   pred(..., [_|Visited]),
+    body_has_ordered_per_path_shape(RecBody, Name, VisitedPos, VisitedVar),
     !.
 
 %% is_recursive_clause_for_ppv(+Name, +Clause)
@@ -747,6 +749,42 @@ body_has_negated_member(\+ member(_, Var), ListVar) :-
 %%   True if the recursive call to Name has [_|VisitedVar] at position Pos.
 body_has_cons_in_recursive_call(Body, Name, Pos, VisitedVar) :-
     extract_goals_ppv(Body, Goals),
+    member(RecCall, Goals),
+    RecCall =.. [Name|CallArgs],
+    nth1(Pos, CallArgs, CallArg),
+    nonvar(CallArg),
+    CallArg = [_|Tail],
+    Tail == VisitedVar.
+
+%% body_has_ordered_per_path_shape(+Body, +Name, +Pos, +VisitedVar)
+%%   True if Body has a non-recursive step goal, optional helper goals,
+%%   then \+ member(_, VisitedVar), and later a recursive call passing
+%%   [_|VisitedVar] at position Pos.
+body_has_ordered_per_path_shape(Body, Name, Pos, VisitedVar) :-
+    extract_goals_ppv(Body, Goals),
+    append(BeforeNeg, [NegGoal|AfterNeg], Goals),
+    BeforeNeg \= [],
+    negated_member_goal_for_ppv(NegGoal, VisitedVar),
+    has_step_goal_before_neg(BeforeNeg, Name, VisitedVar),
+    goals_have_cons_in_recursive_call(AfterNeg, Name, Pos, VisitedVar).
+
+negated_member_goal_for_ppv(\+ member(_, Var), VisitedVar) :-
+    Var == VisitedVar.
+
+has_step_goal_before_neg([Goal|_], Name, VisitedVar) :-
+    step_goal_for_ppv(Goal, Name, VisitedVar),
+    !.
+has_step_goal_before_neg([_|Rest], Name, VisitedVar) :-
+    has_step_goal_before_neg(Rest, Name, VisitedVar).
+
+step_goal_for_ppv(Goal, Name, _VisitedVar) :-
+    callable(Goal),
+    Goal \= (\+ _),
+    Goal =.. [Functor|_],
+    Functor \= Name,
+    Functor \= member.
+
+goals_have_cons_in_recursive_call(Goals, Name, Pos, VisitedVar) :-
     member(RecCall, Goals),
     RecCall =.. [Name|CallArgs],
     nth1(Pos, CallArgs, CallArg),

--- a/src/unifyweaver/targets/typr_target.pl
+++ b/src/unifyweaver/targets/typr_target.pl
@@ -5035,6 +5035,8 @@ typr_per_path_visited_spec(
         from_nodes_expr=FromNodesExpr,
         to_nodes_expr=ToNodesExpr,
         invariant_param_suffix=InvariantParamSuffix,
+        pre_loop_lines=PreLoopLinesText,
+        loop_guard_expr=LoopGuardExpr,
         base_result_expr=BaseResultExpr,
         recursive_result_expr=RecursiveResultExpr
     ]
@@ -5051,7 +5053,9 @@ typr_per_path_visited_spec(
         DriverPos,
         InvariantPositions,
         NodeOutputPos,
-        BaseAccumulatorPairs
+        BaseAccumulatorPairs,
+        BasePreGoals,
+        BaseStepVar
     ),
     typr_per_path_visited_recursive_clause(
         RecClause,
@@ -5062,7 +5066,9 @@ typr_per_path_visited_spec(
         VisitedPos,
         OutputPositions,
         NodeOutputPos,
-        RecursiveAccumulatorPairs
+        RecursiveAccumulatorPairs,
+        RecursivePreGoals,
+        RecursiveStepVar
     ),
     resolve_node_type(Pred/Arity, BasePred/2, NodeTypeTerm),
     typr_per_path_visited_supported_node_type(NodeTypeTerm),
@@ -5075,6 +5081,17 @@ typr_per_path_visited_spec(
     base_pair_vectors(Module, BasePred, NodeTypeTerm, FromNodesExpr, ToNodesExpr),
     typr_per_path_visited_invariant_arg_names(InvariantPositions, InvariantArgNames),
     typr_per_path_visited_param_suffix(InvariantArgNames, InvariantParamSuffix),
+    typr_per_path_visited_shared_pre_loop(
+        BasePreGoals,
+        BaseStepVar,
+        RecursivePreGoals,
+        RecursiveStepVar,
+        BaseClause,
+        RecClause,
+        InvariantPositions,
+        PreLoopLinesText,
+        LoopGuardExpr
+    ),
     typr_per_path_visited_base_output_exprs(OutputPositions, NodeOutputPos, BaseAccumulatorPairs, BaseOutputExprs),
     typr_per_path_visited_recursive_output_exprs(OutputPositions, NodeOutputPos, RecursiveAccumulatorPairs, RecursiveOutputExprs),
     typr_per_path_visited_result_expr(BaseOutputExprs, BaseResultExpr),
@@ -5148,21 +5165,25 @@ typr_per_path_visited_base_clause(
     DriverPos,
     InvariantPositions,
     NodeOutputPos,
-    BaseAccumulatorPairs
+    BaseAccumulatorPairs,
+    BasePreGoals,
+    BaseStepVar
 ) :-
     Head =.. [Pred|HeadArgs],
     nth1(VisitedPos, HeadArgs, VisitedVar),
     var(VisitedVar),
     typr_mutual_goal_list(Body0, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
-    typr_per_path_visited_base_goals(Goals, StepInputVar, VisitedVar, BasePred, StepOutputVar),
+    typr_per_path_visited_base_goals(Goals, StepInputVar, VisitedVar, BasePred, StepOutputVar, BasePreGoals),
+    BaseStepVar = StepOutputVar,
     typr_per_path_visited_driver_and_invariants(InputPositions, HeadArgs, StepInputVar, DriverPos, InvariantPositions),
     typr_per_path_visited_node_output_position(HeadArgs, OutputPositions, StepOutputVar, NodeOutputPos),
     typr_per_path_visited_base_accumulator_pairs(HeadArgs, OutputPositions, NodeOutputPos, BaseAccumulatorPairs).
 
-typr_per_path_visited_base_goals([StepGoal], InputVar, _VisitedVar, BasePred, OutputVar) :-
+typr_per_path_visited_base_goals([StepGoal], InputVar, _VisitedVar, BasePred, OutputVar, []) :-
     typr_per_path_visited_step_goal(StepGoal, InputVar, OutputVar, BasePred).
-typr_per_path_visited_base_goals([StepGoal, NegGoal], InputVar, VisitedVar, BasePred, OutputVar) :-
+typr_per_path_visited_base_goals(Goals, InputVar, VisitedVar, BasePred, OutputVar, PreGoals) :-
+    append([StepGoal|PreGoals], [NegGoal], Goals),
     typr_per_path_visited_step_goal(StepGoal, InputVar, OutputVar, BasePred),
     typr_per_path_visited_negated_member_goal(NegGoal, OutputVar, VisitedVar).
 
@@ -5175,7 +5196,9 @@ typr_per_path_visited_recursive_clause(
     VisitedPos,
     OutputPositions,
     NodeOutputPos,
-    RecursiveAccumulatorPairs
+    RecursiveAccumulatorPairs,
+    RecursivePreGoals,
+    RecursiveStepVar
 ) :-
     Head =.. [Pred|HeadArgs],
     nth1(DriverPos, HeadArgs, InputVar),
@@ -5184,9 +5207,12 @@ typr_per_path_visited_recursive_clause(
     var(VisitedVar),
     typr_mutual_goal_list(Body0, Goals0),
     maplist(typr_strip_module_goal, Goals0, Goals),
-    append([StepGoal, NegGoal, RecCallGoal], AccumulatorGoals, Goals),
+    append([StepGoal|PreAndRestGoals], GoalsTail, Goals),
+    append(RecursivePreGoals, [NegGoal, RecCallGoal], PreAndRestGoals),
+    append(AccumulatorGoals, [], GoalsTail),
     AccumulatorGoals \= [],
     typr_per_path_visited_mid_step_goal(StepGoal, InputVar, MidVar, BasePred),
+    RecursiveStepVar = MidVar,
     typr_per_path_visited_negated_member_goal(NegGoal, MidVar, VisitedVar),
     typr_per_path_visited_recursive_call(
         RecCallGoal,
@@ -5360,6 +5386,55 @@ typr_per_path_visited_param_suffix([], '').
 typr_per_path_visited_param_suffix(Names, Suffix) :-
     atomic_list_concat(Names, ', ', Inner),
     format(string(Suffix), ', ~w', [Inner]).
+
+typr_per_path_visited_shared_pre_loop(
+    BasePreGoals,
+    BaseStepVar,
+    RecursivePreGoals,
+    RecursiveStepVar,
+    BaseHead-_BaseBody,
+    RecHead-_RecBody,
+    InvariantPositions,
+    PreLoopLinesText,
+    LoopGuardExpr
+) :-
+    typr_per_path_visited_pre_loop_text(BasePreGoals, BaseHead, InvariantPositions, BaseStepVar, BaseLinesText, BaseGuardExpr),
+    typr_per_path_visited_pre_loop_text(RecursivePreGoals, RecHead, InvariantPositions, RecursiveStepVar, RecursiveLinesText, RecursiveGuardExpr),
+    BaseLinesText = RecursiveLinesText,
+    BaseGuardExpr = RecursiveGuardExpr,
+    PreLoopLinesText = BaseLinesText,
+    LoopGuardExpr = BaseGuardExpr.
+
+typr_per_path_visited_pre_loop_text([], _BaseHead, _InvariantPositions, _StepVar, '', 'TRUE') :-
+    !.
+typr_per_path_visited_pre_loop_text(PreGoals, BaseHead, InvariantPositions, StepVar, PreLoopLinesText, LoopGuardExpr) :-
+    BaseHead =.. [_|HeadArgs],
+    typr_per_path_visited_pre_goal_varmap(HeadArgs, InvariantPositions, StepVar, VarMap0),
+    typr_goals_to_body(PreGoals, PreBody),
+    compile_tail_recursive_pre_goals(PreBody, VarMap0, _VarMap, GuardConditions, StepLines0),
+    raw_guard_expr(GuardConditions, LoopGuardExpr),
+    typr_per_path_visited_pre_lines_text(StepLines0, PreLoopLinesText).
+
+typr_per_path_visited_pre_goal_varmap(HeadArgs, InvariantPositions, StepVar, [StepVar-"next_node"|InvariantVarMap]) :-
+    typr_per_path_visited_invariant_varmap(InvariantPositions, HeadArgs, InvariantVarMap).
+
+typr_per_path_visited_invariant_varmap([], _HeadArgs, []).
+typr_per_path_visited_invariant_varmap([Pos|Rest], HeadArgs, [HeadVar-Name|RestMap]) :-
+    nth1(Pos, HeadArgs, HeadVar),
+    format(string(Name), 'arg~w', [Pos]),
+    typr_per_path_visited_invariant_varmap(Rest, HeadArgs, RestMap).
+
+typr_per_path_visited_pre_lines_text([], '').
+typr_per_path_visited_pre_lines_text(Lines0, Text) :-
+    maplist(typr_per_path_visited_trim_pre_line, Lines0, Lines),
+    atomic_list_concat(Lines, '\n', Joined),
+    format(string(Text), '~w\n', [Joined]).
+
+typr_per_path_visited_trim_pre_line(Line0, Line) :-
+    (   sub_string(Line0, 0, 8, _, "        ")
+    ->  sub_string(Line0, 8, _, 0, Line)
+    ;   Line = Line0
+    ).
 
 typr_per_path_visited_result_extract_expr(ResultExpr, 1, 1, ResultExpr) :- !.
 typr_per_path_visited_result_extract_expr(ResultExpr, 1, _OutputCount, ExtractExpr) :-

--- a/templates/targets/typr/per_path_visited.mustache
+++ b/templates/targets/typr/per_path_visited.mustache
@@ -25,7 +25,7 @@ let {{pred}}_worker <- function(current, visited{{invariant_param_suffix}}, from
 	neighbors <- {{base}}_neighbors(current, from_nodes, to_nodes);
 
 	for (next_node in neighbors) {
-		if (!any(visited == next_node)) {
+{{pre_loop_lines}}		if (({{loop_guard_expr}}) && !any(visited == next_node)) {
 			results <- c(results, {{base_result_expr}});
 			sub_results <- {{pred}}_worker(next_node, c(visited, next_node){{invariant_param_suffix}}, from_nodes, to_nodes);
 

--- a/templates/targets/typr/ppv_definitions.mustache
+++ b/templates/targets/typr/ppv_definitions.mustache
@@ -48,7 +48,7 @@ let {{pred}}_worker <- function(current, visited{{invariant_param_suffix}}, from
 	neighbors <- {{base}}_neighbors(current, from_nodes, to_nodes);
 
 	for (next_node in neighbors) {
-		if (!any(visited == next_node)) {
+{{pre_loop_lines}}		if (({{loop_guard_expr}}) && !any(visited == next_node)) {
 			results <- c(results, {{base_result_expr}});
 			sub_results <- {{pred}}_worker(next_node, c(visited, next_node){{invariant_param_suffix}}, from_nodes, to_nodes);
 

--- a/tests/test_typr_target.pl
+++ b/tests/test_typr_target.pl
@@ -5721,4 +5721,36 @@ test(recursive_compiler_supports_typr_invariant_per_path_visited_function_input_
     \+ sub_string(Code, _, _, _, "@{"),
     generated_typr_is_valid(Code, exit(0)).
 
+test(recursive_compiler_supports_typr_invariant_guarded_per_path_visited_recursion) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_guarded(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_guarded(_, _, _, _, _))),
+    assertz(user:category_parent(a, b)),
+    assertz(user:category_parent(b, c)),
+    assertz(user:mode(category_ancestor_guarded(+, +, -, -, +))),
+    assertz(user:(category_ancestor_guarded(Cat, Limit, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        Allowed is Limit - 1,
+        Parent =< Allowed,
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_guarded(Cat, Limit, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        Allowed is Limit - 1,
+        Mid =< Allowed,
+        \+ member(Mid, Visited),
+        category_ancestor_guarded(Mid, Limit, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_guarded/5, [target(typr), typed_mode(explicit)], Code)),
+    once(sub_string(Code, _, _, _, "let category_ancestor_guarded_worker <- function(current, visited, arg2, from_nodes, to_nodes)")),
+    once(sub_string(Code, _, _, _, "step_1 = (arg2 + -1);")),
+    once(sub_string(Code, _, _, _, "if ((next_node <= step_1) && !any(visited == next_node)) {")),
+    once(sub_string(Code, _, _, _, "sub_results <- category_ancestor_guarded_worker(next_node, c(visited, next_node), arg2, from_nodes, to_nodes);")),
+    \+ sub_string(Code, _, _, _, "@{"),
+    generated_typr_is_valid(Code, exit(0)).
+
 :- end_tests(typr_target).

--- a/tests/test_typr_toolchain.pl
+++ b/tests/test_typr_toolchain.pl
@@ -4739,6 +4739,44 @@ test(invariant_per_path_visited_function_input_checks_with_typr, [condition(typr
     retractall(user:category_ancestor_limited_fn(_, _, _, _, _)),
     retractall(user:mode(category_ancestor_limited_fn(_, _, _, _, _))).
 
+test(invariant_guarded_per_path_visited_output_checks_with_typr, [condition(typr_cli_available)]) :-
+    clear_type_declarations,
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_guarded(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_guarded(_, _, _, _, _))),
+    assertz(user:category_parent(a, b)),
+    assertz(user:category_parent(b, c)),
+    assertz(user:mode(category_ancestor_guarded(+, +, -, -, +))),
+    assertz(user:(category_ancestor_guarded(Cat, Limit, Parent, 1, Visited) :-
+        category_parent(Cat, Parent),
+        Allowed is Limit - 1,
+        Parent =< Allowed,
+        \+ member(Parent, Visited)
+    )),
+    assertz(user:(category_ancestor_guarded(Cat, Limit, Ancestor, Hops, Visited) :-
+        category_parent(Cat, Mid),
+        Allowed is Limit - 1,
+        Mid =< Allowed,
+        \+ member(Mid, Visited),
+        category_ancestor_guarded(Mid, Limit, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1
+    )),
+    assertz(type_declarations:uw_type(category_parent/2, 1, atom)),
+    assertz(type_declarations:uw_type(category_parent/2, 2, atom)),
+    once(recursive_compiler:compile_recursive(category_ancestor_guarded/5, [target(typr), typed_mode(explicit)], Code)),
+    setup_call_cleanup(
+        create_smoke_project(ProjectDir),
+        (
+            write_generated_typr_program(ProjectDir, Code),
+            run_typr(ProjectDir, ['check']),
+            maybe_build_with_r(ProjectDir)
+        ),
+        delete_directory_and_contents(ProjectDir)
+    ),
+    retractall(user:category_parent(_, _)),
+    retractall(user:category_ancestor_guarded(_, _, _, _, _)),
+    retractall(user:mode(category_ancestor_guarded(_, _, _, _, _))).
+
 :- end_tests(typr_toolchain).
 
 typr_cli_available :-


### PR DESCRIPTION
## Summary
This PR adds native TypR support for the next unique-path per-path recursion slice after invariant-input threading: a guarded helper segment between the step relation and the recursive call.

Concretely, TypR now keeps conservative guarded per-path recursion native for shapes where the recursive clause has this order:
- a step goal
- one helper or guard segment over invariant inputs
- a visited check such as `\\+ member(Next, Visited)`
- a recursive call with `[Next|Visited]`

This closes the first real unique-path gap documented in the per-path design work.

## What Changed
- widened shared per-path pattern detection to recognize the ordered guarded shape
- added native TypR lowering for one helper/guard segment between the step relation and recursive call
- fixed two implementation bugs in the new path:
  - invariant varmap construction was copying head vars and breaking identity
  - recursive pre-loop rendering was using the base head instead of the recursive head
- updated TypR per-path templates so helper lines and guard conditions render inside the native worker loop
- added target-level and toolchain-level regression coverage for guarded per-path recursion
- updated the TypR per-path design docs to record this slice as supported and point next toward path-aware aggregation

## Example Supported Shape
This branch supports conservative cases like:
- `Allowed is Limit - 1`
- `Mid =< Allowed`
- then visited check and recursive call

without dropping back to wrapped fallback or raw R.

## Validation
- `swipl -q -g "run_tests([typr_target:recursive_compiler_supports_typr_invariant_guarded_per_path_visited_recursion])" -t halt tests/test_typr_target.pl`
- `swipl -q -g "run_tests([typr_toolchain:invariant_guarded_per_path_visited_output_checks_with_typr])" -t halt tests/test_typr_toolchain.pl`
- `swipl -q -g run_tests -t halt tests/type_declarations_test.pl`
- `swipl -q -g run_tests -t halt tests/test_typr_target.pl`
- `swipl -q -g run_tests -t halt tests/test_typr_toolchain.pl`
- `git diff --check`

## Follow-Up
The next high-signal TypR step is path-aware aggregation, not more loader work.
