### PR TITLE
bench: add dependency reach benchmark

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -393,19 +393,19 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.084s | 0.047s | 0.002s | 0.003s | match |
-| 1k | 0.216s | 0.050s | 0.006s | 0.007s | match |
-| 5k | 5.264s | 0.172s | 0.128s | 0.108s | match |
-| 10k | 42.881s | 0.520s | 0.625s | 0.457s | match |
+| 300 | 0.074s | 0.044s | 0.002s | 0.003s | match |
+| 1k | 0.151s | 0.050s | 0.007s | 0.007s | match |
+| 5k | 1.952s | 0.168s | 0.140s | 0.107s | match |
+| 10k | 8.736s | 0.539s | 0.631s | 0.459s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.56x | 0.03x | 0.04x |
-| 1k | 0.23x | 0.03x | 0.03x |
-| 5k | 0.03x | 0.02x | 0.02x |
-| 10k | 0.01x | 0.01x | 0.01x |
+| 300 | 0.59x | 0.03x | 0.04x |
+| 1k | 0.33x | 0.04x | 0.05x |
+| 5k | 0.09x | 0.07x | 0.05x |
+| 10k | 0.06x | 0.07x | 0.05x |
 
 Comparison note:
 
@@ -415,6 +415,9 @@ Comparison note:
   the DFS outputs, but this benchmark is a useful counterexample showing
   that not every recursive DAG-count workload benefits from the current
   query-engine execution model
+- the current C# query path is already improved over the initial version
+  by using plain `TransitiveClosureNode` rather than path-aware closure,
+  which is a better fit for acyclic unique-reachability
 
 ### Cross-Target Category Influence Results
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -184,10 +184,12 @@ Tables:
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
 | `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, C# DFS, Rust DFS, and Go DFS |
+| `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
+| `generate_dependency_benchmark_data.py` | Generate deterministic synthetic package-DAG benchmark data |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
 
@@ -245,6 +247,11 @@ python examples/benchmark/benchmark_shortest_path_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
 
+# Compare dependency reach count across query engine and DFS targets
+python examples/benchmark/benchmark_dependency_depth_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
+
 # Measure overhead of the generalized path-aware accumulation runtime
 python examples/benchmark/benchmark_path_aware_accumulation.py \
     --scales 300,1k,5k,10k
@@ -269,17 +276,20 @@ The current comparison surface across query and non-query targets is:
 - C# query:
   - all-path effective distance
   - minimum hop distance
+  - dependency reach count
   - positive weighted minimum path distance
   - category influence propagation
 
 - Rust DFS:
   - all-path effective distance
   - minimum hop distance
+  - dependency reach count
   - positive weighted minimum path distance
   - category influence propagation
 - Go DFS:
   - all-path effective distance
   - minimum hop distance
+  - dependency reach count
   - positive weighted minimum path distance
   - category influence propagation
 
@@ -288,6 +298,7 @@ The benchmark split is now:
 - cross-target:
   - `benchmark_effective_distance.py`
   - `benchmark_shortest_path_cross_target.py`
+  - `benchmark_dependency_depth_cross_target.py`
   - `benchmark_weighted_shortest_path_cross_target.py`
   - `benchmark_category_influence_cross_target.py`
 - C# query-engine internal mode comparison:
@@ -360,6 +371,50 @@ Comparison note:
 - the cross-target weighted benchmark now normalizes floating-point
   outputs with a tolerance appropriate for cross-language evaluation
   order differences
