### PR TITLE
perf(csharp-query): add dag reachability fast path

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -402,19 +402,19 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.074s | 0.044s | 0.002s | 0.003s | match |
-| 1k | 0.151s | 0.050s | 0.007s | 0.007s | match |
-| 5k | 1.952s | 0.168s | 0.140s | 0.107s | match |
-| 10k | 8.736s | 0.539s | 0.631s | 0.459s | match |
+| 300 | 0.071s | 0.043s | 0.002s | 0.003s | match |
+| 1k | 0.147s | 0.048s | 0.007s | 0.007s | match |
+| 5k | 0.565s | 0.162s | 0.123s | 0.104s | match |
+| 10k | 1.962s | 0.499s | 0.532s | 0.471s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.59x | 0.03x | 0.04x |
-| 1k | 0.33x | 0.04x | 0.05x |
-| 5k | 0.09x | 0.07x | 0.05x |
-| 10k | 0.06x | 0.07x | 0.05x |
+| 300 | 0.61x | 0.03x | 0.04x |
+| 1k | 0.33x | 0.05x | 0.05x |
+| 5k | 0.29x | 0.22x | 0.18x |
+| 10k | 0.25x | 0.27x | 0.24x |
 
 Comparison note:
 
@@ -427,6 +427,8 @@ Comparison note:
 - the current C# query path is already improved over the initial version
   by using plain `TransitiveClosureNode` rather than path-aware closure,
   which is a better fit for acyclic unique-reachability
+- a gated DAG bitset fast path now reduces the large-scale C# query cost
+  substantially, especially at `5k` and `10k`, without changing outputs
 
 ### Cross-Target Dependency Longest-Depth Results
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -4,6 +4,7 @@
 // emitted by the forthcoming csharp_query target.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
@@ -10787,6 +10788,61 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("TransitiveClosureSeeded", traceKey, hit: false, built: true);
 
+                const int MaxDagBitsetNodeCount = 16384;
+                const int MinDagBitsetSeedCount = 128;
+                const int MinDagBitsetEdgeCount = 8192;
+                if (seeds.Count >= MinDagBitsetSeedCount &&
+                    edges.Count >= MinDagBitsetEdgeCount &&
+                    TryBuildDagReachabilityBitsets(edges, MaxDagBitsetNodeCount, out var dagNodeIds, out var dagNodesById, out var dagReachability))
+                {
+                    trace?.RecordStrategy(closure, "TransitiveClosureSeededDagBitset");
+                    var dagRows = new List<object[]>();
+
+                    foreach (var seed in seeds)
+                    {
+                        if (!dagNodeIds.TryGetValue(seed, out var seedId))
+                        {
+                            continue;
+                        }
+
+                        var reachable = dagReachability[seedId];
+                        for (var targetId = 0; targetId < reachable.Length; targetId++)
+                        {
+                            if (!reachable[targetId])
+                            {
+                                continue;
+                            }
+
+                            dagRows.Add(new object[] { seed!, dagNodesById[targetId]! });
+                        }
+                    }
+
+                    if (canReuseSeededCache)
+                    {
+                        if (!context.TransitiveClosureSeededResults.TryGetValue(cacheKey, out var dagStoreBySeed))
+                        {
+                            dagStoreBySeed = new Dictionary<RowWrapper, IReadOnlyList<object[]>>(StructuralRowWrapperComparer);
+                            context.TransitiveClosureSeededResults.Add(cacheKey, dagStoreBySeed);
+                        }
+
+                        var admitSeededCache = ShouldAdmitSeededCacheRows(
+                            dagRows.Count,
+                            seeds.Count,
+                            useRowsPerSeedGate: true);
+                        TryAdmitLruBoundedRowWrapperCacheEntry(
+                            dagStoreBySeed,
+                            new RowWrapper(seedsKey),
+                            dagRows,
+                            _seededCacheMaxEntries,
+                            admitSeededCache,
+                            trace,
+                            "TransitiveClosureSeeded",
+                            traceKey);
+                    }
+
+                    return dagRows;
+                }
+
                 const int MaxMemoizedSeedCount = 32;
                 var canMemoizeSeeds =
                     _cacheContext is not null &&
@@ -11018,6 +11074,111 @@ namespace UnifyWeaver.QueryRuntime
             {
                 context.FixpointDepth--;
             }
