### PR TITLE
docs: instrument dag longest-depth phases

### DIFF
--- a/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
+++ b/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
@@ -1,0 +1,124 @@
+# DAG Longest-Depth Instrumentation Note
+
+This note records the first phase-timing pass for the C# query-engine
+`dependency_longest_depth` benchmark.
+
+The purpose of this pass was not to change semantics or claim a new
+optimization. It was to answer a narrower question:
+
+- where is the current longest-depth query time actually going?
+
+## Setup
+
+Instrumentation was added to the `SeedGroupedDagLongestDepthNode` runtime
+path and the generated `csharp_query` benchmark program was updated to
+print per-phase timings to `stderr`.
+
+The measured phases were:
+
+1. `build_graph`
+2. `seed_grouping`
+3. `reachable_cone`
+4. `topological_order`
+5. `suffix_depth_dp`
+6. `group_reduction`
+
+## 10k Measurement
+
+For the synthetic `10k` dependency benchmark, a direct run of the
+generated `csharp_query` longest-depth program produced:
+
+- `load_ms=38`
+- `query_ms=27`
+- `aggregation_ms=0`
+- `total_ms=65`
+- `seed_count=500`
+- `tuple_count=500`
+- `project_count=500`
+
+And the query-phase breakdown was:
+
+| Phase | Time |
+|---|---:|
+| `build_graph` | `12.591 ms` |
+| `seed_grouping` | `0.514 ms` |
+| `reachable_cone` | `0.282 ms` |
+| `topological_order` | `0.230 ms` |
+| `suffix_depth_dp` | `0.113 ms` |
+| `group_reduction` | `0.046 ms` |
+
+## Main Finding
+
+The dominant bucket is:
+
+- **graph building**
+
+Not:
+
+- reachable-cone restriction
+- topological ordering
+- the scalar suffix-depth DP itself
+- the final grouped reduction
+
+That matters because the recent optimization guesses had focused more on
+execution structure than on graph construction cost.
+
+The measurement says the opposite:
+
+- the suffix-depth algorithm is already cheap
+- the runtime is spending much more time turning tuples into an in-memory
+  graph than it is solving the DAG longest-depth problem
+
+## Interpretation
+
+For this benchmark family, the current longest-depth performance gap is
+now best explained as:
+
+- **graph construction overhead**
+  plus
+- residual generic runtime cost
+
+rather than a weak depth-DP algorithm.
+
+This also explains why some earlier ideas did not pay off:
+
+- global/full-graph variants did not help because they did not attack the
+  graph-build cost enough
+- transitive reduction did not help because the DP is already cheap
+- prefix/suffix decomposition is conceptually correct, but does not by
+  itself solve the dominant cost center
+
+## Recommended Next Step
+
+The next longest-depth optimization pass should focus on:
+
+1. reducing `build_graph` cost
+2. not on further DAG-math changes first
+
+Promising directions include:
+
+- pre-sizing and allocation reduction in graph construction
+- reducing object/tuple decoding overhead from fact rows
+- reusing a more direct graph representation when the benchmark shape
+  permits it
+
+Less promising immediate directions are:
+
+- more cone-restriction tuning
+- more topological-order tuning
+- more suffix-depth recurrence changes
+
+## Relationship To Other Notes
+
+This note complements:
+
+- `DAG_QUERY_EXECUTION_THEORY.md`
+- `DAG_RUNTIME_COST_EXPERIMENTS_NOTE.md`
+
+Those notes explain:
+
+- the DAG/non-DAG conceptual split
+- prior runtime-cost experiments
+
+This note adds the first phase-level evidence for the remaining
+longest-depth bottleneck.

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1491,7 +1491,8 @@ class Program
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan).ToList();
+        var trace = new QueryExecutionTrace();
+        var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -1524,6 +1525,10 @@ class Program
         Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
+        foreach (var phase in trace.SnapshotPhases().Where(p => p.NodeType == nameof(SeedGroupedDagLongestDepthNode)))
+        {{
+            Console.Error.WriteLine($"phase_ms_{{phase.Phase}}={{phase.Elapsed.TotalMilliseconds:F3}}");
+        }}
     }}
 }}
 '''
@@ -1884,7 +1889,8 @@ class Program
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan).ToList();
+        var trace = new QueryExecutionTrace();
+        var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -1917,6 +1923,10 @@ class Program
         Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
+        foreach (var phase in trace.SnapshotPhases().Where(p => p.NodeType == nameof(SeedGroupedDagLongestDepthNode)))
+        {{
+            Console.Error.WriteLine($"phase_ms_{{phase.Phase}}={{phase.Elapsed.TotalMilliseconds:F3}}");
+        }}
     }}
 }}
 '''

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -448,6 +448,13 @@ namespace UnifyWeaver.QueryRuntime
         int TotalRows
     );
 
