### PR TITLE
perf(csharp-query): trim dag longest-depth overhead

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -447,27 +447,29 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.059s | 0.043s | 0.002s | 0.002s | match |
-| 1k | 0.061s | 0.043s | 0.003s | 0.003s | match |
-| 5k | 0.089s | 0.051s | 0.006s | 0.006s | match |
-| 10k | 0.105s | 0.059s | 0.010s | 0.011s | match |
+| 300 | 0.052s | 0.045s | 0.002s | 0.002s | match |
+| 1k | 0.058s | 0.051s | 0.003s | 0.004s | match |
+| 5k | 0.097s | 0.057s | 0.006s | 0.006s | match |
+| 10k | 0.090s | 0.060s | 0.019s | 0.011s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.74x | 0.03x | 0.04x |
-| 1k | 0.71x | 0.04x | 0.05x |
-| 5k | 0.57x | 0.07x | 0.07x |
-| 10k | 0.56x | 0.10x | 0.11x |
+| 300 | 0.85x | 0.03x | 0.04x |
+| 1k | 0.87x | 0.06x | 0.06x |
+| 5k | 0.59x | 0.06x | 0.06x |
+| 10k | 0.67x | 0.21x | 0.12x |
 
 Comparison note:
 
 - this benchmark now includes a real `csharp-query` DAG longest-depth
   path built on a dedicated query-runtime node
-- the query engine matches all DFS outputs and is now in the right
-  algorithmic family, but it still carries more runtime overhead than the
-  hand-written DFS targets
+- the latest runtime-overhead pass removes local-id subgraph rebuilding
+  and avoids runtime-side row sorting inside the longest-depth node
+- the query engine matches all DFS outputs and is now somewhat closer to
+  the hand-written C# DFS baseline, but it still carries more runtime
+  overhead than the hand-written DFS targets
 - that makes it a good DAG benchmark baseline for further query-runtime
   optimization rather than a finished performance story
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1780,7 +1780,7 @@ class Program
         var adj = LoadTsvPairs(args[0]);
         var projectDeps = LoadTsvPairs(args[1]);
         var memo = new Dictionary<string, int>(StringComparer.Ordinal);
-        var results = new List<(int Depth, string Project)>();
+        var results = new List<(int Depth, string Project)>(projectDeps.Count);
 
         foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
         {
@@ -1888,7 +1888,7 @@ class Program
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var results = new List<(int Depth, string Project)>();
+        var results = new List<(int Depth, string Project)>(rows.Count);
         foreach (var row in rows)
         {{
             var project = row[0]?.ToString() ?? "";

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -8850,7 +8850,6 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             var nodeIds = new Dictionary<object?, int>();
-            var nodeValues = new List<object?>();
             var successors = new List<List<int>>();
 
             int GetNodeId(object? value)
@@ -8860,9 +8859,8 @@ namespace UnifyWeaver.QueryRuntime
                     return id;
                 }
 
-                id = nodeValues.Count;
+                id = successors.Count;
                 nodeIds.Add(value, id);
-                nodeValues.Add(value);
                 successors.Add(new List<int>());
                 return id;
             }
@@ -8879,13 +8877,14 @@ namespace UnifyWeaver.QueryRuntime
                 successors[fromId].Add(toId);
             }
 
-            if (nodeValues.Count == 0 || nodeValues.Count > maxNodeCount)
+            if (successors.Count == 0 || successors.Count > maxNodeCount)
             {
                 return false;
             }
 
-            var reachable = new bool[nodeValues.Count];
-            var queue = new Queue<int>();
+            var groupIds = new Dictionary<object?, int>();
+            var groupValues = new List<object?>();
+            var seedPairs = new List<(int GroupId, int NodeId)>();
             foreach (var seed in seeds)
             {
                 if (seed is null || seed.Length < 2)
@@ -8893,7 +8892,31 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                if (!nodeIds.TryGetValue(seed[1], out var nodeId) || reachable[nodeId])
+                if (!nodeIds.TryGetValue(seed[1], out var nodeId))
+                {
+                    continue;
+                }
+
+                if (!groupIds.TryGetValue(seed[0], out var groupId))
+                {
+                    groupId = groupValues.Count;
+                    groupIds.Add(seed[0], groupId);
+                    groupValues.Add(seed[0]);
+                }
+
+                seedPairs.Add((groupId, nodeId));
+            }
+
+            if (seedPairs.Count == 0)
+            {
+                return true;
+            }
+
+            var reachable = new bool[successors.Count];
+            var queue = new Queue<int>(seedPairs.Count);
+            foreach (var (_, nodeId) in seedPairs)
+            {
+                if (reachable[nodeId])
                 {
                     continue;
                 }
@@ -8931,34 +8954,14 @@ namespace UnifyWeaver.QueryRuntime
                 return true;
             }
 
