### PR TITLE
bench: share csharp benchmark packaging

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -190,6 +190,17 @@ Tables:
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
 
+Packaging note:
+
+- the shared `generate_pipeline.py` generator now owns packaged C#
+  benchmark output for the cross-target runners, including:
+  - `Program.cs`
+  - `QueryRuntime.cs` where needed for `csharp_query`
+  - `benchmark.csproj`
+- the benchmark runners are correspondingly narrower now: they mainly
+  generate, build, run, and compare, rather than assembling one-off C#
+  projects in-script
+
 ## Usage
 
 ```bash

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import shutil
 import statistics
 import subprocess
@@ -28,189 +29,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
-QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
-
-QE_PROGRAM = """\
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using UnifyWeaver.QueryRuntime;
-
-class Program
-{
-    const string ROOT_CATEGORY = "Physics";
-    const double N = 5.0;
-    const int MAX_DEPTH = 10;
-
-    static void Main(string[] args)
-    {
-        if (args.Length < 2)
-        {
-            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
-            Environment.Exit(1);
-        }
-
-        var swTotal = Stopwatch.StartNew();
-
-        var provider = new InMemoryRelationProvider();
-        var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_ancestor", 3);
-        var articleCategories = new Dictionary<string, List<string>>();
-
-        var swLoad = Stopwatch.StartNew();
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {
-                continue;
-            }
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }
-        }
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {
-                continue;
-            }
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {
-                continue;
-            }
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }
-
-            categories.Add(parts[1]);
-        }
-        swLoad.Stop();
-
-        var plan = new QueryPlan(
-            predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH),
-            true,
-            new int[] { 0 }
-        );
-
-        var uniqueSeeds = new HashSet<string>();
-        foreach (var categories in articleCategories.Values)
-        {
-            foreach (var category in categories)
-            {
-                uniqueSeeds.Add(category);
-            }
-        }
-
-        var seedParams = uniqueSeeds.Select(category => new object[] { category }).ToList();
-
-        var swExec = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider);
-        var rows = executor.Execute(plan, seedParams).ToList();
-        swExec.Stop();
-
-        var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>();
-        foreach (var row in rows)
-        {
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var hops = Convert.ToInt32(row[2]);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {
-                bucket = new List<(string, int)>();
-                ancestorIndex[source] = bucket;
-            }
-
-            bucket.Add((ancestor, hops));
-        }
-
-        var results = new List<(double Deff, string Article)>();
-        foreach (var article in articleCategories.Keys.OrderBy(x => x))
-        {
-            var allHops = new List<int>();
-            foreach (var category in articleCategories[article])
-            {
-                if (category == ROOT_CATEGORY)
-                {
-                    allHops.Add(1);
-                }
-
-                if (ancestorIndex.TryGetValue(category, out var ancestors))
-                {
-                    foreach (var (ancestor, hops) in ancestors)
-                    {
-                        if (ancestor == ROOT_CATEGORY)
-                        {
-                            allHops.Add(hops + 1);
-                        }
-                    }
-                }
-            }
-
-            if (allHops.Count > 0)
-            {
-                results.Add((ComputeDeff(allHops), article));
-            }
-        }
-        swAgg.Stop();
-
-        results.Sort((a, b) =>
-        {
-            var cmp = a.Deff.CompareTo(b.Deff);
-            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
-        });
-
-        Console.WriteLine("article\\troot_category\\teffective_distance");
-        foreach (var (deff, article) in results)
-        {
-            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{deff:F6}");
-        }
-
-        swTotal.Stop();
-        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"query_ms={swExec.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"seed_count={seedParams.Count}");
-        Console.Error.WriteLine($"tuple_count={rows.Count}");
-        Console.Error.WriteLine($"article_count={results.Count}");
-    }
-
-    static double ComputeDeff(List<int> hops)
-    {
-        if (hops.Count == 0)
-        {
-            return double.PositiveInfinity;
-        }
-
-        var weightSum = hops.Sum(h => Math.Pow(h, -N));
-        return weightSum > 0 ? Math.Pow(weightSum, -1.0 / N) : double.PositiveInfinity;
-    }
-}
-"""
-
-CSHARP_PROJECT = """\
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-</Project>
-"""
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 
 
 @dataclass
@@ -259,6 +78,7 @@ def run(
     cwd: Path | None = None,
     check: bool = True,
     capture_output: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd,
@@ -266,6 +86,7 @@ def run(
         check=check,
         capture_output=capture_output,
         text=True,
+        env=env,
     )
 
 
@@ -291,36 +112,73 @@ def available_targets(requested: list[str]) -> list[str]:
     return targets
 
 
+def generate_pipeline_source(root: Path, target: str) -> Path:
+    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go"}[target]
+    filename = "Program.cs" if target == "csharp" else f"effective_distance{ext}"
+    output = root / filename
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(BENCH_DIR / "10k" / "facts.pl"),
+            "--root",
+            "Physics",
+            "--workload",
+            "effective_distance",
+            "--target",
+            target,
+            "--output",
+            str(output),
+        ]
+    )
+    return output
+
+
+def generate_pipeline_package(root: Path, target: str) -> Path:
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(BENCH_DIR / "10k" / "facts.pl"),
+            "--root",
+            "Physics",
+            "--workload",
+            "effective_distance",
+            "--target",
+            target,
+            "--output-dir",
+            str(root),
+        ]
+    )
+    return root
+
+
 def build_csharp_query(root: Path) -> list[str]:
     project_dir = root / "csharp_query"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "Program.cs").write_text(QE_PROGRAM, encoding="utf-8")
-    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
-    (project_dir / "benchmark_qe.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
-    run(["dotnet", "build", "benchmark_qe.csproj", "-c", "Release"], cwd=project_dir)
+    generate_pipeline_package(project_dir, "csharp_query")
+    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
     return [
         "dotnet",
-        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_qe.dll"),
+        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll"),
     ]
 
 
 def build_csharp_dfs(root: Path) -> list[str]:
     project_dir = root / "csharp_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = require_file(BENCH_DIR / "10k" / "pipelines" / "EffectiveDistance.cs")
-    (project_dir / "Program.cs").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
-    (project_dir / "benchmark_dfs.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
-    run(["dotnet", "build", "benchmark_dfs.csproj", "-c", "Release"], cwd=project_dir)
+    generate_pipeline_package(project_dir, "csharp")
+    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
     return [
         "dotnet",
-        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_dfs.dll"),
+        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll"),
     ]
 
 
 def build_rust_dfs(root: Path) -> list[str]:
     project_dir = root / "rust_dfs"
     project_dir.mkdir(parents=True, exist_ok=True)
-    source = require_file(BENCH_DIR / "10k" / "pipelines" / "effective_distance.rs")
+    source = generate_pipeline_source(project_dir, "rust")
     binary = project_dir / "effective_distance_rust"
     run(["rustc", "-O", str(source), "-o", str(binary)])
     return [str(binary)]
@@ -329,9 +187,12 @@ def build_rust_dfs(root: Path) -> list[str]:
 def build_go_dfs(root: Path) -> list[str]:
     project_dir = root / "go_dfs"
     project_dir.mkdir(parents=True, exist_ok=True)
-    source = require_file(BENCH_DIR / "10k" / "pipelines" / "effective_distance.go")
+    source = generate_pipeline_source(project_dir, "go")
     binary = project_dir / "effective_distance_go"
-    run(["go", "build", "-o", str(binary), str(source)])
+    go_cache = project_dir / ".gocache"
+    go_cache.mkdir(exist_ok=True)
+    env = dict(os.environ, GOCACHE=str(go_cache))
+    run(["go", "build", "-o", str(binary), str(source)], env=env)
     return [str(binary)]
 
 

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -21,188 +21,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
-QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
-
-CSHARP_PROJECT = """\
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-</Project>
-"""
-
-QE_PROGRAM = """\
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using UnifyWeaver.QueryRuntime;
-
-class Program
-{
-    const string ROOT_CATEGORY = "Physics";
-    const int MAX_DEPTH = 10;
-
-    static void Main(string[] args)
-    {
-        if (args.Length < 2)
-        {
-            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
-            Environment.Exit(1);
-        }
-
-        var swTotal = Stopwatch.StartNew();
-        var swLoad = Stopwatch.StartNew();
-
-        var provider = new InMemoryRelationProvider();
-        var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_ancestor", 3);
-        var articleCategories = new Dictionary<string, List<string>>();
-
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {
-                continue;
-            }
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }
-        }
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {
-                continue;
-            }
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {
-                continue;
-            }
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }
-
-            categories.Add(parts[1]);
-        }
-
-        swLoad.Stop();
-
-        var plan = new QueryPlan(
-            predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.Min),
-            true,
-            new int[] { 0 }
-        );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var categories in articleCategories.Values)
-        {
-            foreach (var category in categories)
-            {
-                uniqueSeeds.Add(category);
-            }
-        }
-
-        var seedParams = uniqueSeeds
-            .OrderBy(category => category, StringComparer.Ordinal)
-            .Select(category => new object[] { category })
-            .ToList();
-
-        var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
-        swQuery.Stop();
-
-        var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var hops = Convert.ToInt32(row[2]);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {
-                bucket = new List<(string, int)>();
-                ancestorIndex[source] = bucket;
-            }
-
-            bucket.Add((ancestor, hops));
-        }
-
-        var results = new List<(int Distance, string Article)>();
-        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
-        {
-            int? best = null;
-            foreach (var category in articleCategories[article])
-            {
-                if (category == ROOT_CATEGORY)
-                {
-                    best = best is null ? 1 : Math.Min(best.Value, 1);
-                }
-
-                if (!ancestorIndex.TryGetValue(category, out var ancestors))
-                {
-                    continue;
-                }
-
-                foreach (var (ancestor, hops) in ancestors)
-                {
-                    if (ancestor != ROOT_CATEGORY)
-                    {
-                        continue;
-                    }
-
-                    var dist = hops + 1;
-                    best = best is null ? dist : Math.Min(best.Value, dist);
-                }
-            }
-
-            if (best is not null)
-            {
-                results.Add((best.Value, article));
-            }
-        }
-        swAgg.Stop();
-        swTotal.Stop();
-
-        results.Sort((a, b) =>
-        {
-            var cmp = a.Distance.CompareTo(b.Distance);
-            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
-        });
-
-        Console.WriteLine("article\\troot_category\\tshortest_path");
-        foreach (var (distance, article) in results)
-        {
-            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{distance}");
-        }
-
-        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"seed_count={seedParams.Count}");
-        Console.Error.WriteLine($"tuple_count={rows.Count}");
-        Console.Error.WriteLine($"article_count={results.Count}");
-    }
-}
-"""
 
 
 @dataclass
@@ -294,23 +114,38 @@ def generate_pipeline_source(root: Path, target: str) -> Path:
     return output
 
 
+def generate_pipeline_package(root: Path, target: str) -> Path:
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(FACTS_PATH),
+            "--root",
+            "Physics",
+            "--workload",
+            "shortest_path_to_root",
+            "--target",
+            target,
+            "--output-dir",
+            str(root),
+        ]
+    )
+    return root
+
+
 def build_csharp_query(root: Path) -> list[str]:
     project_dir = root / "csharp_query"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "Program.cs").write_text(QE_PROGRAM, encoding="utf-8")
-    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
-    (project_dir / "benchmark_shortest_path_query.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
-    run(["dotnet", "build", "benchmark_shortest_path_query.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_shortest_path_query.dll")]
+    generate_pipeline_package(project_dir, "csharp_query")
+    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
 
 
 def build_csharp_dfs(root: Path) -> list[str]:
     project_dir = root / "csharp_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    generate_pipeline_source(project_dir, "csharp")
-    (project_dir / "benchmark_shortest_path_dfs.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
-    run(["dotnet", "build", "benchmark_shortest_path_dfs.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_shortest_path_dfs.dll")]
+    generate_pipeline_package(project_dir, "csharp")
+    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
 
 
 def build_rust_dfs(root: Path) -> list[str]:

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -21,213 +21,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
-QRY_RUNTIME = ROOT / "src" / "unifyweaver" / "targets" / "csharp_query_runtime" / "QueryRuntime.cs"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
-
-CSHARP_PROJECT = """\
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-</Project>
-"""
-
-QE_PROGRAM = """\
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using UnifyWeaver.QueryRuntime;
-
-class Program
-{
-    const string ROOT_CATEGORY = "Physics";
-    const int MAX_DEPTH = 10;
-
-    static void Main(string[] args)
-    {
-        if (args.Length < 2)
-        {
-            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
-            Environment.Exit(1);
-        }
-
-        var swTotal = Stopwatch.StartNew();
-        var swLoad = Stopwatch.StartNew();
-
-        var provider = new InMemoryRelationProvider();
-        var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_weighted_shortest", 3);
-        var weightId = new PredicateId("category_weight", 2);
-        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-        var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
-        var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {
-                continue;
-            }
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {
-                continue;
-            }
-
-            provider.AddFact(edgeId, parts[0], parts[1]);
-            sourceNodes.Add(parts[0]);
-            outDegree[parts[0]] = outDegree.TryGetValue(parts[0], out var degree) ? degree + 1 : 1;
-        }
-
-        foreach (var source in sourceNodes)
-        {
-            outDegree.TryGetValue(source, out var degree);
-            var weight = 1.0 + Math.Log(Math.Max(1, degree), 5.0);
-            provider.AddFact(weightId, source, weight);
-        }
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {
-                continue;
-            }
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {
-                continue;
-            }
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }
-
-            categories.Add(parts[1]);
-        }
-
-        swLoad.Stop();
-
-        var plan = new QueryPlan(
-            predId,
-            new PathAwareAccumulationNode(
-                edgeId,
-                predId,
-                weightId,
-                new ColumnExpression(3),
-                new BinaryArithmeticExpression(
-                    ArithmeticBinaryOperator.Add,
-                    new ColumnExpression(2),
-                    new ColumnExpression(3)),
-                MAX_DEPTH,
-                TableMode.Min,
-                true),
-            true,
-            new int[] { 0 }
-        );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var categories in articleCategories.Values)
-        {
-            foreach (var category in categories)
-            {
-                uniqueSeeds.Add(category);
-            }
-        }
-
-        var seedParams = uniqueSeeds
-            .OrderBy(category => category, StringComparer.Ordinal)
-            .Select(category => new object[] { category })
-            .ToList();
-
-        var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
-        swQuery.Stop();
-
-        var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, double Weight)>>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var weight = Convert.ToDouble(row[2], CultureInfo.InvariantCulture);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {
-                bucket = new List<(string, double)>();
-                ancestorIndex[source] = bucket;
-            }
-
-            bucket.Add((ancestor, weight));
-        }
-
-        var results = new List<(double Distance, string Article)>();
-        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
-        {
-            double? best = null;
-            foreach (var category in articleCategories[article])
-            {
-                if (category == ROOT_CATEGORY)
-                {
-                    best = best is null ? 0.0 : Math.Min(best.Value, 0.0);
-                }
-
-                if (!ancestorIndex.TryGetValue(category, out var ancestors))
-                {
-                    continue;
-                }
-
-                foreach (var (ancestor, weight) in ancestors)
-                {
-                    if (ancestor != ROOT_CATEGORY)
-                    {
-                        continue;
-                    }
-
-                    best = best is null ? weight : Math.Min(best.Value, weight);
-                }
-            }
-
-            if (best is not null)
-            {
-                results.Add((best.Value, article));
-            }
-        }
-        swAgg.Stop();
-        swTotal.Stop();
-
-        results.Sort((a, b) =>
-        {
-            var cmp = a.Distance.CompareTo(b.Distance);
-            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
-        });
-
-        Console.WriteLine("article\\troot_category\\tweighted_shortest_path");
-        foreach (var (distance, article) in results)
-        {
-            Console.WriteLine($"{article}\\t{ROOT_CATEGORY}\\t{distance.ToString("F12", CultureInfo.InvariantCulture)}");
-        }
-
-        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"query_ms={swQuery.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"aggregation_ms={swAgg.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
-        Console.Error.WriteLine($"seed_count={seedParams.Count}");
-        Console.Error.WriteLine($"tuple_count={rows.Count}");
-        Console.Error.WriteLine($"article_count={results.Count}");
-    }
-}
-"""
 
 
 @dataclass
@@ -319,23 +114,38 @@ def generate_pipeline_source(root: Path, target: str) -> Path:
     return output
 
 
+def generate_pipeline_package(root: Path, target: str) -> Path:
+    run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--facts",
+            str(FACTS_PATH),
+            "--root",
+            "Physics",
+            "--workload",
+            "weighted_shortest_path",
+            "--target",
+            target,
+            "--output-dir",
+            str(root),
+        ]
+    )
+    return root
+
+
 def build_csharp_query(root: Path) -> list[str]:
     project_dir = root / "csharp_query"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    (project_dir / "Program.cs").write_text(QE_PROGRAM, encoding="utf-8")
-    (project_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
-    (project_dir / "benchmark_weighted_shortest_path_query.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
-    run(["dotnet", "build", "benchmark_weighted_shortest_path_query.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path_query.dll")]
+    generate_pipeline_package(project_dir, "csharp_query")
+    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
 
 
 def build_csharp_dfs(root: Path) -> list[str]:
     project_dir = root / "csharp_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    generate_pipeline_source(project_dir, "csharp")
-    (project_dir / "benchmark_weighted_shortest_path_dfs.csproj").write_text(CSHARP_PROJECT, encoding="utf-8")
-    run(["dotnet", "build", "benchmark_weighted_shortest_path_dfs.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_weighted_shortest_path_dfs.dll")]
+    generate_pipeline_package(project_dir, "csharp")
+    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
 
 
 def build_rust_dfs(root: Path) -> list[str]:

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1836,6 +1836,550 @@ class Program
 '''
 
 
+def generate_csharp_query_effective_distance(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = sorted(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Effective distance benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const string ROOT_CATEGORY = "{root}";
+    const double N = {float(n)};
+    const int MAX_DEPTH = {max_depth};
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_ancestor", 3);
+        var articleCategories = new Dictionary<string, List<string>>();
+
+        var swLoad = Stopwatch.StartNew();
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }}
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {{
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }}
+
+            categories.Add(parts[1]);
+        }}
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>();
+        foreach (var categories in articleCategories.Values)
+        {{
+            foreach (var category in categories)
+            {{
+                uniqueSeeds.Add(category);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds.Select(category => new object[] {{ category }}).ToList();
+
+        var swExec = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider);
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swExec.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>();
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var hops = Convert.ToInt32(row[2]);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {{
+                bucket = new List<(string, int)>();
+                ancestorIndex[source] = bucket;
+            }}
+
+            bucket.Add((ancestor, hops));
+        }}
+
+        var results = new List<(double Deff, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x))
+        {{
+            var allHops = new List<int>();
+            foreach (var category in articleCategories[article])
+            {{
+                if (category == ROOT_CATEGORY)
+                {{
+                    allHops.Add(1);
+                }}
+
+                if (ancestorIndex.TryGetValue(category, out var ancestors))
+                {{
+                    foreach (var (ancestor, hops) in ancestors)
+                    {{
+                        if (ancestor == ROOT_CATEGORY)
+                        {{
+                            allHops.Add(hops + 1);
+                        }}
+                    }}
+                }}
+            }}
+
+            if (allHops.Count > 0)
+            {{
+                results.Add((ComputeDeff(allHops), article));
+            }}
+        }}
+        swAgg.Stop();
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Deff.CompareTo(b.Deff);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("article\\troot_category\\teffective_distance");
+        foreach (var (deff, article) in results)
+        {{
+            Console.WriteLine($"{{article}}\\t{{ROOT_CATEGORY}}\\t{{deff:F6}}");
+        }}
+
+        swTotal.Stop();
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swExec.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"article_count={{results.Count}}");
+    }}
+
+    static double ComputeDeff(List<int> hops)
+    {{
+        if (hops.Count == 0)
+        {{
+            return double.PositiveInfinity;
+        }}
+
+        var weightSum = hops.Sum(h => Math.Pow(h, -N));
+        return weightSum > 0 ? Math.Pow(weightSum, -1.0 / N) : double.PositiveInfinity;
+    }}
+}}
+'''
+
+
+def generate_csharp_query_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = sorted(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Shortest path to root benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const string ROOT_CATEGORY = "{root}";
+    const int MAX_DEPTH = {max_depth};
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_ancestor", 3);
+        var articleCategories = new Dictionary<string, List<string>>();
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }}
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {{
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }}
+
+            categories.Add(parts[1]);
+        }}
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.Min),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {{
+            foreach (var category in categories)
+            {{
+                uniqueSeeds.Add(category);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] {{ category }})
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var hops = Convert.ToInt32(row[2]);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {{
+                bucket = new List<(string, int)>();
+                ancestorIndex[source] = bucket;
+            }}
+
+            bucket.Add((ancestor, hops));
+        }}
+
+        var results = new List<(int Distance, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            int? best = null;
+            foreach (var category in articleCategories[article])
+            {{
+                if (category == ROOT_CATEGORY)
+                {{
+                    best = best is null ? 1 : Math.Min(best.Value, 1);
+                }}
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {{
+                    continue;
+                }}
+
+                foreach (var (ancestor, hops) in ancestors)
+                {{
+                    if (ancestor != ROOT_CATEGORY)
+                    {{
+                        continue;
+                    }}
+
+                    var dist = hops + 1;
+                    best = best is null ? dist : Math.Min(best.Value, dist);
+                }}
+            }}
+
+            if (best is not null)
+            {{
+                results.Add((best.Value, article));
+            }}
+        }}
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("article\\troot_category\\tshortest_path");
+        foreach (var item in results)
+        {{
+            Console.WriteLine($"{{item.Article}}\\t{{ROOT_CATEGORY}}\\t{{item.Distance}}");
+        }}
+
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"article_count={{results.Count}}");
+    }}
+}}
+'''
+
+
+def generate_csharp_query_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    root = sorted(root_cats)[0] if root_cats else "Physics"
+
+    return f'''// Weighted shortest path to root benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const string ROOT_CATEGORY = "{root}";
+    const int MAX_DEPTH = {max_depth};
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("category_weighted_shortest", 3);
+        var weightId = new PredicateId("category_weight", 2);
+        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+        var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            provider.AddFact(edgeId, parts[0], parts[1]);
+            sourceNodes.Add(parts[0]);
+            outDegree[parts[0]] = outDegree.TryGetValue(parts[0], out var degree) ? degree + 1 : 1;
+        }}
+
+        foreach (var source in sourceNodes)
+        {{
+            outDegree.TryGetValue(source, out var degree);
+            var weight = 1.0 + Math.Log(Math.Max(1, degree), 5.0);
+            provider.AddFact(weightId, source, weight);
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!articleCategories.TryGetValue(parts[0], out var categories))
+            {{
+                categories = new List<string>();
+                articleCategories[parts[0]] = categories;
+            }}
+
+            categories.Add(parts[1]);
+        }}
+
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareAccumulationNode(
+                edgeId,
+                predId,
+                weightId,
+                new ColumnExpression(3),
+                new BinaryArithmeticExpression(
+                    ArithmeticBinaryOperator.Add,
+                    new ColumnExpression(2),
+                    new ColumnExpression(3)),
+                MAX_DEPTH,
+                TableMode.Min,
+                true),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var categories in articleCategories.Values)
+        {{
+            foreach (var category in categories)
+            {{
+                uniqueSeeds.Add(category);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds
+            .OrderBy(category => category, StringComparer.Ordinal)
+            .Select(category => new object[] {{ category }})
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var ancestorIndex = new Dictionary<string, List<(string Ancestor, double Weight)>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var ancestor = row[1]?.ToString() ?? "";
+            var weight = Convert.ToDouble(row[2], CultureInfo.InvariantCulture);
+            if (!ancestorIndex.TryGetValue(source, out var bucket))
+            {{
+                bucket = new List<(string, double)>();
+                ancestorIndex[source] = bucket;
+            }}
+
+            bucket.Add((ancestor, weight));
+        }}
+
+        var results = new List<(double Distance, string Article)>();
+        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            double? best = null;
+            foreach (var category in articleCategories[article])
+            {{
+                if (category == ROOT_CATEGORY)
+                {{
+                    best = best is null ? 0.0 : Math.Min(best.Value, 0.0);
+                }}
+
+                if (!ancestorIndex.TryGetValue(category, out var ancestors))
+                {{
+                    continue;
+                }}
+
+                foreach (var (ancestor, weight) in ancestors)
+                {{
+                    if (ancestor != ROOT_CATEGORY)
+                    {{
+                        continue;
+                    }}
+
+                    best = best is null ? weight : Math.Min(best.Value, weight);
+                }}
+            }}
+
+            if (best is not null)
+            {{
+                results.Add((best.Value, article));
+            }}
+        }}
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Distance.CompareTo(b.Distance);
+            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("article\\troot_category\\tweighted_shortest_path");
+        foreach (var item in results)
+        {{
+            Console.WriteLine($"{{item.Article}}\\t{{ROOT_CATEGORY}}\\t{{item.Distance.ToString("F12", CultureInfo.InvariantCulture)}}");
+        }}
+
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"article_count={{results.Count}}");
+    }}
+}}
+'''
+
+
 def generate_csharp_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -1960,16 +2504,19 @@ GENERATORS = {
         'go': generate_go_effective_distance,
         'rust': generate_rust_effective_distance,
         'csharp': generate_csharp_effective_distance,
+        'csharp_query': generate_csharp_query_effective_distance,
     },
     'shortest_path_to_root': {
         'go': generate_go_shortest_path,
         'rust': generate_rust_shortest_path,
         'csharp': generate_csharp_shortest_path,
+        'csharp_query': generate_csharp_query_shortest_path,
     },
     'weighted_shortest_path': {
         'go': generate_go_weighted_shortest_path,
         'rust': generate_rust_weighted_shortest_path,
         'csharp': generate_csharp_weighted_shortest_path,
+        'csharp_query': generate_csharp_query_weighted_shortest_path,
     },
     'category_influence': {
         'csharp_query': generate_csharp_query_category_influence,
@@ -1983,10 +2530,11 @@ def write_output_artifacts(target, code, output=None, output_dir=None):
     if output_dir:
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
-        if target == "csharp_query":
+        if target in {"csharp", "csharp_query"}:
             (out_dir / "Program.cs").write_text(code, encoding="utf-8")
-            (out_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
-            (out_dir / "benchmark_qe.csproj").write_text(CSHARP_BENCHMARK_PROJECT, encoding="utf-8")
+            if target == "csharp_query":
+                (out_dir / "QueryRuntime.cs").write_text(QRY_RUNTIME.read_text(encoding="utf-8"), encoding="utf-8")
+            (out_dir / "benchmark.csproj").write_text(CSHARP_BENCHMARK_PROJECT, encoding="utf-8")
             return
 
         ext = {"go": ".go", "rust": ".rs"}.get(target)


### PR DESCRIPTION
  ## Summary

  This PR removes the remaining runner-owned C# packaging logic from the
  other cross-target benchmark scripts and moves it into the shared
  benchmark generator.

  After the earlier `category_influence` cleanup, the remaining benchmark
  runners still had their own C#-specific project assembly logic for:

  - `effective_distance`
  - `shortest_path_to_root`
  - `weighted_shortest_path`

  This PR applies the same pattern there:

  - `generate_pipeline.py` now owns packaged C# benchmark output
  - the runners just generate, build, run, and compare

  ## What Changed

  ### Shared C# Benchmark Packaging

  Extended:

  - `examples/benchmark/generate_pipeline.py`

  The shared generator now supports packaged output for both:

  - `csharp`
  - `csharp_query`

  across these workloads:

  - `effective_distance`
  - `shortest_path_to_root`
  - `weighted_shortest_path`
  - `category_influence` (already supported before this PR)

  For packaged C# output, the generator now emits:

  - `Program.cs`
  - `benchmark.csproj`
  - `QueryRuntime.cs` when needed for `csharp_query`

  This means the generator, not the runners, now owns the minimal C#
  benchmark project layout.

  ### Effective Distance Runner

  Updated:

  - `examples/benchmark/benchmark_effective_distance.py`

  Changes:
  - remove embedded `QE_PROGRAM`
  - remove runner-owned C# project template
  - generate both:
    - `csharp-query`
    - `csharp-dfs`
    from the shared generator
  - keep the same runtime behavior and comparison logic

  Also fixed:
  - local `GOCACHE` handling for the Go smoke path, matching the other
    benchmark runners

  ### Shortest Path Runner

  Updated:

  - `examples/benchmark/benchmark_shortest_path_cross_target.py`

  Changes:
  - remove embedded C# query-engine benchmark program
  - remove runner-owned `.csproj` / `QueryRuntime.cs` assembly
  - generate both:
    - `csharp-query`
    - `csharp-dfs`
    through the shared generator

  ### Weighted Shortest Path Runner

  Updated:

  - `examples/benchmark/benchmark_weighted_shortest_path_cross_target.py`

  Changes:
  - remove embedded C# query-engine benchmark program
  - remove runner-owned `.csproj` / `QueryRuntime.cs` assembly
  - generate both:
    - `csharp-query`
    - `csharp-dfs`
    through the shared generator

  ### Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now states the general rule clearly:

  - the shared generator owns packaged C# benchmark output
  - the runners mainly orchestrate generation, build, execution, and result
    comparison

  ## Why This Matters

  Before this PR, benchmark cleanup was uneven:

  - `category_influence` had already moved to shared C# package generation
  - the other major cross-target runners still embedded C# query code and
    built C# project scaffolding in-script

  That left the benchmark layer more target-specific than it needed to be.

  This PR makes the benchmark infrastructure more consistent and reduces
  benchmark-only logic outside `generate_pipeline.py`.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py

  ### Smoke benchmarks run locally

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  ### Smoke results

  All three runners still produced matching outputs across targets.

  #### Effective distance

  - csharp-dfs: 0.523s
  - csharp-query: 0.653s
  - go-dfs: 0.521s
  - rust-dfs: 0.355s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Shortest path

  - csharp-dfs: 0.452s
  - csharp-query: 0.156s
  - go-dfs: 0.478s
  - rust-dfs: 0.401s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Weighted shortest path

  - csharp-dfs: 0.497s
  - csharp-query: 0.190s
  - go-dfs: 0.501s
  - rust-dfs: 0.368s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  ## Scope

  This PR is benchmark-infrastructure cleanup.

  It does not introduce new runtime semantics or new lowering features.

  The main change is that the shared generator now owns packaged C#
  benchmark output for the remaining cross-target benchmark families.

  ## Follow-Up

  Likely next work:

  - continue shrinking benchmark-only orchestration where it still exists
    in non-C# paths
  - keep using workload-driven generator cleanup to align benchmark
    infrastructure with actual compiler/lowering capabilities