### PR TITLE
feat(prolog): add weighted seeded min closure

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -188,12 +188,14 @@ Tables:
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
-| `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, C# DFS, Rust DFS, and Go DFS |
+| `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
 | `benchmark_prolog_seeded_min_closure.py` | Compare seeded Prolog `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
+| `generate_prolog_weighted_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog weighted-shortest-path scripts for seeded `all` vs mode-directed `min` closure |
+| `benchmark_prolog_weighted_min_closure.py` | Compare seeded Prolog weighted `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
 | `generate_dependency_benchmark_data.py` | Generate deterministic synthetic package-DAG benchmark data |
 | `effective_distance.pl` | Benchmark Prolog program |
 | `run_benchmark.sh` | Compile all targets + generate reference output |
@@ -219,10 +221,10 @@ Packaging note:
   - rounded float row outputs in common 2-column and 3-column forms
 - workloads can still keep custom normalization when their semantics or
   ordering rules are genuinely different
-- the seeded Prolog shortest-path benchmark now loads `facts.pl` at
-  runtime from a small generated driver instead of inlining facts into
-  the generated script, so `load_ms` is reported separately from
-  `query_ms`
+- the seeded Prolog shortest-path and weighted-shortest-path benchmarks
+  now load `facts.pl` at runtime from a small generated driver instead
+  of inlining facts into the generated script, so `load_ms` is reported
+  separately from `query_ms`
 
 ## Usage
 
@@ -277,7 +279,7 @@ python examples/benchmark/benchmark_weighted_shortest_path.py \
 # Compare positive weighted minimum path distance across query engine and DFS targets
 python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
     --scales 300,1k,5k,10k \
-    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min
 
 # Compare category influence propagation across the C# query engine, Rust, and Go
 python examples/benchmark/benchmark_category_influence_cross_target.py \
@@ -291,6 +293,11 @@ python examples/benchmark/benchmark_prolog_branch_pruning.py \
 
 # Compare seeded Prolog all-path closure vs mode-directed min closure
 python examples/benchmark/benchmark_prolog_seeded_min_closure.py \
+    --scales 300,1k,5k,10k \
+    --targets prolog-all,prolog-min
+
+# Compare seeded Prolog weighted all-path closure vs mode-directed min closure
+python examples/benchmark/benchmark_prolog_weighted_min_closure.py \
     --scales 300,1k,5k,10k \
     --targets prolog-all,prolog-min
 ```
@@ -320,6 +327,7 @@ The current comparison surface across query and non-query targets is:
   - category influence propagation
 - Prolog seeded `min`:
   - minimum hop distance
+  - positive weighted minimum path distance
 
 The benchmark split is now:
 
@@ -333,6 +341,7 @@ The benchmark split is now:
 - Prolog target:
   - `benchmark_prolog_branch_pruning.py`
   - `benchmark_prolog_seeded_min_closure.py`
+  - `benchmark_prolog_weighted_min_closure.py`
 - C# query-engine internal mode comparison:
   - `benchmark_shortest_path_to_root.py`
   - `benchmark_weighted_shortest_path.py`
@@ -450,36 +459,82 @@ Command:
 ```bash
 python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
     --scales 300,1k,5k,10k \
-    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
     --repetitions 1
 ```
 
 Latest local results:
 
-| Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
-|-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.181s | 0.466s | 0.353s | 0.487s | match |
-| 1k | 0.142s | 1.409s | 1.447s | 2.206s | match |
-| 5k | 0.250s | 5.957s | 7.994s | 12.404s | match |
-| 10k | 0.381s | 10.593s | 14.234s | 19.460s | match |
+| Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
+|-------|---------:|-----------:|--------:|---------:|-------:|---------|
+| 300 | 0.180s | 0.118s | 0.497s | 0.363s | 0.540s | match |
+| 1k | 0.137s | 0.140s | 1.352s | 1.526s | 2.238s | match |
+| 5k | 0.217s | 0.280s | 5.973s | 7.869s | 12.033s | match |
+| 10k | 0.391s | 0.509s | 10.975s | 14.789s | 19.974s | match |
+
+Direct C# query vs Prolog seeded `min`:
+
+| Scale | Faster target | Speedup |
+|-------|---------------|--------:|
+| 300 | Prolog Min | 1.52x |
+| 1k | C# Query | 1.02x |
+| 5k | C# Query | 1.29x |
+| 10k | C# Query | 1.30x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 2.57x | 1.95x | 2.69x |
-| 1k | 9.91x | 10.18x | 15.51x |
-| 5k | 23.81x | 31.94x | 49.57x |
-| 10k | 23.57x | 33.02x | 44.65x |
+| 300 | 2.77x | 2.02x | 3.01x |
+| 1k | 9.84x | 11.10x | 16.28x |
+| 5k | 27.55x | 36.29x | 55.49x |
+| 10k | 28.08x | 37.84x | 51.11x |
 
 Comparison note:
 
