### PR TITLE
bench: share benchmark runner utilities

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -180,6 +180,7 @@ Tables:
 | `generate_facts_from_db.py` | Extract facts from SQLite → Prolog/TSV (no crawling) |
 | `generate_facts.py` | Alternative: fetch from Wikipedia API (for small datasets) |
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
+| `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
 | `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -200,6 +201,9 @@ Packaging note:
 - the benchmark runners are correspondingly narrower now: they mainly
   generate, build, run, and compare, rather than assembling one-off C#
   projects in-script
+- shared Rust/Go/C# runner utilities now live in `benchmark_common.py`
+  so new workload runners do not need to reimplement the same temp/build
+  scaffolding
 
 ## Usage
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -8,15 +8,21 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import os
-import shutil
 import statistics
-import subprocess
-import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_rust_binary,
+    require_file,
+    run_command,
+    scale_sort_key,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -52,108 +58,22 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run(
-    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env)
-
-
-def require_file(path: Path) -> Path:
-    if not path.exists():
-        raise FileNotFoundError(path)
-    return path
-
-
-def scale_sort_key(scale: str) -> tuple[int, str]:
-    digits = "".join(ch for ch in scale if ch.isdigit())
-    suffix = "".join(ch for ch in scale if not ch.isdigit())
-    if not digits:
-        return (0, scale)
-    value = int(digits)
-    if suffix.lower() == "k":
-        value *= 1000
-    return (value, scale)
-
-
-def available_targets(requested: list[str]) -> list[str]:
-    targets: list[str] = []
-    for target in requested:
-        if target == "csharp-query" and shutil.which("dotnet") is None:
-            print("skip csharp-query: dotnet not found", file=sys.stderr)
-            continue
-        if target == "rust-dfs" and shutil.which("rustc") is None:
-            print("skip rust-dfs: rustc not found", file=sys.stderr)
-            continue
-        if target == "go-dfs" and shutil.which("go") is None:
-            print("skip go-dfs: go not found", file=sys.stderr)
-            continue
-        targets.append(target)
-    return targets
-
-
-def generate_pipeline_source(root: Path, target: str) -> Path:
-    ext = {"csharp_query": ".cs", "rust": ".rs", "go": ".go"}[target]
-    filename = f"category_influence{ext}"
-    output = root / filename
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(FACTS_PATH),
-            "--workload",
-            "category_influence",
-            "--target",
-            target,
-            "--output",
-            str(output),
-        ]
-    )
-    return output
-
-
 def build_csharp_query(root: Path) -> list[str]:
-    project_dir = root / "csharp_query"
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(FACTS_PATH),
-            "--workload",
-            "category_influence",
-            "--target",
-            "csharp_query",
-            "--output-dir",
-            str(project_dir),
-        ]
+    return build_csharp_package(
+        GENERATOR, FACTS_PATH, "category_influence", "csharp_query", root / "csharp_query"
     )
-    run(["dotnet", "build", "benchmark_qe.csproj", "-c", "Release"], cwd=project_dir)
-    return [
-        "dotnet",
-        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark_qe.dll"),
-    ]
 
 
 def build_rust_dfs(root: Path) -> list[str]:
-    project_dir = root / "rust_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "rust")
-    binary = project_dir / "category_influence_rust"
-    run(["rustc", "-O", str(source), "-o", str(binary)])
-    return [str(binary)]
+    return build_rust_binary(
+        GENERATOR, FACTS_PATH, "category_influence", root / "rust_dfs", "category_influence_rust"
+    )
 
 
 def build_go_dfs(root: Path) -> list[str]:
-    project_dir = root / "go_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "go")
-    binary = project_dir / "category_influence_go"
-    go_cache = project_dir / ".gocache"
-    go_cache.mkdir(exist_ok=True)
-    env = dict(os.environ, GOCACHE=str(go_cache))
-    run(["go", "build", "-o", str(binary), str(source)], env=env)
-    return [str(binary)]
+    return build_go_binary(
+        GENERATOR, FACTS_PATH, "category_influence", root / "go_dfs", "category_influence_go"
+    )
 
 
 def normalize_output(output: str) -> str:
