### PR TITLE
Feat/go goal parallelism and improved term handling

### DIFF
--- a/PHASE_WAM_GO_COMPLETED.md
+++ b/PHASE_WAM_GO_COMPLETED.md
@@ -29,10 +29,18 @@ Successfully implemented the core WAM-to-Go transpilation pipeline, including pa
 - Implemented robust recursive structural unification (`WamState.Unify`) for complex terms.
 - Refined halt logic using a dedicated `Halted` field instead of a PC sentinel.
 
+### Phase 5b: Order-Independent Goal Parallelism
+- Added support for `:- order_independent/1` and `:- parallel_safe/1` directives in the clause body analysis pipeline.
+- Implemented `classify_parallelism/3` to determine if a predicate's goals can be run in parallel based on purity and disjoint variable bindings.
+- Updated Go native lowering logic to emit `sync.WaitGroup` and goroutines for predicates classified as `goal_parallel`.
+- Improved output variable detection in `goal_output_var_simple/2` to support general predicate calls.
+
 ## Files Created/Modified
-- `src/unifyweaver/targets/wam_go_target.pl`: Main transpilation logic, project orchestration, and parallel helper generation.
-- `templates/targets/go_wam/`: Go module templates (`go.mod`, `value.go`, `state.go`, `instructions.go`, `runtime.go`).
-- `tests/test_wam_go_generator.pl`: Unit tests for instruction lowering and parser robustness.
+- `src/unifyweaver/core/clause_body_analysis.pl`: Analysis logic for goal parallelism and directives.
+- `src/unifyweaver/targets/go_target.pl`: Go code generation for goroutine-based goal parallelism.
+- `templates/targets/go_wam/`: Go module templates.
+- `tests/test_wam_go_generator.pl`: Unit tests for instruction lowering.
+- `tests/test_go_goal_parallel.pl`: Unit tests for goal parallelism analysis and code generation.
 - `PHASE_WAM_GO_COMPLETED.md`: This completion report.
 - `docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md`: Updated design plan.
 

--- a/docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md
+++ b/docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md
@@ -295,7 +295,7 @@ is straightforward (WaitGroup + goroutines).
 | 3 | step_wam/3 → Go type switch | **Completed** | High | Phase 0, 1 |
 | 4 | Hybrid module assembly | **Completed** | Medium | Phase 2, 3 |
 | 5a | Goroutine WAM parallel search | **Completed** | High | Phase 4 |
-| 5b | Order-independent goal parallelism | Planned | Medium | Phase 0 (no WAM needed) |
+| 5b | Order-independent goal parallelism | **Completed** | Medium | Phase 0 (no WAM needed) |
 
 ## Differences from Rust Implementation Plan
 

--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -934,11 +934,11 @@ ensure_var_name_from(_, _, "_").
 
 %% classify_parallelism(+PredIndicator, +Clauses, -Strategy)
 %  Determine the parallelism strategy for a predicate.
-classify_parallelism(_PredIndicator, [Head-Body], goal_parallel(Head, ParallelGoals, ResultGoal)) :-
+classify_parallelism(_PredIndicator, [Head-Body], goal_parallel(Head, ParallelGoals, ResultGoals)) :-
     % Only single-clause predicates for goal parallelism for now
     normalize_goals(Body, Goals),
-    % Expect at least 3 goals: G1, G2, Result
-    append(ParallelGoals, [ResultGoal], Goals),
+    term_variables(Head, HeadVars),
+    partition_parallel_goals(Goals, HeadVars, [], ParallelGoals, ResultGoals),
     ParallelGoals = [_,_|_],
     goals_are_independent(ParallelGoals),
     !.
@@ -947,14 +947,32 @@ classify_parallelism(PredIndicator, _Clauses, clause_parallel) :-
     !.
 classify_parallelism(_, _, sequential).
 
+%% partition_parallel_goals(+Goals, +HeadVars, +SeenVars, -Parallel, -Result)
+%  Collect goals into Parallel list until a data dependency or impurity is found.
+partition_parallel_goals([], _, _, [], []).
+partition_parallel_goals([G|Rest], HeadVars, SeenVars, Parallel, Result) :-
+    is_pure_goal(G),
+    term_variables(G, GVars),
+    % Variables introduced in this goal list (excluding head inputs)
+    exclude_vars_by_identity(GVars, HeadVars, IntroVars),
+    % Check for dependencies: IntroVars must not intersect with SeenVars
+    (   intersection_by_identity(IntroVars, SeenVars, [])
+    ->  Parallel = [G|RestParallel],
+        append(IntroVars, SeenVars, NewSeenVars),
+        partition_parallel_goals(Rest, HeadVars, NewSeenVars, RestParallel, Result)
+    ;   Parallel = [],
+        Result = [G|Rest]
+    ).
+
 %% is_order_independent(+PredIndicator, -Reason)
 %  True if the predicate's clauses can be evaluated in any order.
 is_order_independent(PredIndicator, declared) :-
     order_independent(PredIndicator),
     !.
