### PR TITLE
bench(prolog): add seeded effective-distance benchmark

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -12,47 +12,49 @@ and specification.
 
 ## Benchmark Results
 
-### C# Query Engine vs DFS Pipelines
+### Seeded Prolog and Query Engine vs DFS Pipelines
 
-The C# parameterized query engine (`PathAwareTransitiveClosureNode`) is
-dramatically faster than all DFS (depth-first search) pipeline
-implementations, including compiled Rust:
+The effective-distance benchmark now has a seeded Prolog path that
+reuses `category_ancestor/4` once per unique category seed and then
+aggregates distances per article. On the current benchmark surface, that
+seeded Prolog path is faster than the current C# query-engine path while
+still matching its output exactly.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **C# Query Engine** | 0.60s | **0.41s** | **1.25s** | **3.13s** |
-| C# DFS pipeline | **0.44s** | 1.25s | 5.36s | 9.96s |
-| Rust DFS pipeline | — | 1.36s | 7.33s | 13.68s |
-| Go DFS pipeline | 0.43s | 1.96s | 11.36s | 18.71s |
-| Codon DFS pipeline | 0.67s | 2.55s | 10.98s | 22.14s |
-| CPython DFS pipeline | 0.73s | 2.93s | 15.71s | — |
-| Prolog | 1.26s | — | — | — |
-| AWK | 2.46s | — | — | — |
+| **Prolog seeded** | **0.36s** | **0.30s** | **1.11s** | **2.48s** |
+| C# Query Engine | 0.61s | 0.42s | 1.33s | 3.24s |
+| C# DFS pipeline | 0.45s | 1.25s | 5.70s | 10.25s |
+| Rust DFS pipeline | 0.36s | 1.45s | 7.71s | 14.45s |
+| Go DFS pipeline | 0.48s | 2.10s | 11.88s | 19.91s |
 
-**Speedup of C# Query Engine over DFS pipelines:**
+**Speedup of seeded Prolog over the current C# query engine:**
 
-| vs Target | 300 art | 1K art | 5K art | 10K art |
-|-----------|---------|--------|--------|---------|
-| vs C# DFS | 0.7x | 3.1x | 4.3x | 3.2x |
-| vs Rust | — | 3.3x | 5.9x | 4.4x |
-| vs Go | 1.1x | 8.9x | 17.2x | 12.4x |
+| Scale | Speedup |
+|-------|---------|
+| 300 art | 1.67x |
+| 1K art | 1.39x |
+| 5K art | 1.20x |
+| 10K art | 1.30x |
 
 Semantic note:
 
 - The current C# query-engine benchmark path preserves per-path cycle
   checks without collapsing distinct simple paths that happen to reach
   the same ancestor with the same hop count.
-- `benchmark_effective_distance.py` compares the query-engine output
-  against the C# DFS reference and reports the result via
-  `query_vs_csharp_dfs`.
+- `benchmark_effective_distance.py` now compares the query-engine output
+  against both the C# DFS reference and seeded Prolog, reporting
+  `query_vs_csharp_dfs` and `query_vs_prolog_seeded`.
 - Current post-fix runs report `query_vs_csharp_dfs = match` at
   `300`, `1k`, `5k`, and `10k`.
+- Current seeded Prolog runs also report `query_vs_prolog_seeded = match`
+  at `300`, `1k`, `5k`, and `10k`.
 
-### Why the Query Engine Wins
+### Why Seeded Closures Win
 
-The query engine's advantage comes from **seed deduplication**: many
-articles share the same categories, so the engine computes ancestors
-once per unique category seed, not once per article.
+The main advantage comes from **seed deduplication**: many articles
+share the same categories, so the benchmark computes ancestors once per
+unique category seed, not once per article.
 
 | Scale | Articles | Unique category seeds | Redundancy factor |
 |-------|----------|-----------------------|-------------------|
@@ -62,14 +64,15 @@ once per unique category seed, not once per article.
 | 10K | 10,000 | 888 | ~11x |
 
 At 1K scale, 1000 articles map to only 89 unique category seeds — the
-engine does ~11x less seed expansion work. Even with full per-path
-semantics restored, the precomputed ancestor index still makes
+seeded benchmark does ~11x less seed expansion work. Even with full
+per-path semantics restored, the precomputed ancestor index still makes
 per-article aggregation much cheaper than rerunning DFS from scratch for
