### PR TITLE
perf(csharp-query): reduce dag reach materialization overhead

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -185,7 +185,7 @@ Tables:
 | `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
-| `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# DFS, Rust DFS, and Go DFS |
+| `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -402,27 +402,30 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.060s | 0.045s | 0.002s | 0.003s | match |
-| 1k | 0.097s | 0.051s | 0.007s | 0.009s | match |
-| 5k | 0.199s | 0.167s | 0.130s | 0.106s | match |
-| 10k | 0.485s | 0.511s | 0.572s | 0.457s | match |
+| 300 | 0.058s | 0.046s | 0.002s | 0.002s | match |
+| 1k | 0.088s | 0.050s | 0.007s | 0.007s | match |
+| 5k | 0.091s | 0.179s | 0.162s | 0.109s | match |
+| 10k | 0.103s | 0.517s | 0.573s | 0.463s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.75x | 0.04x | 0.05x |
-| 1k | 0.52x | 0.07x | 0.10x |
-| 5k | 0.84x | 0.65x | 0.53x |
-| 10k | 1.05x | 1.18x | 0.94x |
+| 300 | 0.78x | 0.04x | 0.04x |
+| 1k | 0.57x | 0.08x | 0.08x |
+| 5k | 1.97x | 1.78x | 1.20x |
+| 10k | 5.02x | 5.57x | 4.49x |
 
 Comparison note:
 
 - the current C# query path now uses a project-grouped reachability node
   rather than raw per-seed closure followed by regrouping
-- this changed the workload shape materially: the query engine is still
-  behind at `300` and `1k`, but is now close to parity at `5k` and
-  slightly ahead of C# DFS and Rust DFS at `10k`
+- the latest runtime-overhead pass pushes the final count aggregation
+  into the query runtime too, so the benchmark no longer materializes the
+  full `(project, reachable_dependency)` relation just to count it
+- this changed the cost profile materially: the query engine is still
+  behind at `300` and `1k`, but is now clearly ahead of all DFS targets
+  from `5k` onward
 - outputs still match across all four targets
 
 ### Cross-Target Dependency Longest-Depth Results
@@ -444,19 +447,19 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.063s | 0.041s | 0.002s | 0.002s | match |
-| 1k | 0.060s | 0.044s | 0.003s | 0.003s | match |
-| 5k | 0.098s | 0.051s | 0.006s | 0.006s | match |
-| 10k | 0.104s | 0.057s | 0.011s | 0.011s | match |
+| 300 | 0.059s | 0.043s | 0.002s | 0.002s | match |
+| 1k | 0.061s | 0.043s | 0.003s | 0.003s | match |
+| 5k | 0.089s | 0.051s | 0.006s | 0.006s | match |
+| 10k | 0.105s | 0.059s | 0.010s | 0.011s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.65x | 0.03x | 0.03x |
-| 1k | 0.73x | 0.05x | 0.05x |
-| 5k | 0.52x | 0.06x | 0.06x |
-| 10k | 0.55x | 0.10x | 0.11x |
+| 300 | 0.74x | 0.03x | 0.04x |
+| 1k | 0.71x | 0.04x | 0.05x |
+| 5k | 0.57x | 0.07x | 0.07x |
+| 10k | 0.56x | 0.10x | 0.11x |
 
 Comparison note:
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1449,7 +1449,7 @@ class Program
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("project_dependency", 2);
         var predId = new PredicateId("dependency_reach", 2);
-        var projectDeps = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var projects = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
         {{
@@ -1478,20 +1478,14 @@ class Program
                 continue;
             }}
 
-            if (!projectDeps.TryGetValue(parts[0], out var deps))
-            {{
-                deps = new List<string>();
-                projectDeps[parts[0]] = deps;
-            }}
-
-            deps.Add(parts[1]);
+            projects.Add(parts[0]);
             provider.AddFact(seedId, parts[0], parts[1]);
         }}
         swLoad.Stop();
 
         var plan = new QueryPlan(
             predId,
-            new SeedGroupedTransitiveClosureNode(edgeId, seedId, predId),
+            new SeedGroupedTransitiveClosureCountNode(edgeId, seedId, predId),
             true
         );
 
@@ -1501,15 +1495,13 @@ class Program
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var reachCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var results = new List<(int Count, string Project)>(rows.Count);
         foreach (var row in rows)
         {{
             var project = row[0]?.ToString() ?? "";
-            reachCounts[project] = reachCounts.TryGetValue(project, out var count) ? count + 1 : 1;
+            var count = Convert.ToInt32(row[1]);
+            results.Add((count, project));
         }}
-        var results = reachCounts
-            .Select(kvp => (Count: kvp.Value, Project: kvp.Key))
-            .ToList();
         swAgg.Stop();
         swTotal.Stop();
 
@@ -1529,7 +1521,7 @@ class Program
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{projectDeps.Count}}");
+        Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
     }}
@@ -1850,7 +1842,7 @@ class Program
         var edgeId = new PredicateId("category_parent", 2);
         var seedId = new PredicateId("project_dependency", 2);
         var predId = new PredicateId("dependency_longest_depth", 2);
-        var projectDeps = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var projects = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
         {{
@@ -1879,13 +1871,7 @@ class Program
                 continue;
             }}
 
-            if (!projectDeps.TryGetValue(parts[0], out var deps))
-            {{
-                deps = new List<string>();
-                projectDeps[parts[0]] = deps;
-            }}
-
-            deps.Add(parts[1]);
+            projects.Add(parts[0]);
             provider.AddFact(seedId, parts[0], parts[1]);
         }}
         swLoad.Stop();
@@ -1928,7 +1914,7 @@ class Program
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{projectDeps.Count}}");
+        Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -244,6 +244,17 @@ namespace UnifyWeaver.QueryRuntime
     ) : PlanNode;
 
     /// <summary>
+    /// Propagates group labels from an external seed relation across a plain
+    /// transitive closure edge relation, producing (group, reachable_count)
+    /// rows directly.
+    /// </summary>
+    public sealed record SeedGroupedTransitiveClosureCountNode(
+        PredicateId EdgeRelation,
+        PredicateId SeedRelation,
+        PredicateId Predicate
+    ) : PlanNode;
+
+    /// <summary>
     /// Computes the maximum DAG depth reachable from grouped seed nodes,
     /// producing (group, depth) rows directly.
     /// </summary>
@@ -868,6 +879,7 @@ namespace UnifyWeaver.QueryRuntime
                     case TransitiveClosureNode:
                     case GroupedTransitiveClosureNode:
                     case SeedGroupedTransitiveClosureNode:
+                    case SeedGroupedTransitiveClosureCountNode:
                     case SeedGroupedDagLongestDepthNode:
                     case PathAwareTransitiveClosureNode:
                     case PathAwareAccumulationNode:
@@ -1007,6 +1019,7 @@ namespace UnifyWeaver.QueryRuntime
                 TransitiveClosureNode closure => $"TransitiveClosure edge={closure.EdgeRelation}",
                 GroupedTransitiveClosureNode closure => $"GroupedTransitiveClosure edge={closure.EdgeRelation} groups=[{string.Join(",", closure.GroupIndices)}]",
                 SeedGroupedTransitiveClosureNode closure => $"SeedGroupedTransitiveClosure edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
+                SeedGroupedTransitiveClosureCountNode closure => $"SeedGroupedTransitiveClosureCount edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 SeedGroupedDagLongestDepthNode closure => $"SeedGroupedDagLongestDepth edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode} positiveStep={closure.PositiveStepProven}",
@@ -1225,6 +1238,20 @@ namespace UnifyWeaver.QueryRuntime
                     return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedClosure, rows);
                 }
 
+                if (plan.Root is SeedGroupedTransitiveClosureCountNode seedGroupedCount)
+                {
+                    var rows = ExecuteSeedGroupedTransitiveClosureCount(seedGroupedCount, context);
+                    var contextCancellationToken = context.CancellationToken;
+                    if (contextCancellationToken.CanBeCanceled)
+                    {
+                        rows = WithCancellation(rows, contextCancellationToken);
+                    }
+
+                    var activeTrace = context.Trace;
+                    activeTrace?.RecordInvocation(seedGroupedCount);
+                    return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedCount, rows);
+                }
+
                 if (plan.Root is SeedGroupedDagLongestDepthNode seedGroupedDepth)
                 {
                     var rows = ExecuteSeedGroupedDagLongestDepth(seedGroupedDepth, context);
@@ -1335,6 +1362,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.TransitiveClosureSeededByTargetResults.Clear();
             _cacheContext.TransitiveClosurePairProbeResults.Clear();
             _cacheContext.GroupedTransitiveClosureResults.Clear();
+            _cacheContext.SeedGroupedTransitiveClosureCountResults.Clear();
             _cacheContext.SeedGroupedDagLongestDepthResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededByTargetResults.Clear();
@@ -1437,6 +1465,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 case SeedGroupedTransitiveClosureNode closure:
                     result = ExecuteSeedGroupedTransitiveClosure(closure, context);
+                    break;
+
+                case SeedGroupedTransitiveClosureCountNode closure:
+                    result = ExecuteSeedGroupedTransitiveClosureCount(closure, context);
                     break;
 
                 case SeedGroupedDagLongestDepthNode closure:
@@ -1879,6 +1911,11 @@ namespace UnifyWeaver.QueryRuntime
                     return;
 
                 case SeedGroupedTransitiveClosureNode closure:
+                    predicates.Add(closure.EdgeRelation);
+                    predicates.Add(closure.SeedRelation);
+                    return;
+
+                case SeedGroupedTransitiveClosureCountNode closure:
                     predicates.Add(closure.EdgeRelation);
                     predicates.Add(closure.SeedRelation);
                     return;
@@ -8132,6 +8169,125 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        private IEnumerable<object[]> ExecuteSeedGroupedTransitiveClosureCount(SeedGroupedTransitiveClosureCountNode closure, EvaluationContext? parentContext)
+        {
+            if (closure is null) throw new ArgumentNullException(nameof(closure));
+
+            var width = closure.Predicate.Arity;
+            if (width < 2)
+            {
+                return Array.Empty<object[]>();
+            }
+
+            var context = parentContext ?? new EvaluationContext();
+            context.FixpointDepth++;
+            try
+            {
+                var trace = context.Trace;
+                trace?.RecordStrategy(closure, "SeedGroupedTransitiveClosureCount");
+
+                var predicate = closure.Predicate;
+                var cacheKey = (closure.EdgeRelation, closure.SeedRelation, predicate);
+                var traceKey = $"{predicate.Name}/{predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:seeds={closure.SeedRelation.Name}/{closure.SeedRelation.Arity}";
+                if (context.SeedGroupedTransitiveClosureCountResults.TryGetValue(cacheKey, out var cachedRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedTransitiveClosureCount", traceKey, hit: true, built: false);
+                    return cachedRows;
+                }
+
+                var edges = GetFactsList(closure.EdgeRelation, context);
+                var seeds = GetFactsList(closure.SeedRelation, context);
+
+                const int MaxDagNodeCount = 16384;
+                const int MaxDagGroupCount = 4096;
+                const int MinDagGroupCount = 64;
+                const int MinDagEdgeCount = 8192;
+                if (seeds.Count >= MinDagGroupCount &&
+                    edges.Count >= MinDagEdgeCount &&
+                    TryBuildProjectGroupedDagReachCountRows(edges, seeds, MaxDagNodeCount, MaxDagGroupCount, out var dagRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedTransitiveClosureCount", traceKey, hit: false, built: true);
+                    trace?.RecordStrategy(closure, "SeedGroupedTransitiveClosureCountDag");
+                    context.SeedGroupedTransitiveClosureCountResults[cacheKey] = dagRows;
+                    return dagRows;
+                }
+
+                trace?.RecordCacheLookup("SeedGroupedTransitiveClosureCount", traceKey, hit: false, built: true);
+
+                var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
+                var wrapperComparer = new RowWrapperComparer(StructuralArrayComparer.Instance);
+                var visited = new HashSet<RowWrapper>(wrapperComparer);
+                var groupCounts = new Dictionary<object?, int>();
+                var delta = new List<object[]>();
+
+                foreach (var seed in seeds)
+                {
+                    if (seed is null || seed.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    var group = seed[0];
+                    var node = seed[1];
+                    var key = new object[] { group!, node! };
+                    if (visited.Add(new RowWrapper(key)))
+                    {
+                        delta.Add(key);
+                        groupCounts[group] = groupCounts.TryGetValue(group, out var count) ? count + 1 : 1;
+                    }
+                }
+
+                var iteration = 0;
+                trace?.RecordFixpointIteration(closure, predicate, iteration, delta.Count, visited.Count);
+
+                while (delta.Count > 0)
+                {
+                    iteration++;
+                    var nextDelta = new List<object[]>();
+
+                    foreach (var pair in delta)
+                    {
+                        var node = pair[1];
+                        var lookupKey = node ?? NullFactIndexKey;
+                        if (!succIndex.TryGetValue(lookupKey, out var bucket))
+                        {
+                            continue;
+                        }
+
+                        foreach (var edge in bucket)
+                        {
+                            if (edge is null || edge.Length < 2)
+                            {
+                                continue;
+                            }
+
+                            var next = edge[1];
+                            var nextKey = new object[] { pair[0], next! };
+                            if (visited.Add(new RowWrapper(nextKey)))
+                            {
+                                nextDelta.Add(nextKey);
+                                var group = pair[0];
+                                groupCounts[group] = groupCounts.TryGetValue(group, out var count) ? count + 1 : 1;
+                            }
+                        }
+                    }
+
+                    delta = nextDelta;
+                    trace?.RecordFixpointIteration(closure, predicate, iteration, delta.Count, visited.Count);
+                }
+
+                var rows = groupCounts
+                    .Select(kvp => new object[] { kvp.Key!, kvp.Value })
+                    .ToList();
+                context.SeedGroupedTransitiveClosureCountResults[cacheKey] = rows;
+                return rows;
+            }
+            finally
+            {
+                context.FixpointDepth--;
+            }
+        }
+
         private IEnumerable<object[]> ExecuteSeedGroupedDagLongestDepth(SeedGroupedDagLongestDepthNode closure, EvaluationContext? parentContext)
         {
             if (closure is null) throw new ArgumentNullException(nameof(closure));
@@ -8428,6 +8584,254 @@ namespace UnifyWeaver.QueryRuntime
                         word &= word - 1;
                     }
                 }
+            }
+
+            return true;
+        }
+
+        private static bool TryBuildProjectGroupedDagReachCountRows(
+            IReadOnlyList<object[]> edges,
+            IReadOnlyList<object[]> seeds,
+            int maxNodeCount,
+            int maxGroupCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            if (edges.Count == 0 || seeds.Count == 0)
+            {
+                return false;
+            }
+
+            var globalNodeIds = new Dictionary<object?, int>();
+            var globalSuccessors = new List<List<int>>();
+
+            int GetGlobalNodeId(object? value)
+            {
+                if (globalNodeIds.TryGetValue(value, out var id))
+                {
+                    return id;
+                }
+
+                id = globalSuccessors.Count;
+                globalNodeIds.Add(value, id);
+                globalSuccessors.Add(new List<int>());
+                return id;
+            }
+
+            foreach (var edge in edges)
+            {
+                if (edge is null || edge.Length < 2)
+                {
+                    continue;
+                }
+
+                var fromId = GetGlobalNodeId(edge[0]);
+                var toId = GetGlobalNodeId(edge[1]);
+                globalSuccessors[fromId].Add(toId);
+            }
+
+            if (globalSuccessors.Count == 0 || globalSuccessors.Count > maxNodeCount)
+            {
+                return false;
+            }
+
+            var groupIds = new Dictionary<object?, int>();
+            var groupValues = new List<object?>();
+            var seedPairs = new List<(int GroupId, int NodeId)>();
+            foreach (var seed in seeds)
+            {
+                if (seed is null || seed.Length < 2)
+                {
+                    continue;
+                }
+
+                if (!globalNodeIds.TryGetValue(seed[1], out var nodeId))
+                {
+                    continue;
+                }
+
+                if (!groupIds.TryGetValue(seed[0], out var groupId))
+                {
+                    groupId = groupValues.Count;
+                    if (groupId >= maxGroupCount)
+                    {
+                        return false;
+                    }
+
+                    groupIds.Add(seed[0], groupId);
+                    groupValues.Add(seed[0]);
+                }
+
+                seedPairs.Add((groupId, nodeId));
+            }
+
+            if (seedPairs.Count == 0)
+            {
+                return true;
+            }
+
+            var included = new bool[globalSuccessors.Count];
+            var queue = new Queue<int>();
+            foreach (var (_, nodeId) in seedPairs)
+            {
+                if (included[nodeId])
+                {
+                    continue;
+                }
+
+                included[nodeId] = true;
+                queue.Enqueue(nodeId);
+            }
+
+            while (queue.Count > 0)
+            {
+                var nodeId = queue.Dequeue();
+                foreach (var next in globalSuccessors[nodeId])
+                {
+                    if (included[next])
+                    {
+                        continue;
+                    }
+
+                    included[next] = true;
+                    queue.Enqueue(next);
+                }
+            }
+
+            var includedCount = 0;
+            foreach (var isIncluded in included)
+            {
+                if (isIncluded)
+                {
+                    includedCount++;
+                }
+            }
+
+            if (includedCount == 0 || includedCount > maxNodeCount)
+            {
+                return false;
+            }
+
+            var localIds = new int[included.Length];
+            Array.Fill(localIds, -1);
+            var localSuccessors = new List<List<int>>(includedCount);
+            var localIndegree = new int[includedCount];
+            var nextLocalId = 0;
+
+            for (var globalId = 0; globalId < included.Length; globalId++)
+            {
+                if (!included[globalId])
+                {
+                    continue;
+                }
+
+                localIds[globalId] = nextLocalId;
+                localSuccessors.Add(new List<int>());
+                nextLocalId++;
+            }
+
+            for (var globalId = 0; globalId < included.Length; globalId++)
+            {
+                if (!included[globalId])
+                {
+                    continue;
+                }
+
+                var fromLocalId = localIds[globalId];
+                foreach (var nextGlobalId in globalSuccessors[globalId])
+                {
+                    if (!included[nextGlobalId])
+                    {
+                        continue;
+                    }
+
+                    var toLocalId = localIds[nextGlobalId];
+                    localSuccessors[fromLocalId].Add(toLocalId);
+                    localIndegree[toLocalId]++;
+                }
+            }
+
+            var topoQueue = new Queue<int>();
+            for (var i = 0; i < localIndegree.Length; i++)
+            {
+                if (localIndegree[i] == 0)
+                {
+                    topoQueue.Enqueue(i);
+                }
+            }
+
+            var topo = new List<int>(includedCount);
+            while (topoQueue.Count > 0)
+            {
+                var localId = topoQueue.Dequeue();
+                topo.Add(localId);
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    localIndegree[successorLocalId]--;
+                    if (localIndegree[successorLocalId] == 0)
+                    {
+                        topoQueue.Enqueue(successorLocalId);
+                    }
+                }
+            }
+
+            if (topo.Count != includedCount)
+            {
+                return false;
+            }
+
+            var wordCount = (groupValues.Count + 63) >> 6;
+            var nodeGroupBits = new ulong[includedCount][];
+            for (var i = 0; i < includedCount; i++)
+            {
+                nodeGroupBits[i] = new ulong[wordCount];
+            }
+
+            foreach (var (groupId, nodeId) in seedPairs)
+            {
+                var localNodeId = localIds[nodeId];
+                nodeGroupBits[localNodeId][groupId >> 6] |= 1UL << (groupId & 63);
+            }
+
+            foreach (var localId in topo)
+            {
+                var sourceBits = nodeGroupBits[localId];
+                if (IsZeroWordArray(sourceBits))
+                {
+                    continue;
+                }
+
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    OrInto(nodeGroupBits[successorLocalId], sourceBits);
+                }
+            }
+
+            var counts = new int[groupValues.Count];
+            for (var localId = 0; localId < includedCount; localId++)
+            {
+                var bits = nodeGroupBits[localId];
+                for (var wordIndex = 0; wordIndex < bits.Length; wordIndex++)
+                {
+                    var word = bits[wordIndex];
+                    while (word != 0)
+                    {
+                        var bit = BitOperations.TrailingZeroCount(word);
+                        var groupId = (wordIndex << 6) + bit;
+                        if (groupId < counts.Length)
+                        {
+                            counts[groupId]++;
+                        }
+
+                        word &= word - 1;
+                    }
+                }
+            }
+
+            rows = new List<object[]>(groupValues.Count);
+            for (var groupId = 0; groupId < groupValues.Count; groupId++)
+            {
+                rows.Add(new object[] { groupValues[groupId]!, counts[groupId] });
             }
 
             return true;
@@ -13449,6 +13853,8 @@ namespace UnifyWeaver.QueryRuntime
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, bool>>();
                 GroupedTransitiveClosureResults = parent?.GroupedTransitiveClosureResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), IReadOnlyList<object[]>>();
+                SeedGroupedTransitiveClosureCountResults = parent?.SeedGroupedTransitiveClosureCountResults
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
                 SeedGroupedDagLongestDepthResults = parent?.SeedGroupedDagLongestDepthResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
                 GroupedTransitiveClosureSeededResults = parent?.GroupedTransitiveClosureSeededResults
@@ -13505,6 +13911,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate), Dictionary<RowWrapper, bool>> TransitiveClosurePairProbeResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), IReadOnlyList<object[]>> GroupedTransitiveClosureResults { get; }
+
+            public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>> SeedGroupedTransitiveClosureCountResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>> SeedGroupedDagLongestDepthResults { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR targets the next low-hanging DAG runtime-cost issue in the C#
  query engine:

  - the dependency-reach benchmark was still materializing the full
    `(project, reachable_dependency)` relation
  - the benchmark then immediately aggregated those rows back down to
    `(project, reach_count)`

  That was avoidable overhead.

  This PR adds a count-producing grouped DAG reach node to the query
  runtime and rewrites the C# query dependency-reach benchmark to use it
  directly.

  The result is a major performance improvement at larger scales.

  ## What Changed

  ### New C# Query Runtime Node

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `SeedGroupedTransitiveClosureCountNode`

  This node is the count-producing counterpart to the existing:

  - `SeedGroupedTransitiveClosureNode`

  Instead of returning:

  - `(project, reachable_dependency)`

  it returns:

  - `(project, reach_count)`

  directly.

  ### DAG Fast Path

  For the synthetic dependency DAG workload, the runtime now:

  1. builds the seed-reachable cone
  2. propagates project bitsets through the DAG
  3. counts reachable nodes per project directly from those bitsets
  4. emits only the final `(project, count)` rows

  That avoids allocating and materializing the full grouped reachability
  relation when the benchmark only needs counts.

  ### Generic Fallback

  The non-DAG/smaller fallback path was also tightened:

  - it now counts directly while exploring grouped reachability
  - it no longer accumulates all result tuples only to count them later

  So this optimization improves both:
  - the DAG-specialized path
  - the generic grouped-closure fallback

  ### Benchmark Generator

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The C# query version of `dependency_depth` now uses:

  - `SeedGroupedTransitiveClosureCountNode`

  instead of:

  - `SeedGroupedTransitiveClosureNode`

  The benchmark harness also no longer keeps unused per-project dependency
  lists; it only tracks the project set for reporting.

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects:
  - the new count-producing query-runtime path
  - the refreshed dependency-reach numbers
  - the updated performance story

  ## Why This Matters

  Earlier DAG work got the C# query engine onto the right algorithmic path:

  - project-grouped reachability
  - DAG longest-depth DP

  But there was still avoidable runtime overhead around result
  materialization.

  This PR proves that the next gains really were in the non-graph-theory
  layer:

  - not new closure math
  - not transitive reduction
  - not more topology transforms

  Just removing unnecessary tuple materialization was enough to move the
  query engine from near parity to clear leadership on the dependency-reach
  benchmark at larger scales.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  ### Dependency reach benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ### Dependency longest-depth benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ## Updated Dependency Reach Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.058s | 0.046s | 0.002s | 0.002s | match |
  | 1k | 0.088s | 0.050s | 0.007s | 0.007s | match |
  | 5k | 0.091s | 0.179s | 0.162s | 0.109s | match |
  | 10k | 0.103s | 0.517s | 0.573s | 0.463s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.78x | 0.04x | 0.04x |
  | 1k | 0.57x | 0.08x | 0.08x |
  | 5k | 1.97x | 1.78x | 1.20x |
  | 10k | 5.02x | 5.57x | 4.49x |

  ## Interpretation

  This is a meaningful runtime-overhead win.

  Before this PR:

  - C# query was competitive on dependency reach only at the largest scale

  After this PR:

  - it is still behind at 300 and 1k
  - it is clearly ahead of all DFS targets from 5k onward

  That is a strong signal that non-graph-theory runtime costs were still
  dominating this workload, and that reducing those costs can matter more
  than further DAG topology tricks at this stage.

  ## Scope

  This PR is focused on the dependency-reach DAG workload.

  It does not yet optimize:

  - the C# query longest-depth runtime path
  - shared DAG preprocessing
  - transitive reduction
  - non-DAG recursion

  ## Follow-Up

  Likely next work:

  - apply the same runtime-cost mindset to the csharp-query
    longest-depth path
  - focus on:
      - seed-reachable cone construction
      - node-id / adjacency build overhead
      - allocation reduction
  - only after that reassess whether more DAG-structure work is still worth
    pursuing