@@ -184,7 +104,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run(command + [str(edge_path), str(article_path)])
+        result = run_command(command + [str(edge_path), str(article_path)])
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        check=check,
+        capture_output=capture_output,
+        text=True,
+    )
+
+
+def require_file(path: Path) -> Path:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return path
+
+
+def scale_sort_key(scale: str) -> tuple[int, str]:
+    digits = "".join(ch for ch in scale if ch.isdigit())
+    suffix = "".join(ch for ch in scale if not ch.isdigit())
+    if not digits:
+        return (0, scale)
+    value = int(digits)
+    if suffix.lower() == "k":
+        value *= 1000
+    return (value, scale)
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    targets: list[str] = []
+    for target in requested:
+        if target.startswith("csharp-") and shutil.which("dotnet") is None:
+            print(f"skip {target}: dotnet not found", file=sys.stderr)
+            continue
+        if target.startswith("rust-") and shutil.which("rustc") is None:
+            print(f"skip {target}: rustc not found", file=sys.stderr)
+            continue
+        if target.startswith("go-") and shutil.which("go") is None:
+            print(f"skip {target}: go not found", file=sys.stderr)
+            continue
+        targets.append(target)
+    return targets
+
+
+def generate_pipeline_source(
+    generator: Path,
+    facts_path: Path,
+    workload: str,
+    target: str,
+    output_dir: Path,
+    *,
+    root: str | None = None,
+    output_name: str | None = None,
+) -> Path:
+    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go", "csharp_query": ".cs"}[target]
+    filename = output_name or ("Program.cs" if target.startswith("csharp") else f"{workload}{ext}")
+    output = output_dir / filename
+    cmd = [
+        sys.executable,
+        str(generator),
+        "--facts",
+        str(facts_path),
+    ]
+    if root is not None:
+        cmd.extend(["--root", root])
+    cmd.extend([
+        "--workload",
+        workload,
+        "--target",
+        target,
+        "--output",
+        str(output),
+    ])
+    run_command(cmd)
+    return output
+
+
+def generate_pipeline_package(
+    generator: Path,
+    facts_path: Path,
+    workload: str,
+    target: str,
+    output_dir: Path,
+    *,
+    root: str | None = None,
+) -> Path:
+    cmd = [
+        sys.executable,
+        str(generator),
+        "--facts",
+        str(facts_path),
+    ]
+    if root is not None:
+        cmd.extend(["--root", root])
+    cmd.extend([
+        "--workload",
+        workload,
+        "--target",
+        target,
+        "--output-dir",
+        str(output_dir),
+    ])
+    run_command(cmd)
+    return output_dir
+
+
+def build_csharp_package(
+    generator: Path,
+    facts_path: Path,
+    workload: str,
+    target: str,
+    project_dir: Path,
+    *,
+    root: str | None = None,
+) -> list[str]:
+    generate_pipeline_package(generator, facts_path, workload, target, project_dir, root=root)
+    run_command(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
+    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
+
+
+def build_rust_binary(
+    generator: Path,
+    facts_path: Path,
+    workload: str,
+    project_dir: Path,
+    binary_name: str,
+    *,
+    root: str | None = None,
+    source_name: str | None = None,
+) -> list[str]:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(
+        generator,
+        facts_path,
+        workload,
+        "rust",
+        project_dir,
+        root=root,
+        output_name=source_name,
+    )
+    binary = project_dir / binary_name
+    run_command(["rustc", "-O", str(source), "-o", str(binary)])
+    return [str(binary)]
+
+
+def build_go_binary(
+    generator: Path,
+    facts_path: Path,
+    workload: str,
+    project_dir: Path,
+    binary_name: str,
+    *,
+    root: str | None = None,
+    source_name: str | None = None,
+) -> list[str]:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    source = generate_pipeline_source(
+        generator,
+        facts_path,
+        workload,
+        "go",
+        project_dir,
+        root=root,
+        output_name=source_name,
+    )
+    binary = project_dir / binary_name
+    go_cache = project_dir / ".gocache"
+    go_cache.mkdir(exist_ok=True)
+    env = dict(os.environ, GOCACHE=str(go_cache))
+    run_command(["go", "build", "-o", str(binary), str(source)], env=env)
+    return [str(binary)]

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -16,15 +16,22 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import os
-import shutil
 import statistics
-import subprocess
 import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_rust_binary,
+    require_file,
+    run_command,
+    scale_sort_key,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -72,128 +79,28 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run(
-    cmd: list[str],
-    *,
-    cwd: Path | None = None,
-    check: bool = True,
-    capture_output: bool = True,
-    env: dict[str, str] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        cmd,
-        cwd=cwd,
-        check=check,
-        capture_output=capture_output,
-        text=True,
-        env=env,
-    )
-
-
-def require_file(path: Path) -> Path:
-    if not path.exists():
-        raise FileNotFoundError(path)
-    return path
-
-
-def available_targets(requested: list[str]) -> list[str]:
-    targets: list[str] = []
-    for target in requested:
-        if target == "rust-dfs" and shutil.which("rustc") is None:
-            print("skip rust-dfs: rustc not found", file=sys.stderr)
-            continue
-        if target == "go-dfs" and shutil.which("go") is None:
-            print("skip go-dfs: go not found", file=sys.stderr)
-            continue
-        if target.startswith("csharp-") and shutil.which("dotnet") is None:
-            print(f"skip {target}: dotnet not found", file=sys.stderr)
-            continue
-        targets.append(target)
-    return targets
-
-
-def generate_pipeline_source(root: Path, target: str) -> Path:
-    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go"}[target]
-    filename = "Program.cs" if target == "csharp" else f"effective_distance{ext}"
-    output = root / filename
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(BENCH_DIR / "10k" / "facts.pl"),
-            "--root",
-            "Physics",
-            "--workload",
-            "effective_distance",
-            "--target",
-            target,
-            "--output",
-            str(output),
-        ]
-    )
-    return output
-
-
-def generate_pipeline_package(root: Path, target: str) -> Path:
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(BENCH_DIR / "10k" / "facts.pl"),
-            "--root",
-            "Physics",
-            "--workload",
-            "effective_distance",
-            "--target",
-            target,
-            "--output-dir",
-            str(root),
-        ]
-    )
-    return root
-
-
 def build_csharp_query(root: Path) -> list[str]:
