### PR TITLE
docs: capture longest-depth row-decoding experiment

### DIFF
--- a/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
+++ b/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
@@ -108,6 +108,86 @@ Less promising immediate directions are:
 - more topological-order tuning
 - more suffix-depth recurrence changes
 
+## Follow-Up Experiment: String-Specialized Row Decoding
+
+After the instrumentation pass, a targeted experiment tried to reduce
+`build_graph` cost by adding a string-specialized fast path for
+`SeedGroupedDagLongestDepthNode`.
+
+The idea was:
+
+- the synthetic dependency benchmark uses string-valued edge rows
+- the current runtime path builds the graph from generic `object[]` rows
+- perhaps avoiding generic `object` lookups/casts would materially reduce
+  graph-build overhead
+
+The experiment was intentionally narrow:
+
+- keep the existing DAG recurrence unchanged
+- keep the same phase structure
+- only specialize graph construction and seed grouping when all relevant
+  values are strings
+
+### Result
+
+The specialized path was:
+
+- correct
+- benchmark-compatible
+- but slower end to end
+
+Full benchmark timings regressed to approximately:
+
+| Scale | C# Query |
+|---|---:|
+| `300` | `0.071s` |
+| `1k` | `0.073s` |
+| `5k` | `0.099s` |
+| `10k` | `0.114s` |
+
+Those numbers were worse than the current `main` baseline, so the change
+was reverted.
+
+### Interpretation
+
+This is useful because it narrows the bottleneck further.
+
+It suggests that the remaining graph-build cost is **not** solved by a
+simple “string instead of object” specialization layered on top of the
+current implementation.
+
+In practice, that fast path added enough extra checking and duplicated
+logic that it lost any benefit from typed dictionary access.
+
+So the next promising target is more likely:
+
+- lower-level fact-row access overhead
+- relation-provider / executor overhead around graph construction
+- or a more direct graph ingestion path
+
+and less likely:
+
+- another shallow specialization of the same graph-build loop
+
+## Questions Worth Handing To External Research
+
+If we want to ask Perplexity or another research assistant for ideas, the
+useful questions are now fairly concrete:
+
+1. For a DAG longest-path query over string-labeled edges, what exact
+   engineering techniques reduce graph-build overhead more reliably than
+   typed dictionary specialization?
+2. In query engines that ingest generic tuple rows, where do successful
+   DAG implementations usually win:
+   - row decoding
+   - symbol interning
+   - adjacency construction
+   - or result materialization?
+3. What are good exact designs for building a temporary DAG view from a
+   generic relation provider with minimal allocation?
+4. When the DP itself is cheap, what benchmark patterns typically expose
+   tuple/object overhead as the dominant cost in graph workloads?
+
 ## Relationship To Other Notes
 
 This note complements:


### PR DESCRIPTION
  ## Summary

  This PR updates the longest-depth DAG instrumentation note to record the
  next failed optimization attempt after the initial phase-timing work.

  The main value here is preserving context:

  - what the measured bottleneck is
  - what optimization was tried
  - how it performed
  - why it was reverted
  - what the next research questions should be

  This keeps the longest-depth optimization track evidence-based instead of
  rediscovering the same dead ends later.

  ## What Changed

  Updated:

  - `docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md`

  The note now includes a follow-up experiment section for a
  string-specialized row-decoding fast path in
  `SeedGroupedDagLongestDepthNode`.

  ## What The New Section Records

  ### Current Bottleneck

  The note already established that for the synthetic `10k`
  `dependency_longest_depth` benchmark:

  - `build_graph` is the dominant query-phase bucket

  while:

  - reachable-cone restriction
  - topological ordering
  - suffix-depth DP
  - grouped reduction

  are all comparatively cheap.

  ### Experiment Tried

  The follow-up experiment attempted to reduce `build_graph` cost by adding
  a fast path that:

  - applies only when both edge and seed rows are string-valued
  - uses typed string dictionaries instead of the generic `object[]` path
  - keeps the DAG recurrence and phase structure unchanged

  ### Outcome

  The result was:

  - correct
  - benchmark-compatible
  - but slower end to end

  Recorded regressed timings:

  | Scale | C# Query |
  |---|---:|
  | `300` | `0.071s` |
  | `1k` | `0.073s` |
  | `5k` | `0.099s` |
  | `10k` | `0.114s` |

  Those were worse than the current `main` baseline, so the code change was
  reverted.

  ### Updated Interpretation

  The note now makes the current conclusion more precise:

  - the longest-depth bottleneck is still in graph construction
  - but a shallow typed row-decoding specialization was **not** enough to
    fix it
  - the next likely target is lower-level fact-row / relation-provider /
    graph-ingestion overhead rather than another surface-level graph-build
    rewrite

  ## Why This Matters

  This PR is useful precisely because the experiment did **not** land.

  The repo now keeps a clean record that:

  - the bottleneck was measured
  - the row-decoding idea was tried
  - it did not pay off
  - the next work should move one layer lower in the runtime stack

  That is the right kind of context to preserve before:
  - further local optimization passes
  - or handing the problem to external research tools like Perplexity

  ## Scope

  This PR is docs-only.

  It does **not** change runtime behavior or benchmark results.

  It records the outcome of an experiment that was intentionally reverted.

  ## Follow-Up

  Likely next work:

  - investigate lower-level graph-ingestion overhead in the C# query
    longest-depth path
  - focus on:
    - fact-row access cost
    - relation-provider overhead
    - graph allocation/ingestion strategy
  - use the new “Questions Worth Handing To External Research” section in
    the note to drive Perplexity follow-up if we want outside ideas