-is_order_independent(Pred/Arity, proven(Reasons)) :-
+is_order_independent(Module:Pred/Arity, proven(Reasons)) :-
+    !,
     functor(Head, Pred, Arity),
-    findall(Head-Body, user:clause(Head, Body), Clauses),
+    findall(Head-Body, clause(Module:Head, Body), Clauses),
     Clauses \= [],
     % Static analysis for order independence: all goals must be pure
     forall(member(_-Body, Clauses), (
@@ -962,6 +980,8 @@ is_order_independent(Pred/Arity, proven(Reasons)) :-
         forall(member(G, Goals), is_pure_goal(G))
     )),
     Reasons = [pure_goals].
+is_order_independent(Pred/Arity, Reason) :-
+    is_order_independent(user:Pred/Arity, Reason).
 
 %% goals_are_independent(+Goals)
 %  True if a list of goals can be executed in parallel.
@@ -972,16 +992,34 @@ goals_are_independent(Goals) :-
 %% is_pure_goal(+Goal)
 %  True if the goal has no side effects.
 is_pure_goal(Goal) :-
+    Goal =.. [Pred|_],
+    parallel_safe(Pred),
+    !.
+is_pure_goal(Goal) :-
     \+ is_impure_builtin(Goal).
 
+% I/O Impure
 is_impure_builtin(write(_)).
 is_impure_builtin(nl).
 is_impure_builtin(format(_,_)).
+is_impure_builtin(read(_)).
+is_impure_builtin(read_term(_,_)).
+is_impure_builtin(get_char(_)).
+is_impure_builtin(get_code(_)).
+is_impure_builtin(peek_char(_)).
+is_impure_builtin(peek_code(_)).
+% Database Impure
 is_impure_builtin(assert(_)).
 is_impure_builtin(asserta(_)).
 is_impure_builtin(assertz(_)).
 is_impure_builtin(retract(_)).
 is_impure_builtin(retractall(_)).
+% Global Variable Impure
+is_impure_builtin(nb_setval(_,_)).
+is_impure_builtin(b_setval(_,_)).
+% Target-specific / Domain-specific
+is_impure_builtin(send_message(_,_)).
+is_impure_builtin(succ_or_zero(_,_)).
 
 %% goals_have_disjoint_bindings(+Goals)
 %  Conservative check for disjoint bindings.

--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -78,8 +78,18 @@
     % Recursive compile_expression framework
     compile_expression/6,           % +Target, +Goal, +VarMap, -Code, -OutputVars, -VarMapOut
     compile_branch/6,               % +Target, +Branch, +VarMap, -Lines, -OutputVars, -VarMapOut
-    compile_classified_sequence/5   % +Target, +ClassifiedGoals, +VarMap, -Lines, -VarMapOut
+    compile_classified_sequence/5,  % +Target, +ClassifiedGoals, +VarMap, -Lines, -VarMapOut
+
+    % Parallelism analysis
+    classify_parallelism/3,         % +PredIndicator, +Clauses, -Strategy
+    is_order_independent/2,         % +PredIndicator, -Reason
+    order_independent/1,            % Directive
+    parallel_safe/1                 % Directive
 ]).
+
+% Directives
+:- dynamic order_independent/1.
+:- dynamic parallel_safe/1.
 
 %% Multifile hooks for target-specific rendering
 :- multifile render_output_goal/6.      % +Target, +Goal, +VarMap, -Line, -VarName, -VarMapOut
@@ -258,6 +268,14 @@ goal_output_var_simple(_Module:Goal, OutputVar) :-
 goal_output_var_simple(Var is _, Var) :- var(Var), !.
 goal_output_var_simple(Var = _, Var) :- var(Var), !.
 goal_output_var_simple(_ = Var, Var) :- var(Var), !.
