### PR TITLE
feat(prolog): add seeded min closure for counted PPV

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -192,6 +192,8 @@ Tables:
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
+| `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
+| `benchmark_prolog_seeded_min_closure.py` | Compare seeded Prolog `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
 | `generate_dependency_benchmark_data.py` | Generate deterministic synthetic package-DAG benchmark data |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
@@ -217,6 +219,10 @@ Packaging note:
   - rounded float row outputs in common 2-column and 3-column forms
 - workloads can still keep custom normalization when their semantics or
   ordering rules are genuinely different
+- the seeded Prolog shortest-path benchmark now loads `facts.pl` at
+  runtime from a small generated driver instead of inlining facts into
+  the generated script, so `load_ms` is reported separately from
+  `query_ms`
 
 ## Usage
 

--- a/examples/benchmark/benchmark_prolog_seeded_min_closure.py
+++ b/examples/benchmark/benchmark_prolog_seeded_min_closure.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Benchmark seeded shortest-path closure generation for the Prolog target.
+
+Targets:
+  - prolog-all : generated Prolog using seeded all-path closure per (seed, root)
+  - prolog-min : generated Prolog using seeded mode-directed $min closure
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_sorted_lines,
+    print_pair_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_shortest_path_seeded_benchmark.pl"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="prolog-all,prolog-min",
+        help="Comma-separated targets: prolog-all,prolog-min",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    if shutil.which("swipl") is None:
+        print("skip prolog seeded benchmark: swipl not found", file=sys.stderr)
+        return []
+    supported = {"prolog-all", "prolog-min"}
+    targets: list[str] = []
+    for target in requested:
+        if target not in supported:
+            raise ValueError(f"unsupported target: {target}")
+        targets.append(target)
+    return targets
+
+
+def scale_facts_path(scale: str) -> Path:
+    return require_file(BENCH_DIR / scale / "facts.pl")
+
+
+def build_generated_script(root: Path, scale: str, variant: str, script_name: str) -> list[str]:
+    facts_path = scale_facts_path(scale)
+    script_path = root / scale / script_name
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command, cwd=ROOT)
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_sorted_lines(stdout)
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        all_mode = find_result(entries, "prolog-all")
+        min_mode = find_result(entries, "prolog-min")
+        print_pair_match_status(scale, "all_vs_min", all_mode, min_mode)
+        print_speedup(scale, "speedup_min_vs_all", all_mode, min_mode)
+        print_phase_metrics(scale, "all_metrics", all_mode)
+        print_phase_metrics(scale, "min_metrics", min_mode)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-prolog-seeded-min-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-prolog-seeded-min-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        results: list[RunResult] = []
+        for scale in scales:
+            commands: dict[str, list[str]] = {}
+            for target in targets:
+                if target == "prolog-all":
+                    commands[target] = build_generated_script(temp_root, scale, "all", "shortest_path_all.pl")
+                elif target == "prolog-min":
+                    commands[target] = build_generated_script(temp_root, scale, "min", "shortest_path_min.pl")
+                else:
+                    raise ValueError(f"unsupported target: {target}")
+
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}", file=sys.stderr)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_prolog_shortest_path_seeded_benchmark.pl
+++ b/examples/benchmark/generate_prolog_shortest_path_seeded_benchmark.pl
@@ -1,0 +1,154 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'shortest_path_to_root.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPath, OutputPath, VariantAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: swipl -q -s generate_prolog_shortest_path_seeded_benchmark.pl -- <facts.pl> <output-script> <all|min>~n',
+            []),
+        halt(1)
+    ),
+    parse_variant(VariantAtom, Variant, Options),
+    benchmark_workload_path(WorkloadPath),
+    absolute_file_name(FactsPath, FactsAbsPath, [access(read)]),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    Predicates = [
+        max_depth/1,
+        category_ancestor/4,
+        category_ancestor/3
+    ],
+    prolog_target:generate_prolog_script(Predicates, Options, BaseScriptCode),
+    benchmark_driver_code(Variant, FactsAbsPath, DriverCode),
+    atomic_list_concat([BaseScriptCode, DriverCode], '\n\n', ScriptCode),
+    prolog_target:write_prolog_script(ScriptCode, OutputPath).
+
+parse_variant('all', all, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(false)
+    ]) :-
+    !.
+parse_variant('min', min, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(auto)
+    ]) :-
+    !.
+parse_variant(Atom, _, _) :-
+    format(user_error,
+        'Unsupported seeded benchmark variant: ~w (expected all or min)~n',
+        [Atom]),
+    halt(1).
+
+benchmark_driver_code(Variant, FactsPath, Code) :-
+    format(atom(FactsPathLine), 'facts_path(~q).', [FactsPath]),
+    benchmark_query_line(Variant, QueryLine),
+    benchmark_mode_line(Variant, ModeLine),
+    Lines = [
+        ':- use_module(library(aggregate)).',
+        ':- dynamic bench_seed_distance/3.',
+        FactsPathLine,
+        '',
+        'load_benchmark_facts :-',
+        '    facts_path(Path),',
+        '    load_files(Path, [silent(true)]).',
+        '',
+        'collect_seed_categories(Seeds) :-',
+        '    setof(Cat, Article^article_category(Article, Cat), Seeds).',
+        '',
+        'collect_articles(Articles) :-',
+        '    setof(Article, Cat^article_category(Article, Cat), Articles).',
+        '',
+        'clear_seed_distance_index :-',
+        '    retractall(bench_seed_distance(_, _, _)).',
+        '',
+        'seed_distance_query(Cat, Root, Hops) :-',
+        QueryLine,
+        '',
+        'build_seed_distance_index(Root, SeedCount, TupleCount) :-',
+        '    clear_seed_distance_index,',
+        '    collect_seed_categories(Seeds),',
+        '    length(Seeds, SeedCount),',
+        '    forall(',
+        '        member(Cat, Seeds),',
+        '        forall(',
+        '            seed_distance_query(Cat, Root, Hops),',
+        '            assertz(bench_seed_distance(Cat, Root, Hops))',
+        '        )',
+        '    ),',
+        '    aggregate_all(count, bench_seed_distance(_, _, _), TupleCount).',
+        '',
+        'seeded_article_root_distance(Article, Root, 1) :-',
+        '    article_category(Article, Root).',
+        'seeded_article_root_distance(Article, Root, Distance) :-',
+        '    article_category(Article, Cat),',
+        '    Cat \\= Root,',
+        '    bench_seed_distance(Cat, Root, Hops),',
+        '    Distance is Hops + 1.',
+        '',
+        'compute_shortest_path_results(Root, Results) :-',
+        '    collect_articles(Articles),',
+        '    findall(MinHops-Article,',
+        '        (   member(Article, Articles),',
+        '            aggregate_all(min(Dist),',
+        '                seeded_article_root_distance(Article, Root, Dist),',
+        '                MinHops),',
+        '            MinHops \\= inf',
+        '        ),',
+        '        Pairs),',
+        '    sort(Pairs, Results).',
+        '',
+        'print_shortest_path_results(Root, Results) :-',
+        '    format("article\\troot_category\\tshortest_path~n"),',
+        '    forall(',
+        '        member(Hops-Article, Results),',
+        '        format("~w\\t~w\\t~w~n", [Article, Root, Hops])',
+        '    ).',
+        '',
+        'run_benchmark :-',
+        '    get_time(TLoad0),',
+        '    load_benchmark_facts,',
+        '    get_time(TLoad1),',
+        '    statistics(inferences, InferencesBefore),',
+        '    root_category(Root),',
+        '    build_seed_distance_index(Root, SeedCount, TupleCount),',
+        '    get_time(T1),',
+        '    compute_shortest_path_results(Root, Results),',
+        '    get_time(T2),',
+        '    print_shortest_path_results(Root, Results),',
+        '    statistics(inferences, InferencesAfter),',
+        '    LoadMs is round((TLoad1 - TLoad0) * 1000),',
+        '    QueryMs is round((T1 - TLoad1) * 1000),',
+        '    AggregationMs is round((T2 - T1) * 1000),',
+        '    TotalMs is round((T2 - TLoad0) * 1000),',
+        '    Inferences is InferencesAfter - InferencesBefore,',
+        '    length(Results, ArticleCount),',
+        ModeLine,
+        '    format(user_error, ''load_ms=~w~n'', [LoadMs]),',
+        '    format(user_error, ''query_ms=~w~n'', [QueryMs]),',
+        '    format(user_error, ''aggregation_ms=~w~n'', [AggregationMs]),',
+        '    format(user_error, ''total_ms=~w~n'', [TotalMs]),',
+        '    format(user_error, ''inferences=~w~n'', [Inferences]),',
+        '    format(user_error, ''seed_count=~w~n'', [SeedCount]),',
+        '    format(user_error, ''tuple_count=~w~n'', [TupleCount]),',
+        '    format(user_error, ''article_count=~w~n'', [ArticleCount]).'
+    ],
+    atomic_list_concat(Lines, '\n', Code).
+
+benchmark_query_line(all, '    category_ancestor(Cat, Root, Hops).').
+benchmark_query_line(min, '    ''category_ancestor$min''(Cat, Root, Hops).').
+
+benchmark_mode_line(all, '    format(user_error, ''mode=all~n'', []),').
+benchmark_mode_line(min, '    format(user_error, ''mode=min~n'', []),').

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -50,6 +50,10 @@
 %       - branch_pruning(auto/false) - Enable or disable SWI PPV pruning
 %         helpers (default: auto). Use false when benchmarking the
 %         non-pruned baseline or when comparing generated variants.