-each article.
+each article. The current Prolog effective-distance path now uses that
+same strategy directly.
 
 ### DFS Pipeline Execute Time Scaling
 
-For completeness, the original DFS pipeline comparison:
+For historical context, the original DFS-only pipeline comparison:
 
 | Target | 300 art | 1K art | 5K art | 10K art | Trend |
 |--------|---------|--------|--------|---------|-------|
@@ -92,41 +95,41 @@ For completeness, the original DFS pipeline comparison:
 
 ### Key Findings
 
-1. **The C# Query Engine remains the fastest target in the intended
-   large-scale regime** — after restoring full per-path semantics, it is
-   still 3.1x faster than C# DFS at `1k`, 4.3x faster at `5k`, and 3.2x
-   faster at `10k`.
+1. **Seeded Prolog is currently the fastest effective-distance path on
+   this benchmark surface** — it beats the current C# query-engine path
+   by `1.67x` at `300`, `1.39x` at `1k`, `1.20x` at `5k`, and `1.30x`
+   at `10k`.
 
-2. **At small scale, the semantic fix makes the query engine slightly
-   slower than C# DFS** — at `300`, the query engine is `0.60s` vs
-   `0.44s` for C# DFS because it now preserves full path multiplicity
-   instead of collapsing equal `(ancestor, hops)` tuples.
+2. **The C# query engine still beats the DFS baselines comfortably** —
+   it is `2.97x` faster than C# DFS at `1k`, `4.28x` at `5k`, and
+   `3.17x` at `10k`.
 
-3. **Among DFS pipelines, C# still leads at scale** — at `10k` it is
-   faster than Rust DFS (`9.96s` vs `13.68s`) and much faster than Go.
+3. **Among the compiled DFS targets, C# still leads at scale** — at
+   `10k` it is faster than Rust DFS (`10.25s` vs `14.45s`) and much
+   faster than Go DFS (`19.91s`).
 
-4. **The query engine still beats Rust DFS comfortably at scale** —
-   `3.3x` faster at `1k`, `5.9x` at `5k`, and `4.4x` at `10k`.
+4. **Seed reuse is the real win; branch pruning is not** — on the new
+   seeded Prolog effective-distance benchmark, the pruned and unpruned
+   variants have the same tuple count and inferences, with timing
+   differences that stay within noise.
 
-5. **Go falls behind at scale** — `map[string]bool` copy-on-branch
-   semantics are heavier than C#'s `HashSet`. Go is 2x slower than C#
-   at 10K.
+5. **The current C# query-engine path is still materializing far more
+   tuples than seeded Prolog on this workload** — at `10k`, the C#
+   query run emits `3616699` tuples versus `105287` for seeded Prolog.
 
-6. **Codon approaches Go** — at 5K they were nearly tied (11.0s vs 11.4s).
-   At 10K Go pulled ahead again (18.7s vs 22.1s), but the gap is narrowing.
-
-7. **Prolog needs demand analysis** to compete — naive all-simple-paths
-   exploration is combinatorially explosive. Design docs for this optimization
-   are in `docs/proposals/PROLOG_TARGET_DEMAND_ANALYSIS_*.md`.
+6. **The next effective-distance step is not more pruning** — it is
+   improving the retained-state strategy for accumulation-style
+   workloads, since this benchmark is already showing that seeded reuse
+   alone carries most of the benefit.
 
 ### Target Recommendations by Audience
 
 | Audience | Recommended Target | Why |
 |----------|-------------------|-----|
-| Enterprise / .NET | C# Query Engine | Fastest at all scales, purpose-built |
-| ML / Data Science | Codon | Stay in Python, competitive performance |
+| SWI / Prolog-first | Seeded Prolog | Fastest current effective-distance path, stays close to source semantics |
+| Enterprise / .NET | C# Query Engine | Strong seeded runtime, broad query-engine surface |
 | Cloud / DevOps | Go | Fast compile, good ecosystem |
-| Systems / Embedded | Rust | No runtime overhead, fastest DFS at small scale |
+| Systems / Embedded | Rust | No runtime overhead, strong DFS baseline |
 
 ## Data Provenance
 
