### PR TITLE
feat(csharp-query): add dag longest-depth runtime

### DIFF
--- a/docs/proposals/DAG_QUERY_EXECUTION_THEORY.md
+++ b/docs/proposals/DAG_QUERY_EXECUTION_THEORY.md
@@ -1,0 +1,171 @@
+# DAG Query Execution Theory
+
+## Summary
+
+This note captures the current theory direction behind the recent DAG
+work in the C# query runtime.
+
+The central split is:
+
+- **DAG workloads**
+  - state can usually be summarized per node or per node-plus-group
+  - dynamic programming is the right execution model
+- **non-DAG simple-path workloads**
+  - state must include path or visited-set information
+  - exact execution is fundamentally more expensive
+
+This note is only about the DAG side.
+
+## Core Principle
+
+For DAGs, the useful state is not a path. It is a **summary over a node
+in topological context**.
+
+That summary can take different forms depending on the query:
+
+1. **pair reachability**
+   - question: can `u` reach `v`?
+   - natural summary: descendant or ancestor reachability sets
+
+2. **grouped reachability**
+   - question: which labels/groups reach this node?
+   - natural summary: propagated group bitsets on nodes
+
+3. **longest depth**
+   - question: what is the longest path from this node to a sink?
+   - natural summary: a single integer depth per node
+
+The mistake to avoid is treating all DAG problems as path enumeration.
+
+## Why DAGs Are Different
+
+In a DAG:
+
+- topological order exists
+- recursion is well-founded
+- no visited-set/path-state is needed for exactness
+
+So fixed-point evaluation can often be collapsed to:
+
+- one preprocessing pass
+- one topological dynamic-programming pass
+
+rather than repeated frontier growth over richer path states.
+
+## Reachability Shapes
+
+### 1. Plain Reachability
+
+For ungrouped transitive closure:
+
+- state: reachable descendants per node
+- useful execution: topological propagation with exact bitsets or other
+  memoized descendant summaries
+
+This was the basis of the earlier DAG reachability fast path.
+
+### 2. Grouped Reachability
+
+For dependency reach count, the important lesson was:
+
+- the output is grouped by **project**
+- not by raw dependency seed
+
+So the right grouped state is:
+
+- project membership propagated over reachable nodes
+
+not:
+
+- raw dependency-seed membership propagated over reachable nodes
+
+That is why the recent `SeedGroupedTransitiveClosureNode` uses:
+
+- a plain edge relation
+- a separate `(group, seed)` relation
+- grouped propagation inside the runtime
+
+instead of materializing raw `(seed, reachable)` closure and regrouping
+later.
+
+## Longest Depth Shape
+
+For longest depth on a DAG:
+
+- each node needs only one value:
+  - `depth(node) = 1 + max(depth(successor))`
+  - or `1` for sinks
+
+This is simpler than grouped reachability:
+
+- no bitsets are needed
+- only a reverse topological pass and a scalar memo
+
+At the grouped level, project longest depth becomes:
+
+- `max(depth(seed))` over the direct dependency seeds of the project
+
+So the grouped state for longest depth lives mostly at the **seed
+relation**, not in the propagation itself.
+
+That is why the runtime node for the benchmark can be:
+
+- `SeedGroupedDagLongestDepthNode(edgeRelation, seedRelation, predicate)`
+
+which:
+
+1. computes scalar node depths on the DAG
+2. reduces them by group over the seed relation
+
+## Design Rule
+
+When choosing a DAG execution strategy, first ask:
+
+- what is the smallest exact summary state that answers this workload?
+
+Examples:
+
+- reachability pair query:
+  - descendant summary
+- grouped reach count:
+  - group-bitset summary
+- longest depth:
+  - scalar max-depth summary
+
+The runtime should not carry richer state than the query requires.
+
+## Relationship To Non-DAG Work
+
+This theory note is intentionally separate from the non-DAG path-state
+design docs.
+
+For non-DAG simple-path workloads:
+
+- state includes visited/path information
+- hashing can help with indexing
+- exact verification is still required
+
+That is a different execution family.
+
+The point of keeping these notes separate is to prevent DAG workloads
+from inheriting unnecessary path-state complexity.
+
+## Current Practical Takeaway
+
+The C# query runtime now has two useful DAG-specialized directions:
+
+1. **project-grouped reachability**
+2. **grouped DAG longest depth**
+
+Both are exact.
+Both avoid path-state tracking.
+Both are better understood as topological dynamic programming than as
+general recursive search.
+
+## Likely Next Theory Questions
+
+- when should DAG preprocessing be shared across multiple query-runtime
+  nodes on the same edge relation?
+- when is transitive reduction worth the preprocessing cost?
+- how much of the current benchmark-driven DAG runtime should become
+  planner-emitted general-purpose lowering?

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -432,7 +432,7 @@ Command:
 ```bash
 python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
     --scales 300,1k,5k,10k \
-    --targets csharp-dfs,rust-dfs,go-dfs \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
     --repetitions 1
 ```
 
