### PR TITLE
feat(csharp-query): add runtime retention modes

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -10,7 +10,7 @@ a supported fallback.
 
 Status:
 
-- in progress / partially implemented
+- implemented for the current DAG benchmark paths
 
 Work:
 
@@ -41,6 +41,8 @@ Success criteria:
 
 - fewer ambiguous materialization decisions outside the engine
 - clearer runtime contracts for new operators
+- explicit provider/runtime hooks for choosing streaming, replayable, or
+  external-materialized access
 
 ## Stage 3: Expand Streamed Ingestion Beyond Current DAG Cases
 
@@ -85,6 +87,8 @@ Success criteria:
 Near-term implementation work should continue to prefer:
 
 - streamed sources into the runtime
+- explicit runtime retention requests (`Streaming`, `Replayable`,
+  `ExternalMaterialized`)
 - operator-owned retained state
 - external materialization only when the streamed/operator-owned path is not yet
   available or is measurably worse

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -19,6 +19,21 @@ move toward.
 - external materialization: facts are fully built outside the engine and then
   handed in as in-memory relations
 
+## Current Runtime Hooks
+
+The current runtime now exposes a narrow explicit retention contract:
+
+- `RelationRetentionMode`
+  - `Streaming`
+  - `Replayable`
+  - `ExternalMaterialized`
+- `RelationBinding`
+- `IRetentionAwareRelationProvider`
+
+These hooks do not solve every ingestion case yet, but they make the
+retention choice explicit at the runtime/provider boundary instead of hiding it
+inside benchmark-specific wiring.
+
 ## Required Capabilities
 
 ### 1. Streaming-capable providers
@@ -82,11 +97,13 @@ engine, not the parser, should decide when that is warranted.
 
 ## Current Narrow Implementation Pattern
 
-For the current DAG benchmark operators, the streamed path is:
+For the current benchmark/runtime surface, the streamed path is:
 
 1. provider exposes delimited relation sources
-2. engine reads rows directly from those sources
-3. engine builds only the graph/group state needed by the DAG operator
-4. benchmark code avoids preloading raw facts into in-memory relations first
+2. the runtime requests either `Streaming` or `Replayable` access
+3. DAG and scan-oriented operators read rows through that retention boundary
+4. the operator builds only the retained state it actually needs
+5. benchmark code avoids preloading raw facts into in-memory relations first
 
-This is a first step, not the full endpoint.
+This is still a first step, not the full endpoint, but it is now broader than
+just the original DAG-only fast paths.

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2490,19 +2490,7 @@ class Program
         var predId = new PredicateId("category_ancestor", 3);
         var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
 
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {{
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }}
-        }}
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
 
         foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
         {{
@@ -2688,19 +2676,7 @@ class Program
         var articleCategories = new Dictionary<string, List<string>>();
 
         var swLoad = Stopwatch.StartNew();
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {{
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }}
-        }}
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
 
         foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
         {{
@@ -2862,19 +2838,7 @@ class Program
         var predId = new PredicateId("category_ancestor", 3);
         var articleCategories = new Dictionary<string, List<string>>();
 
-        foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length == 2)
-            {{
-                provider.AddFact(edgeId, parts[0], parts[1]);
-            }}
-        }}
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
 
         foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
         {{
@@ -3038,6 +3002,7 @@ class Program
         var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
         var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
 
+        provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
         {{
             if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
@@ -3051,7 +3016,6 @@ class Program
                 continue;
             }}
 
-            provider.AddFact(edgeId, parts[0], parts[1]);
             sourceNodes.Add(parts[0]);
             outDegree[parts[0]] = outDegree.TryGetValue(parts[0], out var degree) ? degree + 1 : 1;
         }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -36,15 +36,26 @@ namespace UnifyWeaver.QueryRuntime
         IEnumerable<object[]> GetFacts(PredicateId predicate);
     }
 