@@ -182,7 +185,7 @@ Tables:
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
 | `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
-| `benchmark_effective_distance.py` | Rebuild and time the C# query engine vs C#/Rust/Go DFS binaries |
+| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, seeded Prolog, and C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -192,6 +195,8 @@ Tables:
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
+| `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse with optional branch pruning |
+| `benchmark_prolog_effective_distance.py` | Compare seeded Prolog effective-distance scripts with and without branch pruning and report phase/work metrics |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
 | `benchmark_prolog_seeded_min_closure.py` | Compare seeded Prolog `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
 | `generate_prolog_weighted_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog weighted-shortest-path scripts for seeded `all` vs mode-directed `min` closure |
@@ -221,10 +226,10 @@ Packaging note:
   - rounded float row outputs in common 2-column and 3-column forms
 - workloads can still keep custom normalization when their semantics or
   ordering rules are genuinely different
-- the seeded Prolog shortest-path and weighted-shortest-path benchmarks
-  now load `facts.pl` at runtime from a small generated driver instead
-  of inlining facts into the generated script, so `load_ms` is reported
-  separately from `query_ms`
+- the seeded Prolog effective-distance, shortest-path, and
+  weighted-shortest-path benchmarks now load `facts.pl` at runtime from
+  a small generated driver instead of inlining facts into the generated
+  script, so `load_ms` is reported separately from `query_ms`
 
 ## Usage
 
@@ -251,7 +256,12 @@ go build -o bench pipelines/effective_distance.go
 # Re-run the current non-regression benchmark
 python examples/benchmark/benchmark_effective_distance.py \
     --scales 300,1k,5k,10k \
-    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded
+
+# Compare seeded effective-distance Prolog with and without branch pruning
+python examples/benchmark/benchmark_prolog_effective_distance.py \
+    --scales 300,1k,5k,10k \
+    --targets prolog-seeded,prolog-pruned
 
 # Compare minimum-hop shortest path across query engine and DFS targets
 python examples/benchmark/benchmark_shortest_path_cross_target.py \
@@ -325,7 +335,8 @@ The current comparison surface across query and non-query targets is:
   - dependency longest depth
   - positive weighted minimum path distance
   - category influence propagation
-- Prolog seeded `min`:
+- Prolog seeded closures:
+  - all-path effective distance
   - minimum hop distance
   - positive weighted minimum path distance
 
@@ -339,12 +350,37 @@ The benchmark split is now:
   - `benchmark_weighted_shortest_path_cross_target.py`
   - `benchmark_category_influence_cross_target.py`
 - Prolog target:
+  - `benchmark_prolog_effective_distance.py`
   - `benchmark_prolog_branch_pruning.py`
   - `benchmark_prolog_seeded_min_closure.py`
   - `benchmark_prolog_weighted_min_closure.py`
 - C# query-engine internal mode comparison:
   - `benchmark_shortest_path_to_root.py`
   - `benchmark_weighted_shortest_path.py`
