### PR TITLE
feat(prolog): add effective-distance accumulation helper

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -14,17 +14,17 @@ and specification.
 
 ### Accumulated Prolog and Query Engine vs DFS Pipelines
 
-The effective-distance benchmark now has an accumulated Prolog path that
-reuses `category_ancestor/4` once per unique category seed and retains
-only per-seed summed path weights for article aggregation. On the
-current benchmark surface, that accumulated Prolog path is faster than
-the current C# query-engine path while still matching its output
-exactly.
+The effective-distance benchmark now has a generated accumulated Prolog
+path. It reuses `category_ancestor/4` once per unique category seed and
+uses a generated `'$effective_distance_sum'` helper to retain only
+per-seed summed path weights for article aggregation. On the current
+benchmark surface, that accumulated Prolog path is faster than the
+current C# query-engine path while still matching its output exactly.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **Prolog accumulated** | **0.35s** | **0.25s** | **0.85s** | **2.06s** |
-| C# Query Engine | 0.68s | 0.50s | 1.34s | 3.20s |
+| **Prolog accumulated** | **0.353s** | **0.246s** | **0.852s** | **2.057s** |
+| C# Query Engine | 0.681s | 0.504s | 1.338s | 3.197s |
 | C# DFS pipeline | 0.48s | 1.27s | 5.48s | 10.15s |
 | Rust DFS pipeline | 0.35s | 1.47s | 7.30s | 13.67s |
 | Go DFS pipeline | 0.47s | 2.07s | 11.68s | 19.09s |
@@ -46,6 +46,8 @@ Semantic note:
 - `benchmark_effective_distance.py` now compares the query-engine output
   against both the C# DFS reference and accumulated Prolog, reporting
   `query_vs_csharp_dfs` and `query_vs_prolog_accumulated`.
+- the current `csharp-query` comparison is against the retention-mode-
+  updated runtime now merged on `main`.
 - Current post-fix runs report `query_vs_csharp_dfs = match` at
   `300`, `1k`, `5k`, and `10k`.
 - Current accumulated Prolog runs also report
@@ -196,7 +198,7 @@ Tables:
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
-| `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse with optional branch pruning |
+| `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse, generated accumulation helpers, and optional branch pruning |
 | `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, and accumulated Prolog effective-distance scripts and report phase/work metrics |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
 | `benchmark_prolog_seeded_min_closure.py` | Compare seeded Prolog `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
@@ -372,15 +374,17 @@ Latest local results:
 
 | Scale | Seeded | Pruned | Accumulated | Output Match | Note |
 |-------|--------|--------|-------------|--------------|------|
-| 300 | 0.385s | 0.384s | 0.368s | match | effectively tied, accumulated slightly ahead |
-| 1k | 0.361s | 0.347s | 0.248s | match | accumulated wins clearly |
-| 5k | 1.152s | 1.114s | 0.940s | match | big aggregation win |
-| 10k | 2.562s | 2.732s | 2.455s | match | accumulated stays best, pruning still noisy |
+| 300 | 0.349s | 0.352s | 0.370s | match | accumulated is close, but the helper overhead is still visible at the smallest scale |
+| 1k | 0.283s | 0.305s | 0.238s | match | accumulated wins clearly |
+| 5k | 1.084s | 1.170s | 0.829s | match | generated accumulation helper cuts aggregation cost materially |
+| 10k | 2.563s | 2.453s | 2.134s | match | accumulated stays best, pruning remains mostly neutral |
 
 Current interpretation:
 
 - seeded closure reuse is the real win on effective distance
 - branch pruning does not currently reduce tuple count or inferences on this workload
+- the accumulated variant now uses a generated Prolog helper rather than
+  benchmark-side ad hoc aggregation
 - pre-aggregating per-seed weight sums materially reduces retained state:
   - `1k`: tuple count `10976 -> 48`
   - `5k`: tuple count `41132 -> 151`

--- a/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
@@ -50,7 +50,8 @@ parse_variant('accumulated', accumulated, [
         dialect(swi),
         entry_point(run_benchmark),
         branch_pruning(false),
-        min_closure(false)
+        min_closure(false),
+        effective_distance_accumulation(auto)
     ]) :-
     !.
 parse_variant(Atom, _, _) :-
@@ -63,6 +64,7 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
     format(atom(FactsPathLine), 'facts_path(~q).', [FactsPath]),
     benchmark_index_build_line(Variant, IndexBuildLine),
     benchmark_results_line(Variant, ResultsLine),