-- the earlier apparent weighted `10k` mismatch turned out to be
-  benchmark normalization sensitivity at roughly `1e-12`, not a semantic
-  query-engine bug
-- the cross-target weighted benchmark now normalizes floating-point
-  outputs with a tolerance appropriate for cross-language evaluation
-  order differences
+- seeded Prolog `min` is now competitive with the C# query engine on
+  the weighted shortest-path workload too: it wins at `300`, is
+  effectively tied at `1k`, and remains within about `1.29x` to `1.30x`
+  of the C# query engine at `5k` and `10k`
+- the cross-target weighted benchmark normalizes floating-point outputs
+  with a tolerance appropriate for cross-language evaluation order
+  differences
+
+### Prolog Weighted Min-Closure Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_prolog_weighted_min_closure.py \
+    --scales 300,1k,5k,10k --repetitions 1
+```
+
+Latest local results:
+
+| Scale | Prolog All | Prolog Min | Output Match |
+|-------|-----------:|-----------:|--------------|
+| 300 | 0.441s | 0.117s | match |
+| 1k | 0.303s | 0.129s | match |
+| 5k | 1.189s | 0.292s | match |
+| 10k | 2.762s | 0.552s | match |
+
+Speedups of seeded Prolog weighted `min` over seeded `all`:
+
+| Scale | Speedup |
+|-------|--------:|
+| 300 | 3.78x |
+| 1k | 2.35x |
+| 5k | 4.08x |
+| 10k | 5.01x |
+
+The retained work also drops sharply:
+
+| Scale | `all` tuple count | `min` tuple count |
+|-------|------------------:|------------------:|
+| 300 | 11172 | 213 |
+| 1k | 10976 | 48 |
+| 5k | 41132 | 151 |
+| 10k | 105287 | 462 |
 
 ### Cross-Target Dependency Reach Results
 

--- a/examples/benchmark/benchmark_prolog_weighted_min_closure.py
+++ b/examples/benchmark/benchmark_prolog_weighted_min_closure.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Benchmark seeded weighted shortest-path closure generation for the Prolog target.
+
+Targets:
+  - prolog-all : generated Prolog using seeded all-path weighted closure
+  - prolog-min : generated Prolog using seeded mode-directed $min closure
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_three_column_float_rows,
+    print_pair_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_weighted_shortest_path_benchmark.pl"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="prolog-all,prolog-min",
+        help="Comma-separated targets: prolog-all,prolog-min",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    if shutil.which("swipl") is None:
+        print("skip prolog weighted benchmark: swipl not found", file=sys.stderr)
+        return []
+    supported = {"prolog-all", "prolog-min"}
+    targets: list[str] = []
+    for target in requested:
+        if target not in supported:
+            raise ValueError(f"unsupported target: {target}")
+        targets.append(target)
+    return targets
+
+
+def scale_facts_path(scale: str) -> Path:
+    return require_file(BENCH_DIR / scale / "facts.pl")
+
+
+def build_generated_script(root: Path, scale: str, variant: str, script_name: str) -> list[str]:
+    facts_path = scale_facts_path(scale)
+    script_path = root / scale / script_name
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command, cwd=ROOT)
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_three_column_float_rows(stdout, decimals=9)
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        all_mode = find_result(entries, "prolog-all")
+        min_mode = find_result(entries, "prolog-min")
+        print_pair_match_status(scale, "all_vs_min", all_mode, min_mode)
+        print_speedup(scale, "speedup_min_vs_all", all_mode, min_mode)
+        print_phase_metrics(scale, "all_metrics", all_mode)
+        print_phase_metrics(scale, "min_metrics", min_mode)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-prolog-weighted-min-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-prolog-weighted-min-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        results: list[RunResult] = []
+        for scale in scales:
+            commands: dict[str, list[str]] = {}
+            for target in targets:
+                if target == "prolog-all":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "all", "weighted_shortest_path_all.pl"
+                    )
+                elif target == "prolog-min":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "min", "weighted_shortest_path_min.pl"
+                    )
+                else:
+                    raise ValueError(f"unsupported target: {target}")
+
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}", file=sys.stderr)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
+++ b/examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
 Benchmark positive weighted shortest-path-to-root across the C# query engine
-and generated DFS binaries for C#, Rust, and Go.
+and generated DFS binaries for C#, Rust, and Go, plus seeded Prolog `min` closure.
 """
 
 from __future__ import annotations
 
 import argparse
 import statistics
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -24,6 +25,7 @@ from benchmark_common import (
     normalize_three_column_float_rows,
     print_match_status,
     print_pair_match_status,
+    print_phase_metrics,
     print_result_table,
     print_speedup,
     require_file,
@@ -34,6 +36,7 @@ from benchmark_common import (
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_weighted_shortest_path_benchmark.pl"
 FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
 
 
@@ -56,8 +59,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--scales", default="300,1k,5k,10k")
     parser.add_argument(
         "--targets",
-        default="csharp-query,csharp-dfs,rust-dfs,go-dfs",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -88,21 +91,51 @@ def build_go_dfs(root: Path) -> list[str]:
     )
 
 
+def build_prolog_min(root: Path, scale: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    script_path = root / "prolog_min" / scale / "weighted_shortest_path_min.pl"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(PROLOG_GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            "min",
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
 def normalize_output(output: str) -> str:
     return normalize_three_column_float_rows(output, decimals=9)
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
-    scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
-    edge_path = scale_dir / "category_parent.tsv"
-    article_path = scale_dir / "article_category.tsv"
+def print_head_to_head(scale: str, left: RunResult | None, right: RunResult | None, label: str) -> None:
+    if left and right:
+        faster = left if left.median < right.median else right
+        slower = right if faster is left else left
+        print(f"{scale}\t{label}_faster\t{faster.target}")
+        print(f"{scale}\t{label}_speedup\t{slower.median / faster.median:.2f}x")
 
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
     times: list[float] = []
     stdout = ""
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run_command(command + [str(edge_path), str(article_path)])
+        if target == "prolog-min":
+            result = run_command(command, cwd=ROOT)
+        else:
+            scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+            edge_path = scale_dir / "category_parent.tsv"
+            article_path = scale_dir / "article_category.tsv"
+            result = run_command(command + [str(edge_path), str(article_path)])
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
@@ -121,14 +154,19 @@ def print_summary(results: list[RunResult]) -> None:
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
         go_dfs = find_result(entries, "go-dfs")
-        dfs_like = [item for item in entries if item.target != "csharp-query"]
+        prolog_min = find_result(entries, "prolog-min")
+        dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
             print_match_status(scale, "dfs_outputs", dfs_like)
         print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
+        print_pair_match_status(scale, "query_vs_prolog_min", qe, prolog_min)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_go_dfs", go_dfs, qe)
+        print_head_to_head(scale, qe, prolog_min, "query_vs_prolog_min")
+        print_phase_metrics(scale, "csharp-query-metrics", qe)
+        print_phase_metrics(scale, "prolog-min-metrics", prolog_min)
 
 
 def main() -> int:
@@ -157,13 +195,17 @@ def main() -> int:
                 commands[target] = build_rust_dfs(temp_root)
             elif target == "go-dfs":
                 commands[target] = build_go_dfs(temp_root)
-            else:
+            elif target != "prolog-min":
                 raise ValueError(f"unsupported target: {target}")
 
         results: list[RunResult] = []
         for scale in scales:
             for target in targets:
-                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+                if target == "prolog-min":
+                    command = build_prolog_min(temp_root, scale)
+                else:
+                    command = commands[target]
+                results.append(benchmark_target(command, scale, args.repetitions, target))
 
         print_summary(results)
         return 0

--- a/examples/benchmark/generate_prolog_weighted_shortest_path_benchmark.pl
+++ b/examples/benchmark/generate_prolog_weighted_shortest_path_benchmark.pl
@@ -1,0 +1,171 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'weighted_shortest_path_to_root.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPath, OutputPath, VariantAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: swipl -q -s generate_prolog_weighted_shortest_path_benchmark.pl -- <facts.pl> <output-script> <all|min>~n',
+            []),
+        halt(1)
+    ),
+    parse_variant(VariantAtom, Variant, Options),
+    benchmark_workload_path(WorkloadPath),
+    absolute_file_name(FactsPath, FactsAbsPath, [access(read)]),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_weighted_ancestor(_, _, _, _))),
+    assertz(user:mode(category_weighted_ancestor(-, +, -, +))),
+    Predicates = [
+        max_depth/1,
+        category_weighted_ancestor/4,
+        category_weighted_ancestor/3
+    ],
+    prolog_target:generate_prolog_script(Predicates, Options, BaseScriptCode),
+    benchmark_driver_code(Variant, FactsAbsPath, DriverCode),
+    atomic_list_concat([BaseScriptCode, DriverCode], '\n\n', ScriptCode),
+    prolog_target:write_prolog_script(ScriptCode, OutputPath).
+
+parse_variant('all', all, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(false)
+    ]) :-
+    !.
+parse_variant('min', min, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(auto)
+    ]) :-
+    !.
+parse_variant(Atom, _, _) :-
+    format(user_error,
+        'Unsupported weighted benchmark variant: ~w (expected all or min)~n',
+        [Atom]),
+    halt(1).
+
+benchmark_driver_code(Variant, FactsPath, Code) :-
+    format(atom(FactsPathLine), 'facts_path(~q).', [FactsPath]),
+    benchmark_query_line(Variant, QueryLine),
+    benchmark_mode_line(Variant, ModeLine),
+    Lines = [
+        ':- use_module(library(aggregate)).',
+        ':- dynamic bench_seed_distance/3.',
+        ':- dynamic category_weight/2.',
+        FactsPathLine,
+        '',
+        'load_benchmark_facts :-',
+        '    facts_path(Path),',
+        '    load_files(Path, [silent(true)]).',
+        '',
+        'clear_category_weights :-',
+        '    retractall(category_weight(_, _)).',
+        '',
+        'build_category_weights :-',
+        '    clear_category_weights,',
+        '    findall(Child, category_parent(Child, _), Children0),',
+        '    sort(Children0, Children),',
+        '    forall(',
+        '        member(Child, Children),',
+        '        (   aggregate_all(count, category_parent(Child, _), Degree),',
+        '            SafeDegree is max(1, Degree),',
+        '            Weight is 1.0 + log(SafeDegree) / log(5.0),',
+        '            assertz(category_weight(Child, Weight))',
+        '        )',
+        '    ).',
+        '',
+        'collect_seed_categories(Seeds) :-',
+        '    setof(Cat, Article^article_category(Article, Cat), Seeds).',
+        '',
+        'collect_articles(Articles) :-',
+        '    setof(Article, Cat^article_category(Article, Cat), Articles).',
+        '',
+        'clear_seed_distance_index :-',
+        '    retractall(bench_seed_distance(_, _, _)).',
+        '',
+        'seed_distance_query(Cat, Root, Weight) :-',
+        QueryLine,
+        '',
+        'build_seed_distance_index(Root, SeedCount, TupleCount) :-',
+        '    clear_seed_distance_index,',
+        '    collect_seed_categories(Seeds),',
+        '    length(Seeds, SeedCount),',
+        '    forall(',
+        '        member(Cat, Seeds),',
+        '        forall(',
+        '            seed_distance_query(Cat, Root, Weight),',
+        '            assertz(bench_seed_distance(Cat, Root, Weight))',
+        '        )',
+        '    ),',
+        '    aggregate_all(count, bench_seed_distance(_, _, _), TupleCount).',
+        '',
+        'seeded_article_root_distance(Article, Root, 0.0) :-',
+        '    article_category(Article, Root).',
+        'seeded_article_root_distance(Article, Root, Distance) :-',
+        '    article_category(Article, Cat),',
+        '    Cat \\= Root,',
+        '    bench_seed_distance(Cat, Root, Distance).',
+        '',
+        'compute_weighted_shortest_path_results(Root, Results) :-',
+        '    collect_articles(Articles),',
+        '    findall(MinWeight-Article,',
+        '        (   member(Article, Articles),',
+        '            aggregate_all(min(Dist),',
+        '                seeded_article_root_distance(Article, Root, Dist),',
+        '                MinWeight),',
+        '            MinWeight \\= inf',
+        '        ),',
+        '        Pairs),',
+        '    sort(Pairs, Results).',
+        '',
+        'print_weighted_shortest_path_results(Root, Results) :-',
+        '    format("article\\troot_category\\tweighted_shortest_path~n"),',
+        '    forall(',
+        '        member(Weight-Article, Results),',
+        '        format("~w\\t~w\\t~12f~n", [Article, Root, Weight])',
+        '    ).',
+        '',
+        'run_benchmark :-',
+        '    statistics(walltime, [LoadStartMs, _]),',
+        '    load_benchmark_facts,',
+        '    build_category_weights,',
+        '    statistics(walltime, [LoadEndMs, _]),',
+        '    statistics(inferences, InferencesBefore),',
+        '    root_category(Root),',
+        '    build_seed_distance_index(Root, SeedCount, TupleCount),',
+        '    statistics(walltime, [QueryEndMs, _]),',
+        '    compute_weighted_shortest_path_results(Root, Results),',
+        '    statistics(walltime, [AggEndMs, _]),',
+        '    print_weighted_shortest_path_results(Root, Results),',
+        '    statistics(inferences, InferencesAfter),',
+        '    LoadMs is LoadEndMs - LoadStartMs,',
+        '    QueryMs is QueryEndMs - LoadEndMs,',
+        '    AggregationMs is AggEndMs - QueryEndMs,',
+        '    TotalMs is AggEndMs - LoadStartMs,',
+        '    Inferences is InferencesAfter - InferencesBefore,',
+        '    length(Results, ArticleCount),',
+        ModeLine,
+        '    format(user_error, ''load_ms=~w~n'', [LoadMs]),',
+        '    format(user_error, ''query_ms=~w~n'', [QueryMs]),',
+        '    format(user_error, ''aggregation_ms=~w~n'', [AggregationMs]),',
+        '    format(user_error, ''total_ms=~w~n'', [TotalMs]),',
+        '    format(user_error, ''inferences=~w~n'', [Inferences]),',
+        '    format(user_error, ''seed_count=~w~n'', [SeedCount]),',
+        '    format(user_error, ''tuple_count=~w~n'', [TupleCount]),',
+        '    format(user_error, ''article_count=~w~n'', [ArticleCount]).'
+    ],
+    atomic_list_concat(Lines, '\n', Code).
+
+benchmark_query_line(all, '    category_weighted_ancestor(Cat, Root, Weight).').
+benchmark_query_line(min, '    ''category_weighted_ancestor$min''(Cat, Root, Weight).').
+
+benchmark_mode_line(all, '    format(user_error, ''mode=all~n'', []),').
+benchmark_mode_line(min, '    format(user_error, ''mode=min~n'', []),').

--- a/examples/benchmark/weighted_shortest_path_to_root.pl
+++ b/examples/benchmark/weighted_shortest_path_to_root.pl
@@ -1,0 +1,36 @@
+% Weighted shortest path to root
+%
+% For each article, find the minimum positive weighted distance to the
+% root category through the category hierarchy.
+%
+% The step weight is attached to the source category via
+% category_weight/2. The generated Prolog min helper can then retain
+% only the best known accumulated weight per seeded query while still
+% preserving the original recursive predicate.
+
+:- discontiguous category_parent/2.
+:- discontiguous article_category/2.
+:- discontiguous root_category/1.
+:- discontiguous category_weight/2.
+
+max_depth(10).
+
+category_weighted_ancestor(Cat, Parent, Weight, Visited) :-
+    category_parent(Cat, Parent),
+    category_weight(Cat, Step),
+    Step > 0,
+    Weight is Step,
+    \+ member(Parent, Visited).
+
+category_weighted_ancestor(Cat, Ancestor, Weight, Visited) :-
+    max_depth(MaxD),
+    length(Visited, Depth), Depth < MaxD, !,
+    category_parent(Cat, Mid),
+    category_weight(Cat, Step),
+    Step > 0,
+    \+ member(Mid, Visited),
+    category_weighted_ancestor(Mid, Ancestor, PrevWeight, [Mid|Visited]),
+    Weight is PrevWeight + Step.
+
+category_weighted_ancestor(Cat, Ancestor, Weight) :-
+    category_weighted_ancestor(Cat, Ancestor, Weight, [Cat]).

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -30,6 +30,7 @@
 :- use_module(library(debug)).
 :- use_module(prolog_dialects).
 :- use_module(prolog_constraints).
+:- use_module('../core/constraint_analyzer', [get_constraints/2]).
 :- use_module('../core/advanced/pattern_matchers', [is_per_path_visited_pattern/4]).
 
 %% ============================================
@@ -51,9 +52,10 @@
 %         helpers (default: auto). Use false when benchmarking the
 %         non-pruned baseline or when comparing generated variants.
 %       - min_closure(auto/false) - Emit a SWI mode-directed min helper
-%         for canonical counted PPV recursion when available (default:
-%         auto). This preserves the original predicate and adds a
-%         separate '$min' helper for bound shortest-path style queries.
+%         for canonical counted or positive-weighted PPV recursion when
+%         available (default: auto). This preserves the original
+%         predicate and adds a separate '$min' helper for bound
+%         shortest-path style queries.
 %  @arg ScriptCode Generated script as atom
 %
 %  @example Generate script for user predicates
@@ -381,6 +383,12 @@ maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode, Code) :-
 maybe_generate_min_closure_helper(Pred/Arity, Options, Code) :-
     option(dialect(Dialect), Options, swi),
     Dialect == swi,
+    (   maybe_generate_counted_min_closure_helper(Pred/Arity, Code)
+    ;   maybe_generate_weighted_min_closure_helper(Pred/Arity, Code)
+    ),
+    !.
+
+maybe_generate_counted_min_closure_helper(Pred/Arity, Code) :-
     findall(Head-Body,
         (   functor(Head, Pred, Arity),
             user:clause(Head, Body0),
@@ -405,6 +413,47 @@ maybe_generate_min_closure_helper(Pred/Arity, Options, Code) :-
             StepIncrement, BudgetMode, RecClause)),
     build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
         MetricPos, VisitedPos, BaseDepth, StepIncrement, BudgetMode, Code).
+
+maybe_generate_weighted_min_closure_helper(Pred/Arity, Code) :-
+    findall(Head-Body,
+        (   functor(Head, Pred, Arity),
+            user:clause(Head, Body0),
+            strip_codegen_module_qualifiers(Body0, Body)
+        ),
+        Clauses),
+    Clauses \= [],
+    partition(is_recursive_clause_for_pred(Pred), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos),
+    counted_ppv_driver_position(Pred, Arity, RecClauses, VisitedPos, DriverPos),
+    branch_pruning_mode_positions(Pred/Arity, VisitedPos, InvariantPositions),
+    branch_pruning_signature_positions(DriverPos, InvariantPositions, SignaturePositions),
+    min_closure_metric_position(Arity, VisitedPos, SignaturePositions, MetricPos),
+    findall(BasePositive,
+        (   member(BaseClause, BaseClauses),
+            weighted_min_base_clause_shape(MetricPos, VisitedPos, BaseClause, BasePositive)
+        ),
+        BasePositives),
+    length(BasePositives, BaseCount),
+    length(BaseClauses, BaseCount),
+    RecClauses = [FirstRec|RestRecClauses],
+    weighted_min_recursive_shape(Pred, Arity, VisitedPos, MetricPos, FirstRec,
+        BudgetMode, FirstRecPositive),
+    BudgetMode = budget(_),
+    findall(RestPositive,
+        (   member(RecClause, RestRecClauses),
+            weighted_min_recursive_shape(Pred, Arity, VisitedPos, MetricPos, RecClause,
+                ClauseBudgetMode, RestPositive),
+            budget_mode_compatible(BudgetMode, ClauseBudgetMode)
+        ),
+        RestRecPositives),
+    length(RestRecPositives, RestCount),
+    length(RestRecClauses, RestCount),
+    weighted_positive_step_proven(Pred/Arity, MetricPos, BasePositives,
+        [FirstRecPositive|RestRecPositives]),
+    build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
+        MetricPos, VisitedPos, 1, 1, BudgetMode, Code).
 
 counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos) :-
     member(Head-Body, RecClauses),
@@ -563,6 +612,110 @@ strip_counted_ppv_setup_goals(Goals, VisitedVar, BudgetMode, CleanGoals) :-
         CleanGoals = GoalsNoCuts
     ).
 
+weighted_positive_step_proven(Pred/Arity, MetricPos, _BasePositives, _RecPositives) :-
+    weighted_positive_step_metadata(Pred/Arity, MetricPos),
+    !.
+weighted_positive_step_proven(_PredArity, _MetricPos, BasePositives, RecPositives) :-
+    forall(member(Positive, BasePositives), Positive == true),
+    forall(member(Positive, RecPositives), Positive == true).
+
+weighted_positive_step_metadata(Pred/Arity, Position) :-
+    get_constraints(Pred/Arity, Constraints),
+    member(positive_step(Position), Constraints).
+
+weighted_min_base_clause_shape(MetricPos, VisitedPos, Head-Body, PositiveStepProven) :-
+    Head =.. [_|HeadArgs],
+    nth1(VisitedPos, HeadArgs, VisitedVar),
+    nth1(MetricPos, HeadArgs, MetricArg),
+    body_goals(Body, Goals0),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), Goals0, Goals1),
+    strip_counted_ppv_setup_goals(Goals1, VisitedVar, _IgnoredBudgetMode, Goals2),
+    select(MetricGoal, Goals2, Goals3),
+    weighted_metric_base_goal(MetricArg, MetricGoal, StepVar),
+    weighted_extract_positive_step_guard(Goals3, StepVar, Goals, PositiveStepProven),
+    \+ goals_reference_samevar(Goals, VisitedVar),
+    weighted_step_auxiliary_goal(HeadArgs, StepVar, Goals).
+
+weighted_metric_base_goal(MetricArg, Goal0, StepVar) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [is, MetricArg, StepVar]
+    ;   Goal =.. ['=', MetricArg, StepVar]
+    ),
+    var(StepVar),
+    StepVar \== MetricArg.
+
+weighted_min_recursive_shape(Pred, Arity, VisitedPos, MetricPos, Head-Body,
+        BudgetMode, PositiveStepProven) :-
+    counted_ppv_clause_parts(Pred, Arity, VisitedPos, Head-Body,
+        HeadArgs, PreRecGoals0, RecCall, PostGoals0, _StepGoal, _NextVar, VisitedVar),
+    strip_counted_ppv_setup_goals(PreRecGoals0, VisitedVar, BudgetMode, PreRecGoals1),
+    exclude(branch_pruning_negated_member_goal_for(VisitedVar), PreRecGoals1, PreRecGoals2),
+    RecCall =.. [_|RecArgs],
+    nth1(MetricPos, HeadArgs, HeadMetric),
+    nth1(MetricPos, RecArgs, RecMetric),
+    select(MetricGoal, PostGoals0, PostGoals),
+    weighted_metric_recursive_goal(HeadMetric, RecMetric, MetricGoal, StepVar),
+    weighted_extract_positive_step_guard(PreRecGoals2, StepVar, PreRecGoals, PositiveStepProven),
+    weighted_step_auxiliary_goal(HeadArgs, StepVar, PreRecGoals),
+    \+ goals_reference_samevar(PreRecGoals, VisitedVar),
+    \+ goals_reference_samevar(PostGoals, VisitedVar).
+
+weighted_metric_recursive_goal(HeadMetric, RecMetric, Goal0, StepVar) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [is, HeadMetric, Expr]
+    ;   Goal =.. ['=', HeadMetric, Expr]
+    ),
+    Expr =.. [+, Left, Right],
+    (   Left == RecMetric,
+        var(Right),
+        StepVar = Right
+    ;   Right == RecMetric,
+        var(Left),
+        StepVar = Left
+    ),
+    StepVar \== RecMetric.
+
+weighted_extract_positive_step_guard(Terms, StepVar, RemainingTerms, true) :-
+    select(Guard0, Terms, RemainingTerms),
+    weighted_positive_step_guard(Guard0, StepVar),
+    !.
+weighted_extract_positive_step_guard(Terms, _StepVar, Terms, false).
+
+weighted_positive_step_guard(Goal0, StepVar) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [>, StepVar, Value],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [<, Value, StepVar],
+        number(Value),
+        Value >= 0
+    ;   Goal =.. [>=, StepVar, Value],
+        number(Value),
+        Value > 0
+    ;   Goal =.. [=<, Value, StepVar],
+        number(Value),
+        Value > 0
+    ).
+
+weighted_step_auxiliary_goal(HeadArgs, StepVar, Goals) :-
+    member(Goal, Goals),
+    weighted_step_auxiliary_goal_shape(HeadArgs, StepVar, Goal),
+    !.
+
+weighted_step_auxiliary_goal_shape(HeadArgs, StepVar, Goal0) :-
+    strip_module(Goal0, _, Goal),
+    callable(Goal),
+    Goal \= (\+ _),
+    Goal \= not(_),
+    Goal \= !,
+    Goal =.. [Functor, DriverVar, AuxValue],
+    Functor \= member,
+    var(DriverVar),
+    member_samevar(DriverVar, HeadArgs),
+    AuxValue == StepVar,
+    var(StepVar),
+    StepVar \== DriverVar.
+
 is_cut_goal(!).
 
 max_depth_budget_goal(Goal0, MaxVar) :-
@@ -602,7 +755,7 @@ build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
     clauses_to_code(InnerClauses, InnerCode),
     clauses_to_code(OuterClauseTerms, OuterCode),
     atomic_list_concat([
-        '% Mode-directed min helper for canonical counted per-path recursion.',
+        '% Mode-directed min helper for canonical shortest-path style per-path recursion.',
         TableDeclCode,
         InnerCode,
         OuterCode

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -2,6 +2,7 @@
 
 :- use_module(library(plunit)).
 :- use_module(library(gensym)).
+:- use_module('../../src/unifyweaver/core/constraint_analyzer').
 :- use_module('../../src/unifyweaver/targets/prolog_target').
 
 run_prolog_target_tests :-
@@ -108,6 +109,92 @@ cleanup_min_closure_fixture :-
     retractall(user:test_min_ppv_reach(_, _, _, _)),
     retractall(user:mode(test_min_ppv_reach(_, _, _, _))).
 
+setup_weighted_min_closure_fixture :-
+    cleanup_weighted_min_closure_fixture,
+    assertz(user:test_weighted_min_edge(a, b)),
+    assertz(user:test_weighted_min_edge(a, c)),
+    assertz(user:test_weighted_min_edge(b, d)),
+    assertz(user:test_weighted_min_edge(c, d)),
+    assertz(user:test_weighted_min_cost(a, 1)),
+    assertz(user:test_weighted_min_cost(b, 5)),
+    assertz(user:test_weighted_min_cost(c, 2)),
+    assertz(user:max_depth(4)),
+    assertz(user:(test_weighted_min_ppv_reach(Cat, Parent, Cost, Visited) :-
+        test_weighted_min_edge(Cat, Parent),
+        test_weighted_min_cost(Cat, Step),
+        Step > 0,
+        Cost is Step,
+        \+ member(Parent, Visited))),
+    assertz(user:(test_weighted_min_ppv_reach(Cat, Ancestor, Cost, Visited) :-
+        max_depth(MaxD),
+        length(Visited, Depth), Depth < MaxD, !,
+        test_weighted_min_edge(Cat, Mid),
+        test_weighted_min_cost(Cat, Step),
+        Step > 0,
+        \+ member(Mid, Visited),
+        test_weighted_min_ppv_reach(Mid, Ancestor, PrevCost, [Mid|Visited]),
+        Cost is PrevCost + Step)),
+    assertz(user:mode(test_weighted_min_ppv_reach(-, +, -, +))).
+
+cleanup_weighted_min_closure_fixture :-
+    retractall(user:test_weighted_min_edge(_, _)),
+    retractall(user:test_weighted_min_cost(_, _)),
+    retractall(user:max_depth(_)),
+    retractall(user:test_weighted_min_ppv_reach(_, _, _, _)),
+    retractall(user:mode(test_weighted_min_ppv_reach(_, _, _, _))),
+    clear_constraints(test_weighted_min_ppv_reach/4).
+
+setup_weighted_min_metadata_fixture :-
+    cleanup_weighted_min_closure_fixture,
+    assertz(user:test_weighted_min_edge(a, b)),
+    assertz(user:test_weighted_min_edge(a, c)),
+    assertz(user:test_weighted_min_edge(b, d)),
+    assertz(user:test_weighted_min_edge(c, d)),
+    assertz(user:test_weighted_min_cost(a, 1)),
+    assertz(user:test_weighted_min_cost(b, 5)),
+    assertz(user:test_weighted_min_cost(c, 2)),
+    assertz(user:max_depth(4)),
+    assertz(user:(test_weighted_min_ppv_reach(Cat, Parent, Cost, Visited) :-
+        test_weighted_min_edge(Cat, Parent),
+        test_weighted_min_cost(Cat, Step),
+        Cost is Step,
+        \+ member(Parent, Visited))),
+    assertz(user:(test_weighted_min_ppv_reach(Cat, Ancestor, Cost, Visited) :-
+        max_depth(MaxD),
+        length(Visited, Depth), Depth < MaxD, !,
+        test_weighted_min_edge(Cat, Mid),
+        test_weighted_min_cost(Cat, Step),
+        \+ member(Mid, Visited),
+        test_weighted_min_ppv_reach(Mid, Ancestor, PrevCost, [Mid|Visited]),
+        Cost is PrevCost + Step)),
+    assertz(user:mode(test_weighted_min_ppv_reach(-, +, -, +))),
+    declare_constraint(test_weighted_min_ppv_reach/4, [positive_step(3)]).
+
+setup_weighted_min_unproven_fixture :-
+    cleanup_weighted_min_closure_fixture,
+    assertz(user:test_weighted_min_edge(a, b)),
+    assertz(user:test_weighted_min_edge(a, c)),
+    assertz(user:test_weighted_min_edge(b, d)),
+    assertz(user:test_weighted_min_edge(c, d)),
+    assertz(user:test_weighted_min_cost(a, 1)),
+    assertz(user:test_weighted_min_cost(b, 5)),
+    assertz(user:test_weighted_min_cost(c, 2)),
+    assertz(user:max_depth(4)),
+    assertz(user:(test_weighted_min_ppv_reach(Cat, Parent, Cost, Visited) :-
+        test_weighted_min_edge(Cat, Parent),
+        test_weighted_min_cost(Cat, Step),
+        Cost is Step,
+        \+ member(Parent, Visited))),
+    assertz(user:(test_weighted_min_ppv_reach(Cat, Ancestor, Cost, Visited) :-
+        max_depth(MaxD),
+        length(Visited, Depth), Depth < MaxD, !,
+        test_weighted_min_edge(Cat, Mid),
+        test_weighted_min_cost(Cat, Step),
+        \+ member(Mid, Visited),
+        test_weighted_min_ppv_reach(Mid, Ancestor, PrevCost, [Mid|Visited]),
+        Cost is PrevCost + Step)),
+    assertz(user:mode(test_weighted_min_ppv_reach(-, +, -, +))).
+
 build_execution_runtime_source(ModuleName, PredicateCode, Source) :-
     atomic_list_concat([
         'test_exec_edge(a, b).',
@@ -169,6 +256,36 @@ collect_generated_min_hops(Options, PredicateCode, Hops) :-
             Goal =.. ['test_min_ppv_reach$min', a, c, H],
             findall(H, ModuleName:Goal, Hops0),
             sort(Hops0, Hops)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
+build_weighted_min_runtime_source(ModuleName, PredicateCode, Source) :-
+    atomic_list_concat([
+        'test_weighted_min_edge(a, b).',
+        'test_weighted_min_edge(a, c).',
+        'test_weighted_min_edge(b, d).',
+        'test_weighted_min_edge(c, d).',
+        'test_weighted_min_cost(a, 1).',
+        'test_weighted_min_cost(b, 5).',
+        'test_weighted_min_cost(c, 2).',
+        'max_depth(4).'
+    ], '\n', FactsCode),
+    format(atom(Source),
+        ':- module(~q, []).~n:- use_module(library(lists)).~n~w~n~n~w~n',
+        [ModuleName, FactsCode, PredicateCode]).
+
+collect_generated_weighted_min_costs(Options, PredicateCode, Costs) :-
+    once(prolog_target:generate_predicate_code(test_weighted_min_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_weighted_min_ppv_runtime_, ModuleName),
+    build_weighted_min_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_weighted_min_ppv_reach$min', a, d, Cost],
+            findall(Cost, ModuleName:Goal, Costs0),
+            sort(Costs0, Costs)
         ),
         cleanup_temp_module_source(Path)
     ).
@@ -258,5 +375,26 @@ test(skips_min_closure_helper_when_disabled_explicitly,
          cleanup(cleanup_min_closure_fixture)]) :-
     once(generate_prolog_script([test_min_ppv_reach/4], [dialect(swi), min_closure(false)], Code)),
     \+ sub_atom(Code, _, _, _, 'test_min_ppv_reach$min').
+
+test(emits_weighted_min_closure_helper_for_positive_weighted_ppv,
+        [setup(setup_weighted_min_closure_fixture),
+         cleanup(cleanup_weighted_min_closure_fixture)]) :-
+    collect_generated_weighted_min_costs([dialect(swi)], PredicateCode, Actual),
+    once(sub_atom(PredicateCode, _, _, _, 'test_weighted_min_ppv_reach$min')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_weighted_min_ppv_reach$min_budget')),
+    Actual == [3].
+
+test(emits_weighted_min_closure_helper_from_positive_step_metadata,
+        [setup(setup_weighted_min_metadata_fixture),
+         cleanup(cleanup_weighted_min_closure_fixture)]) :-
+    collect_generated_weighted_min_costs([dialect(swi)], PredicateCode, Actual),
+    once(sub_atom(PredicateCode, _, _, _, 'test_weighted_min_ppv_reach$min')),
+    Actual == [3].
+
+test(skips_weighted_min_closure_without_positive_step_proof,
+        [setup(setup_weighted_min_unproven_fixture),
+         cleanup(cleanup_weighted_min_closure_fixture)]) :-
+    once(generate_prolog_script([test_weighted_min_ppv_reach/4], [dialect(swi)], Code)),
+    \+ sub_atom(Code, _, _, _, 'test_weighted_min_ppv_reach$min').
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This extends the Prolog seeded `min` lowering from counted shortest path to the weighted shortest-path case.

  The new lowering targets canonical positive-weighted per-path-visited recursion and adds a seeded Prolog `min` helper
  that retains only the best known accumulated weight per demand signature, instead of keeping the full weighted closure.

  This is the Prolog analogue of the useful part of the C# parameterized query engine for weighted shortest path: seeded
  reuse plus dominated-state elimination.

  ## What Changed

  - extended `src/unifyweaver/targets/prolog_target.pl` with weighted seeded `min` lowering
  - kept the existing counted shortest-path `min` lowering intact and generalized the dispatcher so it can select:
    - counted shortest-path `min`
    - positive-weighted shortest-path `min`
  - added weighted positive-step proof paths:
    - explicit goal guards such as `Step > 0`
    - metadata via `positive_step(Position)` constraints
  - added focused weighted tests in `tests/core/test_prolog_target.pl` for:
    - weighted helper emission
    - metadata-driven positive-step acceptance
    - fallback when positivity is not provable
  - added a new weighted benchmark workload in `examples/benchmark/weighted_shortest_path_to_root.pl`
  - added a standalone weighted Prolog benchmark generator:
    - `examples/benchmark/generate_prolog_weighted_shortest_path_benchmark.pl`
  - added a standalone weighted Prolog benchmark runner:
    - `examples/benchmark/benchmark_prolog_weighted_min_closure.py`
  - extended the weighted cross-target benchmark:
    - `examples/benchmark/benchmark_weighted_shortest_path_cross_target.py`
    - now includes `prolog-min` alongside `csharp-query`, `csharp-dfs`, `rust-dfs`, and `go-dfs`
  - updated `examples/benchmark/README.md` with the new weighted Prolog benchmark path and current results

  ## Why

  The earlier Prolog seeded `min` work achieved strong wins for counted shortest path, but the weighted shortest-path
  benchmark was still missing.

  This PR pushes the same idea one step further:

  - prove that the step contribution is positive
  - compute once per unique seed
  - retain only the best known accumulated weight per seeded query
  - compare the result directly against the existing C#/Rust/Go weighted benchmark surface

  That gives the Prolog target a meaningful optimization path for another benchmark that had previously favored the C#
  query engine.

  ## Result

  ### Standalone Prolog weighted benchmark

  Seeded weighted `min` now beats seeded weighted `all` at every tested scale with matching outputs:

  - `300`: `3.96x`
  - `1k`: `2.49x`
  - `5k`: `3.81x`
  - `10k`: `4.78x`

  Retained work drops sharply as well:

  - `300`: tuple count `11172 -> 213`
  - `1k`: tuple count `10976 -> 48`
  - `5k`: tuple count `41132 -> 151`
  - `10k`: tuple count `105287 -> 462`

  ### Cross-target weighted benchmark

  Latest local weighted cross-target run showed matching outputs across all targets at all tested scales.

  `prolog-min` vs `csharp-query`:

  - `300`: Prolog faster by `1.44x`
  - `1k`: Prolog faster by `1.12x`
  - `5k`: C# faster by `1.26x`
  - `10k`: C# faster by `1.41x`

  So Prolog has reached parity or near parity for weighted shortest path at smaller scales, while C# still retains a
  modest lead at larger scales.

  ## Verification

  - `swipl -q -t halt -s src/unifyweaver/targets/prolog_target.pl`
  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python -m py_compile examples/benchmark/benchmark_weighted_shortest_path_cross_target.py examples/benchmark/
  benchmark_prolog_weighted_min_closure.py`
  - `python examples/benchmark/benchmark_prolog_weighted_min_closure.py --scales 300,1k,5k,10k --repetitions 1`
  - `python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py --scales 300,1k,5k,10k --targets csharp-
  query,csharp-dfs,rust-dfs,go-dfs,prolog-min --repetitions 1`

  ## Notes

  - this lowering is still intentionally narrow: it targets canonical positive-weighted PPV shortest-path recursion
  - weighted `min` is only enabled when positivity can be proven from the body or from declared constraints
  - the generated Prolog benchmark continues to load `facts.pl` at runtime rather than inlining facts, so load cost stays
  visible and separate from query cost