### PR TITLE
feat(csharp-query): add replayable relation bindings

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -27,6 +27,10 @@ Success criteria:
 
 ## Stage 2: Clarify Retention Modes In The Runtime
 
+Status:
+
+- implemented for streamed and replayable relation bindings in the current C# query runtime
+
 Work:
 
 - make the distinction clearer between:
@@ -45,6 +49,10 @@ Success criteria:
   external-materialized access
 
 ## Stage 3: Expand Streamed Ingestion Beyond Current DAG Cases
+
+Status:
+
+- started for scan-oriented and path-aware benchmark paths using the shared retention boundary
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -29,6 +29,7 @@ The current runtime now exposes a narrow explicit retention contract:
   - `ExternalMaterialized`
 - `RelationBinding`
 - `IRetentionAwareRelationProvider`
+- `IReplayableRelationSource`
 
 These hooks do not solve every ingestion case yet, but they make the
 retention choice explicit at the runtime/provider boundary instead of hiding it
@@ -101,9 +102,10 @@ For the current benchmark/runtime surface, the streamed path is:
 
 1. provider exposes delimited relation sources
 2. the runtime requests either `Streaming` or `Replayable` access
-3. DAG and scan-oriented operators read rows through that retention boundary
-4. the operator builds only the retained state it actually needs
-5. benchmark code avoids preloading raw facts into in-memory relations first
+3. replayable bindings can cache a reusable relation source instead of ad hoc `ToList()` calls
+4. DAG, scan, and path-aware operators read rows through that retention boundary
+5. the operator builds only the retained state it actually needs
+6. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -49,9 +49,16 @@ namespace UnifyWeaver.QueryRuntime
         int SkipRows = 1,
         int ExpectedWidth = 2);
 
+    public interface IReplayableRelationSource
+    {
+        IEnumerable<object[]> Stream();
+        List<object[]> Materialize();
+    }
+
     public readonly record struct RelationBinding(
         RelationRetentionMode Mode,
-        DelimitedRelationSource? DelimitedSource = null);
+        DelimitedRelationSource? DelimitedSource = null,
+        IReplayableRelationSource? ReplayableSource = null);
 
     public interface IRetentionAwareRelationProvider : IRelationProvider
     {
@@ -1187,14 +1194,44 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    internal sealed class ReplayableRelationSource : IReplayableRelationSource
+    {
+        private readonly Func<IEnumerable<object[]>> _factory;
+        private readonly object _gate = new();
+        private List<object[]>? _buffer;
+
+        public ReplayableRelationSource(Func<IEnumerable<object[]>> factory)
+        {
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        }
+
+        public IEnumerable<object[]> Stream() => Materialize();
+
+        public List<object[]> Materialize()
+        {
+            if (_buffer is not null)
+            {
+                return _buffer;
+            }
+
+            lock (_gate)
+            {
+                _buffer ??= _factory().ToList();
+                return _buffer;
+            }
+        }
+    }
+
     public sealed class InMemoryRelationProvider : IRetentionAwareRelationProvider
     {
         private readonly Dictionary<PredicateId, List<object[]>> _store = new();
         private readonly Dictionary<PredicateId, DelimitedRelationSource> _delimitedSources = new();
+        private readonly Dictionary<PredicateId, IReplayableRelationSource> _replayableSources = new();
 
         public void RegisterDelimitedSource(PredicateId predicate, DelimitedRelationSource source)
         {
             _delimitedSources[predicate] = source;
+            _replayableSources.Remove(predicate);
         }
 
         public void AddFact(PredicateId predicate, params object[] values)
@@ -1221,6 +1258,7 @@ namespace UnifyWeaver.QueryRuntime
                 _store[predicate] = list;
             }
             list.Add(tuple);
+            _replayableSources.Remove(predicate);
         }
 
         public IEnumerable<object[]> GetFacts(PredicateId predicate)