+    public sealed record QueryPhaseTrace(
+        int NodeId,
+        string NodeType,
+        string Phase,
+        TimeSpan Elapsed
+    );
+
     public sealed class QueryExecutionTrace
     {
         private sealed class NodeStats
@@ -500,6 +507,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly Dictionary<(string Cache, string Key), CacheStats> _cacheStats = new();
         private readonly Dictionary<(PlanNode Node, string Strategy), long> _strategies = new(new PlanNodeStrategyComparer());
         private readonly List<QueryFixpointIterationTrace> _fixpointIterations = new();
+        private readonly Dictionary<(PlanNode Node, string Phase), TimeSpan> _phases = new(new PlanNodeStrategyComparer());
         private int _nextId = 1;
 
         private NodeStats GetOrAdd(PlanNode node)
@@ -618,6 +626,27 @@ namespace UnifyWeaver.QueryRuntime
                 totalRows));
         }
 
+        internal void RecordPhase(PlanNode node, string phase, TimeSpan elapsed)
+        {
+            if (node is null) throw new ArgumentNullException(nameof(node));
+            if (phase is null) throw new ArgumentNullException(nameof(phase));
+            if (elapsed <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            _ = GetOrAdd(node);
+            var key = (node, phase);
+            if (_phases.TryGetValue(key, out var existing))
+            {
+                _phases[key] = existing + elapsed;
+            }
+            else
+            {
+                _phases.Add(key, elapsed);
+            }
+        }
+
         internal IEnumerable<object[]> WrapEnumeration(PlanNode node, IEnumerable<object[]> source)
         {
             if (node is null) throw new ArgumentNullException(nameof(node));
@@ -711,6 +740,23 @@ namespace UnifyWeaver.QueryRuntime
                 .OrderBy(s => s.NodeId)
                 .ThenBy(s => s.Predicate, StringComparer.Ordinal)
                 .ThenBy(s => s.Iteration)
+                .ToList();
+        }
+
+        public IReadOnlyList<QueryPhaseTrace> SnapshotPhases()
+        {
+            return _phases
+                .Select(kvp =>
+                {
+                    var node = kvp.Key.Node;
+                    return new QueryPhaseTrace(
+                        GetOrAdd(node).Id,
+                        node.GetType().Name,
+                        kvp.Key.Phase,
+                        kvp.Value);
+                })
+                .OrderBy(s => s.NodeId)
+                .ThenBy(s => s.Phase, StringComparer.Ordinal)
                 .ToList();
         }
 
@@ -8319,7 +8365,7 @@ namespace UnifyWeaver.QueryRuntime
                 var edges = GetFactsList(closure.EdgeRelation, context);
                 var seeds = GetFactsList(closure.SeedRelation, context);
                 const int MaxDagNodeCount = 65536;
-                if (!TryBuildSeedGroupedDagLongestDepthRows(edges, seeds, MaxDagNodeCount, out var rows))
+                if (!TryBuildSeedGroupedDagLongestDepthRows(closure, trace, edges, seeds, MaxDagNodeCount, out var rows))
                 {
                     throw new InvalidOperationException("SeedGroupedDagLongestDepthNode requires an acyclic edge relation.");
                 }
@@ -8838,6 +8884,8 @@ namespace UnifyWeaver.QueryRuntime
         }
 
         private static bool TryBuildSeedGroupedDagLongestDepthRows(
+            PlanNode traceNode,
+            QueryExecutionTrace? trace,
             IReadOnlyList<object[]> edges,
             IReadOnlyList<object[]> seeds,
             int maxNodeCount,
@@ -8849,6 +8897,7 @@ namespace UnifyWeaver.QueryRuntime
                 return false;
             }
 
+            var phaseStopwatch = Stopwatch.StartNew();
             var nodeIds = new Dictionary<object?, int>();
             var successors = new List<List<int>>();
 
@@ -8881,7 +8930,10 @@ namespace UnifyWeaver.QueryRuntime
             {
                 return false;
             }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "build_graph", phaseStopwatch.Elapsed);
 
+            phaseStopwatch.Restart();
             var groupIds = new Dictionary<object?, int>();
             var groupValues = new List<object?>();
             var seedPairs = new List<(int GroupId, int NodeId)>();
@@ -8911,7 +8963,10 @@ namespace UnifyWeaver.QueryRuntime
             {
                 return true;
             }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "seed_grouping", phaseStopwatch.Elapsed);
 