+goal_output_var_simple(Goal, OutputVar) :-
+    compound(Goal),
+    Goal =.. [Pred|Args],
+    \+ comparison_op(Pred),
+    \+ type_check_pred(Pred),
+    last(Args, OutputVar),
+    var(OutputVar),
+    !.
 
 %% alternative_output_var(+Alternative, -OutputVar)
 %  Find the last output variable in an alternative branch.
@@ -909,3 +927,99 @@ compile_disj_branches(Target, [Alt|Rest], VarMap, OutputVars, Lines) :-
 ensure_var_name_from(VarMap, Var, Name) :-
     lookup_var(Var, VarMap, Name), !.
 ensure_var_name_from(_, _, "_").
+
+% ============================================================================
+% PARALLELISM ANALYSIS
+% ============================================================================
+
+%% classify_parallelism(+PredIndicator, +Clauses, -Strategy)
+%  Determine the parallelism strategy for a predicate.
+classify_parallelism(_PredIndicator, [Head-Body], goal_parallel(Head, ParallelGoals, ResultGoal)) :-
+    % Only single-clause predicates for goal parallelism for now
+    normalize_goals(Body, Goals),
+    % Expect at least 3 goals: G1, G2, Result
+    append(ParallelGoals, [ResultGoal], Goals),
+    ParallelGoals = [_,_|_],
+    goals_are_independent(ParallelGoals),
+    !.
+classify_parallelism(PredIndicator, _Clauses, clause_parallel) :-
+    is_order_independent(PredIndicator, _),
+    !.
+classify_parallelism(_, _, sequential).
+
+%% is_order_independent(+PredIndicator, -Reason)
+%  True if the predicate's clauses can be evaluated in any order.
+is_order_independent(PredIndicator, declared) :-
+    order_independent(PredIndicator),
+    !.
+is_order_independent(Pred/Arity, proven(Reasons)) :-
+    functor(Head, Pred, Arity),
+    findall(Head-Body, user:clause(Head, Body), Clauses),
+    Clauses \= [],
+    % Static analysis for order independence: all goals must be pure
+    forall(member(_-Body, Clauses), (
+        normalize_goals(Body, Goals),
+        forall(member(G, Goals), is_pure_goal(G))
+    )),
+    Reasons = [pure_goals].
+
+%% goals_are_independent(+Goals)
+%  True if a list of goals can be executed in parallel.
+goals_are_independent(Goals) :-
+    forall(member(G, Goals), is_pure_goal(G)),
+    goals_have_disjoint_bindings(Goals).
+
+%% is_pure_goal(+Goal)
+%  True if the goal has no side effects.
+is_pure_goal(Goal) :-
+    \+ is_impure_builtin(Goal).
+
+is_impure_builtin(write(_)).
+is_impure_builtin(nl).
+is_impure_builtin(format(_,_)).
+is_impure_builtin(assert(_)).
+is_impure_builtin(asserta(_)).
+is_impure_builtin(assertz(_)).
+is_impure_builtin(retract(_)).
+is_impure_builtin(retractall(_)).
+
+%% goals_have_disjoint_bindings(+Goals)
+%  Conservative check for disjoint bindings.
+%  We allow shared inputs, but outputs must be disjoint from all other goals' variables.
+goals_have_disjoint_bindings(Goals) :-
+    maplist(get_goal_io_vars, Goals, GoalIOVars),
+    all_goal_outputs_disjoint(GoalIOVars).
+
+%% get_goal_io_vars(+Goal, -IOVars)
+get_goal_io_vars(Goal, io(Inputs, Outputs)) :-
+    term_variables(Goal, AllVars),
+    (   goal_output_vars(Goal, Outputs) -> true ; Outputs = [] ),
+    exclude_vars_by_identity(AllVars, Outputs, Inputs).
+
+%% all_goal_outputs_disjoint(+GoalIOVars)
+all_goal_outputs_disjoint([]).
+all_goal_outputs_disjoint([io(In1, Out1)|Rest]) :-
+    forall(member(io(In2, Out2), Rest), (
+        intersection_by_identity(Out1, In2, []),
+        intersection_by_identity(Out1, Out2, []),
+        intersection_by_identity(Out2, In1, [])
+    )),
+    all_goal_outputs_disjoint(Rest).
+
+%% exclude_vars_by_identity(+AllVars, +ToExclude, -Result)
+exclude_vars_by_identity([], _, []).
+exclude_vars_by_identity([X|Rest], List, Result) :-
+    (   var_member_by_identity(X, List)
+    ->  Result = RestResult
+    ;   Result = [X|RestResult]
+    ),
+    exclude_vars_by_identity(Rest, List, RestResult).
+
+%% intersection_by_identity(+List1, +List2, -Intersection)
+intersection_by_identity([], _, []).
+intersection_by_identity([X|Rest], List, Result) :-
+    (   var_member_by_identity(X, List)
+    ->  Result = [X|RestResult]
+    ;   Result = RestResult
+    ),
+    intersection_by_identity(Rest, List, RestResult).

