### PR TITLE
feat(csharp-query): stream dag benchmark facts into runtime

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PHILOSOPHY.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PHILOSOPHY.md
@@ -1,0 +1,81 @@
+# Query Engine Materialization Philosophy
+
+## Summary
+
+The parameterized query engine should own materialization decisions.
+
+The ingestion/parser layer should prefer streaming decoded tuples into the
+engine. The engine should then decide whether a plan node or operator needs:
+
+- pure streaming evaluation
+- replayable input
+- compact retained state
+- indexed retained state
+- full external materialization as a fallback
+
+External pre-materialization remains supported, but it is the non-preferred
+route.
+
+## Core Position
+
+The parser should not eagerly decide to retain all facts.
+
+That decision belongs in the query engine because only the engine knows:
+
+- which operator is executing
+- whether a second pass is needed
+- whether random access is needed
+- whether grouped or recursive state is needed
+- whether a compact specialized retained form is enough
+
+So the preferred ownership boundary is:
+
+- parser responsibility: stream decoded tuples
+- engine responsibility: retain only the state warranted by the plan
+
+## Why This Matters
+
+Recent profiling showed two distinct strengths of the query engine:
+
+- pruning wins on computationally heavy workloads
+- intended lazy/streamed execution should reduce unnecessary retention work
+
+The pruning story is already demonstrated.
+
+The streaming/materialization story has only been partially realized because
+some benchmark paths were still building eager structures before the engine got
+control of the data.
+
+Moving materialization into the engine makes the benchmark behavior align more
+closely with the intended architecture.
+
+## Preferred Order Of Strategies
+
+When the engine has a choice, it should prefer these strategies in roughly this
+order:
+
+1. streaming with no retained source copy
+2. streaming into compact operator-owned retained state
+3. replayable or indexed retained state owned by the engine
+4. external pre-materialization owned by the caller
+
+This is a heuristic order, not a hard law. A plan may still choose a more
+materialized strategy when repeated access or indexing clearly pays for itself.
+
+## External Materialization
+
+External materialization is still valid when:
+
+- an integration point cannot yet stream into the engine
+- a caller already has the facts in memory
+- a workload needs a compatibility path first
+- debugging or inspection is easier with prebuilt relations
+
+But it should be treated as:
+
+- compatible
+- supported
+- non-preferred
+
+The preferred long-term path is for the engine to decide what state to retain,
+not for the parser or benchmark harness to decide prematurely.

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -1,0 +1,90 @@
+# Query Engine Materialization Plan
+
+## Goal
+
+Move the parameterized query engine toward engine-owned materialization by
+making streamed ingestion the preferred route and external pre-materialization
+a supported fallback.
+
+## Stage 1: Narrow Benchmark-Driven Streaming Paths
+
+Status:
+
+- in progress / partially implemented
+
+Work:
+
+- allow providers to expose streamed delimited sources
+- let DAG-specialized runtime nodes ingest those sources directly
+- stop preloading benchmark TSV rows into `InMemoryRelationProvider` when the
+  runtime can ingest them itself
+
+Success criteria:
+
+- correctness unchanged
+- benchmark harness becomes thinner
+- engine owns more of the retained-state decision
+
+## Stage 2: Clarify Retention Modes In The Runtime
+
+Work:
+
+- make the distinction clearer between:
+  - streaming source
+  - replayable source
+  - operator-owned retained state
+  - externally materialized source
+- document which operators can stay single-pass and which need replay/indexed
+  access
+
+Success criteria:
+
+- fewer ambiguous materialization decisions outside the engine
+- clearer runtime contracts for new operators
+
+## Stage 3: Expand Streamed Ingestion Beyond Current DAG Cases
+
+Work:
+
+- identify additional operators that can ingest directly from streamed sources
+- move retained-state construction into those operators where it pays off
+- avoid generic `object[]` fact preloading when a narrower retained form is
+  sufficient
+
+Success criteria:
+
+- more benchmark/program paths use engine-owned retention
+- reduced parser-side or harness-side eager structure building
+
+## Stage 4: Cost-Based Strategy Selection
+
+Work:
+
+- use measured cost buckets to guide whether the engine prefers:
+  - direct streaming
+  - replayable buffering
+  - indexed retained state
+  - fallback external materialization
+- keep this heuristic-driven at first, then refine as profiling improves
+
+Success criteria:
+
+- the materialization strategy is chosen where operator knowledge exists
+- eager fallback remains available but is no longer the default instinct
+
+## Guardrails
+
+- do not remove external materialization compatibility prematurely
+- do not force purely streaming execution onto operators that clearly need
+  retained state
+- do not push retention policy back into the parser just to simplify the
+  engine's current implementation
+
+## Current Recommendation
+
+Near-term implementation work should continue to prefer:
+
+- streamed sources into the runtime
+- operator-owned retained state
+- external materialization only when the streamed/operator-owned path is not yet
+  available or is measurably worse

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -1,0 +1,92 @@
+# Query Engine Materialization Specification
+
+## Scope
+
+This document specifies the intended materialization boundary for the
+parameterized query engine.
+
+It does not attempt to fully redesign every provider or plan node. It defines a
+narrow architectural contract that current and future implementations should
+move toward.
+
+## Terminology
+
+- streamed source: tuples are decoded on demand and not eagerly retained by the
+  parser layer
+- replayable source: the engine can ask for a second pass without requiring the
+  original caller to rebuild the source manually
+- retained state: operator-owned in-memory state built by the engine
+- external materialization: facts are fully built outside the engine and then
+  handed in as in-memory relations
+
+## Required Capabilities
+
+### 1. Streaming-capable providers
+
+A relation provider may expose a streamed source for a predicate.
+
+Current narrow example:
+
+- delimited two-column TSV relation sources for benchmark DAG workloads
+
+Future streamed providers may expose:
+
+- other delimited layouts
+- structured binary sources
+- database-backed iterators
+- socket or pipe-backed tuple streams
+
+### 2. Engine-owned retained state
+
+A plan node may consume a streamed source and build only the retained state it
+needs.
+
+Examples:
+
+- DAG grouped reachability builds adjacency and grouped bitset/count state
+- DAG longest depth builds adjacency and scalar suffix-depth state
+- other operators may request replay buffers or indexes when needed
+
+### 3. External materialization fallback
+
+The engine must still work when facts are already externally materialized.
+
+That means:
+
+- existing `IRelationProvider` behavior remains valid
+- `InMemoryRelationProvider` remains supported
+- streamed ingestion augments the engine rather than replacing compatibility
+  paths
+
+## Preferred Execution Rule
+
+When both of these are true:
+
+- the provider can stream tuples for a predicate
+- the operator has a specialized streamed-ingestion path
+
+then the engine should prefer the streamed path over eager external
+materialization.
+
+## Non-Goals
+
+This specification does not require:
+
+- purely streaming execution for every recursive operator
+- zero retained state
+- removal of all external materialization support
+- one universal streaming strategy for all workloads
+
+Some operators will still need retained state. The design point is that the
+engine, not the parser, should decide when that is warranted.
+
+## Current Narrow Implementation Pattern
+
+For the current DAG benchmark operators, the streamed path is:
+
+1. provider exposes delimited relation sources
+2. engine reads rows directly from those sources
+3. engine builds only the graph/group state needed by the DAG operator
+4. benchmark code avoids preloading raw facts into in-memory relations first
+
+This is a first step, not the full endpoint.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -557,33 +557,36 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.067s | 0.046s | 0.003s | 0.007s | match |
-| 1k | 0.086s | 0.051s | 0.008s | 0.007s | match |
-| 5k | 0.088s | 0.180s | 0.143s | 0.113s | match |
-| 10k | 0.103s | 0.516s | 0.546s | 0.469s | match |
+| 300 | 0.064s | 0.044s | 0.002s | 0.002s | match |
+| 1k | 0.082s | 0.048s | 0.007s | 0.008s | match |
+| 5k | 0.072s | 0.172s | 0.157s | 0.109s | match |
+| 10k | 0.073s | 0.528s | 0.733s | 0.481s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.69x | 0.04x | 0.10x |
-| 1k | 0.59x | 0.09x | 0.09x |
-| 5k | 2.04x | 1.61x | 1.27x |
-| 10k | 4.99x | 5.28x | 4.54x |
+| 300 | 0.68x | 0.03x | 0.04x |
+| 1k | 0.59x | 0.08x | 0.10x |
+| 5k | 2.39x | 2.18x | 1.52x |
+| 10k | 7.20x | 10.01x | 6.57x |
 
 Comparison note:
 