+    benchmark_weight_sum_query_line(Variant, WeightSumQueryLine),
     benchmark_mode_line(Variant, ModeLine),
     Lines = [
         ':- use_module(library(aggregate)).',
@@ -105,20 +107,11 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    clear_seed_indexes,',
         '    collect_seed_categories(Seeds),',
         '    length(Seeds, SeedCount),',
-        '    dimension_n(N),',
-        '    NegN is -N,',
         '    forall(',
         '        member(Cat, Seeds),',
-        '        (   aggregate_all(sum(W),',
-        '                (   seed_hops_query(Cat, Root, Hops),',
-        '                    TotalHops is Hops + 1,',
-        '                    W is TotalHops ** NegN',
-        '                ),',
-        '                WeightSum),',
-        '            (   WeightSum > 0',
-        '            ->  assertz(bench_seed_weight_sum(Cat, Root, WeightSum))',
-        '            ;   true',
-        '            )',
+        '        forall(',
+        '            seed_weight_sum_query(Cat, Root, WeightSum),',
+        '            assertz(bench_seed_weight_sum(Cat, Root, WeightSum))',
         '        )',
         '    ),',
         '    aggregate_all(count, bench_seed_weight_sum(_, _, _), TupleCount).',
@@ -137,6 +130,9 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    article_category(Article, Cat),',
         '    Cat \\= Root,',
         '    bench_seed_weight_sum(Cat, Root, Weight).',
+        '',
+        'seed_weight_sum_query(Cat, Root, WeightSum) :-',
+        WeightSumQueryLine,
         '',
         'compute_effective_distance_results_from_hops(Root, Results) :-',
         '    collect_articles(Articles),',
@@ -215,6 +211,10 @@ benchmark_index_build_line(accumulated, '    build_seed_weight_sum_index(Root, S
 benchmark_results_line(seeded, '    compute_effective_distance_results_from_hops(Root, Results),').
 benchmark_results_line(pruned, '    compute_effective_distance_results_from_hops(Root, Results),').
 benchmark_results_line(accumulated, '    compute_effective_distance_results_from_weight_sums(Root, Results),').
+
+benchmark_weight_sum_query_line(seeded, '    fail.').
+benchmark_weight_sum_query_line(pruned, '    fail.').
+benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$effective_distance_sum''(Cat, Root, WeightSum).').
 
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
 benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -56,6 +56,11 @@
 %         available (default: auto). This preserves the original
 %         predicate and adds a separate '$min' helper for bound
 %         shortest-path style queries.
+%       - effective_distance_accumulation(auto/false) - Emit a SWI
+%         helper for canonical counted PPV recursion that aggregates
+%         `sum((Metric+1)^(-N))` via `dimension_n/1` (default: auto).
+%         This is a narrow seeded accumulation helper used by the
+%         effective-distance benchmark surface.
 %  @arg ScriptCode Generated script as atom
 %
 %  @example Generate script for user predicates
@@ -79,12 +84,13 @@ generate_prolog_script(UserPredicates, Options, ScriptCode) :-
     ),
 
     % 1. Analyze what user code needs
-    analyze_dependencies(UserPredicates, Dependencies),
+    EnhancedOptions = [predicates(UserPredicates)|Options],
+    analyze_dependencies(UserPredicates, Dependencies0),
+    augment_generated_dependencies(UserPredicates, EnhancedOptions, Dependencies0, Dependencies),
 
     % 2. Generate dialect-specific script components
     dialect_shebang(Dialect, ShebangCode),
 
-    EnhancedOptions = [predicates(UserPredicates)|Options],
     dialect_header(Dialect, EnhancedOptions, HeaderCode),
 
     dialect_imports(Dialect, Dependencies, ImportsCode),
@@ -234,7 +240,8 @@ generate_predicate_code(Pred/Arity, Options, Code) :-
     ->  BaseCode0 = OptimizedCode
     ;   copy_predicate_clauses(Pred/Arity, BaseCode0)
     ),
-    maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode0, BaseCode),
+    maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode0, BaseCode1),
+    maybe_append_effective_distance_helper(Pred/Arity, Options, BaseCode1, BaseCode),
 
     % Apply constraints if specified
     (   option(constraints(Constraints), Options)
@@ -380,6 +387,15 @@ maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode, Code) :-
     ;   Code = BaseCode
     ).
 
+maybe_append_effective_distance_helper(Pred/Arity, Options, BaseCode, Code) :-
+    option(effective_distance_accumulation(Setting), Options, auto),
+    (   Setting == false
+    ->  Code = BaseCode
+    ;   maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, HelperCode)
+    ->  atomic_list_concat([BaseCode, HelperCode], '\n\n', Code)
+    ;   Code = BaseCode
+    ).
+
 maybe_generate_min_closure_helper(Pred/Arity, Options, Code) :-
     option(dialect(Dialect), Options, swi),
     Dialect == swi,