+%       - min_closure(auto/false) - Emit a SWI mode-directed min helper
+%         for canonical counted PPV recursion when available (default:
+%         auto). This preserves the original predicate and adds a
+%         separate '$min' helper for bound shortest-path style queries.
 %  @arg ScriptCode Generated script as atom
 %
 %  @example Generate script for user predicates
@@ -225,9 +229,10 @@ generate_predicate_code(Pred/Arity, Options, Code) :-
     % Copy predicate clauses verbatim, or generate an optimized worker when
     % the source matches a parameterized per-path recursion shape.
     (   maybe_generate_branch_pruned_predicate(Pred/Arity, Options, OptimizedCode)
-    ->  BaseCode = OptimizedCode
-    ;   copy_predicate_clauses(Pred/Arity, BaseCode)
+    ->  BaseCode0 = OptimizedCode
+    ;   copy_predicate_clauses(Pred/Arity, BaseCode0)
     ),
+    maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode0, BaseCode),
 
     % Apply constraints if specified
     (   option(constraints(Constraints), Options)
@@ -363,6 +368,357 @@ maybe_generate_branch_pruned_predicate(Pred/Arity, Options, Code) :-
 branch_pruning_debug(Pred/Arity, Message, Args) :-
     atom_concat('Skipping branch pruning for ~w/~w: ', Message, Format),
     debug(prolog_branch_pruning, Format, [Pred, Arity|Args]).
+
+maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode, Code) :-
+    option(min_closure(Setting), Options, auto),
+    (   Setting == false
+    ->  Code = BaseCode
+    ;   maybe_generate_min_closure_helper(Pred/Arity, Options, HelperCode)
+    ->  atomic_list_concat([BaseCode, HelperCode], '\n\n', Code)
+    ;   Code = BaseCode
+    ).
+
+maybe_generate_min_closure_helper(Pred/Arity, Options, Code) :-
+    option(dialect(Dialect), Options, swi),
+    Dialect == swi,
+    findall(Head-Body,
+        (   functor(Head, Pred, Arity),
+            user:clause(Head, Body0),
+            strip_codegen_module_qualifiers(Body0, Body)
+        ),
+        Clauses),
+    Clauses \= [],
+    partition(is_recursive_clause_for_pred(Pred), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos),
+    counted_ppv_driver_position(Pred, Arity, RecClauses, VisitedPos, DriverPos),
+    branch_pruning_mode_positions(Pred/Arity, VisitedPos, InvariantPositions),
+    branch_pruning_signature_positions(DriverPos, InvariantPositions, SignaturePositions),
+    min_closure_metric_position(Arity, VisitedPos, SignaturePositions, MetricPos),
+    maplist(min_closure_base_depth(MetricPos, VisitedPos), BaseClauses, BaseDepths),
+    sort(BaseDepths, [BaseDepth]),
+    RecClauses = [FirstRec|RestRecClauses],
+    min_closure_recursive_shape(Pred, Arity, VisitedPos, MetricPos, FirstRec, StepIncrement, BudgetMode),
+    forall(member(RecClause, RestRecClauses),
+        min_closure_recursive_shape_compatible(Pred, Arity, VisitedPos, MetricPos,
+            StepIncrement, BudgetMode, RecClause)),
+    build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
+        MetricPos, VisitedPos, BaseDepth, StepIncrement, BudgetMode, Code).
+
+counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos) :-
+    member(Head-Body, RecClauses),
+    Head =.. [Pred|HeadArgs],
+    between(1, Arity, VisitedPos),
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    var(VisitedVar),
+    counted_ppv_clause_parts(Pred, Arity, VisitedPos, Head-Body,
+        _HeadArgs, _PreRecGoals, _RecCall, _PostGoals, _StepGoal, _NextVar, VisitedVar),
+    !.
+
+counted_ppv_driver_position(Pred, Arity, RecClauses, VisitedPos, DriverPos) :-
+    maplist(counted_ppv_clause_driver_position(Pred, Arity, VisitedPos), RecClauses, DriverPositions),
+    sort(DriverPositions, [DriverPos]).
+
+counted_ppv_clause_driver_position(Pred, Arity, VisitedPos, Head-Body, DriverPos) :-
+    counted_ppv_clause_parts(Pred, Arity, VisitedPos, Head-Body,
+        HeadArgs, _PreRecGoals, _RecCall, _PostGoals, StepGoal, _NextVar, _VisitedVar),
+    step_goal_input_var(StepGoal, StepInputVar),
+    findall(Pos,
+        (   between(1, Arity, Pos),
+            nth1(Pos, HeadArgs, Arg),
+            Arg == StepInputVar
+        ),
+        [DriverPos]).
+
+counted_ppv_clause_parts(Pred, Arity, VisitedPos, Head-Body,
+        HeadArgs, PreRecGoals, RecCall, PostGoals, StepGoal, NextVar, VisitedVar) :-
+    Head =.. [Pred|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    body_goals(Body, Goals),
+    append(PreRecGoals, [RecCall|PostGoals], Goals),
+    branch_pruning_recursive_goal(Pred, Arity, RecCall),
+    RecCall =.. [_|RecArgs],
+    nth1(1, RecArgs, NextVar),
+    nth1(VisitedPos, RecArgs, VisitedArg),
+    nonvar(VisitedArg),
+    VisitedArg = [NextVar|Tail],
+    Tail == VisitedVar,
+    counted_ppv_step_goal(HeadArgs, PreRecGoals, NextVar, StepGoal).
+
+counted_ppv_step_goal(HeadArgs, Goals, NextVar, StepGoal) :-
+    member(StepGoal, Goals),
+    counted_ppv_step_goal_shape(StepGoal, HeadArgs, NextVar),
+    !.
+
+counted_ppv_step_goal_shape(Goal0, HeadArgs, NextVar) :-
+    strip_module(Goal0, _, Goal),
+    callable(Goal),
+    Goal \= (\+ _),
+    Goal \= not(_),
+    Goal \= !,
+    Goal =.. [Functor|Args],
+    Functor \= member,
+    Args = [DriverVar|RestArgs],
+    var(DriverVar),
+    member_samevar(DriverVar, HeadArgs),
+    member_samevar(NextVar, RestArgs),
+    var(NextVar),
+    NextVar \== DriverVar.
+
+member_samevar(Var, [Candidate|_]) :-
+    Candidate == Var,
+    !.
+member_samevar(Var, [_|Rest]) :-
+    member_samevar(Var, Rest).
+
+min_closure_metric_position(Arity, VisitedPos, SignaturePositions, MetricPos) :-
+    findall(Pos,
+        (   between(1, Arity, Pos),
+            Pos =\= VisitedPos,
+            \+ memberchk(Pos, SignaturePositions)
+        ),
+        [MetricPos]).
+
+min_closure_base_depth(MetricPos, VisitedPos, Head-Body, BaseDepth) :-
+    Head =.. [_|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    body_goals(Body, Goals0),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), Goals0, Goals1),
+    strip_counted_ppv_setup_goals(Goals1, VisitedVar, _BudgetMode, Goals),
+    min_closure_metric_constant(HeadArgs, MetricPos, Goals, BaseDepth),
+    number(BaseDepth),
+    BaseDepth > 0.
+
+min_closure_metric_constant(HeadArgs, MetricPos, _Goals, BaseDepth) :-
+    nth1(MetricPos, HeadArgs, BaseDepth),
+    number(BaseDepth),
+    !.
+min_closure_metric_constant(HeadArgs, MetricPos, Goals, BaseDepth) :-
+    nth1(MetricPos, HeadArgs, MetricVar),
+    member(Goal, Goals),
+    metric_constant_goal(MetricVar, Goal, BaseDepth),
+    !.
+
+metric_constant_goal(HeadVar, Goal0, Value) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [is, HeadVar, Expr]
+    ;   Goal =.. ['=', HeadVar, Expr]
+    ),
+    number(Expr),
+    Value = Expr.
+
+min_closure_recursive_shape(Pred, Arity, VisitedPos, MetricPos, Head-Body, StepIncrement, BudgetMode) :-
+    counted_ppv_clause_parts(Pred, Arity, VisitedPos, Head-Body,
+        HeadArgs, PreRecGoals0, RecCall, PostGoals, _StepGoal, _NextVar, VisitedVar),
+    strip_counted_ppv_setup_goals(PreRecGoals0, VisitedVar, BudgetMode, PreRecGoals),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), PreRecGoals, _UsefulPreGoals),
+    RecCall =.. [_|RecArgs],
+    nth1(MetricPos, HeadArgs, HeadMetric),
+    nth1(MetricPos, RecArgs, RecMetric),
+    member(MetricGoal, PostGoals),
+    metric_increment_goal(HeadMetric, RecMetric, MetricGoal, StepIncrement),
+    number(StepIncrement),
+    StepIncrement > 0.
+
+min_closure_recursive_shape_compatible(Pred, Arity, VisitedPos, MetricPos,
+        StepIncrement, BudgetMode, Clause) :-
+    min_closure_recursive_shape(Pred, Arity, VisitedPos, MetricPos, Clause,
+        StepIncrement, ClauseBudgetMode),
+    budget_mode_compatible(BudgetMode, ClauseBudgetMode).
+
+budget_mode_compatible(unbounded, unbounded).
+budget_mode_compatible(budget(GoalA), budget(GoalB)) :-
+    functor(GoalA, Functor, Arity),
+    functor(GoalB, Functor, Arity).
+
+metric_increment_goal(HeadVar, RecVar, Goal0, Increment) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [is, HeadVar, Expr]
+    ;   Goal =.. ['=', HeadVar, Expr]
+    ),
+    additive_metric_expr(Expr, RecVar, Increment).
+
+additive_metric_expr(Expr, RecVar, Increment) :-
+    Expr =.. [+, Left, Right],
+    (   Left == RecVar,
+        number(Right),
+        Increment = Right
+    ;   Right == RecVar,
+        number(Left),
+        Increment = Left
+    ).
+
+strip_counted_ppv_setup_goals(Goals, VisitedVar, BudgetMode, CleanGoals) :-
+    exclude(is_cut_goal, Goals, GoalsNoCuts),
+    (   select(MaxGoal, GoalsNoCuts, Goals1),
+        max_depth_budget_goal(MaxGoal, MaxVar),
+        select(LengthGoal, Goals1, Goals2),
+        length_visited_goal(LengthGoal, VisitedVar, DepthVar),
+        select(CompareGoal, Goals2, Goals3),
+        depth_less_goal(CompareGoal, DepthVar, MaxVar)
+    ->  BudgetMode = budget(MaxGoal),
+        CleanGoals = Goals3
+    ;   BudgetMode = unbounded,
+        CleanGoals = GoalsNoCuts
+    ).
+
+is_cut_goal(!).
+
+max_depth_budget_goal(Goal0, MaxVar) :-
+    strip_module(Goal0, _, Goal),
+    compound(Goal),
+    Goal =.. [max_depth, MaxVar],
+    var(MaxVar).
+
+length_visited_goal(Goal0, VisitedVar, DepthVar) :-
+    strip_module(Goal0, _, Goal),
+    Goal =.. [length, ListVar, DepthVar],
+    ListVar == VisitedVar,
+    var(DepthVar).
+
+depth_less_goal(Goal0, DepthVar, MaxVar) :-
+    strip_module(Goal0, _, Goal),
+    Goal =.. [<, Left, Right],
+    Left == DepthVar,
+    Right == MaxVar.
+
+build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
+        MetricPos, VisitedPos, BaseDepth, StepIncrement, BudgetMode, Code) :-
+    atom_concat(Pred, '$min', MinName),
+    (   BudgetMode = unbounded
+    ->  InnerName = MinName,
+        OuterClauseTerms = []
+    ;   atom_concat(Pred, '$min_budget', InnerName),
+        OuterClauseTerms = [OuterClause],
+        build_min_outer_clause(MinName, InnerName, SignaturePositions, BudgetMode, OuterClause)
+    ),
+    maplist(build_min_base_clause(InnerName, SignaturePositions, MetricPos, VisitedPos,
+            BaseDepth, BudgetMode), BaseClauses, MinBaseClauses),
+    maplist(build_min_recursive_clause(Pred, Arity, InnerName, SignaturePositions, MetricPos,
+            VisitedPos, BaseDepth, StepIncrement, BudgetMode), RecClauses, MinRecClauses),
+    append(MinBaseClauses, MinRecClauses, InnerClauses),
+    build_min_table_decl(InnerName, SignaturePositions, BudgetMode, TableDeclCode),
+    clauses_to_code(InnerClauses, InnerCode),
+    clauses_to_code(OuterClauseTerms, OuterCode),
+    atomic_list_concat([
+        '% Mode-directed min helper for canonical counted per-path recursion.',
+        TableDeclCode,
+        InnerCode,
+        OuterCode
+    ], '\n\n', Code).
+
+build_min_outer_clause(MinName, InnerName, SignaturePositions, budget(MaxGoalTemplate), ClauseTerm) :-
+    length(SignaturePositions, SigCount),
+    build_min_signature_vars(SigCount, SignatureArgs),
+    append(SignatureArgs, [MetricArg], MinHeadArgs),
+    MinHead =.. [MinName|MinHeadArgs],
+    copy_term(MaxGoalTemplate, MaxGoal),
+    MaxGoal =.. [_Functor, BudgetArg],
+    append(SignatureArgs, [BudgetArg, MetricArg], InnerCallArgs),
+    InnerCall =.. [InnerName|InnerCallArgs],
+    Body = (MaxGoal, InnerCall),
+    ClauseTerm = (MinHead :- Body).
+
+build_min_signature_vars(0, []).
+build_min_signature_vars(Count, [_|Rest]) :-
+    Count > 0,
+    NextCount is Count - 1,
+    build_min_signature_vars(NextCount, Rest).
+
+build_min_table_decl(InnerName, SignaturePositions, BudgetMode, Code) :-
+    length(SignaturePositions, SignatureCount),
+    (   BudgetMode = unbounded
+    ->  KeyCount = SignatureCount
+    ;   KeyCount is SignatureCount + 1
+    ),
+    build_plus_modes(KeyCount, KeyModes),
+    append(KeyModes, [min], Modes),
+    TableSpec =.. [InnerName|Modes],
+    format(atom(Code), ':- table ~q.', [TableSpec]).
+
+build_plus_modes(0, []) :- !.
+build_plus_modes(Count, [+|Rest]) :-
+    Count > 0,
+    NextCount is Count - 1,
+    build_plus_modes(NextCount, Rest).
+
+build_min_base_clause(InnerName, SignaturePositions, MetricPos, VisitedPos, BaseDepth,
+        BudgetMode, Head-Body, ClauseTerm) :-
+    Head =.. [_|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    body_goals(Body, Goals0),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), Goals0, Goals1),
+    strip_counted_ppv_setup_goals(Goals1, VisitedVar, _IgnoredBudgetMode, Goals),
+    \+ goals_reference_samevar(Goals, VisitedVar),
+    select_positions_1based(SignaturePositions, HeadArgs, SignatureArgs),
+    nth1(MetricPos, HeadArgs, MetricArg),
+    build_min_base_head(InnerName, SignatureArgs, MetricArg, BudgetMode, HeadTerm, BudgetArg),
+    (   BudgetMode = unbounded
+    ->  BodyGoals = Goals
+    ;   BudgetGuard = (BudgetArg >= BaseDepth),
+        BodyGoals = [BudgetGuard|Goals]
+    ),
+    goals_to_body(BodyGoals, BodyTerm),
+    clause_term(HeadTerm, BodyTerm, ClauseTerm).
+
+build_min_base_head(InnerName, SignatureArgs, MetricArg, unbounded, HeadTerm, _BudgetArg) :-
+    append(SignatureArgs, [MetricArg], Args),
+    HeadTerm =.. [InnerName|Args].
+build_min_base_head(InnerName, SignatureArgs, MetricArg, budget(_), HeadTerm, BudgetArg) :-
+    append(SignatureArgs, [BudgetArg, MetricArg], Args),
+    HeadTerm =.. [InnerName|Args].
+
+build_min_recursive_clause(Pred, Arity, InnerName, SignaturePositions, MetricPos, VisitedPos,
+        BaseDepth, StepIncrement, BudgetMode, Head-Body, ClauseTerm) :-
+    counted_ppv_clause_parts(Pred, Arity, VisitedPos, Head-Body,
+        HeadArgs, PreRecGoals0, RecCall0, PostGoals, _StepGoal, _NextVar, VisitedVar),
+    strip_counted_ppv_setup_goals(PreRecGoals0, VisitedVar, _IgnoredBudgetMode, PreRecGoals1),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), PreRecGoals1, PreRecGoals),
+    \+ goals_reference_samevar(PreRecGoals, VisitedVar),
+    \+ goals_reference_samevar(PostGoals, VisitedVar),
+    RecCall0 =.. [_|RecArgs],
+    select_positions_1based(SignaturePositions, HeadArgs, SignatureArgs),
+    select_positions_1based(SignaturePositions, RecArgs, NextSignatureArgs),
+    nth1(MetricPos, HeadArgs, MetricArg),
+    nth1(MetricPos, RecArgs, RecMetricArg),
+    build_min_recursive_head(InnerName, SignatureArgs, MetricArg, BudgetMode, HeadTerm, BudgetArg),
+    build_min_recursive_call(InnerName, NextSignatureArgs, RecMetricArg, BudgetMode,
+        StepIncrement, BaseDepth, RecursiveGoals, BudgetArg),
+    append(PreRecGoals, RecursiveGoals, BodyGoals0),
+    append(BodyGoals0, PostGoals, BodyGoals),
+    goals_to_body(BodyGoals, BodyTerm),
+    clause_term(HeadTerm, BodyTerm, ClauseTerm).
+
+build_min_recursive_head(InnerName, SignatureArgs, MetricArg, unbounded, HeadTerm, _BudgetArg) :-
+    append(SignatureArgs, [MetricArg], Args),
+    HeadTerm =.. [InnerName|Args].
+build_min_recursive_head(InnerName, SignatureArgs, MetricArg, budget(_), HeadTerm, BudgetArg) :-
+    append(SignatureArgs, [BudgetArg, MetricArg], Args),
+    HeadTerm =.. [InnerName|Args].
+
+build_min_recursive_call(InnerName, NextSignatureArgs, RecMetricArg, unbounded,
+        _StepIncrement, _BaseDepth, [RecursiveCall], _BudgetArg) :-
+    append(NextSignatureArgs, [RecMetricArg], Args),
+    RecursiveCall =.. [InnerName|Args].
+build_min_recursive_call(InnerName, NextSignatureArgs, RecMetricArg, budget(_),
+        StepIncrement, BaseDepth, [BudgetCalc, BudgetGuard, RecursiveCall], BudgetArg) :-
+    BudgetCalc = (NextBudget is BudgetArg - StepIncrement),
+    BudgetGuard = (NextBudget >= BaseDepth),
+    append(NextSignatureArgs, [NextBudget, RecMetricArg], Args),
+    RecursiveCall =.. [InnerName|Args].
+
+goals_reference_samevar([Goal|_], Var) :-
+    term_contains_samevar(Goal, Var),
+    !.
+goals_reference_samevar([_|Rest], Var) :-
+    goals_reference_samevar(Rest, Var).
+
+term_contains_samevar(Term, Var) :-
+    term_variables(Term, Vars),
+    member(Candidate, Vars),
+    Candidate == Var,
+    !.
 
 clauses_to_pattern_pairs([], []).
 clauses_to_pattern_pairs([Head-Body|Rest], [(Head, Body)|Pairs]) :-

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -82,6 +82,32 @@ cleanup_noncanonical_step_fixture :-
     retractall(user:test_noncanonical_ppv_reach(_, _, _, _)),
     retractall(user:mode(test_noncanonical_ppv_reach(_, _, _, _))).
 
