### PR TITLE
perf(csharp-query): add project-grouped dag reach

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -402,33 +402,28 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.071s | 0.043s | 0.002s | 0.003s | match |
-| 1k | 0.147s | 0.048s | 0.007s | 0.007s | match |
-| 5k | 0.565s | 0.162s | 0.123s | 0.104s | match |
-| 10k | 1.962s | 0.499s | 0.532s | 0.471s | match |
+| 300 | 0.060s | 0.045s | 0.002s | 0.003s | match |
+| 1k | 0.097s | 0.051s | 0.007s | 0.009s | match |
+| 5k | 0.199s | 0.167s | 0.130s | 0.106s | match |
+| 10k | 0.485s | 0.511s | 0.572s | 0.457s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.61x | 0.03x | 0.04x |
-| 1k | 0.33x | 0.05x | 0.05x |
-| 5k | 0.29x | 0.22x | 0.18x |
-| 10k | 0.25x | 0.27x | 0.24x |
+| 300 | 0.75x | 0.04x | 0.05x |
+| 1k | 0.52x | 0.07x | 0.10x |
+| 5k | 0.84x | 0.65x | 0.53x |
+| 10k | 1.05x | 1.18x | 0.94x |
 
 Comparison note:
 
-- this workload currently favors the plain DFS targets over the C#
-  query-engine path
-- the C# query implementation is still semantically correct and matches
-  the DFS outputs, but this benchmark is a useful counterexample showing
-  that not every recursive DAG-count workload benefits from the current
-  query-engine execution model
-- the current C# query path is already improved over the initial version
-  by using plain `TransitiveClosureNode` rather than path-aware closure,
-  which is a better fit for acyclic unique-reachability
-- a gated DAG bitset fast path now reduces the large-scale C# query cost
-  substantially, especially at `5k` and `10k`, without changing outputs
+- the current C# query path now uses a project-grouped reachability node
+  rather than raw per-seed closure followed by regrouping
+- this changed the workload shape materially: the query engine is still
+  behind at `300` and `1k`, but is now close to parity at `5k` and
+  slightly ahead of C# DFS and Rust DFS at `10k`
+- outputs still match across all four targets
 
 ### Cross-Target Dependency Longest-Depth Results
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1447,7 +1447,8 @@ class Program
 
         var provider = new InMemoryRelationProvider();
         var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("dependency_reach", 3);
+        var seedId = new PredicateId("project_dependency", 2);
+        var predId = new PredicateId("dependency_reach", 2);
         var projectDeps = new Dictionary<string, List<string>>(StringComparer.Ordinal);
 
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
@@ -1484,67 +1485,31 @@ class Program
             }}
 
             deps.Add(parts[1]);
+            provider.AddFact(seedId, parts[0], parts[1]);
         }}
         swLoad.Stop();
 
         var plan = new QueryPlan(
             predId,
-            new TransitiveClosureNode(edgeId, predId),
-            true,
-            new int[] {{ 0 }}
+            new SeedGroupedTransitiveClosureNode(edgeId, seedId, predId),
+            true
         );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var deps in projectDeps.Values)