+            phaseStopwatch.Restart();
             var reachable = new bool[successors.Count];
             var queue = new Queue<int>(seedPairs.Count);
             foreach (var (_, nodeId) in seedPairs)
@@ -8953,7 +9008,10 @@ namespace UnifyWeaver.QueryRuntime
             {
                 return true;
             }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "reachable_cone", phaseStopwatch.Elapsed);
 
+            phaseStopwatch.Restart();
             var indegree = new int[successors.Count];
             for (var globalId = 0; globalId < successors.Count; globalId++)
             {
@@ -9006,7 +9064,10 @@ namespace UnifyWeaver.QueryRuntime
             {
                 return false;
             }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "topological_order", phaseStopwatch.Elapsed);
 
+            phaseStopwatch.Restart();
             var depths = new int[successors.Count];
             for (var i = topo.Count - 1; i >= 0; i--)
             {
@@ -9028,7 +9089,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 depths[nodeId] = best;
             }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "suffix_depth_dp", phaseStopwatch.Elapsed);
 
+            phaseStopwatch.Restart();
             var groupBest = new int[groupValues.Count];
             foreach (var (groupId, nodeId) in seedPairs)
             {
@@ -9049,6 +9113,8 @@ namespace UnifyWeaver.QueryRuntime
             {
                 rows.Add(new object[] { groupValues[groupId]!, groupBest[groupId] });
             }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "group_reduction", phaseStopwatch.Elapsed);
 
             return true;
         }


### PR DESCRIPTION
  ## Summary

  This PR adds lightweight phase instrumentation for the C# query-engine
  `dependency_longest_depth` DAG path and records the first measured phase
  breakdown in a proposal note.

  The goal here is not to claim another optimization yet. It is to stop
  guessing and identify the real remaining bottleneck in the longest-depth
  query path.

  ## What Changed

  ### Query Runtime Phase Instrumentation

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added phase timing support to `QueryExecutionTrace` and instrumented the
  `SeedGroupedDagLongestDepthNode` path with these phases:

  - `build_graph`
  - `seed_grouping`
  - `reachable_cone`
  - `topological_order`
  - `suffix_depth_dp`
  - `group_reduction`

  This keeps the runtime semantics the same, but makes the internal cost
  distribution observable.

  ### Generated Benchmark Trace Output

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` benchmark program for
  `dependency_longest_depth` now:

  - creates a `QueryExecutionTrace`
  - passes it into the query executor
  - prints longest-depth phase timings to `stderr`

  This makes it easy to inspect the phase breakdown from the generated
  benchmark itself.

  ### New Note

  Added:

  - `docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md`

  The note records the first direct `10k` measurement and explains the main
  result.

  ## Key Measurement

  For a direct `10k` run of the generated `csharp_query`
  `dependency_longest_depth` benchmark:

  - `load_ms=38`
  - `query_ms=27`
  - `aggregation_ms=0`
  - `total_ms=65`

  Query-phase breakdown:

  | Phase | Time |
  |---|---:|
  | `build_graph` | `12.591 ms` |
  | `seed_grouping` | `0.514 ms` |
  | `reachable_cone` | `0.282 ms` |
  | `topological_order` | `0.230 ms` |
  | `suffix_depth_dp` | `0.113 ms` |
  | `group_reduction` | `0.046 ms` |

  ## Main Finding

  The dominant cost is now clearly:

  - **graph building**

  Not:

  - reachable-cone restriction
  - topological ordering
  - the suffix-depth dynamic programming itself
  - final grouped reduction

  That is the most important conclusion of this PR.

  ## Why This Matters

  Recent DAG optimization work showed that:

  - reach-count and longest-depth are separate performance tracks

  This PR sharpens the longest-depth track further.

  It tells us that the next optimization effort should not start with:
  - new DAG recurrence ideas
  - more cone-restriction tuning
  - more topological-order tuning

  Instead, it should start with:
  - reducing graph-construction cost
  - reducing tuple/object decoding overhead
  - reducing graph allocation overhead

  So this PR turns the next step from speculation into a measurement-driven
  task.

  ## Scope

  This PR is instrumentation and documentation only.

  It does **not** change:
  - query semantics
  - benchmark outputs
  - the longest-depth recurrence itself

  Its purpose is to expose the remaining bottleneck clearly.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  A direct generated 10k csharp_query benchmark build/run was also used
  to capture the phase breakdown recorded in the note.

  ## Follow-Up

  Likely next work:

  - optimize build_graph in the longest-depth runtime path
  - specifically target:
      - allocation reduction
      - faster graph construction from fact rows
      - lower tuple decoding / dictionary overhead
  - continue treating longest-depth as its own optimization track rather
    than assuming reach-count optimizations will transfer automatically