-            var localIds = new int[nodeValues.Count];
-            Array.Fill(localIds, -1);
-            var localSuccessors = new List<List<int>>(includedCount);
-            var localNodeValues = new object?[includedCount];
-            var indegree = new int[includedCount];
-            var nextLocalId = 0;
-
-            for (var globalId = 0; globalId < reachable.Length; globalId++)
+            var indegree = new int[successors.Count];
+            for (var globalId = 0; globalId < successors.Count; globalId++)
             {
                 if (!reachable[globalId])
                 {
                     continue;
                 }
 
-                localIds[globalId] = nextLocalId;
-                localNodeValues[nextLocalId] = nodeValues[globalId];
-                localSuccessors.Add(new List<int>());
-                nextLocalId++;
-            }
-
-            for (var globalId = 0; globalId < reachable.Length; globalId++)
-            {
-                if (!reachable[globalId])
-                {
-                    continue;
-                }
-
-                var fromLocalId = localIds[globalId];
                 foreach (var nextGlobalId in successors[globalId])
                 {
                     if (!reachable[nextGlobalId])
@@ -8966,16 +8969,14 @@ namespace UnifyWeaver.QueryRuntime
                         continue;
                     }
 
-                    var toLocalId = localIds[nextGlobalId];
-                    localSuccessors[fromLocalId].Add(toLocalId);
-                    indegree[toLocalId]++;
+                    indegree[nextGlobalId]++;
                 }
             }
 
-            var topoQueue = new Queue<int>();
-            for (var i = 0; i < indegree.Length; i++)
+            var topoQueue = new Queue<int>(includedCount);
+            for (var i = 0; i < successors.Count; i++)
             {
-                if (indegree[i] == 0)
+                if (reachable[i] && indegree[i] == 0)
                 {
                     topoQueue.Enqueue(i);
                 }
@@ -8984,14 +8985,19 @@ namespace UnifyWeaver.QueryRuntime
             var topo = new List<int>(includedCount);
             while (topoQueue.Count > 0)
             {
-                var localId = topoQueue.Dequeue();
-                topo.Add(localId);
-                foreach (var successorLocalId in localSuccessors[localId])
+                var nodeId = topoQueue.Dequeue();
+                topo.Add(nodeId);
+                foreach (var successorId in successors[nodeId])
                 {
-                    indegree[successorLocalId]--;
-                    if (indegree[successorLocalId] == 0)
+                    if (!reachable[successorId])
                     {
-                        topoQueue.Enqueue(successorLocalId);
+                        continue;
+                    }
+
+                    indegree[successorId]--;
+                    if (indegree[successorId] == 0)
+                    {
+                        topoQueue.Enqueue(successorId);
                     }
                 }
             }
@@ -9001,47 +9007,49 @@ namespace UnifyWeaver.QueryRuntime
                 return false;
             }
 
-            var depths = new int[includedCount];
+            var depths = new int[successors.Count];
             for (var i = topo.Count - 1; i >= 0; i--)
             {
-                var localId = topo[i];
+                var nodeId = topo[i];
                 var best = 1;
-                foreach (var successorLocalId in localSuccessors[localId])
+                foreach (var successorId in successors[nodeId])
                 {
-                    var candidate = depths[successorLocalId] + 1;
+                    if (!reachable[successorId])
+                    {
+                        continue;
+                    }
+
+                    var candidate = depths[successorId] + 1;
                     if (candidate > best)
                     {
                         best = candidate;
                     }
                 }
 
-                depths[localId] = best;
+                depths[nodeId] = best;
             }
 
-            var groupBest = new Dictionary<object?, int>();
-            foreach (var seed in seeds)
+            var groupBest = new int[groupValues.Count];
+            foreach (var (groupId, nodeId) in seedPairs)
             {
-                if (seed is null || seed.Length < 2)
+                if (!reachable[nodeId])
                 {
                     continue;
                 }
 
-                if (!nodeIds.TryGetValue(seed[1], out var globalId) || !reachable[globalId])
+                var depth = depths[nodeId];
+                if (depth > groupBest[groupId])
                 {
-                    continue;
-                }
-
-                var depth = depths[localIds[globalId]];
-                if (!groupBest.TryGetValue(seed[0], out var best) || depth > best)
-                {
-                    groupBest[seed[0]] = depth;
+                    groupBest[groupId] = depth;
                 }
             }
 