-    project_dir = root / "csharp_query"
-    generate_pipeline_package(project_dir, "csharp_query")
-    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
-    return [
-        "dotnet",
-        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll"),
-    ]
+    return build_csharp_package(
+        GENERATOR, BENCH_DIR / "10k" / "facts.pl", "effective_distance", "csharp_query", root / "csharp_query", root="Physics"
+    )
 
 
 def build_csharp_dfs(root: Path) -> list[str]:
-    project_dir = root / "csharp_dfs"
-    generate_pipeline_package(project_dir, "csharp")
-    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
-    return [
-        "dotnet",
-        str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll"),
-    ]
+    return build_csharp_package(
+        GENERATOR, BENCH_DIR / "10k" / "facts.pl", "effective_distance", "csharp", root / "csharp_dfs", root="Physics"
+    )
 
 
 def build_rust_dfs(root: Path) -> list[str]:
-    project_dir = root / "rust_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "rust")
-    binary = project_dir / "effective_distance_rust"
-    run(["rustc", "-O", str(source), "-o", str(binary)])
-    return [str(binary)]
+    return build_rust_binary(
+        GENERATOR, BENCH_DIR / "10k" / "facts.pl", "effective_distance", root / "rust_dfs", "effective_distance_rust", root="Physics"
+    )
 
 
 def build_go_dfs(root: Path) -> list[str]:
-    project_dir = root / "go_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "go")
-    binary = project_dir / "effective_distance_go"
-    go_cache = project_dir / ".gocache"
-    go_cache.mkdir(exist_ok=True)
-    env = dict(os.environ, GOCACHE=str(go_cache))
-    run(["go", "build", "-o", str(binary), str(source)], env=env)
-    return [str(binary)]
+    return build_go_binary(
+        GENERATOR, BENCH_DIR / "10k" / "facts.pl", "effective_distance", root / "go_dfs", "effective_distance_go", root="Physics"
+    )
 
 
 def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