+
+### Cross-Target Dependency Reach Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_dependency_depth_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
+    --repetitions 1
+```
+
+This workload uses a deterministic synthetic package DAG and reports, for
+each project, the size of its unique transitive dependency closure. It is
+named `dependency_depth` in the generator and runner for continuity with
+the original benchmark idea, but the current metric is more precisely a
+dependency **reach count** than a maximum-chain depth.
+
+Latest local results:
+
+| Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
+|-------|---------:|--------:|---------:|-------:|-----------------|
+| 300 | 0.084s | 0.047s | 0.002s | 0.003s | match |
+| 1k | 0.216s | 0.050s | 0.006s | 0.007s | match |
+| 5k | 5.264s | 0.172s | 0.128s | 0.108s | match |
+| 10k | 42.881s | 0.520s | 0.625s | 0.457s | match |
+
+Speedups of C# query engine:
+
+| Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
+|-------|----------:|------------:|----------:|
+| 300 | 0.56x | 0.03x | 0.04x |
+| 1k | 0.23x | 0.03x | 0.03x |
+| 5k | 0.03x | 0.02x | 0.02x |
+| 10k | 0.01x | 0.01x | 0.01x |
+
+Comparison note:
+
+- this workload currently favors the plain DFS targets over the C#
+  query-engine path
+- the C# query implementation is still semantically correct and matches
+  the DFS outputs, but this benchmark is a useful counterexample showing
+  that not every recursive DAG-count workload benefits from the current
+  query-engine execution model
 
 ### Cross-Target Category Influence Results
 

--- a/examples/benchmark/benchmark_dependency_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_depth_cross_target.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Benchmark dependency reach-count analysis across the C# query engine and
+generated DFS binaries for C#, Rust, and Go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_rust_binary,
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_sorted_lines,
+    print_match_status,
+    print_pair_match_status,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+DATA_GENERATOR = ROOT / "examples" / "benchmark" / "generate_dependency_benchmark_data.py"
+SCALES = {"300": 300, "1k": 1000, "5k": 5000, "10k": 10000}
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def build_dataset(root: Path, scale: str) -> Path:
+    dataset_dir = root / "datasets" / scale
+    run_command(
+        [
+            sys.executable,
+            str(DATA_GENERATOR),
+            "--output-dir",
+            str(dataset_dir),
+            "--scale",
+            scale,
+        ]
+    )
+    return dataset_dir
+
+
+def build_csharp_query(root: Path, facts_path: Path) -> list[str]:
+    return build_csharp_package(
+        GENERATOR, facts_path, "dependency_depth", "csharp_query", root / "csharp_query"
+    )
+
+
+def build_csharp_dfs(root: Path, facts_path: Path) -> list[str]:
+    return build_csharp_package(
+        GENERATOR, facts_path, "dependency_depth", "csharp", root / "csharp_dfs"
+    )
+
+
+def build_rust_dfs(root: Path, facts_path: Path) -> list[str]:
+    return build_rust_binary(
+        GENERATOR, facts_path, "dependency_depth", root / "rust_dfs", "dependency_depth_rust"
+    )
+
+
+def build_go_dfs(root: Path, facts_path: Path) -> list[str]:
+    return build_go_binary(
+        GENERATOR, facts_path, "dependency_depth", root / "go_dfs", "dependency_depth_go"
+    )
+
+
+def benchmark_target(command: list[str], dataset_dir: Path, repetitions: int, target: str, scale: str) -> RunResult:
+    edge_path = require_file(dataset_dir / "category_parent.tsv")
+    article_path = require_file(dataset_dir / "article_category.tsv")
+
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command + [str(edge_path), str(article_path)])
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    digest, row_count = digest_normalized_output(normalize_sorted_lines(stdout))
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        qe = find_result(entries, "csharp-query")
+        csharp_dfs = find_result(entries, "csharp-dfs")
+        rust_dfs = find_result(entries, "rust-dfs")
+        go_dfs = find_result(entries, "go-dfs")
+        dfs_like = [item for item in entries if item.target != "csharp-query"]
+        if len(dfs_like) > 1:
+            print_match_status(scale, "dfs_outputs", dfs_like)
+        print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
+        print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
+        print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
+        print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    for scale in scales:
+        if scale not in SCALES:
+            raise SystemExit(f"Unsupported scale {scale!r}; expected one of {', '.join(SCALES)}")
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available")
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-dependency-depth-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-dependency-depth-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        seed_dataset = build_dataset(temp_root, scales[-1])
+        seed_facts = seed_dataset / "facts.pl"
+
+        commands: dict[str, list[str]] = {}
+        for target in targets:
+            if target == "csharp-query":
+                commands[target] = build_csharp_query(temp_root, seed_facts)
+            elif target == "csharp-dfs":
+                commands[target] = build_csharp_dfs(temp_root, seed_facts)
+            elif target == "rust-dfs":
+                commands[target] = build_rust_dfs(temp_root, seed_facts)
+            elif target == "go-dfs":
+                commands[target] = build_go_dfs(temp_root, seed_facts)
+            else:
+                raise ValueError(f"unsupported target: {target}")
+
+        results: list[RunResult] = []
+        for scale in scales:
+            dataset_dir = build_dataset(temp_root, scale)
+            for target in targets:
+                results.append(benchmark_target(commands[target], dataset_dir, args.repetitions, target, scale))
+
+        print_summary(results)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_dependency_benchmark_data.py
+++ b/examples/benchmark/generate_dependency_benchmark_data.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+SCALE_MAP = {
+    "300": 300,
+    "1k": 1000,
+    "5k": 5000,
+    "10k": 10000,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate deterministic dependency DAG benchmark data")
+    parser.add_argument("--output-dir", required=True, help="Directory to write benchmark TSV/facts files into")
+    parser.add_argument("--scale", help="Named scale such as 300, 1k, 5k, 10k")
+    parser.add_argument("--packages", type=int, help="Override package count directly")
+    parser.add_argument("--projects", type=int, help="Override project count")
+    return parser.parse_args()
+
+
+def package_count_from_args(args: argparse.Namespace) -> int:
+    if args.packages is not None:
+        return args.packages
+    if args.scale is not None:
+        if args.scale not in SCALE_MAP:
+            raise SystemExit(f"Unknown scale {args.scale!r}; expected one of {', '.join(SCALE_MAP)}")
+        return SCALE_MAP[args.scale]
+    raise SystemExit("One of --scale or --packages is required")
+
+
+def build_dependency_edges(package_count: int) -> list[tuple[str, str]]:
+    edges: list[tuple[str, str]] = []
+    for i in range(1, package_count + 1):
+        child = f"pkg_{i:05d}"
+        parents: list[int] = []
+        if i > 1:
+            parents.append(i - 1)
+        if i > 2:
+            parents.append(i // 2)
+        if i > 5 and i % 3 == 0:
+            parents.append(i - 3)
+        if i > 9 and i % 5 == 0:
+            parents.append(i - 7)
+        for parent_idx in sorted(set(p for p in parents if p >= 1 and p < i)):
+            edges.append((child, f"pkg_{parent_idx:05d}"))
+    return edges
+
+
+def build_project_deps(package_count: int, project_count: int) -> list[tuple[str, str]]:
+    edges: list[tuple[str, str]] = []
+    span = max(11, package_count // max(1, project_count))
+    for i in range(1, project_count + 1):
+        project = f"proj_{i:05d}"
+        start = max(1, package_count - (i - 1) * span)
+        deps = [start, max(1, start - 3), max(1, start - 9)]
+        for dep_idx in sorted(set(deps), reverse=True):
+            edges.append((project, f"pkg_{dep_idx:05d}"))
+    return edges
+
+
+def write_tsv(path: Path, header: tuple[str, str], rows: list[tuple[str, str]]) -> None:
+    lines = ["\t".join(header)]
+    lines.extend(f"{left}\t{right}" for left, right in rows)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_facts(path: Path, project_deps: list[tuple[str, str]], package_edges: list[tuple[str, str]]) -> None:
+    lines: list[str] = []
+    for project, dep in project_deps:
+        lines.append(f"article_category('{project}', '{dep}').")
+    for child, parent in package_edges:
+        lines.append(f"category_parent('{child}', '{parent}').")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    package_count = package_count_from_args(args)
+    project_count = args.projects if args.projects is not None else max(12, package_count // 20)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    package_edges = build_dependency_edges(package_count)
+    project_deps = build_project_deps(package_count, project_count)
+
+    write_tsv(out_dir / "category_parent.tsv", ("child", "parent"), package_edges)
+    write_tsv(out_dir / "article_category.tsv", ("article", "category"), project_deps)
+    write_facts(out_dir / "facts.pl", project_deps, package_edges)
+
+    print(f"Generated dependency benchmark data in {out_dir}")
+    print(f"  packages={package_count}")
+    print(f"  projects={project_count}")
+    print(f"  dependency_edges={len(package_edges)}")
+    print(f"  project_edges={len(project_deps)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1489,7 +1489,7 @@ class Program
 
         var plan = new QueryPlan(
             predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.Min),
+            new TransitiveClosureNode(edgeId, predId),
             true,
             new int[] {{ 0 }}
         );

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1165,6 +1165,413 @@ class ShortestPathBenchmark
 '''
 
 
+def generate_go_dependency_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    return f'''// Dependency reach-count benchmark (Go)
+package main
+
+import (
+\t"bufio"
+\t"fmt"
+\t"os"
+\t"sort"
+\t"strings"
+)
+
+func loadTSVPairs(path string) map[string][]string {{
+\tm := make(map[string][]string)
+\tf, err := os.Open(path)
+\tif err != nil {{
+\t\tfmt.Fprintf(os.Stderr, "Cannot open %s: %v\\n", path, err)
+\t\tos.Exit(1)
+\t}}
+\tdefer f.Close()
+\tscanner := bufio.NewScanner(f)
+\tfirst := true
+\tfor scanner.Scan() {{
+\t\tline := scanner.Text()
+\t\tif first {{
+\t\t\tfirst = false
+\t\t\tif strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {{
+\t\t\t\tcontinue
+\t\t\t}}
+\t\t}}
+\t\tparts := strings.SplitN(line, "\\t", 2)
+\t\tif len(parts) == 2 {{
+\t\t\tm[parts[0]] = append(m[parts[0]], parts[1])
+\t\t}}
+\t}}
+\treturn m
+}}
+
+func collectDependencies(node string, adj map[string][]string, seen map[string]bool) {{
+\tif seen[node] {{
+\t\treturn
+\t}}
+\tseen[node] = true
+\tfor _, dep := range adj[node] {{
+\t\tcollectDependencies(dep, adj, seen)
+\t}}
+}}
+
+type projectResult struct {{
+\tproject string
+\tcount   int
+}}
+
+func main() {{
+\tif len(os.Args) < 3 {{
+\t\tfmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\\n", os.Args[0])
+\t\tos.Exit(1)
+\t}}
+
+\tadj := loadTSVPairs(os.Args[1])
+\tprojectDeps := loadTSVPairs(os.Args[2])
+
+\tvar projects []string
+\tfor project := range projectDeps {{
+\t\tprojects = append(projects, project)
+\t}}
+\tsort.Strings(projects)
+
+\tresults := make([]projectResult, 0, len(projects))
+\tfor _, project := range projects {{
+\t\tseen := make(map[string]bool)
+\t\tfor _, dep := range projectDeps[project] {{
+\t\t\tcollectDependencies(dep, adj, seen)
+\t\t}}
+\t\tresults = append(results, projectResult{{project: project, count: len(seen)}})
+\t}}
+
+\tresults = results[:0+len(results)]
+\tsort.Slice(results, func(i, j int) bool {{
+\t\tif results[i].count != results[j].count {{
+\t\t\treturn results[i].count < results[j].count
+\t\t}}
+\t\treturn results[i].project < results[j].project
+\t}})
+
+\tfmt.Println("project\\tdependency_reach_count")
+\tfor _, result := range results {{
+\t\tfmt.Printf("%s\\t%d\\n", result.project, result.count)
+\t}}
+}}
+'''
+
+
+def generate_rust_dependency_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    return '''// Dependency reach-count benchmark (Rust)
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::io::{BufRead, BufReader};
+
+fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let file = fs::File::open(path).unwrap_or_else(|e| panic!("Cannot open {}: {}", path, e));
+    let reader = BufReader::new(file);
+    for (i, line) in reader.lines().enumerate() {
+        let line = line.unwrap();
+        if (i == 0) && (line.starts_with("article") || line.starts_with("child")) {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '\\t').collect();
+        if parts.len() == 2 {
+            map.entry(parts[0].to_string()).or_insert_with(Vec::new).push(parts[1].to_string());
+        }
+    }
+    map
+}
+
+fn collect_dependencies(node: &str, adj: &HashMap<String, Vec<String>>, seen: &mut HashSet<String>) {
+    if !seen.insert(node.to_string()) {
+        return;
+    }
+    if let Some(deps) = adj.get(node) {
+        for dep in deps {
+            collect_dependencies(dep, adj, seen);
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <category_parent.tsv> <article_category.tsv>", args[0]);
+        std::process::exit(1);
+    }
+
+    let adj = load_tsv_pairs(&args[1]);
+    let project_deps = load_tsv_pairs(&args[2]);
+
+    let mut projects: Vec<&String> = project_deps.keys().collect();
+    projects.sort();
+
+    let mut results: Vec<(i32, String)> = Vec::new();
+    for project in projects {
+        let mut seen = HashSet::new();
+        if let Some(deps) = project_deps.get(project) {
+            for dep in deps {
+                collect_dependencies(dep, &adj, &mut seen);
+            }
+        }
+        results.push((seen.len() as i32, project.to_string()));
+    }
+
+    results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    println!("project\tdependency_reach_count");
+    for (count, project) in results {
+        println!("{}\t{}", project, count);
+    }
+}
+'''
+
+
+def generate_csharp_dependency_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    return '''// Dependency reach-count benchmark (C#)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+class Program
+{
+    static Dictionary<string, List<string>> LoadTsvPairs(string path)
+    {
+        var map = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var (line, i) in File.ReadLines(path).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!map.TryGetValue(parts[0], out var bucket))
+            {
+                bucket = new List<string>();
+                map[parts[0]] = bucket;
+            }
+
+            bucket.Add(parts[1]);
+        }
+
+        return map;
+    }
+
+    static void CollectDependencies(string node, Dictionary<string, List<string>> adj, HashSet<string> seen)
+    {
+        if (!seen.Add(node))
+        {
+            return;
+        }
+
+        if (!adj.TryGetValue(node, out var deps))
+        {
+            return;
+        }
+
+        foreach (var dep in deps)
+        {
+            CollectDependencies(dep, adj, seen);
+        }
+    }
+
+    static void Main(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }
+
+        var adj = LoadTsvPairs(args[0]);
+        var projectDeps = LoadTsvPairs(args[1]);
+        var results = new List<(int Count, string Project)>();
+
+        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var dep in projectDeps[project])
+            {
+                CollectDependencies(dep, adj, seen);
+            }
+
+            results.Add((seen.Count, project));
+        }
+
+        results.Sort((a, b) =>
+        {
+            var cmp = a.Count.CompareTo(b.Count);
+            return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
+        });
+
+        Console.WriteLine("project\tdependency_reach_count");
+        foreach (var (count, project) in results)
+        {
+            Console.WriteLine($"{project}\t{count}");
+        }
+    }
+}
+'''
+
+
+def generate_csharp_query_dependency_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    depth_bound = max(max_depth, 20000)
+    return f'''// Dependency reach-count benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const int MAX_DEPTH = {depth_bound};
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("dependency_reach", 3);
+        var projectDeps = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }}
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!projectDeps.TryGetValue(parts[0], out var deps))
+            {{
+                deps = new List<string>();
+                projectDeps[parts[0]] = deps;
+            }}
+
+            deps.Add(parts[1]);
+        }}
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.Min),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var deps in projectDeps.Values)
+        {{
+            foreach (var dep in deps)
+            {{
+                uniqueSeeds.Add(dep);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds
+            .OrderBy(dep => dep, StringComparer.Ordinal)
+            .Select(dep => new object[] {{ dep }})
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var reachIndex = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var dep = row[1]?.ToString() ?? "";
+            if (!reachIndex.TryGetValue(source, out var bucket))
+            {{
+                bucket = new HashSet<string>(StringComparer.Ordinal);
+                reachIndex[source] = bucket;
+            }}
+            bucket.Add(dep);
+        }}
+
+        var results = new List<(int Count, string Project)>();
+        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            var allDeps = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var dep in projectDeps[project])
+            {{
+                allDeps.Add(dep);
+                if (reachIndex.TryGetValue(dep, out var closure))
+                {{
+                    foreach (var item in closure)
+                    {{
+                        allDeps.Add(item);
+                    }}
+                }}
+            }}
+
+            results.Add((allDeps.Count, project));
+        }}
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Count.CompareTo(b.Count);
+            return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("project\\tdependency_reach_count");
+        foreach (var item in results)
+        {{
+            Console.WriteLine($"{{item.Project}}\\t{{item.Count}}");
+        }}
+
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"project_count={{results.Count}}");
+    }}
+}}
+'''
+
+
 def generate_go_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -2511,6 +2918,12 @@ GENERATORS = {
         'rust': generate_rust_shortest_path,
         'csharp': generate_csharp_shortest_path,
         'csharp_query': generate_csharp_query_shortest_path,
+    },
+    'dependency_depth': {
+        'go': generate_go_dependency_depth,
+        'rust': generate_rust_dependency_depth,
+        'csharp': generate_csharp_dependency_depth,
+        'csharp_query': generate_csharp_query_dependency_depth,
     },
     'weighted_shortest_path': {
         'go': generate_go_weighted_shortest_path,


### PR DESCRIPTION
  ## Summary

  This PR adds a new cross-target benchmark workload for dependency-graph
  analysis.

  The new workload is a deterministic synthetic package DAG and reports, for
  each project, the size of its unique transitive dependency closure.

  The workload is named `dependency_depth` in the generator and runner for
  continuity with the original benchmark direction, but the current metric is
  more precisely a dependency **reach count** than a true maximum-chain depth.

  The PR also includes a follow-up optimization to the C# query benchmark
  path, switching it from path-aware closure to plain transitive closure,
  which is a better fit for this acyclic unique-reachability workload.

  ## What Changed

  ### New Synthetic Dataset Generator

  Added:

  - `examples/benchmark/generate_dependency_benchmark_data.py`

  This script generates deterministic synthetic dependency benchmark data as:

  - `category_parent.tsv`
  - `article_category.tsv`
  - `facts.pl`

  The generated graph is acyclic by construction:

  - package nodes depend only on lower-index package nodes
  - projects depend on a few high-index packages

  That makes it a clean DAG workload for transitive reachability/counting.

  ### New Workload in `generate_pipeline.py`

  Extended:

  - `examples/benchmark/generate_pipeline.py`

  New workload:

  - `dependency_depth`

  Supported targets:

  - `csharp`
  - `csharp_query`
  - `rust`
  - `go`

  All four generated programs now compute:

  - one row per project
  - output format:
    - `project\tdependency_reach_count`

  ### New Cross-Target Runner

  Added:

  - `examples/benchmark/benchmark_dependency_depth_cross_target.py`

  The new runner compares:

  - `csharp-query`
  - `csharp-dfs`
  - `rust-dfs`
  - `go-dfs`

  It uses the new synthetic dataset generator to build the benchmark inputs
  per scale and then measures output agreement and runtime across targets.

  ### C# Query Optimization

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The C# query path for this workload originally used:

  - `PathAwareTransitiveClosureNode(..., TableMode.Min)`

  That was semantically correct, but too expensive for this acyclic unique
  reachability problem.

  The benchmark now uses:

  - `TransitiveClosureNode(...)`

  instead, which is a better match for:

  - DAG reachability
  - unique target counting
  - no need for per-path state

  This materially improved the C# query timings while preserving output
  agreement.

  ### Documentation

  Updated:

  - `examples/benchmark/README.md`

  The README now documents:

  - the new benchmark script
  - the synthetic dataset generator
  - the benchmark command
  - local `300/1k/5k/10k` results
  - the important interpretation that this workload currently favors the
    DFS targets over the query engine

  ## Why This Matters

  This PR moves the benchmark suite back toward compiler/workload generality
  rather than more benchmark infrastructure cleanup.

  It adds a new workload family with a very different shape from the recent
  path-sensitive benchmarks:

  - acyclic graph
  - unique reachability/counting
  - no need for simple-path multiplicity handling

  That makes it a useful counterexample.

  The results show that the C# query engine is not universally fastest for
  all recursive workloads. In particular, this DAG-count workload currently
  favors the plain DFS targets.

  That is a good benchmark outcome:
  - it broadens the comparison surface
  - it highlights where the query engine is still too general-purpose
  - it suggests where DAG-specific optimization work could matter later

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_dependency_benchmark_data.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  Benchmarks run locally:

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 1k,5k,10k \
      --repetitions 1

  ## Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.074s | 0.044s | 0.002s | 0.003s | match |
  | 1k | 0.151s | 0.050s | 0.007s | 0.007s | match |
  | 5k | 1.952s | 0.168s | 0.140s | 0.107s | match |
  | 10k | 8.736s | 0.539s | 0.631s | 0.459s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.59x | 0.03x | 0.04x |
  | 1k | 0.33x | 0.04x | 0.05x |
  | 5k | 0.09x | 0.07x | 0.05x |
  | 10k | 0.06x | 0.07x | 0.05x |

  ## Interpretation

  This benchmark currently favors the DFS targets.

  That is not a correctness problem:

  - all four targets match
  - the C# query path is semantically correct

  It is a workload-shape result:

  - this benchmark is a DAG reachability/count workload
  - the current C# query path still pays more generic closure machinery cost
  - the DFS targets are effectively doing cheap memoizable reachability on
    an acyclic graph

  So this PR should be read as:

  - adding an important new benchmark family
  - improving the C# query implementation for that family
  - and documenting a real case where the query engine is still not the
    best execution strategy

  ## Scope

  This PR adds:

  - a new benchmark workload
  - a synthetic data generator
  - a new cross-target runner
  - target code generation for that workload
  - a targeted C# query optimization for the workload

  It does not yet add:

  - true DAG longest-path / maximum-depth benchmarking
  - non-DAG dependency semantics
  - a C# query optimization that closes the current large performance gap

  ## Follow-Up

  Likely next work:

  - add a second DAG benchmark for true dependency depth
  - treat DAG and non-DAG dependency problems as separate benchmark families
  - later, for the non-DAG case, consider hashed path-state indexing with
    exact collision verification as a way to make simple-path tracking
    cheaper without sacrificing correctness