### PR TITLE
bench(prolog): pre-aggregate effective distance seeds

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -12,30 +12,31 @@ and specification.
 
 ## Benchmark Results
 
-### Seeded Prolog and Query Engine vs DFS Pipelines
+### Accumulated Prolog and Query Engine vs DFS Pipelines
 
-The effective-distance benchmark now has a seeded Prolog path that
-reuses `category_ancestor/4` once per unique category seed and then
-aggregates distances per article. On the current benchmark surface, that
-seeded Prolog path is faster than the current C# query-engine path while
-still matching its output exactly.
+The effective-distance benchmark now has an accumulated Prolog path that
+reuses `category_ancestor/4` once per unique category seed and retains
+only per-seed summed path weights for article aggregation. On the
+current benchmark surface, that accumulated Prolog path is faster than
+the current C# query-engine path while still matching its output
+exactly.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **Prolog seeded** | **0.36s** | **0.30s** | **1.11s** | **2.48s** |
-| C# Query Engine | 0.61s | 0.42s | 1.33s | 3.24s |
-| C# DFS pipeline | 0.45s | 1.25s | 5.70s | 10.25s |
-| Rust DFS pipeline | 0.36s | 1.45s | 7.71s | 14.45s |
-| Go DFS pipeline | 0.48s | 2.10s | 11.88s | 19.91s |
+| **Prolog accumulated** | **0.35s** | **0.25s** | **0.85s** | **2.06s** |
+| C# Query Engine | 0.68s | 0.50s | 1.34s | 3.20s |
+| C# DFS pipeline | 0.48s | 1.27s | 5.48s | 10.15s |
+| Rust DFS pipeline | 0.35s | 1.47s | 7.30s | 13.67s |
+| Go DFS pipeline | 0.47s | 2.07s | 11.68s | 19.09s |
 
-**Speedup of seeded Prolog over the current C# query engine:**
+**Speedup of accumulated Prolog over the current C# query engine:**
 
 | Scale | Speedup |
 |-------|---------|
-| 300 art | 1.67x |
-| 1K art | 1.39x |
-| 5K art | 1.20x |
-| 10K art | 1.30x |
+| 300 art | 1.93x |
+| 1K art | 2.05x |
+| 5K art | 1.57x |
+| 10K art | 1.55x |
 
 Semantic note:
 
@@ -43,12 +44,13 @@ Semantic note:
   checks without collapsing distinct simple paths that happen to reach
   the same ancestor with the same hop count.
 - `benchmark_effective_distance.py` now compares the query-engine output
-  against both the C# DFS reference and seeded Prolog, reporting
-  `query_vs_csharp_dfs` and `query_vs_prolog_seeded`.
+  against both the C# DFS reference and accumulated Prolog, reporting
+  `query_vs_csharp_dfs` and `query_vs_prolog_accumulated`.
 - Current post-fix runs report `query_vs_csharp_dfs = match` at
   `300`, `1k`, `5k`, and `10k`.
-- Current seeded Prolog runs also report `query_vs_prolog_seeded = match`
-  at `300`, `1k`, `5k`, and `10k`.
+- Current accumulated Prolog runs also report
+  `query_vs_prolog_accumulated = match` at `300`, `1k`, `5k`, and
+  `10k`.
 
 ### Why Seeded Closures Win
 
@@ -95,38 +97,37 @@ For historical context, the original DFS-only pipeline comparison:
 
 ### Key Findings
 
-1. **Seeded Prolog is currently the fastest effective-distance path on
-   this benchmark surface** — it beats the current C# query-engine path
-   by `1.67x` at `300`, `1.39x` at `1k`, `1.20x` at `5k`, and `1.30x`
-   at `10k`.
+1. **Accumulated Prolog is currently the fastest effective-distance path
+   on this benchmark surface** — it beats the current C# query-engine
+   path by `1.93x` at `300`, `2.05x` at `1k`, `1.57x` at `5k`, and
+   `1.55x` at `10k`.
 
 2. **The C# query engine still beats the DFS baselines comfortably** —
-   it is `2.97x` faster than C# DFS at `1k`, `4.28x` at `5k`, and
+   it is `2.52x` faster than C# DFS at `1k`, `4.10x` at `5k`, and
    `3.17x` at `10k`.
 
 3. **Among the compiled DFS targets, C# still leads at scale** — at
