### PR TITLE
docs: propose hashed path-state indexing for non-dag recursion

### DIFF
--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PHILOSOPHY.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PHILOSOPHY.md
@@ -1,0 +1,116 @@
+# Non-DAG Path-State Hashing: Philosophy
+
+## Problem
+
+We now have a clearer separation between two classes of recursive graph
+workloads:
+
+1. **DAG workloads**
+   - well-founded by structure
+   - no revisitation ambiguity
+   - often admit dynamic programming or plain closure/count algorithms
+
+2. **Non-DAG workloads**
+   - cycles are present
+   - simple-path semantics matter
+   - per-path visited state is part of the meaning, not just an
+     implementation detail
+
+The recent dependency reach benchmark reinforced this split. The DAG case
+should be optimized as a DAG. The non-DAG case should not be forced into
+DAG-style scalar summaries that lose correctness.
+
+## Core Position
+
+For non-DAG simple-path workloads, we should treat **path identity** or
+**visited-state identity** as a first-class execution concern.
+
+However, we should not continue paying the full cost of exact path-state
+comparison using large heap-heavy structures such as:
+
+- `HashSet<object?>` copied per branch
+- frontier scans over exact visited sets without indexing
+
+That is correct, but too expensive.
+
+The right direction is:
+
+- keep exact semantics
+- make path-state lookup cheaper
+- use hashing as an index, not as a semantic shortcut
+
+## What Hashing Is For
+
+Hashing should be used to make state management cheaper in three ways:
+
+1. **Incremental path fingerprints**
+   - every path extension updates a deterministic fingerprint cheaply
+2. **Fast candidate lookup**
+   - explored-state tables can be keyed by compact fingerprints instead
+     of probing richer structures first
+3. **Subset / equivalence prefiltering**
+   - fingerprints, sizes, and compact summaries can reject most
+     impossible matches before exact verification
+
+The important boundary is:
+
+- a hash is a performance device
+- not the full proof of state equality
+
+If exactness matters, hash equality must still fall through to exact
+verification on collision or possible match.
+
+## Why This Is Better Than Pure Frontier Scans
+
+The current exact non-DAG approaches we explored earlier were dominated
+by the cost of comparing rich path states repeatedly.
+
+Hashed path-state indexing changes the shape of that work:
+
+- instead of scanning many frontier states blindly
+- first jump to a much smaller candidate bucket
+- then verify only those states that might actually match or dominate
+
+This preserves semantics while making the common case cheaper.
+
+## Why This Is Better Than Approximate Hash-Only Semantics
+
+Hash-only equality would be tempting, but it is the wrong abstraction for
+the compiler/runtime:
+
+- collisions would create semantic risk
+- correctness would become probabilistic
+- debugging would become much harder
+
+So the design should stay exact:
+
+- deterministic fingerprint
+- exact collision verification
+
+That keeps the optimization honest.
+
+## Relationship to DAG Work
+
+This proposal is specifically for the **non-DAG** side.
+
+It should not be used to paper over DAG workloads that ought to be
+compiled differently. The right split is:
+
+- DAG: exploit acyclicity directly
+- non-DAG: use path-state indexing for exact simple-path semantics
+
+That division gives us a cleaner compiler story and better benchmarks.
+
+## Recommended Framing
+
+The non-DAG runtime direction should be described as:
+
+- **hashed path-state indexing with exact verification**
+
+not:
+
+- “probabilistic path equality”
+- “approximate deduplication”
+- “hash-based semantics”
+
+The semantics remain exact. Only the indexing changes.

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md
@@ -1,0 +1,100 @@
+# Non-DAG Path-State Hashing: Implementation Plan
+
+## Phase 0: Preserve the Split
+
+Before implementation work, keep the benchmark and planner framing clear:
+
+- DAG workloads are optimized as DAGs
+- non-DAG simple-path workloads use exact path-state machinery
+
+This avoids mixing the two problem classes again.
+
+## Phase 1: Runtime Instrumentation
+
+Add measurement around the current exact non-DAG path-state paths:
+
+- frontier candidate count
+- exact comparison count
+- subset-check count
+- bucket sizes if any preliminary indexing already exists
+
+Goal:
+
+- identify the real hot spots before changing representation
+
+## Phase 2: Integer-State Normalization
+
+Normalize relevant non-DAG recursive executors to use:
+
+- stable integer ids for graph nodes
+
+This is a prerequisite for compact exact path-state representation and
+cheap hashing.
+
+## Phase 3: Fingerprint-Carrying State
+
+Extend the relevant recursive state structures to carry:
+
+- exact visited state
+- deterministic fingerprint
+- optional compact summaries
+
+At this phase, correctness should remain unchanged. The fingerprint is
+added first as metadata, not yet as the sole lookup route.
+
+## Phase 4: Bucketed Lookup
+
+Introduce fingerprint-indexed buckets for:
+
+1. exact deduplication
+2. `Min` frontier candidate lookup
+
+Workflow:
+
+- derive candidate bucket from the fingerprint key
+- run exact verification inside the bucket
+- keep fallback correctness behavior intact
+
+## Phase 5: Dominance Prefilters
+
+Add cheap prefilters before exact subset / equality checks, such as:
+
+- visited cardinality checks
+- summary mismatches
+- node-local bucket partitioning
+
+Only after those pass should exact dominance verification run.
+
+## Phase 6: Benchmark Validation
+
+Use cyclic simple-path benchmarks to compare:
+
+- previous exact implementation
+- hashed path-state indexed implementation
+
+Measure:
+
+- runtime
+- memory
+- candidate bucket sizes
+- exact verification counts
+
+## Phase 7: Planner Integration
+
+Make the runtime selection explicit:
+
+- DAG fast path when structural acyclicity is known
+- hashed non-DAG path-state strategy when simple-path cyclic semantics
+  are required
+
+## Immediate Follow-Up After This Proposal
+
+Do **not** implement this before finishing the current DAG benchmark
+follow-up work.
+
+The next concrete coding step after these docs should still be DAG-side:
+
+- improve the dependency reach / depth story on acyclic graphs
+
+This proposal exists so the non-DAG direction is not lost while that DAG
+work proceeds.