@@ -1238,11 +1276,34 @@ namespace UnifyWeaver.QueryRuntime
 
         public bool TryBindRelation(PredicateId predicate, RelationRetentionMode preferredMode, out RelationBinding binding)
         {
-            if (preferredMode != RelationRetentionMode.ExternalMaterialized &&
-                _delimitedSources.TryGetValue(predicate, out var source))
+            if (preferredMode == RelationRetentionMode.Streaming &&
+                _delimitedSources.TryGetValue(predicate, out var streamingSource))
             {
-                binding = new RelationBinding(preferredMode, source);
+                binding = new RelationBinding(RelationRetentionMode.Streaming, streamingSource);
                 return true;
+            }
+
+            if (preferredMode == RelationRetentionMode.Replayable)
+            {
+                if (!_replayableSources.TryGetValue(predicate, out var replayableSource))
+                {
+                    if (_delimitedSources.TryGetValue(predicate, out var replayableDelimitedSource))
+                    {
+                        replayableSource = new ReplayableRelationSource(() => DelimitedRelationReader.ReadRows(replayableDelimitedSource));
+                        _replayableSources[predicate] = replayableSource;
+                    }
+                    else if (_store.TryGetValue(predicate, out var replayableList))
+                    {
+                        replayableSource = new ReplayableRelationSource(() => replayableList);
+                        _replayableSources[predicate] = replayableSource;
+                    }
+                }
+
+                if (replayableSource is not null)
+                {
+                    binding = new RelationBinding(RelationRetentionMode.Replayable, ReplayableSource: replayableSource);
+                    return true;
+                }
             }
 
             if (preferredMode == RelationRetentionMode.ExternalMaterialized && _store.ContainsKey(predicate))
@@ -1496,6 +1557,7 @@ namespace UnifyWeaver.QueryRuntime
 
             _cacheContext.Facts.Clear();
             _cacheContext.FactSources.Clear();
+            _cacheContext.ReplayableFactSources.Clear();
             _cacheContext.FactSets.Clear();
             _cacheContext.FactIndices.Clear();
             _cacheContext.JoinIndices.Clear();
@@ -1537,7 +1599,7 @@ namespace UnifyWeaver.QueryRuntime
 
                 case RelationScanNode scan:
                     result = context is null
-                        ? GetFactStream(scan.Relation)
+                        ? GetFactStream(scan.Relation, context)
                         : GetFactsList(scan.Relation, context);
                     break;
 
@@ -1783,7 +1845,7 @@ namespace UnifyWeaver.QueryRuntime
 
             if (context is null)
             {
-                return GetFactStream(scan.Relation).Where(tuple =>
+                return GetFactStream(scan.Relation, context).Where(tuple =>
                     tuple is not null && TupleMatchesPattern(tuple, scan.Pattern));
             }
 
@@ -5561,21 +5623,55 @@ namespace UnifyWeaver.QueryRuntime
             return false;
         }
 
-        private IEnumerable<object[]> GetFactStream(PredicateId predicate)
+        private bool TryGetReplayableSource(PredicateId predicate, EvaluationContext? context, out IReplayableRelationSource source)
         {
+            if (context is not null && context.ReplayableFactSources.TryGetValue(predicate, out var cached))
+            {
+                source = cached;
+                return true;
+            }
+
+            if (TryBindRelation(predicate, RelationRetentionMode.Replayable, out var binding) &&
+                binding.ReplayableSource is { } replayableSource)
+            {
+                if (context is not null)
+                {
+                    context.ReplayableFactSources[predicate] = replayableSource;
+                }
+
+                source = replayableSource;
+                return true;
+            }
+
+            source = default!;
+            return false;
+        }
+
+        private IEnumerable<object[]> GetFactStream(PredicateId predicate, EvaluationContext? context = null)
+        {
+            if (context is not null && TryGetReplayableSource(predicate, context, out var replayableSource))
+            {
+                return replayableSource.Stream();
+            }
+
             if (TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var source))
             {
                 return DelimitedRelationReader.ReadRows(source);
             }
 
+            if (TryGetReplayableSource(predicate, context, out replayableSource))
+            {
+                return replayableSource.Stream();
+            }
+
             return _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
         }
 
-        private List<object[]> MaterializeFacts(PredicateId predicate)
+        private List<object[]> MaterializeFacts(PredicateId predicate, EvaluationContext? context)
         {
-            if (TryGetDelimitedSource(predicate, RelationRetentionMode.Replayable, out var source))
+            if (TryGetReplayableSource(predicate, context, out var replayableSource))
             {
-                return DelimitedRelationReader.ReadRows(source).ToList();
+                return replayableSource.Materialize();
             }
 
             var factsSource = _provider.GetFacts(predicate) ?? Enumerable.Empty<object[]>();
@@ -5586,7 +5682,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             if (context is null)
             {
-                return MaterializeFacts(predicate);
+                return MaterializeFacts(predicate, context);
             }
 
             if (context.Facts.TryGetValue(predicate, out var cached))
@@ -5606,7 +5702,7 @@ namespace UnifyWeaver.QueryRuntime
                 missTrace.RecordCacheLookup("Facts", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
             }
 
-            var facts = MaterializeFacts(predicate);
+            var facts = MaterializeFacts(predicate, context);
             context.Facts[predicate] = facts;
             return facts;
         }
