### PR TITLE
perf(benchmark): trim csharp longest-depth loader overhead

### DIFF
--- a/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
+++ b/docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md
@@ -250,6 +250,106 @@ allocates more bytes than the DFS path, so lowering allocation pressure may
 still help CPU/cache behavior. But the evidence so far does not support GC
 itself as the main bottleneck.
 
+
+## Follow-Up Experiment: Cross-Language Handwritten Baseline Breakdown
+
+A direct `10k` comparison was also run across the handwritten longest-depth
+baselines for:
+
+- `csharp-dfs`
+- `rust-dfs`
+- `go-dfs`
+
+All three generated programs were instrumented to report:
+
+- load time
+- solve time
+- emit time
+- total time
+
+For the C# baseline, the existing allocation/GC counters were also kept.
+
+### 10k Comparison
+
+#### C# DFS
+
+- `load_ms=20`
+- `solve_ms=7`
+- `emit_ms=7`
+- `total_ms=35`
+- `gc0_collections=0`
+- `gc1_collections=0`
+- `gc2_collections=0`
+- `allocated_bytes=7,880,720`
+- `project_count=500`
+
+#### Rust DFS
+
+- `load_ms=6`
+- `solve_ms=2`
+- `emit_ms=0`
+- `total_ms=9`
+- `project_count=500`
+
+#### Go DFS
+
+- `load_ms=6`
+- `solve_ms=2`
+- `emit_ms=0`
+- `total_ms=8`
+- `project_count=500`
+
+### Main Finding
+
+This confirms that the longest-depth gap is not only a query-engine issue.
+
+Even the handwritten C# DFS baseline is materially slower than the Rust and
+Go baselines on the same workload.
+
+More specifically:
+
+- the handwritten C# solver is slower in the core DP (`7 ms` vs `2 ms`)
+- but the bigger relative gap is in surrounding managed-runtime work,
+  especially load and emit
+- Rust and Go are both substantially cheaper in the full end-to-end path
+  even before the query engine enters the picture
+
+### Interpretation
+
+This sharpens the optimization story again.
+
+The remaining `csharp-query` vs `rust/go` gap should now be split into:
+
+1. **C# baseline gap**
+- the handwritten C# implementation is already slower than Rust and Go
+- so part of the end-to-end difference is language/runtime/data-structure
+  cost, not query-framework cost
+
+2. **Query-engine gap on top of C#**
+- the query path still adds further overhead beyond the handwritten C#
+  baseline
+
+That means future longest-depth work should ask two separate questions:
+
+- how much closer can we get `csharp-query` to handwritten `csharp-dfs`?
+- how much of the remaining `csharp-dfs` vs `rust/go` gap is worth chasing
+  at all, given broader managed-runtime costs?
+
+### Practical Implication
+
+The next optimization pass should probably stay measurement-first and keep
+those two baselines separate.
+
+For example:
+
+- C# data-structure/runtime tuning may help both `csharp-dfs` and
+  `csharp-query`
+- query-framework tuning only helps the second layer of the gap
+
+So this experiment supports the idea that not all remaining work should be
+framed as “query engine vs native code.” Some of it is simply “C# vs
+Rust/Go on this benchmark shape.”
+
 ## Questions Worth Handing To External Research
 
 If we want to ask Perplexity or another research assistant for ideas, the
@@ -283,3 +383,68 @@ Those notes explain:
 
 This note adds the first phase-level evidence for the remaining
 longest-depth bottleneck.