+    public enum RelationRetentionMode
+    {
+        Streaming,
+        Replayable,
+        ExternalMaterialized
+    }
+
     public readonly record struct DelimitedRelationSource(
         string InputPath,
         char Delimiter = '	',
         int SkipRows = 1,
         int ExpectedWidth = 2);
 
-    public interface IStreamingRelationProvider : IRelationProvider
+    public readonly record struct RelationBinding(
+        RelationRetentionMode Mode,
+        DelimitedRelationSource? DelimitedSource = null);
+
+    public interface IRetentionAwareRelationProvider : IRelationProvider
     {
-        bool TryGetDelimitedSource(PredicateId predicate, out DelimitedRelationSource source);
+        bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding);
     }
 
     /// <summary>
@@ -1131,7 +1142,52 @@ namespace UnifyWeaver.QueryRuntime
     /// Currently supports non-recursive plans; recursion-aware fixpoint
     /// iteration will be layered on later.
     /// </summary>
-    public sealed class InMemoryRelationProvider : IStreamingRelationProvider
+    internal static class DelimitedRelationReader
+    {
+        public static IEnumerable<object[]> ReadRows(DelimitedRelationSource source)
+        {
+            using var reader = OpenSequentialReader(source.InputPath);
+            for (var i = 0; i < source.SkipRows; i++)
+            {
+                if (reader.ReadLine() is null)
+                {
+                    yield break;
+                }
+            }
+
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (!TrySplitTwoColumnLine(line, source.Delimiter, out var left, out var right))
+                {
+                    continue;
+                }
+
+                yield return new object[] { left, right };
+            }
+        }
+
+        public static StreamReader OpenSequentialReader(string path) =>
+            new(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1 << 16);
+
+        public static bool TrySplitTwoColumnLine(string line, char delimiter, out string left, out string right)
+        {
+            var span = line.AsSpan();
+            var split = span.IndexOf(delimiter);
+            if (split <= 0 || split >= span.Length - 1)
+            {
+                left = string.Empty;
+                right = string.Empty;
+                return false;
+            }
+
+            left = span.Slice(0, split).ToString();
+            right = span.Slice(split + 1).ToString();
+            return true;
+        }
+    }
+
+    public sealed class InMemoryRelationProvider : IRetentionAwareRelationProvider
     {
         private readonly Dictionary<PredicateId, List<object[]>> _store = new();
         private readonly Dictionary<PredicateId, DelimitedRelationSource> _delimitedSources = new();
@@ -1175,53 +1231,28 @@ namespace UnifyWeaver.QueryRuntime
             }
             if (_delimitedSources.TryGetValue(predicate, out var source))
             {
-                return ReadDelimitedSource(source);
+                return DelimitedRelationReader.ReadRows(source);
             }
             return Array.Empty<object[]>();
         }
 
-        public bool TryGetDelimitedSource(PredicateId predicate, out DelimitedRelationSource source) =>
-            _delimitedSources.TryGetValue(predicate, out source);
-
-        private static IEnumerable<object[]> ReadDelimitedSource(DelimitedRelationSource source)
+        public bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding)
         {
-            using var reader = OpenSequentialReader(source.InputPath);
-            for (var i = 0; i < source.SkipRows; i++)
+            if (preferredMode != RelationRetentionMode.ExternalMaterialized &&
+                _delimitedSources.TryGetValue(predicate, out var source))
             {
-                if (reader.ReadLine() is null)
-                {
-                    yield break;
-                }
+                binding = new RelationBinding(preferredMode, source);
+                return true;
             }
 
-            string? line;
-            while ((line = reader.ReadLine()) is not null)
+            if (preferredMode == RelationRetentionMode.ExternalMaterialized && _store.ContainsKey(predicate))
             {
-                if (!TrySplitTwoColumnLine(line, source.Delimiter, out var left, out var right))
-                {
-                    continue;
-                }
-                yield return new object[] { left, right };
-            }
-        }
-
-        private static StreamReader OpenSequentialReader(string path) =>
-            new(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1 << 16);
-
-        private static bool TrySplitTwoColumnLine(string line, char delimiter, out string left, out string right)
-        {
-            var span = line.AsSpan();
-            var split = span.IndexOf(delimiter);
-            if (split <= 0 || split >= span.Length - 1)
-            {
-                left = string.Empty;
-                right = string.Empty;
-                return false;
+                binding = new RelationBinding(RelationRetentionMode.ExternalMaterialized);
+                return true;
             }
 
-            left = span.Slice(0, split).ToString();
-            right = span.Slice(split + 1).ToString();
-            return true;
+            binding = default;
+            return false;
         }
     }
 