-        {{
-            foreach (var dep in deps)
-            {{
-                uniqueSeeds.Add(dep);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds
-            .OrderBy(dep => dep, StringComparer.Ordinal)
-            .Select(dep => new object[] {{ dep }})
-            .ToList();
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));
-        var rows = executor.Execute(plan, seedParams).ToList();
+        var rows = executor.Execute(plan).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var reachIndex = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        var reachCounts = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (var row in rows)
         {{
-            var source = row[0]?.ToString() ?? "";
-            var dep = row[1]?.ToString() ?? "";
-            if (!reachIndex.TryGetValue(source, out var bucket))
-            {{
-                bucket = new HashSet<string>(StringComparer.Ordinal);
-                reachIndex[source] = bucket;
-            }}
-            bucket.Add(dep);
+            var project = row[0]?.ToString() ?? "";
+            reachCounts[project] = reachCounts.TryGetValue(project, out var count) ? count + 1 : 1;
         }}
-
-        var results = new List<(int Count, string Project)>();
-        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
-        {{
-            var allDeps = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var dep in projectDeps[project])
-            {{
-                allDeps.Add(dep);
-                if (reachIndex.TryGetValue(dep, out var closure))
-                {{
-                    foreach (var item in closure)
-                    {{
-                        allDeps.Add(item);
-                    }}
-                }}
-            }}
-
-            results.Add((allDeps.Count, project));
-        }}
+        var results = reachCounts
+            .Select(kvp => (Count: kvp.Value, Project: kvp.Key))
+            .ToList();
         swAgg.Stop();
         swTotal.Stop();
 
@@ -1564,7 +1529,7 @@ class Program
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"seed_count={{projectDeps.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System.IO;
+using System.Numerics;
 using System.Text;
 using System.Text.Json;
 using System.Globalization;
@@ -230,6 +231,16 @@ namespace UnifyWeaver.QueryRuntime
         PredicateId EdgeRelation,
         PredicateId Predicate,
         IReadOnlyList<int> GroupIndices
+    ) : PlanNode;
+
+    /// <summary>
+    /// Propagates group labels from an external seed relation across a plain
+    /// transitive closure edge relation, producing (group, reachable) rows.
+    /// </summary>
+    public sealed record SeedGroupedTransitiveClosureNode(
+        PredicateId EdgeRelation,
+        PredicateId SeedRelation,
+        PredicateId Predicate
     ) : PlanNode;
 
     /// <summary>
@@ -846,6 +857,7 @@ namespace UnifyWeaver.QueryRuntime
                     case UnitNode:
                     case TransitiveClosureNode:
                     case GroupedTransitiveClosureNode:
+                    case SeedGroupedTransitiveClosureNode:
                     case PathAwareTransitiveClosureNode:
                     case PathAwareAccumulationNode:
                         return;
@@ -983,6 +995,7 @@ namespace UnifyWeaver.QueryRuntime
                 OffsetNode offset => $"Offset count={offset.Count}",
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
+                SeedGroupedTransitiveClosureNode closure => $"SeedGroupedTransitiveClosure edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode} positiveStep={closure.PositiveStepProven}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
@@ -1186,6 +1199,20 @@ namespace UnifyWeaver.QueryRuntime
                     return activeTrace is null ? rows : activeTrace.WrapEnumeration(groupedClosure, rows);
                 }
 