@@ -5615,7 +5711,7 @@ namespace UnifyWeaver.QueryRuntime
         {
             if (context is null)
             {
-                return new HashSet<object[]>(MaterializeFacts(predicate), StructuralArrayComparer.Instance);
+                return new HashSet<object[]>(MaterializeFacts(predicate, context), StructuralArrayComparer.Instance);
             }
 
             if (context.FactSets.TryGetValue(predicate, out var cached))
@@ -14622,6 +14718,7 @@ namespace UnifyWeaver.QueryRuntime
                 FixpointDepth = parent?.FixpointDepth ?? 0;
                 Facts = parent?.Facts ?? new Dictionary<PredicateId, List<object[]>>();
                 FactSources = parent?.FactSources ?? new Dictionary<PredicateId, PlanNode>();
+                ReplayableFactSources = parent?.ReplayableFactSources ?? new Dictionary<PredicateId, IReplayableRelationSource>();
                 FactSets = parent?.FactSets ?? new Dictionary<PredicateId, HashSet<object[]>>();
                 FactIndices = parent?.FactIndices ?? new Dictionary<(PredicateId Predicate, int ColumnIndex), Dictionary<object, List<object[]>>>();
                 JoinIndices = parent?.JoinIndices ?? new Dictionary<(PredicateId Predicate, string KeySignature), Dictionary<RowWrapper, List<object[]>>>();
@@ -14677,6 +14774,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<PredicateId, List<object[]>> Facts { get; }
 
             public Dictionary<PredicateId, PlanNode> FactSources { get; }
+
+            public Dictionary<PredicateId, IReplayableRelationSource> ReplayableFactSources { get; }
 
             public Dictionary<PredicateId, HashSet<object[]>> FactSets { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR implements the next step in the query runtime materialization work:

  - `Replayable` is now a real runtime relation mode
  - not just a local `ReadRows(...).ToList()` fallback

  The recent retention-mode work established the contract:

  - `Streaming`
  - `Replayable`
  - `ExternalMaterialized`

  But `Replayable` was still weak in practice. For streamed delimited
  relations, it mostly degraded to one-off eager list materialization at the
  call site.

  This PR fixes that by adding a replayable relation abstraction and routing
  runtime fact-list/fact-set access through it.

  ## What Changed

  ### New Replayable Relation Abstraction

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `IReplayableRelationSource`
  - `ReplayableRelationSource`

  `IReplayableRelationSource` provides two operations:

  - `Stream()`
  - `Materialize()`

  The default implementation memoizes the relation rows behind a single
  runtime-owned replay buffer.

  This is a better match for the retention model than repeated ad hoc list
  construction.

  ### Relation Binding Now Carries Replayable Sources

  Updated:

  - `RelationBinding`

  It can now carry either:

  - a streamed delimited source
  - or a replayable relation source

  That makes replayability an explicit part of the provider/runtime contract
  instead of an implicit local behavior inside `QueryExecutor`.

  ### InMemoryRelationProvider Exposes Stable Replayable Bindings

  Updated:

  - `InMemoryRelationProvider`

  The provider now keeps replayable relation bindings for:

  - registered delimited sources
  - in-memory stored facts

  So when the runtime requests `RelationRetentionMode.Replayable`, it gets a
  stable reusable source object instead of re-deciding how to materialize the
  relation each time.

  ### QueryExecutor Uses Replayable Bindings

  Updated:

  - `QueryExecutor`

  The runtime now:

  - caches replayable relation sources in the evaluation context
  - routes `GetFactsList(...)` through `IReplayableRelationSource.Materialize()`
  - routes `GetFactsSet(...)` through the same shared replayable materialization
  - lets scan-style fact access reuse replayable sources when available

  This means the replayable retention boundary is now actually being used by
  runtime consumers, not just declared.

  ## Why This Matters

  This PR is more about runtime ownership than about a single benchmark
  headline.

  The main improvement is structural:

  - when an operator needs repeatable relation access, the runtime can now
    request and cache a replayable source explicitly
  - that avoids scattering “materialize this relation into a list right now”
    logic across multiple call sites

  It also extends the new materialization model beyond the original DAG-only
  streaming fast paths.

  The retention story is now cleaner:

  - `Streaming`: one-pass row access
  - `Replayable`: reusable runtime-owned replay buffer
  - `ExternalMaterialized`: fallback for already-built facts

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile examples/benchmark/generate_pipeline.py

  ### DAG smokes

  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Both still matched across all four targets.

  Representative results:

  - reach-count 300
      - csharp-query 0.060s
      - csharp-dfs 0.043s
      - rust 0.002s
      - go 0.003s
  - longest-depth 300
      - csharp-query 0.051s
      - csharp-dfs 0.040s
      - rust 0.002s
      - go 0.002s

  ### Path-aware families on the shared retention boundary

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Both still built and matched.

  Representative results:

  - shortest path 300
      - csharp-query 0.149s
      - csharp-dfs 0.435s
      - rust 0.353s
      - go 0.470s
  - weighted shortest path 300
      - csharp-query 0.187s
      - csharp-dfs 0.471s
      - rust 0.406s
      - go 0.478s

  ## Documentation Updates

  Updated:

  - docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
  - docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md

  These docs now reflect that:

  - replayable relation bindings are implemented in the runtime
  - Stage 2 of the materialization plan is no longer just conceptual
  - Stage 3 has started for scan-oriented and path-aware benchmark paths

  ## Scope

  This PR adds:

  - real replayable relation bindings
  - runtime reuse of replayable sources through evaluation-context caching
  - doc updates describing the stronger retention boundary

  It does not yet add:

  - a cost-based planner that chooses between Streaming and Replayable
  - operator-specific replay strategies beyond the generic replay buffer
  - full streaming-first rewrites for every operator family

  ## Follow-Up

  Likely next work:

  - extend replayable/streamed retention to more operator families
  - identify where replayable buffering should be replaced by narrower
    operator-owned retained state
  - start moving from static retention choices to measured/cost-guided
    runtime selection