@@ -442,21 +442,31 @@ chain length over the synthetic package DAG.
 
 Latest local results:
 
-| Scale | C# DFS | Rust DFS | Go DFS | Outputs |
-|-------|--------:|---------:|-------:|---------|
-| 300 | 0.091s | 0.003s | 0.003s | match |
-| 1k | 0.139s | 0.004s | 0.003s | match |
-| 5k | 0.055s | 0.006s | 0.006s | match |
-| 10k | 0.059s | 0.012s | 0.011s | match |
+| Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
+|-------|---------:|--------:|---------:|-------:|-----------------|
+| 300 | 0.063s | 0.041s | 0.002s | 0.002s | match |
+| 1k | 0.060s | 0.044s | 0.003s | 0.003s | match |
+| 5k | 0.098s | 0.051s | 0.006s | 0.006s | match |
+| 10k | 0.104s | 0.057s | 0.011s | 0.011s | match |
+
+Speedups of C# query engine:
+
+| Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
+|-------|----------:|------------:|----------:|
+| 300 | 0.65x | 0.03x | 0.03x |
+| 1k | 0.73x | 0.05x | 0.05x |
+| 5k | 0.52x | 0.06x | 0.06x |
+| 10k | 0.55x | 0.10x | 0.11x |
 
 Comparison note:
 
-- this benchmark currently compares the DFS-style targets only
-- a like-for-like `csharp-query` longest-depth path is not yet included,
-  because the current query engine does not have a clean max-depth DAG
-  execution mode comparable to the DFS dynamic-programming formulation
-- that makes this benchmark a useful marker for future DAG-specialized
-  query-engine work rather than a finished query-vs-DFS comparison
+- this benchmark now includes a real `csharp-query` DAG longest-depth
+  path built on a dedicated query-runtime node
+- the query engine matches all DFS outputs and is now in the right
+  algorithmic family, but it still carries more runtime overhead than the
+  hand-written DFS targets
+- that makes it a good DAG benchmark baseline for further query-runtime
+  optimization rather than a finished performance story
 
 ### Cross-Target Category Influence Results
 