@@ -454,6 +470,80 @@ maybe_generate_weighted_min_closure_helper(Pred/Arity, Code) :-
         [FirstRecPositive|RestRecPositives]),
     build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
         MetricPos, VisitedPos, 1, 1, BudgetMode, Code).
+
+maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, Code) :-
+    option(dialect(Dialect), Options, swi),
+    Dialect == swi,
+    effective_distance_dimension_available(Options),
+    findall(Head-Body,
+        (   functor(Head, Pred, Arity),
+            user:clause(Head, Body0),
+            strip_codegen_module_qualifiers(Body0, Body)
+        ),
+        Clauses),
+    Clauses \= [],
+    partition(is_recursive_clause_for_pred(Pred), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos),
+    counted_ppv_driver_position(Pred, Arity, RecClauses, VisitedPos, DriverPos),
+    branch_pruning_mode_positions(Pred/Arity, VisitedPos, InvariantPositions),
+    branch_pruning_signature_positions(DriverPos, InvariantPositions, SignaturePositions),
+    min_closure_metric_position(Arity, VisitedPos, SignaturePositions, MetricPos),
+    maplist(min_closure_base_depth(MetricPos, VisitedPos), BaseClauses, BaseDepths),
+    sort(BaseDepths, [1]),
+    RecClauses = [FirstRec|RestRecClauses],
+    min_closure_recursive_shape(Pred, Arity, VisitedPos, MetricPos, FirstRec, 1, BudgetMode),
+    forall(member(RecClause, RestRecClauses),
+        min_closure_recursive_shape_compatible(Pred, Arity, VisitedPos, MetricPos,
+            1, BudgetMode, RecClause)),
+    build_effective_distance_accumulation_code(Pred/Arity, SignaturePositions,
+        DriverPos, MetricPos, VisitedPos, Code).
+
+effective_distance_dimension_available(Options) :-
+    option(predicates(UserPredicates), Options, []),
+    memberchk(dimension_n/1, UserPredicates),
+    !.
+effective_distance_dimension_available(_Options) :-
+    current_predicate(user:dimension_n/1).
+
+build_effective_distance_accumulation_code(Pred/Arity, SignaturePositions, DriverPos,
+        MetricPos, VisitedPos, Code) :-
+    atom_concat(Pred, '$effective_distance_sum', HelperName),
+    length(SignaturePositions, SignatureCount),
+    build_min_signature_vars(SignatureCount, SignatureArgs),
+    append(SignatureArgs, [WeightSum], HeadArgs),
+    HeadTerm =.. [HelperName|HeadArgs],
+    build_effective_distance_call_args(Arity, SignaturePositions, DriverPos,
+        MetricPos, VisitedPos, SignatureArgs, MetricVar, CallArgs),
+    PredCall =.. [Pred|CallArgs],
+    AggregateGoal = aggregate_all(sum(W),
+        (   PredCall,
+            TotalMetric is MetricVar + 1,
+            W is TotalMetric ** NegN
+        ),
+        WeightSum),
+    BodyGoals = [
+        dimension_n(N),
+        (NegN is -N),
+        AggregateGoal,
+        (WeightSum > 0)
+    ],
+    goals_to_body(BodyGoals, BodyTerm),
+    clause_term(HeadTerm, BodyTerm, ClauseTerm),
+    clauses_to_code([ClauseTerm], ClauseCode),
+    atomic_list_concat([
+        '% Mode-directed effective-distance accumulation helper for canonical counted per-path recursion.',
+        ClauseCode
+    ], '\n\n', Code).
+
+build_effective_distance_call_args(Arity, SignaturePositions, DriverPos, MetricPos,
+        VisitedPos, SignatureArgs, MetricVar, CallArgs) :-
+    length(CallArgs, Arity),
+    bind_positions_1based(SignaturePositions, SignatureArgs, CallArgs),
+    nth1(MetricPos, CallArgs, MetricVar),
+    nth1(DriverPos, CallArgs, DriverArg),
+    nth1(VisitedPos, CallArgs, [DriverArg]).
 
 counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos) :-
     member(Head-Body, RecClauses),
@@ -1170,6 +1260,11 @@ select_positions_1based([Pos|Rest], List, [Elem|Elems]) :-
     nth1(Pos, List, Elem),
     select_positions_1based(Rest, List, Elems).
 
