### PR TITLE
perf(benchmark): disable one-shot dag query caches

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -402,19 +402,19 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.058s | 0.046s | 0.002s | 0.002s | match |
-| 1k | 0.088s | 0.050s | 0.007s | 0.007s | match |
-| 5k | 0.091s | 0.179s | 0.162s | 0.109s | match |
-| 10k | 0.103s | 0.517s | 0.573s | 0.463s | match |
+| 300 | 0.067s | 0.046s | 0.003s | 0.007s | match |
+| 1k | 0.086s | 0.051s | 0.008s | 0.007s | match |
+| 5k | 0.088s | 0.180s | 0.143s | 0.113s | match |
+| 10k | 0.103s | 0.516s | 0.546s | 0.469s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.78x | 0.04x | 0.04x |
-| 1k | 0.57x | 0.08x | 0.08x |
-| 5k | 1.97x | 1.78x | 1.20x |
-| 10k | 5.02x | 5.57x | 4.49x |
+| 300 | 0.69x | 0.04x | 0.10x |
+| 1k | 0.59x | 0.09x | 0.09x |
+| 5k | 2.04x | 1.61x | 1.27x |
+| 10k | 4.99x | 5.28x | 4.54x |
 
 Comparison note:
 
@@ -423,6 +423,9 @@ Comparison note:
 - the latest runtime-overhead pass pushes the final count aggregation
   into the query runtime too, so the benchmark no longer materializes the
   full `(project, reachable_dependency)` relation just to count it
+- for the one-shot generated benchmark programs, disabling query-runtime
+  cache reuse also helped slightly by removing cache bookkeeping that is
+  not reused within a single run
 - this changed the cost profile materially: the query engine is still
   behind at `300` and `1k`, but is now clearly ahead of all DFS targets
   from `5k` onward
@@ -447,26 +450,27 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.052s | 0.045s | 0.002s | 0.002s | match |
-| 1k | 0.058s | 0.051s | 0.003s | 0.004s | match |
-| 5k | 0.097s | 0.057s | 0.006s | 0.006s | match |
-| 10k | 0.090s | 0.060s | 0.019s | 0.011s | match |
+| 300 | 0.059s | 0.046s | 0.002s | 0.002s | match |
+| 1k | 0.056s | 0.047s | 0.002s | 0.003s | match |
+| 5k | 0.081s | 0.053s | 0.006s | 0.006s | match |
+| 10k | 0.094s | 0.068s | 0.012s | 0.011s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.85x | 0.03x | 0.04x |
-| 1k | 0.87x | 0.06x | 0.06x |
-| 5k | 0.59x | 0.06x | 0.06x |
-| 10k | 0.67x | 0.21x | 0.12x |
+| 300 | 0.78x | 0.03x | 0.04x |
+| 1k | 0.84x | 0.04x | 0.05x |
+| 5k | 0.65x | 0.08x | 0.07x |
+| 10k | 0.72x | 0.13x | 0.12x |
 
 Comparison note:
 
 - this benchmark now includes a real `csharp-query` DAG longest-depth
   path built on a dedicated query-runtime node
-- the latest runtime-overhead pass removes local-id subgraph rebuilding
-  and avoids runtime-side row sorting inside the longest-depth node
+- the latest runtime-overhead passes remove some setup overhead inside
+  the longest-depth node and also disable cache reuse for the one-shot
+  generated benchmark program
 - the query engine matches all DFS outputs and is now somewhat closer to
   the hand-written C# DFS baseline, but it still carries more runtime
   overhead than the hand-written DFS targets

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1490,7 +1490,7 @@ class Program
         );
 
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
         var rows = executor.Execute(plan).ToList();
         swQuery.Stop();
 
@@ -1883,7 +1883,7 @@ class Program
         );
 
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true));
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
         var rows = executor.Execute(plan).ToList();
         swQuery.Stop();
 


### PR DESCRIPTION
  ## Summary

  This PR makes a narrow but useful benchmark-side performance adjustment for
  the generated C# query DAG workloads.

  The recent DAG work made it clear that:

  - dependency reach-count and
  - dependency longest depth

  now follow separate performance tracks.

  While investigating deeper longest-depth specialization, one smaller but
  reliable result emerged first:

  - the generated benchmark binaries are one-shot programs
  - they execute a single query plan once
  - so `ReuseCaches: true` adds cache bookkeeping without getting any reuse
    benefit in the same process

  This PR turns cache reuse off for those generated one-shot C# query DAG
  benchmarks.

  ## What Changed

  ### Generated C# Query DAG Benchmarks

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  For the generated C# query versions of:

  - `dependency_depth`
  - `dependency_longest_depth`

  the benchmark program now constructs the executor as:

  ```csharp
  new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false))

  instead of:

  new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: true))

  This keeps the runtime semantics the same, but removes cache bookkeeping
  that is not reused within these benchmark executables.

  ### Benchmark Docs

  Updated:

  - examples/benchmark/README.md

  The README now reflects:

  - the refreshed dependency reach-count results
  - the refreshed dependency longest-depth results
  - the fact that disabling cache reuse helped slightly for these one-shot
    generated DAG benchmark binaries

  ## Why This Matters

  This is a good example of the distinction we discussed:

  - some remaining performance differences are not graph-theory issues
  - they are execution-mode / runtime-overhead issues

  For the current generated benchmark binaries, cache reuse is one of those
  cases:

  - useful in a long-lived process with repeated related queries
  - not useful when the process starts, runs one query, prints results, and
    exits

  So this PR trims that unnecessary cost before we spend more time on
  deeper DAG-specific specialization.

  ## Verification

  Passed locally:

  python -m py_compile \
      examples/benchmark/benchmark_dependency_depth_cross_target.py \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  ### Dependency longest-depth benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ### Dependency reach-count non-regression

  Ran locally:

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ## Updated Dependency Reach Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.067s | 0.046s | 0.003s | 0.007s | match |
  | 1k | 0.086s | 0.051s | 0.008s | 0.007s | match |
  | 5k | 0.088s | 0.180s | 0.143s | 0.113s | match |
  | 10k | 0.103s | 0.516s | 0.546s | 0.469s | match |

  ## Updated Dependency Longest-Depth Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.059s | 0.046s | 0.002s | 0.002s | match |
  | 1k | 0.056s | 0.047s | 0.002s | 0.003s | match |
  | 5k | 0.081s | 0.053s | 0.006s | 0.006s | match |
  | 10k | 0.094s | 0.068s | 0.012s | 0.011s | match |

  ## Interpretation

  This is a modest win, not a breakthrough.

  It improves the one-shot DAG benchmark mode a bit, especially for the
  longest-depth path, but it does not close the remaining performance
  gap to the DFS implementations.

  That is still useful because it sharpens the optimization picture:

  - reach-count got its big win from direct grouped counting
  - longest depth still needs its own deeper optimization track
  - but the benchmark harness/execution mode also had a small amount of
    removable overhead, and this PR removes it

  ## Scope

  This PR is benchmark execution-mode tuning only.

  It does not:

  - change query semantics
  - add a new DAG runtime node
  - solve the remaining longest-depth performance gap

  ## Follow-Up

  Likely next work:

  - continue the longest-depth-specific optimization track
  - focus on scalar-depth runtime specialization rather than grouped-reach
    machinery
  - keep separating:
      - graph-structure ideas
      - runtime-overhead ideas
      - benchmark execution-mode ideas
        so we can see which layer is actually paying off