-- the current C# query path now uses a project-grouped reachability node
-  rather than raw per-seed closure followed by regrouping
-- the latest runtime-overhead pass pushes the final count aggregation
-  into the query runtime too, so the benchmark no longer materializes the
-  full `(project, reachable_dependency)` relation just to count it
+- the current C# query path uses a project-grouped reachability node
+  with direct count aggregation inside the query runtime
+- the latest change also moves relation ingestion/materialization for the
+  benchmark inputs into the query runtime via delimited-source streaming,
+  instead of eagerly loading all edge and seed facts into the benchmark
+  program first
 - for the one-shot generated benchmark programs, disabling query-runtime
-  cache reuse also helped slightly by removing cache bookkeeping that is
-  not reused within a single run
-- this changed the cost profile materially: the query engine is still
-  behind at `300` and `1k`, but is now clearly ahead of all DFS targets
-  from `5k` onward
+  cache reuse still helps slightly by removing bookkeeping that is not
+  reused within a single run
+- this pushes the benchmark closer to the intended ownership boundary:
+  the parser streams tuples, and the engine decides what state to retain
+  for the operator
+- the query engine is still behind at `300` and `1k`, but is now clearly
+  ahead of all DFS targets from `5k` onward
 - outputs still match across all four targets
 
 ### Cross-Target Dependency Longest-Depth Results
@@ -605,38 +608,38 @@ Latest local results:
 
 | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
 |-------|---------:|--------:|---------:|-------:|-----------------|