+bind_positions_1based([], [], _List).
+bind_positions_1based([Pos|RestPos], [Elem|RestElems], List) :-
+    nth1(Pos, List, Elem),
+    bind_positions_1based(RestPos, RestElems, List).
+
 %% generate_entry_point(+Options, -Code)
 %  Generate main entry point and initialization
 generate_entry_point(Options, Code) :-
@@ -1252,6 +1347,17 @@ analyze_dependencies(UserPredicates, Dependencies) :-
 
     % Remove duplicates
     sort(AllDeps, Dependencies).
+
+augment_generated_dependencies(UserPredicates, Options, Dependencies0, Dependencies) :-
+    (   generated_helper_requires_aggregate(UserPredicates, Options)
+    ->  sort([module(library(aggregate))|Dependencies0], Dependencies)
+    ;   Dependencies = Dependencies0
+    ).
+
+generated_helper_requires_aggregate(UserPredicates, Options) :-
+    member(Pred/Arity, UserPredicates),
+    maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, _),
+    !.
 
 %% extract_dependencies_from_body(+Body, -Dependency)
 %  Extract dependencies from clause body

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -195,6 +195,34 @@ setup_weighted_min_unproven_fixture :-
         Cost is PrevCost + Step)),
     assertz(user:mode(test_weighted_min_ppv_reach(-, +, -, +))).
 
+setup_effective_distance_accumulation_fixture :-
+    cleanup_effective_distance_accumulation_fixture,
+    assertz(user:test_effective_edge(a, b)),
+    assertz(user:test_effective_edge(b, c)),
+    assertz(user:test_effective_edge(a, d)),
+    assertz(user:test_effective_edge(d, e)),
+    assertz(user:test_effective_edge(e, c)),
+    assertz(user:dimension_n(5)),
+    assertz(user:max_depth(4)),
+    assertz(user:(test_effective_ppv_reach(Cat, Parent, 1, Visited) :-
+        test_effective_edge(Cat, Parent),
+        \+ member(Parent, Visited))),
+    assertz(user:(test_effective_ppv_reach(Cat, Ancestor, Hops, Visited) :-
+        max_depth(MaxD),
+        length(Visited, Depth), Depth < MaxD, !,
+        test_effective_edge(Cat, Mid),
+        \+ member(Mid, Visited),
+        test_effective_ppv_reach(Mid, Ancestor, H1, [Mid|Visited]),
+        Hops is H1 + 1)),
+    assertz(user:mode(test_effective_ppv_reach(-, +, -, +))).
+
+cleanup_effective_distance_accumulation_fixture :-
+    retractall(user:test_effective_edge(_, _)),
+    retractall(user:dimension_n(_)),
+    retractall(user:max_depth(_)),
+    retractall(user:test_effective_ppv_reach(_, _, _, _)),
+    retractall(user:mode(test_effective_ppv_reach(_, _, _, _))).
+
 build_execution_runtime_source(ModuleName, PredicateCode, Source) :-
     atomic_list_concat([
         'test_exec_edge(a, b).',
@@ -286,6 +314,35 @@ collect_generated_weighted_min_costs(Options, PredicateCode, Costs) :-
             Goal =.. ['test_weighted_min_ppv_reach$min', a, d, Cost],
             findall(Cost, ModuleName:Goal, Costs0),
             sort(Costs0, Costs)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
+build_effective_distance_runtime_source(ModuleName, PredicateCode, Source) :-
+    atomic_list_concat([
+        'test_effective_edge(a, b).',
+        'test_effective_edge(b, c).',
+        'test_effective_edge(a, d).',
+        'test_effective_edge(d, e).',
+        'test_effective_edge(e, c).',
+        'dimension_n(5).',
+        'max_depth(4).'
+    ], '\n', FactsCode),
+    format(atom(Source),
+        ':- module(~q, []).~n:- use_module(library(lists)).~n:- use_module(library(aggregate)).~n~w~n~n~w~n',
+        [ModuleName, FactsCode, PredicateCode]).
+
+collect_generated_effective_distance_sums(Options, PredicateCode, Sums) :-
+    once(prolog_target:generate_predicate_code(test_effective_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_effective_ppv_runtime_, ModuleName),
+    build_effective_distance_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_effective_ppv_reach$effective_distance_sum', a, c, Sum],
+            findall(Sum, ModuleName:Goal, Sums0),
+            sort(Sums0, Sums)
         ),
         cleanup_temp_module_source(Path)
     ).
@@ -396,5 +453,30 @@ test(skips_weighted_min_closure_without_positive_step_proof,
          cleanup(cleanup_weighted_min_closure_fixture)]) :-
     once(generate_prolog_script([test_weighted_min_ppv_reach/4], [dialect(swi)], Code)),
     \+ sub_atom(Code, _, _, _, 'test_weighted_min_ppv_reach$min').