@@ -206,7 +113,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     last_stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run(command + [str(edge_path), str(article_path)])
+        result = run_command(command + [str(edge_path), str(article_path)])
         elapsed = time.perf_counter() - started
         times.append(elapsed)
         last_stdout = result.stdout

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -8,15 +8,21 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import os
-import shutil
 import statistics
-import subprocess
-import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_rust_binary,
+    require_file,
+    run_command,
+    scale_sort_key,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -52,121 +58,28 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run(
-    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env)
-
-
-def require_file(path: Path) -> Path:
-    if not path.exists():
-        raise FileNotFoundError(path)
-    return path
-
-
-def scale_sort_key(scale: str) -> tuple[int, str]:
-    digits = "".join(ch for ch in scale if ch.isdigit())
-    suffix = "".join(ch for ch in scale if not ch.isdigit())
-    if not digits:
-        return (0, scale)
-    value = int(digits)
-    if suffix.lower() == "k":
-        value *= 1000
-    return (value, scale)
-
-
-def available_targets(requested: list[str]) -> list[str]:
-    targets: list[str] = []
-    for target in requested:
-        if target == "rust-dfs" and shutil.which("rustc") is None:
-            print("skip rust-dfs: rustc not found", file=sys.stderr)
-            continue
-        if target == "go-dfs" and shutil.which("go") is None:
-            print("skip go-dfs: go not found", file=sys.stderr)
-            continue
-        if target.startswith("csharp-") and shutil.which("dotnet") is None:
-            print(f"skip {target}: dotnet not found", file=sys.stderr)
-            continue
-        targets.append(target)
-    return targets
-
-
-def generate_pipeline_source(root: Path, target: str) -> Path:
-    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go"}[target]
-    filename = "Program.cs" if target == "csharp" else f"shortest_path_to_root{ext}"
-    output = root / filename
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(FACTS_PATH),
-            "--root",
-            "Physics",
-            "--workload",
-            "shortest_path_to_root",
-            "--target",
-            target,
-            "--output",
-            str(output),
-        ]
-    )
-    return output
-
-
-def generate_pipeline_package(root: Path, target: str) -> Path:
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(FACTS_PATH),
-            "--root",
-            "Physics",
-            "--workload",
-            "shortest_path_to_root",
-            "--target",
-            target,
-            "--output-dir",
-            str(root),
-        ]
-    )
-    return root
-
-
 def build_csharp_query(root: Path) -> list[str]:
-    project_dir = root / "csharp_query"
-    generate_pipeline_package(project_dir, "csharp_query")
-    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
+    return build_csharp_package(
+        GENERATOR, FACTS_PATH, "shortest_path_to_root", "csharp_query", root / "csharp_query", root="Physics"
+    )
 
 
 def build_csharp_dfs(root: Path) -> list[str]:
-    project_dir = root / "csharp_dfs"
-    generate_pipeline_package(project_dir, "csharp")
-    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
+    return build_csharp_package(
+        GENERATOR, FACTS_PATH, "shortest_path_to_root", "csharp", root / "csharp_dfs", root="Physics"
+    )
 
 
 def build_rust_dfs(root: Path) -> list[str]:
-    project_dir = root / "rust_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "rust")
-    binary = project_dir / "shortest_path_rust"
-    run(["rustc", "-O", str(source), "-o", str(binary)])
-    return [str(binary)]
+    return build_rust_binary(
+        GENERATOR, FACTS_PATH, "shortest_path_to_root", root / "rust_dfs", "shortest_path_rust", root="Physics"
+    )
 
 
 def build_go_dfs(root: Path) -> list[str]:
-    project_dir = root / "go_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "go")
-    binary = project_dir / "shortest_path_go"
-    go_cache = project_dir / ".gocache"
-    go_cache.mkdir(exist_ok=True)
-    env = dict(os.environ, GOCACHE=str(go_cache))
-    run(["go", "build", "-o", str(binary), str(source)], env=env)
-    return [str(binary)]
+    return build_go_binary(
+        GENERATOR, FACTS_PATH, "shortest_path_to_root", root / "go_dfs", "shortest_path_go", root="Physics"
+    )
 
 
 def normalize_output(output: str) -> str:
@@ -186,7 +99,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run(command + [str(edge_path), str(article_path)])
+        result = run_command(command + [str(edge_path), str(article_path)])
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -8,15 +8,21 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import os
-import shutil
 import statistics