-| 300 | 0.057s | 0.043s | 0.002s | 0.002s | match |
-| 1k | 0.056s | 0.045s | 0.002s | 0.003s | match |
-| 5k | 0.087s | 0.056s | 0.006s | 0.006s | match |
-| 10k | 0.091s | 0.055s | 0.013s | 0.012s | match |
+| 300 | 0.056s | 0.041s | 0.002s | 0.002s | match |
+| 1k | 0.053s | 0.044s | 0.004s | 0.003s | match |
+| 5k | 0.070s | 0.053s | 0.007s | 0.006s | match |
+| 10k | 0.077s | 0.053s | 0.012s | 0.011s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 0.75x | 0.03x | 0.04x |
-| 1k | 0.81x | 0.04x | 0.05x |
-| 5k | 0.64x | 0.07x | 0.07x |
-| 10k | 0.60x | 0.14x | 0.14x |
+| 300 | 0.74x | 0.03x | 0.04x |
+| 1k | 0.83x | 0.07x | 0.05x |
+| 5k | 0.76x | 0.10x | 0.08x |
+| 10k | 0.68x | 0.16x | 0.14x |
 
 Comparison note:
 
-- this benchmark now includes a real `csharp-query` DAG longest-depth
-  path built on a dedicated query-runtime node
-- the latest runtime-overhead passes remove some setup overhead inside
-  the longest-depth node, disable cache reuse for the one-shot generated
-  benchmark program, and make phase tracing opt-in instead of always-on
+- this benchmark includes a real `csharp-query` DAG longest-depth path
+  built on a dedicated query-runtime node
+- the latest change moves edge and seed fact ingestion/materialization
+  into the query runtime via delimited-source streaming, instead of
+  eagerly loading all rows into the benchmark program first
 - set `UNIFYWEAVER_BENCH_TRACE=1` when you want the generated
   `csharp-query` longest-depth benchmark to print per-phase timings to
   `stderr`
-- the hand-written C# DFS baseline is now cheaper too, after moving it to a
-  lighter-weight custom TSV loader with manual tab scanning and better
-  pre-sizing
-- the query engine still matches all DFS outputs and remains somewhat
-  behind the hand-written C# DFS baseline, so longest depth is still a
-  separate optimization track from reach-count
-- that makes it a good DAG benchmark baseline for further query-runtime
-  optimization rather than a finished performance story
+- cache reuse remains disabled for these one-shot generated benchmark
+  programs, and trace creation is now opt-in rather than always-on
+- the hand-written C# DFS baseline is still cheaper after its lighter
+  custom TSV loader work, but the query engine now sits closer to that
+  baseline than before while keeping the intended retention boundary in
+  the engine rather than the loader
+- outputs still match across all four targets, and longest depth remains
+  a separate optimization track from reach-count
 
 ### Cross-Target Category Influence Results
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -1451,35 +1451,15 @@ class Program
         var predId = new PredicateId("dependency_reach", 2);
         var projects = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
+        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        foreach (var line in File.ReadLines(args[1]).Skip(1))
         {{
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            var tab = line.IndexOf('\t');
+            if (tab > 0)
             {{
-                continue;
+                projects.Add(line[..tab]);
             }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {{
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }}
-        }}
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            projects.Add(parts[0]);
-            provider.AddFact(seedId, parts[0], parts[1]);
         }}
         swLoad.Stop();
 
@@ -1933,35 +1913,15 @@ class Program
         var predId = new PredicateId("dependency_longest_depth", 2);
         var projects = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
+        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        foreach (var line in File.ReadLines(args[1]).Skip(1))
         {{
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
+            var tab = line.IndexOf('\t');
+            if (tab > 0)
             {{
-                continue;
+                projects.Add(line[..tab]);
             }}
-
-            var parts = line.Split('	', 2);
-            if (parts.Length == 2)
-            {{
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }}
-        }}
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('	', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            projects.Add(parts[0]);
-            provider.AddFact(seedId, parts[0], parts[1]);
         }}
         swLoad.Stop();
 

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -36,6 +36,17 @@ namespace UnifyWeaver.QueryRuntime
         IEnumerable<object[]> GetFacts(PredicateId predicate);
     }
 
+    public readonly record struct DelimitedRelationSource(
+        string InputPath,
+        char Delimiter = '	',
+        int SkipRows = 1,
+        int ExpectedWidth = 2);
+
+    public interface IStreamingRelationProvider : IRelationProvider
+    {
+        bool TryGetDelimitedSource(PredicateId predicate, out DelimitedRelationSource source);
+    }
+
     /// <summary>
     /// Base class for all query plan nodes.
     /// </summary>
@@ -1120,9 +1131,15 @@ namespace UnifyWeaver.QueryRuntime
     /// Currently supports non-recursive plans; recursion-aware fixpoint
     /// iteration will be layered on later.
     /// </summary>