--- a/src/unifyweaver/core/clause_body_analysis.pl
+++ b/src/unifyweaver/core/clause_body_analysis.pl
@@ -949,6 +949,10 @@ classify_parallelism(_, _, sequential).
 
 %% partition_parallel_goals(+Goals, +HeadVars, +SeenVars, -Parallel, -Result)
 %  Collect goals into Parallel list until a data dependency or impurity is found.
+%  Invariant: A goal G is independent if its introduced variables (IntroVars = GVars - HeadVars)
+%  do not intersect with any variables seen in previous goals (SeenVars). 
+%  This catches both "output-after-input" and "input-after-output" dependencies because 
+%  SeenVars accumulates all variables from previous parallel goals.
 partition_parallel_goals([], _, _, [], []).
 partition_parallel_goals([G|Rest], HeadVars, SeenVars, Parallel, Result) :-
     is_pure_goal(G),
@@ -992,8 +996,8 @@ goals_are_independent(Goals) :-
 %% is_pure_goal(+Goal)
 %  True if the goal has no side effects.
 is_pure_goal(Goal) :-
-    Goal =.. [Pred|_],
-    parallel_safe(Pred),
+    functor(Goal, Pred, Arity),
+    parallel_safe(Pred/Arity),
     !.
 is_pure_goal(Goal) :-
     \+ is_impure_builtin(Goal).

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -8,6 +8,7 @@
 
 :- module(go_target, [
     compile_predicate_to_go/3,      % +Predicate, +Options, -GoCode
+    compile_goal_parallel_to_go/5,  % +PredSpec, +Head, +ParallelGoals, +ResultGoal, -Code
     compile_facts_to_go/3,          % +Pred, +Arity, -GoCode  -- NEW
     compile_go_pipeline/3,          % +Predicates, +Options, -GoCode
     write_go_program/2,             % +GoCode, +FilePath
@@ -5983,10 +5984,18 @@ compile_predicate_to_go_normal(Pred, Arity, Options, GoCode) :-
         ;   NeedsStrconv = false
         ),
 
+        % Determine if we need sync import
+        (   (   classify_parallelism(Pred/Arity, Clauses, goal_parallel(_, _, _))
+            ;   classify_parallelism(Pred/Arity, Clauses, clause_parallel)
+            )
+        ->  NeedsSync = true
+        ;   NeedsSync = false
+        ),
+
         % Generate complete Go program
         (   IncludePackage ->
             generate_go_program(Pred, Arity, RecordDelim, FieldDelim, Quoting,
-                               EscapeChar, NeedsStdin, NeedsRegexp, NeedsStrings, NeedsStrconv, ScriptBody, GoCode)
+                               EscapeChar, NeedsStdin, NeedsRegexp, NeedsStrings, NeedsStrconv, NeedsSync, ScriptBody, GoCode)
         ;   GoCode = ScriptBody
         )
     ),
@@ -6014,16 +6023,19 @@ build_go_arg_list(N, ArgList) :-
 
 % Single clause
 native_go_clause_body(PredSpec, [Head-Body], Code) :-
