### PR TITLE
docs: capture query engine streaming vision

### DIFF
--- a/docs/proposals/QUERY_ENGINE_BENCHMARK_INTERPRETATION.md
+++ b/docs/proposals/QUERY_ENGINE_BENCHMARK_INTERPRETATION.md
@@ -1,0 +1,93 @@
+# Query Engine Benchmark Interpretation
+
+## Purpose
+
+This document explains how the current benchmark results should be read.
+The key point is that the query engine already demonstrates one of its major
+advantages clearly, while another intended advantage is only partially
+realized in the current implementation paths.
+
+## Two Positive Stories
+
+The current benchmark work supports two positive claims about the query
+engine:
+
+1. pruning and grouped recursive execution can produce strong wins on
+   computationally heavy workloads
+2. the engine is intended to gain additional advantages from lazy/streamed
+   ownership of retained state
+
+Only the first is fully demonstrated right now.
+
+## What Is Already Demonstrated Well
+
+The strongest demonstrated result so far is this:
+
+- when the workload is computationally heavy and the engine can avoid wasted
+  derivations or materialization, the query engine can beat the DFS-style
+  baselines substantially
+
+This is visible in workloads like:
+
+- grouped reach-count after direct count aggregation was moved into the runtime
+- earlier grouped/prunable recursive benchmarks
+
+So the pruning story is real and already supported by measured results.
+
+## What Is Not Fully Demonstrated Yet
+
+The second intended story is this:
+
+- a lazy/stream-oriented query engine should avoid eager materialization costs
+  that scale poorly in more traditional pipelines
+
+Current profiling suggests this story is not yet fully expressed in all
+benchmark paths.
+
+The clearest example is `dependency_longest_depth`:
+
+- the solve step is comparatively cheap
+- load/build overhead dominates much more of total time
+- handwritten and query-engine C# paths both still pay substantial eager
+  ingestion/setup costs before the main computation wins can show up
+
+So when the query engine loses on such a benchmark, the interpretation should
+be careful.
+
+It does not necessarily mean:
+
+- the engine's computational model is weak
+
+It may instead mean:
+
+- the current benchmark path is still too eager before the engine gets to own
+  retention and streaming behavior
+
+## Why The Handwritten C# Baseline Matters
+
+Recent profiling also showed that handwritten `csharp-dfs` is itself slower
+than Rust and Go on `dependency_longest_depth`.
+
+That matters because it splits the gap into two layers:
+
+1. C# baseline gap relative to Rust/Go
+2. query-engine gap relative to handwritten C#
+
+So not every deficit should be blamed on the query engine specifically.
+Some of it belongs to a broader managed-runtime ingestion/setup story.
+
+## Recommended Reading Of Current Results
+
+The clean reading of the benchmark portfolio today is:
+
+- pruning/computational efficiency is already a demonstrated strength of the
+  query engine
+- lazy/streaming efficiency remains an intended strength whose full benchmark
+  expression is still incomplete
+- therefore current losses on load-dominated workloads should be read as a
+  combination of:
+  - C# baseline ingestion/runtime overhead
+  - incomplete engine ownership of streaming/retained-state decisions
+
+This is still a positive result, because it tells us where the missing work is
+and what kind of work it is.