+
+### Follow-Up Experiment: Lighter-Weight Custom C# TSV Loader
+
+A lighter-weight handwritten C# loader was then tried for the
+`dependency_longest_depth` DFS baseline.
+
+It kept the original string-based graph representation, but changed the
+loader to:
+
+- use `StreamReader` directly
+- skip the header with one explicit read
+- scan each line manually for the tab separator
+- avoid `Enumerable.Select((line, i) => ...)` and `string.Split(...)`
+- pre-size dictionaries using a file-size heuristic
+
+This was compared against two earlier unsuccessful directions:
+
+- `Sep` integration
+- a heavier integerized two-pass loader
+
+#### Direct 10k C# DFS Result
+
+With the lighter-weight loader:
+
+- `load_ms=16`
+- `solve_ms=6`
+- `emit_ms=7`
+- `total_ms=30`
+- `gc0_collections=0`
+- `gc1_collections=0`
+- `gc2_collections=0`
+- `allocated_bytes=5,892,400`
+- `project_count=500`
+
+Compared with the earlier handwritten C# DFS baseline:
+
+- `load_ms=20 -> 16`
+- `solve_ms=7 -> 6`
+- `emit_ms=7 -> 7`
+- `total_ms=35 -> 30`
+- `allocated_bytes=7,880,720 -> 5,892,400`
+
+#### Interpretation
+
+This is the first clearly successful handwritten C# longest-depth loader
+optimization.
+
+It suggests that for this benchmark shape the next wins are more likely to
+come from:
+
+- reducing overhead in the existing string-based ingestion path
+- avoiding general-purpose parsing helpers that allocate extra objects
+- using tighter, benchmark-specific loader logic
+
+than from:
+
+- general-purpose parser libraries like `Sep`
+- or heavier multi-pass graph rewrites during load
+
+It also reinforces a broader point from the recent DAG work:
+
+- when the solve phase is relatively cheap, ingestion and setup overhead can
+  dominate the benchmark result
+- and that is exactly where both handwritten C# and the C# query engine tend
+  to lose most of their ground relative to Rust and Go

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -483,19 +483,19 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.054s | 0.047s | 0.002s | 0.002s | match |
-| 1k | 0.055s | 0.044s | 0.003s | 0.003s | match |
-| 5k | 0.085s | 0.053s | 0.006s | 0.006s | match |
-| 10k | 0.094s | 0.060s | 0.011s | 0.012s | match |
+| 300 | 0.057s | 0.043s | 0.002s | 0.002s | match |
+| 1k | 0.056s | 0.045s | 0.002s | 0.003s | match |
+| 5k | 0.087s | 0.056s | 0.006s | 0.006s | match |
+| 10k | 0.091s | 0.055s | 0.013s | 0.012s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.88x | 0.03x | 0.04x |
-| 1k | 0.81x | 0.05x | 0.05x |
-| 5k | 0.63x | 0.07x | 0.07x |
-| 10k | 0.64x | 0.12x | 0.13x |
+| 300 | 0.75x | 0.03x | 0.04x |
+| 1k | 0.81x | 0.04x | 0.05x |
+| 5k | 0.64x | 0.07x | 0.07x |
+| 10k | 0.60x | 0.14x | 0.14x |
 
 Comparison note:
 
@@ -507,9 +507,12 @@ Comparison note:
 - set `UNIFYWEAVER_BENCH_TRACE=1` when you want the generated
   `csharp-query` longest-depth benchmark to print per-phase timings to
   `stderr`
-- the query engine matches all DFS outputs and is now somewhat closer to
-  the hand-written C# DFS baseline, but it still carries more runtime
-  overhead than the hand-written DFS targets
+- the hand-written C# DFS baseline is now cheaper too, after moving it to a
+  lighter-weight custom TSV loader with manual tab scanning and better
+  pre-sizing
+- the query engine still matches all DFS outputs and remains somewhat
+  behind the hand-written C# DFS baseline, so longest depth is still a
+  separate optimization track from reach-count
 - that makes it a good DAG benchmark baseline for further query-runtime
   optimization rather than a finished performance story
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1539,112 +1539,129 @@ class Program
 
 
 def generate_go_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