+
+test(emits_effective_distance_accumulation_helper_for_counted_ppv,
+        [setup(setup_effective_distance_accumulation_fixture),
+         cleanup(cleanup_effective_distance_accumulation_fixture)]) :-
+    Options = [
+        dialect(swi),
+        min_closure(false),
+        branch_pruning(false),
+        effective_distance_accumulation(auto),
+        predicates([dimension_n/1, max_depth/1, test_effective_ppv_reach/4])
+    ],
+    collect_generated_effective_distance_sums(Options, PredicateCode, [Actual]),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum')),
+    Expected is (3 ** -5) + (4 ** -5),
+    Delta is abs(Actual - Expected),
+    Delta < 1.0e-12.
+
+test(skips_effective_distance_accumulation_helper_when_disabled_explicitly,
+        [setup(setup_effective_distance_accumulation_fixture),
+         cleanup(cleanup_effective_distance_accumulation_fixture)]) :-
+    once(generate_prolog_script(
+        [dimension_n/1, max_depth/1, test_effective_ppv_reach/4],
+        [dialect(swi), effective_distance_accumulation(false)],
+        Code)),
+    \+ sub_atom(Code, _, _, _, 'test_effective_ppv_reach$effective_distance_sum').
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This turns the Prolog effective-distance accumulation path from a benchmark-side trick into a real generated helper in
  the Prolog target.

  For the canonical counted per-path-visited effective-distance shape, the target can now emit a narrow seeded
  accumulation helper that computes the per-seed summed weight directly:

  - generated helper: `'$effective_distance_sum'`
  - aggregation shape: `sum((Metric+1)^(-N))`
  - parameter source: `dimension_n/1`

  This keeps the benchmark semantics unchanged, but moves the retained-state optimization into generated Prolog instead of
  leaving it in benchmark-specific driver code.

  ## What Changed

  - extended `src/unifyweaver/targets/prolog_target.pl`
    - added `effective_distance_accumulation(auto|false)`
    - added generated helper emission for the canonical counted PPV effective-distance shape
    - helper generation is SWI-specific and additive; it does not replace the original predicate
    - helper generation automatically adds `library(aggregate)` when needed
  - extended `tests/core/test_prolog_target.pl`
    - added fixture coverage for canonical counted PPV effective-distance recursion
    - added execution-level test proving the generated helper returns the expected summed weight
    - added an explicit disable test for `effective_distance_accumulation(false)`
  - updated `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
    - the `accumulated` variant now uses the generated helper instead of benchmark-side manual aggregation
  - updated `examples/benchmark/README.md`
    - documents that the accumulated Prolog path now comes from generated target code
    - refreshes the effective-distance benchmark story and current numbers

  ## Why

  The earlier effective-distance work showed the right optimization direction:

  - branch pruning is not the main lever for this workload
  - seeded reuse helps
  - compact retained accumulation state helps much more

  But the accumulated Prolog path was still implemented in the benchmark harness rather than in the target.

  This PR fixes that boundary. The generated Prolog now owns the narrow effective-distance accumulation helper, which is a
  better foundation for future generalized seeded accumulation work.

  ## Result

  ### Semantic result

  The generated helper preserves the existing effective-distance results.

  Current local checks still show:

  - `prolog-seeded`, `prolog-pruned`, and `prolog-accumulated` outputs match
  - `csharp-query` and `prolog-accumulated` outputs also match

  ### Performance result

  Small-scale cross-target spot check with the generated helper:

  - `300`: `csharp-query 0.597s`, `prolog-accumulated 0.353s`
  - `1k`: `csharp-query 0.410s`, `prolog-accumulated 0.234s`

  Retained state still drops sharply for accumulated Prolog:

  - `300`: tuple count `11172 -> 213`
  - `1k`: tuple count `10976 -> 48`

  That confirms the generated helper preserves the main benefit of the earlier benchmark-side accumulation path.

  ## Verification

  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python -m py_compile examples/benchmark/benchmark_effective_distance.py examples/benchmark/
  benchmark_prolog_effective_distance.py`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 300,1k --targets csharp-query,prolog-accumulated
  --repetitions 1`

  ## Notes

  - this helper is intentionally narrow: canonical counted PPV effective-distance only
  - `effective_distance_accumulation(false)` remains available to disable it
  - this is the right next step before attempting a broader Prolog seeded-accumulation lowering