-   `10k` it is faster than Rust DFS (`10.25s` vs `14.45s`) and much
-   faster than Go DFS (`19.91s`).
+   `10k` it is faster than Rust DFS (`10.15s` vs `13.67s`) and much
+   faster than Go DFS (`19.09s`).
 
-4. **Seed reuse is the real win; branch pruning is not** — on the new
-   seeded Prolog effective-distance benchmark, the pruned and unpruned
-   variants have the same tuple count and inferences, with timing
-   differences that stay within noise.
+4. **Retained-state strategy matters more than branch pruning on this
+   workload** — seeded reuse is the first big win, and pre-aggregating
+   per-seed weight sums cuts tuple count from `105287` to `462` at
+   `10k`, while pruning still stays mostly neutral.
 
 5. **The current C# query-engine path is still materializing far more
-   tuples than seeded Prolog on this workload** — at `10k`, the C#
-   query run emits `3616699` tuples versus `105287` for seeded Prolog.
+   tuples than accumulated Prolog on this workload** — at `10k`, the C#
+   query run emits `3616699` tuples versus `462` for accumulated Prolog.
 
-6. **The next effective-distance step is not more pruning** — it is
-   improving the retained-state strategy for accumulation-style
-   workloads, since this benchmark is already showing that seeded reuse
-   alone carries most of the benefit.
+6. **The effective-distance path is now showing the right next design
+   direction** — specialized retained-state strategies for accumulation
+   workloads are more promising than further branch-pruning work here.
 
 ### Target Recommendations by Audience
 
 | Audience | Recommended Target | Why |
 |----------|-------------------|-----|
-| SWI / Prolog-first | Seeded Prolog | Fastest current effective-distance path, stays close to source semantics |
+| SWI / Prolog-first | Accumulated Prolog | Fastest current effective-distance path, with compact retained state |
 | Enterprise / .NET | C# Query Engine | Strong seeded runtime, broad query-engine surface |
 | Cloud / DevOps | Go | Fast compile, good ecosystem |
 | Systems / Embedded | Rust | No runtime overhead, strong DFS baseline |
@@ -185,7 +186,7 @@ Tables:
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
 | `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
-| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, seeded Prolog, and C#/Rust/Go DFS binaries |
+| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, and C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -196,7 +197,7 @@ Tables:
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
 | `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse with optional branch pruning |
