### PR TITLE
feat(prolog): add mode-directed branch pruning for parameterized PPV

### DIFF
--- a/docs/design/PROLOG_TARGET_OPTIMIZATION.md
+++ b/docs/design/PROLOG_TARGET_OPTIMIZATION.md
@@ -1,4 +1,4 @@
-# Prolog Target Optimization: Future Work
+# Prolog Target Optimization
 
 ## Context
 
@@ -7,6 +7,61 @@ Prolog (what the user writes) should remain declarative — using standard
 idioms like `\+ member(X, Visited)` and `[X|Visited]`. The **compiled**
 Prolog (what UnifyWeaver generates for the Prolog target) can differ,
 using SWI-specific optimizations while preserving semantics.
+
+## Current Status
+
+The Prolog target now has an initial SWI-Prolog-specific branch-pruning
+lowering for parameterized per-path visited recursion.
+
+When the compiler sees all of the following:
+- a recursive predicate matching `is_per_path_visited_pattern/4`
+- a concrete `user:mode/1` declaration with at least one non-visited input
+- SWI-Prolog as the target dialect
+
+it can generate:
+- a normal recursive worker
+- a pruned worker used when the mode inputs are bound
+- a tabled prune relation over the driver input and invariant inputs
+- a small cache/guard layer for grounded prune checks
+
+This is conceptually similar to the C# parameterized query engine's
+demand seeding: known inputs restrict the search space before full
+recursive exploration. The generated code is still ordinary Prolog,
+just with helper predicates such as `'$worker'`, `'$pruned'`, and
+`'$prune'`.
+
+## Implemented Strategy
+
+### 1. Mode-Directed Branch Pruning
+
+For a predicate shaped roughly like:
+
+```prolog
+category_ancestor(Cat, Ancestor, Hops, Visited) :-
+    category_parent(Cat, Ancestor),
+    \+ member(Ancestor, Visited),
+    Hops = 1.
+
+category_ancestor(Cat, Ancestor, Hops, Visited) :-
+    category_parent(Cat, Mid),
+    Mid \= blocked,
+    \+ member(Mid, Visited),
+    category_ancestor(Mid, Ancestor, H1, [Mid|Visited]),
+    Hops is H1 + 1.
+
+:- mode(category_ancestor(-, +, -, +)).
+```
+
+the compiler can derive a prune relation keyed by the bound query inputs.
+If those inputs are known at call time, the generated wrapper dispatches
+to a pruned worker that checks whether a branch can still reach the
+requested answer before recursing.
+
+- **Benefit**: Avoids exploring branches that cannot satisfy the bound query
+- **Impact**: Best when one or more answer-shaping inputs are fixed
+- **SWI-specific**: Uses `:- table` and a dynamic cache helper
+- **Requires**: The visited argument must be identified from the actual
+  per-path pattern, not guessed from the first `+` mode position
 
 ## Current Performance
 
@@ -17,7 +72,7 @@ At 10x scale (195 articles, 3932 edges, max-depth=10):
 
 ## Optimization Strategies
 
-### 1. Dict-Based Visited Set (O(1) lookup)
+### 2. Dict-Based Visited Set (O(1) lookup)
 
 Replace `\+ member(X, Visited)` with `\+ get_dict(X, Visited, _)` and
 `[X|Visited]` with `put_dict(X, Visited, true, NewVisited)`.
@@ -28,7 +83,7 @@ Replace `\+ member(X, Visited)` with `\+ get_dict(X, Visited, _)` and
 - **SWI-specific**: Dicts are SWI-Prolog 7+. Not portable.
 - **Requires**: No extra packages (built-in).
 
-### 2. Root-Reachability Pruning
+### 3. Root-Reachability Pruning
 
 Precompute which categories can reach the root, then prune DFS branches
 that lead to unreachable categories:
@@ -58,7 +113,11 @@ category_ancestor(Cat, Mid, ...) :-
 - **Impact**: Potentially orders of magnitude at large scale
 - **Requires**: Pre-processing step (one-time BFS from root backwards)
 