-    public sealed class InMemoryRelationProvider : IRelationProvider
+    public sealed class InMemoryRelationProvider : IStreamingRelationProvider
     {
         private readonly Dictionary<PredicateId, List<object[]>> _store = new();
+        private readonly Dictionary<PredicateId, DelimitedRelationSource> _delimitedSources = new();
+
+        public void RegisterDelimitedSource(PredicateId predicate, DelimitedRelationSource source)
+        {
+            _delimitedSources[predicate] = source;
+        }
 
         public void AddFact(PredicateId predicate, params object[] values)
         {
@@ -1156,7 +1173,55 @@ namespace UnifyWeaver.QueryRuntime
             {
                 return list;
             }
+            if (_delimitedSources.TryGetValue(predicate, out var source))
+            {
+                return ReadDelimitedSource(source);
+            }
             return Array.Empty<object[]>();
+        }
+
+        public bool TryGetDelimitedSource(PredicateId predicate, out DelimitedRelationSource source) =>
+            _delimitedSources.TryGetValue(predicate, out source);
+
+        private static IEnumerable<object[]> ReadDelimitedSource(DelimitedRelationSource source)
+        {
+            using var reader = OpenSequentialReader(source.InputPath);
+            for (var i = 0; i < source.SkipRows; i++)
+            {
+                if (reader.ReadLine() is null)
+                {
+                    yield break;
+                }
+            }
+
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!TrySplitTwoColumnLine(line, source.Delimiter, out var left, out var right))
+                {
+                    continue;
+                }
+                yield return new object[] { left, right };
+            }
+        }
+
+        private static StreamReader OpenSequentialReader(string path) =>
+            new(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1 << 16);
+
+        private static bool TrySplitTwoColumnLine(string line, char delimiter, out string left, out string right)
+        {
+            var span = line.AsSpan();
+            var split = span.IndexOf(delimiter);
+            if (split <= 0 || split >= span.Length - 1)
+            {
+                left = string.Empty;
+                right = string.Empty;
+                return false;
+            }
+
+            left = span.Slice(0, split).ToString();
+            right = span.Slice(split + 1).ToString();
+            return true;
         }
     }
 
@@ -8241,13 +8306,23 @@ namespace UnifyWeaver.QueryRuntime
                     return cachedRows;
                 }
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
-                var seeds = GetFactsList(closure.SeedRelation, context);
-
                 const int MaxDagNodeCount = 16384;
                 const int MaxDagGroupCount = 4096;
                 const int MinDagGroupCount = 64;
                 const int MinDagEdgeCount = 8192;
