### PR TITLE
fix(prolog): harden PPV branch pruning

### DIFF
--- a/src/unifyweaver/core/advanced/pattern_matchers.pl
+++ b/src/unifyweaver/core/advanced/pattern_matchers.pl
@@ -729,7 +729,7 @@ is_per_path_visited_pattern(Name, Arity, Clauses, VisitedPos) :-
     %   PreGoals...,
     %   \+ member(_, Visited),
     %   pred(..., [_|Visited]),
-    body_has_ordered_per_path_shape(RecBody, Name, VisitedPos, VisitedVar),
+    body_has_ordered_per_path_shape(RecBody, Name, RecArgs, VisitedPos, VisitedVar),
     !.
 
 %% is_recursive_clause_for_ppv(+Name, +Clause)
@@ -745,52 +745,51 @@ body_has_negated_member((_, Rest), ListVar) :- !,
 body_has_negated_member(\+ member(_, Var), ListVar) :-
     Var == ListVar.
 
-%% body_has_cons_in_recursive_call(+Body, +Name, +Pos, +VisitedVar)
-%%   True if the recursive call to Name has [_|VisitedVar] at position Pos.
-body_has_cons_in_recursive_call(Body, Name, Pos, VisitedVar) :-
+%% body_has_ordered_per_path_shape(+Body, +Name, +HeadArgs, +Pos, +VisitedVar)
+%%   True if Body begins with a step-like goal whose first argument is a
+%%   head variable and whose later argument becomes the recursive driver's
+%%   next value, followed by optional helper goals, then \+ member(_, VisitedVar),
+%%   and later a recursive call passing [Next|VisitedVar] at position Pos.
+body_has_ordered_per_path_shape(Body, Name, HeadArgs, Pos, VisitedVar) :-
     extract_goals_ppv(Body, Goals),
-    member(RecCall, Goals),
-    RecCall =.. [Name|CallArgs],
-    nth1(Pos, CallArgs, CallArg),
-    nonvar(CallArg),
-    CallArg = [_|Tail],
-    Tail == VisitedVar.
+    append([StepGoal|_BeforeNegTail], [NegGoal|AfterNeg], Goals),
+    negated_member_goal_for_ppv(NegGoal, VisitedVar, NextVar),
+    step_goal_for_ppv(StepGoal, Name, HeadArgs, NextVar),
+    goals_have_driver_cons_recursive_call(AfterNeg, Name, Pos, VisitedVar, NextVar).
 
-%% body_has_ordered_per_path_shape(+Body, +Name, +Pos, +VisitedVar)
-%%   True if Body has a non-recursive step goal, optional helper goals,
-%%   then \+ member(_, VisitedVar), and later a recursive call passing
-%%   [_|VisitedVar] at position Pos.
-body_has_ordered_per_path_shape(Body, Name, Pos, VisitedVar) :-
-    extract_goals_ppv(Body, Goals),
-    append(BeforeNeg, [NegGoal|AfterNeg], Goals),
-    BeforeNeg \= [],
-    negated_member_goal_for_ppv(NegGoal, VisitedVar),
-    has_step_goal_before_neg(BeforeNeg, Name, VisitedVar),
-    goals_have_cons_in_recursive_call(AfterNeg, Name, Pos, VisitedVar).
-
-negated_member_goal_for_ppv(\+ member(_, Var), VisitedVar) :-
+negated_member_goal_for_ppv(\+ member(NextVar, Var), VisitedVar, NextVar) :-
+    Var == VisitedVar.
+negated_member_goal_for_ppv(not(member(NextVar, Var)), VisitedVar, NextVar) :-
     Var == VisitedVar.
 
-has_step_goal_before_neg([Goal|_], Name, VisitedVar) :-
-    step_goal_for_ppv(Goal, Name, VisitedVar),
-    !.
-has_step_goal_before_neg([_|Rest], Name, VisitedVar) :-
-    has_step_goal_before_neg(Rest, Name, VisitedVar).
-
-step_goal_for_ppv(Goal, Name, _VisitedVar) :-
+step_goal_for_ppv(Goal, Name, HeadArgs, NextVar) :-
     callable(Goal),
     Goal \= (\+ _),
-    Goal =.. [Functor|_],
+    Goal \= not(_),
+    Goal =.. [Functor|Args],
     Functor \= Name,
