### PR TITLE
bench: package csharp category influence generation

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -353,19 +353,19 @@ Latest local results:
 
 | Scale | C# Query | Rust DFS | Go DFS | Outputs |
 |-------|---------:|---------:|-------:|---------|
-| 300 | 0.675s | 0.387s | 0.502s | match |
-| 1k | 0.574s | 1.571s | 2.148s | match |
-| 5k | 1.714s | 7.786s | 12.386s | match |
-| 10k | 4.063s | 15.057s | 20.739s | match |
+| 300 | 0.715s | 0.371s | 0.487s | match |
+| 1k | 0.554s | 1.484s | 2.141s | match |
+| 5k | 1.673s | 7.905s | 12.509s | match |
+| 10k | 4.080s | 14.932s | 20.369s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs Rust DFS | vs Go DFS |
 |-------|------------:|----------:|
-| 300 | 0.57x | 0.74x |
-| 1k | 2.74x | 3.74x |
-| 5k | 4.54x | 7.22x |
-| 10k | 3.71x | 5.10x |
+| 300 | 0.52x | 0.68x |
+| 1k | 2.68x | 3.87x |
+| 5k | 4.72x | 7.47x |
+| 10k | 3.66x | 4.99x |
 
 Comparison note:
 
@@ -373,15 +373,16 @@ Comparison note:
 - that path now uses `QueryRuntime` for both:
   - the recursive `category_ancestor` expansion
   - the outer grouped influence sum via `AggregateNode`
-- the C# benchmark source is now generated through `generate_pipeline.py`
-  as `target=csharp_query`, instead of being embedded only inside the
-  benchmark runner
+- the C# benchmark package is now generated through
+  `generate_pipeline.py` as `target=csharp_query`, including:
+  - `Program.cs`
+  - `QueryRuntime.cs`
+  - `benchmark_qe.csproj`
 - Rust and Go remain generated DFS/pipeline binaries
 - so this runner is intentionally a mixed execution-model comparison:
   query engine versus non-query target pipelines
-- the remaining benchmark-only orchestration is therefore smaller now:
-  project wiring plus runtime file inclusion, not a one-off embedded C#
-  workload implementation
+- the remaining benchmark-only orchestration is now just build/run
+  invocation in the runner, not embedded C# workload or package wiring
 - the C# path is still weaker only at `300` and clearly faster from `1k`
   onward on the current workload
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -21,20 +21,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
-QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
-
-CSHARP_PROJECT = """\
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-</Project>
-"""
 
 
 @dataclass
@@ -126,8 +114,6 @@ def generate_pipeline_source(root: Path, target: str) -> Path:
 
 def build_csharp_query(root: Path) -> list[str]:
     project_dir = root / "csharp_query"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    output = project_dir / "Program.cs"
     run(
         [
             sys.executable,
@@ -138,12 +124,10 @@ def build_csharp_query(root: Path) -> list[str]:
             "category_influence",
             "--target",
             "csharp_query",
-            "--output",
-            str(output),
+            "--output-dir",
+            str(project_dir),
         ]
     )