-    return '''// Dependency longest-depth benchmark (Go)
+    return r'''// Dependency longest-depth benchmark (Go)
 package main
 
 import (
-\t"bufio"
-\t"fmt"
-\t"os"
-\t"sort"
-\t"strings"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
 )
 
 func loadTSVPairs(path string) map[string][]string {
-\tm := make(map[string][]string)
-\tf, err := os.Open(path)
-\tif err != nil {
-\t\tfmt.Fprintf(os.Stderr, "Cannot open %s: %v\\n", path, err)
-\t\tos.Exit(1)
-\t}
-\tdefer f.Close()
-\tscanner := bufio.NewScanner(f)
-\tfirst := true
-\tfor scanner.Scan() {
-\t\tline := scanner.Text()
-\t\tif first {
-\t\t\tfirst = false
-\t\t\tif strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {
-\t\t\t\tcontinue
-\t\t\t}
-\t\t}
-\t\tparts := strings.SplitN(line, "\\t", 2)
-\t\tif len(parts) == 2 {
-\t\t\tm[parts[0]] = append(m[parts[0]], parts[1])
-\t\t}
-\t}
-\treturn m
+	m := make(map[string][]string)
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot open %s: %v\n", path, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	first := true
+	for scanner.Scan() {
+		line := scanner.Text()
+		if first {
+			first = false
+			if strings.HasPrefix(line, "article") || strings.HasPrefix(line, "child") {
+				continue
+			}
+		}
+		parts := strings.SplitN(line, "	", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = append(m[parts[0]], parts[1])
+		}
+	}
+	return m
 }
 
 func longestDepth(node string, adj map[string][]string, memo map[string]int) int {
-\tif depth, ok := memo[node]; ok {
-\t\treturn depth
-\t}
-\tbest := 1
-\tfor _, dep := range adj[node] {
-\t\tcandidate := 1 + longestDepth(dep, adj, memo)
-\t\tif candidate > best {
-\t\t\tbest = candidate
-\t\t}
-\t}
-\tmemo[node] = best
-\treturn best
+	if depth, ok := memo[node]; ok {
+		return depth
+	}
+	best := 1
+	for _, dep := range adj[node] {
+		candidate := 1 + longestDepth(dep, adj, memo)
+		if candidate > best {
+			best = candidate
+		}
+	}
+	memo[node] = best
+	return best
 }
 
 type projectResult struct {
-\tproject string
-\tdepth   int
+	project string
+	depth   int
 }
 
 func main() {
-\tif len(os.Args) < 3 {
-\t\tfmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\\n", os.Args[0])
-\t\tos.Exit(1)
-\t}
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <category_parent.tsv> <article_category.tsv>\n", os.Args[0])
+		os.Exit(1)
+	}
 
-\tadj := loadTSVPairs(os.Args[1])
-\tprojectDeps := loadTSVPairs(os.Args[2])
-\tmemo := make(map[string]int)
+	totalStart := time.Now()
+	loadStart := time.Now()
+	adj := loadTSVPairs(os.Args[1])
+	projectDeps := loadTSVPairs(os.Args[2])
+	loadElapsed := time.Since(loadStart)
 
-\tvar projects []string
-\tfor project := range projectDeps {
-\t\tprojects = append(projects, project)
-\t}
-\tsort.Strings(projects)
+	solveStart := time.Now()
+	memo := make(map[string]int)
+	var projects []string
+	for project := range projectDeps {
+		projects = append(projects, project)
+	}
+	sort.Strings(projects)
 
-\tresults := make([]projectResult, 0, len(projects))
-\tfor _, project := range projects {
-\t\tbest := 0
-\t\tfor _, dep := range projectDeps[project] {
-\t\t\tdepth := longestDepth(dep, adj, memo)
-\t\t\tif depth > best {
-\t\t\t\tbest = depth
-\t\t\t}
-\t\t}
-\t\tresults = append(results, projectResult{project: project, depth: best})
-\t}
+	results := make([]projectResult, 0, len(projects))
+	for _, project := range projects {
+		best := 0
+		for _, dep := range projectDeps[project] {
+			depth := longestDepth(dep, adj, memo)
+			if depth > best {
+				best = depth
+			}
+		}
+		results = append(results, projectResult{project: project, depth: best})
+	}
+	solveElapsed := time.Since(solveStart)
 
-\tsort.Slice(results, func(i, j int) bool {
-\t\tif results[i].depth != results[j].depth {
-\t\t\treturn results[i].depth < results[j].depth
-\t\t}
-\t\treturn results[i].project < results[j].project
-\t})
+	emitStart := time.Now()
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].depth != results[j].depth {
+			return results[i].depth < results[j].depth
+		}
+		return results[i].project < results[j].project
+	})
 