-| `benchmark_prolog_effective_distance.py` | Compare seeded Prolog effective-distance scripts with and without branch pruning and report phase/work metrics |
+| `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, and accumulated Prolog effective-distance scripts and report phase/work metrics |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
 | `benchmark_prolog_seeded_min_closure.py` | Compare seeded Prolog `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
 | `generate_prolog_weighted_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog weighted-shortest-path scripts for seeded `all` vs mode-directed `min` closure |
@@ -256,12 +257,12 @@ go build -o bench pipelines/effective_distance.go
 # Re-run the current non-regression benchmark
 python examples/benchmark/benchmark_effective_distance.py \
     --scales 300,1k,5k,10k \
-    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded
+    --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated
 
-# Compare seeded effective-distance Prolog with and without branch pruning
+# Compare seeded, pruned, and accumulated effective-distance Prolog variants
 python examples/benchmark/benchmark_prolog_effective_distance.py \
     --scales 300,1k,5k,10k \
-    --targets prolog-seeded,prolog-pruned
+    --targets prolog-seeded,prolog-pruned,prolog-accumulated
 
 # Compare minimum-hop shortest path across query engine and DFS targets
 python examples/benchmark/benchmark_shortest_path_cross_target.py \
@@ -335,7 +336,7 @@ The current comparison surface across query and non-query targets is:
   - dependency longest depth
   - positive weighted minimum path distance
   - category influence propagation
-- Prolog seeded closures:
+- Prolog seeded closures and accumulations:
   - all-path effective distance
   - minimum hop distance
   - positive weighted minimum path distance
@@ -358,7 +359,7 @@ The benchmark split is now:
   - `benchmark_shortest_path_to_root.py`
   - `benchmark_weighted_shortest_path.py`
 
-### Prolog Effective-Distance Seeded Results
+### Prolog Effective-Distance Retained-State Results
 
 Command:
 
@@ -369,18 +370,22 @@ python examples/benchmark/benchmark_prolog_effective_distance.py \
 
 Latest local results:
 
-| Scale | Seeded | Pruned | Output Match | Note |
-|-------|--------|--------|--------------|------|
-| 300 | 0.373s | 0.399s | match | pruning overhead slightly visible |
-| 1k | 0.320s | 0.330s | match | effectively tied, seeded slightly ahead |
-| 5k | 1.079s | 1.122s | match | pruning still neutral to slightly slower |
-| 10k | 2.589s | 2.486s | match | tiny win for pruned, still same tuple count |
+| Scale | Seeded | Pruned | Accumulated | Output Match | Note |
+|-------|--------|--------|-------------|--------------|------|
+| 300 | 0.385s | 0.384s | 0.368s | match | effectively tied, accumulated slightly ahead |
+| 1k | 0.361s | 0.347s | 0.248s | match | accumulated wins clearly |
+| 5k | 1.152s | 1.114s | 0.940s | match | big aggregation win |
+| 10k | 2.562s | 2.732s | 2.455s | match | accumulated stays best, pruning still noisy |
 
 Current interpretation:
 
 - seeded closure reuse is the real win on effective distance
 - branch pruning does not currently reduce tuple count or inferences on this workload
-- the pruned and unpruned seeded variants are semantically identical at all tested scales
+- pre-aggregating per-seed weight sums materially reduces retained state:
+  - `1k`: tuple count `10976 -> 48`
+  - `5k`: tuple count `41132 -> 151`
+  - `10k`: tuple count `105287 -> 462`
+- the seeded, pruned, and accumulated variants are semantically identical at all tested scales
 
 ### Prolog Branch-Pruning Results
 

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """
 Benchmark the effective-distance workload for the C# query engine, seeded
-Prolog, and the compiled DFS pipelines.
+Prolog, accumulated Prolog, and the compiled DFS pipelines.
 
 Default targets:
   - csharp-query  : current C# query runtime using PathAwareTransitiveClosureNode
   - prolog-seeded : generated Prolog using seeded counted-closure reuse
+  - prolog-accumulated : generated Prolog using seeded pre-aggregated weight sums
   - csharp-dfs    : generated C# DFS pipeline
   - rust-dfs      : generated Rust DFS pipeline
 
@@ -71,8 +72,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--targets",
-        default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned",
+        default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated",
     )
     parser.add_argument(
         "--repetitions",
@@ -164,6 +165,7 @@ def print_summary(results: list[RunResult]) -> None:
         rust_dfs = find_result(entries, "rust-dfs")
         prolog_seeded = find_result(entries, "prolog-seeded")
         prolog_pruned = find_result(entries, "prolog-pruned")
+        prolog_accumulated = find_result(entries, "prolog-accumulated")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
@@ -171,13 +173,16 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_csharp_dfs", qe, csharp_dfs)
         print_pair_match_status(scale, "query_vs_prolog_seeded", qe, prolog_seeded)
         print_pair_match_status(scale, "query_vs_prolog_pruned", qe, prolog_pruned)
+        print_pair_match_status(scale, "query_vs_prolog_accumulated", qe, prolog_accumulated)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_prolog_seeded", prolog_seeded, qe)
         print_speedup(scale, "speedup_vs_prolog_pruned", prolog_pruned, qe)
+        print_speedup(scale, "speedup_vs_prolog_accumulated", prolog_accumulated, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
+        print_phase_metrics(scale, "prolog-accumulated-metrics", prolog_accumulated)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -222,6 +227,8 @@ def main() -> int:
                 continue
             elif target == "prolog-pruned":
                 continue
+            elif target == "prolog-accumulated":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
@@ -232,6 +239,8 @@ def main() -> int:
                     command = build_prolog_effective_distance(temp_root, scale, "seeded")
                 elif target == "prolog-pruned":
                     command = build_prolog_effective_distance(temp_root, scale, "pruned")
+                elif target == "prolog-accumulated":
+                    command = build_prolog_effective_distance(temp_root, scale, "accumulated")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_prolog_effective_distance.py
+++ b/examples/benchmark/benchmark_prolog_effective_distance.py
@@ -5,6 +5,7 @@ Benchmark seeded effective-distance closure generation for the Prolog target.
 Targets:
   - prolog-seeded : generated Prolog using seeded counted closure reuse
   - prolog-pruned : generated Prolog using seeded closure reuse plus branch pruning
+  - prolog-accumulated : generated Prolog using seeded pre-aggregated weight sums
 """
 
 from __future__ import annotations
@@ -56,8 +57,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--scales", default="300,1k,5k,10k")
     parser.add_argument(
         "--targets",
-        default="prolog-seeded,prolog-pruned",
-        help="Comma-separated targets: prolog-seeded,prolog-pruned",
+        default="prolog-seeded,prolog-pruned,prolog-accumulated",
+        help="Comma-separated targets: prolog-seeded,prolog-pruned,prolog-accumulated",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -68,7 +69,7 @@ def available_targets(requested: list[str]) -> list[str]:
     if shutil.which("swipl") is None:
         print("skip prolog effective-distance benchmark: swipl not found", file=sys.stderr)
         return []
-    supported = {"prolog-seeded", "prolog-pruned"}
+    supported = {"prolog-seeded", "prolog-pruned", "prolog-accumulated"}
     targets: list[str] = []
     for target in requested:
         if target not in supported:
@@ -123,10 +124,16 @@ def print_summary(results: list[RunResult]) -> None:
         print_result_table(entries, scale)
         seeded = find_result(entries, "prolog-seeded")
         pruned = find_result(entries, "prolog-pruned")
+        accumulated = find_result(entries, "prolog-accumulated")
         print_pair_match_status(scale, "seeded_vs_pruned", seeded, pruned)
+        print_pair_match_status(scale, "seeded_vs_accumulated", seeded, accumulated)
+        print_pair_match_status(scale, "pruned_vs_accumulated", pruned, accumulated)
         print_speedup(scale, "speedup_pruned_vs_seeded", seeded, pruned)
+        print_speedup(scale, "speedup_accumulated_vs_seeded", seeded, accumulated)
+        print_speedup(scale, "speedup_accumulated_vs_pruned", pruned, accumulated)
         print_phase_metrics(scale, "seeded_metrics", seeded)
         print_phase_metrics(scale, "pruned_metrics", pruned)
+        print_phase_metrics(scale, "accumulated_metrics", accumulated)
 
 
 def main() -> int:
@@ -156,6 +163,10 @@ def main() -> int:
                 elif target == "prolog-pruned":
                     commands[target] = build_generated_script(
                         temp_root, scale, "pruned", "effective_distance_pruned.pl"
+                    )
+                elif target == "prolog-accumulated":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "accumulated", "effective_distance_accumulated.pl"
                     )
                 else:
                     raise ValueError(f"unsupported target: {target}")

--- a/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
@@ -12,7 +12,7 @@ main :-
     (   Argv = [FactsPath, OutputPath, VariantAtom]
     ->  true
     ;   format(user_error,
-            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned>~n',
+            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned|accumulated>~n',
             []),
         halt(1)
     ),
@@ -46,19 +46,29 @@ parse_variant('pruned', pruned, [
         min_closure(false)
     ]) :-
     !.
+parse_variant('accumulated', accumulated, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(false)
+    ]) :-
+    !.
 parse_variant(Atom, _, _) :-
     format(user_error,
-        'Unsupported effective-distance benchmark variant: ~w (expected seeded or pruned)~n',
+        'Unsupported effective-distance benchmark variant: ~w (expected seeded, pruned, or accumulated)~n',
         [Atom]),
     halt(1).
 
 benchmark_driver_code(Variant, FactsPath, Code) :-
     format(atom(FactsPathLine), 'facts_path(~q).', [FactsPath]),
+    benchmark_index_build_line(Variant, IndexBuildLine),
+    benchmark_results_line(Variant, ResultsLine),
     benchmark_mode_line(Variant, ModeLine),
     Lines = [
         ':- use_module(library(aggregate)).',
         ':- use_module(library(lists)).',
         ':- dynamic bench_seed_hops/3.',
+        ':- dynamic bench_seed_weight_sum/3.',
         FactsPathLine,
         '',
         'load_benchmark_facts :-',
@@ -71,14 +81,15 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         'collect_articles(Articles) :-',
         '    setof(Article, Cat^article_category(Article, Cat), Articles).',
         '',
-        'clear_seed_hops_index :-',
-        '    retractall(bench_seed_hops(_, _, _)).',
+        'clear_seed_indexes :-',
+        '    retractall(bench_seed_hops(_, _, _)),',
+        '    retractall(bench_seed_weight_sum(_, _, _)).',
         '',
         'seed_hops_query(Cat, Root, Hops) :-',
         '    category_ancestor(Cat, Root, Hops, [Cat]).',
         '',
         'build_seed_hops_index(Root, SeedCount, TupleCount) :-',
-        '    clear_seed_hops_index,',
+        '    clear_seed_indexes,',
         '    collect_seed_categories(Seeds),',
         '    length(Seeds, SeedCount),',
         '    forall(',
@@ -90,6 +101,28 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    ),',
         '    aggregate_all(count, bench_seed_hops(_, _, _), TupleCount).',
         '',
+        'build_seed_weight_sum_index(Root, SeedCount, TupleCount) :-',
+        '    clear_seed_indexes,',
+        '    collect_seed_categories(Seeds),',
+        '    length(Seeds, SeedCount),',
+        '    dimension_n(N),',
+        '    NegN is -N,',
+        '    forall(',
+        '        member(Cat, Seeds),',
+        '        (   aggregate_all(sum(W),',
+        '                (   seed_hops_query(Cat, Root, Hops),',
+        '                    TotalHops is Hops + 1,',
+        '                    W is TotalHops ** NegN',
+        '                ),',
+        '                WeightSum),',
+        '            (   WeightSum > 0',
+        '            ->  assertz(bench_seed_weight_sum(Cat, Root, WeightSum))',
+        '            ;   true',
+        '            )',
+        '        )',
+        '    ),',
+        '    aggregate_all(count, bench_seed_weight_sum(_, _, _), TupleCount).',
+        '',
         'seeded_article_root_hops(Article, Root, 1) :-',
         '    article_category(Article, Root).',
         'seeded_article_root_hops(Article, Root, Hops) :-',
@@ -98,7 +131,14 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    bench_seed_hops(Cat, Root, CatHops),',
         '    Hops is CatHops + 1.',
         '',
-        'compute_effective_distance_results(Root, Results) :-',
+        'seeded_article_root_weight(Article, Root, 1.0) :-',
+        '    article_category(Article, Root).',
+        'seeded_article_root_weight(Article, Root, Weight) :-',
+        '    article_category(Article, Cat),',
+        '    Cat \\= Root,',
+        '    bench_seed_weight_sum(Cat, Root, Weight).',
+        '',
+        'compute_effective_distance_results_from_hops(Root, Results) :-',
         '    collect_articles(Articles),',
         '    dimension_n(N),',
         '    NegN is -N,',
@@ -111,6 +151,21 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '                WeightSum),',
         '            WeightSum > 0,',
         '            InvN is -1 / N,',
+        '            Deff is WeightSum ** InvN',
+        '        ),',
+        '        Pairs),',
+        '    sort(Pairs, Results).',
+        '',
+        'compute_effective_distance_results_from_weight_sums(Root, Results) :-',
+        '    collect_articles(Articles),',
+        '    dimension_n(N),',
+        '    InvN is -1 / N,',
+        '    findall(Deff-Article,',
+        '        (   member(Article, Articles),',
+        '            aggregate_all(sum(W),',
+        '                seeded_article_root_weight(Article, Root, W),',
+        '                WeightSum),',
+        '            WeightSum > 0,',
         '            Deff is WeightSum ** InvN',
         '        ),',
         '        Pairs),',
@@ -129,9 +184,9 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    statistics(walltime, [LoadEndMs, _]),',
         '    statistics(inferences, InferencesBefore),',
         '    root_category(Root),',
-        '    build_seed_hops_index(Root, SeedCount, TupleCount),',
+        IndexBuildLine,
         '    statistics(walltime, [QueryEndMs, _]),',
-        '    compute_effective_distance_results(Root, Results),',
+        ResultsLine,
         '    statistics(walltime, [AggEndMs, _]),',
         '    print_effective_distance_results(Root, Results),',
         '    statistics(inferences, InferencesAfter),',
@@ -153,5 +208,14 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
     ],
     atomic_list_concat(Lines, '\n', Code).
 
+benchmark_index_build_line(seeded, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
+benchmark_index_build_line(pruned, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
+benchmark_index_build_line(accumulated, '    build_seed_weight_sum_index(Root, SeedCount, TupleCount),').
+
+benchmark_results_line(seeded, '    compute_effective_distance_results_from_hops(Root, Results),').
+benchmark_results_line(pruned, '    compute_effective_distance_results_from_hops(Root, Results),').
+benchmark_results_line(accumulated, '    compute_effective_distance_results_from_weight_sums(Root, Results),').
+
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
 benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').
+benchmark_mode_line(accumulated, '    format(user_error, ''mode=accumulated~n'', []),').


### PR DESCRIPTION
  ## Summary

  This improves the Prolog effective-distance benchmark path by changing what is retained per seed.

  Instead of storing all `(seed, root, hops)` tuples and aggregating `Hops^(-N)` later per article, the new `prolog-
  accumulated` variant pre-aggregates the per-seed weight sum once and stores only `(seed, root, weight_sum)`.

  That keeps the benchmark semantics unchanged, but significantly reduces retained state and aggregation overhead.

  ## What Changed

  - extended `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
    - added a new `accumulated` variant
    - existing variants remain:
      - `seeded`
      - `pruned`
    - the new variant:
      - reuses the same counted `category_ancestor/4` closure per seed
      - computes `sum((Hops+1)^(-N))` once per `(seed, root)`
      - stores `bench_seed_weight_sum/3` instead of raw hop tuples
  - updated `examples/benchmark/benchmark_prolog_effective_distance.py`
    - now compares:
      - `prolog-seeded`
      - `prolog-pruned`
      - `prolog-accumulated`
    - reports match status, speedups, and phase/work metrics for all three
  - updated `examples/benchmark/benchmark_effective_distance.py`
    - added `prolog-accumulated` to the cross-target benchmark
    - made `prolog-accumulated` the default Prolog effective-distance comparison target
  - updated `examples/benchmark/README.md`
    - rewrote the effective-distance top-line story around the accumulated Prolog path
    - documented retained-state reduction and current benchmark results

  ## Why

  The previous seeded Prolog effective-distance benchmark already showed that seeded reuse was the real win and that
  branch pruning was not helping this workload.

  The next logical step was therefore not more pruning, but reducing the amount of aggregation state retained per seed.

  This PR takes that narrower and easier-to-prove step:
  - keep the recursive closure logic the same
  - pre-aggregate per-seed path weights once
  - avoid carrying raw hop tuples into the per-article aggregation phase

  ## Result

  ### Standalone Prolog effective-distance benchmark

  Latest local run:

  | Scale | Seeded | Pruned | Accumulated |
  |-------|--------|--------|-------------|
  | 300 | 0.385s | 0.384s | 0.368s |
  | 1k | 0.361s | 0.347s | 0.248s |
  | 5k | 1.152s | 1.114s | 0.940s |
  | 10k | 2.562s | 2.732s | 2.455s |

  All three variants produce matching outputs.

  Retained state drops sharply from `seeded` to `accumulated`:

  - `1k`: tuple count `10976 -> 48`
  - `5k`: tuple count `41132 -> 151`
  - `10k`: tuple count `105287 -> 462`

  ### Cross-target effective-distance benchmark

  Latest local run with `csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated`:

  | Scale | C# Query | Prolog Accumulated |
  |-------|----------|--------------------|
  | 300 | 0.681s | 0.353s |
  | 1k | 0.504s | 0.246s |
  | 5k | 1.338s | 0.852s |
  | 10k | 3.197s | 2.057s |

  Outputs match across all targets at all tested scales.

  So the accumulated Prolog path is now the fastest effective-distance benchmark path on the current surface.

  ## Verification

  - `python -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/
  benchmark_prolog_effective_distance.py`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k,5k,10k --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 300,1k,5k,10k --targets csharp-query,csharp-
  dfs,rust-dfs,go-dfs,prolog-accumulated --repetitions 1`

  ## Notes

  - this PR is still benchmark/harness work; it does not add a new general Prolog target lowering yet
  - the result reinforces the current design direction:
    - branch pruning is not the main lever for effective distance
    - retained-state strategy for accumulation workloads is
  - this makes a stronger case for a future Prolog-side generalized accumulation optimization analogous to the C# path-
  aware accumulation runtime