-            rows = groupBest
-                .OrderBy(kvp => kvp.Key?.ToString() ?? string.Empty, StringComparer.Ordinal)
-                .Select(kvp => new object[] { kvp.Key!, kvp.Value })
-                .ToList();
+            rows = new List<object[]>(groupValues.Count);
+            for (var groupId = 0; groupId < groupValues.Count; groupId++)
+            {
+                rows.Add(new object[] { groupValues[groupId]!, groupBest[groupId] });
+            }
+
             return true;
         }
 


### PR DESCRIPTION
  ## Summary

  This PR continues the DAG runtime-overhead work, but specifically for the
  `csharp-query` longest-depth path.

  The previous runtime-overhead pass produced a large win for dependency
  reach-count by removing unnecessary grouped-reach materialization.

  This PR targets the other DAG workload:

  - true dependency longest depth

  The goal here is narrower:
  - reduce setup/allocation overhead
  - keep the same exact DAG dynamic-programming semantics
  - avoid introducing more graph-rewrite complexity

  ## What Changed

  ### C# Query Runtime

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  The longest-depth runtime path now avoids some unnecessary work inside:

  - `TryBuildSeedGroupedDagLongestDepthRows(...)`

  Main changes:

  - remove local-id / local-subgraph rebuilding
  - run the scalar depth DP directly on global node ids over the
    seed-reachable cone
  - remove runtime-side sorting from the longest-depth node

  This keeps the algorithm the same:

  - restrict to the seed-reachable DAG cone
  - topologically order it
  - compute scalar depths in reverse topological order
  - reduce by project

  but trims some of the surrounding overhead.

  ### Benchmark Generator

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  Small benchmark-side cleanup for the C# query longest-depth path:

  - pre-size the result list using `rows.Count`

  This is minor, but consistent with the goal of trimming allocation noise.

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects the latest local longest-depth results and notes
  that the recent change reduced overhead without changing the basic
  performance story.

  ## Why This Matters

  The DAG results now make an important distinction clear:

  - **dependency reach-count** and
  - **dependency longest depth**

  do not have the same runtime bottlenecks.

  Reach-count benefited massively from removing grouped relation
  materialization.

  Longest depth is different:
  - it already returns one scalar per project
  - so the remaining cost is more about runtime setup/allocation overhead
    than result-shape waste

  This PR is the first focused pass on that second cost profile.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  ### Longest-depth benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ### Reach-count non-regression

  Ran locally:

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs still matched across all four targets.

  ## Updated Longest-Depth Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.052s | 0.045s | 0.002s | 0.002s | match |
  | 1k | 0.058s | 0.051s | 0.003s | 0.004s | match |
  | 5k | 0.097s | 0.057s | 0.006s | 0.006s | match |
  | 10k | 0.090s | 0.060s | 0.019s | 0.011s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.85x | 0.03x | 0.04x |
  | 1k | 0.87x | 0.06x | 0.06x |
  | 5k | 0.59x | 0.06x | 0.06x |
  | 10k | 0.67x | 0.21x | 0.12x |

  ## Interpretation

  This PR does improve the longest-depth path, especially at:

  - 300
  - 1k
  - 10k

  But it does not produce the same kind of dramatic gain that the
  reach-count runtime-overhead pass did.

  That is useful information, not a failure.

  It suggests that DAG optimization has now split into two performance
  tracks:

  1. grouped reach-count
      - where direct aggregation and grouped propagation were the key wins
  2. longest depth
      - where the remaining bottleneck is more about scalar-DP setup/runtime
        cost

  So this PR improves the second path, but also clarifies that it likely
  needs its own optimization strategy rather than more generic DAG
  refactors.

  ## Scope

  This PR is focused on:

  - the csharp-query longest-depth runtime path
  - setup/allocation overhead reduction
  - preserving exact DAG semantics

  It does not:

  - change the reach-count runtime path
  - add new DAG graph-theory transforms
  - address non-DAG recursion

  ## Follow-Up

  Likely next work:

  - treat DAG reach-count and DAG longest-depth as separate optimization
    tracks
  - keep the current grouped-reach path as the model for one track
  - focus the next longest-depth work on:
      - cone construction cost
      - graph build cost
      - scalar DP execution overhead
      - possibly a more specialized depth-only runtime substrate