### PR TITLE
test(prolog): cover benchmark toggle for PPV branch pruning

### DIFF
--- a/docs/PROLOG_DIALECTS.md
+++ b/docs/PROLOG_DIALECTS.md
@@ -36,6 +36,10 @@ generate_prolog_script(
 ).
 ```
 
+**SWI-specific note:** mode-directed per-path branch pruning is available
+for canonical PPV recursion in the Prolog target. Disable it explicitly
+with `branch_pruning(false)` when benchmarking the non-pruned baseline.
+
 ### GNU Prolog
 
 **Identifier:** `gnu`

--- a/docs/design/PROLOG_TARGET_OPTIMIZATION.md
+++ b/docs/design/PROLOG_TARGET_OPTIMIZATION.md
@@ -63,6 +63,40 @@ requested answer before recursing.
 - **Requires**: The visited argument must be identified from the actual
   per-path pattern, not guessed from the first `+` mode position
 
+### Benchmarking Toggle
+
+Branch pruning can be disabled explicitly at code-generation time:
+
+```prolog
+generate_prolog_script(
+    [category_ancestor/4],
+    [dialect(swi), branch_pruning(false)],
+    Code
+).
+```
+
+Use this when benchmarking the plain generated Prolog against the
+branch-pruned lowering. The generated predicate should preserve the same
+result set either way; only the helper predicates and pruning behavior
+change.
+
+### Fallback Diagnostics
+
+The branch-pruning lowering now emits opt-in debug traces explaining why
+it fell back to normal code generation.
+
+In SWI-Prolog:
+
+```prolog
+?- debug(prolog_branch_pruning).
+```
+
+That will surface reasons such as:
+- no concrete mode declaration for non-visited inputs
+- non-canonical per-path-visited body shape
+- no unique driver position across recursive clauses
+- invariant inputs not remaining fixed across recursion
+
 ## Current Performance
 
 At 10x scale (195 articles, 3932 edges, max-depth=10):

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -47,6 +47,9 @@
 %       - arguments(ArgSpec) - Command-line argument parsing
 %       - output_mode(Mode) - stdout, file, return
 %       - compile(true/false) - Generate compilation command for dialect
+%       - branch_pruning(auto/false) - Enable or disable SWI PPV pruning
+%         helpers (default: auto). Use false when benchmarking the
+%         non-pruned baseline or when comparing generated variants.
 %  @arg ScriptCode Generated script as atom
 %
 %  @example Generate script for user predicates

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -104,6 +104,21 @@ cleanup_temp_module_source(Path) :-
     catch(unload_file(Path), _, true),
     catch(delete_file(Path), _, true).
 
+collect_generated_execution_hops(Options, PredicateCode, Hops) :-
+    once(prolog_target:generate_predicate_code(test_exec_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_exec_ppv_runtime_, ModuleName),
+    build_execution_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. [test_exec_ppv_reach, a, c, H, [a]],
+            findall(H, ModuleName:Goal, Hops0),
+            sort(Hops0, Hops)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
 test(emits_branch_pruning_helpers_for_parameterized_ppv,
         [setup(setup_branch_pruning_fixture),
          cleanup(cleanup_branch_pruning_fixture)]) :-
@@ -125,6 +140,13 @@ test(skips_branch_pruning_for_non_swi_dialect,
         [setup(setup_branch_pruning_fixture),
          cleanup(cleanup_branch_pruning_fixture)]) :-
     once(generate_prolog_script([test_ppv_reach/4], [dialect(gnu)], Code)),
+    \+ sub_atom(Code, _, _, _, 'test_ppv_reach$prune'),
+    \+ sub_atom(Code, _, _, _, 'test_ppv_reach$pruned').
+
+test(skips_branch_pruning_when_disabled_explicitly,
+        [setup(setup_branch_pruning_fixture),
+         cleanup(cleanup_branch_pruning_fixture)]) :-
+    once(generate_prolog_script([test_ppv_reach/4], [dialect(swi), branch_pruning(false)], Code)),
     \+ sub_atom(Code, _, _, _, 'test_ppv_reach$prune'),
     \+ sub_atom(Code, _, _, _, 'test_ppv_reach$pruned').
 
@@ -152,23 +174,21 @@ test(rename_recursive_calls_preserves_foreign_module_qualifiers) :-
 test(exec_generated_branch_pruned_code_preserves_results,
         [setup(setup_execution_branch_pruning_fixture),
          cleanup(cleanup_execution_branch_pruning_fixture)]) :-
-    once(prolog_target:generate_predicate_code(test_exec_ppv_reach/4, [dialect(swi)], PredicateCode)),
+    collect_generated_execution_hops([dialect(swi)], PredicateCode, Actual),
     once(sub_atom(PredicateCode, _, _, _, 'test_exec_ppv_reach$pruned')),
-    gensym(test_exec_ppv_runtime_, ModuleName),
-    build_execution_runtime_source(ModuleName, PredicateCode, Source),
-    write_temp_module_source(Source, Path),
-    setup_call_cleanup(
-        load_files(Path, []),
-        (
-            findall(H, user:test_exec_ppv_reach(a, c, H, [a]), Expected0),
-            sort(Expected0, Expected),
-            Goal =.. [test_exec_ppv_reach, a, c, H, [a]],
-            findall(H, ModuleName:Goal, Actual0),
-            sort(Actual0, Actual),
-            Expected == [2, 3],
-            Actual == Expected
-        ),
-        cleanup_temp_module_source(Path)
-    ).
+    findall(H, user:test_exec_ppv_reach(a, c, H, [a]), Expected0),
+    sort(Expected0, Expected),
+    Expected == [2, 3],
+    Actual == Expected.
+
+test(exec_generated_disabled_branch_pruning_matches_enabled_results,
+        [setup(setup_execution_branch_pruning_fixture),
+         cleanup(cleanup_execution_branch_pruning_fixture)]) :-
+    collect_generated_execution_hops([dialect(swi)], EnabledCode, Enabled),
+    collect_generated_execution_hops([dialect(swi), branch_pruning(false)], DisabledCode, Disabled),
+    once(sub_atom(EnabledCode, _, _, _, 'test_exec_ppv_reach$pruned')),
+    \+ sub_atom(DisabledCode, _, _, _, 'test_exec_ppv_reach$pruned'),
+    Enabled == [2, 3],
+    Disabled == Enabled.
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This expands Prolog branch-pruning coverage in two ways:

  1. documents the existing `branch_pruning(false)` option so the non-pruned baseline is easy to generate for benchmarking
  2. adds broader integration tests showing that generated code with pruning enabled and disabled produces the same
  results

  ## What Changed

  - documented `branch_pruning(false)` in:
    - `src/unifyweaver/targets/prolog_target.pl`
    - `docs/design/PROLOG_TARGET_OPTIMIZATION.md`
    - `docs/PROLOG_DIALECTS.md`
  - added explicit generator coverage in `tests/core/test_prolog_target.pl` for:
    - `branch_pruning(false)` disabling helper emission
    - generated code with pruning disabled matching the same result set as generated code with pruning enabled
  - kept the existing SWI-only branch-pruning and execution-level generated-code tests in place

  ## Why

  The Prolog target already supported `branch_pruning(false)` internally, but it was not surfaced clearly enough for
  benchmarking.

  This PR makes that toggle explicit and verifies the important semantic property for benchmark comparisons: pruning
  changes the generated helper structure and search behavior, but it must not change the result set.

  ## Verification

  - `swipl -q -t halt -s src/unifyweaver/targets/prolog_target.pl`
  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`

  ## Notes

  - branch-pruning remains SWI-Prolog-specific
  - `branch_pruning(false)` is intended for benchmarking or side-by-side generated-code comparisons
  - the benchmark-toggle tests complement the earlier execution-level branch-pruning correctness checks