### PR TITLE
perf(benchmark): trace longest-depth allocations

### DIFF
--- a/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
+++ b/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
@@ -169,6 +169,87 @@ and less likely:
 
 - another shallow specialization of the same graph-build loop
 
+
+## Follow-Up Experiment: Allocation And GC Comparison
+
+A direct `10k` comparison was also run between the generated:
+
+- `csharp-dfs` benchmark program
+- `csharp-query` benchmark program
+
+with both programs instrumented to report:
+
+- total wall-clock time
+- `GC.CollectionCount(0/1/2)` deltas
+- total allocated bytes
+
+### 10k Comparison
+
+#### C# DFS
+
+- `total_ms=35`
+- `gc0_collections=0`
+- `gc1_collections=0`
+- `gc2_collections=0`
+- `allocated_bytes=7,880,720`
+- `project_count=500`
+
+#### C# Query
+
+- `load_ms=39`
+- `query_ms=22`
+- `aggregation_ms=0`
+- `total_ms=62`
+- `gc0_collections=0`
+- `gc1_collections=0`
+- `gc2_collections=0`
+- `allocated_bytes=8,952,104`
+- `seed_count=500`
+- `tuple_count=500`
+- `project_count=500`
+
+### Main Finding
+
+This is strong evidence that the remaining longest-depth gap is **not**
+currently being driven by garbage collection pauses.
+
+At `10k`:
+
+- both C# implementations completed with `0` GC collections
+- the query path does allocate somewhat more than the DFS path
+- but the bigger difference is still CPU/runtime overhead rather than GC
+  interruption
+
+So the current diagnosis becomes more precise:
+
+- **not**: "the query engine is slow because GC is firing repeatedly"
+- more likely: "the query engine still spends extra CPU time in managed
+  runtime/framework overhead, including graph ingestion and generic query
+  machinery"
+
+### Interpretation
+
+This matters because it narrows the next optimization track again.
+
+If GC were the dominant issue, the next work would focus on:
+
+- reducing collection frequency
+- reducing temporary object lifetimes
+- or reusing large buffers to avoid triggering collections
+
+But with `0` collections in both programs at `10k`, the more promising
+next targets are:
+
+- CPU cost of graph ingestion
+- generic tuple/object handling overhead
+- query-framework overhead that remains even after the dedicated DAG node
+  work
+
+That does **not** mean allocations are irrelevant. The query path still
+allocates more bytes than the DFS path, so lowering allocation pressure may
+still help CPU/cache behavior. But the evidence so far does not support GC
+itself as the main bottleneck.
+
 ## Questions Worth Handing To External Research
 
 If we want to ask Perplexity or another research assistant for ideas, the

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1718,9 +1718,10 @@ fn main() {
 
 
 def generate_csharp_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
-    return '''// Dependency longest-depth benchmark (C#)
+    return """// Dependency longest-depth benchmark (C#)
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -1736,7 +1737,7 @@ class Program
                 continue;
             }
 
-            var parts = line.Split('\t', 2);
+            var parts = line.Split('	', 2);
             if (parts.Length != 2)
             {
                 continue;
@@ -1786,6 +1787,15 @@ class Program
             Environment.Exit(1);
         }
 
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        var gc0Before = GC.CollectionCount(0);
+        var gc1Before = GC.CollectionCount(1);
+        var gc2Before = GC.CollectionCount(2);
+        var allocatedBefore = GC.GetTotalAllocatedBytes(true);
+        var swTotal = Stopwatch.StartNew();
+
         var adj = LoadTsvPairs(args[0]);
         var projectDeps = LoadTsvPairs(args[1]);
         var memo = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -1812,19 +1822,28 @@ class Program
             return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
         });
 
-        Console.WriteLine("project\tdependency_longest_depth");
+        Console.WriteLine("project	dependency_longest_depth");
         foreach (var (depth, project) in results)
         {
-            Console.WriteLine($"{project}\t{depth}");
+            Console.WriteLine($"{project}	{depth}");
         }
+
+        swTotal.Stop();
+        Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"gc0_collections={GC.CollectionCount(0) - gc0Before}");
+        Console.Error.WriteLine($"gc1_collections={GC.CollectionCount(1) - gc1Before}");
+        Console.Error.WriteLine($"gc2_collections={GC.CollectionCount(2) - gc2Before}");
+        Console.Error.WriteLine($"allocated_bytes={GC.GetTotalAllocatedBytes(false) - allocatedBefore}");
+        Console.Error.WriteLine($"project_count={results.Count}");
     }
 }
-'''
+"""
+
 
 
 def generate_csharp_query_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
     depth_bound = max(max_depth, 20000)
-    return f'''// Dependency longest-depth benchmark (C# query engine)
+    return f"""// Dependency longest-depth benchmark (C# query engine)
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1844,6 +1863,13 @@ class Program
             Environment.Exit(1);
         }}
 
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        var gc0Before = GC.CollectionCount(0);
+        var gc1Before = GC.CollectionCount(1);
+        var gc2Before = GC.CollectionCount(2);
+        var allocatedBefore = GC.GetTotalAllocatedBytes(true);
         var swTotal = Stopwatch.StartNew();
         var swLoad = Stopwatch.StartNew();
 
@@ -1860,7 +1886,7 @@ class Program
                 continue;
             }}
 