+                if (_provider is IStreamingRelationProvider streamingProvider &&
+                    streamingProvider.TryGetDelimitedSource(closure.EdgeRelation, out var edgeSource) &&
+                    streamingProvider.TryGetDelimitedSource(closure.SeedRelation, out var seedSource) &&
+                    TryBuildProjectGroupedDagReachCountRowsFromDelimitedSources(edgeSource, seedSource, MinDagEdgeCount, MinDagGroupCount, MaxDagNodeCount, MaxDagGroupCount, out var streamedDagRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedTransitiveClosureCount", traceKey, hit: false, built: true);
+                    trace?.RecordStrategy(closure, "SeedGroupedTransitiveClosureCountDagStreamed");
+                    context.SeedGroupedTransitiveClosureCountResults[cacheKey] = streamedDagRows;
+                    return streamedDagRows;
+                }
+
+                var edges = GetFactsList(closure.EdgeRelation, context);
+                var seeds = GetFactsList(closure.SeedRelation, context);
                 if (seeds.Count >= MinDagGroupCount &&
                     edges.Count >= MinDagEdgeCount &&
                     TryBuildProjectGroupedDagReachCountRows(edges, seeds, MaxDagNodeCount, MaxDagGroupCount, out var dagRows))
@@ -8362,9 +8437,18 @@ namespace UnifyWeaver.QueryRuntime
 
                 trace?.RecordCacheLookup("SeedGroupedDagLongestDepth", traceKey, hit: false, built: true);
 
+                const int MaxDagNodeCount = 65536;
+                if (_provider is IStreamingRelationProvider streamingProvider &&
+                    streamingProvider.TryGetDelimitedSource(closure.EdgeRelation, out var edgeSource) &&
+                    streamingProvider.TryGetDelimitedSource(closure.SeedRelation, out var seedSource) &&
+                    TryBuildSeedGroupedDagLongestDepthRowsFromDelimitedSources(closure, trace, edgeSource, seedSource, MaxDagNodeCount, out var streamedRows))
+                {
+                    context.SeedGroupedDagLongestDepthResults[cacheKey] = streamedRows;
+                    return streamedRows;
+                }
+
                 var edges = GetFactsList(closure.EdgeRelation, context);
                 var seeds = GetFactsList(closure.SeedRelation, context);
-                const int MaxDagNodeCount = 65536;
                 if (!TryBuildSeedGroupedDagLongestDepthRows(closure, trace, edges, seeds, MaxDagNodeCount, out var rows))
                 {
                     throw new InvalidOperationException("SeedGroupedDagLongestDepthNode requires an acyclic edge relation.");
@@ -8377,6 +8461,558 @@ namespace UnifyWeaver.QueryRuntime
             {
                 context.FixpointDepth--;
             }
+        }
+
+        private static bool TryBuildProjectGroupedDagReachCountRowsFromDelimitedSources(
+            DelimitedRelationSource edgeSource,
+            DelimitedRelationSource seedSource,
+            int minEdgeCount,
+            int minGroupCount,
+            int maxNodeCount,
+            int maxGroupCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            var globalNodeIds = new Dictionary<string, int>(StringComparer.Ordinal);
+            var globalSuccessors = new List<List<int>>();
+
+            int GetGlobalNodeId(string value)
+            {
+                if (globalNodeIds.TryGetValue(value, out var id))
+                {
+                    return id;
+                }
+
+                id = globalSuccessors.Count;
+                globalNodeIds.Add(value, id);
+                globalSuccessors.Add(new List<int>());
+                return id;
+            }
+
+            var edgeCount = 0;
+            using (var reader = OpenSequentialReader(edgeSource.InputPath))
+            {
+                for (var i = 0; i < edgeSource.SkipRows; i++)
+                {
+                    if (reader.ReadLine() is null)
+                    {
+                        return false;
+                    }
+                }
+
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (!TrySplitTwoColumnLine(line, edgeSource.Delimiter, out var left, out var right))
+                    {
+                        continue;
+                    }
+
+                    var fromId = GetGlobalNodeId(left);
+                    var toId = GetGlobalNodeId(right);
+                    globalSuccessors[fromId].Add(toId);
+                    edgeCount++;
+                }
+            }
+
+            if (edgeCount < minEdgeCount || globalSuccessors.Count == 0 || globalSuccessors.Count > maxNodeCount)
+            {
+                return false;
+            }
+
+            var groupIds = new Dictionary<string, int>(StringComparer.Ordinal);
+            var groupValues = new List<string>();
+            var seedPairs = new List<(int GroupId, int NodeId)>();
+            using (var reader = OpenSequentialReader(seedSource.InputPath))
+            {
+                for (var i = 0; i < seedSource.SkipRows; i++)
+                {
+                    if (reader.ReadLine() is null)
+                    {
+                        return false;
+                    }
+                }
+
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (!TrySplitTwoColumnLine(line, seedSource.Delimiter, out var group, out var node))
+                    {
+                        continue;
+                    }
+
+                    if (!globalNodeIds.TryGetValue(node, out var nodeId))
+                    {
+                        continue;
+                    }
+
+                    if (!groupIds.TryGetValue(group, out var groupId))
+                    {
+                        groupId = groupValues.Count;
+                        if (groupId >= maxGroupCount)
+                        {
+                            return false;
+                        }
+
+                        groupIds.Add(group, groupId);
+                        groupValues.Add(group);
+                    }
+
+                    seedPairs.Add((groupId, nodeId));
+                }
+            }
+
+            if (groupValues.Count < minGroupCount || seedPairs.Count == 0)
+            {
+                return false;
+            }
+
+            return TryBuildProjectGroupedDagReachCountRowsFromGraph(globalSuccessors, groupValues, seedPairs, maxNodeCount, out rows);
+        }
+
+        private static bool TryBuildProjectGroupedDagReachCountRowsFromGraph(
+            List<List<int>> globalSuccessors,
+            List<string> groupValues,
+            List<(int GroupId, int NodeId)> seedPairs,
+            int maxNodeCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            var included = new bool[globalSuccessors.Count];
+            var queue = new Queue<int>();
+            foreach (var (_, nodeId) in seedPairs)
+            {
+                if (included[nodeId])
+                {
+                    continue;
+                }
+
+                included[nodeId] = true;
+                queue.Enqueue(nodeId);
+            }
+
+            while (queue.Count > 0)
+            {
+                var nodeId = queue.Dequeue();
+                foreach (var next in globalSuccessors[nodeId])
+                {
+                    if (included[next])
+                    {
+                        continue;
+                    }
+
+                    included[next] = true;
+                    queue.Enqueue(next);
+                }
+            }
+
+            var includedCount = 0;
+            foreach (var isIncluded in included)
+            {
+                if (isIncluded)
+                {
+                    includedCount++;
+                }
+            }
+
+            if (includedCount == 0 || includedCount > maxNodeCount)
+            {
+                return false;
+            }
+
+            var localIds = new int[included.Length];
+            Array.Fill(localIds, -1);
+            var localSuccessors = new List<List<int>>(includedCount);
+            var localIndegree = new int[includedCount];
+            var nextLocalId = 0;
+
+            for (var globalId = 0; globalId < included.Length; globalId++)
+            {
+                if (!included[globalId])
+                {
+                    continue;
+                }
+
+                localIds[globalId] = nextLocalId;
+                localSuccessors.Add(new List<int>());
+                nextLocalId++;
+            }
+
+            for (var globalId = 0; globalId < included.Length; globalId++)
+            {
+                if (!included[globalId])
+                {
+                    continue;
+                }
+
+                var fromLocalId = localIds[globalId];
+                foreach (var nextGlobalId in globalSuccessors[globalId])
+                {
+                    if (!included[nextGlobalId])
+                    {
+                        continue;
+                    }
+
+                    var toLocalId = localIds[nextGlobalId];
+                    localSuccessors[fromLocalId].Add(toLocalId);
+                    localIndegree[toLocalId]++;
+                }
+            }
+
+            var topoQueue = new Queue<int>();
+            for (var i = 0; i < localIndegree.Length; i++)
+            {
+                if (localIndegree[i] == 0)
+                {
+                    topoQueue.Enqueue(i);
+                }
+            }
+
+            var topo = new List<int>(includedCount);
+            while (topoQueue.Count > 0)
+            {
+                var localId = topoQueue.Dequeue();
+                topo.Add(localId);
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    localIndegree[successorLocalId]--;
+                    if (localIndegree[successorLocalId] == 0)
+                    {
+                        topoQueue.Enqueue(successorLocalId);
+                    }
+                }
+            }
+
+            if (topo.Count != includedCount)
+            {
+                return false;
+            }
+
+            var wordCount = (groupValues.Count + 63) >> 6;
+            var nodeGroupBits = new ulong[includedCount][];
+            for (var i = 0; i < includedCount; i++)
+            {
+                nodeGroupBits[i] = new ulong[wordCount];
+            }
+
+            foreach (var (groupId, nodeId) in seedPairs)
+            {
+                var localNodeId = localIds[nodeId];
+                nodeGroupBits[localNodeId][groupId >> 6] |= 1UL << (groupId & 63);
+            }
+
+            foreach (var localId in topo)
+            {
+                var sourceBits = nodeGroupBits[localId];
+                if (IsZeroWordArray(sourceBits))
+                {
+                    continue;
+                }
+
+                foreach (var successorLocalId in localSuccessors[localId])
+                {
+                    OrInto(nodeGroupBits[successorLocalId], sourceBits);
+                }
+            }
+
+            var counts = new int[groupValues.Count];
+            for (var localId = 0; localId < includedCount; localId++)
+            {
+                var bits = nodeGroupBits[localId];
+                for (var wordIndex = 0; wordIndex < bits.Length; wordIndex++)
+                {
+                    var word = bits[wordIndex];
+                    while (word != 0)
+                    {
+                        var bit = BitOperations.TrailingZeroCount(word);
+                        var groupId = (wordIndex << 6) + bit;
+                        if (groupId < counts.Length)
+                        {
+                            counts[groupId]++;
+                        }
+                        word &= word - 1;
+                    }
+                }
+            }
+
+            rows = new List<object[]>(groupValues.Count);
+            for (var groupId = 0; groupId < groupValues.Count; groupId++)
+            {
+                rows.Add(new object[] { groupValues[groupId], counts[groupId] });
+            }
+
+            return true;
+        }
+
+        private static bool TryBuildSeedGroupedDagLongestDepthRowsFromDelimitedSources(
+            PlanNode traceNode,
+            QueryExecutionTrace? trace,
+            DelimitedRelationSource edgeSource,
+            DelimitedRelationSource seedSource,
+            int maxNodeCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            var phaseStopwatch = Stopwatch.StartNew();
+            var nodeIds = new Dictionary<string, int>(StringComparer.Ordinal);
+            var nodeValues = new List<string>();
+            var successors = new List<List<int>>();
+
+            int GetNodeId(string value)
+            {
+                if (nodeIds.TryGetValue(value, out var id))
+                {
+                    return id;
+                }
+
+                id = successors.Count;
+                nodeIds.Add(value, id);
+                nodeValues.Add(value);
+                successors.Add(new List<int>());
+                return id;
+            }
+
+            using (var reader = OpenSequentialReader(edgeSource.InputPath))
+            {
+                for (var i = 0; i < edgeSource.SkipRows; i++)
+                {
+                    if (reader.ReadLine() is null)
+                    {
+                        return false;
+                    }
+                }
+
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (!TrySplitTwoColumnLine(line, edgeSource.Delimiter, out var left, out var right))
+                    {
+                        continue;
+                    }
+
+                    var fromId = GetNodeId(left);
+                    var toId = GetNodeId(right);
+                    successors[fromId].Add(toId);
+                }
+            }
+
+            if (successors.Count == 0 || successors.Count > maxNodeCount)
+            {
+                return false;
+            }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "build_graph", phaseStopwatch.Elapsed);
+
+            phaseStopwatch.Restart();
+            var groupIds = new Dictionary<string, int>(StringComparer.Ordinal);
+            var groupValues = new List<string>();
+            var seedPairs = new List<(int GroupId, int NodeId)>();
+            using (var reader = OpenSequentialReader(seedSource.InputPath))
+            {
+                for (var i = 0; i < seedSource.SkipRows; i++)
+                {
+                    if (reader.ReadLine() is null)
+                    {
+                        return false;
+                    }
+                }
+
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (!TrySplitTwoColumnLine(line, seedSource.Delimiter, out var group, out var node))
+                    {
+                        continue;
+                    }
+
+                    if (!nodeIds.TryGetValue(node, out var nodeId))
+                    {
+                        continue;
+                    }
+
+                    if (!groupIds.TryGetValue(group, out var groupId))
+                    {
+                        groupId = groupValues.Count;
+                        groupIds.Add(group, groupId);
+                        groupValues.Add(group);
+                    }
+
+                    seedPairs.Add((groupId, nodeId));
+                }
+            }
+
+            if (seedPairs.Count == 0)
+            {
+                return true;
+            }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "seed_grouping", phaseStopwatch.Elapsed);
+
+            return TryBuildSeedGroupedDagLongestDepthRowsFromGraph(traceNode, trace, successors, nodeValues, groupValues, seedPairs, maxNodeCount, out rows);
+        }
+
+        private static bool TryBuildSeedGroupedDagLongestDepthRowsFromGraph(
+            PlanNode traceNode,
+            QueryExecutionTrace? trace,
+            List<List<int>> successors,
+            List<string> nodeValues,
+            List<string> groupValues,
+            List<(int GroupId, int NodeId)> seedPairs,
+            int maxNodeCount,
+            out List<object[]> rows)
+        {
+            rows = new List<object[]>();
+            var phaseStopwatch = Stopwatch.StartNew();
+            var reachable = new bool[successors.Count];
+            var queue = new Queue<int>(seedPairs.Count);
+            foreach (var (_, nodeId) in seedPairs)
+            {
+                if (reachable[nodeId])
+                {
+                    continue;
+                }
+
+                reachable[nodeId] = true;
+                queue.Enqueue(nodeId);
+            }
+
+            while (queue.Count > 0)
+            {
+                var nodeId = queue.Dequeue();
+                foreach (var next in successors[nodeId])
+                {
+                    if (reachable[next])
+                    {
+                        continue;
+                    }
+
+                    reachable[next] = true;
+                    queue.Enqueue(next);
+                }
+            }
+
+            var includedCount = 0;
+            foreach (var isReachable in reachable)
+            {
+                if (isReachable)
+                {
+                    includedCount++;
+                }
+            }
+
+            if (includedCount == 0 || includedCount > maxNodeCount)
+            {
+                return false;
+            }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "reachable_cone", phaseStopwatch.Elapsed);
+
+            phaseStopwatch.Restart();
+            var indegree = new int[successors.Count];
+            for (var globalId = 0; globalId < successors.Count; globalId++)
+            {
+                if (!reachable[globalId])
+                {
+                    continue;
+                }
+
+                foreach (var nextGlobalId in successors[globalId])
+                {
+                    if (!reachable[nextGlobalId])
+                    {
+                        continue;
+                    }
+
+                    indegree[nextGlobalId]++;
+                }
+            }
+
+            var topoQueue = new Queue<int>(includedCount);
+            for (var i = 0; i < successors.Count; i++)
+            {
+                if (reachable[i] && indegree[i] == 0)
+                {
+                    topoQueue.Enqueue(i);
+                }
+            }
+
+            var topo = new List<int>(includedCount);
+            while (topoQueue.Count > 0)
+            {
+                var nodeId = topoQueue.Dequeue();
+                topo.Add(nodeId);
+                foreach (var successorId in successors[nodeId])
+                {
+                    if (!reachable[successorId])
+                    {
+                        continue;
+                    }
+
+                    indegree[successorId]--;
+                    if (indegree[successorId] == 0)
+                    {
+                        topoQueue.Enqueue(successorId);
+                    }
+                }
+            }
+
+            if (topo.Count != includedCount)
+            {
+                return false;
+            }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "topological_order", phaseStopwatch.Elapsed);
+
+            phaseStopwatch.Restart();
+            var depths = new int[successors.Count];
+            for (var i = topo.Count - 1; i >= 0; i--)
+            {
+                var nodeId = topo[i];
+                var best = 1;
+                foreach (var successorId in successors[nodeId])
+                {
+                    if (!reachable[successorId])
+                    {
+                        continue;
+                    }
+
+                    var candidate = depths[successorId] + 1;
+                    if (candidate > best)
+                    {
+                        best = candidate;
+                    }
+                }
+
+                depths[nodeId] = best;
+            }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "suffix_depth_dp", phaseStopwatch.Elapsed);
+
+            phaseStopwatch.Restart();
+            var groupBest = new int[groupValues.Count];
+            foreach (var (groupId, nodeId) in seedPairs)
+            {
+                if (!reachable[nodeId])
+                {
+                    continue;
+                }
+
+                var depth = depths[nodeId];
+                if (depth > groupBest[groupId])
+                {
+                    groupBest[groupId] = depth;
+                }
+            }
+
+            rows = new List<object[]>(groupValues.Count);
+            for (var groupId = 0; groupId < groupValues.Count; groupId++)
+            {
+                rows.Add(new object[] { groupValues[groupId], groupBest[groupId] });
+            }
+            phaseStopwatch.Stop();
+            trace?.RecordPhase(traceNode, "group_reduction", phaseStopwatch.Elapsed);
+
+            return true;
         }
 
         private static bool TryBuildProjectGroupedDagReachRows(
@@ -9116,6 +9752,25 @@ namespace UnifyWeaver.QueryRuntime
             phaseStopwatch.Stop();
             trace?.RecordPhase(traceNode, "group_reduction", phaseStopwatch.Elapsed);
 
+            return true;
+        }
+
+        private static StreamReader OpenSequentialReader(string path) =>
+            new(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1 << 16);
+
+        private static bool TrySplitTwoColumnLine(string line, char delimiter, out string left, out string right)
+        {
+            var span = line.AsSpan();
+            var split = span.IndexOf(delimiter);
+            if (split <= 0 || split >= span.Length - 1)
+            {
+                left = string.Empty;
+                right = string.Empty;
+                return false;
+            }
+
+            left = span.Slice(0, split).ToString();
+            right = span.Slice(split + 1).ToString();
             return true;
         }
 