-    native_go_clause(PredSpec, Head, Body, Condition, ClauseCode),
-    !,
-    (   Condition == "true"
-    ->  Code = ClauseCode
-    ;   format(string(Code),
+    (   classify_parallelism(PredSpec, [Head-Body], goal_parallel(Head, ParallelGoals, ResultGoal))
+    ->  compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoal, Code)
+    ;   native_go_clause(PredSpec, Head, Body, Condition, ClauseCode),
+        !,
+        (   Condition == "true"
+        ->  Code = ClauseCode
+        ;   format(string(Code),
 '\tif ~w {
 ~w
 \t} else {
 \t\tpanic("No matching clause for ~w")
 \t}', [Condition, ClauseCode, PredSpec])
+        )
     ).
 
 % Multi-clause
@@ -9079,10 +9091,10 @@ ternary_step_op_to_go(_, 'currentAcc += 1').  % Fallback
 %% GO PROGRAM GENERATION
 %% ============================================
 
-%% generate_go_program(+Pred, +Arity, +RecordDelim, +FieldDelim, +Quoting, +EscapeChar, +NeedsStdin, +NeedsRegexp, +NeedsStrings, +NeedsStrconv, +Body, -GoCode)
+%% generate_go_program(+Pred, +Arity, +RecordDelim, +FieldDelim, +Quoting, +EscapeChar, +NeedsStdin, +NeedsRegexp, +NeedsStrings, +NeedsStrconv, +NeedsSync, +Body, -GoCode)
 %  Generate complete Go program with imports and main function
 %
-generate_go_program(Pred, Arity, RecordDelim, FieldDelim, Quoting, EscapeChar, NeedsStdin, NeedsRegexp, NeedsStrings, NeedsStrconv, Body, GoCode) :-
+generate_go_program(Pred, Arity, RecordDelim, FieldDelim, Quoting, EscapeChar, NeedsStdin, NeedsRegexp, NeedsStrings, NeedsStrconv, NeedsSync, Body, GoCode) :-
     atom_string(Pred, PredStr),
 
     % Generate imports based on what's needed
@@ -9097,12 +9109,16 @@ generate_go_program(Pred, Arity, RecordDelim, FieldDelim, Quoting, EscapeChar, N
                 format(atom(Import), '\t"strings"', [])
             ;   NeedsStrconv,
                 format(atom(Import), '\t"strconv"', [])
+            ;   NeedsSync,
+                format(atom(Import), '\t"sync"', [])
             ),
             ImportList),
         list_to_set(ImportList, UniqueImports),  % Remove duplicates
         atomic_list_concat(UniqueImports, '\n', Imports)
     ;   NeedsRegexp ->
         Imports = '\t"fmt"\n\t"regexp"'
+    ;   NeedsSync ->
+        Imports = '\t"fmt"\n\t"sync"'
     ;   % Facts only need fmt
         Imports = '\t"fmt"'
     ),
@@ -20948,3 +20964,60 @@ mutual_dispatch_go(Predicates, Code) :-
             [PredStr, PredStr])
     ), Lines),
     atomic_list_concat(Lines, '\n', Code).
+
+%% compile_goal_parallel_to_go(+PredSpec, +Head, +ParallelGoals, +ResultGoal, -Code)
+compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoal, Code) :-
+    PredSpec = _Pred/_Arity,
+    Head =.. [_|HeadArgs],
+    build_head_varmap(HeadArgs, 1, VarMap0),
+    
+    % Prepare variable map for result goal (includes outputs from parallel goals)
+    maplist(goal_output_vars, ParallelGoals, OutputVarsList),
+    flatten(OutputVarsList, AllOutputVars),
+    unique_vars_by_identity(AllOutputVars, UniqueOutputVars),
+    ensure_vars(UniqueOutputVars, VarMap0, _OutputVarPairs, VarMapFinal),
+    
+    % Generate variable declarations for output variables
+    maplist(gen_var_declaration(VarMapFinal), UniqueOutputVars, Decls),
+    atomic_list_concat(Decls, '\n', DeclsCode),
+    
+    % Compile parallel goals into goroutines
+    maplist(compile_parallel_goal_wrapper(VarMapFinal), ParallelGoals, ParallelGoalCodes),
+    atomic_list_concat(ParallelGoalCodes, '\n', ParallelBlock),
+    
+    % Compile result goal
+    native_go_goal_sequence([ResultGoal], VarMapFinal, _Cond, ResultCode),
+    
+    length(ParallelGoals, N),
+    format(string(Code),
+'~w
+\tvar wg sync.WaitGroup
+\twg.Add(~w)
+~w
+\twg.Wait()
+~w', [DeclsCode, N, ParallelBlock, ResultCode]).
+
+gen_var_declaration(VarMap, Var, Code) :-
+    lookup_var(Var, VarMap, Name),
+    format(string(Code), '\tvar ~w interface{}', [Name]).
+
+compile_parallel_goal_wrapper(VarMap, Goal, Code) :-
+    (   Goal = (Var = Expr)
+    ->  go_expr(Expr, VarMap, GoExpr),
+        lookup_var(Var, VarMap, Name),
+        format(string(Code), '\tgo func() { defer wg.Done(); ~w = ~w }()', [Name, GoExpr])
+    ;   Goal = is(Var, Expr)
+    ->  go_expr(Expr, VarMap, GoExpr),
+        lookup_var(Var, VarMap, Name),
+        format(string(Code), '\tgo func() { defer wg.Done(); ~w = ~w }()', [Name, GoExpr])
+    ;   % Predicate call: p(X, Y) where Y is output
+        Goal =.. [Pred|Args],
+        last(Args, OutVar),
+        append(InArgs, [OutVar], Args),
+        maplist(go_expr_wrapper(VarMap), InArgs, GoInArgs),
+        atomic_list_concat(GoInArgs, ', ', ArgsList),
+        (   lookup_var(OutVar, VarMap, OutName) -> true ; OutName = "_" ),
+        format(string(Code), '\tgo func() { defer wg.Done(); ~w = ~w(~w) }()', [OutName, Pred, ArgsList])
+    ).
+
+go_expr_wrapper(VarMap, Arg, GoExpr) :- go_expr(Arg, VarMap, GoExpr).

--- a/src/unifyweaver/targets/go_target.pl
+++ b/src/unifyweaver/targets/go_target.pl
@@ -6023,8 +6023,8 @@ build_go_arg_list(N, ArgList) :-
 
 % Single clause
 native_go_clause_body(PredSpec, [Head-Body], Code) :-
-    (   classify_parallelism(PredSpec, [Head-Body], goal_parallel(Head, ParallelGoals, ResultGoal))
-    ->  compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoal, Code)
+    (   classify_parallelism(PredSpec, [Head-Body], goal_parallel(Head, ParallelGoals, ResultGoals))
+    ->  compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoals, Code)
     ;   native_go_clause(PredSpec, Head, Body, Condition, ClauseCode),
         !,
         (   Condition == "true"
@@ -20965,13 +20965,13 @@ mutual_dispatch_go(Predicates, Code) :-
     ), Lines),
     atomic_list_concat(Lines, '\n', Code).
 