+setup_min_closure_fixture :-
+    cleanup_min_closure_fixture,
+    assertz(user:test_min_edge(a, b)),
+    assertz(user:test_min_edge(b, c)),
+    assertz(user:test_min_edge(a, d)),
+    assertz(user:test_min_edge(d, e)),
+    assertz(user:test_min_edge(e, c)),
+    assertz(user:max_depth(4)),
+    assertz(user:(test_min_ppv_reach(Cat, Parent, 1, Visited) :-
+        test_min_edge(Cat, Parent),
+        \+ member(Parent, Visited))),
+    assertz(user:(test_min_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        max_depth(MaxD),
+        length(Visited, Depth), Depth < MaxD, !,
+        test_min_edge(Cat, Mid),
+        \+ member(Mid, Visited),
+        test_min_ppv_reach(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1)),
+    assertz(user:mode(test_min_ppv_reach(-, +, -, +))).
+
+cleanup_min_closure_fixture :-
+    retractall(user:test_min_edge(_, _)),
+    retractall(user:max_depth(_)),
+    retractall(user:test_min_ppv_reach(_, _, _, _)),
+    retractall(user:mode(test_min_ppv_reach(_, _, _, _))).
+
 build_execution_runtime_source(ModuleName, PredicateCode, Source) :-
     atomic_list_concat([
         'test_exec_edge(a, b).',
@@ -113,6 +139,34 @@ collect_generated_execution_hops(Options, PredicateCode, Hops) :-
         load_files(Path, []),
         (
             Goal =.. [test_exec_ppv_reach, a, c, H, [a]],
+            findall(H, ModuleName:Goal, Hops0),
+            sort(Hops0, Hops)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
+build_min_runtime_source(ModuleName, PredicateCode, Source) :-
+    atomic_list_concat([
+        'test_min_edge(a, b).',
+        'test_min_edge(b, c).',
+        'test_min_edge(a, d).',
+        'test_min_edge(d, e).',
+        'test_min_edge(e, c).',
+        'max_depth(4).'
+    ], '\n', FactsCode),
+    format(atom(Source),
+        ':- module(~q, []).~n:- use_module(library(lists)).~n~w~n~n~w~n',
+        [ModuleName, FactsCode, PredicateCode]).
+
+collect_generated_min_hops(Options, PredicateCode, Hops) :-
+    once(prolog_target:generate_predicate_code(test_min_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_min_ppv_runtime_, ModuleName),
+    build_min_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_min_ppv_reach$min', a, c, H],
             findall(H, ModuleName:Goal, Hops0),
             sort(Hops0, Hops)
         ),
@@ -190,5 +244,19 @@ test(exec_generated_disabled_branch_pruning_matches_enabled_results,
     \+ sub_atom(DisabledCode, _, _, _, 'test_exec_ppv_reach$pruned'),
     Enabled == [2, 3],
     Disabled == Enabled.
+
+test(emits_bounded_min_closure_helper_for_counted_ppv,
+        [setup(setup_min_closure_fixture),
+         cleanup(cleanup_min_closure_fixture)]) :-
+    collect_generated_min_hops([dialect(swi)], PredicateCode, Actual),
+    once(sub_atom(PredicateCode, _, _, _, 'test_min_ppv_reach$min')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_min_ppv_reach$min_budget')),
+    Actual == [2].
+
+test(skips_min_closure_helper_when_disabled_explicitly,
+        [setup(setup_min_closure_fixture),
+         cleanup(cleanup_min_closure_fixture)]) :-
+    once(generate_prolog_script([test_min_ppv_reach/4], [dialect(swi), min_closure(false)], Code)),
+    \+ sub_atom(Code, _, _, _, 'test_min_ppv_reach$min').
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This adds a seeded, mode-directed `min` lowering to the Prolog target for canonical counted per-path-visited shortest-
  path recursion.

  The goal is to bring the Prolog target closer to the useful part of the C# parameterized query engine design: not just
  checking whether a bound branch can still succeed, but reusing a seeded closure and retaining only the best known
  distance per seeded query.

  ## What Changed

  - added mode-directed seeded `min` helper generation in `src/unifyweaver/targets/prolog_target.pl`
  - introduced a canonical counted-PPV detection path for shortest-path-style recursion
  - generated additive `$min` helpers for matching predicates instead of replacing the original predicate semantics
  - supported bounded shortest-path shapes that use `max_depth/1`
  - added focused tests in `tests/core/test_prolog_target.pl` for:
    - generated `$min` helper emission
    - execution-level correctness of generated `$min` code
    - explicit disable path via `min_closure(false)`
  - added seeded benchmark tooling:
    - `examples/benchmark/generate_prolog_shortest_path_seeded_benchmark.pl`
    - `examples/benchmark/benchmark_prolog_seeded_min_closure.py`
  - changed the seeded benchmark harness so it loads `facts.pl` at runtime from a small generated driver instead of
  inlining facts into the generated script
  - benchmark reporting now includes:
    - `load_ms`
    - `query_ms`
    - `aggregation_ms`
    - `total_ms`
    - `inferences`
    - `seed_count`
    - `tuple_count`
    - `article_count`
  - documented the new benchmark path in `examples/benchmark/README.md`

  ## Why

  The earlier Prolog branch-pruning work carried over the demand signal from the C# query engine, but not the main
  shortest-path optimization.

  For shortest-path workloads, the meaningful win is:

  - reusing work once per unique seed category
  - retaining only the best known metric for that seeded demand
  - avoiding large dominated closure sets that do not affect final answers

  This PR gives the Prolog target an initial version of that idea for the canonical counted PPV shape.

  ## Benchmark Result

  The seeded benchmark now shows matching outputs with a substantial reduction in retained work:

  - `300`: `3.47x` speedup, tuple count `11172 -> 213`
  - `1k`: `2.34x` speedup, tuple count `10976 -> 48`
  - `5k`: `3.74x` speedup, tuple count `41132 -> 151`
  - `10k`: `5.16x` speedup, tuple count `105287 -> 462`

  The harness also now separates fact loading from query execution, which makes the results easier to interpret.

  ## Verification

  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python examples/benchmark/benchmark_prolog_seeded_min_closure.py --scales 300 --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_seeded_min_closure.py --scales 1k --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_seeded_min_closure.py --scales 5k,10k --repetitions 1`

  ## Notes

  - this lowering is currently targeted at the canonical counted PPV shortest-path shape
  - `min_closure(false)` remains available to disable the optimization
  - the benchmark harness now avoids generator-side fact inlining so cold-start I/O is easier to separate from query work