-### 3. Cuts for Early Termination
+This is now partially implemented in a more general, mode-directed form:
+rather than precomputing a single fixed root relation, the generated
+Prolog can derive a prune relation from the bound inputs of the query.
+
+### 4. Cuts for Early Termination
 
 Add cuts (`!`) to prevent exploring branches once sufficient paths are
 found. For d_eff with n=5, paths beyond ~3x the shortest contribute
@@ -75,11 +134,15 @@ category_ancestor(Cat, Ancestor, Hops, Visited) :-
 Could also add: once shortest path to root is found, only explore paths
 up to `K * shortest` depth.
 
-### 4. Tabling (NOT recommended for this pattern)
+### 5. Tabling (NOT recommended for the main recursive predicate)
 
 Tested: tabling `category_ancestor/4` is slower (2.58s vs 0.68s) because
 the Visited list makes every call unique, preventing cache hits. Tabling
 is effective for standard transitive closure but not per-path visited.
+
+The current implementation only tables the derived prune helper, where
+the arguments are the demand-signature inputs rather than the full
+visited path.
 
 ## Prolog-Specific Packages
 
@@ -101,7 +164,6 @@ The Prolog target optimization mirrors what other targets do:
 - AWK: string scan → O(n) visited (needs optimization, see
   `docs/design/PER_PATH_VISITED_RECURSION.md`)
 
-The UnifyWeaver compiler could generate the optimized Prolog automatically
-when it detects the `\+ member(X, Visited)` pattern — same pattern
-detection used for other targets (`is_per_path_visited_pattern/4` in
-`pattern_matchers.pl`).
+The UnifyWeaver compiler now does this for one useful subset:
+parameterized per-path recursion with explicit mode information in the
+SWI target. Other optimizations in this note remain future work.

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -262,8 +262,9 @@ strip_codegen_module_qualifiers(Goal0, Goal) :-
     Goal0 = Module:Inner0,
     !,
     strip_codegen_module_qualifiers(Inner0, Inner),
-    (   Module == prolog_target
-    ;   Module == user
+    (   (   Module == prolog_target
+        ;   Module == user
+        )
     ->  Goal = Inner
     ;   Goal = Module:Inner
     ).
@@ -369,7 +370,11 @@ contains_predicate_call(Goal0, Pred) :-
     ;   false
     ).
 
-branch_pruning_driver_position(Pred, Arity, [Head-Body|_], DriverPos) :-
+branch_pruning_driver_position(Pred, Arity, RecClauses, DriverPos) :-
+    maplist(branch_pruning_clause_driver_position(Pred, Arity), RecClauses, DriverPositions),
+    sort(DriverPositions, [DriverPos]).
+
+branch_pruning_clause_driver_position(Pred, Arity, Head-Body, DriverPos) :-
     Head =.. [Pred|HeadArgs],
     body_goals(Body, [StepGoal|_]),
     step_goal_input_var(StepGoal, StepInputVar),
@@ -544,8 +549,9 @@ rename_recursive_calls(Goal0, Pred, Arity, NewName, Goal) :-
     Goal0 = Module:Inner0,
     !,
     rename_recursive_calls(Inner0, Pred, Arity, NewName, Renamed),
-    (   Module == user
-    ;   Module == prolog_target
+    (   (   Module == user
+        ;   Module == prolog_target
+        )
     ->  Goal = Renamed
     ;   Goal = Module:Renamed
     ).

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -29,6 +29,7 @@
 :- use_module(library(option)).
 :- use_module(prolog_dialects).
 :- use_module(prolog_constraints).
+:- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4]).
 
 %% ============================================
 %% MAIN ENTRY POINT
@@ -217,8 +218,12 @@ generate_predicate_code(Pred/Arity, Options, Code) :-
     % Get dialect for constraint handling
     option(dialect(Dialect), Options, swi),
 