+                if (plan.Root is SeedGroupedTransitiveClosureNode seedGroupedClosure)
+                {
+                    var rows = ExecuteSeedGroupedTransitiveClosure(seedGroupedClosure, context);
+                    var contextCancellationToken = context.CancellationToken;
+                    if (contextCancellationToken.CanBeCanceled)
+                    {
+                        rows = WithCancellation(rows, contextCancellationToken);
+                    }
+
+                    var activeTrace = context.Trace;
+                    activeTrace?.RecordInvocation(seedGroupedClosure);
+                    return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedClosure, rows);
+                }
+
                 if (plan.Root is PathAwareTransitiveClosureNode pathAwareClosure)
                 {
                     IEnumerable<object[]> rows;
@@ -1379,6 +1406,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 case GroupedTransitiveClosureNode closure:
                     result = ExecuteGroupedTransitiveClosure(closure, context);
+                    break;
+
+                case SeedGroupedTransitiveClosureNode closure:
+                    result = ExecuteSeedGroupedTransitiveClosure(closure, context);
                     break;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -1814,6 +1845,11 @@ namespace UnifyWeaver.QueryRuntime
 
                 case GroupedTransitiveClosureNode closure:
                     predicates.Add(closure.EdgeRelation);
+                    return;
+
+                case SeedGroupedTransitiveClosureNode closure:
+                    predicates.Add(closure.EdgeRelation);
+                    predicates.Add(closure.SeedRelation);
                     return;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -7951,6 +7987,389 @@ namespace UnifyWeaver.QueryRuntime
             finally
             {
                 context.FixpointDepth--;
+            }
+        }
+
+        private IEnumerable<object[]> ExecuteSeedGroupedTransitiveClosure(SeedGroupedTransitiveClosureNode closure, EvaluationContext? parentContext)
+        {
+            if (closure is null) throw new ArgumentNullException(nameof(closure));
+
+            var width = closure.Predicate.Arity;
+            if (width < 2)
+            {
+                return Array.Empty<object[]>();
+            }
+
+            var context = parentContext ?? new EvaluationContext();
+            context.FixpointDepth++;
+            try
+            {
+                var trace = context.Trace;
+                trace?.RecordStrategy(closure, "SeedGroupedTransitiveClosure");
+
+                var predicate = closure.Predicate;
+                var traceKey = $"{predicate.Name}/{predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:seeds={closure.SeedRelation.Name}/{closure.SeedRelation.Arity}";
+                var edges = GetFactsList(closure.EdgeRelation, context);
+                var seeds = GetFactsList(closure.SeedRelation, context);
+
+                const int MaxDagNodeCount = 16384;
+                const int MaxDagGroupCount = 4096;
+                const int MinDagGroupCount = 64;
+                const int MinDagEdgeCount = 8192;
+                if (seeds.Count >= MinDagGroupCount &&
+                    edges.Count >= MinDagEdgeCount &&
+                    TryBuildProjectGroupedDagReachRows(edges, seeds, MaxDagNodeCount, MaxDagGroupCount, out var dagRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedTransitiveClosure", traceKey, hit: false, built: true);
+                    trace?.RecordStrategy(closure, "SeedGroupedTransitiveClosureDag");
+                    return dagRows;
+                }
+
+                trace?.RecordCacheLookup("SeedGroupedTransitiveClosure", traceKey, hit: false, built: true);
+
+                var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
+                var wrapperComparer = new RowWrapperComparer(StructuralArrayComparer.Instance);
+                var visited = new HashSet<RowWrapper>(wrapperComparer);
+                var totalRows = new List<object[]>();
+                var delta = new List<object[]>();
+
+                foreach (var seed in seeds)
+                {
+                    if (seed is null || seed.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    var group = seed[0];
+                    var node = seed[1];
+                    var key = new object[] { group!, node! };
+                    if (visited.Add(new RowWrapper(key)))
+                    {
+                        totalRows.Add((object[])key.Clone());
+                        delta.Add(key);
+                    }
+                }
+
+                var iteration = 0;
+                trace?.RecordFixpointIteration(closure, predicate, iteration, delta.Count, totalRows.Count);
+
+                while (delta.Count > 0)
+                {
+                    iteration++;
+                    var nextDelta = new List<object[]>();
+
+                    foreach (var pair in delta)
+                    {
+                        var node = pair[1];
+                        var lookupKey = node ?? NullFactIndexKey;
+                        if (!succIndex.TryGetValue(lookupKey, out var bucket))
+                        {
+                            continue;
+                        }
+
+                        foreach (var edge in bucket)
+                        {
+                            if (edge is null || edge.Length < 2)
+                            {
+                                continue;
+                            }
+
+                            var next = edge[1];
+                            var nextKey = new object[] { pair[0], next! };
+                            if (visited.Add(new RowWrapper(nextKey)))
+                            {
+                                totalRows.Add((object[])nextKey.Clone());
+                                nextDelta.Add(nextKey);
+                            }
+                        }
+                    }
+
+                    delta = nextDelta;
+                    trace?.RecordFixpointIteration(closure, predicate, iteration, delta.Count, totalRows.Count);
+                }
+
+                return totalRows;
+            }
+            finally
+            {
+                context.FixpointDepth--;
+            }
+        }
+
+        private static bool TryBuildProjectGroupedDagReachRows(
+            IReadOnlyList<object[]> edges,
+            IReadOnlyList<object[]> seeds,
+            int maxNodeCount,
+            int maxGroupCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            if (edges.Count == 0 || seeds.Count == 0)
+            {
+                return false;
+            }
+
+            var globalNodeIds = new Dictionary<object?, int>();
+            var globalSuccessors = new List<List<int>>();
+            var nodeValues = new List<object?>();
+
+            int GetGlobalNodeId(object? value)
+            {
+                if (globalNodeIds.TryGetValue(value, out var id))
+                {
+                    return id;
+                }
+
+                id = nodeValues.Count;
+                globalNodeIds.Add(value, id);
+                nodeValues.Add(value);
+                globalSuccessors.Add(new List<int>());
+                return id;
+            }
+
+            foreach (var edge in edges)
+            {
+                if (edge is null || edge.Length < 2)
+                {
+                    continue;
+                }
+
+                var fromId = GetGlobalNodeId(edge[0]);
+                var toId = GetGlobalNodeId(edge[1]);
+                globalSuccessors[fromId].Add(toId);
+            }
+
+            if (nodeValues.Count == 0 || nodeValues.Count > maxNodeCount)
+            {
+                return false;
+            }
+
+            var globalIndegree = new int[nodeValues.Count];
+            for (var i = 0; i < globalSuccessors.Count; i++)
+            {
+                foreach (var next in globalSuccessors[i])
+                {
+                    globalIndegree[next]++;
+                }
+            }
+
+            var groupIds = new Dictionary<object?, int>();
+            var groupValues = new List<object?>();
+            var seedPairs = new List<(int GroupId, int NodeId)>();
+            foreach (var seed in seeds)
+            {
+                if (seed is null || seed.Length < 2)
+                {
+                    continue;
+                }
+
+                if (!globalNodeIds.TryGetValue(seed[1], out var nodeId))
+                {
+                    continue;
+                }
+
+                if (!groupIds.TryGetValue(seed[0], out var groupId))
+                {
+                    groupId = groupValues.Count;
+                    if (groupId >= maxGroupCount)
+                    {
+                        return false;
+                    }
+
+                    groupIds.Add(seed[0], groupId);
+                    groupValues.Add(seed[0]);
+                }
+
+                seedPairs.Add((groupId, nodeId));
+            }
+
+            if (seedPairs.Count == 0)
+            {
+                return true;
+            }
+
+            var included = new bool[nodeValues.Count];
+            var queue = new Queue<int>();
+            foreach (var (_, nodeId) in seedPairs)
+            {
+                if (included[nodeId])
+                {
+                    continue;
+                }
+
+                included[nodeId] = true;
+                queue.Enqueue(nodeId);
+            }
+
+            while (queue.Count > 0)
+            {
+                var nodeId = queue.Dequeue();
+                foreach (var next in globalSuccessors[nodeId])
+                {
+                    if (included[next])
+                    {
+                        continue;
+                    }
+
+                    included[next] = true;
+                    queue.Enqueue(next);
+                }
+            }
+
+            var includedCount = 0;
+            foreach (var isIncluded in included)
+            {
+                if (isIncluded)
+                {
+                    includedCount++;
+                }
+            }
+
+            if (includedCount == 0 || includedCount > maxNodeCount)
+            {
+                return false;
+            }
+
+            var localIds = new int[nodeValues.Count];
+            Array.Fill(localIds, -1);
+            var localNodeValues = new object?[includedCount];
+            var localSuccessors = new List<List<int>>(includedCount);
+            var localIndegree = new int[includedCount];
+            var nextLocalId = 0;
+
+            for (var globalId = 0; globalId < included.Length; globalId++)
+            {
+                if (!included[globalId])
+                {
+                    continue;
+                }
+
+                localIds[globalId] = nextLocalId;
+                localNodeValues[nextLocalId] = nodeValues[globalId];
+                localSuccessors.Add(new List<int>());
+                nextLocalId++;
+            }
+
+            for (var globalId = 0; globalId < included.Length; globalId++)
+            {
+                if (!included[globalId])
+                {
+                    continue;
+                }
+
+                var fromLocalId = localIds[globalId];
+                foreach (var nextGlobalId in globalSuccessors[globalId])
+                {
+                    if (!included[nextGlobalId])
+                    {
+                        continue;
+                    }
+
+                    var toLocalId = localIds[nextGlobalId];
+                    localSuccessors[fromLocalId].Add(toLocalId);
+                    localIndegree[toLocalId]++;
+                }
+            }
+
+            var topoQueue = new Queue<int>();
+            for (var i = 0; i < localIndegree.Length; i++)
+            {
+                if (localIndegree[i] == 0)
+                {
+                    topoQueue.Enqueue(i);
+                }
+            }
+
+            var topo = new List<int>(includedCount);
+            while (topoQueue.Count > 0)
+            {
+                var localId = topoQueue.Dequeue();
+                topo.Add(localId);
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    localIndegree[successorLocalId]--;
+                    if (localIndegree[successorLocalId] == 0)
+                    {
+                        topoQueue.Enqueue(successorLocalId);
+                    }
+                }
+            }
+
+            if (topo.Count != includedCount)
+            {
+                return false;
+            }
+
+            var wordCount = (groupValues.Count + 63) >> 6;
+            var nodeGroupBits = new ulong[includedCount][];
+            for (var i = 0; i < includedCount; i++)
+            {
+                nodeGroupBits[i] = new ulong[wordCount];
+            }
+
+            foreach (var (groupId, nodeId) in seedPairs)
+            {
+                var localNodeId = localIds[nodeId];
+                nodeGroupBits[localNodeId][groupId >> 6] |= 1UL << (groupId & 63);
+            }
+
+            foreach (var localId in topo)
+            {
+                var sourceBits = nodeGroupBits[localId];
+                if (IsZeroWordArray(sourceBits))
+                {
+                    continue;
+                }
+
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    OrInto(nodeGroupBits[successorLocalId], sourceBits);
+                }
+            }
+
+            rows = new List<object[]>(Math.Max(includedCount, seedPairs.Count));
+            for (var localId = 0; localId < includedCount; localId++)
+            {
+                var nodeValue = localNodeValues[localId];
+                var bits = nodeGroupBits[localId];
+                for (var wordIndex = 0; wordIndex < bits.Length; wordIndex++)
+                {
+                    var word = bits[wordIndex];
+                    while (word != 0)
+                    {
+                        var bit = BitOperations.TrailingZeroCount(word);
+                        var groupId = (wordIndex << 6) + bit;
+                        if (groupId < groupValues.Count)
+                        {
+                            rows.Add(new object[] { groupValues[groupId]!, nodeValue! });
+                        }
+
+                        word &= word - 1;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsZeroWordArray(ulong[] words)
+        {
+            for (var i = 0; i < words.Length; i++)
+            {
+                if (words[i] != 0UL)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static void OrInto(ulong[] target, ulong[] source)
+        {
+            for (var i = 0; i < target.Length; i++)
+            {
+                target[i] |= source[i];
             }
         }
 


### PR DESCRIPTION
  ## Summary

  This PR adds a project-grouped DAG reachability path to the C# query
  runtime and rewrites the dependency-reach benchmark to use it directly.

  Previously, the C# query benchmark for synthetic dependency reach worked
  like this:

  1. compute closure from each unique direct dependency seed
  2. materialize `(seed, reachable)` rows
  3. regroup those rows by project in the benchmark harness

  That was semantically correct, but it optimized the wrong grouped unit.

  This PR fixes that by introducing a runtime node that propagates
  **project labels** directly across the DAG and emits:

  - `(project, reachable_dependency)`

  rows from the query runtime itself.

  ## What Changed

  ### New C# Query Runtime Node

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `SeedGroupedTransitiveClosureNode`

  This node takes:

  - a plain edge relation, e.g. `category_parent/2`
  - a seed relation, e.g. `project_dependency/2`
  - a target predicate id

  and computes grouped reachability of the form:

  - `(group, reachable)`

  without requiring the group label to already be embedded in every edge.

  This is the key difference from the existing
  `GroupedTransitiveClosureNode`, which assumes the group columns are part
  of the edge tuples themselves.

  ### DAG Fast Path for Project-Grouped Reach

  The new node includes a DAG-specialized fast path.

  For larger acyclic workloads it:

  1. builds the DAG from the plain edge relation
  2. restricts to the reachable cone of the grouped seeds
  3. assigns integer ids to nodes and groups
  4. propagates **project bitsets** through the DAG
  5. emits `(project, reachable)` rows directly from those bitsets

  For smaller cases, it falls back to a generic grouped closure strategy.

  This is the runtime version of the design correction captured in the
  recent note:

  - the dependency benchmark is grouped by **project**
  - not by raw dependency seed

  ### Dependency Benchmark Generator

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The C# query version of `dependency_depth` now:

  - loads `project_dependency/2` into the relation provider
  - uses `SeedGroupedTransitiveClosureNode`
  - executes grouped project reachability directly in `QueryRuntime`
  - counts per-project reach from the runtime output

  It no longer performs:

  - raw per-seed closure
  - then benchmark-side regrouping from seeds back to projects

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The dependency-reach section now reflects:

  - the new project-grouped query-runtime path
  - updated local results
  - the fact that the performance gap has narrowed dramatically

  ## Why This Matters

  The previous dependency-reach experiments taught us an important lesson:

  - optimizing raw dependency-seed closure is not the same as optimizing
    the benchmark

  The benchmark result is grouped by project. That means the natural shared
  state is:

  - project membership on reachable nodes

  not:

  - raw dependency-seed membership on reachable nodes

  This PR implements that correction directly in the C# query runtime.

  ## Verification

  ### Generated C# package build

  Passed locally for a generated `dependency_depth` benchmark package.

  ### Python benchmark tooling

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  ### Cross-target dependency-reach benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs still matched across all four targets.

  ## Updated Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.060s | 0.045s | 0.002s | 0.003s | match |
  | 1k | 0.097s | 0.051s | 0.007s | 0.009s | match |
  | 5k | 0.199s | 0.167s | 0.130s | 0.106s | match |
  | 10k | 0.485s | 0.511s | 0.572s | 0.457s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.75x | 0.04x | 0.05x |
  | 1k | 0.52x | 0.07x | 0.10x |
  | 5k | 0.84x | 0.65x | 0.53x |
  | 10k | 1.05x | 1.18x | 0.94x |

  ## Interpretation

  This changes the performance story materially.

  Before this PR, the C# query engine was still far behind on dependency
  reach even after the earlier DAG fast path improvements.

  After this PR:

  - it is still behind at 300 and 1k
  - it is near parity at 5k
  - it is slightly faster than:
      - C# DFS
      - Rust DFS
        at 10k
  - it is still just behind Go DFS at 10k

  So the query engine is now competitive on this DAG workload once the
  runtime is grouped around the actual benchmark output grain.

  ## Scope

  This PR is focused on:

  - project-grouped DAG reachability
  - inside the C# query runtime
  - for the dependency-reach benchmark family

  It does not yet add:

  - a general planner path that emits this node from source Prolog
  - a C# query path for true longest DAG dependency depth
  - transitive reduction or other additional DAG preprocessing

  ## Follow-Up

  Likely next work:

  - use the new DAG substrate to add a clean csharp-query path for true
    longest dependency depth
  - decide whether this grouped DAG node should become a more general
    compiler-emitted primitive rather than remaining benchmark-driven
  - add the theory docs we discussed for:
      - pair reachability on DAGs
      - grouped reachability on DAGs
      - longest-depth DAG dynamic programming