@@ -1506,7 +1537,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 case RelationScanNode scan:
                     result = context is null
-                        ? _provider.GetFacts(scan.Relation) ?? Enumerable.Empty<object[]>()
+                        ? GetFactStream(scan.Relation)
                         : GetFactsList(scan.Relation, context);
                     break;
 
@@ -1752,7 +1783,7 @@ namespace UnifyWeaver.QueryRuntime
 
             if (context is null)
             {
-                return (_provider.GetFacts(scan.Relation) ?? Enumerable.Empty<object[]>()).Where(tuple =>
+                return GetFactStream(scan.Relation).Where(tuple =>
                     tuple is not null && TupleMatchesPattern(tuple, scan.Pattern));
             }
 
@@ -5506,12 +5537,56 @@ namespace UnifyWeaver.QueryRuntime
             return output;
         }
 
+        private bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding)
+        {
+            if (_provider is IRetentionAwareRelationProvider retentionAwareProvider &&
+                retentionAwareProvider.TryBindRelation(predicate, preferredMode, out binding))
+            {
+                return true;
+            }
+
+            binding = default;
+            return false;
+        }
+
+        private bool TryGetDelimitedSource(PredicateId predicate, RelationRetentionMode preferredMode, out DelimitedRelationSource source)
+        {
+            if (TryBindRelation(predicate, preferredMode, out var binding) && binding.DelimitedSource is { } delimitedSource)
+            {
+                source = delimitedSource;
+                return true;
+            }
+
+            source = default;
+            return false;
+        }
+
+        private IEnumerable<object[]> GetFactStream(PredicateId predicate)
+        {
+            if (TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var source))
+            {
+                return DelimitedRelationReader.ReadRows(source);
+            }
+
+            return _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+        }
+
+        private List<object[]> MaterializeFacts(PredicateId predicate)
+        {
+            if (TryGetDelimitedSource(predicate, RelationRetentionMode.Replayable, out var source))
+            {
+                return DelimitedRelationReader.ReadRows(source).ToList();
+            }
+
+            var factsSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
+            return factsSource as List<object[]> ?? factsSource.ToList();
+        }
+
         private List<object[]> GetFactsList(PredicateId predicate, EvaluationContext? context)
         {
             if (context is null)
             {
-                var source = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
-                return source as List<object[]> ?? source.ToList();
+                return MaterializeFacts(predicate);
             }
 
             if (context.Facts.TryGetValue(predicate, out var cached))
@@ -5531,8 +5606,7 @@ namespace UnifyWeaver.QueryRuntime
                 missTrace.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
             }
 
-            var factsSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
-            var facts = factsSource as List<object[]> ?? factsSource.ToList();
+            var facts = MaterializeFacts(predicate);
             context.Facts[predicate] = facts;
             return facts;
         }
@@ -5541,7 +5615,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             if (context is null)
             {
-                return new HashSet<object[]>(_provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>(), StructuralArrayComparer.Instance);
+                return new HashSet<object[]>(MaterializeFacts(predicate), StructuralArrayComparer.Instance);
             }
 
             if (context.FactSets.TryGetValue(predicate, out var cached))
