### PR TITLE
bench(prolog): add branch pruning benchmark harness

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -190,6 +190,8 @@ Tables:
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
+| `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
+| `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
 | `generate_dependency_benchmark_data.py` | Generate deterministic synthetic package-DAG benchmark data |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
@@ -275,6 +277,11 @@ python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
 python examples/benchmark/benchmark_category_influence_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,rust-dfs,go-dfs
+
+# Compare handwritten Prolog vs generated pruned and unpruned Prolog
+python examples/benchmark/benchmark_prolog_branch_pruning.py \
+    --scales 300,1k,5k,10k \
+    --targets prolog-source,prolog-pruned,prolog-unpruned
 ```
 
 The current comparison surface across query and non-query targets is:
@@ -310,9 +317,35 @@ The benchmark split is now:
   - `benchmark_dependency_longest_depth_cross_target.py`
   - `benchmark_weighted_shortest_path_cross_target.py`
   - `benchmark_category_influence_cross_target.py`
+- Prolog target:
+  - `benchmark_prolog_branch_pruning.py`
 - C# query-engine internal mode comparison:
   - `benchmark_shortest_path_to_root.py`
   - `benchmark_weighted_shortest_path.py`
+
+### Prolog Branch-Pruning Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_prolog_branch_pruning.py \
+    --scales 300,1k,5k,10k --repetitions 1
+```
+
+Latest local results:
+
+| Scale | Source | Pruned | Unpruned | Output Match | Note |
+|-------|--------|--------|----------|--------------|------|
+| 300 | 2.718s | 2.748s | 2.804s | match | pruning overhead slightly visible |
+| 1k | 1.694s | 1.786s | 1.776s | match | still slightly slower than source |
+| 5k | 8.916s | 8.968s | 8.915s | match | essentially neutral |
+| 10k | 17.530s | 17.490s | 17.475s | match | effectively tied |
+
+This is a useful validation result even though it is not yet a strong
+speedup result: the generated pruned and unpruned Prolog variants match
+the handwritten source output across all tested dataset scales, and the
+current shortest-path workload gives a stable baseline for future
+benchmarks that should stress pruning more directly.
 
 ### Cross-Target Shortest-Path Results
 

--- a/examples/benchmark/benchmark_prolog_branch_pruning.py
+++ b/examples/benchmark/benchmark_prolog_branch_pruning.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Benchmark the Prolog shortest-path-to-root workload with branch pruning
+enabled and disabled.
+
+Targets:
+  - prolog-source    : original handwritten Prolog benchmark source
+  - prolog-pruned    : generated Prolog target with branch_pruning(auto)
+  - prolog-unpruned  : generated Prolog target with branch_pruning(false)
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_sorted_lines,
+    print_match_status,
+    print_pair_match_status,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_shortest_path_benchmark.pl"
+SOURCE_WORKLOAD = ROOT / "examples" / "benchmark" / "shortest_path_to_root.pl"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="prolog-source,prolog-pruned,prolog-unpruned",
+        help="Comma-separated targets: prolog-source,prolog-pruned,prolog-unpruned",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    if shutil.which("swipl") is None:
+        print("skip prolog benchmark: swipl not found", file=sys.stderr)
+        return []
+    supported = {"prolog-source", "prolog-pruned", "prolog-unpruned"}
+    targets: list[str] = []
+    for target in requested:
+        if target not in supported:
+            raise ValueError(f"unsupported target: {target}")
+        targets.append(target)
+    return targets
+
+
+def scale_facts_path(scale: str) -> Path:
+    return require_file(BENCH_DIR / scale / "facts.pl")
+
+
+def build_generated_script(root: Path, scale: str, branch_setting: str, script_name: str) -> list[str]:
+    facts_path = scale_facts_path(scale)
+    script_path = root / scale / script_name
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            branch_setting,
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
+def build_source_command(scale: str) -> list[str]:
+    facts_path = scale_facts_path(scale)
+    return [
+        "swipl",
+        "-q",
+        "-s",
+        str(facts_path),
+        "-s",
+        str(SOURCE_WORKLOAD),
+    ]
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command, cwd=ROOT)
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_sorted_lines(stdout)
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        print_match_status(scale, "all_outputs", entries)
+
+        source = find_result(entries, "prolog-source")
+        pruned = find_result(entries, "prolog-pruned")
+        unpruned = find_result(entries, "prolog-unpruned")
+
+        print_pair_match_status(scale, "pruned_vs_unpruned", pruned, unpruned)
+        print_pair_match_status(scale, "pruned_vs_source", pruned, source)
+        print_pair_match_status(scale, "unpruned_vs_source", unpruned, source)
+        print_speedup(scale, "speedup_pruned_vs_unpruned", unpruned, pruned)
+        print_speedup(scale, "speedup_pruned_vs_source", source, pruned)
+        print_speedup(scale, "speedup_unpruned_vs_source", source, unpruned)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-prolog-pruning-bench-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-prolog-pruning-bench-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        results: list[RunResult] = []
+        for scale in scales:
+            commands: dict[str, list[str]] = {}
+            for target in targets:
+                if target == "prolog-source":
+                    commands[target] = build_source_command(scale)
+                elif target == "prolog-pruned":
+                    commands[target] = build_generated_script(temp_root, scale, "auto", "shortest_path_pruned.pl")
+                elif target == "prolog-unpruned":
+                    commands[target] = build_generated_script(temp_root, scale, "false", "shortest_path_unpruned.pl")
+                else:
+                    raise ValueError(f"unsupported target: {target}")
+
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}", file=sys.stderr)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_prolog_shortest_path_benchmark.pl
+++ b/examples/benchmark/generate_prolog_shortest_path_benchmark.pl
@@ -1,0 +1,50 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'shortest_path_to_root.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPath, OutputPath, BranchSettingAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: swipl -q -s generate_prolog_shortest_path_benchmark.pl -- <facts.pl> <output-script> <auto|false>~n',
+            []),
+        halt(1)
+    ),
+    parse_branch_setting(BranchSettingAtom, BranchSetting),
+    benchmark_workload_path(WorkloadPath),
+    load_files(FactsPath, [silent(true)]),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    Predicates = [
+        category_parent/2,
+        article_category/2,
+        root_category/1,
+        max_depth/1,
+        category_ancestor/4,
+        category_ancestor/3,
+        shortest_path/3,
+        article_root_distance/3,
+        run/0
+    ],
+    Options = [
+        dialect(swi),
+        entry_point(run),
+        branch_pruning(BranchSetting)
+    ],
+    prolog_target:generate_prolog_script(Predicates, Options, ScriptCode),
+    prolog_target:write_prolog_script(ScriptCode, OutputPath).
+
+parse_branch_setting('auto', auto) :- !.
+parse_branch_setting('false', false) :- !.
+parse_branch_setting(Atom, _) :-
+    format(user_error,
+        'Unsupported branch_pruning setting: ~w (expected auto or false)~n',
+        [Atom]),
+    halt(1).