-            var parts = line.Split('\\t', 2);
+            var parts = line.Split('	', 2);
             if (parts.Length == 2)
             {{
                 provider.AddFact(edgeId, parts[0], parts[1]);
@@ -1874,7 +1900,7 @@ class Program
                 continue;
             }}
 
-            var parts = line.Split('\\t', 2);
+            var parts = line.Split('	', 2);
             if (parts.Length != 2)
             {{
                 continue;
@@ -1915,16 +1941,20 @@ class Program
             return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
         }});
 
-        Console.WriteLine("project\\tdependency_longest_depth");
+        Console.WriteLine("project\tdependency_longest_depth");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Project}}\\t{{item.Depth}}");
+            Console.WriteLine($"{{item.Project}}\t{{item.Depth}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
+        Console.Error.WriteLine($"gc0_collections={{GC.CollectionCount(0) - gc0Before}}");
+        Console.Error.WriteLine($"gc1_collections={{GC.CollectionCount(1) - gc1Before}}");
+        Console.Error.WriteLine($"gc2_collections={{GC.CollectionCount(2) - gc2Before}}");
+        Console.Error.WriteLine($"allocated_bytes={{GC.GetTotalAllocatedBytes(false) - allocatedBefore}}");
         Console.Error.WriteLine($"seed_count={{projects.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"project_count={{results.Count}}");
@@ -1937,7 +1967,7 @@ class Program
         }}
     }}
 }}
-'''
+"""
 
 
 def generate_go_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):


### PR DESCRIPTION
  ## Summary

  This PR adds allocation and GC instrumentation to the generated C#
  `dependency_longest_depth` benchmark programs and records the first direct
  `10k` comparison between:

  - `csharp-dfs`
  - `csharp-query`

  The goal is to answer a narrower question than “how do we optimize longest
  depth?”:

  - is the remaining gap being driven by garbage collection?

  The result is useful and fairly clear:

  - no, not at the current benchmark scales

  Both generated C# programs complete the `10k` run with zero GC
  collections.

  ## What Changed

  ### Generated C# DFS Longest-Depth Benchmark

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp` `dependency_longest_depth` benchmark now reports to
  `stderr`:

  - `total_ms`
  - `gc0_collections`
  - `gc1_collections`
  - `gc2_collections`
  - `allocated_bytes`
  - `project_count`

  It also performs an explicit GC cleanup before the measured run so the
  reported collection deltas are easier to interpret.

  ### Generated C# Query Longest-Depth Benchmark

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` `dependency_longest_depth` benchmark now
  adds the same GC/allocation reporting:

  - `gc0_collections`
  - `gc1_collections`
  - `gc2_collections`
  - `allocated_bytes`

  alongside the existing timing output:

  - `load_ms`
  - `query_ms`
  - `aggregation_ms`
  - `total_ms`

  It still supports opt-in phase tracing via:

  - `UNIFYWEAVER_BENCH_TRACE=1`

  ### Longest-Depth Instrumentation Note

  Updated:

  - `docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md`

  The note now includes a direct `10k` C# DFS vs C# query comparison of:

  - wall-clock time
  - GC collection counts
  - allocated bytes

  and records the main conclusion.

  ## Why This Matters

  Recent longest-depth work already established that:

  - the DAG recurrence is not the bottleneck
  - `build_graph` is the dominant query-phase bucket

  A reasonable follow-up hypothesis was:

  - maybe the query engine is also losing because GC is firing more often

  This PR tests that directly.

  It shows that the current longest-depth gap is **not** primarily a GC-pause
  problem.

  That means the next optimization work should focus more on:

  - CPU/runtime overhead
  - graph ingestion cost
  - generic query-framework overhead

  and less on:

  - GC tuning in the narrow sense

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile examples/benchmark/generate_pipeline.py

  ### Direct 10k generated C# runs

  Built and ran generated dependency_longest_depth benchmark packages for:

  - csharp
  - csharp_query

  against the synthetic 10k dataset.

  ## Direct 10k Comparison

  ### C# DFS

  - total_ms=35
  - gc0_collections=0
  - gc1_collections=0
  - gc2_collections=0
  - allocated_bytes=7,880,720
  - project_count=500

  ### C# Query

  - load_ms=39
  - query_ms=22
  - aggregation_ms=0
  - total_ms=62
  - gc0_collections=0
  - gc1_collections=0
  - gc2_collections=0
  - allocated_bytes=8,952,104
  - seed_count=500
  - tuple_count=500
  - project_count=500

  ## Interpretation

  The key result is:

  - both implementations completed with zero GC collections

  So the current longest-depth gap is not well explained by “the query
  engine is spending its time in GC pauses.”

  What the data does suggest:

  - the query path allocates somewhat more than the DFS path
  - but the dominant remaining issue is still extra CPU/runtime overhead,
    not collection events

  That makes the diagnosis sharper:

  - not “fight the GC first”
  - more likely “reduce graph-ingestion and generic managed-runtime cost”

  ## Scope

  This PR is instrumentation and analysis only.

  It does not change:

  - longest-depth semantics
  - the DAG recurrence
  - the query runtime implementation

  It adds better evidence for choosing the next optimization step.

  ## Follow-Up

  Likely next work:

  - continue the longest-depth runtime-overhead track
  - focus on:
      - graph ingestion CPU cost
      - generic tuple/object handling overhead
      - remaining query-framework overhead after the dedicated DAG node work

  The new note should also make it easier to ask more focused external
  research questions now that GC itself looks less likely to be the main
  problem.