--- a/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
+++ b/docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md
@@ -1,0 +1,147 @@
+# Non-DAG Path-State Hashing: Specification
+
+## Goal
+
+Define a sound execution strategy for cyclic simple-path workloads that:
+
+- preserves exact semantics
+- reduces path-state comparison cost
+- composes with existing `All` and `Min` recursive execution machinery
+
+This proposal is for workloads where revisiting a node on the same path
+is forbidden or otherwise semantically significant.
+
+## Target Workloads
+
+Representative shapes include:
+
+1. counted simple-path closure on cyclic graphs
+2. weighted `Min` simple-path recursion on cyclic graphs
+3. future non-DAG dependency workloads with explicit simple-path
+   semantics
+
+Out of scope:
+
+- DAG-only workloads that can be solved by topological dynamic
+  programming
+- approximate graph search
+
+## State Model
+
+Each active recursive state should carry:
+
+1. current node or recursive position
+2. current accumulator / depth if the workload uses one
+3. exact visited-state representation
+4. deterministic path-state fingerprint
+5. optional compact summaries used only as prefilters
+
+Examples of compact summaries:
+
+- visited cardinality
+- node-id bitset blocks where feasible
+- min/max node id seen
+- XOR / rolling hash summaries
+
+These summaries may accelerate lookup but do not replace exact visited
+state.
+
+## Correctness Rule
+
+Two states may be treated as identical or as dominance candidates only if
+their exact semantics justify it.
+
+Therefore:
+
+- hash equality alone is insufficient
+- summary equality alone is insufficient
+
+Exact verification is required before:
+
+1. deduplicating states
+2. concluding dominance
+3. rejecting a newly derived state
+
+## Fingerprint Requirements
+
+The path-state fingerprint should be:
+
+- deterministic
+- cheap to update incrementally when extending a path
+- stable across execution order
+
+Possible constructions:
+
+- rolling hash over canonical path sequence
+- hash over canonical visited-set encoding
+- combined `(current_node, fingerprint)` key where needed
+
+The proposal does not commit to one concrete hash function yet, but it
+does require:
+
+- no semantic dependence on collision-freeness
+
+## Lookup Model
+
+### Exact deduplication
+
+Use:
+
+- `(current node, fingerprint)` as the first lookup key
+
+Then:
+
+- verify candidate states exactly inside the bucket
+
+### Dominance for `Min`
+
+Use:
+
+- node
+- accumulator band or exact accumulator
+- fingerprint bucket
+- optional subset-friendly summaries
+
+Then:
+
+- verify exact dominance relation using the exact visited-state
+  representation before pruning
+
+## Visited-State Representation
+
+The implementation should prefer more compact exact structures than the
+earlier generic `HashSet<object?>` frontier representation.
+
+Preferred direction:
+
+- integer node ids
+- compact exact visited encoding
+- path fingerprint derived from that encoding
+
+Exact structure options include:
+
+1. sorted integer path vector
+2. compact persistent bitset
+3. hybrid structure:
+   - compact exact membership structure
+   - hash/fingerprint cache
+
+## Runtime Applicability
+
+This strategy should be used only for workloads that actually need
+non-DAG simple-path semantics.
+
+It should not replace:
+
+- DAG-specific fast paths
+- scalar closure/count strategies on acyclic graphs
+
+The planner/runtime should continue to select the cheapest correct model
+for the workload class.
+
+## Success Criteria
+
+1. Exact output agreement with current exact non-DAG implementations
+2. Reduced frontier lookup cost on cyclic simple-path benchmarks
+3. Lower memory overhead than naive exact visited-set tracking
+4. Clear separation from DAG-specialized execution paths