-%% compile_goal_parallel_to_go(+PredSpec, +Head, +ParallelGoals, +ResultGoal, -Code)
-compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoal, Code) :-
+%% compile_goal_parallel_to_go(+PredSpec, +Head, +ParallelGoals, +ResultGoals, -Code)
+compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoals, Code) :-
     PredSpec = _Pred/_Arity,
     Head =.. [_|HeadArgs],
     build_head_varmap(HeadArgs, 1, VarMap0),
     
-    % Prepare variable map for result goal (includes outputs from parallel goals)
+    % Prepare variable map for result goals (includes outputs from parallel goals)
     maplist(goal_output_vars, ParallelGoals, OutputVarsList),
     flatten(OutputVarsList, AllOutputVars),
     unique_vars_by_identity(AllOutputVars, UniqueOutputVars),
@@ -20985,8 +20985,8 @@ compile_goal_parallel_to_go(PredSpec, Head, ParallelGoals, ResultGoal, Code) :-
     maplist(compile_parallel_goal_wrapper(VarMapFinal), ParallelGoals, ParallelGoalCodes),
     atomic_list_concat(ParallelGoalCodes, '\n', ParallelBlock),
     
-    % Compile result goal
-    native_go_goal_sequence([ResultGoal], VarMapFinal, _Cond, ResultCode),
+    % Compile result goals
+    native_go_goal_sequence(ResultGoals, VarMapFinal, _Cond, ResultCode),
     
     length(ParallelGoals, N),
     format(string(Code),

--- a/tests/test_go_goal_parallel.pl
+++ b/tests/test_go_goal_parallel.pl
@@ -33,11 +33,11 @@ test(classify_declared_independent) :-
     retract(clause_body_analysis:order_independent(my_pred/2)).
 
 test(parallel_safe_hook) :-
-    assertz(clause_body_analysis:parallel_safe(my_impure_looking_pred)),
+    assertz(clause_body_analysis:parallel_safe(my_impure_looking_pred/2)),
     Clause = p(X, Y) - (my_impure_looking_pred(X, Y1), g2(X, Y2), Y is Y1 + Y2),
     classify_parallelism(p/2, [Clause], Strategy),
     assertion(Strategy = goal_parallel(_, [_,_], _)),
-    retract(clause_body_analysis:parallel_safe(my_impure_looking_pred)).
+    retract(clause_body_analysis:parallel_safe(my_impure_looking_pred/2)).
 
 test(compile_parallel_code) :-
     Clause = node_score(X, Y) - (feature_a(X, Y1), feature_b(X, Y2), Y is Y1 + Y2),

--- a/tests/test_go_goal_parallel.pl
+++ b/tests/test_go_goal_parallel.pl
@@ -9,7 +9,10 @@ test(classify_parallel_simple) :-
     % p(X, Y) :- g1(X, Y1), g2(X, Y2), Y is Y1 + Y2.
     Clause = p(X, Y) - (g1(X, Y1), g2(X, Y2), Y is Y1 + Y2),
     classify_parallelism(p/2, [Clause], Strategy),
-    assertion(Strategy = goal_parallel(p(X, Y), [g1(X, Y1), g2(X, Y2)], Y is Y1 + Y2)).
+    assertion(Strategy = goal_parallel(Head, Pars, Results)),
+    assertion(functor(Head, p, 2)),
+    assertion(length(Pars, 2)),
+    assertion(Results = [_ is _ + _]).
 
 test(classify_parallel_impure) :-
     % p(X) :- write(X), g1(X).
@@ -23,12 +26,25 @@ test(classify_parallel_dependent) :-
     classify_parallelism(p/2, [Clause], Strategy),
     assertion(Strategy = sequential).
 
+test(classify_declared_independent) :-
+    assertz(clause_body_analysis:order_independent(my_pred/2)),
+    classify_parallelism(my_pred/2, [h1-b1, h2-b2], Strategy),
+    assertion(Strategy = clause_parallel),
+    retract(clause_body_analysis:order_independent(my_pred/2)).
+
+test(parallel_safe_hook) :-
+    assertz(clause_body_analysis:parallel_safe(my_impure_looking_pred)),
+    Clause = p(X, Y) - (my_impure_looking_pred(X, Y1), g2(X, Y2), Y is Y1 + Y2),
+    classify_parallelism(p/2, [Clause], Strategy),
+    assertion(Strategy = goal_parallel(_, [_,_], _)),
+    retract(clause_body_analysis:parallel_safe(my_impure_looking_pred)).
+
 test(compile_parallel_code) :-
     Clause = node_score(X, Y) - (feature_a(X, Y1), feature_b(X, Y2), Y is Y1 + Y2),
-    classify_parallelism(node_score/2, [Clause], goal_parallel(Head, ParallelGoals, ResultGoal)),
-    compile_goal_parallel_to_go(node_score/2, Head, ParallelGoals, ResultGoal, Code),
-    format('Generated code:~n~s~n', [Code]),
+    classify_parallelism(node_score/2, [Clause], goal_parallel(Head, ParallelGoals, ResultGoals)),
+    compile_goal_parallel_to_go(node_score/2, Head, ParallelGoals, ResultGoals, Code),
     assertion(sub_string(Code, _, _, _, 'sync.WaitGroup')),
-    assertion(sub_string(Code, _, _, _, 'go func()')).
+    assertion(sub_string(Code, _, _, _, 'go func()')),
+    assertion(sub_string(Code, _, _, _, 'wg.Wait()')).
 
 :- end_tests(go_goal_parallel).

--- a/tests/test_go_goal_parallel.pl
+++ b/tests/test_go_goal_parallel.pl
@@ -1,0 +1,34 @@
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/core/clause_body_analysis').
+:- use_module('../src/unifyweaver/targets/go_target').
+
+:- begin_tests(go_goal_parallel).
+
+test(classify_parallel_simple) :-
+    % p(X, Y) :- g1(X, Y1), g2(X, Y2), Y is Y1 + Y2.
+    Clause = p(X, Y) - (g1(X, Y1), g2(X, Y2), Y is Y1 + Y2),
+    classify_parallelism(p/2, [Clause], Strategy),
+    assertion(Strategy = goal_parallel(p(X, Y), [g1(X, Y1), g2(X, Y2)], Y is Y1 + Y2)).
+
+test(classify_parallel_impure) :-
+    % p(X) :- write(X), g1(X).
+    Clause = p(X) - (write(X), g1(X)),
+    classify_parallelism(p/1, [Clause], Strategy),
+    assertion(Strategy = sequential).
+
+test(classify_parallel_dependent) :-
+    % p(X, Y) :- g1(X, Z), g2(Z, Y).
+    Clause = p(X, Y) - (g1(X, Z), g2(Z, Y)),
+    classify_parallelism(p/2, [Clause], Strategy),
+    assertion(Strategy = sequential).
+
+test(compile_parallel_code) :-
+    Clause = node_score(X, Y) - (feature_a(X, Y1), feature_b(X, Y2), Y is Y1 + Y2),
+    classify_parallelism(node_score/2, [Clause], goal_parallel(Head, ParallelGoals, ResultGoal)),
+    compile_goal_parallel_to_go(node_score/2, Head, ParallelGoals, ResultGoal, Code),
+    format('Generated code:~n~s~n', [Code]),
+    assertion(sub_string(Code, _, _, _, 'sync.WaitGroup')),
+    assertion(sub_string(Code, _, _, _, 'go func()')).
+
+:- end_tests(go_goal_parallel).


### PR DESCRIPTION
## Summary

Successfully implemented the core WAM-to-Go transpilation pipeline, including parallel search capabilities and improved term handling.

## Accomplishments

### Phase 2: WAM Instruction Lowering to Go
- Implemented a robust WAM assembly parser `wam_lines_to_go/4` in `wam_go_target.pl`.
- Created mappings for all standard WAM instructions to Go struct literals.
- Handled complex instructions like `switch_on_constant` and `switch_on_structure` with nested case data.

### Phase 3: step_wam/3 Transpilation via Type Switch
- Implemented `compile_step_wam_to_go/2` which generates a Go `Step()` method.
- Used Go's type switch (`switch i := instr.(type)`) for efficient instruction dispatch.
- Implemented the core unification and control logic for all WAM instructions in Go.

### Phase 4: Hybrid Module Assembly
- Created `write_wam_go_project/3` to automate the creation of a full Go module.
- Implemented a suite of Mustache templates in `templates/targets/go_wam/` for Go boilerplate (Value system, State, Instructions, Runtime).
- Integrated the hybrid compilation strategy: attempts native Go lowering first, falling back to WAM for complex predicates.
- Fixed `include_package(false)` usage to ensure syntactically correct `lib.go`.

### Phase 5a: Goroutine-Based Parallel Search
- Implemented `WamState.Clone()` and `WamState.ForkAtChoicePoint()` for state branching.
- Added `WamState.RunParallel(maxWorkers)` using goroutines and a worker semaphore to explore choice points concurrently.
- Fixed a race condition in `RunParallel` by ensuring semaphore tokens are passed through to child goroutines.
- Added `WamState.CollectResults()` to gather values from argument registers.
- Improved the WAM runtime with `Compound` term support and basic builtin execution (`write/1`, `nl/0`, numeric comparisons).
- Implemented robust recursive structural unification (`WamState.Unify`) for complex terms.
- Refined halt logic using a dedicated `Halted` field instead of a PC sentinel.

### Phase 5b: Order-Independent Goal Parallelism
- Added support for `:- order_independent/1` and `:- parallel_safe/1` directives in the clause body analysis pipeline.
- Implemented `classify_parallelism/3` to determine if a predicate's goals can be run in parallel based on purity and disjoint variable bindings.
- Updated Go native lowering logic to emit `sync.WaitGroup` and goroutines for predicates classified as `goal_parallel`.
- Improved output variable detection in `goal_output_var_simple/2` to support general predicate calls.

## Files Created/Modified
- `src/unifyweaver/core/clause_body_analysis.pl`: Analysis logic for goal parallelism and directives.
- `src/unifyweaver/targets/go_target.pl`: Go code generation for goroutine-based goal parallelism.
- `templates/targets/go_wam/`: Go module templates.
- `tests/test_wam_go_generator.pl`: Unit tests for instruction lowering.
- `tests/test_go_goal_parallel.pl`: Unit tests for goal parallelism analysis and code generation.
- `PHASE_WAM_GO_COMPLETED.md`: This completion report.
- `docs/design/WAM_GO_TRANSPILATION_IMPLEMENTATION_PLAN.md`: Updated design plan.

## Verification Results
- Generated a complete Go project from a test predicate.
- Verified that the generated code is syntactically correct and compiles using `go build`.
- Confirmed that parallel search helpers are correctly generated and the project is self-contained.
- Added a new unit test suite `tests/test_wam_go_generator.pl` covering instruction lowering and parser robustness.

## Next Steps
- **Phase 5b:** Implement order-independent goal parallelism.
- Expand builtin support in `WamState.executeBuiltin` (e.g., `is/2`, arithmetic).
- Add more comprehensive integration tests for parallel execution results.
