### PR TITLE
perf(benchmark): make dag longest-depth tracing opt-in

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -483,27 +483,30 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.059s | 0.046s | 0.002s | 0.002s | match |
-| 1k | 0.056s | 0.047s | 0.002s | 0.003s | match |
-| 5k | 0.081s | 0.053s | 0.006s | 0.006s | match |
-| 10k | 0.094s | 0.068s | 0.012s | 0.011s | match |
+| 300 | 0.054s | 0.047s | 0.002s | 0.002s | match |
+| 1k | 0.055s | 0.044s | 0.003s | 0.003s | match |
+| 5k | 0.085s | 0.053s | 0.006s | 0.006s | match |
+| 10k | 0.094s | 0.060s | 0.011s | 0.012s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.78x | 0.03x | 0.04x |
-| 1k | 0.84x | 0.04x | 0.05x |
-| 5k | 0.65x | 0.08x | 0.07x |
-| 10k | 0.72x | 0.13x | 0.12x |
+| 300 | 0.88x | 0.03x | 0.04x |
+| 1k | 0.81x | 0.05x | 0.05x |
+| 5k | 0.63x | 0.07x | 0.07x |
+| 10k | 0.64x | 0.12x | 0.13x |
 
 Comparison note:
 
 - this benchmark now includes a real `csharp-query` DAG longest-depth
   path built on a dedicated query-runtime node
 - the latest runtime-overhead passes remove some setup overhead inside
-  the longest-depth node and also disable cache reuse for the one-shot
-  generated benchmark program
+  the longest-depth node, disable cache reuse for the one-shot generated
+  benchmark program, and make phase tracing opt-in instead of always-on
+- set `UNIFYWEAVER_BENCH_TRACE=1` when you want the generated
+  `csharp-query` longest-depth benchmark to print per-phase timings to
+  `stderr`
 - the query engine matches all DFS outputs and is now somewhat closer to
   the hand-written C# DFS baseline, but it still carries more runtime
   overhead than the hand-written DFS targets

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1491,7 +1491,8 @@ class Program
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var trace = new QueryExecutionTrace();
+        var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
+        QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
@@ -1525,9 +1526,12 @@ class Program
         Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
-        foreach (var phase in trace.SnapshotPhases().Where(p => p.NodeType == nameof(SeedGroupedDagLongestDepthNode)))
+        if (trace is not null)
         {{
-            Console.Error.WriteLine($"phase_ms_{{phase.Phase}}={{phase.Elapsed.TotalMilliseconds:F3}}");
+            foreach (var phase in trace.SnapshotPhases().Where(p => p.NodeType == nameof(SeedGroupedDagLongestDepthNode)))
+            {{
+                Console.Error.WriteLine($"phase_ms_{{phase.Phase}}={{phase.Elapsed.TotalMilliseconds:F3}}");
+            }}
         }}
     }}
 }}
@@ -1889,7 +1893,8 @@ class Program
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var trace = new QueryExecutionTrace();
+        var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
+        QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
         var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
@@ -1923,9 +1928,12 @@ class Program
         Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
-        foreach (var phase in trace.SnapshotPhases().Where(p => p.NodeType == nameof(SeedGroupedDagLongestDepthNode)))
+        if (trace is not null)
         {{
-            Console.Error.WriteLine($"phase_ms_{{phase.Phase}}={{phase.Elapsed.TotalMilliseconds:F3}}");
+            foreach (var phase in trace.SnapshotPhases().Where(p => p.NodeType == nameof(SeedGroupedDagLongestDepthNode)))
+            {{
+                Console.Error.WriteLine($"phase_ms_{{phase.Phase}}={{phase.Elapsed.TotalMilliseconds:F3}}");
+            }}
         }}
     }}
 }}


### PR DESCRIPTION
  ## Summary

  This PR removes always-on trace collection from the generated
  `csharp-query` `dependency_longest_depth` benchmark path.

  The recent longest-depth work established two things:

  - the query engine now uses the right DAG dynamic-programming model
  - the remaining performance gap is mostly runtime overhead, not DAG math

  At the same time, the generated benchmark binary was still always
  creating a `QueryExecutionTrace`, wrapping the result enumeration, and
  printing phase timings on every normal benchmark run.

  That was useful for instrumentation, but it is not the right default for
  performance measurement.

  This PR makes that tracing opt-in.

  ## What Changed

  ### Generated C# Query Longest-Depth Benchmark

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` program for `dependency_longest_depth` now
  enables tracing only when:

  - `UNIFYWEAVER_BENCH_TRACE=1`

  is present in the environment.

  Default benchmark runs now use:

  - no `QueryExecutionTrace`
  - no phase snapshot enumeration
  - no benchmark-time trace wrapping overhead

  ### Trace Mode Still Exists

  When tracing is explicitly requested:

  ```bash
  UNIFYWEAVER_BENCH_TRACE=1 ...

  the generated program still:

  - creates a QueryExecutionTrace
  - passes it to QueryExecutor
  - prints SeedGroupedDagLongestDepthNode phase timings to stderr

  So this PR does not remove the instrumentation path. It just stops
  charging that overhead to every ordinary benchmark run.

  ### Benchmark Docs

  Updated:

  - examples/benchmark/README.md

  The README now reflects:

  - the refreshed longest-depth results
  - that phase tracing is opt-in
  - how to re-enable it for instrumentation runs

  ## Why This Matters

  This is a benchmark-mode cleanup, not an algorithm change.

  That distinction matters.

  We already know from the instrumentation note that the actual
  longest-depth bottleneck is in:

  - graph construction

  not in:

  - topological ordering
  - suffix-depth DP
  - grouped reduction

  So keeping always-on tracing in the default benchmark path only made the
  measurement noisier.

  This PR gives us a cleaner default benchmark while preserving the ability
  to profile phases when we explicitly want that diagnostic mode.

  ## Verification

  Passed locally:

  python -m py_compile \
      examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_common.py

  ### Default cross-target benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched across all four targets.

  ### Trace-enabled smoke run

  Ran locally:

  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 10k \
      --targets csharp-query \
      --repetitions 1

  This confirmed that phase timing output still works when explicitly
  requested.

  ## Updated Longest-Depth Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.054s | 0.047s | 0.002s | 0.002s | match |
  | 1k | 0.055s | 0.044s | 0.003s | 0.003s | match |
  | 5k | 0.085s | 0.053s | 0.006s | 0.006s | match |
  | 10k | 0.094s | 0.060s | 0.011s | 0.012s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.88x | 0.03x | 0.04x |
  | 1k | 0.81x | 0.05x | 0.05x |
  | 5k | 0.63x | 0.07x | 0.07x |
  | 10k | 0.64x | 0.12x | 0.13x |

  ## Interpretation

  This is a modest improvement and a cleaner benchmark mode, not the final
  longest-depth optimization.

  The important effect is:

  - ordinary benchmark runs now measure the runtime path more directly
  - instrumentation remains available on demand

  That keeps the longest-depth performance story cleaner while we continue
  the deeper runtime-overhead work.

  ## Scope

  This PR is benchmark execution-mode tuning only.

  It does not:

  - change longest-depth semantics
  - change the DAG recurrence
  - close the remaining performance gap to the DFS targets

  ## Follow-Up

  Likely next work:

  - continue the longest-depth-specific runtime-overhead track
  - focus below the graph-theory layer on:
      - graph ingestion cost
      - fact-row / object handling overhead
      - other runtime setup costs
  - use UNIFYWEAVER_BENCH_TRACE=1 only when needed for diagnosis, not as
    the default benchmark mode