### PR DESCRIPTION
  ## Summary

  This adds a dedicated Prolog benchmark path for the new PPV branch-pruning work.

  The benchmark compares three variants of the `shortest_path_to_root` workload:

  - handwritten Prolog source
  - generated Prolog with `branch_pruning(auto)`
  - generated Prolog with `branch_pruning(false)`

  This gives us a reproducible way to validate both semantic parity and the current performance profile of the Prolog
  branch-pruning lowering.

  ## What Changed

  - added `examples/benchmark/benchmark_prolog_branch_pruning.py`
    - benchmarks `prolog-source`, `prolog-pruned`, and `prolog-unpruned`
    - normalizes and hashes output so result-set equality is checked alongside timing
    - reports per-scale timing plus pairwise output-match and speedup summaries
  - added `examples/benchmark/generate_prolog_shortest_path_benchmark.pl`
    - generates standalone SWI-Prolog benchmark scripts for the shortest-path workload
    - supports `branch_pruning(auto|false)` so pruned and baseline variants are produced from the same source workload
  - updated `examples/benchmark/README.md`
    - documents the new Prolog benchmark scripts
    - adds usage examples
    - records the latest local benchmark results

  ## Why

  We already had focused tests proving that branch pruning preserves correctness for small PPV fixtures, but we did not
  yet have a workload-level benchmark that:

  - compares generated pruned vs generated unpruned Prolog
  - compares both generated variants against the handwritten Prolog source
  - makes `branch_pruning(false)` practical for side-by-side benchmarking

  This PR fills that gap and aligns the Prolog benchmarking story more closely with the recent C# cross-target benchmark
  work.

  ## Verification

  - `python -m py_compile examples/benchmark/benchmark_prolog_branch_pruning.py`
  - `python examples/benchmark/benchmark_prolog_branch_pruning.py --scales 300,1k,5k,10k --repetitions 1`

  ## Current Result

  Latest local run showed:

  - output parity across all three variants at `300`, `1k`, `5k`, and `10k`
  - pruning is currently performance-neutral to slightly slower on this `shortest_path_to_root` workload, rather than a
  clear win

  That is still a useful result: it validates the current lowering on a realistic workload and gives us a stable benchmark
  harness for future Prolog optimization work.

  ## Notes

  - this benchmark path is SWI-Prolog-specific
  - the generator helper now resolves the workload file relative to its own location, so it does not depend on the
  caller's current working directory
  - the next likely follow-up is a benchmark workload where bound-demand pruning can cut more dead branches than this
  shortest-path workload currently does