-\tfmt.Println("project\\tdependency_longest_depth")
-\tfor _, result := range results {
-\t\tfmt.Printf("%s\\t%d\\n", result.project, result.depth)
-\t}
+	fmt.Println("project	dependency_longest_depth")
+	for _, result := range results {
+		fmt.Printf("%s\t%d\n", result.project, result.depth)
+	}
+	emitElapsed := time.Since(emitStart)
+	totalElapsed := time.Since(totalStart)
+
+	fmt.Fprintf(os.Stderr, "load_ms=%d\n", loadElapsed.Milliseconds())
+	fmt.Fprintf(os.Stderr, "solve_ms=%d\n", solveElapsed.Milliseconds())
+	fmt.Fprintf(os.Stderr, "emit_ms=%d\n", emitElapsed.Milliseconds())
+	fmt.Fprintf(os.Stderr, "total_ms=%d\n", totalElapsed.Milliseconds())
+	fmt.Fprintf(os.Stderr, "project_count=%d\n", len(results))
 }
 '''
 
 
+
 def generate_rust_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
-    return '''// Dependency longest-depth benchmark (Rust)
+    return r'''// Dependency longest-depth benchmark (Rust)
 use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
+use std::time::Instant;
 
 fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
@@ -1655,7 +1672,7 @@ fn load_tsv_pairs(path: &str) -> HashMap<String, Vec<String>> {
         if (i == 0) && (line.starts_with("article") || line.starts_with("child")) {
             continue;
         }
-        let parts: Vec<&str> = line.splitn(2, '\\t').collect();
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
         if parts.len() == 2 {
             map.entry(parts[0].to_string()).or_insert_with(Vec::new).push(parts[1].to_string());
         }
@@ -1687,10 +1704,14 @@ fn main() {
         std::process::exit(1);
     }
 
+    let total_start = Instant::now();
+    let load_start = Instant::now();
     let adj = load_tsv_pairs(&args[1]);
     let project_deps = load_tsv_pairs(&args[2]);
-    let mut memo: HashMap<String, i32> = HashMap::new();
+    let load_elapsed = load_start.elapsed();
 
+    let solve_start = Instant::now();
+    let mut memo: HashMap<String, i32> = HashMap::new();
     let mut projects: Vec<&String> = project_deps.keys().collect();
     projects.sort();
 
@@ -1707,14 +1728,25 @@ fn main() {
         }
         results.push((best, project.to_string()));
     }
+    let solve_elapsed = solve_start.elapsed();
 
+    let emit_start = Instant::now();
     results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-    println!("project\tdependency_longest_depth");
-    for (depth, project) in results {
-        println!("{}\t{}", project, depth);
+    println!("project	dependency_longest_depth");
+    for (depth, project) in results.iter() {
+        println!("{}	{}", project, depth);
     }
+    let emit_elapsed = emit_start.elapsed();
+    let total_elapsed = total_start.elapsed();
+
+    eprintln!("load_ms={}", load_elapsed.as_millis());
+    eprintln!("solve_ms={}", solve_elapsed.as_millis());
+    eprintln!("emit_ms={}", emit_elapsed.as_millis());
+    eprintln!("total_ms={}", total_elapsed.as_millis());
+    eprintln!("project_count={}", results.len());
 }
 '''
+
 
 
 def generate_csharp_dependency_longest_depth(article_cats, category_parents, root_cats, n=5, max_depth=10):
