### PR TITLE
bench: generate csharp category influence workload

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -353,19 +353,19 @@ Latest local results:
 
 | Scale | C# Query | Rust DFS | Go DFS | Outputs |
 |-------|---------:|---------:|-------:|---------|
-| 300 | 0.662s | 0.394s | 0.490s | match |
-| 1k | 0.517s | 1.531s | 2.125s | match |
-| 5k | 1.695s | 7.854s | 12.580s | match |
-| 10k | 4.661s | 15.703s | 21.378s | match |
+| 300 | 0.675s | 0.387s | 0.502s | match |
+| 1k | 0.574s | 1.571s | 2.148s | match |
+| 5k | 1.714s | 7.786s | 12.386s | match |
+| 10k | 4.063s | 15.057s | 20.739s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs Rust DFS | vs Go DFS |
 |-------|------------:|----------:|
-| 300 | 0.59x | 0.74x |
-| 1k | 2.96x | 4.11x |
-| 5k | 4.63x | 7.42x |
-| 10k | 3.37x | 4.59x |
+| 300 | 0.57x | 0.74x |
+| 1k | 2.74x | 3.74x |
+| 5k | 4.54x | 7.22x |
+| 10k | 3.71x | 5.10x |
 
 Comparison note:
 
@@ -373,12 +373,16 @@ Comparison note:
 - that path now uses `QueryRuntime` for both:
   - the recursive `category_ancestor` expansion
   - the outer grouped influence sum via `AggregateNode`
+- the C# benchmark source is now generated through `generate_pipeline.py`
+  as `target=csharp_query`, instead of being embedded only inside the
+  benchmark runner
 - Rust and Go remain generated DFS/pipeline binaries
 - so this runner is intentionally a mixed execution-model comparison:
   query engine versus non-query target pipelines
-- pushing the outer grouped sum into query-runtime aggregate machinery did
-  add some overhead versus the earlier ad hoc dictionary aggregation, but
-  the C# path is still weaker only at `300` and clearly faster from `1k`
+- the remaining benchmark-only orchestration is therefore smaller now:
+  project wiring plus runtime file inclusion, not a one-off embedded C#
+  workload implementation
+- the C# path is still weaker only at `300` and clearly faster from `1k`
   onward on the current workload
 
 ### Weighted `Min` Results

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -51,16 +51,6 @@ class RunResult:
         return statistics.median(self.times)
 
 
-def load_root_categories(facts_path: Path) -> list[str]:
-    roots: set[str] = set()
-    for line in facts_path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if line.startswith("root_category("):
-            inner = line[len("root_category("):-2]
-            roots.add(inner.strip("'"))
-    return sorted(roots) or ["Physics"]
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scales", default="300,1k,5k,10k")
@@ -114,7 +104,7 @@ def available_targets(requested: list[str]) -> list[str]:
 
 
 def generate_pipeline_source(root: Path, target: str) -> Path:
-    ext = {"rust": ".rs", "go": ".go"}[target]
+    ext = {"csharp_query": ".cs", "rust": ".rs", "go": ".go"}[target]
     filename = f"category_influence{ext}"
     output = root / filename
     run(
@@ -134,209 +124,24 @@ def generate_pipeline_source(root: Path, target: str) -> Path:
     return output
 
 
-def generate_csharp_query_program(root_categories: list[str]) -> str:
-    root_entries = ", ".join(f'"{root}"' for root in root_categories)
-    return f"""// Category influence benchmark (C# query engine)
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using UnifyWeaver.QueryRuntime;
-
-class Program
-{{
-    const double N = 5.0;
-    const int MAX_DEPTH = 10;
-    static readonly HashSet<string> ROOTS = new(new[] {{ {root_entries} }}, StringComparer.Ordinal);
-
-    static void Main(string[] args)
-    {{
-        if (args.Length < 2)
-        {{
-            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
-            Environment.Exit(1);
-        }}
-
-        var swTotal = Stopwatch.StartNew();
-        var swLoad = Stopwatch.StartNew();
-
-        var provider = new InMemoryRelationProvider();
-        var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_ancestor", 3);
-        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {{
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }}
-        }}
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {{
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }}
-
-            categories.Add(parts[1]);
-        }}
-
-        swLoad.Stop();
-
-        var plan = new QueryPlan(
-            predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.All),
-            true,
-            new int[] {{ 0 }}
-        );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var categories in articleCategories.Values)
-        {{
-            foreach (var category in categories)
-            {{
-                uniqueSeeds.Add(category);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds
-            .OrderBy(category => category, StringComparer.Ordinal)
-            .Select(category => new object[] {{ category }})
-            .ToList();
-
-        var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
-        swQuery.Stop();
-
-        var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {{
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var hops = Convert.ToInt32(row[2], CultureInfo.InvariantCulture);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {{
-                bucket = new List<(string, int)>();
-                ancestorIndex[source] = bucket;
-            }}
-
-            bucket.Add((ancestor, hops));
-        }}
-
-        var rootId = new PredicateId("root_category", 1);
-        var weightId = new PredicateId("article_root_weight", 3);
-        var resultId = new PredicateId("category_influence", 2);
-
-        foreach (var root in ROOTS.OrderBy(x => x, StringComparer.Ordinal))
-        {{
-            provider.AddFact(rootId, root);
-        }}
-
-        foreach (var (_, categories) in articleCategories.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
-        {{
-            foreach (var category in categories)
-            {{
-                if (ROOTS.Contains(category))
-                {{
-                    provider.AddFact(weightId, "_", category, 1.0);
-                }}
-
-                if (!ancestorIndex.TryGetValue(category, out var ancestors))
-                {{
-                    continue;
-                }}
-
-                foreach (var (ancestor, hops) in ancestors)
-                {{
-                    if (!ROOTS.Contains(ancestor))
-                    {{
-                        continue;
-                    }}
-
-                    var distance = hops + 1;
-                    var weight = Math.Pow(distance, -N);
-                    provider.AddFact(weightId, "_", ancestor, weight);
-                }}
-            }}
-        }}
-
-        var aggregatePlan = new QueryPlan(
-            resultId,
-            new ProjectionNode(
-                new SelectionNode(
-                    new AggregateNode(
-                        new RelationScanNode(rootId),
-                        weightId,
-                        AggregateOperation.Sum,
-                        tuple => new object[] {{ Wildcard.Value, tuple[0], Wildcard.Value }},
-                        Array.Empty<int>(),
-                        2,
-                        2),
-                    tuple => QueryExecutor.CompareValues(tuple[1], 0) > 0),
-                tuple => new object[] {{ tuple[0], tuple[1] }}),
-            false,
-            null
-        );
-
-        var aggregateRows = executor.Execute(aggregatePlan).ToList();
-        swAgg.Stop();
-        swTotal.Stop();
-
-        var results = aggregateRows
-            .Select(row => (
-                Root: row[0]?.ToString() ?? "",
-                Score: Convert.ToDouble(row[1], CultureInfo.InvariantCulture)))
-            .OrderByDescending(item => item.Score)
-            .ThenBy(item => item.Root, StringComparer.Ordinal)
-            .ToList();
-
-        Console.WriteLine("root_category\\tinfluence_score");
-        foreach (var item in results)
-        {{
-            Console.WriteLine($"{{item.Root}}\\t{{item.Score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
-        }}
-
-        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
-        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
-        Console.Error.WriteLine($"root_count={{results.Count}}");
-    }}
-}}
-"""
-
-
 def build_csharp_query(root: Path) -> list[str]:
     project_dir = root / "csharp_query"
     project_dir.mkdir(parents=True, exist_ok=True)
-    roots = load_root_categories(FACTS_PATH)
-    (project_dir / "Program.cs").write_text(generate_csharp_query_program(roots), encoding="utf-8")
+    output = project_dir / "Program.cs"
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(FACTS_PATH),
+            "--workload",
+            "category_influence",
+            "--target",
+            "csharp_query",
+            "--output",
+            str(output),
+        ]
+    )
     (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
     (project_dir / "benchmark_qe.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
     run(["dotnet", "build", "benchmark_qe.csproj", "-c", "Release"], cwd=project_dir)

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1622,6 +1622,206 @@ fn main() {{
 '''
 
 
+def generate_csharp_query_category_influence(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    roots = sorted(root_cats) if root_cats else ["Physics"]
+    root_entries = ", ".join(f'"{root}"' for root in roots)
+
+    return f'''// Category influence benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const double N = {float(n)};
+    const int MAX_DEPTH = {max_depth};
+    static readonly HashSet<string> ROOTS = new(new[] {{ {root_entries} }}, StringComparer.Ordinal);
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_ancestor", 3);
+        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }}
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {{
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }}
+
+            categories.Add(parts[1]);
+        }}
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.All),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {{
+            foreach (var category in categories)
+            {{
+                uniqueSeeds.Add(category);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] {{ category }})
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var hops = Convert.ToInt32(row[2], CultureInfo.InvariantCulture);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {{
+                bucket = new List<(string, int)>();
+                ancestorIndex[source] = bucket;
+            }}
+
+            bucket.Add((ancestor, hops));
+        }}
+
+        var rootId = new PredicateId("root_category", 1);
+        var weightId = new PredicateId("article_root_weight", 3);
+        var resultId = new PredicateId("category_influence", 2);
+
+        foreach (var root in ROOTS.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            provider.AddFact(rootId, root);
+        }}
+
+        foreach (var (_, categories) in articleCategories.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+        {{
+            foreach (var category in categories)
+            {{
+                if (ROOTS.Contains(category))
+                {{
+                    provider.AddFact(weightId, "_", category, 1.0);
+                }}
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {{
+                    continue;
+                }}
+
+                foreach (var (ancestor, hops) in ancestors)
+                {{
+                    if (!ROOTS.Contains(ancestor))
+                    {{
+                        continue;
+                    }}
+
+                    var distance = hops + 1;
+                    var weight = Math.Pow(distance, -N);
+                    provider.AddFact(weightId, "_", ancestor, weight);
+                }}
+            }}
+        }}
+
+        var aggregatePlan = new QueryPlan(
+            resultId,
+            new ProjectionNode(
+                new SelectionNode(
+                    new AggregateNode(
+                        new RelationScanNode(rootId),
+                        weightId,
+                        AggregateOperation.Sum,
+                        tuple => new object[] {{ Wildcard.Value, tuple[0], Wildcard.Value }},
+                        Array.Empty<int>(),
+                        2,
+                        2),
+                    tuple => QueryExecutor.CompareValues(tuple[1], 0) > 0),
+                tuple => new object[] {{ tuple[0], tuple[1] }}),
+            false,
+            null
+        );
+
+        var aggregateRows = executor.Execute(aggregatePlan).ToList();
+        swAgg.Stop();
+        swTotal.Stop();
+
+        var results = aggregateRows
+            .Select(row => (
+                Root: row[0]?.ToString() ?? "",
+                Score: Convert.ToDouble(row[1], CultureInfo.InvariantCulture)))
+            .OrderByDescending(item => item.Score)
+            .ThenBy(item => item.Root, StringComparer.Ordinal)
+            .ToList();
+
+        Console.WriteLine("root_category\\tinfluence_score");
+        foreach (var item in results)
+        {{
+            Console.WriteLine($"{{item.Root}}\\t{{item.Score.ToString("F12", CultureInfo.InvariantCulture)}}");
+        }}
+
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"root_count={{results.Count}}");
+    }}
+}}
+'''
+
+
 def generate_csharp_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -1758,6 +1958,7 @@ GENERATORS = {
         'csharp': generate_csharp_weighted_shortest_path,
     },
     'category_influence': {
+        'csharp_query': generate_csharp_query_category_influence,
         'go': generate_go_category_influence,
         'rust': generate_rust_category_influence,
     },


### PR DESCRIPTION
  ## Summary

  This PR reduces the remaining benchmark-only C# orchestration around
  `category_influence` by moving the C# workload source into the shared
  benchmark generator.

  Instead of embedding a one-off C# program directly inside the benchmark
  runner, the runner now generates the C# query workload through
  `generate_pipeline.py`, just like the other benchmark targets.

  This makes the benchmark path cleaner, more reusable, and better aligned
  with the generator-driven workflow already used for Rust and Go.

  ## What Changed

  ### Shared Benchmark Generation

  Extended:

  - `examples/benchmark/generate_pipeline.py`

  The generator now supports:

  - `workload = category_influence`
  - `target = csharp_query`

  The generated C# source:

  - loads `category_parent.tsv` and `article_category.tsv`
  - runs recursive `category_ancestor` expansion through `QueryRuntime`
  - materializes `article_root_weight`
  - performs the outer grouped root influence sum with query-runtime
    aggregate machinery
  - emits sorted `root_category\tinfluence_score` output
  - emits useful runtime metrics to stderr

  ### Category-Influence Cross-Target Runner

  Updated:

  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  The C# path no longer carries a hardcoded embedded workload template.

  Instead, it now:

  - calls `generate_pipeline.py`
  - generates `Program.cs` directly for the benchmark
  - compiles that generated C# source together with `QueryRuntime.cs`

  This keeps the benchmark runner focused on build/run/compare work rather
  than owning target-specific workload logic.

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects:

  - the generator-based C# category-influence path
  - refreshed benchmark numbers
  - the remaining benchmark-only orchestration that still exists:
    - project-file wiring
    - inclusion of `QueryRuntime.cs`

  ## Why This Matters

  Before this PR, the C# category-influence benchmark was already using the
  query engine, but the workload itself still lived as a custom embedded
  program inside the benchmark runner.

  That was the last obvious benchmark-only piece.

  This PR removes that mismatch and makes the C# category-influence path
  more consistent with the rest of the benchmark infrastructure.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_category_influence_cross_target.py

  Benchmarks run locally:

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 1k,5k,10k --repetitions 1

  ## Results

  | Scale | C# Query | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---|
  | 300 | 0.675s | 0.387s | 0.502s | match |
  | 1k | 0.574s | 1.571s | 2.148s | match |
  | 5k | 1.714s | 7.786s | 12.386s | match |
  | 10k | 4.063s | 15.057s | 20.739s | match |

  Speedups of C# query engine:

  | Scale | vs Rust DFS | vs Go DFS |
  |---|---:|---:|
  | 300 | 0.57x | 0.74x |
  | 1k | 2.74x | 3.74x |
  | 5k | 4.54x | 7.22x |
  | 10k | 3.71x | 5.10x |

  ## Interpretation

  The performance shape still holds after moving the C# workload into the
  shared generator:

  - C# query loses at 300
  - C# query clearly wins from 1k onward
  - outputs still match across C#, Rust, and Go

  So the benchmark cleanup did not weaken the large-scale performance
  story.

  ## Scope

  This PR is benchmark-infrastructure cleanup and alignment.

  It does not introduce a new general-purpose C# compiler feature by
  itself. The main change is that the category-influence C# workload is now
  generated through the shared pipeline instead of being embedded directly
  in the runner.

  ## Follow-Up

  Likely next work:

  - continue reducing the remaining benchmark-only C# wiring around
    category influence
  - keep broadening grouped/correlated aggregate support in the query
    engine so more of this workload can be represented through shared
    compiler paths