@@ -8310,9 +8384,8 @@ namespace UnifyWeaver.QueryRuntime
                 const int MaxDagGroupCount = 4096;
                 const int MinDagGroupCount = 64;
                 const int MinDagEdgeCount = 8192;
-                if (_provider is IStreamingRelationProvider streamingProvider &&
-                    streamingProvider.TryGetDelimitedSource(closure.EdgeRelation, out var edgeSource) &&
-                    streamingProvider.TryGetDelimitedSource(closure.SeedRelation, out var seedSource) &&
+                if (TryGetDelimitedSource(closure.EdgeRelation, RelationRetentionMode.Streaming, out var edgeSource) &&
+                    TryGetDelimitedSource(closure.SeedRelation, RelationRetentionMode.Streaming, out var seedSource) &&
                     TryBuildProjectGroupedDagReachCountRowsFromDelimitedSources(edgeSource, seedSource, MinDagEdgeCount, MinDagGroupCount, MaxDagNodeCount, MaxDagGroupCount, out var streamedDagRows))
                 {
                     trace?.RecordCacheLookup("SeedGroupedTransitiveClosureCount", traceKey, hit: false, built: true);
@@ -8438,9 +8511,8 @@ namespace UnifyWeaver.QueryRuntime
                 trace?.RecordCacheLookup("SeedGroupedDagLongestDepth", traceKey, hit: false, built: true);
 
                 const int MaxDagNodeCount = 65536;
-                if (_provider is IStreamingRelationProvider streamingProvider &&
-                    streamingProvider.TryGetDelimitedSource(closure.EdgeRelation, out var edgeSource) &&
-                    streamingProvider.TryGetDelimitedSource(closure.SeedRelation, out var seedSource) &&
+                if (TryGetDelimitedSource(closure.EdgeRelation, RelationRetentionMode.Streaming, out var edgeSource) &&
+                    TryGetDelimitedSource(closure.SeedRelation, RelationRetentionMode.Streaming, out var seedSource) &&
                     TryBuildSeedGroupedDagLongestDepthRowsFromDelimitedSources(closure, trace, edgeSource, seedSource, MaxDagNodeCount, out var streamedRows))
                 {
                     context.SeedGroupedDagLongestDepthResults[cacheKey] = streamedRows;
@@ -8490,7 +8562,7 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             var edgeCount = 0;
-            using (var reader = OpenSequentialReader(edgeSource.InputPath))
+            using (var reader = DelimitedRelationReader.OpenSequentialReader(edgeSource.InputPath))
             {
                 for (var i = 0; i < edgeSource.SkipRows; i++)
                 {
@@ -8503,7 +8575,7 @@ namespace UnifyWeaver.QueryRuntime
                 string? line;
                 while ((line = reader.ReadLine()) is not null)
                 {
-                    if (!TrySplitTwoColumnLine(line, edgeSource.Delimiter, out var left, out var right))
+                    if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, edgeSource.Delimiter, out var left, out var right))
                     {
                         continue;
                     }
@@ -8523,7 +8595,7 @@ namespace UnifyWeaver.QueryRuntime
             var groupIds = new Dictionary<string, int>(StringComparer.Ordinal);
             var groupValues = new List<string>();
             var seedPairs = new List<(int GroupId, int NodeId)>();
-            using (var reader = OpenSequentialReader(seedSource.InputPath))
+            using (var reader = DelimitedRelationReader.OpenSequentialReader(seedSource.InputPath))
             {
                 for (var i = 0; i < seedSource.SkipRows; i++)
                 {
@@ -8536,7 +8608,7 @@ namespace UnifyWeaver.QueryRuntime
                 string? line;
                 while ((line = reader.ReadLine()) is not null)
                 {
-                    if (!TrySplitTwoColumnLine(line, seedSource.Delimiter, out var group, out var node))
+                    if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, seedSource.Delimiter, out var group, out var node))
                     {
                         continue;
                     }
@@ -8772,7 +8844,7 @@ namespace UnifyWeaver.QueryRuntime
                 return id;
             }
 
-            using (var reader = OpenSequentialReader(edgeSource.InputPath))
+            using (var reader = DelimitedRelationReader.OpenSequentialReader(edgeSource.InputPath))
             {
                 for (var i = 0; i < edgeSource.SkipRows; i++)
                 {
@@ -8785,7 +8857,7 @@ namespace UnifyWeaver.QueryRuntime
                 string? line;
                 while ((line = reader.ReadLine()) is not null)
                 {
-                    if (!TrySplitTwoColumnLine(line, edgeSource.Delimiter, out var left, out var right))
+                    if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, edgeSource.Delimiter, out var left, out var right))
                     {
                         continue;
                     }
@@ -8807,7 +8879,7 @@ namespace UnifyWeaver.QueryRuntime
             var groupIds = new Dictionary<string, int>(StringComparer.Ordinal);
             var groupValues = new List<string>();
             var seedPairs = new List<(int GroupId, int NodeId)>();
-            using (var reader = OpenSequentialReader(seedSource.InputPath))
+            using (var reader = DelimitedRelationReader.OpenSequentialReader(seedSource.InputPath))
             {
                 for (var i = 0; i < seedSource.SkipRows; i++)
                 {
@@ -8820,7 +8892,7 @@ namespace UnifyWeaver.QueryRuntime
                 string? line;
                 while ((line = reader.ReadLine()) is not null)
                 {
-                    if (!TrySplitTwoColumnLine(line, seedSource.Delimiter, out var group, out var node))
+                    if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, seedSource.Delimiter, out var group, out var node))
                     {
                         continue;
                     }
@@ -9752,25 +9824,6 @@ namespace UnifyWeaver.QueryRuntime
             phaseStopwatch.Stop();
             trace?.RecordPhase(traceNode, "group_reduction", phaseStopwatch.Elapsed);
 
-            return true;
-        }
-
-        private static StreamReader OpenSequentialReader(string path) =>
-            new(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1 << 16, FileOptions.SequentialScan), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1 << 16);
-
-        private static bool TrySplitTwoColumnLine(string line, char delimiter, out string left, out string right)
-        {
-            var span = line.AsSpan();
-            var split = span.IndexOf(delimiter);
-            if (split <= 0 || split >= span.Length - 1)
-            {
-                left = string.Empty;
-                right = string.Empty;
-                return false;
-            }
-
-            left = span.Slice(0, split).ToString();
-            right = span.Slice(split + 1).ToString();
             return true;
         }
 


### PR DESCRIPTION
  ## Summary

  This PR makes relation retention/materialization modes explicit in the C#
  query runtime and applies that boundary beyond the original DAG benchmark
  fast paths.

  The recent DAG ingestion work already moved benchmark fact materialization
  closer to the engine.

  This PR is the next step:

  - make the retention choice explicit at the runtime/provider boundary
  - use that shared boundary inside the runtime
  - extend engine-owned edge ingestion beyond the dependency DAG benchmarks

  The result is a cleaner runtime contract and a broader proof that the
  query engine, not the parser or benchmark harness, should decide how much
  state to retain.

  ## What Changed

  ### Explicit Runtime Retention Modes

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `RelationRetentionMode`
    - `Streaming`
    - `Replayable`
    - `ExternalMaterialized`
  - `RelationBinding`
  - `IRetentionAwareRelationProvider`

  These types make the materialization/retention request explicit.

  Instead of special-casing “does this provider happen to have a delimited
  source?” inside individual operators, the runtime can now ask for a
  relation in a preferred retention mode.

  ### Shared Delimited Reader

  Added:

  - `DelimitedRelationReader`

  This centralizes the narrow delimited TSV reader logic used by the
  current benchmark/runtime integration.

  That avoids duplicating parsing helpers across the provider and executor
  layers and makes the streamed source boundary easier to reuse.

  ### Runtime Binding Helpers

  Updated:

  - `QueryExecutor`

  Added shared helpers for:

  - binding a relation through the retention-aware provider boundary
  - getting a streamed fact source
  - materializing a replayable fact list only when needed

  This is the core implementation shift in the PR.

  ### DAG Nodes Now Use The Shared Retention Boundary

  Refactored:

  - grouped DAG reach-count path
  - grouped DAG longest-depth path

  These operators no longer probe a special streaming provider interface
  directly. They now use the shared runtime retention helpers.

  So the streamed DAG ingestion path is still there, but it now sits on a
  cleaner runtime contract.

  ### Scan Nodes Also Use The Retention Boundary

  Updated:

  - `RelationScanNode`
  - `PatternScanNode`

  When evaluated without an execution-context fact cache, these scans now go
  through the same runtime retention boundary rather than directly reading
  only from eager provider facts.

  That makes the new retention model broader than the original DAG-only
  work.

  ### Path-Aware Query Benchmarks Now Hand Edge Ingestion To The Runtime

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` programs for these workloads now register the
  `category_parent` edge relation as a streamed runtime source instead of
  preloading all edge facts manually:

  - `category_influence`
  - `effective_distance`
  - `shortest_path`
  - `weighted_shortest_path`

  Their other benchmark-side data handling remains intact, but the graph
  edge relation now crosses the same engine-owned retention boundary as the
  newer DAG benchmarks.

  ### Materialization Docs Refreshed

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`

  These docs now reflect the concrete runtime hooks added here, rather than
  describing the retention model only in abstract terms.

  ## Why This Matters

  The main architectural point of this PR is:

  - streamed ingestion is no longer just a benchmark-specific DAG shortcut
  - it is now represented as an explicit runtime/provider contract

  That matters because it keeps the materialization decision where operator
  knowledge actually exists:

  - inside the engine

  It also broadens the evidence for the query-engine story:

  - pruning wins were already demonstrated
  - now the engine-owned retention boundary is becoming a real reusable
    mechanism rather than a one-off DAG benchmark trick

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile examples/benchmark/generate_pipeline.py

  ### DAG benchmark smokes

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Both still matched across all four targets.

  ### Path-aware query benchmark smokes

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  All still built and produced matching outputs where expected.

  ## Representative Smoke Results

  ### Shortest path (300)

  - csharp-query: 0.144s
  - csharp-dfs: 0.447s
  - rust-dfs: 0.330s
  - go-dfs: 0.469s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  ### Weighted shortest path (300)

  - csharp-query: 0.187s
  - csharp-dfs: 0.486s
  - rust-dfs: 0.375s
  - go-dfs: 0.483s

  Status:

  - dfs_outputs = match
  - query_vs_csharp_dfs = match

  ### Category influence (300)

  - csharp-query: 0.865s
  - rust-dfs: 0.405s
  - go-dfs: 0.911s

  Status:

  - outputs = match

  ## Interpretation

  This PR is mostly about runtime structure and ownership boundaries, not a
  single headline benchmark win.

  The key improvement is that the runtime now has a clearer answer to:

  - should this relation be streamed?
  - should it be replayable/materialized?
  - is external materialization just a fallback?

  That is a better foundation for future work than continuing to hide those
  decisions inside individual benchmark generators or ad hoc operator
  branches.

  ## Scope

  This PR adds:

  - explicit retention-mode/runtime binding types
  - shared retention helpers in the C# query runtime
  - scan-node use of the retention boundary
  - broader benchmark integration for runtime-owned edge ingestion
  - doc updates for the materialization contract

  It does not yet add:

  - a fully general cost-based retention planner
  - replay-buffer implementations beyond current narrow materialization paths
  - streaming-first rewrites for every operator family

  ## Follow-Up

  Likely next work:

  - keep expanding engine-owned retention beyond the current streamed edge
    cases
  - make replayable-source handling more explicit where operators need
    multiple passes
  - use the new retention boundary as the place where future cost-based
    strategy selection happens