### PR TITLE
bench: share benchmark normalization helpers

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -204,6 +204,9 @@ Packaging note:
 - shared Rust/Go/C# runner utilities now live in `benchmark_common.py`
   so new workload runners do not need to reimplement the same temp/build
   scaffolding
+- `benchmark_common.py` now also carries shared output-digest and summary
+  helpers, so only workload-specific normalization and extra reporting
+  stay in the individual runners
 
 ## Usage
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -7,7 +7,6 @@ generated Rust/Go binaries.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import statistics
 import tempfile
 import time
@@ -19,6 +18,13 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    print_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
     require_file,
     run_command,
     scale_sort_key,
@@ -110,45 +116,27 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
         stderr = result.stderr
 
     normalized = normalize_output(stdout)
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    row_count = max(0, len(normalized.splitlines()) - 1)
+    digest, row_count = digest_normalized_output(normalized)
     return RunResult(target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
-    by_scale: dict[str, list[RunResult]] = {}
-    for result in results:
-        by_scale.setdefault(result.scale, []).append(result)
-
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
-    for scale in sorted(by_scale.keys(), key=scale_sort_key):
-        entries = sorted(by_scale[scale], key=lambda item: item.target)
-        for result in entries:
-            print(
-                f"{scale}\t{result.target}\t{result.median:.3f}\t"
-                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
-                f"{result.row_count}\t{result.stdout_sha256[:12]}"
-            )
-
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
         if len(entries) > 1:
-            hashes = {item.stdout_sha256 for item in entries}
-            print(f"{scale}\toutputs\t{'match' if len(hashes) == 1 else 'MISMATCH'}")
-            csharp = next((item for item in entries if item.target == "csharp-query"), None)
-            rust = next((item for item in entries if item.target == "rust-dfs"), None)
-            go = next((item for item in entries if item.target == "go-dfs"), None)
-            if csharp and rust:
-                print(f"{scale}\tspeedup_vs_rust_dfs\t{rust.median / csharp.median:.2f}x")
-            if csharp and go:
-                print(f"{scale}\tspeedup_vs_go_dfs\t{go.median / csharp.median:.2f}x")
+            print_match_status(scale, "outputs", entries)
+            csharp = find_result(entries, "csharp-query")
+            rust = find_result(entries, "rust-dfs")
+            go = find_result(entries, "go-dfs")
+            print_speedup(scale, "speedup_vs_rust_dfs", rust, csharp)
+            print_speedup(scale, "speedup_vs_go_dfs", go, csharp)
             if rust and go:
                 faster = "rust-dfs" if rust.median < go.median else "go-dfs"
                 speedup = (go.median / rust.median) if faster == "rust-dfs" else (rust.median / go.median)
                 print(f"{scale}\tfaster_target\t{faster}")
                 print(f"{scale}\tspeedup\t{speedup:.2f}x")
-            if csharp and csharp.stderr:
-                phase_lines = [line.strip() for line in csharp.stderr.splitlines() if "=" in line]
-                if phase_lines:
-                    print(f"{scale}\tcsharp-query-metrics\t" + " ".join(phase_lines))
+            print_phase_metrics(scale, "csharp-query-metrics", csharp)
 
 
 def main() -> int:

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 import subprocess
@@ -186,3 +187,51 @@ def build_go_binary(
     env = dict(os.environ, GOCACHE=str(go_cache))
     run_command(["go", "build", "-o", str(binary), str(source)], env=env)
     return [str(binary)]
+
+
+def digest_normalized_output(normalized: str) -> tuple[str, int]:
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    row_count = max(0, len(normalized.splitlines()) - 1)
+    return digest, row_count
+
+
+def group_results_by_scale(results: list[object], sort_key=scale_sort_key) -> list[tuple[str, list[object]]]:
+    by_scale: dict[str, list[object]] = {}
+    for result in results:
+        by_scale.setdefault(result.scale, []).append(result)
+    return [(scale, by_scale[scale]) for scale in sorted(by_scale.keys(), key=sort_key)]
+
+
+def print_result_table(entries: list[object], scale: str) -> None:
+    for result in sorted(entries, key=lambda item: item.target):
+        print(
+            f"{scale}\t{result.target}\t{result.median:.3f}\t"
+            f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
+            f"{result.row_count}\t{result.stdout_sha256[:12]}"
+        )
+
+
+def find_result(entries: list[object], target: str) -> object | None:
+    return next((item for item in entries if item.target == target), None)
+
+
+def print_match_status(scale: str, label: str, entries: list[object]) -> None:
+    hashes = {item.stdout_sha256 for item in entries}
+    print(f"{scale}\t{label}\t{'match' if len(hashes) == 1 else 'MISMATCH'}")
+
+
+def print_pair_match_status(scale: str, label: str, left: object | None, right: object | None) -> None:
+    if left and right:
+        print(f"{scale}\t{label}\t{'match' if left.stdout_sha256 == right.stdout_sha256 else 'DIFFERENT'}")
+
+
+def print_speedup(scale: str, label: str, faster_baseline: object | None, measured: object | None) -> None:
+    if faster_baseline and measured:
+        print(f"{scale}\t{label}\t{faster_baseline.median / measured.median:.2f}x")
+
+
+def print_phase_metrics(scale: str, label: str, result: object | None) -> None:
+    if result and result.stderr:
+        phase_lines = [line.strip() for line in result.stderr.splitlines() if "=" in line]
+        if phase_lines:
+            print(f"{scale}\t{label}\t" + " ".join(phase_lines))

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -28,9 +28,15 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    find_result,
+    group_results_by_scale,
+    print_match_status,
+    print_pair_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
     require_file,
     run_command,
-    scale_sort_key,
 )
 
 
@@ -129,42 +135,21 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
 
 
 def print_summary(results: list[RunResult]) -> None:
-    by_scale: dict[str, list[RunResult]] = {}
-    for result in results:
-        by_scale.setdefault(result.scale, []).append(result)
-
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
-    for scale in sorted(by_scale.keys(), key=scale_sort_key):
-        for result in sorted(by_scale[scale], key=lambda item: item.target):
-            print(
-                f"{scale}\t{result.target}\t{result.median:.3f}\t"
-                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
-                f"{result.row_count}\t{result.stdout_sha256[:12]}"
-            )
+    for scale, entries in group_results_by_scale(results, sort_key=scale_sort_key):
+        print_result_table(entries, scale)
 
-        qe = next((item for item in by_scale[scale] if item.target == "csharp-query"), None)
-        csharp_dfs = next((item for item in by_scale[scale] if item.target == "csharp-dfs"), None)
-        rust_dfs = next((item for item in by_scale[scale] if item.target == "rust-dfs"), None)
-        dfs_like = [item for item in by_scale[scale] if item.target != "csharp-query"]
+        qe = find_result(entries, "csharp-query")
+        csharp_dfs = find_result(entries, "csharp-dfs")
+        rust_dfs = find_result(entries, "rust-dfs")
+        dfs_like = [item for item in entries if item.target != "csharp-query"]
 
         if len(dfs_like) > 1:
-            dfs_hashes = {item.stdout_sha256 for item in dfs_like}
-            status = "match" if len(dfs_hashes) == 1 else "MISMATCH"
-            print(f"{scale}\tdfs_outputs\t{status}")
-
-        if qe and csharp_dfs:
-            same = "match" if qe.stdout_sha256 == csharp_dfs.stdout_sha256 else "DIFFERENT"
-            print(f"{scale}\tquery_vs_csharp_dfs\t{same}")
-
-        if qe and csharp_dfs:
-            print(f"{scale}\tspeedup_vs_csharp_dfs\t{csharp_dfs.median / qe.median:.2f}x")
-        if qe and rust_dfs:
-            print(f"{scale}\tspeedup_vs_rust_dfs\t{rust_dfs.median / qe.median:.2f}x")
-
-        if qe and qe.stderr:
-            phase_lines = [line.strip() for line in qe.stderr.splitlines() if "=" in line]
-            if phase_lines:
-                print(f"{scale}\tcsharp-query-metrics\t" + " ".join(phase_lines))
+            print_match_status(scale, "dfs_outputs", dfs_like)
+        print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
+        print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
+        print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
+        print_phase_metrics(scale, "csharp-query-metrics", qe)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -7,7 +7,6 @@ DFS binaries for C#, Rust, and Go.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import statistics
 import tempfile
 import time
@@ -19,6 +18,14 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    print_match_status,
+    print_pair_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
     require_file,
     run_command,
     scale_sort_key,
@@ -105,42 +112,27 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
         stderr = result.stderr
 
     normalized = normalize_output(stdout)
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    row_count = max(0, len(normalized.splitlines()) - 1)
+    digest, row_count = digest_normalized_output(normalized)
     return RunResult(target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
-    by_scale: dict[str, list[RunResult]] = {}
-    for result in results:
-        by_scale.setdefault(result.scale, []).append(result)
-
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
-    for scale in sorted(by_scale.keys(), key=scale_sort_key):
-        entries = sorted(by_scale[scale], key=lambda item: item.target)
-        for result in entries:
-            print(
-                f"{scale}\t{result.target}\t{result.median:.3f}\t"
-                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
-                f"{result.row_count}\t{result.stdout_sha256[:12]}"
-            )
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
 
-        qe = next((item for item in entries if item.target == "csharp-query"), None)
-        csharp_dfs = next((item for item in entries if item.target == "csharp-dfs"), None)
-        rust_dfs = next((item for item in entries if item.target == "rust-dfs"), None)
-        go_dfs = next((item for item in entries if item.target == "go-dfs"), None)
+        qe = find_result(entries, "csharp-query")
+        csharp_dfs = find_result(entries, "csharp-dfs")
+        rust_dfs = find_result(entries, "rust-dfs")
+        go_dfs = find_result(entries, "go-dfs")
         dfs_like = [item for item in entries if item.target != "csharp-query"]
 
         if len(dfs_like) > 1:
-            dfs_hashes = {item.stdout_sha256 for item in dfs_like}
-            print(f"{scale}\tdfs_outputs\t{'match' if len(dfs_hashes) == 1 else 'MISMATCH'}")
-        if qe and csharp_dfs:
-            print(f"{scale}\tquery_vs_csharp_dfs\t{'match' if qe.stdout_sha256 == csharp_dfs.stdout_sha256 else 'DIFFERENT'}")
-            print(f"{scale}\tspeedup_vs_csharp_dfs\t{csharp_dfs.median / qe.median:.2f}x")
-        if qe and rust_dfs:
-            print(f"{scale}\tspeedup_vs_rust_dfs\t{rust_dfs.median / qe.median:.2f}x")
-        if qe and go_dfs:
-            print(f"{scale}\tspeedup_vs_go_dfs\t{go_dfs.median / qe.median:.2f}x")
+            print_match_status(scale, "dfs_outputs", dfs_like)
+        print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
+        print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
+        print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
+        print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
 
 
 def main() -> int:

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -7,7 +7,6 @@ and generated DFS binaries for C#, Rust, and Go.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import statistics
 import tempfile
 import time
@@ -19,6 +18,13 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    print_match_status,
+    print_pair_match_status,
+    print_result_table,
+    print_speedup,
     require_file,
     run_command,
     scale_sort_key,
@@ -118,42 +124,27 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
         stderr = result.stderr
 
     normalized = normalize_output(stdout)
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    row_count = max(0, len(normalized.splitlines()) - 1)
+    digest, row_count = digest_normalized_output(normalized)
     return RunResult(target, scale, times, digest, row_count, stderr)
 
 
 def print_summary(results: list[RunResult]) -> None:
-    by_scale: dict[str, list[RunResult]] = {}
-    for result in results:
-        by_scale.setdefault(result.scale, []).append(result)
-
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
-    for scale in sorted(by_scale.keys(), key=scale_sort_key):
-        entries = sorted(by_scale[scale], key=lambda item: item.target)
-        for result in entries:
-            print(
-                f"{scale}\t{result.target}\t{result.median:.3f}\t"
-                f"{min(result.times):.3f}\t{max(result.times):.3f}\t"
-                f"{result.row_count}\t{result.stdout_sha256[:12]}"
-            )
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
 
-        qe = next((item for item in entries if item.target == "csharp-query"), None)
-        csharp_dfs = next((item for item in entries if item.target == "csharp-dfs"), None)
-        rust_dfs = next((item for item in entries if item.target == "rust-dfs"), None)
-        go_dfs = next((item for item in entries if item.target == "go-dfs"), None)
+        qe = find_result(entries, "csharp-query")
+        csharp_dfs = find_result(entries, "csharp-dfs")
+        rust_dfs = find_result(entries, "rust-dfs")
+        go_dfs = find_result(entries, "go-dfs")
         dfs_like = [item for item in entries if item.target != "csharp-query"]
 
         if len(dfs_like) > 1:
-            dfs_hashes = {item.stdout_sha256 for item in dfs_like}
-            print(f"{scale}\tdfs_outputs\t{'match' if len(dfs_hashes) == 1 else 'MISMATCH'}")
-        if qe and csharp_dfs:
-            print(f"{scale}\tquery_vs_csharp_dfs\t{'match' if qe.stdout_sha256 == csharp_dfs.stdout_sha256 else 'DIFFERENT'}")
-            print(f"{scale}\tspeedup_vs_csharp_dfs\t{csharp_dfs.median / qe.median:.2f}x")
-        if qe and rust_dfs:
-            print(f"{scale}\tspeedup_vs_rust_dfs\t{rust_dfs.median / qe.median:.2f}x")
-        if qe and go_dfs:
-            print(f"{scale}\tspeedup_vs_go_dfs\t{go_dfs.median / qe.median:.2f}x")
+            print_match_status(scale, "dfs_outputs", dfs_like)
+        print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
+        print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
+        print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
+        print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
 
 
 def main() -> int:


### PR DESCRIPTION
  ## Summary

  This PR extends the shared benchmark helper layer from build/run plumbing
  into the normalization and reporting path.

  After the previous refactor, the cross-target benchmark runners already
  shared:

  - target availability checks
  - generator invocation
  - C#/Rust/Go build helpers
  - temp/build scaffolding

  But each runner still duplicated a lot of result-processing code:

  - digesting normalized output
  - row counting
  - grouping by scale
  - printing the standard result table
  - printing common match-status lines
  - printing common speedup lines
  - printing common phase-metric lines

  This PR moves that common layer into `benchmark_common.py` and leaves the
  runners with only:

  - workload-specific normalization
  - any workload-specific extra summary lines

  ## What Changed

  ### Shared Benchmark Normalization/Reporting Helpers

  Extended:

  - `examples/benchmark/benchmark_common.py`

  New shared helpers include:

  - `digest_normalized_output(...)`
  - `group_results_by_scale(...)`
  - `print_result_table(...)`
  - `find_result(...)`
  - `print_match_status(...)`
  - `print_pair_match_status(...)`
  - `print_speedup(...)`
  - `print_phase_metrics(...)`

  These helpers cover the common parts of cross-target benchmark result
  reporting while staying agnostic about workload-specific normalization.

  ### Refactored Benchmark Runners

  Updated:

  - `examples/benchmark/benchmark_effective_distance.py`
  - `examples/benchmark/benchmark_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_weighted_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  The runners now reuse the shared reporting helpers and keep only the
  parts that are actually workload-specific.

  Examples of what remains runner-specific:

  - how output lines are normalized and sorted
  - weighted floating-point rounding policy
  - extra per-workload summary lines like:
    - `faster_target`
    - `speedup`
    - the custom `dev`-aware scale ordering in effective distance

  ### Documentation

  Updated:

  - `examples/benchmark/README.md`

  The README now notes that `benchmark_common.py` owns not only shared
  build/run utilities, but also shared digest/summary helpers.

  ## Why This Matters

  The benchmark infrastructure is now cleaner in two dimensions:

  1. build/package execution is shared
  2. common result comparison/reporting is shared

  That reduces duplication and makes it less likely that one runner will
  quietly drift from the others in how it:

  - hashes outputs
  - counts rows
  - reports match status
  - formats standard summary lines

  It also makes future benchmark additions cheaper because a new runner now
  only needs to define:

  - workload-specific normalization
  - workload-specific comparisons

  instead of rebuilding the whole summary stack.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_common.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_category_influence_cross_target.py

  ### Smoke benchmarks run locally

  python examples/benchmark/benchmark_effective_distance.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
    --scales 300 \
    --targets csharp-query,rust-dfs,go-dfs \
    --repetitions 1

  ### Smoke results

  All benchmark smoke runs still produced matching outputs across their
  respective targets.

  #### Effective distance

  - csharp-dfs: 0.459s
  - csharp-query: 0.713s
  - go-dfs: 0.495s
  - rust-dfs: 0.373s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Shortest path

  - csharp-dfs: 0.463s
  - csharp-query: 0.155s
  - go-dfs: 0.493s
  - rust-dfs: 0.387s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Weighted shortest path

  - csharp-dfs: 0.507s
  - csharp-query: 0.199s
  - go-dfs: 0.515s
  - rust-dfs: 0.403s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Category influence

  - csharp-query: 0.788s
  - go-dfs: 1.211s
  - rust-dfs: 0.586s

  Status:

  - outputs = match

  ## Scope

  This PR is benchmark-infrastructure refactoring only.

  It does not change compiler lowering behavior or query semantics.

  The goal is to make result normalization and summary reporting more
  consistent across benchmark runners.

  ## Follow-Up

  Likely next work:

  - continue using workload-driven benchmark additions to stress compiler
    generality
  - consider whether additional workload-specific normalization logic can
    eventually be abstracted safely once more patterns stabilize