--- a/docs/proposals/QUERY_ENGINE_STREAMING_GAP_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_STREAMING_GAP_PLAN.md
@@ -1,0 +1,140 @@
+# Query Engine Streaming Gap Plan
+
+## Purpose
+
+This document turns the streaming vision and recent benchmark interpretation
+into a concrete implementation agenda.
+
+The central problem is:
+
+- the query engine is intended to own retained state
+- but some current benchmark paths still build too much retained structure
+  before the engine gets to make that decision
+
+## Problem Statement
+
+The current longest-depth/load profiling suggests that the main missing piece
+is not another DAG recurrence idea.
+
+Instead, the gap is that tuple ingestion and retained-state ownership are not
+yet aligned with the engine's intended model.
+
+In other words:
+
+- too much state is still created by benchmark-side or program-side ingestion
+- too little of that state selection is owned by the query runtime itself
+
+## Near-Term Goals
+
+### 1. Preserve What Already Works
+
+Do not regress the query-engine paths that already demonstrate strong wins on
+computationally heavy workloads.
+
+In particular:
+
+- keep the grouped reach-count runtime gains
+- keep the DAG longest-depth runtime specialization
+- keep using benchmark profiling to distinguish compute cost from ingestion cost
+
+### 2. Move Toward Streamed Tuple Ingestion
+
+The parser layer should aim to provide streamed decoded tuples with minimal
+retained state.
+
+The query engine should increasingly decide whether to:
+
+- retain nothing
+- retain summaries
+- retain indexes
+- retain a full relation representation when truly needed
+
+### 3. Let Operators Own Their State
+
+Operators like these should explicitly own their retained state strategy:
+
+- grouped DAG reachability
+- DAG longest depth
+- recursive grouped aggregation
+
+That means the engine should become the component that says:
+
+- "this operator needs adjacency"
+- "this operator needs grouped bitsets"
+- "this operator only needs counts"
+
+rather than inheriting a pre-built structure from a generic ingestion layer.
+
+## Concrete Stages
+
+### Stage 1: Keep Profiling Boundaries Clear
+
+Continue measuring these separately whenever possible:
+
+- load/ingestion
+- graph/state build
+- solve
+- emit
+
+This is necessary to distinguish:
+
+- baseline runtime issues
+- query-engine issues
+- benchmark-wrapper issues
+
+### Stage 2: Shrink Parser Responsibility
+
+Move the parser toward:
+
+- row decoding
+- tuple streaming
+- minimal canonicalization only when clearly beneficial
+
+Avoid turning the parser into a second planner or index builder.
+
+### Stage 3: Add Engine-Owned Retention Paths
+
+Add or strengthen runtime paths where the engine consumes tuple streams and
+constructs only the state required by the operator.
+
+Priority examples:
+
+- streamed edge ingestion for DAG operators
+- streamed grouped seed ingestion
+- count/summarize directly rather than materializing relations first
+
+### Stage 4: Re-evaluate Streaming Benchmarks
+
+Once the engine owns more of the retained-state choice, revisit benchmarks
+like `dependency_longest_depth` and ask:
+
+- does the lazy/streaming advantage now appear more clearly?
+- how much of the remaining gap is still just baseline C# cost?
+
+## What Not To Do
+
+### Do not overfit the parser
+
+A highly specialized benchmark parser may improve one benchmark while moving
+architectural responsibility in the wrong direction.
+
+### Do not treat every loss as a query-engine failure
+
+Some benchmark losses are still baseline C# ingestion/runtime losses.
+Those should be recognized separately.
+
+### Do not assume graph-theory improvements are the next step by default
+
+On several recent longest-depth iterations, the missing win was not a better
+recurrence but lower-level ingestion/runtime ownership.
+
+## Success Criteria
+
+This gap is meaningfully closed when:
+
+- benchmark ingestion paths are thinner
+- the engine owns more retained-state decisions directly
+- load-dominated workloads stop masking the engine's intended lazy/streaming
+  advantages as much as they do today
+- pruning and streaming are both visible as distinct strengths of the query
+  engine in the benchmark suite

--- a/docs/proposals/QUERY_ENGINE_STREAMING_VISION.md
+++ b/docs/proposals/QUERY_ENGINE_STREAMING_VISION.md
@@ -1,0 +1,99 @@
+# Query Engine Streaming Vision
+
+## Purpose
+
+This document clarifies an intended property of the query engine that has
+been easy to lose sight of while chasing benchmark performance:
+
+- the query engine is meant to own retained state
+- the parser/ingestion layer is meant to stream tuples into the engine
+- eager pre-materialization outside the engine is a compromise, not the ideal
+
+This is not a new design direction. It is a restatement of the engine's
+existing architectural intent, sharpened by recent profiling work.
+
+## Core Principle
+
+The parser should do as little as possible beyond decoding rows into tuples.
+
+The query engine should decide:
+
+- what state to retain
+- when to index or group
+- when full materialization is actually required
+- when a plan can stay streaming or partially streaming
+
+So the architectural split should be:
+
+- parser responsibility: stream decoded tuples
+- query-engine responsibility: build only the retained state required by the operator plan
+
+## Why This Matters
+
+A parser that eagerly constructs heavyweight data structures is making a
+query-planning decision too early.
+
+That has several costs:
+
+- peak memory goes up before the engine can prune or aggregate
+- the runtime pays allocation and ingestion overhead even for queries that do
+  not need all rows retained
+- benchmark results become dominated by pre-engine setup rather than by query
+  execution properties
+
+This is especially harmful when the query engine is supposed to be compared
+against hand-written pipelines partly on the basis of lazy execution.
+
+## What Profiling Has Already Shown
+
+Recent benchmark work has already shown one major strength clearly:
+
+- the query engine wins strongly on computationally heavy, prunable workloads
+
+This is already visible in the grouped recursive benchmarks where pruning and
+avoiding wasted derivations matter more than raw ingestion speed.
+
+But the profiling has also shown an important gap:
+
+- the query engine's intended streaming/lazy advantage is not yet fully
+  expressed in every benchmark path
+
+The clearest example is `dependency_longest_depth`:
+
+- the actual DAG dynamic programming is cheap
+- load/build overhead dominates much more of the total time
+- too much eager structure-building still happens before the engine fully owns
+  the retained state story
+
+## Architectural Position
+
+The right goal is not "no data structures".
+
+The right goal is:
+
+- no retained state earlier than necessary
+- no retained state outside the engine unless the engine explicitly requires it
+- retained state chosen by the operator plan, not by the parser
+
+That means some operators will still build substantial state.
+For example:
+
+- grouped reachability on DAGs
+- longest-depth DAG summaries
+- recursive aggregation indexes
+
+But the engine should build those intentionally, from streamed tuples, rather
+than inheriting them from an eager pre-processing layer by default.
+
+## Practical Implication
+
+When a benchmark currently performs badly because of load/setup cost, that
+should not always be interpreted as an algorithmic weakness of the query
+engine.
+
+Sometimes it is revealing something narrower:
+
+- the benchmark path is not yet allowing the engine to exercise its intended
+  streaming ownership of state
+
+That is a real implementation gap, not a refutation of the streaming vision.