@@ -1727,29 +1759,39 @@ using System.Linq;
 
 class Program
 {
+    static int EstimateRows(string path, int avgBytesPerRow)
+    {
+        var length = new FileInfo(path).Length;
+        var estimate = (int)Math.Max(16, length / Math.Max(1, avgBytesPerRow));
+        return estimate;
+    }
+
     static Dictionary<string, List<string>> LoadTsvPairs(string path)
     {
-        var map = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-        foreach (var (line, i) in File.ReadLines(path).Select((l, i) => (l, i)))
+        var estimatedRows = EstimateRows(path, 24);
+        var map = new Dictionary<string, List<string>>(Math.Max(estimatedRows / 3, 16), StringComparer.Ordinal);
+        using var reader = new StreamReader(path);
+        _ = reader.ReadLine();
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
         {
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
+            var span = line.AsSpan();
+            var tab = span.IndexOf('	');
+            if (tab <= 0 || tab >= span.Length - 1)
             {
                 continue;
             }
 
-            var parts = line.Split('	', 2);
-            if (parts.Length != 2)
+            var left = span.Slice(0, tab).ToString();
+            var right = span.Slice(tab + 1).ToString();
+
+            if (!map.TryGetValue(left, out var bucket))
             {
-                continue;
+                bucket = new List<string>(4);
+                map[left] = bucket;
             }
 
-            if (!map.TryGetValue(parts[0], out var bucket))
-            {
-                bucket = new List<string>();
-                map[parts[0]] = bucket;
-            }
-
-            bucket.Add(parts[1]);
+            bucket.Add(right);
         }
 
         return map;
@@ -1796,12 +1838,18 @@ class Program
         var allocatedBefore = GC.GetTotalAllocatedBytes(true);
         var swTotal = Stopwatch.StartNew();
 
+        var swLoad = Stopwatch.StartNew();
         var adj = LoadTsvPairs(args[0]);
         var projectDeps = LoadTsvPairs(args[1]);
-        var memo = new Dictionary<string, int>(StringComparer.Ordinal);
-        var results = new List<(int Depth, string Project)>(projectDeps.Count);
+        swLoad.Stop();
 
-        foreach (var project in projectDeps.Keys.OrderBy(x => x, StringComparer.Ordinal))
+        var swSolve = Stopwatch.StartNew();
+        var memo = new Dictionary<string, int>(adj.Count, StringComparer.Ordinal);
+        var projectIds = projectDeps.Keys.ToList();
+        projectIds.Sort(StringComparer.Ordinal);
+        var results = new List<(int Depth, string Project)>(projectIds.Count);
+
+        foreach (var project in projectIds)
         {
             var best = 0;
             foreach (var dep in projectDeps[project])
@@ -1821,14 +1869,20 @@ class Program
             var cmp = a.Depth.CompareTo(b.Depth);
             return cmp != 0 ? cmp : string.Compare(a.Project, b.Project, StringComparison.Ordinal);
         });
+        swSolve.Stop();
 
+        var swEmit = Stopwatch.StartNew();
         Console.WriteLine("project	dependency_longest_depth");
         foreach (var (depth, project) in results)
         {
             Console.WriteLine($"{project}	{depth}");
         }
 
+        swEmit.Stop();
         swTotal.Stop();
+        Console.Error.WriteLine($"load_ms={swLoad.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"solve_ms={swSolve.ElapsedMilliseconds}");
+        Console.Error.WriteLine($"emit_ms={swEmit.ElapsedMilliseconds}");
         Console.Error.WriteLine($"total_ms={swTotal.ElapsedMilliseconds}");
         Console.Error.WriteLine($"gc0_collections={GC.CollectionCount(0) - gc0Before}");
         Console.Error.WriteLine($"gc1_collections={GC.CollectionCount(1) - gc1Before}");


### PR DESCRIPTION
  ## Summary

  This PR improves the handwritten C# `dependency_longest_depth` benchmark
  baseline by trimming TSV ingestion overhead.

  Recent longest-depth investigation showed that the remaining performance
  story was not only about the query engine. The handwritten `csharp-dfs`
  baseline itself was already materially slower than Rust and Go, with a
  large part of that gap showing up in:

  - load time
  - other setup/runtime overhead around a relatively cheap DAG solve phase

  This PR keeps the same handwritten C# algorithm, but replaces the older
  general-purpose row-loading path with a lighter-weight custom TSV loader.

  ## What Changed

  ### Handwritten C# Longest-Depth Loader

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp` `dependency_longest_depth` benchmark now uses a
  lighter-weight loader that:

  - uses `StreamReader` directly
  - skips the header with one explicit `ReadLine()`
  - scans each line manually for the tab separator
  - avoids:
    - `Enumerable.Select((line, i) => ...)`
    - `string.Split(...)`
  - pre-sizes dictionaries using a simple file-size heuristic

  The graph representation remains the same:

  - `Dictionary<string, List<string>>`

  So this is a loader/runtime-overhead optimization, not a semantic or
  algorithmic rewrite.

  ### Cross-Language Handwritten Baseline Instrumentation

  Also kept in:

  - `examples/benchmark/generate_pipeline.py`

  The generated handwritten `dependency_longest_depth` benchmarks for:

  - `csharp`
  - `rust`
  - `go`

  now report comparable phase timings:

  - `load_ms`
  - `solve_ms`
  - `emit_ms`
  - `total_ms`

  For C#, the benchmark also still reports:

  - `gc0_collections`
  - `gc1_collections`
  - `gc2_collections`
  - `allocated_bytes`

  This makes the handwritten cross-language baseline easier to reason about.

  ### Documentation

  Updated:

  - `examples/benchmark/README.md`
  - `docs/proposals/DAG_LONGEST_DEPTH_INSTRUMENTATION_NOTE.md`

  The docs now record:

  - the handwritten cross-language baseline breakdown
  - the failed `Sep` parser experiment
  - the failed heavier integerized multi-pass loader experiment
  - the successful lighter-weight custom C# loader result

  ## Why This Matters

  The recent longest-depth work established a few useful facts:

  1. the actual DAG DP is cheap
  2. the dominant remaining cost is not GC pauses
  3. the handwritten C# baseline itself is slower than Rust/Go

  That meant the next best step was not more graph-theory work. It was
  reducing ingestion/setup overhead in the handwritten C# baseline first.

  This PR does that.

  It also clarifies a broader benchmark lesson:

  - when the solve phase is cheap, ingestion/setup overhead dominates much
    more of the total time
  - that is one of the main places where both handwritten C# and the C#
    query engine still lose ground to Rust and Go

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile examples/benchmark/generate_pipeline.py

  ### Direct handwritten C# DFS 10k run

  Generated and ran the handwritten C# dependency_longest_depth benchmark
  against the synthetic 10k dependency-DAG dataset.

  Result after this change:

  - load_ms=16
  - solve_ms=6
  - emit_ms=7
  - total_ms=30
  - gc0_collections=0
  - gc1_collections=0
  - gc2_collections=0
  - allocated_bytes=5,892,400
  - project_count=500

  Previous baseline:

  - load_ms=20
  - solve_ms=7
  - emit_ms=7
  - total_ms=35
  - allocated_bytes=7,880,720

  ### Cross-target longest-depth benchmark

  Ran locally:

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs still matched across all four targets.

  ## Updated Longest-Depth Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.057s | 0.043s | 0.002s | 0.002s | match |
  | 1k | 0.056s | 0.045s | 0.002s | 0.003s | match |
  | 5k | 0.087s | 0.056s | 0.006s | 0.006s | match |
  | 10k | 0.091s | 0.055s | 0.013s | 0.012s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.75x | 0.03x | 0.04x |
  | 1k | 0.81x | 0.04x | 0.05x |
  | 5k | 0.64x | 0.07x | 0.07x |
  | 10k | 0.60x | 0.14x | 0.14x |

  ## Interpretation

  This is a real improvement, but it is specifically an improvement to the
  handwritten C# baseline.

  That matters because it sharpens the next optimization split:

  1. C# baseline gap
      - now smaller than before
      - still present relative to Rust/Go
  2. C# query-engine gap
      - still present relative to handwritten C# DFS

  So the next most valuable work is likely:

  - apply the same ingestion/runtime-overhead mindset to the
    csharp-query longest-depth path
  - not more DAG-theory work first

  ## Scope

  This PR is focused on:

  - the handwritten C# dependency_longest_depth benchmark
  - TSV ingestion/runtime-overhead reduction
  - cross-language baseline instrumentation and documentation

  It does not:

  - change query semantics
  - change the DAG recurrence
  - optimize the csharp-query longest-depth runtime directly

  ## Follow-Up

  Likely next work:

  - apply similar ingestion/runtime-overhead reductions to the
    csharp-query longest-depth path
  - continue treating:
      - C# baseline performance
      - query-engine-specific performance
        as separate layers of the remaining gap
  - keep graph-theory work secondary until the low-hanging runtime-cost
    improvements are exhausted