-    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
-    (project_dir / "benchmark_qe.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
     run(["dotnet", "build", "benchmark_qe.csproj", "-c", "Release"], cwd=project_dir)
     return [
         "dotnet",

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -25,6 +25,20 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[2]
+QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
+
+CSHARP_BENCHMARK_PROJECT = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
 
 def load_facts(facts_path):
     """Load facts from Prolog file."""
@@ -1965,6 +1979,27 @@ GENERATORS = {
 }
 
 
+def write_output_artifacts(target, code, output=None, output_dir=None):
+    if output_dir:
+        out_dir = Path(output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        if target == "csharp_query":
+            (out_dir / "Program.cs").write_text(code, encoding="utf-8")
+            (out_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+            (out_dir / "benchmark_qe.csproj").write_text(CSHARP_BENCHMARK_PROJECT, encoding="utf-8")
+            return
+
+        ext = {"go": ".go", "rust": ".rs"}.get(target)
+        if ext is None:
+            raise ValueError(f"Unsupported packaged target: {target}")
+        (out_dir / f"generated{ext}").write_text(code, encoding="utf-8")
+        return
+
+    out_path = Path(output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(code, encoding="utf-8")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate self-contained benchmark pipeline per target"
@@ -1978,7 +2013,8 @@ def main():
         help="Benchmark workload to generate",
     )
     parser.add_argument("--target", required=True, help="Target language")
-    parser.add_argument("--output", required=True, help="Output file path")
+    parser.add_argument("--output", help="Output file path")
+    parser.add_argument("--output-dir", help="Output directory for packaged targets")
     parser.add_argument("--n", type=float, default=5, help="Dimensionality parameter")
     parser.add_argument("--max-depth", type=int, default=10,
                         help="Max DFS depth (paths beyond this are trimmed; "
@@ -2000,11 +2036,13 @@ def main():
     code = generator(article_cats, category_parents, root_cats,
                      n=int(args.n), max_depth=args.max_depth)
 
-    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
-    with open(args.output, 'w') as f:
-        f.write(code)
+    if bool(args.output) == bool(args.output_dir):
+        print("Exactly one of --output or --output-dir is required", file=sys.stderr)
+        sys.exit(2)
 
-    print(f"Generated {args.target} pipeline: {args.output}")
+    write_output_artifacts(args.target, code, args.output, args.output_dir)
+
+    print(f"Generated {args.target} pipeline: {args.output_dir or args.output}")
     print(f"  Articles: {len(article_cats)}")
     print(f"  Category edges: {sum(len(v) for v in category_parents.values())}")
     print(f"  Root: {args.root}")


### PR DESCRIPTION
  ## Summary

  This PR removes another layer of C#-specific benchmark wiring from the
  `category_influence` runner by moving the C# benchmark package creation
  into the shared benchmark generator.

  Before this change, the runner still had to own:

  - `Program.cs` placement
  - `QueryRuntime.cs` copying
  - `benchmark_qe.csproj` generation

  Now the shared generator handles that packaging for
  `target=csharp_query`, and the runner only builds and runs the generated
  package.

  ## What Changed

  ### Shared Generator Packaging

  Extended:

  - `examples/benchmark/generate_pipeline.py`

  The generator now supports a packaged output mode via:

  - `--output-dir`

  For `target=csharp_query`, that packaged output includes:

  - `Program.cs`
  - `QueryRuntime.cs`
  - `benchmark_qe.csproj`

  So the generator now owns not just the C# workload source, but the full
  minimal benchmark package needed to build and run it.

  The old `--output` path still works for the existing single-file targets.

  ### Category-Influence Runner Simplification

  Updated:

  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  The runner no longer embeds or writes:

  - the C# project template
  - the `QueryRuntime.cs` copy step

  Instead it now simply asks `generate_pipeline.py` for the packaged C#
  benchmark directory and builds that output.

  This keeps the runner focused on:

  - generation orchestration
  - target builds
  - execution
  - comparison

  instead of target-specific package assembly.

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects that:

  - the C# category-influence workload is generator-produced
  - the C# benchmark package itself is generator-produced
  - the remaining benchmark-only orchestration for C# is now just build/run
    invocation in the runner

  ## Why This Matters

  We had already removed the one-off embedded C# workload source from the
  runner in the previous step.

  The remaining mismatch was that the runner still owned the package-level
  C# scaffolding.

  This PR removes that too.

  That makes the C# category-influence benchmark path more consistent with
  the broader benchmark architecture and further reduces special-case logic
  outside the shared generator.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_category_influence_cross_target.py

  Benchmarks run locally:

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 1k,5k,10k --repetitions 1

  ## Results

  | Scale | C# Query | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---|
  | 300 | 0.715s | 0.371s | 0.487s | match |
  | 1k | 0.554s | 1.484s | 2.141s | match |
  | 5k | 1.673s | 7.905s | 12.509s | match |
  | 10k | 4.080s | 14.932s | 20.369s | match |

  Speedups of C# query engine:

  | Scale | vs Rust DFS | vs Go DFS |
  |---|---:|---:|
  | 300 | 0.52x | 0.68x |
  | 1k | 2.68x | 3.87x |
  | 5k | 4.72x | 7.47x |
  | 10k | 3.66x | 4.99x |

  ## Interpretation

  The benchmark cleanup did not change the overall performance story:

  - C# query is still weaker at 300
  - C# query is clearly faster from 1k onward
  - outputs still match across C#, Rust, and Go

  So the benchmark path is now cleaner without weakening the large-scale
  result.

  ## Scope

  This PR is benchmark infrastructure cleanup.

  It does not change the underlying query-engine semantics or add a new
  general-purpose compiler feature on its own.

  The main improvement is that the C# category-influence benchmark package
  is now created by the shared generator instead of by the benchmark
  runner.

  ## Follow-Up

  Likely next work:

  - continue reducing any remaining benchmark-only C# orchestration where it
    still exists in other workload runners
  - keep broadening grouped/correlated aggregate support in shared compiler
    paths so more of these benchmark workloads correspond directly to
    reusable lowering features