### PR TITLE
bench: share benchmark output normalizers

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -207,6 +207,11 @@ Packaging note:
 - `benchmark_common.py` now also carries shared output-digest and summary
   helpers, so only workload-specific normalization and extra reporting
   stay in the individual runners
+- safe shared normalization helpers also live there now for:
+  - exact sorted-line outputs
+  - rounded float row outputs in common 2-column and 3-column forms
+- workloads can still keep custom normalization when their semantics or
+  ordering rules are genuinely different
 
 ## Usage
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -21,13 +21,13 @@ from benchmark_common import (
     digest_normalized_output,
     find_result,
     group_results_by_scale,
+    normalize_two_column_float_rows,
     print_match_status,
     print_phase_metrics,
     print_result_table,
     print_speedup,
     require_file,
     run_command,
-    scale_sort_key,
 )
 
 
@@ -83,21 +83,7 @@ def build_go_dfs(root: Path) -> list[str]:
 
 
 def normalize_output(output: str) -> str:
-    lines = output.splitlines()
-    if not lines:
-        return ""
-    header = lines[0]
-    rows: list[tuple[str, float]] = []
-    for line in lines[1:]:
-        parts = line.split("\t")
-        if len(parts) != 2:
-            continue
-        rows.append((parts[0], round(float(parts[1]), 9)))
-    rows.sort(key=lambda item: (-item[1], item[0]))
-    normalized = [header]
-    for root, score in rows:
-        normalized.append(f"{root}\t{score:.9f}")
-    return "\n".join(normalized)
+    return normalize_two_column_float_rows(output, decimals=9, descending_numeric=True)
 
 
 def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:

--- a/examples/benchmark/benchmark_common.py
+++ b/examples/benchmark/benchmark_common.py
@@ -195,6 +195,58 @@ def digest_normalized_output(normalized: str) -> tuple[str, int]:
     return digest, row_count
 
 
+def normalize_sorted_lines(output: str) -> str:
+    lines = output.splitlines()
+    header = lines[:1]
+    body = sorted(lines[1:])
+    return "\n".join(header + body)
+
+
+def normalize_two_column_float_rows(
+    output: str,
+    *,
+    decimals: int = 9,
+    descending_numeric: bool = False,
+) -> str:
+    lines = output.splitlines()
+    if not lines:
+        return ""
+    header = lines[0]
+    rows: list[tuple[str, float]] = []
+    for line in lines[1:]:
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        rows.append((parts[0], round(float(parts[1]), decimals)))
+    rows.sort(key=lambda item: ((-item[1]) if descending_numeric else item[1], item[0]))
+    normalized = [header]
+    for label, value in rows:
+        normalized.append(f"{label}\t{value:.{decimals}f}")
+    return "\n".join(normalized)
+
+
+def normalize_three_column_float_rows(
+    output: str,
+    *,
+    decimals: int = 9,
+) -> str:
+    lines = output.splitlines()
+    if not lines:
+        return ""
+    header = lines[0]
+    rows: list[tuple[str, str, float]] = []
+    for line in lines[1:]:
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        rows.append((parts[0], parts[1], round(float(parts[2]), decimals)))
+    rows.sort(key=lambda item: (item[2], item[0], item[1]))
+    normalized = [header]
+    for col1, col2, value in rows:
+        normalized.append(f"{col1}\t{col2}\t{value:.{decimals}f}")
+    return "\n".join(normalized)
+
+
 def group_results_by_scale(results: list[object], sort_key=scale_sort_key) -> list[tuple[str, list[object]]]:
     by_scale: dict[str, list[object]] = {}
     for result in results:

--- a/examples/benchmark/benchmark_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_shortest_path_cross_target.py
@@ -21,14 +21,13 @@ from benchmark_common import (
     digest_normalized_output,
     find_result,
     group_results_by_scale,
+    normalize_sorted_lines,
     print_match_status,
     print_pair_match_status,
-    print_phase_metrics,
     print_result_table,
     print_speedup,
     require_file,
     run_command,
-    scale_sort_key,
 )
 
 
@@ -90,10 +89,7 @@ def build_go_dfs(root: Path) -> list[str]:
 
 
 def normalize_output(output: str) -> str:
-    lines = output.splitlines()
-    header = lines[:1]
-    body = sorted(lines[1:])
-    return "\n".join(header + body)
+    return normalize_sorted_lines(output)
 
 
 def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -21,13 +21,13 @@ from benchmark_common import (
     digest_normalized_output,
     find_result,
     group_results_by_scale,
+    normalize_three_column_float_rows,
     print_match_status,
     print_pair_match_status,
     print_result_table,
     print_speedup,
     require_file,
     run_command,
-    scale_sort_key,
 )
 
 