### PR DESCRIPTION
  ## Summary

  This PR moves DAG benchmark fact materialization for the parameterized C#
  query engine into the query runtime.

  Instead of eagerly loading all benchmark TSV rows into
  `InMemoryRelationProvider` as prebuilt facts, the generated `csharp_query`
  dependency benchmarks now register streamed delimited relation sources and
  let the runtime decide what retained state to build for the operator.

  This is the first narrow implementation of the materialization boundary we
  have been discussing:

  - parsers should stream tuples
  - the engine should own retention/materialization decisions
  - external pre-materialization should remain supported, but non-preferred

  ## What Changed

  ### Query Runtime: Streamed Delimited Relation Sources

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `DelimitedRelationSource`
  - `IStreamingRelationProvider`
  - `InMemoryRelationProvider.RegisterDelimitedSource(...)`

  `InMemoryRelationProvider` can now expose a predicate as a streamed
  delimited source instead of requiring that every row be eagerly inserted
  with `AddFact(...)`.

  This keeps existing in-memory fact behavior intact while adding a
  streamed-ingestion path.

  ### Query Runtime: DAG Operators Ingest Streams Directly

  Updated DAG-specialized query-runtime paths:

  - grouped project reach-count
  - grouped longest depth

  These paths now try a streamed delimited-source ingestion route first.

  For the current synthetic DAG benchmark shape, the runtime now:

  1. reads edge rows directly from the edge TSV source
  2. reads seed rows directly from the seed TSV source
  3. builds only the operator-owned graph/group state it needs
  4. avoids preloading raw `(object[])` fact rows into the benchmark program
     first

  Fallback behavior remains unchanged:
  - if the streamed path is unavailable, the runtime still works with normal
    externally materialized facts

  ### Generated C# Query Benchmarks

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` programs for:

  - `dependency_depth`
  - `dependency_longest_depth`

  now:

  - register `category_parent` and `project_dependency` as streamed
    delimited sources
  - avoid eager `provider.AddFact(...)` loading for those benchmark inputs
  - still collect the project set for benchmark reporting

  This makes the benchmark harness thinner and moves the materialization
  decision closer to the engine.

  ### Materialization Vision Docs

  Added:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PHILOSOPHY.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`

  These documents capture the position that:

  - parser responsibility: stream decoded tuples
  - engine responsibility: retain only the state warranted by the plan

  They also make explicit that:

  - external materialization is still supported
  - but it is the non-preferred route

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects:

  - the new streamed-ingestion runtime path
  - refreshed dependency reach-count results
  - refreshed dependency longest-depth results
  - the fact that the benchmark now better matches the intended engine
    ownership boundary

  ## Why This Matters

  This PR is important for architecture, not just speed.

  Recent benchmark work already showed:

  - strong pruning wins on computationally heavy workloads
  - weaker results on some load-dominated DAG workloads

  The current interpretation is not that the query engine model is wrong.
  It is that some benchmark paths were still too eager before the engine
  got to own retained-state decisions.

  This PR is the first concrete correction of that gap.

  It moves the benchmark closer to the intended execution model:

  - stream tuples into the engine
  - let the engine decide how much materialization is warranted

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile examples/benchmark/generate_pipeline.py
  ```
  ### Dependency reach benchmark
  ```
  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Outputs matched across all four targets.

  ### Dependency longest-depth benchmark
  ```
  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Outputs matched across all four targets.

  ## Updated Dependency Reach Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.064s | 0.044s | 0.002s | 0.002s | match |
  | 1k | 0.082s | 0.048s | 0.007s | 0.008s | match |
  | 5k | 0.072s | 0.172s | 0.157s | 0.109s | match |
  | 10k | 0.073s | 0.528s | 0.733s | 0.481s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.68x | 0.03x | 0.04x |
  | 1k | 0.59x | 0.08x | 0.10x |
  | 5k | 2.39x | 2.18x | 1.52x |
  | 10k | 7.20x | 10.01x | 6.57x |

  ## Updated Dependency Longest-Depth Results

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS | Query vs C# DFS |
  |---|---:|---:|---:|---:|---|
  | 300 | 0.056s | 0.041s | 0.002s | 0.002s | match |
  | 1k | 0.053s | 0.044s | 0.004s | 0.003s | match |
  | 5k | 0.070s | 0.053s | 0.007s | 0.006s | match |
  | 10k | 0.077s | 0.053s | 0.012s | 0.011s | match |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.74x | 0.03x | 0.04x |
  | 1k | 0.83x | 0.07x | 0.05x |
  | 5k | 0.76x | 0.10x | 0.08x |
  | 10k | 0.68x | 0.16x | 0.14x |

  ## Interpretation

  This PR does not make longest depth the query engine’s best benchmark.

  What it does do is more important structurally:

  - it moves materialization into the engine
  - it keeps external materialization as a fallback
  - it improves the csharp-query path on both DAG benchmark families
  - it makes the benchmark story align better with the intended lazy /
    streamed architecture

  The strongest benchmark effect is still on dependency reach-count, where
  the query engine is clearly ahead at scale.

  For longest depth, the query engine is still behind handwritten C# DFS,
  but it is now closer while using the more correct ownership boundary.

  ## Scope

  This PR adds:

  - streamed delimited relation sources in the query runtime
  - streamed DAG ingestion paths for grouped reach-count and longest depth
  - generated benchmark integration for those paths
  - focused philosophy/spec/plan docs for engine-owned materialization

  It does not yet add:

  - a universal streamed-ingestion framework for every operator
  - removal of external materialization support
  - a full cost-based planner for retention strategy selection

  ## Follow-Up

  Likely next work:

  - expand engine-owned streamed ingestion beyond the current DAG benchmark
    operators
  - clarify runtime retention modes further:
      - streamed
      - replayable
      - compact retained
      - externally materialized fallback
  - continue using the new materialization docs as the guide for moving
    retention decisions into the engine rather than the parser or benchmark
    harness