### PR DESCRIPTION
  ## Summary

  This PR adds a small set of vision documents to clarify how the recent
  benchmark and profiling work should be interpreted.

  These are not “new design docs” in the sense of introducing a different
  architecture.

  Instead, they restate and sharpen an existing architectural intent:

  - the query engine should own retained state
  - the parser/ingestion layer should stream tuples into the engine
  - eager pre-materialization outside the engine is a compromise, not the
    intended end state

  Recent profiling work made this worth writing down explicitly.

  ## Added

  - `docs/proposals/QUERY_ENGINE_STREAMING_VISION.md`
  - `docs/proposals/QUERY_ENGINE_BENCHMARK_INTERPRETATION.md`
  - `docs/proposals/QUERY_ENGINE_STREAMING_GAP_PLAN.md`

  ## Why These Docs Matter

  The benchmark work has revealed two positive stories about the query
  engine:

  1. **Pruning / grouped recursive execution is already a demonstrated
     strength**
  2. **Lazy / streaming ownership of retained state is an intended
     strength, but is not yet fully expressed in every benchmark path**

  That distinction is important.

  Without writing it down clearly, it is too easy to misread some of the
  current benchmark losses as evidence against the query engine’s model,
  when in fact they often reflect something narrower:

  - benchmark-side or program-side ingestion is still too eager before the
    engine gets to own retained-state decisions

  These docs give us a common language for that gap.

  ## Document Overview

  ### `QUERY_ENGINE_STREAMING_VISION.md`

  This is the architectural-position document.

  It states that:

  - the parser should stream decoded tuples
  - the query engine should decide what to retain
  - retained state should be chosen by operator needs, not by generic
    ingestion code

  It also makes an important clarification:

  - the goal is **not** “no data structures”
  - the goal is “no retained state earlier than necessary, and no retained
    state outside the engine unless the engine requires it”

  ### `QUERY_ENGINE_BENCHMARK_INTERPRETATION.md`

  This is the benchmark-reading document.

  It explains that the current benchmark portfolio supports two positive
  claims:

  - the query engine already wins strongly on computationally heavy,
    prunable workloads
  - the engine’s intended streaming/lazy advantage is only partially
    realized in current benchmark paths

  It also incorporates the recent profiling result that handwritten
  `csharp-dfs` itself can be materially slower than Rust/Go on
  load-dominated longest-depth workloads, which means not every gap should
  be blamed on the query engine specifically.

  ### `QUERY_ENGINE_STREAMING_GAP_PLAN.md`

  This is the implementation-gap document.

  It turns the vision and benchmark interpretation into a staged plan:

  1. keep profiling boundaries clear
  2. shrink parser responsibility
  3. move more retained-state ownership into the engine
  4. re-evaluate streaming-sensitive benchmarks once the engine owns more
     of the ingestion/retention story

  It also explicitly warns against a few easy failure modes:

  - overfitting the parser
  - treating every loss as a query-engine failure
  - assuming more graph-theory work is automatically the next step

  ## Main Position Captured by This PR

  The most important idea these docs preserve is:

  - current profiling does **not** undermine the query engine story

  Instead, it sharpens it.

  What the benchmarks show today is:

  - **pruning wins are real and already measured**
  - **streaming wins are intended, but are not yet fully exposed because
    some paths still materialize too much too early**

  That is a useful conclusion for both future implementation work and for
  how we explain benchmark outcomes to ourselves and others.

  ## Scope

  This PR is docs-only.

  It does **not** change:

  - runtime behavior
  - planner behavior
  - benchmark code

  Its purpose is to preserve the current architectural interpretation while
  the profiling context is still fresh.

  ## Follow-Up

  Likely next work:

  - use these docs as the framing for the next engine-side ingestion work
  - continue distinguishing:
    - pruning/computation wins already demonstrated
    - streaming/retained-state wins not yet fully realized
  - use the gap-plan document as the guide for moving more retained-state
    ownership into the query engine itself