@@ -89,23 +89,7 @@ def build_go_dfs(root: Path) -> list[str]:
 
 
 def normalize_output(output: str) -> str:
-    lines = output.splitlines()
-    if not lines:
-        return ""
-    header = lines[0]
-    rows: list[tuple[str, str, float]] = []
-    for line in lines[1:]:
-        parts = line.split("\t")
-        if len(parts) != 3:
-            continue
-        # Cross-target weighted runs can differ by ~1e-12 due to floating-point
-        # formatting/evaluation order while still being semantically identical.
-        rows.append((parts[0], parts[1], round(float(parts[2]), 9)))
-    rows.sort(key=lambda item: (item[2], item[0], item[1]))
-    normalized = [header]
-    for article, root, value in rows:
-        normalized.append(f"{article}\t{root}\t{value:.9f}")
-    return "\n".join(normalized)
+    return normalize_three_column_float_rows(output, decimals=9)
 
 
 def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:


### PR DESCRIPTION
  ## Summary

  This PR extends the shared benchmark helper layer again, this time into
  safe output normalization.

  After the previous cleanup, the benchmark runners already shared:

  - build/run utilities
  - target availability checks
  - package generation
  - binary compilation
  - common digest/reporting helpers

  But several runners still duplicated normalization logic for common
  output shapes.

  This PR moves the safe shared cases into `benchmark_common.py` and keeps
  only genuinely workload-specific normalization in the individual runners.

  ## What Changed

  ### Shared Output Normalizers

  Extended:

  - `examples/benchmark/benchmark_common.py`

  New shared normalizers include:

  - `normalize_sorted_lines(...)`
  - `normalize_two_column_float_rows(...)`
  - `normalize_three_column_float_rows(...)`

  These cover the common cases where it is safe to normalize in the same
  way across multiple runners:

  - exact line-based tuple outputs
  - 2-column numeric score outputs
  - 3-column numeric distance outputs

  ### Runner Updates

  Updated:

  - `examples/benchmark/benchmark_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_weighted_shortest_path_cross_target.py`
  - `examples/benchmark/benchmark_category_influence_cross_target.py`

  These runners now use the shared normalizers instead of carrying their
  own local implementations.

  ### Intentional Non-Change

  - `examples/benchmark/benchmark_effective_distance.py`

  Effective distance is intentionally still left with its custom
  normalization/ordering path.

  That runner has slightly different normalization and summary behavior, so
  this PR does **not** try to force it into the same abstraction
  prematurely.

  ### Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now clarifies that `benchmark_common.py` owns:

  - shared build/run helpers
  - shared digest/summary helpers
  - shared safe normalization helpers

  while workloads can still keep custom normalization when their semantics
  or ordering rules differ.

  ## Why This Matters

  The benchmark infrastructure now has a clearer boundary:

  - shared helpers own the common mechanics
  - runners own only the genuinely workload-specific behavior

  That reduces duplication again and makes it less likely that two runners
  with the same normalization shape will drift apart over time.

  It also lowers the cost of adding new benchmark families, because new
  runners can reuse:

  - exact sorted-line normalization
  - rounded float-row normalization

  without reimplementing them.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_common.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_category_influence_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py

  ### Smoke benchmarks run locally

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
    --scales 300 \
    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
    --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
    --scales 300 \
    --targets csharp-query,rust-dfs,go-dfs \
    --repetitions 1

  ### Smoke Results

  All smoke runs still produced matching outputs across their respective
  targets.

  #### Shortest path

  - csharp-dfs: 0.453s
  - csharp-query: 0.145s
  - go-dfs: 0.475s
  - rust-dfs: 0.364s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Weighted shortest path

  - csharp-dfs: 0.486s
  - csharp-query: 0.205s
  - go-dfs: 0.486s
  - rust-dfs: 0.394s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  #### Category influence

  - csharp-query: 0.891s
  - go-dfs: 0.933s
  - rust-dfs: 0.395s

  Status:

  - outputs = match

  ## Scope

  This PR is benchmark-infrastructure cleanup only.

  It does not change lowering behavior, query semantics, or runtime
  algorithms.

  The goal is simply to share safe normalization logic and keep custom
  policies only where they are actually warranted.

  ## Follow-Up

  Likely next work:

  - continue using workload additions to test compiler generality
  - only generalize the remaining custom normalization paths where the
    abstraction is clearly safe
  - avoid over-unifying benchmark logic in ways that could hide meaningful
    semantic differences