### PR DESCRIPTION
  ## Summary

  This PR adds a compact proposal set for the non-DAG side of recursive
  graph execution.

  The recent dependency-reach benchmark made the DAG/non-DAG split clearer:

  - DAG workloads should be optimized as DAGs
  - non-DAG simple-path workloads still need exact path-state reasoning

  This PR captures the non-DAG direction while that context is fresh.

  The proposed strategy is:

  - hashed path-state indexing
  - with exact verification after lookup

  So hashing is used as an execution/indexing optimization, not as an
  approximate semantic shortcut.

  ## Included Docs

  - `docs/proposals/NON_DAG_PATH_STATE_HASHING_PHILOSOPHY.md`
  - `docs/proposals/NON_DAG_PATH_STATE_HASHING_SPEC.md`
  - `docs/proposals/NON_DAG_PATH_STATE_HASHING_PLAN.md`

  ## Why This Proposal Exists

  Earlier weighted-`Min` and simple-path work already exposed the central
  non-DAG problem:

  - in cyclic graphs, scalar summaries are not enough
  - path identity / visited-state identity still matters
  - exact semantics become expensive if we compare large path-state objects
    directly and repeatedly

  At the same time, the new dependency benchmark clarified that DAG
  workloads should not be forced through the same machinery.

  So this proposal formalizes the split:

  - **DAG**: use DAG-specific execution strategies
  - **non-DAG**: keep exact simple-path semantics, but make path-state
    lookup cheaper

  ## Main Idea

  The proposed non-DAG strategy is:

  1. keep exact visited-state semantics
  2. carry a deterministic path-state fingerprint
  3. use the fingerprint for candidate lookup / bucketing
  4. verify exact equality or dominance before dedup/pruning

  This means:

  - hashes are for indexing
  - exact verification still guards correctness

  So the design is explicitly **not**:

  - approximate hash-only deduplication
  - probabilistic semantics
  - collision-tolerant pruning

  ## What the Docs Cover

  ### Philosophy

  Explains why non-DAG simple-path workloads need their own execution
  strategy and why hashing should be treated as a performance tool rather
  than as the semantics itself.

  Main point:
  - exactness stays
  - lookup gets cheaper

  ### Specification

  Defines the intended state model:

  - current node / recursive position
  - accumulator or depth when relevant
  - exact visited-state representation
  - deterministic fingerprint
  - optional compact summaries for prefiltering

  Main point:
  - hash equality alone is never sufficient for semantic equality or
    dominance

  ### Implementation Plan

  Stages the work as:

  1. preserve the DAG vs non-DAG split
  2. instrument current exact non-DAG hot spots
  3. normalize to integer node ids
  4. add fingerprint-carrying state
  5. add bucketed lookup
  6. add cheap dominance prefilters
  7. benchmark and integrate with planner/runtime selection

  Main point:
  - do not implement this by guessing
  - instrument first, then tighten the representation

  ## Relationship to Current Work

  This PR is docs-only.

  It does not change runtime behavior yet.

  On the same branch, a DAG-side follow-up was investigated:

  - a global-closure variant for the dependency-reach benchmark

  That experiment regressed badly versus the current seeded plain-closure
  path, so it was intentionally not kept. The branch therefore remains
  cleanly focused on the non-DAG proposal set.

  ## Why This Matters

  This proposal gives us a cleaner long-term recursive execution story:

  - DAG workloads can be optimized structurally
  - cyclic simple-path workloads can stay exact without paying the full
    cost of naive visited-set frontier scans

  It also matches the direction discussed in review:

  - for the non-DAG case, path hashing can be useful
  - but it should be paired with exact lookup verification

  ## Scope

  Included:

  - non-DAG execution philosophy
  - exact hashed path-state indexing proposal
  - staged implementation plan

  Not included yet:

  - runtime implementation
  - benchmark changes
  - DAG longest-path work
  - non-DAG dependency benchmark execution

  ## Follow-Up

  Likely next work:

  - continue on the DAG side with a separate benchmark or optimization pass
  - most likely:
    - true DAG dependency depth, or
    - a grouped/project-labeled DAG closure strategy
  - keep this proposal as the reference design for the later cyclic
    simple-path optimization track