-import subprocess
-import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_rust_binary,
+    require_file,
+    run_command,
+    scale_sort_key,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -52,121 +58,28 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run(
-    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, env=env)
-
-
-def require_file(path: Path) -> Path:
-    if not path.exists():
-        raise FileNotFoundError(path)
-    return path
-
-
-def scale_sort_key(scale: str) -> tuple[int, str]:
-    digits = "".join(ch for ch in scale if ch.isdigit())
-    suffix = "".join(ch for ch in scale if not ch.isdigit())
-    if not digits:
-        return (0, scale)
-    value = int(digits)
-    if suffix.lower() == "k":
-        value *= 1000
-    return (value, scale)
-
-
-def available_targets(requested: list[str]) -> list[str]:
-    targets: list[str] = []
-    for target in requested:
-        if target == "rust-dfs" and shutil.which("rustc") is None:
-            print("skip rust-dfs: rustc not found", file=sys.stderr)
-            continue
-        if target == "go-dfs" and shutil.which("go") is None:
-            print("skip go-dfs: go not found", file=sys.stderr)
-            continue
-        if target.startswith("csharp-") and shutil.which("dotnet") is None:
-            print(f"skip {target}: dotnet not found", file=sys.stderr)
-            continue
-        targets.append(target)
-    return targets
-
-
-def generate_pipeline_source(root: Path, target: str) -> Path:
-    ext = {"csharp": ".cs", "rust": ".rs", "go": ".go"}[target]
-    filename = "Program.cs" if target == "csharp" else f"weighted_shortest_path{ext}"
-    output = root / filename
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(FACTS_PATH),
-            "--root",
-            "Physics",
-            "--workload",
-            "weighted_shortest_path",
-            "--target",
-            target,
-            "--output",
-            str(output),
-        ]
-    )
-    return output
-
-
-def generate_pipeline_package(root: Path, target: str) -> Path:
-    run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--facts",
-            str(FACTS_PATH),
-            "--root",
-            "Physics",
-            "--workload",
-            "weighted_shortest_path",
-            "--target",
-            target,
-            "--output-dir",
-            str(root),
-        ]
-    )
-    return root
-
-
 def build_csharp_query(root: Path) -> list[str]:
-    project_dir = root / "csharp_query"
-    generate_pipeline_package(project_dir, "csharp_query")
-    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
+    return build_csharp_package(
+        GENERATOR, FACTS_PATH, "weighted_shortest_path", "csharp_query", root / "csharp_query", root="Physics"
+    )
 
 
 def build_csharp_dfs(root: Path) -> list[str]:
-    project_dir = root / "csharp_dfs"
-    generate_pipeline_package(project_dir, "csharp")
-    run(["dotnet", "build", "benchmark.csproj", "-c", "Release"], cwd=project_dir)
-    return ["dotnet", str(project_dir / "bin" / "Release" / "net9.0" / "benchmark.dll")]
+    return build_csharp_package(
+        GENERATOR, FACTS_PATH, "weighted_shortest_path", "csharp", root / "csharp_dfs", root="Physics"
+    )
 
 
 def build_rust_dfs(root: Path) -> list[str]:
-    project_dir = root / "rust_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "rust")
-    binary = project_dir / "weighted_shortest_path_rust"
-    run(["rustc", "-O", str(source), "-o", str(binary)])
-    return [str(binary)]
+    return build_rust_binary(
+        GENERATOR, FACTS_PATH, "weighted_shortest_path", root / "rust_dfs", "weighted_shortest_path_rust", root="Physics"
+    )
 
 
 def build_go_dfs(root: Path) -> list[str]:
-    project_dir = root / "go_dfs"
-    project_dir.mkdir(parents=True, exist_ok=True)
-    source = generate_pipeline_source(project_dir, "go")
-    binary = project_dir / "weighted_shortest_path_go"
-    go_cache = project_dir / ".gocache"
-    go_cache.mkdir(exist_ok=True)
-    env = dict(os.environ, GOCACHE=str(go_cache))
-    run(["go", "build", "-o", str(binary), str(source)], env=env)
-    return [str(binary)]
+    return build_go_binary(
+        GENERATOR, FACTS_PATH, "weighted_shortest_path", root / "go_dfs", "weighted_shortest_path_go", root="Physics"
+    )
 
 
 def normalize_output(output: str) -> str:
@@ -199,7 +112,7 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run(command + [str(edge_path), str(article_path)])
+        result = run_command(command + [str(edge_path), str(article_path)])
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr


### PR DESCRIPTION
  ## Summary

  This PR factors the repeated build/run scaffolding out of the cross-target
  benchmark runners into a shared utility module.

  After the recent C# packaging cleanup, the benchmark runners were still
  carrying a lot of duplicated infrastructure for:

  - target availability checks
  - source/package generation
  - C# package builds
  - Rust binary builds
  - Go binary builds
  - temp-directory conventions
  - subprocess execution helpers

  This PR centralizes that logic in `benchmark_common.py` and leaves the
  runners focused on workload-specific comparison behavior.

  ## What Changed

  ### New Shared Benchmark Helper Module

  Added:

  - `examples/benchmark/benchmark_common.py`

  This module now provides shared helpers for:

  - `run_command(...)`
  - `require_file(...)`
  - `scale_sort_key(...)`
  - `available_targets(...)`
  - `generate_pipeline_source(...)`
  - `generate_pipeline_package(...)`
  - `build_csharp_package(...)`
  - `build_rust_binary(...)`
  - `build_go_binary(...)`

  The helpers handle:

  - generator invocation
  - package generation for C# and C# query
  - Rust compilation
  - Go compilation with local `GOCACHE`
  - basic target/tool availability checks

  ### Refactored Benchmark Runners

  Updated:

  - `examples/benchmark/benchmark_effective_distance.py`
  - `examples/benchmark/benchmark_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_weighted_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  These runners now use the shared helper layer instead of reimplementing
  the same build/generation plumbing themselves.

  That means the remaining code in each runner is more clearly about:

  - workload-specific normalization
  - output comparison rules
  - per-workload summary formatting
  - workload-specific metrics

  rather than repeated infrastructure.

  ### Documentation

  Updated:

  - `examples/benchmark/README.md`

  The README now documents:

  - `benchmark_common.py`
  - the fact that cross-target benchmark runners now share a common
    build/run helper layer

  ## Why This Matters

  We had already cleaned up benchmark packaging significantly, especially on
  the C# side.

  But the benchmark runner layer was still too repetitive. That made it:

  - easier to introduce inconsistent fixes
  - harder to add new workloads cleanly
  - harder to keep Go/Rust/C# build behavior aligned

  This PR reduces that duplication and makes future benchmark additions
  cheaper and less error-prone.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_common.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/generate_pipeline.py

  ### Smoke benchmarks run locally

  python examples/benchmark/benchmark_effective_distance.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
    --scales 300 \
    --targets csharp-query,rust-dfs,go-dfs \
    --repetitions 1

  ### Smoke Results

  All benchmark smoke runs still produced matching outputs across their
  respective targets.

  #### Effective distance

  - csharp-dfs: 0.463s
  - csharp-query: 0.712s
  - go-dfs: 0.483s
  - rust-dfs: 0.358s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Shortest path

  - csharp-dfs: 0.481s
  - csharp-query: 0.166s
  - go-dfs: 0.490s
  - rust-dfs: 0.389s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Weighted shortest path

  - csharp-dfs: 0.503s
  - csharp-query: 0.212s
  - go-dfs: 0.497s
  - rust-dfs: 0.379s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Category influence

  - csharp-query: 0.698s
  - go-dfs: 0.490s
  - rust-dfs: 0.387s

  Status:

  - outputs = match

  ## Scope

  This PR is benchmark-infrastructure refactoring.

  It does not change lowering semantics or query-engine behavior.

  The goal is to make the benchmark runners more maintainable and less
  duplicated while preserving their existing behavior.

  ## Follow-Up

  Likely next work:

  - continue using workload-driven benchmark additions to test compiler
    generality
  - keep pushing remaining workload-specific orchestration into shared
    compiler/generator paths where possible
  - consider whether any benchmark normalization logic should also be
    partially shared once more workload families stabilize