-    Functor \= member.
+    Functor \= member,
+    Args = [DriverVar|RestArgs],
+    var(DriverVar),
+    member_samevar(DriverVar, HeadArgs),
+    member_samevar(NextVar, RestArgs),
+    var(NextVar),
+    NextVar \== DriverVar.
 
-goals_have_cons_in_recursive_call(Goals, Name, Pos, VisitedVar) :-
+goals_have_driver_cons_recursive_call(Goals, Name, Pos, VisitedVar, NextVar) :-
     member(RecCall, Goals),
     RecCall =.. [Name|CallArgs],
+    CallArgs = [NextVar|_],
     nth1(Pos, CallArgs, CallArg),
     nonvar(CallArg),
-    CallArg = [_|Tail],
+    CallArg = [NextVar|Tail],
     Tail == VisitedVar.
+
+member_samevar(Var, [Candidate|_]) :-
+    Candidate == Var,
+    !.
+member_samevar(Var, [_|Rest]) :-
+    member_samevar(Var, Rest).
 
 %% extract_goals_ppv(+Body, -Goals)
 extract_goals_ppv((A, B), Goals) :- !,

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -27,6 +27,7 @@
 :- use_module(library(lists)).
 :- use_module(library(apply)).
 :- use_module(library(option)).
+:- use_module(library(debug)).
 :- use_module(prolog_dialects).
 :- use_module(prolog_constraints).
 :- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4]).
@@ -294,27 +295,71 @@ strip_codegen_module_qualifiers(Goal, Goal).
 %  impossible branches before entering the recursive worker.
 maybe_generate_branch_pruned_predicate(Pred/Arity, Options, Code) :-
     option(branch_pruning(Setting), Options, auto),
-    Setting \= false,
+    (   Setting \= false
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'disabled by option', []),
+        fail
+    ),
     option(dialect(Dialect), Options, swi),
-    Dialect == swi,
+    (   Dialect == swi
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'dialect ~w is not supported', [Dialect]),
+        fail
+    ),
     findall(Head-Body,
         (   functor(Head, Pred, Arity),
             user:clause(Head, Body0),
             strip_codegen_module_qualifiers(Body0, Body)
         ),
         Clauses),
-    Clauses \= [],
+    (   Clauses \= []
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'no clauses found', []),
+        fail
+    ),
     clauses_to_pattern_pairs(Clauses, ClausePairs),
-    is_per_path_visited_pattern(Pred, Arity, ClausePairs, VisitedPos),
-    branch_pruning_mode_positions(Pred/Arity, VisitedPos, InputPositions),
+    (   is_per_path_visited_pattern(Pred, Arity, ClausePairs, VisitedPos)
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'predicate does not match canonical per-path visited recursion', []),
+        fail
+    ),
+    (   branch_pruning_mode_positions(Pred/Arity, VisitedPos, InputPositions)
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'missing concrete mode declaration for non-visited inputs', []),
+        fail
+    ),
     partition(is_recursive_clause_for_pred(Pred), Clauses, RecClauses, BaseClauses),
-    RecClauses \= [],
-    BaseClauses \= [],
-    branch_pruning_driver_position(Pred, Arity, RecClauses, DriverPos),
+    (   RecClauses \= []
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'no recursive clauses found after PPV matching', []),
+        fail
+    ),
+    (   BaseClauses \= []
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'no base clauses found after PPV matching', []),
+        fail
+    ),
+    (   branch_pruning_driver_position(Pred, Arity, RecClauses, DriverPos)
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'could not infer a unique driver position', []),
+        fail
+    ),
     delete(InputPositions, DriverPos, InvariantPositions),
-    branch_pruning_invariants_static(Pred, Arity, RecClauses, VisitedPos, InvariantPositions),
-    build_branch_pruning_code(Pred/Arity, Clauses, BaseClauses, RecClauses,
-        VisitedPos, DriverPos, InputPositions, InvariantPositions, Code).
+    (   branch_pruning_invariants_static(Pred, Arity, RecClauses, VisitedPos, InvariantPositions)
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'input invariants do not stay fixed across recursive clauses', []),
+        fail
+    ),
+    (   build_branch_pruning_code(Pred/Arity, Clauses, BaseClauses, RecClauses,
+            VisitedPos, DriverPos, InputPositions, InvariantPositions, Code)
+    ->  true
+    ;   branch_pruning_debug(Pred/Arity, 'failed while emitting pruned helper predicates', []),
+        fail
+    ).
+
+branch_pruning_debug(Pred/Arity, Message, Args) :-
+    atom_concat('Skipping branch pruning for ~w/~w: ', Message, Format),
+    debug(prolog_branch_pruning, Format, [Pred, Arity|Args]).
 
 clauses_to_pattern_pairs([], []).
 clauses_to_pattern_pairs([Head-Body|Rest], [(Head, Body)|Pairs]) :-

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -1,6 +1,7 @@
 :- module(test_prolog_target, [run_prolog_target_tests/0]).
 
 :- use_module(library(plunit)).