--- a/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
+++ b/examples/benchmark/benchmark_dependency_longest_depth_cross_target.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Benchmark dependency longest-depth analysis across generated DFS binaries
-for C#, Rust, and Go.
+Benchmark dependency longest-depth analysis across generated C# query and
+DFS binaries for C#, Rust, and Go.
 """
 
 from __future__ import annotations
@@ -57,8 +57,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--scales", default="300,1k,5k,10k")
     parser.add_argument(
         "--targets",
-        default="csharp-dfs,rust-dfs,go-dfs",
-        help="Comma-separated targets: csharp-dfs,rust-dfs,go-dfs",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -126,12 +126,20 @@ def print_summary(results: list[RunResult]) -> None:
     print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
     for scale, entries in group_results_by_scale(results):
         print_result_table(entries, scale)
+        csharp_query = find_result(entries, "csharp-query")
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         go_dfs = find_result(entries, "go-dfs")
-        dfs_like = list(entries)
+        dfs_like = [entry for entry in entries if entry.target != "csharp-query"]
         if len(dfs_like) > 1:
             print_match_status(scale, "dfs_outputs", dfs_like)
+        if csharp_query and csharp_dfs:
+            print_pair_match_status(scale, "query_vs_csharp_dfs", csharp_query, csharp_dfs)
+            print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, csharp_query)
+        if csharp_query and rust_dfs:
+            print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, csharp_query)
+        if csharp_query and go_dfs:
+            print_speedup(scale, "speedup_vs_go_dfs", go_dfs, csharp_query)
 
 
 def main() -> int:
@@ -158,14 +166,14 @@ def main() -> int:
 
         commands: dict[str, list[str]] = {}
         for target in targets:
-            if target == "csharp-dfs":
+            if target == "csharp-query":
+                commands[target] = build_csharp_query(temp_root, seed_facts)
+            elif target == "csharp-dfs":
                 commands[target] = build_csharp_dfs(temp_root, seed_facts)
             elif target == "rust-dfs":
                 commands[target] = build_rust_dfs(temp_root, seed_facts)
             elif target == "go-dfs":
                 commands[target] = build_go_dfs(temp_root, seed_facts)
-            elif target == "csharp-query":
-                raise ValueError("csharp-query longest-depth mode is not ready yet; use csharp-dfs,rust-dfs,go-dfs")
             else:
                 raise ValueError(f"unsupported target: {target}")
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1848,7 +1848,8 @@ class Program
 
         var provider = new InMemoryRelationProvider();
         var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("dependency_depth", 3);
+        var seedId = new PredicateId("project_dependency", 2);
+        var predId = new PredicateId("dependency_longest_depth", 2);
         var projectDeps = new Dictionary<string, List<string>>(StringComparer.Ordinal);
 
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
@@ -1885,63 +1886,28 @@ class Program
             }}
 
             deps.Add(parts[1]);
+            provider.AddFact(seedId, parts[0], parts[1]);
         }}
         swLoad.Stop();
 
         var plan = new QueryPlan(
             predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.All),
-            true,
-            new int[] {{ 0 }}
+            new SeedGroupedDagLongestDepthNode(edgeId, seedId, predId),
+            true
         );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var deps in projectDeps.Values)
-        {{
-            foreach (var dep in deps)
-            {{
-                uniqueSeeds.Add(dep);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds
-            .OrderBy(dep => dep, StringComparer.Ordinal)
-            .Select(dep => new object[] {{ dep }})
-            .ToList();
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));
-        var rows = executor.Execute(plan, seedParams).ToList();
+        var rows = executor.Execute(plan).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var depthIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        var results = new List<(int Depth, string Project)>();
         foreach (var row in rows)
         {{
-            var source = row[0]?.ToString() ?? "";
-            var depth = Convert.ToInt32(row[2]);
-            if (!depthIndex.TryGetValue(source, out var best) || depth > best)
-            {{
-                depthIndex[source] = depth;
-            }}
-        }}
-
-        var results = new List<(int Depth, string Project)>();
-        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
-        {{
-            var best = 0;
-            foreach (var dep in projectDeps[project])
-            {{
-                if (depthIndex.TryGetValue(dep, out var depth) && depth > best)
-                {{
-                    best = depth;
-                }}
-                else if (best < 1)
-                {{
-                    best = 1;
-                }}
-            }}
-            results.Add((best, project));
+            var project = row[0]?.ToString() ?? "";
+            var depth = Convert.ToInt32(row[1]);
+            results.Add((depth, project));
         }}
         swAgg.Stop();
         swTotal.Stop();
@@ -1962,7 +1928,7 @@ class Program
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"seed_count={{projectDeps.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -244,6 +244,16 @@ namespace UnifyWeaver.QueryRuntime
     ) : PlanNode;
 
     /// <summary>
+    /// Computes the maximum DAG depth reachable from grouped seed nodes,
+    /// producing (group, depth) rows directly.
+    /// </summary>
+    public sealed record SeedGroupedDagLongestDepthNode(
+        PredicateId EdgeRelation,
+        PredicateId SeedRelation,
+        PredicateId Predicate
+    ) : PlanNode;
+
+    /// <summary>
     /// Computes a counted transitive closure while preventing cycles on each
     /// derivation path instead of deduplicating globally by node or tuple.
     /// </summary>
@@ -858,6 +868,7 @@ namespace UnifyWeaver.QueryRuntime
                     case TransitiveClosureNode:
                     case GroupedTransitiveClosureNode:
                     case SeedGroupedTransitiveClosureNode:
+                    case SeedGroupedDagLongestDepthNode:
                     case PathAwareTransitiveClosureNode:
                     case PathAwareAccumulationNode:
                         return;
@@ -996,6 +1007,7 @@ namespace UnifyWeaver.QueryRuntime
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
                 SeedGroupedTransitiveClosureNode closure => $"SeedGroupedTransitiveClosure edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
+                SeedGroupedDagLongestDepthNode closure => $"SeedGroupedDagLongestDepth edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode} positiveStep={closure.PositiveStepProven}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
@@ -1213,6 +1225,20 @@ namespace UnifyWeaver.QueryRuntime
                     return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedClosure, rows);
                 }
 
+                if (plan.Root is SeedGroupedDagLongestDepthNode seedGroupedDepth)
+                {
+                    var rows = ExecuteSeedGroupedDagLongestDepth(seedGroupedDepth, context);
+                    var contextCancellationToken = context.CancellationToken;
+                    if (contextCancellationToken.CanBeCanceled)
+                    {
+                        rows = WithCancellation(rows, contextCancellationToken);
+                    }
+
+                    var activeTrace = context.Trace;
+                    activeTrace?.RecordInvocation(seedGroupedDepth);
+                    return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedDepth, rows);
+                }
+
                 if (plan.Root is PathAwareTransitiveClosureNode pathAwareClosure)
                 {
                     IEnumerable<object[]> rows;
@@ -1309,6 +1335,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.TransitiveClosureSeededByTargetResults.Clear();
             _cacheContext.TransitiveClosurePairProbeResults.Clear();
             _cacheContext.GroupedTransitiveClosureResults.Clear();
+            _cacheContext.SeedGroupedDagLongestDepthResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededByTargetResults.Clear();
             _cacheContext.GroupedTransitiveClosurePairProbeResults.Clear();
@@ -1410,6 +1437,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 case SeedGroupedTransitiveClosureNode closure:
                     result = ExecuteSeedGroupedTransitiveClosure(closure, context);
+                    break;
+
+                case SeedGroupedDagLongestDepthNode closure:
+                    result = ExecuteSeedGroupedDagLongestDepth(closure, context);
                     break;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -1848,6 +1879,11 @@ namespace UnifyWeaver.QueryRuntime
                     return;
 
                 case SeedGroupedTransitiveClosureNode closure:
+                    predicates.Add(closure.EdgeRelation);
+                    predicates.Add(closure.SeedRelation);
+                    return;
+
+                case SeedGroupedDagLongestDepthNode closure:
                     predicates.Add(closure.EdgeRelation);
                     predicates.Add(closure.SeedRelation);
                     return;
@@ -8096,6 +8132,51 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        private IEnumerable<object[]> ExecuteSeedGroupedDagLongestDepth(SeedGroupedDagLongestDepthNode closure, EvaluationContext? parentContext)
+        {
+            if (closure is null) throw new ArgumentNullException(nameof(closure));
+
+            var width = closure.Predicate.Arity;
+            if (width < 2)
+            {
+                return Array.Empty<object[]>();
+            }
+
+            var context = parentContext ?? new EvaluationContext();
+            context.FixpointDepth++;
+            try
+            {
+                var trace = context.Trace;
+                trace?.RecordStrategy(closure, "SeedGroupedDagLongestDepth");
+
+                var predicate = closure.Predicate;
+                var cacheKey = (closure.EdgeRelation, closure.SeedRelation, predicate);
+                var traceKey = $"{predicate.Name}/{predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:seeds={closure.SeedRelation.Name}/{closure.SeedRelation.Arity}";
+                if (context.SeedGroupedDagLongestDepthResults.TryGetValue(cacheKey, out var cachedRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedDagLongestDepth", traceKey, hit: true, built: false);
+                    return cachedRows;
+                }
+
+                trace?.RecordCacheLookup("SeedGroupedDagLongestDepth", traceKey, hit: false, built: true);
+
+                var edges = GetFactsList(closure.EdgeRelation, context);
+                var seeds = GetFactsList(closure.SeedRelation, context);
+                const int MaxDagNodeCount = 65536;
+                if (!TryBuildSeedGroupedDagLongestDepthRows(edges, seeds, MaxDagNodeCount, out var rows))
+                {
+                    throw new InvalidOperationException("SeedGroupedDagLongestDepthNode requires an acyclic edge relation.");
+                }
+
+                context.SeedGroupedDagLongestDepthResults[cacheKey] = rows;
+                return rows;
+            }
+            finally
+            {
+                context.FixpointDepth--;
+            }
+        }
+
         private static bool TryBuildProjectGroupedDagReachRows(
             IReadOnlyList<object[]> edges,
             IReadOnlyList<object[]> seeds,
@@ -8349,6 +8430,214 @@ namespace UnifyWeaver.QueryRuntime
                 }
             }
 
+            return true;
+        }
+
+        private static bool TryBuildSeedGroupedDagLongestDepthRows(
+            IReadOnlyList<object[]> edges,
+            IReadOnlyList<object[]> seeds,
+            int maxNodeCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            if (edges.Count == 0 || seeds.Count == 0)
+            {
+                return false;
+            }
+
+            var nodeIds = new Dictionary<object?, int>();
+            var nodeValues = new List<object?>();
+            var successors = new List<List<int>>();
+
+            int GetNodeId(object? value)
+            {
+                if (nodeIds.TryGetValue(value, out var id))
+                {
+                    return id;
+                }
+
+                id = nodeValues.Count;
+                nodeIds.Add(value, id);
+                nodeValues.Add(value);
+                successors.Add(new List<int>());
+                return id;
+            }
+
+            foreach (var edge in edges)
+            {
+                if (edge is null || edge.Length < 2)
+                {
+                    continue;
+                }
+
+                var fromId = GetNodeId(edge[0]);
+                var toId = GetNodeId(edge[1]);
+                successors[fromId].Add(toId);
+            }
+
+            if (nodeValues.Count == 0 || nodeValues.Count > maxNodeCount)
+            {
+                return false;
+            }
+
+            var reachable = new bool[nodeValues.Count];
+            var queue = new Queue<int>();
+            foreach (var seed in seeds)
+            {
+                if (seed is null || seed.Length < 2)
+                {
+                    continue;
+                }
+
+                if (!nodeIds.TryGetValue(seed[1], out var nodeId) || reachable[nodeId])
+                {
+                    continue;
+                }
+
+                reachable[nodeId] = true;
+                queue.Enqueue(nodeId);
+            }
+
+            while (queue.Count > 0)
+            {
+                var nodeId = queue.Dequeue();
+                foreach (var next in successors[nodeId])
+                {
+                    if (reachable[next])
+                    {
+                        continue;
+                    }
+
+                    reachable[next] = true;
+                    queue.Enqueue(next);
+                }
+            }
+
+            var includedCount = 0;
+            foreach (var isReachable in reachable)
+            {
+                if (isReachable)
+                {
+                    includedCount++;
+                }
+            }
+
+            if (includedCount == 0)
+            {
+                return true;
+            }
+
+            var localIds = new int[nodeValues.Count];
+            Array.Fill(localIds, -1);
+            var localSuccessors = new List<List<int>>(includedCount);
+            var localNodeValues = new object?[includedCount];
+            var indegree = new int[includedCount];
+            var nextLocalId = 0;
+
+            for (var globalId = 0; globalId < reachable.Length; globalId++)
+            {
+                if (!reachable[globalId])
+                {
+                    continue;
+                }
+
+                localIds[globalId] = nextLocalId;
+                localNodeValues[nextLocalId] = nodeValues[globalId];
+                localSuccessors.Add(new List<int>());
+                nextLocalId++;
+            }
+
+            for (var globalId = 0; globalId < reachable.Length; globalId++)
+            {
+                if (!reachable[globalId])
+                {
+                    continue;
+                }
+
+                var fromLocalId = localIds[globalId];
+                foreach (var nextGlobalId in successors[globalId])
+                {
+                    if (!reachable[nextGlobalId])
+                    {
+                        continue;
+                    }
+
+                    var toLocalId = localIds[nextGlobalId];
+                    localSuccessors[fromLocalId].Add(toLocalId);
+                    indegree[toLocalId]++;
+                }
+            }
+
+            var topoQueue = new Queue<int>();
+            for (var i = 0; i < indegree.Length; i++)
+            {
+                if (indegree[i] == 0)
+                {
+                    topoQueue.Enqueue(i);
+                }
+            }
+
+            var topo = new List<int>(includedCount);
+            while (topoQueue.Count > 0)
+            {
+                var localId = topoQueue.Dequeue();
+                topo.Add(localId);
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    indegree[successorLocalId]--;
+                    if (indegree[successorLocalId] == 0)
+                    {
+                        topoQueue.Enqueue(successorLocalId);
+                    }
+                }
+            }
+
+            if (topo.Count != includedCount)
+            {
+                return false;
+            }
+
+            var depths = new int[includedCount];
+            for (var i = topo.Count - 1; i >= 0; i--)
+            {
+                var localId = topo[i];
+                var best = 1;
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    var candidate = depths[successorLocalId] + 1;
+                    if (candidate > best)
+                    {
+                        best = candidate;
+                    }
+                }
+
+                depths[localId] = best;
+            }
+
+            var groupBest = new Dictionary<object?, int>();
+            foreach (var seed in seeds)
+            {
+                if (seed is null || seed.Length < 2)
+                {
+                    continue;
+                }
+
+                if (!nodeIds.TryGetValue(seed[1], out var globalId) || !reachable[globalId])
+                {
+                    continue;
+                }
+
+                var depth = depths[localIds[globalId]];
+                if (!groupBest.TryGetValue(seed[0], out var best) || depth > best)
+                {
+                    groupBest[seed[0]] = depth;
+                }
+            }
+
+            rows = groupBest
+                .OrderBy(kvp => kvp.Key?.ToString() ?? string.Empty, StringComparer.Ordinal)
+                .Select(kvp => new object[] { kvp.Key!, kvp.Value })
+                .ToList();
             return true;
         }
 
@@ -13160,6 +13449,8 @@ namespace UnifyWeaver.QueryRuntime
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, bool>>();
                 GroupedTransitiveClosureResults = parent?.GroupedTransitiveClosureResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), IReadOnlyList<object[]>>();
+                SeedGroupedDagLongestDepthResults = parent?.SeedGroupedDagLongestDepthResults
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
                 GroupedTransitiveClosureSeededResults = parent?.GroupedTransitiveClosureSeededResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
                 GroupedTransitiveClosureSeededByTargetResults = parent?.GroupedTransitiveClosureSeededByTargetResults
@@ -13214,6 +13505,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, bool>> TransitiveClosurePairProbeResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), IReadOnlyList<object[]>> GroupedTransitiveClosureResults { get; }
+
+            public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>> SeedGroupedDagLongestDepthResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>> GroupedTransitiveClosureSeededResults { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR adds a real DAG-specific longest-depth execution path to the C#
  query runtime and uses it for the synthetic dependency longest-depth
  benchmark.

  Previously, the `csharp_query` version of this workload was still using a
  path-aware closure workaround and then reducing the result in the
  benchmark harness.

  That was semantically valid, but it was the wrong execution model for a
  DAG problem.

  This PR replaces that with a dedicated runtime node that:

  - treats longest depth as a DAG dynamic-programming problem
  - computes node depths directly in the query runtime
  - reduces those depths by project over the seed relation

  ## What Changed

  ### New C# Query Runtime Node

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `SeedGroupedDagLongestDepthNode`

  This node takes:

  - a plain edge relation, e.g. `category_parent/2`
  - a seed relation, e.g. `project_dependency/2`
  - a target predicate id

  and computes:

  - `(project, dependency_longest_depth)`

  directly.

  It is the scalar-depth analog of the recent grouped DAG reachability
  work, but simpler:

  - each node needs only one scalar depth summary
  - project results are the max depth over that project’s seed nodes

  ### DAG Longest-Depth Algorithm

  The runtime implementation:

  1. loads the plain edge relation
  2. restricts to the seed-reachable DAG cone
  3. topologically orders that restricted DAG
  4. computes node depths in reverse topological order:
     - `depth(node) = 1 + max(depth(successor))`
     - sinks get depth `1`
  5. reduces those node depths by project over the seed relation

  The node also caches results in the query runtime, following the same
  pattern as the other specialized closure paths.

  ### Benchmark Generator

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The `csharp_query` generator for `dependency_longest_depth` now uses:

  - `SeedGroupedDagLongestDepthNode`

  instead of the older:

  - `PathAwareTransitiveClosureNode(..., TableMode.All)`

  plus benchmark-side max-depth reconstruction.

  So the benchmark now reflects a real query-runtime DAG longest-depth path
  rather than a workaround.

  ### Cross-Target Runner

  Updated:

  - `examples/benchmark/benchmark_dependency_longest_depth_cross_target.py`

  This runner now includes:

  - `csharp-query`

  alongside:

  - `csharp-dfs`
  - `rust-dfs`
  - `go-dfs`

  and prints the usual:

  - match status
  - speedups against each baseline

  ### Theory Note

  Added:

  - `docs/proposals/DAG_QUERY_EXECUTION_THEORY.md`

  This note captures the emerging DAG execution model:

  1. pair reachability on DAGs
  2. grouped reachability on DAGs
  3. longest-depth DAG dynamic programming

  and explicitly separates those from the non-DAG path-state story.

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects:

  - the new `csharp-query` longest-depth mode
  - the latest local results
  - the fact that the query engine is now in the right algorithmic family
    for this workload, even though more performance work is still warranted

  ## Why This Matters

  The recent DAG work established an important principle:

  - DAG workloads should use DAG summaries, not path-aware recursion

  We already applied that to grouped reachability.

  This PR applies the same principle to longest depth.

  That matters for both correctness of abstraction and future optimization:
  - the query engine is now using the right execution model
  - further DAG improvements can build on that substrate
  - we no longer need to treat longest depth as a path-enumeration problem

  ## Verification

  ### Python benchmark tooling

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py
  ```
  ### Generated C# package build

  Passed locally for a generated dependency_longest_depth benchmark
  package.

  ### Cross-target longest-depth benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ## Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.063s | 0.041s | 0.002s | 0.002s | match |
  | 1k | 0.060s | 0.044s | 0.003s | 0.003s | match |
  | 5k | 0.098s | 0.051s | 0.006s | 0.006s | match |
  | 10k | 0.104s | 0.057s | 0.011s | 0.011s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.65x | 0.03x | 0.03x |
  | 1k | 0.73x | 0.05x | 0.05x |
  | 5k | 0.52x | 0.06x | 0.06x |
  | 10k | 0.55x | 0.10x | 0.11x |

  ## Interpretation

  This PR does not make the query engine fastest on longest depth.

  What it does do is:

  - put csharp-query on the correct DAG execution model
  - preserve exact output agreement
  - replace a path-aware workaround with a proper scalar-depth DP node
  - create a cleaner baseline for further DAG optimization

  The current query path is still roughly 1.5x to 2x slower than the
  hand-written C# DFS baseline, so there is still room to optimize the DAG
  runtime further.

  ## Scope

  This PR is focused on:

  - exact DAG longest depth
  - in the C# query runtime
  - for the dependency benchmark family

  It does not yet add:

  - planner-emitted general-purpose lowering for this node from source
    Prolog
  - shared DAG preprocessing between longest-depth and grouped reachability
  - transitive reduction or other extra DAG preprocessing
  - non-DAG path-state work

  ## Follow-Up

  Likely next work:

  - continue pushing DAG performance in the C# query runtime
  - investigate shared DAG preprocessing across:
      - grouped reachability
      - longest depth
  - decide whether transitive reduction or other DAG preprocessing is worth
    it
  - only after the DAG work stabilizes, return to the harder non-DAG
    path-state track