-    % Copy predicate clauses verbatim
-    copy_predicate_clauses(Pred/Arity, BaseCode),
+    % Copy predicate clauses verbatim, or generate an optimized worker when
+    % the source matches a parameterized per-path recursion shape.
+    (   maybe_generate_branch_pruned_predicate(Pred/Arity, Options, OptimizedCode)
+    ->  BaseCode = OptimizedCode
+    ;   copy_predicate_clauses(Pred/Arity, BaseCode)
+    ),
 
     % Apply constraints if specified
     (   option(constraints(Constraints), Options)
@@ -233,7 +238,8 @@ copy_predicate_clauses(Pred/Arity, Code) :-
 
     % Find all clauses
     findall(ClauseStr, (
-        clause(Head, Body),
+        user:clause(Head, Body0),
+        strip_codegen_module_qualifiers(Body0, Body),
         clause_to_string((Head :- Body), ClauseStr)
     ), ClauseStrs),
 
@@ -250,6 +256,356 @@ clause_to_string(Clause, String) :-
     with_output_to(atom(String),
         portray_clause(Clause)
     ).
+
+strip_codegen_module_qualifiers(Goal0, Goal) :-
+    nonvar(Goal0),
+    Goal0 = Module:Inner0,
+    !,
+    strip_codegen_module_qualifiers(Inner0, Inner),
+    (   Module == prolog_target
+    ;   Module == user
+    ->  Goal = Inner
+    ;   Goal = Module:Inner
+    ).
+strip_codegen_module_qualifiers(true, true) :- !.
+strip_codegen_module_qualifiers((A0, B0), (A, B)) :-
+    !,
+    strip_codegen_module_qualifiers(A0, A),
+    strip_codegen_module_qualifiers(B0, B).
+strip_codegen_module_qualifiers((A0 ; B0), (A ; B)) :-
+    !,
+    strip_codegen_module_qualifiers(A0, A),
+    strip_codegen_module_qualifiers(B0, B).
+strip_codegen_module_qualifiers((A0 -> B0 ; C0), (A -> B ; C)) :-
+    !,
+    strip_codegen_module_qualifiers(A0, A),
+    strip_codegen_module_qualifiers(B0, B),
+    strip_codegen_module_qualifiers(C0, C).
+strip_codegen_module_qualifiers((A0 -> B0), (A -> B)) :-
+    !,
+    strip_codegen_module_qualifiers(A0, A),
+    strip_codegen_module_qualifiers(B0, B).
+strip_codegen_module_qualifiers(Goal, Goal).
+
+%% maybe_generate_branch_pruned_predicate(+Pred/Arity, +Options, -Code)
+%  For recursive per-path predicates with a concrete mode/1 declaration,
+%  generate a standard Prolog wrapper plus helper predicates that prune
+%  impossible branches before entering the recursive worker.
+maybe_generate_branch_pruned_predicate(Pred/Arity, Options, Code) :-
+    option(branch_pruning(Setting), Options, auto),
+    Setting \= false,
+    option(dialect(Dialect), Options, swi),
+    Dialect == swi,
+    findall(Head-Body,
+        (   functor(Head, Pred, Arity),
+            user:clause(Head, Body0),
+            strip_codegen_module_qualifiers(Body0, Body)
+        ),
+        Clauses),
+    Clauses \= [],
+    clauses_to_pattern_pairs(Clauses, ClausePairs),
+    is_per_path_visited_pattern(Pred, Arity, ClausePairs, VisitedPos),
+    branch_pruning_mode_positions(Pred/Arity, VisitedPos, InputPositions),
+    partition(is_recursive_clause_for_pred(Pred), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    branch_pruning_driver_position(Pred, Arity, RecClauses, DriverPos),
+    delete(InputPositions, DriverPos, InvariantPositions),
+    branch_pruning_invariants_static(Pred, Arity, RecClauses, VisitedPos, InvariantPositions),
+    build_branch_pruning_code(Pred/Arity, Clauses, BaseClauses, RecClauses,
+        VisitedPos, DriverPos, InputPositions, InvariantPositions, Code).
+
+clauses_to_pattern_pairs([], []).
+clauses_to_pattern_pairs([Head-Body|Rest], [(Head, Body)|Pairs]) :-
+    clauses_to_pattern_pairs(Rest, Pairs).
+
+branch_pruning_mode_positions(Pred/Arity, VisitedPos, InputPositions) :-
+    current_predicate(user:mode/1),
+    user:mode(ModeSpec),
+    mode_term_signature(ModeSpec, Pred/Arity),
+    parse_mode_spec(ModeSpec, Modes),
+    \+ member(any, Modes),
+    nth1(VisitedPos, Modes, input),
+    findall(Pos,
+        (   nth1(Pos, Modes, input),
+            Pos =\= VisitedPos
+        ),
+        InputPositions),
+    InputPositions \= [],
+    !.
+
+mode_term_signature(Term, Pred/Arity) :-
+    compound(Term),
+    Term =.. [Pred|Args],
+    length(Args, Arity).
+
+parse_mode_spec(Term, Modes) :-
+    Term =.. [_|Args],
+    maplist(parse_mode_symbol, Args, Modes).
+
+parse_mode_symbol(+, input) :- !.
+parse_mode_symbol(-, output) :- !.
+parse_mode_symbol(?, any) :- !.
+
+is_recursive_clause_for_pred(Pred, _Head-Body) :-
+    contains_predicate_call(Body, Pred).
+
+contains_predicate_call(Goal0, Pred) :-
+    strip_module(Goal0, _, Goal),
+    (   compound(Goal),
+        Goal =.. [Pred|_]
+    ->  true
+    ;   Goal = (A, B)
+    ->  (contains_predicate_call(A, Pred) ; contains_predicate_call(B, Pred))
+    ;   Goal = (A ; B)
+    ->  (contains_predicate_call(A, Pred) ; contains_predicate_call(B, Pred))
+    ;   Goal = (A -> B)
+    ->  (contains_predicate_call(A, Pred) ; contains_predicate_call(B, Pred))
+    ;   Goal = (A -> B ; C)
+    ->  ( contains_predicate_call(A, Pred)
+        ; contains_predicate_call(B, Pred)
+        ; contains_predicate_call(C, Pred)
+        )
+    ;   false
+    ).
+
+branch_pruning_driver_position(Pred, Arity, [Head-Body|_], DriverPos) :-
+    Head =.. [Pred|HeadArgs],
+    body_goals(Body, [StepGoal|_]),
+    step_goal_input_var(StepGoal, StepInputVar),
+    findall(Pos,
+        (   between(1, Arity, Pos),
+            nth1(Pos, HeadArgs, Arg),
+            Arg == StepInputVar
+        ),
+        [DriverPos]).
+
+step_goal_input_var(Goal0, InputVar) :-
+    strip_module(Goal0, _, Goal),
+    compound(Goal),
+    \+ branch_pruning_negated_member_goal(Goal, _),
+    arg(1, Goal, InputVar),
+    var(InputVar).
+
+branch_pruning_invariants_static(_, _, [], _, _).
+branch_pruning_invariants_static(Pred, Arity, [Head-Body|Rest], VisitedPos, InvariantPositions) :-
+    Head =.. [Pred|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    body_goals(Body, Goals),
+    recursive_prefix_goals(Pred, Arity, Goals, VisitedVar, _PrefixGoals, RecCall),
+    RecCall =.. [_|RecArgs],
+    forall(member(Pos, InvariantPositions),
+        (   nth1(Pos, HeadArgs, HeadArg),
+            nth1(Pos, RecArgs, RecArg),
+            HeadArg == RecArg
+        )),
+    branch_pruning_invariants_static(Pred, Arity, Rest, VisitedPos, InvariantPositions).
+
+build_branch_pruning_code(Pred/Arity, Clauses, BaseClauses, RecClauses,
+        VisitedPos, DriverPos, InputPositions, InvariantPositions, Code) :-
+    atom_concat(Pred, '$worker', WorkerName),
+    atom_concat(Pred, '$pruned', PrunedName),
+    atom_concat(Pred, '$prune', PruneName),
+    atom_concat(Pred, '$prune_guard', PruneGuardName),
+    atom_concat(Pred, '$prune_cache', PruneCacheName),
+    branch_pruning_signature_positions(DriverPos, InvariantPositions, SignaturePositions),
+    length(SignaturePositions, PruneArity),
+    build_branch_pruning_wrapper(Pred/Arity, WorkerName, PrunedName, InputPositions, WrapperClause),
+    build_branch_pruning_guard(PruneGuardName, PruneName, PruneCacheName, PruneArity, GuardClauses),
+    maplist(build_prune_base_clause(Pred, PruneName, SignaturePositions, VisitedPos), BaseClauses, PruneBaseClauses),
+    maplist(build_prune_recursive_clause(Pred, Arity, PruneName, PruneGuardName,
+            SignaturePositions, VisitedPos), RecClauses, PruneRecClauses),
+    append(PruneBaseClauses, PruneRecClauses, PruneClauses),
+    maplist(rename_clause_for_worker(Pred, Arity, WorkerName, none), Clauses, WorkerClauses),
+    guard_spec(SignaturePositions, PruneGuardName, GuardSpec),
+    maplist(rename_clause_for_worker(Pred, Arity, PrunedName, GuardSpec), Clauses, PrunedClauses),
+    format(atom(TableDeclCode), ':- table ~q/~d.', [PruneName, PruneArity]),
+    format(atom(CacheDeclCode), ':- dynamic ~q/~d.', [PruneCacheName, PruneArity]),
+    clauses_to_code(GuardClauses, GuardCode),
+    clauses_to_code(PruneClauses, PruneCode),
+    clauses_to_code(WorkerClauses, WorkerCode),
+    clauses_to_code(PrunedClauses, PrunedCode),
+    clause_to_string(WrapperClause, WrapperCode),
+    atomic_list_concat([
+        '% Branch-pruned Prolog generated from a parameterized per-path recursion.',
+        TableDeclCode,
+        CacheDeclCode,
+        GuardCode,
+        PruneCode,
+        WorkerCode,
+        PrunedCode,
+        WrapperCode
+    ], '\n\n', Code).
+
+branch_pruning_signature_positions(DriverPos, InvariantPositions, [DriverPos|InvariantPositions]).
+
+build_branch_pruning_wrapper(Pred/Arity, WorkerName, PrunedName, InputPositions, ClauseTerm) :-
+    functor(Head, Pred, Arity),
+    Head =.. [Pred|Args],
+    build_nonvar_guard(InputPositions, Args, BoundGoal),
+    WorkerCall =.. [WorkerName|Args],
+    PrunedCall =.. [PrunedName|Args],
+    ClauseTerm = (Head :- (BoundGoal -> PrunedCall ; WorkerCall)).
+
+build_nonvar_guard([Pos], Args, nonvar(Arg)) :-
+    !,
+    nth1(Pos, Args, Arg).
+build_nonvar_guard([Pos|Rest], Args, (nonvar(Arg), Tail)) :-
+    nth1(Pos, Args, Arg),
+    build_nonvar_guard(Rest, Args, Tail).
+
+build_branch_pruning_guard(GuardName, PruneName, CacheName, Arity, [ClauseTerm]) :-
+    functor(Head, GuardName, Arity),
+    Head =.. [GuardName|Args],
+    CacheCall =.. [CacheName|Args],
+    RawCall =.. [PruneName|Args],
+    GroundCheck = ground(Args),
+    Body =
+        (   GroundCheck
+        ->  (   CacheCall
+            ->  true
+            ;   once(RawCall),
+                (   CacheCall
+                ->  true
+                ;   assertz(CacheCall)
+                )
+            )
+        ;   RawCall
+        ),
+    ClauseTerm = (Head :- Body).
+
+build_prune_base_clause(Pred, PruneName, SignaturePositions, VisitedPos, Head-Body, ClauseTerm) :-
+    Head =.. [Pred|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    body_goals(Body, Goals),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), Goals, BodyGoals),
+    BodyGoals \= [],
+    select_positions_1based(SignaturePositions, HeadArgs, PruneArgs),
+    PruneHead =.. [PruneName|PruneArgs],
+    goals_to_body(BodyGoals, PruneBody),
+    clause_term(PruneHead, PruneBody, ClauseTerm).
+
+build_prune_recursive_clause(Pred, Arity, PruneName, PruneGuardName,
+        SignaturePositions, VisitedPos, Head-Body, ClauseTerm) :-
+    Head =.. [Pred|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    body_goals(Body, Goals),
+    recursive_prefix_goals(Pred, Arity, Goals, VisitedVar, PrefixGoals, RecCall),
+    PrefixGoals \= [],
+    RecCall =.. [_|RecArgs],
+    select_positions_1based(SignaturePositions, HeadArgs, PruneHeadArgs),
+    select_positions_1based(SignaturePositions, RecArgs, NextPruneArgs),
+    PruneGuardCall =.. [PruneGuardName|NextPruneArgs],
+    append(PrefixGoals, [PruneGuardCall], PruneGoals),
+    PruneHead =.. [PruneName|PruneHeadArgs],
+    goals_to_body(PruneGoals, PruneBody),
+    clause_term(PruneHead, PruneBody, ClauseTerm).
+
+recursive_prefix_goals(Pred, Arity, Goals, VisitedVar, PrefixGoals, RecCall) :-
+    append(Prefix0, [RecCall|_], Goals),
+    branch_pruning_recursive_goal(Pred, Arity, RecCall),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), Prefix0, PrefixGoals).
+
+branch_pruning_recursive_goal(Pred, Arity, Goal0) :-
+    strip_module(Goal0, _, Goal),
+    compound(Goal),
+    functor(Goal, Pred, GoalArity),
+    GoalArity =:= Arity.
+
+branch_pruning_negated_member_goal_for(VisitedVar, Goal) :-
+    branch_pruning_negated_member_goal(Goal, VisitedVar).
+
+branch_pruning_negated_member_goal(Goal0, VisitedVar) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. ['\\+', Inner],
+        Inner =.. [member, _, Var]
+    ;   Goal =.. [not, Inner],
+        Inner =.. [member, _, Var]
+    ),
+    Var == VisitedVar.
+
+rename_clause_for_worker(Pred, Arity, NewName, GuardSpec, Head-Body0, ClauseTerm) :-
+    Head =.. [_|HeadArgs],
+    NewHead =.. [NewName|HeadArgs],
+    rename_recursive_calls(Body0, Pred, Arity, NewName, Body1),
+    (   GuardSpec = none
+    ->  FinalBody = Body1
+    ;   GuardSpec = guard(SignaturePositions, GuardName),
+        select_positions_1based(SignaturePositions, HeadArgs, GuardArgs),
+        GuardCall =.. [GuardName|GuardArgs],
+        prepend_goal(GuardCall, Body1, FinalBody)
+    ),
+    clause_term(NewHead, FinalBody, ClauseTerm).
+
+guard_spec(SignaturePositions, GuardName, guard(SignaturePositions, GuardName)).
+
+rename_recursive_calls(Goal0, Pred, Arity, NewName, Goal) :-
+    nonvar(Goal0),
+    Goal0 = Module:Inner0,
+    !,
+    rename_recursive_calls(Inner0, Pred, Arity, NewName, Renamed),
+    (   Module == user
+    ;   Module == prolog_target
+    ->  Goal = Renamed
+    ;   Goal = Module:Renamed
+    ).
+rename_recursive_calls(Goal0, Pred, Arity, NewName, Goal) :-
+    rename_recursive_calls_plain(Goal0, Pred, Arity, NewName, Goal).
+
+rename_recursive_calls_plain(true, _Pred, _Arity, _NewName, true) :- !.
+rename_recursive_calls_plain((A0, B0), Pred, Arity, NewName, (A, B)) :-
+    !,
+    rename_recursive_calls(A0, Pred, Arity, NewName, A),
+    rename_recursive_calls(B0, Pred, Arity, NewName, B).
+rename_recursive_calls_plain((A0 ; B0), Pred, Arity, NewName, (A ; B)) :-
+    !,
+    rename_recursive_calls(A0, Pred, Arity, NewName, A),
+    rename_recursive_calls(B0, Pred, Arity, NewName, B).
+rename_recursive_calls_plain((A0 -> B0), Pred, Arity, NewName, (A -> B)) :-
+    !,
+    rename_recursive_calls(A0, Pred, Arity, NewName, A),
+    rename_recursive_calls(B0, Pred, Arity, NewName, B).
+rename_recursive_calls_plain(Goal0, Pred, Arity, NewName, Goal) :-
+    compound(Goal0),
+    functor(Goal0, Pred, GoalArity),
+    GoalArity =:= Arity,
+    !,
+    Goal0 =.. [_|Args],
+    Goal =.. [NewName|Args].
+rename_recursive_calls_plain(Goal, _Pred, _Arity, _NewName, Goal).
+
+prepend_goal(Goal, true, Goal) :- !.
+prepend_goal(Goal, Body, (Goal, Body)).
+
+body_goals(true, []) :- !.
+body_goals(Body0, Goals) :-
+    strip_module(Body0, _, Body),
+    body_goals_plain(Body, Goals).
+
+body_goals_plain(true, []) :- !.
+body_goals_plain((A, B), Goals) :-
+    !,
+    body_goals_plain(A, GoalsA),
+    body_goals_plain(B, GoalsB),
+    append(GoalsA, GoalsB, Goals).
+body_goals_plain(Goal, [Goal]).
+
+goals_to_body([], true).
+goals_to_body([Goal], Goal) :- !.
+goals_to_body([Goal|Rest], (Goal, Tail)) :-
+    goals_to_body(Rest, Tail).
+
+clause_term(Head, true, Head) :- !.
+clause_term(Head, Body, (Head :- Body)).
+
+clauses_to_code(Clauses, Code) :-
+    maplist(clause_to_string, Clauses, ClauseStrings),
+    atomic_list_concat(ClauseStrings, '\n', Code).
+
+select_positions_1based([], _List, []).
+select_positions_1based([Pos|Rest], List, [Elem|Elems]) :-
+    nth1(Pos, List, Elem),
+    select_positions_1based(Rest, List, Elems).
 
 %% generate_entry_point(+Options, -Code)
 %  Generate main entry point and initialization

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -1,0 +1,54 @@
+:- module(test_prolog_target, [run_prolog_target_tests/0]).
+
+:- use_module(library(plunit)).
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+run_prolog_target_tests :-
+    run_tests([prolog_target]).
+
+:- begin_tests(prolog_target).
+
+setup_branch_pruning_fixture :-
+    cleanup_branch_pruning_fixture,
+    assertz(user:test_ppv_edge(a, b)),
+    assertz(user:test_ppv_edge(b, c)),
+    assertz(user:test_ppv_edge(b, blocked)),
+    assertz(user:(test_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        test_ppv_edge(Cat, Ancestor),
+        \+ member(Ancestor, Visited),
+        Hops = 1)),
+    assertz(user:(test_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        test_ppv_edge(Cat, Mid),
+        Mid \= blocked,
+        \+ member(Mid, Visited),
+        test_ppv_reach(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1)),
+    assertz(user:mode(test_ppv_reach(-, +, -, +))).
+
+cleanup_branch_pruning_fixture :-
+    retractall(user:test_ppv_edge(_, _)),
+    retractall(user:test_ppv_reach(_, _, _, _)),
+    retractall(user:mode(test_ppv_reach(_, _, _, _))).
+
+setup_no_mode_fixture :-
+    setup_branch_pruning_fixture,
+    retractall(user:mode(test_ppv_reach(_, _, _, _))).
+
+test(emits_branch_pruning_helpers_for_parameterized_ppv,
+        [setup(setup_branch_pruning_fixture),
+         cleanup(cleanup_branch_pruning_fixture)]) :-
+    once(generate_prolog_script([test_ppv_reach/4], [dialect(swi)], Code)),
+    once(sub_atom(Code, _, _, _, 'test_ppv_reach$prune')),
+    once(sub_atom(Code, _, _, _, 'test_ppv_reach$prune_guard')),
+    once(sub_atom(Code, _, _, _, 'test_ppv_reach$prune_cache')),
+    once(sub_atom(Code, _, _, _, 'test_ppv_reach$pruned')),
+    once(sub_atom(Code, _, _, _, ':- table')).
+
+test(skips_branch_pruning_without_mode_signal,
+        [setup(setup_no_mode_fixture),
+         cleanup(cleanup_branch_pruning_fixture)]) :-
+    once(generate_prolog_script([test_ppv_reach/4], [dialect(swi)], Code)),
+    \+ sub_atom(Code, _, _, _, 'test_ppv_reach$prune'),
+    \+ sub_atom(Code, _, _, _, 'test_ppv_reach$pruned').
+
+:- end_tests(prolog_target).

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -51,4 +51,25 @@ test(skips_branch_pruning_without_mode_signal,
     \+ sub_atom(Code, _, _, _, 'test_ppv_reach$prune'),
     \+ sub_atom(Code, _, _, _, 'test_ppv_reach$pruned').
 
+test(skips_branch_pruning_for_non_swi_dialect,
+        [setup(setup_branch_pruning_fixture),
+         cleanup(cleanup_branch_pruning_fixture)]) :-
+    once(generate_prolog_script([test_ppv_reach/4], [dialect(gnu)], Code)),
+    \+ sub_atom(Code, _, _, _, 'test_ppv_reach$prune'),
+    \+ sub_atom(Code, _, _, _, 'test_ppv_reach$pruned').
+
+test(strips_only_codegen_module_qualifiers) :-
+    prolog_target:strip_codegen_module_qualifiers(user:(foo(X), prolog_target:bar(X), other:baz(X)), Goal),
+    Goal = (foo(X), bar(X), other:baz(X)).
+
+test(rename_recursive_calls_preserves_foreign_module_qualifiers) :-
+    prolog_target:rename_recursive_calls(
+        (user:test_ppv_reach(A, B, C, D), other:test_ppv_reach(A, B, C, D)),
+        test_ppv_reach,
+        4,
+        'test_ppv_reach$worker',
+        Goal
+    ),
+    Goal = ('test_ppv_reach$worker'(A, B, C, D), other:'test_ppv_reach$worker'(A, B, C, D)).
+
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This adds an initial SWI-Prolog-specific branch-pruning lowering for parameterized per-path-visited recursion in the
  Prolog target.

  The optimization is mode-directed: when a predicate matches the PPV shape and has a concrete `user:mode/1` declaration
  with bound query inputs, the generated Prolog emits a pruned worker path that checks whether a branch can still
  contribute to the requested answer before recursing.

  ## What Changed

  - added branch-pruning code generation to `src/unifyweaver/targets/prolog_target.pl`
  - integrated `is_per_path_visited_pattern/4` into the Prolog target optimization gate
  - derived the visited position from the actual PPV pattern, then used `user:mode/1` to identify the remaining bound
  inputs
  - emitted helper predicates for optimized lowering:
    - `'$worker'`
    - `'$pruned'`
    - `'$prune'`
    - `'$prune_guard'`
    - `'$prune_cache'`
  - tabled the prune helper and cached grounded existential guard checks
  - normalized codegen-owned module qualifiers before copying and rewriting clause bodies
  - tightened recursive driver-position detection so all recursive clauses must agree
  - documented the optimization in `docs/design/PROLOG_TARGET_OPTIMIZATION.md`
  - added focused PLUnit coverage in `tests/core/test_prolog_target.pl`

  ## Why

  This ports the key idea of the C# parameterized query engine's demand seeding into the Prolog target.

  Instead of changing user-authored Prolog, the target now generates standard-looking Prolog with helper predicates that
  prune branches when query-shaping inputs are already bound. That keeps the source declarative while still enabling
  target-specific optimization.

  ## Verification

  - `swipl -q -t halt -s src/unifyweaver/targets/prolog_target.pl`
  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`

  ## Notes

  - this optimization is currently gated to the SWI-Prolog dialect
  - predicates that do not match the canonical PPV + mode-directed shape fall back to normal Prolog generation
  - execution-level testing of generated code is still a reasonable follow-up, but focused generator and regression
  coverage is included here