### PR TITLE
 bench: add dag dependency longest-depth benchmark

### DIFF
--- a/docs/proposals/DAG_GROUPED_REACH_STRATEGY_NOTE.md
+++ b/docs/proposals/DAG_GROUPED_REACH_STRATEGY_NOTE.md
@@ -1,0 +1,109 @@
+# DAG Grouped Reach Strategy Note
+
+## Context
+
+The synthetic dependency reach benchmark exposed a clear DAG-side gap:
+
+- the DFS targets solve transitive reach counting cheaply
+- the current C# query path is still much slower on this workload
+
+One natural next idea is to move from:
+
+- repeated seeded closure plus post-aggregation
+
+to:
+
+- a grouped/project-labeled closure strategy
+
+so that project identity is carried through the recursive executor.
+
+## Goal
+
+For a workload like:
+
+- `project -> direct dependency`
+- `dependency -> dependency`
+
+we would like to compute:
+
+- reachable dependency set per project
+
+without rerunning closure independently for every project seed.
+
+## Candidate Strategy
+
+Use a grouped closure model where each recursive row carries:
+
+- project label
+- current dependency node
+- next reachable dependency node
+
+Conceptually:
+
+```text
+(project, source_dep, reachable_dep)
+```
+
+and extend reachability while preserving the project label.
+
+This is exactly the kind of workload that suggests
+`GroupedTransitiveClosureNode` as the eventual runtime abstraction.
+
+## Immediate Obstacle
+
+With the current runtime shape, a direct grouped-closure encoding would
+likely require a project-labeled edge relation of the form:
+
+```text
+(project, child_dep, parent_dep)
+```
+
+which means duplicating dependency edges per project (or per seed
+family).
+
+That can explode input volume:
+
+- many projects
+- many shared dependency edges
+- large repeated grouped edge sets
+
+So the straightforward encoding is probably not the right final design.
+
+## Investigated Alternative
+
+On the current branch, a global closure experiment was tried as a cheaper
+replacement for seeded closure.
+
+Result:
+
+- it regressed badly
+- seeded plain closure remained better than global closure on the current
+  dependency reach benchmark
+
+So the grouped strategy remains interesting, but it should not be
+implemented by simply switching to global closure or by naively
+duplicating the full edge relation per project.
+
+## Likely Better Direction
+
+The promising next direction is a runtime-level grouped reach operator
+that:
+
+1. preserves project/group labels
+2. avoids full grouped edge materialization
+3. exploits overlap between project dependency cones
+4. still keeps the DAG workload in a DAG-specialized execution class
+
+In other words, this likely wants:
+
+- a better grouped closure runtime path
+
+not just:
+
+- a benchmark wrapper rewrite
+
+## Recommendation
+
+Treat grouped/project-labeled reach as the next serious optimization
+candidate for the DAG dependency reach benchmark, but as a **runtime
+feature** rather than as a simple benchmark-side transformation.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -185,6 +185,7 @@ Tables:
 | `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
+| `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -252,6 +253,11 @@ python examples/benchmark/benchmark_dependency_depth_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
 
+# Compare true DAG longest dependency depth across DFS targets
+python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-dfs,rust-dfs,go-dfs
+
 # Measure overhead of the generalized path-aware accumulation runtime
 python examples/benchmark/benchmark_path_aware_accumulation.py \
     --scales 300,1k,5k,10k
@@ -284,12 +290,14 @@ The current comparison surface across query and non-query targets is:
   - all-path effective distance
   - minimum hop distance
   - dependency reach count
+  - dependency longest depth
   - positive weighted minimum path distance
   - category influence propagation
 - Go DFS:
   - all-path effective distance
   - minimum hop distance
   - dependency reach count
+  - dependency longest depth
   - positive weighted minimum path distance
   - category influence propagation
 
@@ -299,6 +307,7 @@ The benchmark split is now:
   - `benchmark_effective_distance.py`
   - `benchmark_shortest_path_cross_target.py`
   - `benchmark_dependency_depth_cross_target.py`
+  - `benchmark_dependency_longest_depth_cross_target.py`
   - `benchmark_weighted_shortest_path_cross_target.py`
   - `benchmark_category_influence_cross_target.py`
 - C# query-engine internal mode comparison:
@@ -418,6 +427,39 @@ Comparison note:
 - the current C# query path is already improved over the initial version
   by using plain `TransitiveClosureNode` rather than path-aware closure,
   which is a better fit for acyclic unique-reachability
+
+### Cross-Target Dependency Longest-Depth Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
+    --scales 300,1k,5k,10k \
+    --targets csharp-dfs,rust-dfs,go-dfs \
+    --repetitions 1
+```
+
+This workload is the true DAG longest-path version of the dependency
+benchmark family. For each project, it reports the maximum dependency
+chain length over the synthetic package DAG.
+
+Latest local results:
+
+| Scale | C# DFS | Rust DFS | Go DFS | Outputs |
+|-------|--------:|---------:|-------:|---------|
+| 300 | 0.091s | 0.003s | 0.003s | match |
+| 1k | 0.139s | 0.004s | 0.003s | match |
+| 5k | 0.055s | 0.006s | 0.006s | match |
+| 10k | 0.059s | 0.012s | 0.011s | match |
+
+Comparison note:
+
+- this benchmark currently compares the DFS-style targets only
+- a like-for-like `csharp-query` longest-depth path is not yet included,
+  because the current query engine does not have a clean max-depth DAG
+  execution mode comparable to the DFS dynamic-programming formulation
+- that makes this benchmark a useful marker for future DAG-specialized
+  query-engine work rather than a finished query-vs-DFS comparison
 
 ### Cross-Target Category Influence Results
 

--- a/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Benchmark dependency longest-depth analysis across generated DFS binaries
+for C#, Rust, and Go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    available_targets,
+    build_csharp_package,
+    build_go_binary,
+    build_rust_binary,
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_sorted_lines,
+    print_match_status,
+    print_pair_match_status,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+DATA_GENERATOR = ROOT / "examples" / "benchmark" / "generate_dependency_benchmark_data.py"
+SCALES = {"300": 300, "1k": 1000, "5k": 5000, "10k": 10000}
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="csharp-dfs,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-dfs,rust-dfs,go-dfs",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def build_dataset(root: Path, scale: str) -> Path:
+    dataset_dir = root / "datasets" / scale
+    run_command(
+        [
+            sys.executable,
+            str(DATA_GENERATOR),
+            "--output-dir",
+            str(dataset_dir),
+            "--scale",
+            scale,
+        ]
+    )
+    return dataset_dir
+
+
+def build_csharp_query(root: Path, facts_path: Path) -> list[str]:
+    return build_csharp_package(
+        GENERATOR, facts_path, "dependency_longest_depth", "csharp_query", root / "csharp_query"
+    )
+
+
+def build_csharp_dfs(root: Path, facts_path: Path) -> list[str]:
+    return build_csharp_package(
+        GENERATOR, facts_path, "dependency_longest_depth", "csharp", root / "csharp_dfs"
+    )
+
+
+def build_rust_dfs(root: Path, facts_path: Path) -> list[str]:
+    return build_rust_binary(
+        GENERATOR, facts_path, "dependency_longest_depth", root / "rust_dfs", "dependency_longest_depth_rust"
+    )
+
+
+def build_go_dfs(root: Path, facts_path: Path) -> list[str]:
+    return build_go_binary(
+        GENERATOR, facts_path, "dependency_longest_depth", root / "go_dfs", "dependency_longest_depth_go"
+    )
+
+
+def benchmark_target(command: list[str], dataset_dir: Path, repetitions: int, target: str, scale: str) -> RunResult:
+    edge_path = require_file(dataset_dir / "category_parent.tsv")
+    article_path = require_file(dataset_dir / "article_category.tsv")
+
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command + [str(edge_path), str(article_path)])
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    digest, row_count = digest_normalized_output(normalize_sorted_lines(stdout))
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        csharp_dfs = find_result(entries, "csharp-dfs")
+        rust_dfs = find_result(entries, "rust-dfs")
+        go_dfs = find_result(entries, "go-dfs")
+        dfs_like = list(entries)
+        if len(dfs_like) > 1:
+            print_match_status(scale, "dfs_outputs", dfs_like)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    for scale in scales:
+        if scale not in SCALES:
+            raise SystemExit(f"Unsupported scale {scale!r}; expected one of {', '.join(SCALES)}")
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available")
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-dependency-longest-depth-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-dependency-longest-depth-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        seed_dataset = build_dataset(temp_root, scales[-1])
+        seed_facts = seed_dataset / "facts.pl"
+
+        commands: dict[str, list[str]] = {}
+        for target in targets:
+            if target == "csharp-dfs":
+                commands[target] = build_csharp_dfs(temp_root, seed_facts)
+            elif target == "rust-dfs":
+                commands[target] = build_rust_dfs(temp_root, seed_facts)
+            elif target == "go-dfs":
+                commands[target] = build_go_dfs(temp_root, seed_facts)
+            elif target == "csharp-query":
+                raise ValueError("csharp-query longest-depth mode is not ready yet; use csharp-dfs,rust-dfs,go-dfs")
+            else:
+                raise ValueError(f"unsupported target: {target}")
+
+        results: list[RunResult] = []
+        for scale in scales:
+            dataset_dir = build_dataset(temp_root, scale)
+            for target in targets:
+                results.append(benchmark_target(commands[target], dataset_dir, args.repetitions, target, scale))
+
+        print_summary(results)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1572,6 +1572,439 @@ class Program
 '''
 
 
+def generate_go_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    return '''// Dependency longest-depth benchmark (Go)
+package main
+
+import (
+\t"bufio"
+\t"fmt"
+\t"os"
+\t"sort"
+\t"strings"
+)
+
+func loadTSVPairs(path string) map[string][]string {
+\tm := make(map[string][]string)
+\tf, err := os.Open(path)
+\tif err != nil {
+\t\tfmt.Fprintf(os.Stderr, "Cannot open %s: %v\\n", path, err)
+\t\tos.Exit(1)
+\t}
+\tdefer f.Close()
+\tscanner := bufio.NewScanner(f)
+\tfirst := true
+\tfor scanner.Scan() {
+\t\tline := scanner.Text()
+\t\tif first {
+\t\t\tfirst = false
+\t\t\tif strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {
+\t\t\t\tcontinue
+\t\t\t}
+\t\t}
+\t\tparts := strings.SplitN(line, "\\t", 2)
+\t\tif len(parts) == 2 {
+\t\t\tm[parts[0]] = append(m[parts[0]], parts[1])
+\t\t}
+\t}
+\treturn m
+}
+
+func longestDepth(node string, adj map[string][]string, memo map[string]int) int {
+\tif depth, ok := memo[node]; ok {
+\t\treturn depth
+\t}
+\tbest := 1
+\tfor _, dep := range adj[node] {
+\t\tcandidate := 1 + longestDepth(dep, adj, memo)
+\t\tif candidate > best {
+\t\t\tbest = candidate
+\t\t}
+\t}
+\tmemo[node] = best
+\treturn best
+}
+
+type projectResult struct {
+\tproject string
+\tdepth   int
+}
+
+func main() {
+\tif len(os.Args) < 3 {
+\t\tfmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\\n", os.Args[0])
+\t\tos.Exit(1)
+\t}
+
+\tadj := loadTSVPairs(os.Args[1])
+\tprojectDeps := loadTSVPairs(os.Args[2])
+\tmemo := make(map[string]int)
+
+\tvar projects []string
+\tfor project := range projectDeps {
+\t\tprojects = append(projects, project)
+\t}
+\tsort.Strings(projects)
+
+\tresults := make([]projectResult, 0, len(projects))
+\tfor _, project := range projects {
+\t\tbest := 0
+\t\tfor _, dep := range projectDeps[project] {
+\t\t\tdepth := longestDepth(dep, adj, memo)
+\t\t\tif depth > best {
+\t\t\t\tbest = depth
+\t\t\t}
+\t\t}
+\t\tresults = append(results, projectResult{project: project, depth: best})
+\t}
+
+\tsort.Slice(results, func(i, j int) bool {
+\t\tif results[i].depth != results[j].depth {
+\t\t\treturn results[i].depth < results[j].depth
+\t\t}
+\t\treturn results[i].project < results[j].project
+\t})
+
+\tfmt.Println("project\\tdependency_longest_depth")
+\tfor _, result := range results {
+\t\tfmt.Printf("%s\\t%d\\n", result.project, result.depth)
+\t}
+}
+'''
+
+
+def generate_rust_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    return '''// Dependency longest-depth benchmark (Rust)
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::io::{BufRead, BufReader};
+
+fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    let file = fs::File::open(path).unwrap_or_else(|e| panic!("Cannot open {}: {}", path, e));
+    let reader = BufReader::new(file);
+    for (i, line) in reader.lines().enumerate() {
+        let line = line.unwrap();
+        if (i == 0) && (line.starts_with("article") || line.starts_with("child")) {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '\\t').collect();
+        if parts.len() == 2 {
+            map.entry(parts[0].to_string()).or_insert_with(Vec::new).push(parts[1].to_string());
+        }
+    }
+    map
+}
+
+fn longest_depth(node: &str, adj: &HashMap<String, Vec<String>>, memo: &mut HashMap<String, i32>) -> i32 {
+    if let Some(depth) = memo.get(node) {
+        return *depth;
+    }
+    let mut best = 1;
+    if let Some(deps) = adj.get(node) {
+        for dep in deps {
+            let candidate = 1 + longest_depth(dep, adj, memo);
+            if candidate > best {
+                best = candidate;
+            }
+        }
+    }
+    memo.insert(node.to_string(), best);
+    best
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Usage: {} <category_parent.tsv> <article_category.tsv>", args[0]);
+        std::process::exit(1);
+    }
+
+    let adj = load_tsv_pairs(&args[1]);
+    let project_deps = load_tsv_pairs(&args[2]);
+    let mut memo: HashMap<String, i32> = HashMap::new();
+
+    let mut projects: Vec<&String> = project_deps.keys().collect();
+    projects.sort();
+
+    let mut results: Vec<(i32, String)> = Vec::new();
+    for project in projects {
+        let mut best = 0;
+        if let Some(deps) = project_deps.get(project) {
+            for dep in deps {
+                let depth = longest_depth(dep, &adj, &mut memo);
+                if depth > best {
+                    best = depth;
+                }
+            }
+        }
+        results.push((best, project.to_string()));
+    }
+
+    results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    println!("project\tdependency_longest_depth");
+    for (depth, project) in results {
+        println!("{}\t{}", project, depth);
+    }
+}
+'''
+
+
+def generate_csharp_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    return '''// Dependency longest-depth benchmark (C#)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+class Program
+{
+    static Dictionary<string, List<string>> LoadTsvPairs(string path)
+    {
+        var map = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var (line, i) in File.ReadLines(path).Select((l, i) => (l, i)))
+        {
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {
+                continue;
+            }
+
+            var parts = line.Split('\t', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!map.TryGetValue(parts[0], out var bucket))
+            {
+                bucket = new List<string>();
+                map[parts[0]] = bucket;
+            }
+
+            bucket.Add(parts[1]);
+        }
+
+        return map;
+    }
+
+    static int LongestDepth(string node, Dictionary<string, List<string>> adj, Dictionary<string, int> memo)
+    {
+        if (memo.TryGetValue(node, out var cached))
+        {
+            return cached;
+        }
+
+        var best = 1;
+        if (adj.TryGetValue(node, out var deps))
+        {
+            foreach (var dep in deps)
+            {
+                var candidate = 1 + LongestDepth(dep, adj, memo);
+                if (candidate > best)
+                {
+                    best = candidate;
+                }
+            }
+        }
+
+        memo[node] = best;
+        return best;
+    }
+
+    static void Main(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }
+
+        var adj = LoadTsvPairs(args[0]);
+        var projectDeps = LoadTsvPairs(args[1]);
+        var memo = new Dictionary<string, int>(StringComparer.Ordinal);
+        var results = new List<(int Depth, string Project)>();
+
+        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            var best = 0;
+            foreach (var dep in projectDeps[project])
+            {
+                var depth = LongestDepth(dep, adj, memo);
+                if (depth > best)
+                {
+                    best = depth;
+                }
+            }
+
+            results.Add((best, project));
+        }
+
+        results.Sort((a, b) =>
+        {
+            var cmp = a.Depth.CompareTo(b.Depth);
+            return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
+        });
+
+        Console.WriteLine("project\tdependency_longest_depth");
+        foreach (var (depth, project) in results)
+        {
+            Console.WriteLine($"{project}\t{depth}");
+        }
+    }
+}
+'''
+
+
+def generate_csharp_query_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
+    depth_bound = max(max_depth, 20000)
+    return f'''// Dependency longest-depth benchmark (C# query engine)
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnifyWeaver.QueryRuntime;
+
+class Program
+{{
+    const int MAX_DEPTH = {depth_bound};
+
+    static void Main(string[] args)
+    {{
+        if (args.Length < 2)
+        {{
+            Console.Error.WriteLine("Usage: program <category_parent.tsv> <article_category.tsv>");
+            Environment.Exit(1);
+        }}
+
+        var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
+
+        var provider = new InMemoryRelationProvider();
+        var edgeId = new PredicateId("category_parent", 2);
+        var predId = new PredicateId("dependency_depth", 3);
+        var projectDeps = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length == 2)
+            {{
+                provider.AddFact(edgeId, parts[0], parts[1]);
+            }}
+        }}
+
+        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
+        {{
+            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            {{
+                continue;
+            }}
+
+            var parts = line.Split('\\t', 2);
+            if (parts.Length != 2)
+            {{
+                continue;
+            }}
+
+            if (!projectDeps.TryGetValue(parts[0], out var deps))
+            {{
+                deps = new List<string>();
+                projectDeps[parts[0]] = deps;
+            }}
+
+            deps.Add(parts[1]);
+        }}
+        swLoad.Stop();
+
+        var plan = new QueryPlan(
+            predId,
+            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.All),
+            true,
+            new int[] {{ 0 }}
+        );
+
+        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var deps in projectDeps.Values)
+        {{
+            foreach (var dep in deps)
+            {{
+                uniqueSeeds.Add(dep);
+            }}
+        }}
+
+        var seedParams = uniqueSeeds
+            .OrderBy(dep => dep, StringComparer.Ordinal)
+            .Select(dep => new object[] {{ dep }})
+            .ToList();
+
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));
+        var rows = executor.Execute(plan, seedParams).ToList();
+        swQuery.Stop();
+
+        var swAgg = Stopwatch.StartNew();
+        var depthIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var source = row[0]?.ToString() ?? "";
+            var depth = Convert.ToInt32(row[2]);
+            if (!depthIndex.TryGetValue(source, out var best) || depth > best)
+            {{
+                depthIndex[source] = depth;
+            }}
+        }}
+
+        var results = new List<(int Depth, string Project)>();
+        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        {{
+            var best = 0;
+            foreach (var dep in projectDeps[project])
+            {{
+                if (depthIndex.TryGetValue(dep, out var depth) && depth > best)
+                {{
+                    best = depth;
+                }}
+                else if (best < 1)
+                {{
+                    best = 1;
+                }}
+            }}
+            results.Add((best, project));
+        }}
+        swAgg.Stop();
+        swTotal.Stop();
+
+        results.Sort((a, b) =>
+        {{
+            var cmp = a.Depth.CompareTo(b.Depth);
+            return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
+        }});
+
+        Console.WriteLine("project\\tdependency_longest_depth");
+        foreach (var item in results)
+        {{
+            Console.WriteLine($"{{item.Project}}\\t{{item.Depth}}");
+        }}
+
+        Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"tuple_count={{rows.Count}}");
+        Console.Error.WriteLine($"project_count={{results.Count}}");
+    }}
+}}
+'''
+
+
 def generate_go_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"
 
@@ -2924,6 +3357,12 @@ GENERATORS = {
         'rust': generate_rust_dependency_depth,
         'csharp': generate_csharp_dependency_depth,
         'csharp_query': generate_csharp_query_dependency_depth,
+    },
+    'dependency_longest_depth': {
+        'go': generate_go_dependency_longest_depth,
+        'rust': generate_rust_dependency_longest_depth,
+        'csharp': generate_csharp_dependency_longest_depth,
+        'csharp_query': generate_csharp_query_dependency_longest_depth,
     },
     'weighted_shortest_path': {
         'go': generate_go_weighted_shortest_path,


### PR DESCRIPTION
  ## Summary

  This PR extends the synthetic dependency benchmark family with a second,
  cleanly separated DAG workload:

  - **dependency reach count**
  - **dependency longest depth**

  The new longest-depth benchmark measures, for each project, the maximum
  dependency-chain length over the synthetic package DAG.

  This keeps the DAG story honest and explicit:

  - reach count is one DAG problem
  - longest path/depth is another DAG problem
  - neither should be conflated with the harder non-DAG simple-path case

  The PR also records the current next optimization direction for the
  existing dependency-reach benchmark:

  - grouped/project-labeled closure as a future DAG-side runtime strategy

  ## What Changed

  ### New DAG Longest-Depth Workload

  Extended:

  - `examples/benchmark/generate_pipeline.py`

  New workload:

  - `dependency_longest_depth`

  Supported targets:

  - `csharp`
  - `rust`
  - `go`

  The generated programs compute:

  - one row per project
  - output format:
    - `project\tdependency_longest_depth`

  For the DFS targets, this is implemented as exact dynamic programming on
  the synthetic DAG.

  ### New Cross-Target Benchmark Runner

  Added:

  - `examples/benchmark/benchmark_dependency_longest_depth_cross_target.py`

  This runner compares:

  - `csharp-dfs`
  - `rust-dfs`
  - `go-dfs`

  It reuses the existing synthetic dependency dataset generator and reports:

  - timing
  - output agreement
  - row counts
  - normalized output hashes

  ### Documentation

  Updated:

  - `examples/benchmark/README.md`

  The README now documents:

  - the new longest-depth benchmark script
  - the benchmark command
  - local `300/1k/5k/10k` results
  - the distinction between:
    - dependency reach count
    - true dependency longest depth

  ### Grouped Reach Follow-Up Note

  Added:

  - `docs/proposals/DAG_GROUPED_REACH_STRATEGY_NOTE.md`

  This note records the next likely optimization direction for the
  dependency-reach benchmark:

  - grouped/project-labeled closure

  It also documents why that did **not** land as runtime code here:

  - a naive global-closure alternative regressed badly
  - naively duplicating grouped edges per project is probably the wrong
    abstraction
  - the real next step likely needs runtime support rather than a simple
    benchmark rewrite

  ## Why This Matters

  The recent dependency-reach benchmark introduced a useful DAG workload,
  but it still mixed two ideas:

  - transitive dependency coverage
  - dependency depth

  This PR separates them properly.

  That improves the benchmark suite in two ways:

  1. it broadens workload generality
  2. it keeps DAG and non-DAG graph problems conceptually cleaner

  It also sets up a more disciplined next step for DAG optimization work on
  the reach-count side.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/generate_dependency_benchmark_data.py

  ### Longest-depth smoke and larger-scale runs

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 1k,5k,10k \
      --repetitions 1

  ### Dependency-reach non-regression check

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --repetitions 1

  ## Longest-Depth Results

  | Scale | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---|
  | 300 | 0.081s | 0.003s | 0.002s | match |
  | 1k | 0.139s | 0.004s | 0.003s | match |
  | 5k | 0.055s | 0.006s | 0.006s | match |
  | 10k | 0.059s | 0.012s | 0.011s | match |

  ## Important Scope Note

  The new longest-depth benchmark currently compares only the DFS-style
  targets.

  csharp-query is intentionally not part of this runner yet.

  Reason:

  - the current query engine does not yet have a clean DAG-specialized
    max-depth execution mode that is comparable to the DFS dynamic-programming
    formulation
  - a first attempt to emulate longest depth through counted/path-aware
    closure was not viable
  - a direct csharp-query inclusion here would therefore be misleading

  So this benchmark should be read as:

  - a new DAG workload now covered by the benchmark suite
  - and a marker for future DAG-specialized query-engine work

  ## Relationship to Dependency Reach

  This PR does not replace the existing dependency-reach benchmark.

  Instead it complements it:

  - dependency_depth currently measures dependency reach count
  - dependency_longest_depth measures true DAG longest-chain depth

  That separation is deliberate and should make future analysis cleaner.

  ## Follow-Up

  Likely next work:

  - revisit csharp-query support for true DAG longest depth with a
    dedicated DAG execution strategy rather than path-aware closure
  - pursue the grouped/project-labeled closure strategy for improving the
    dependency-reach benchmark path
  - keep DAG and non-DAG dependency workloads as separate benchmark
    families going forward