+        }
+
+        private static bool TryBuildDagReachabilityBitsets(
+            IReadOnlyList<object[]> edges,
+            int maxNodeCount,
+            out Dictionary<object?, int> nodeIds,
+            out object?[] nodesById,
+            out BitArray[] reachability)
+        {
+            var localNodeIds = new Dictionary<object?, int>();
+            nodeIds = localNodeIds;
+            nodesById = Array.Empty<object?>();
+            reachability = Array.Empty<BitArray>();
+
+            if (edges.Count == 0)
+            {
+                return false;
+            }
+
+            var successors = new List<List<int>>();
+            var indegree = new List<int>();
+            var nodeValues = new List<object?>();
+
+            int GetNodeId(object? value)
+            {
+                if (localNodeIds.TryGetValue(value, out var id))
+                {
+                    return id;
+                }
+
+                id = nodeValues.Count;
+                localNodeIds.Add(value, id);
+                nodeValues.Add(value);
+                successors.Add(new List<int>());
+                indegree.Add(0);
+                return id;
+            }
+
+            foreach (var edge in edges)
+            {
+                if (edge is null || edge.Length < 2)
+                {
+                    continue;
+                }
+
+                var fromId = GetNodeId(edge[0]);
+                var toId = GetNodeId(edge[1]);
+                successors[fromId].Add(toId);
+                indegree[toId]++;
+            }
+
+            if (nodeValues.Count == 0 || nodeValues.Count > maxNodeCount)
+            {
+                return false;
+            }
+
+            var queue = new Queue<int>();
+            for (var i = 0; i < indegree.Count; i++)
+            {
+                if (indegree[i] == 0)
+                {
+                    queue.Enqueue(i);
+                }
+            }
+
+            var topo = new List<int>(nodeValues.Count);
+            while (queue.Count > 0)
+            {
+                var id = queue.Dequeue();
+                topo.Add(id);
+                foreach (var next in successors[id])
+                {
+                    indegree[next]--;
+                    if (indegree[next] == 0)
+                    {
+                        queue.Enqueue(next);
+                    }
+                }
+            }
+
+            if (topo.Count != nodeValues.Count)
+            {
+                return false;
+            }
+
+            reachability = new BitArray[nodeValues.Count];
+            for (var i = 0; i < reachability.Length; i++)
+            {
+                reachability[i] = new BitArray(nodeValues.Count);
+            }
+
+            for (var index = topo.Count - 1; index >= 0; index--)
+            {
+                var nodeId = topo[index];
+                var bits = reachability[nodeId];
+                foreach (var next in successors[nodeId])
+                {
+                    bits[next] = true;
+                    bits.Or(reachability[next]);
+                }
+            }
+
+            nodesById = nodeValues.ToArray();
+            nodeIds = localNodeIds;
+            return true;
         }
 
         private IEnumerable<object[]> ExecuteSeededTransitiveClosureByTarget(


### PR DESCRIPTION
  ## Summary

  This PR adds a DAG-specific fast path for the C# query engine’s seeded
  transitive-closure execution.

  It targets the synthetic dependency-reach benchmark, which is a true DAG
  workload and had become a clear counterexample where the query engine was
  semantically correct but much slower than the DFS targets.

  The new path detects acyclic edge graphs and computes seeded reachability
  using exact descendant bitsets over a topological order instead of the
  older generic closure strategy.

  The result is a large improvement at bigger scales while preserving the
  existing behavior on small graphs.

  ## What Changed

  ### C# Query Runtime

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Inside seeded transitive closure, the runtime now has a DAG-specific
  strategy that:

  1. inspects the edge relation and attempts to build a DAG model
  2. assigns integer node ids
  3. computes indegrees and a topological order
  4. builds one exact `BitArray` descendant set per node in reverse
     topological order
  5. answers seeded closure requests by reading those descendant bitsets

  The strategy is exact for reachability:
  - it does **not** enumerate all paths
  - it does **not** approximate with a probabilistic hash
  - it still emits the same `(seed, reachable)` pairs as before

  ### Activation Gate

  The DAG bitset path is intentionally gated.

  It only activates when the benchmark shape is large enough that the
  bitset setup cost is worthwhile.

  That avoids regressing the smaller scales, where the generic seeded
  closure path is already cheap enough.

  Current gate:

  - minimum seeded relation size
  - minimum edge count
  - maximum node count for the bitset representation

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The dependency-reach benchmark section now records the new local results
  and notes that the C# query path now includes a gated DAG bitset fast
  path.

  ## Why This Matters

  The synthetic dependency-reach workload is a DAG problem:

  - unique reachability
  - no simple-path state needed
  - no cycle handling needed

  So it was a poor fit for the query engine’s more general recursive
  machinery.

  This PR corrects that mismatch for a major slice of the problem by adding
  a DAG-aware reachability strategy inside the query runtime itself, rather
  than rewriting the benchmark or introducing a benchmark-only shortcut.

  That makes the benchmark outcome more informative:

  - the C# query engine still loses on this workload
  - but the loss is now much smaller
  - and the runtime is better aligned with DAG semantics

  ## Verification

  ### Direct C# package build

  Passed locally for a generated dependency-reach benchmark package.

  ### Dependency-reach benchmark

  Ran locally:

  ```bash
  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs still matched across all four targets.

  ## Updated Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.071s | 0.043s | 0.002s | 0.003s | match |
  | 1k | 0.147s | 0.048s | 0.007s | 0.007s | match |
  | 5k | 0.565s | 0.162s | 0.123s | 0.104s | match |
  | 10k | 1.962s | 0.499s | 0.532s | 0.471s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.61x | 0.03x | 0.04x |
  | 1k | 0.33x | 0.05x | 0.05x |
  | 5k | 0.29x | 0.22x | 0.18x |
  | 10k | 0.25x | 0.27x | 0.24x |

  ## Interpretation

  Before this PR, the C# query engine was roughly:

  - 11.6x slower than C# DFS at 5k
  - 16.2x slower than C# DFS at 10k

  After this PR, it is roughly:

  - 3.5x slower at 5k
  - 3.9x slower at 10k

  So this does not make the query engine fastest on dependency reach.

  But it materially narrows the gap on the exact workload shape where DAG
  awareness should matter most.

  ## Scope

  This PR is focused on:

  - DAG seeded reachability
  - inside the C# query runtime
  - for exact transitive closure results

  It does not yet add:

  - a full grouped/project-labeled closure strategy
  - query-engine support for true DAG longest depth
  - any non-DAG simple-path optimization work

  ## Follow-Up

  Likely next work:

  - continue improving DAG efficiency in the query engine, especially for
    grouped/project-labeled reachability
  - evaluate whether the same DAG substrate can support a clean
    csharp-query path for true longest dependency depth
  - keep the non-DAG path-state work separate, using the recent hashed
    path-state design docs as the guide for that harder case