### PR TITLE
feat(csharp-query): push category influence into aggregate runtime

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -353,30 +353,33 @@ Latest local results:
 
 | Scale | C# Query | Rust DFS | Go DFS | Outputs |
 |-------|---------:|---------:|-------:|---------|
-| 300 | 0.673s | 0.384s | 0.488s | match |
-| 1k | 0.484s | 1.500s | 2.022s | match |
-| 5k | 1.399s | 8.036s | 12.318s | match |
-| 10k | 3.861s | 14.450s | 19.990s | match |
+| 300 | 0.662s | 0.394s | 0.490s | match |
+| 1k | 0.517s | 1.531s | 2.125s | match |
+| 5k | 1.695s | 7.854s | 12.580s | match |
+| 10k | 4.661s | 15.703s | 21.378s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs Rust DFS | vs Go DFS |
 |-------|------------:|----------:|
-| 300 | 0.57x | 0.72x |
-| 1k | 3.10x | 4.18x |
-| 5k | 5.74x | 8.80x |
-| 10k | 3.74x | 5.18x |
+| 300 | 0.59x | 0.74x |
+| 1k | 2.96x | 4.11x |
+| 5k | 4.63x | 7.42x |
+| 10k | 3.37x | 4.59x |
 
 Comparison note:
 
 - the benchmark now includes a dedicated C# query-engine path
-- that path uses `QueryRuntime` for the recursive `category_ancestor`
-  expansion and performs the outer grouped sum in-process
+- that path now uses `QueryRuntime` for both:
+  - the recursive `category_ancestor` expansion
+  - the outer grouped influence sum via `AggregateNode`
 - Rust and Go remain generated DFS/pipeline binaries
 - so this runner is intentionally a mixed execution-model comparison:
   query engine versus non-query target pipelines
-- the current C# path is weaker than Rust/Go at `300`, but clearly faster
-  from `1k` onward on the current workload
+- pushing the outer grouped sum into query-runtime aggregate machinery did
+  add some overhead versus the earlier ad hoc dictionary aggregation, but
+  the C# path is still weaker only at `300` and clearly faster from `1k`
+  onward on the current workload
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -247,14 +247,22 @@ class Program
             bucket.Add((ancestor, hops));
         }}
 
-        var influence = new Dictionary<string, double>(StringComparer.Ordinal);
+        var rootId = new PredicateId("root_category", 1);
+        var weightId = new PredicateId("article_root_weight", 3);
+        var resultId = new PredicateId("category_influence", 2);
+
+        foreach (var root in ROOTS.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            provider.AddFact(rootId, root);
+        }}
+
         foreach (var (_, categories) in articleCategories.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
         {{
             foreach (var category in categories)
             {{
                 if (ROOTS.Contains(category))
                 {{
-                    influence[category] = influence.TryGetValue(category, out var score) ? score + 1.0 : 1.0;
+                    provider.AddFact(weightId, "_", category, 1.0);
                 }}
 
                 if (!ancestorIndex.TryGetValue(category, out var ancestors))
@@ -271,23 +279,45 @@ class Program
 
                     var distance = hops + 1;
                     var weight = Math.Pow(distance, -N);
-                    influence[ancestor] = influence.TryGetValue(ancestor, out var score) ? score + weight : weight;
+                    provider.AddFact(weightId, "_", ancestor, weight);
                 }}
             }}
         }}
+
+        var aggregatePlan = new QueryPlan(
+            resultId,
+            new ProjectionNode(
+                new SelectionNode(
+                    new AggregateNode(
+                        new RelationScanNode(rootId),
+                        weightId,
+                        AggregateOperation.Sum,
+                        tuple => new object[] {{ Wildcard.Value, tuple[0], Wildcard.Value }},
+                        Array.Empty<int>(),
+                        2,
+                        2),
+                    tuple => QueryExecutor.CompareValues(tuple[1], 0) > 0),
+                tuple => new object[] {{ tuple[0], tuple[1] }}),
+            false,
+            null
+        );
+
+        var aggregateRows = executor.Execute(aggregatePlan).ToList();
         swAgg.Stop();
         swTotal.Stop();
 