+:- use_module(library(gensym)).
 :- use_module('../../src/unifyweaver/targets/prolog_target').
 
 run_prolog_target_tests :-
@@ -34,6 +35,75 @@ setup_no_mode_fixture :-
     setup_branch_pruning_fixture,
     retractall(user:mode(test_ppv_reach(_, _, _, _))).
 
+setup_execution_branch_pruning_fixture :-
+    cleanup_execution_branch_pruning_fixture,
+    assertz(user:test_exec_edge(a, b)),
+    assertz(user:test_exec_edge(b, c)),
+    assertz(user:test_exec_edge(a, d)),
+    assertz(user:test_exec_edge(d, e)),
+    assertz(user:test_exec_edge(e, c)),
+    assertz(user:(test_exec_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        test_exec_edge(Cat, Ancestor),
+        \+ member(Ancestor, Visited),
+        Hops = 1)),
+    assertz(user:(test_exec_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        test_exec_edge(Cat, Mid),
+        \+ member(Mid, Visited),
+        test_exec_ppv_reach(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1)),
+    assertz(user:mode(test_exec_ppv_reach(-, +, -, +))).
+
+cleanup_execution_branch_pruning_fixture :-
+    retractall(user:test_exec_edge(_, _)),
+    retractall(user:test_exec_ppv_reach(_, _, _, _)),
+    retractall(user:mode(test_exec_ppv_reach(_, _, _, _))).
+
+setup_noncanonical_step_fixture :-
+    cleanup_noncanonical_step_fixture,
+    assertz(user:test_noncanonical_guard(a, warmed)),
+    assertz(user:test_noncanonical_guard(b, warmed)),
+    assertz(user:test_noncanonical_edge(a, b)),
+    assertz(user:test_noncanonical_edge(b, c)),
+    assertz(user:(test_noncanonical_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        test_noncanonical_edge(Cat, Ancestor),
+        \+ member(Ancestor, Visited),
+        Hops = 1)),
+    assertz(user:(test_noncanonical_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        test_noncanonical_guard(Cat, warmed),
+        test_noncanonical_edge(Cat, Mid),
+        \+ member(Mid, Visited),
+        test_noncanonical_ppv_reach(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1)),
+    assertz(user:mode(test_noncanonical_ppv_reach(-, +, -, +))).
+
+cleanup_noncanonical_step_fixture :-
+    retractall(user:test_noncanonical_guard(_, _)),
+    retractall(user:test_noncanonical_edge(_, _)),
+    retractall(user:test_noncanonical_ppv_reach(_, _, _, _)),
+    retractall(user:mode(test_noncanonical_ppv_reach(_, _, _, _))).
+
+build_execution_runtime_source(ModuleName, PredicateCode, Source) :-
+    atomic_list_concat([
+        'test_exec_edge(a, b).',
+        'test_exec_edge(b, c).',
+        'test_exec_edge(a, d).',
+        'test_exec_edge(d, e).',
+        'test_exec_edge(e, c).'
+    ], '\n', FactsCode),
+    format(atom(Source),
+        ':- module(~q, [test_exec_ppv_reach/4]).~n:- use_module(library(lists)).~n~w~n~n~w~n',
+        [ModuleName, FactsCode, PredicateCode]).
+
+write_temp_module_source(Source, Path) :-
+    tmp_file_stream(text, Path, Stream),
+    write(Stream, Source),
+    nl(Stream),
+    close(Stream).
+
+cleanup_temp_module_source(Path) :-
+    catch(unload_file(Path), _, true),
+    catch(delete_file(Path), _, true).
+
 test(emits_branch_pruning_helpers_for_parameterized_ppv,
         [setup(setup_branch_pruning_fixture),
          cleanup(cleanup_branch_pruning_fixture)]) :-
@@ -58,6 +128,13 @@ test(skips_branch_pruning_for_non_swi_dialect,
     \+ sub_atom(Code, _, _, _, 'test_ppv_reach$prune'),
     \+ sub_atom(Code, _, _, _, 'test_ppv_reach$pruned').
 
+test(rejects_noncanonical_ppv_leading_goal,
+        [setup(setup_noncanonical_step_fixture),
+         cleanup(cleanup_noncanonical_step_fixture)]) :-
+    once(generate_prolog_script([test_noncanonical_ppv_reach/4], [dialect(swi)], Code)),
+    \+ sub_atom(Code, _, _, _, 'test_noncanonical_ppv_reach$prune'),
+    \+ sub_atom(Code, _, _, _, 'test_noncanonical_ppv_reach$pruned').
+
 test(strips_only_codegen_module_qualifiers) :-
     prolog_target:strip_codegen_module_qualifiers(user:(foo(X), prolog_target:bar(X), other:baz(X)), Goal),
     Goal = (foo(X), bar(X), other:baz(X)).
@@ -71,5 +148,27 @@ test(rename_recursive_calls_preserves_foreign_module_qualifiers) :-
         Goal
     ),
     Goal = ('test_ppv_reach$worker'(A, B, C, D), other:'test_ppv_reach$worker'(A, B, C, D)).
+
+test(exec_generated_branch_pruned_code_preserves_results,
+        [setup(setup_execution_branch_pruning_fixture),
+         cleanup(cleanup_execution_branch_pruning_fixture)]) :-
+    once(prolog_target:generate_predicate_code(test_exec_ppv_reach/4, [dialect(swi)], PredicateCode)),
+    once(sub_atom(PredicateCode, _, _, _, 'test_exec_ppv_reach$pruned')),
+    gensym(test_exec_ppv_runtime_, ModuleName),
+    build_execution_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            findall(H, user:test_exec_ppv_reach(a, c, H, [a]), Expected0),
+            sort(Expected0, Expected),
+            Goal =.. [test_exec_ppv_reach, a, c, H, [a]],
+            findall(H, ModuleName:Goal, Actual0),
+            sort(Actual0, Actual),
+            Expected == [2, 3],
+            Actual == Expected
+        ),
+        cleanup_temp_module_source(Path)
+    ).
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This hardens the Prolog per-path-visited branch-pruning follow-up by tightening the PPV matcher contract, adding
  execution-level verification for generated code, and improving diagnostics when pruning is skipped.

  ## What Changed

  - tightened `is_per_path_visited_pattern/4` acceptance in `src/unifyweaver/core/advanced/pattern_matchers.pl`
  - aligned the accepted PPV step-goal shape with the Prolog target's driver-detection assumptions:
    - the first pre-negation goal must carry the head driver in argument 1
    - the recursive-next variable must come from a later argument of that same step goal
    - that same variable must become the recursive call's first argument and the visited-cons head
  - added opt-in fallback traces in `src/unifyweaver/targets/prolog_target.pl` using `debug(prolog_branch_pruning, ...)`
  - added stronger tests in `tests/core/test_prolog_target.pl`:
    - execution-level test that loads generated branch-pruned Prolog and checks result completeness
    - regression proving noncanonical leading-goal shapes do not trigger branch pruning
    - existing text-generation and qualifier-rewrite coverage remains in place

  ## Why

  The initial Prolog branch-pruning work was correct for the canonical PPV shape, but the matcher was looser than the
  target's downstream assumptions.

  This PR makes the acceptance criteria explicit and enforced at the gate, so we reject ambiguous/noncanonical shapes
  instead of relying on later heuristics. It also adds an execution-level test to verify that generated branch-pruned code
  preserves complete results, not just expected helper emission.

  ## Verification

  - `swipl -q -t halt -s src/unifyweaver/core/advanced/pattern_matchers.pl`
  - `swipl -q -t halt -s src/unifyweaver/targets/prolog_target.pl`
  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`

  ## Notes

  - branch-pruning remains SWI-Prolog-specific
  - noncanonical PPV bodies now fall back more explicitly instead of matching loosely
  - fallback diagnostics are opt-in through SWI's `debug/3` mechanism