+
+### Prolog Effective-Distance Seeded Results
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_prolog_effective_distance.py \
+    --scales 300,1k,5k,10k --repetitions 1
+```
+
+Latest local results:
+
+| Scale | Seeded | Pruned | Output Match | Note |
+|-------|--------|--------|--------------|------|
+| 300 | 0.373s | 0.399s | match | pruning overhead slightly visible |
+| 1k | 0.320s | 0.330s | match | effectively tied, seeded slightly ahead |
+| 5k | 1.079s | 1.122s | match | pruning still neutral to slightly slower |
+| 10k | 2.589s | 2.486s | match | tiny win for pruned, still same tuple count |
+
+Current interpretation:
+
+- seeded closure reuse is the real win on effective distance
+- branch pruning does not currently reduce tuple count or inferences on this workload
+- the pruned and unpruned seeded variants are semantically identical at all tested scales
 
 ### Prolog Branch-Pruning Results
 

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Benchmark the effective-distance workload for the C# query engine and the
-compiled DFS pipelines.
+Benchmark the effective-distance workload for the C# query engine, seeded
+Prolog, and the compiled DFS pipelines.
 
 Default targets:
   - csharp-query  : current C# query runtime using PathAwareTransitiveClosureNode
+  - prolog-seeded : generated Prolog using seeded counted-closure reuse
   - csharp-dfs    : generated C# DFS pipeline
   - rust-dfs      : generated Rust DFS pipeline
 
@@ -15,7 +16,6 @@ benchmark scales, and reports median wall-clock times plus output agreement.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import statistics
 import sys
 import tempfile
@@ -28,8 +28,10 @@ from benchmark_common import (
     build_csharp_package,
     build_go_binary,
     build_rust_binary,
+    digest_normalized_output,
     find_result,
     group_results_by_scale,
+    normalize_three_column_float_rows,
     print_match_status,
     print_pair_match_status,
     print_phase_metrics,
@@ -43,6 +45,7 @@ from benchmark_common import (
 ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
+PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
 
 
 @dataclass
@@ -68,8 +71,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--targets",
-        default="csharp-query,csharp-dfs,rust-dfs",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned",
     )
     parser.add_argument(
         "--repetitions",
@@ -109,28 +112,45 @@ def build_go_dfs(root: Path) -> list[str]:
     )
 
 
-def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
-    scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
-    edge_path = scale_dir / "category_parent.tsv"
-    article_path = scale_dir / "article_category.tsv"
+def build_prolog_effective_distance(root: Path, scale: str, variant: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    script_path = root / f"prolog_{variant}" / scale / f"effective_distance_{variant}.pl"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(PROLOG_GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            variant,
+        ]
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
 
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
     times: list[float] = []
     last_stdout = ""
     last_stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run_command(command + [str(edge_path), str(article_path)])
+        if target.startswith("prolog-"):
+            result = run_command(command)
+        else:
+            scale_dir = require_file(BENCH_DIR / scale / "category_parent.tsv").parent
+            edge_path = scale_dir / "category_parent.tsv"
+            article_path = scale_dir / "article_category.tsv"
+            result = run_command(command + [str(edge_path), str(article_path)])
         elapsed = time.perf_counter() - started
         times.append(elapsed)
         last_stdout = result.stdout
         last_stderr = result.stderr
 
-    lines = last_stdout.splitlines()
-    header = lines[:1]
-    body = sorted(lines[1:])
-    normalized = "\n".join(header + body)
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    rows = len(body)
+    normalized = normalize_three_column_float_rows(last_stdout, decimals=6)
+    digest, rows = digest_normalized_output(normalized)
     return RunResult(target=target, scale=scale, times=times, stdout_sha256=digest, row_count=rows, stderr=last_stderr)
 
 
@@ -142,14 +162,22 @@ def print_summary(results: list[RunResult]) -> None:
         qe = find_result(entries, "csharp-query")
         csharp_dfs = find_result(entries, "csharp-dfs")
         rust_dfs = find_result(entries, "rust-dfs")
-        dfs_like = [item for item in entries if item.target != "csharp-query"]
+        prolog_seeded = find_result(entries, "prolog-seeded")
+        prolog_pruned = find_result(entries, "prolog-pruned")
+        dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
             print_match_status(scale, "dfs_outputs", dfs_like)
         print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
+        print_pair_match_status(scale, "query_vs_prolog_seeded", qe, prolog_seeded)
+        print_pair_match_status(scale, "query_vs_prolog_pruned", qe, prolog_pruned)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
+        print_speedup(scale, "speedup_vs_prolog_seeded", prolog_seeded, qe)
+        print_speedup(scale, "speedup_vs_prolog_pruned", prolog_pruned, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
+        print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
+        print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -190,13 +218,23 @@ def main() -> int:
                 commands[target] = build_rust_dfs(temp_root)
             elif target == "go-dfs":
                 commands[target] = build_go_dfs(temp_root)
+            elif target == "prolog-seeded":
+                continue
+            elif target == "prolog-pruned":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
         results: list[RunResult] = []
         for scale in scales:
             for target in targets:
-                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+                if target == "prolog-seeded":
+                    command = build_prolog_effective_distance(temp_root, scale, "seeded")
+                elif target == "prolog-pruned":
+                    command = build_prolog_effective_distance(temp_root, scale, "pruned")
+                else:
+                    command = commands[target]
+                results.append(benchmark_target(command, scale, args.repetitions, target))
 
         print_summary(results)
         if args.keep_temp:

--- a/examples/benchmark/benchmark_prolog_effective_distance.py
+++ b/examples/benchmark/benchmark_prolog_effective_distance.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Benchmark seeded effective-distance closure generation for the Prolog target.
+
+Targets:
+  - prolog-seeded : generated Prolog using seeded counted closure reuse
+  - prolog-pruned : generated Prolog using seeded closure reuse plus branch pruning
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_three_column_float_rows,
+    print_pair_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_effective_distance_benchmark.pl"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="prolog-seeded,prolog-pruned",
+        help="Comma-separated targets: prolog-seeded,prolog-pruned",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    if shutil.which("swipl") is None:
+        print("skip prolog effective-distance benchmark: swipl not found", file=sys.stderr)
+        return []
+    supported = {"prolog-seeded", "prolog-pruned"}
+    targets: list[str] = []
+    for target in requested:
+        if target not in supported:
+            raise ValueError(f"unsupported target: {target}")
+        targets.append(target)
+    return targets
+
+
+def scale_facts_path(scale: str) -> Path:
+    return require_file(BENCH_DIR / scale / "facts.pl")
+
+
+def build_generated_script(root: Path, scale: str, variant: str, script_name: str) -> list[str]:
+    facts_path = scale_facts_path(scale)
+    script_path = root / scale / script_name
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command, cwd=ROOT)
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_three_column_float_rows(stdout, decimals=6)
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        seeded = find_result(entries, "prolog-seeded")
+        pruned = find_result(entries, "prolog-pruned")
+        print_pair_match_status(scale, "seeded_vs_pruned", seeded, pruned)
+        print_speedup(scale, "speedup_pruned_vs_seeded", seeded, pruned)
+        print_phase_metrics(scale, "seeded_metrics", seeded)
+        print_phase_metrics(scale, "pruned_metrics", pruned)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-prolog-effective-distance-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-prolog-effective-distance-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        results: list[RunResult] = []
+        for scale in scales:
+            commands: dict[str, list[str]] = {}
+            for target in targets:
+                if target == "prolog-seeded":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "seeded", "effective_distance_seeded.pl"
+                    )
+                elif target == "prolog-pruned":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "pruned", "effective_distance_pruned.pl"
+                    )
+                else:
+                    raise ValueError(f"unsupported target: {target}")
+
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}", file=sys.stderr)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
@@ -1,0 +1,157 @@
+:- initialization(main, main).
+
+:- use_module('../../src/unifyweaver/targets/prolog_target').
+
+benchmark_workload_path(Path) :-
+    source_file(benchmark_workload_path(_), ThisFile),
+    file_directory_name(ThisFile, Here),
+    directory_file_path(Here, 'effective_distance.pl', Path).
+
+main :-
+    current_prolog_flag(argv, Argv),
+    (   Argv = [FactsPath, OutputPath, VariantAtom]
+    ->  true
+    ;   format(user_error,
+            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned>~n',
+            []),
+        halt(1)
+    ),
+    parse_variant(VariantAtom, Variant, Options),
+    benchmark_workload_path(WorkloadPath),
+    absolute_file_name(FactsPath, FactsAbsPath, [access(read)]),
+    load_files(WorkloadPath, [silent(true)]),
+    retractall(user:mode(category_ancestor(_, _, _, _))),
+    assertz(user:mode(category_ancestor(-, +, -, +))),
+    Predicates = [
+        dimension_n/1,
+        max_depth/1,
+        category_ancestor/4
+    ],
+    prolog_target:generate_prolog_script(Predicates, Options, BaseScriptCode),
+    benchmark_driver_code(Variant, FactsAbsPath, DriverCode),
+    atomic_list_concat([BaseScriptCode, DriverCode], '\n\n', ScriptCode),
+    prolog_target:write_prolog_script(ScriptCode, OutputPath).
+
+parse_variant('seeded', seeded, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(false)
+    ]) :-
+    !.
+parse_variant('pruned', pruned, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(auto),
+        min_closure(false)
+    ]) :-
+    !.
+parse_variant(Atom, _, _) :-
+    format(user_error,
+        'Unsupported effective-distance benchmark variant: ~w (expected seeded or pruned)~n',
+        [Atom]),
+    halt(1).
+
+benchmark_driver_code(Variant, FactsPath, Code) :-
+    format(atom(FactsPathLine), 'facts_path(~q).', [FactsPath]),
+    benchmark_mode_line(Variant, ModeLine),
+    Lines = [
+        ':- use_module(library(aggregate)).',
+        ':- use_module(library(lists)).',
+        ':- dynamic bench_seed_hops/3.',
+        FactsPathLine,
+        '',
+        'load_benchmark_facts :-',
+        '    facts_path(Path),',
+        '    load_files(Path, [silent(true)]).',
+        '',
+        'collect_seed_categories(Seeds) :-',
+        '    setof(Cat, Article^article_category(Article, Cat), Seeds).',
+        '',
+        'collect_articles(Articles) :-',
+        '    setof(Article, Cat^article_category(Article, Cat), Articles).',
+        '',
+        'clear_seed_hops_index :-',
+        '    retractall(bench_seed_hops(_, _, _)).',
+        '',
+        'seed_hops_query(Cat, Root, Hops) :-',
+        '    category_ancestor(Cat, Root, Hops, [Cat]).',
+        '',
+        'build_seed_hops_index(Root, SeedCount, TupleCount) :-',
+        '    clear_seed_hops_index,',
+        '    collect_seed_categories(Seeds),',
+        '    length(Seeds, SeedCount),',
+        '    forall(',
+        '        member(Cat, Seeds),',
+        '        forall(',
+        '            seed_hops_query(Cat, Root, Hops),',
+        '            assertz(bench_seed_hops(Cat, Root, Hops))',
+        '        )',
+        '    ),',
+        '    aggregate_all(count, bench_seed_hops(_, _, _), TupleCount).',
+        '',
+        'seeded_article_root_hops(Article, Root, 1) :-',
+        '    article_category(Article, Root).',
+        'seeded_article_root_hops(Article, Root, Hops) :-',
+        '    article_category(Article, Cat),',
+        '    Cat \\= Root,',
+        '    bench_seed_hops(Cat, Root, CatHops),',
+        '    Hops is CatHops + 1.',
+        '',
+        'compute_effective_distance_results(Root, Results) :-',
+        '    collect_articles(Articles),',
+        '    dimension_n(N),',
+        '    NegN is -N,',
+        '    findall(Deff-Article,',
+        '        (   member(Article, Articles),',
+        '            aggregate_all(sum(W),',
+        '                (   seeded_article_root_hops(Article, Root, Hops),',
+        '                    W is Hops ** NegN',
+        '                ),',
+        '                WeightSum),',
+        '            WeightSum > 0,',
+        '            InvN is -1 / N,',
+        '            Deff is WeightSum ** InvN',
+        '        ),',
+        '        Pairs),',
+        '    sort(Pairs, Results).',
+        '',
+        'print_effective_distance_results(Root, Results) :-',
+        '    format("article\\troot_category\\teffective_distance~n"),',
+        '    forall(',
+        '        member(Distance-Article, Results),',
+        '        format("~w\\t~w\\t~6f~n", [Article, Root, Distance])',
+        '    ).',
+        '',
+        'run_benchmark :-',
+        '    statistics(walltime, [LoadStartMs, _]),',
+        '    load_benchmark_facts,',
+        '    statistics(walltime, [LoadEndMs, _]),',
+        '    statistics(inferences, InferencesBefore),',
+        '    root_category(Root),',
+        '    build_seed_hops_index(Root, SeedCount, TupleCount),',
+        '    statistics(walltime, [QueryEndMs, _]),',
+        '    compute_effective_distance_results(Root, Results),',
+        '    statistics(walltime, [AggEndMs, _]),',
+        '    print_effective_distance_results(Root, Results),',
+        '    statistics(inferences, InferencesAfter),',
+        '    LoadMs is LoadEndMs - LoadStartMs,',
+        '    QueryMs is QueryEndMs - LoadEndMs,',
+        '    AggregationMs is AggEndMs - QueryEndMs,',
+        '    TotalMs is AggEndMs - LoadStartMs,',
+        '    Inferences is InferencesAfter - InferencesBefore,',
+        '    length(Results, ArticleCount),',
+        ModeLine,
+        '    format(user_error, ''load_ms=~w~n'', [LoadMs]),',
+        '    format(user_error, ''query_ms=~w~n'', [QueryMs]),',
+        '    format(user_error, ''aggregation_ms=~w~n'', [AggregationMs]),',
+        '    format(user_error, ''total_ms=~w~n'', [TotalMs]),',
+        '    format(user_error, ''inferences=~w~n'', [Inferences]),',
+        '    format(user_error, ''seed_count=~w~n'', [SeedCount]),',
+        '    format(user_error, ''tuple_count=~w~n'', [TupleCount]),',
+        '    format(user_error, ''article_count=~w~n'', [ArticleCount]).'
+    ],
+    atomic_list_concat(Lines, '\n', Code).
+
+benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
+benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').


### PR DESCRIPTION
  ## Summary

  This adds a seeded Prolog benchmark path for the effective-distance workload and integrates it into the main cross-
  target benchmark.

  The new Prolog path reuses the counted `category_ancestor/4` closure once per unique category seed and then performs
  effective-distance aggregation per article. It does not introduce a new Prolog target optimization yet; it gives us a
  clean benchmark surface to measure what seeded reuse alone buys on the effective-distance workload.

  ## What Changed

  - added `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
    - generates standalone SWI-Prolog effective-distance scripts
    - supports:
      - `seeded`: seeded counted-closure reuse
      - `pruned`: seeded counted-closure reuse plus existing branch pruning
    - loads `facts.pl` at runtime from a small driver
    - reports:
      - `load_ms`
      - `query_ms`
      - `aggregation_ms`
      - `total_ms`
      - `inferences`
      - `seed_count`
      - `tuple_count`
      - `article_count`
  - added `examples/benchmark/benchmark_prolog_effective_distance.py`
    - compares `prolog-seeded` vs `prolog-pruned`
    - verifies output equality
    - prints timing and phase/work metrics
  - extended `examples/benchmark/benchmark_effective_distance.py`
    - now supports `prolog-seeded` and `prolog-pruned`
    - compares seeded Prolog directly against:
      - `csharp-query`
      - `csharp-dfs`
      - `rust-dfs`
      - `go-dfs`
  - updated `examples/benchmark/README.md`
    - documents the new seeded Prolog effective-distance path
    - updates the effective-distance benchmark story with current results
    - records that seeded reuse, not branch pruning, is the meaningful lever on this workload

  ## Why

  The effective-distance benchmark had been treated mostly as a C# query-engine vs DFS story.

  But after the recent Prolog shortest-path and weighted-shortest-path work, the next obvious question was whether the
  same seeded-reuse idea would help effective distance too. This PR answers that directly by benchmarking seeded Prolog on
  the existing workload before trying to design a more ambitious accumulation-specific Prolog optimization.

  ## Result

  ### Standalone seeded Prolog effective-distance benchmark

  Seeded and pruned variants match exactly at all tested scales.

  Current local result:

  - `300`: seeded `0.373s`, pruned `0.399s`
  - `1k`: seeded `0.320s`, pruned `0.330s`
  - `5k`: seeded `1.079s`, pruned `1.122s`
  - `10k`: seeded `2.589s`, pruned `2.486s`

  Interpretation:

  - seeded closure reuse is the real win
  - current branch pruning does not reduce tuple count or inferences on this workload
  - pruning is therefore neutral to slightly noisy here rather than a clear optimization

  ### Cross-target effective-distance benchmark

  Latest local run with `csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded` showed matching outputs at all tested
  scales.

  `prolog-seeded` vs `csharp-query`:

  - `300`: `0.363s` vs `0.607s`
  - `1k`: `0.302s` vs `0.421s`
  - `5k`: `1.109s` vs `1.332s`
  - `10k`: `2.480s` vs `3.236s`

  So on the current effective-distance benchmark surface, seeded Prolog is now faster than the current C# query-engine
  path.

  ## Verification

  - `python -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/
  benchmark_prolog_effective_distance.py`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k,5k,10k --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 300,1k,5k,10k --targets csharp-query,csharp-
  dfs,rust-dfs,go-dfs,prolog-seeded --repetitions 1`

  ## Notes

  - this PR is benchmark and documentation work, not a new Prolog target transformation
  - seeded effective distance currently relies on seeded counted-closure reuse plus Prolog-side aggregation
  - the benchmark evidence suggests that the next effective-distance optimization should focus on retained-state strategy
  for accumulation workloads, not additional branch pruning