-        var results = influence
-            .Where(kvp => kvp.Value > 0.0)
-            .OrderByDescending(kvp => kvp.Value)
-            .ThenBy(kvp => kvp.Key, StringComparer.Ordinal)
+        var results = aggregateRows
+            .Select(row => (
+                Root: row[0]?.ToString() ?? "",
+                Score: Convert.ToDouble(row[1], CultureInfo.InvariantCulture)))
+            .OrderByDescending(item => item.Score)
+            .ThenBy(item => item.Root, StringComparer.Ordinal)
             .ToList();
 
         Console.WriteLine("root_category\\tinfluence_score");
-        foreach (var (root, score) in results)
+        foreach (var item in results)
         {{
-            Console.WriteLine($"{{root}}\\t{{score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Root}}\\t{{item.Score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");

--- a/src/unifyweaver/targets/csharp_target.pl
+++ b/src/unifyweaver/targets/csharp_target.pl
@@ -2616,7 +2616,8 @@ build_aggregate_node(GroupSpecs, HeadSpec, Term0, InputNode, VarMapIn, WidthIn, 
     ;   format(user_error, 'C# query target: aggregate value selector must be a variable (~q).~n', [ValueVar]),
         fail
     ),
-    (   plain_relation_goal(Goal, Pred, Args)
+    (   plain_relation_goal(Goal, Pred, Args),
+        \+ aggregate_goal_requires_subplan(Pred, Args)
     ->  build_simple_aggregate_node(GroupSpecs, HeadSpec, Type, Op, Pred, Args, GroupTerm, ValueVar, ResVar,
             InputNode, VarMapIn, WidthIn, RelationsIn,
             NodeOut, VarMapOut, WidthOut, RelationsOut)
@@ -2624,6 +2625,11 @@ build_aggregate_node(GroupSpecs, HeadSpec, Term0, InputNode, VarMapIn, WidthIn, 
             InputNode, VarMapIn, WidthIn, RelationsIn,
             NodeOut, VarMapOut, WidthOut, RelationsOut)
     ).
+
+aggregate_goal_requires_subplan(Pred, Args) :-
+    length(Args, Arity),
+    query_predicate_has_rule(Pred/Arity),
+    \+ query_materialized_relation(Pred/Arity).
 
 parse_query_aggregate_term(aggregate_all(OpTerm, Goal, Result), all, Op, Goal, _GroupTerm, ValueVar, Result) :-
     nonvar(Goal),

--- a/tests/core/test_csharp_query_target.pl
+++ b/tests/core/test_csharp_query_target.pl
@@ -100,6 +100,11 @@
 :- dynamic user:test_sale_customers_bag/1.
 :- dynamic user:test_sale_alice_or_bob_count/1.
 :- dynamic user:test_sale_alice_or_bob_nested_count/1.
+:- dynamic user:test_ci_root_category/1.
+:- dynamic user:test_ci_article_category/2.
+:- dynamic user:test_ci_category_ancestor/3.
+:- dynamic user:test_ci_article_root_weight/3.
+:- dynamic user:test_ci_category_influence/2.
 :- dynamic user:test_banned/1.
 :- dynamic user:test_allowed/1.
 :- dynamic user:test_blocked/1.
@@ -262,6 +267,7 @@ test_csharp_query_target :-
         verify_aggregate_subplan_avg_with_constraint_plan,
         verify_aggregate_subplan_set_with_negation_plan,
         verify_aggregate_subplan_grouped_sum_with_negation_plan,
+        verify_category_influence_aggregate_subplan_plan,
         verify_negation_plan,
         verify_non_stratified_negation_cycle_rejected,
         verify_stratified_negation_derived_runtime,
@@ -752,6 +758,29 @@ setup_test_data :-
     )),
     assertz(user:(test_non_banned_sale_sum_grouped(Customer, Sum) :-
         aggregate_all(sum(Amount), (test_sale(Customer, Amount), \+ test_banned(Customer)), Customer, Sum)
+    )),
+    assertz(user:test_ci_root_category(science)),
+    assertz(user:test_ci_article_category(a1, science)),
+    assertz(user:test_ci_article_category(a2, physics)),
+    assertz(user:test_ci_category_ancestor(physics, science, 1)),
+    assertz(user:(test_ci_article_root_weight(Article, Root, Weight) :-
+        test_ci_article_category(Article, Cat),
+        test_ci_root_category(Root),
+        Cat = Root,
+        Weight is 1.0
+    )),
+    assertz(user:(test_ci_article_root_weight(Article, Root, Weight) :-
+        test_ci_article_category(Article, Cat),
+        test_ci_root_category(Root),
+        Cat \= Root,
+        test_ci_category_ancestor(Cat, Root, Hops),
+        Hops = 1,
+        Weight is 0.5
+    )),
+    assertz(user:(test_ci_category_influence(Root, Score) :-
+        test_ci_root_category(Root),
+        aggregate_all(sum(W), test_ci_article_root_weight(_, Root, W), Score),
+        Score > 0
     )),
     assertz(user:test_banned(bob)),
     assertz(user:(test_allowed(X) :- test_fact(X, _), \+ test_banned(X))),
@@ -1369,6 +1398,11 @@ cleanup_test_data :-
     retractall(user:test_banned_sale_count(_)),
     retractall(user:test_sale_alice_or_bob_count(_)),
     retractall(user:test_sale_alice_or_bob_nested_count(_)),
+    retractall(user:test_ci_root_category(_)),
+    retractall(user:test_ci_article_category(_, _)),
+    retractall(user:test_ci_category_ancestor(_, _, _)),
+    retractall(user:test_ci_article_root_weight(_, _, _)),
+    retractall(user:test_ci_category_influence(_, _)),
     retractall(user:test_sale_count_filtered_by_customer(_, _)),
     retractall(user:test_non_banned_sale_count_grouped(_, _)),
     retractall(user:test_sale_filtered_sum(_)),
@@ -2194,6 +2228,21 @@ verify_aggregate_subplan_grouped_sum_with_negation_plan :-
     sub_string(Source, _, _, _, 'AggregateOperation.Sum'),
     sub_string(Source, _, _, _, 'NegationNode'),
     maybe_run_query_runtime(Plan, ['alice,15']).
+
+verify_category_influence_aggregate_subplan_plan :-
+    csharp_query_target:build_query_plan(test_ci_category_influence/2, [target(csharp_query)], Plan),
+    get_dict(root, Plan, Root),
+    sub_term(Agg, Root),
+    is_dict(Agg, aggregate),
+    get_dict(op, Agg, sum),
+    get_dict(predicate, Agg, predicate{name:test_ci_article_root_weight, arity:3}),
+    get_dict(group_indices, Agg, []),
+    get_dict(value_index, Agg, 2),
+    sub_term(define_relation{type:define_relation, predicate:predicate{name:test_ci_article_root_weight, arity:3}, plan:_}, Root),
+    csharp_query_target:render_plan_to_csharp(Plan, Source),
+    sub_string(Source, _, _, _, 'DefineRelationNode'),
+    sub_string(Source, _, _, _, 'AggregateNode'),
+    sub_string(Source, _, _, _, 'AggregateOperation.Sum').
 
 verify_parameterized_multi_key_join_runtime :-
     csharp_query_target:build_query_plan(test_sale_item_param/3, [target(csharp_query)], Plan),


### PR DESCRIPTION
  ## Summary

  This PR moves more of the `category_influence` workload into the C# query
  engine proper.

  Previously, the C# category-influence benchmark path already used
  `QueryRuntime` for recursive `category_ancestor` expansion, but the outer
  root influence sum was still computed in the benchmark harness with a raw
  dictionary aggregation loop.

  This PR improves that in two ways:

  1. it tightens the C# query planner so derived helper predicates under
     `aggregate_all` are routed through the right aggregate path
  2. it updates the benchmark runner so the outer influence sum is also
     executed through query-runtime aggregate machinery

  So the benchmark now reflects a cleaner query-engine execution path for
  this workload.

  ## What Changed

  ### C# Query Planner

  Updated:

  - `src/unifyweaver/targets/csharp_target.pl`

  The aggregate planner now recognizes when an apparently “plain relation”
  aggregate goal is actually a derived helper predicate and should not be
  forced down the base-facts aggregate path.

  Concretely:

  - `aggregate_all(sum(W), article_root_weight(_, Root, W), Score)`

  can now route correctly when `article_root_weight/3` is a derived helper
  predicate rather than only an extensional fact relation.

  This is important for `category_influence`-style workloads where the
  aggregate ranges over a helper relation defined by other rules.

  ### C# Query Regression

  Extended:

  - `tests/core/test_csharp_query_target.pl`

  Added a focused `category_influence`-style query test using:

  - `test_ci_article_root_weight/3`
  - `test_ci_category_influence/2`

  The regression verifies that the normalized shape lowers to a C# query
  plan containing:

  - a defined helper relation for `article_root_weight`
  - an aggregate node over that helper relation
  - the expected aggregate operation (`sum`)

  This keeps the feature grounded in the query target, not only in a
  benchmark harness.

  ### Category-Influence Benchmark Runner

  Updated:

  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  The C# query path no longer performs the outer grouped influence sum with
  an ad hoc Python/C# dictionary loop.

  Instead it now:

  1. runs the recursive `category_ancestor` expansion in `QueryRuntime`
  2. materializes `article_root_weight` facts
  3. runs a second query-runtime plan using `AggregateNode` for the outer
     per-root influence sum

  That means the benchmark uses query-runtime aggregate machinery for both:

  - recursive helper computation
  - outer aggregation

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects:

  - the cleaner C# query execution path
  - refreshed benchmark numbers for the new implementation
  - the tradeoff that this cleaner path adds some overhead versus the prior
    ad hoc outer aggregation loop

  ## Why This Matters

  The previous benchmark was already useful, but it still had an awkward
  split:

  - recursion in the query engine
  - outer aggregation outside the query engine

  This PR narrows that gap.

  It makes the C# `category_influence` benchmark a better representation of
  the actual query-engine aggregate/query machinery rather than relying on
  benchmark-only post-processing for the final sum.

  ## Verification

  ### Focused regression

  Passed locally:

  ```bash
  swipl -q -g "use_module(tests/core/test_csharp_query_target), \
    test_csharp_query_target:setup_test_data, \
    test_csharp_query_target:verify_category_influence_aggregate_subplan_plan, \
    test_csharp_query_target:cleanup_test_data, halt"

  ### Full C# query suite

  Passed locally:

  SKIP_CSHARP_EXECUTION=1 swipl -q -f init.pl -s tests/core/test_csharp_query_target.pl \
    -g "test_csharp_query_target:test_csharp_query_target" -t halt

  Result:

  - 233/233 tests passed

  ### Benchmark runner

  Passed locally:

  python -m py_compile examples/benchmark/benchmark_category_influence_cross_target.py

  python examples/benchmark/benchmark_category_influence_cross_target.py \
    --scales 300 --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
    --scales 1k,5k,10k --repetitions 1

  ## Updated Results

  | Scale | C# Query | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---|
  | 300 | 0.662s | 0.394s | 0.490s | match |
  | 1k | 0.517s | 1.531s | 2.125s | match |
  | 5k | 1.695s | 7.854s | 12.580s | match |
  | 10k | 4.661s | 15.703s | 21.378s | match |

  Speedups of C# query engine:

  | Scale | vs Rust DFS | vs Go DFS |
  |---|---:|---:|
  | 300 | 0.59x | 0.74x |
  | 1k | 2.96x | 4.11x |
  | 5k | 4.63x | 7.42x |
  | 10k | 3.37x | 4.59x |

  ## Interpretation

  Pushing the outer grouped influence sum into query-runtime aggregate
  machinery did add some overhead relative to the earlier benchmark-specific
  dictionary loop.

  But even with that cleaner and more honest execution path, the C# query
  engine still shows strong large-scale performance:

  - it loses only at 300
  - it is already about 3x faster than Rust at 1k
  - it remains materially ahead at 5k and 10k

  So the performance story still holds after moving more of the workload
  into the actual query runtime.

  ## Scope

  This PR improves the C# query path for the benchmark and the planner
  routing around derived aggregate goals.

  It does not yet claim fully general end-to-end compilation of the
  entire category_influence/2 source into a single C# query plan without
  benchmark-side orchestration.

  ## Follow-Up

  Likely next work:

  - keep reducing benchmark-only orchestration around category_influence
  - continue broadening grouped recursive aggregation support in C# query
  - use the same pattern to tighten other aggregate-heavy benchmarks so
    more of their work is represented inside QueryRuntime