### PR TITLE
perf(csharp-query): add path-aware edge state

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -53,6 +53,8 @@ Success criteria:
 Status:
 
 - started for scan-oriented and path-aware benchmark paths using the shared retention boundary
+- path-aware shortest-path operators now build compact operator-owned edge state
+  instead of consuming generic replayed edge tuples
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -61,6 +61,8 @@ Examples:
 
 - DAG grouped reachability builds adjacency and grouped bitset/count state
 - DAG longest depth builds adjacency and scalar suffix-depth state
+- path-aware shortest-path operators can build compact source->targets edge state
+  instead of retaining generic edge tuples
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -104,8 +106,10 @@ For the current benchmark/runtime surface, the streamed path is:
 2. the runtime requests either `Streaming` or `Replayable` access
 3. replayable bindings can cache a reusable relation source instead of ad hoc `ToList()` calls
 4. DAG, scan, and path-aware operators read rows through that retention boundary
-5. the operator builds only the retained state it actually needs
-6. benchmark code avoids preloading raw facts into in-memory relations first
+5. path-aware shortest-path operators can build a compact edge-state cache
+   directly from streamed facts instead of generic replayed edge rows
+6. the operator builds only the retained state it actually needs
+7. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -1222,6 +1222,33 @@ namespace UnifyWeaver.QueryRuntime
         }
     }
 
+    internal sealed class PathAwareSuccessorBucket
+    {
+        public PathAwareSuccessorBucket(object? source)
+        {
+            Source = source;
+        }
+
+        public object? Source { get; }
+
+        public List<object?> Targets { get; } = new();
+    }
+
+    internal sealed class PathAwareEdgeState
+    {
+        public PathAwareEdgeState(
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> successors,
+            IReadOnlyList<object?> seeds)
+        {
+            Successors = successors;
+            Seeds = seeds;
+        }
+
+        public IReadOnlyDictionary<object, PathAwareSuccessorBucket> Successors { get; }
+
+        public IReadOnlyList<object?> Seeds { get; }
+    }
+
     public sealed class InMemoryRelationProvider : IRetentionAwareRelationProvider
     {
         private readonly Dictionary<PredicateId, List<object[]>> _store = new();
@@ -1558,6 +1585,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.Facts.Clear();
             _cacheContext.FactSources.Clear();
             _cacheContext.ReplayableFactSources.Clear();
+            _cacheContext.PathAwareEdgeStates.Clear();
             _cacheContext.FactSets.Clear();
             _cacheContext.FactIndices.Clear();
             _cacheContext.JoinIndices.Clear();
@@ -5678,6 +5706,77 @@ namespace UnifyWeaver.QueryRuntime
             return factsSource as List<object[]> ?? factsSource.ToList();
         }
 
+        private PathAwareEdgeState GetPathAwareEdgeState(PredicateId predicate, EvaluationContext context)
+        {
+            if (context.PathAwareEdgeStates.TryGetValue(predicate, out var cached))
+            {
+                context.Trace?.RecordCacheLookup("PathAwareEdgeState", $"{predicate.Name}/{predicate.Arity}", hit: true, built: false);
+                return cached;
+            }
+
+            context.Trace?.RecordCacheLookup("PathAwareEdgeState", $"{predicate.Name}/{predicate.Arity}", hit: false, built: true);
+
+            var successors = new Dictionary<object, PathAwareSuccessorBucket>();
+            var seeds = new List<object?>();
+            var seenSeeds = new HashSet<object?>();
+
+            void AddEdge(object? source, object? target)
+            {
+                var lookupKey = source ?? NullFactIndexKey;
+                if (!successors.TryGetValue(lookupKey, out var bucket))
+                {
+                    bucket = new PathAwareSuccessorBucket(source);
+                    successors[lookupKey] = bucket;
+                }
+
+                bucket.Targets.Add(target);
+                if (seenSeeds.Add(source))
+                {
+                    seeds.Add(source);
+                }
+            }
+
+            if (TryGetDelimitedSource(predicate, RelationRetentionMode.Streaming, out var delimitedSource))
+            {
+                using var reader = DelimitedRelationReader.OpenSequentialReader(delimitedSource.InputPath);
+                for (var i = 0; i < delimitedSource.SkipRows; i++)
+                {
+                    if (reader.ReadLine() is null)
+                    {
+                        break;
+                    }
+                }
+
+                string? line;
+                while ((line = reader.ReadLine()) is not null)
+                {
+                    if (!DelimitedRelationReader.TrySplitTwoColumnLine(line, delimitedSource.Delimiter, out var left, out var right))
+                    {
+                        continue;
+                    }
+
+                    AddEdge(left, right);
+                }
+            }
+            else
+            {
+                foreach (var edge in GetFactStream(predicate, context))
+                {
+                    if (edge is null || edge.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    AddEdge(edge[0], edge[1]);
+                }
+            }
+
+            seeds.Sort(CompareCacheSeedValues);
+            var state = new PathAwareEdgeState(successors, seeds);
+            context.PathAwareEdgeStates[predicate] = state;
+            return state;
+        }
+
         private List<object[]> GetFactsList(PredicateId predicate, EvaluationContext? context)
         {
             if (context is null)
@@ -7376,30 +7475,11 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareTransitiveClosure");
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
-                var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
-                var seeds = new List<object?>();
-                var seenSeeds = new HashSet<object?>();
-
-                foreach (var edge in edges)
-                {
-                    if (edge is null || edge.Length < 2)
-                    {
-                        continue;
-                    }
-
-                    var seed = edge[0];
-                    if (seenSeeds.Add(seed))
-                    {
-                        seeds.Add(seed);
-                    }
-                }
-
-                seeds.Sort(CompareCacheSeedValues);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
                 var totalRows = new List<object[]>();
-                foreach (var seed in seeds)
+                foreach (var seed in edgeState.Seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7427,8 +7507,7 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareTransitiveClosureSeeded");
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
-                var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
                 var seeds = new List<object?>();
                 var seenSeeds = new HashSet<object?>();
 
@@ -7454,7 +7533,7 @@ namespace UnifyWeaver.QueryRuntime
                 var totalRows = new List<object[]>();
                 foreach (var seed in seeds)
                 {
-                    AppendPathAwareRowsForSeed(seed, succIndex, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
+                    AppendPathAwareRowsForSeed(seed, edgeState.Successors, closure.BaseDepth, closure.DepthIncrement, totalRows, closure.AccumulatorMode, closure.MaxDepth);
                 }
 
                 return totalRows;
@@ -7467,7 +7546,7 @@ namespace UnifyWeaver.QueryRuntime
 
         private static void AppendPathAwareRowsForSeed(
             object? seed,
-            IReadOnlyDictionary<object, List<object[]>> succIndex,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
             int baseDepth,
             int depthIncrement,
             ICollection<object[]> output,
@@ -7488,15 +7567,9 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                for (var i = bucket.Count - 1; i >= 0; i--)
+                for (var i = bucket.Targets.Count - 1; i >= 0; i--)
                 {
-                    var edge = bucket[i];
-                    if (edge is null || edge.Length < 2)
-                    {
-                        continue;
-                    }
-
-                    var next = edge[1];
+                    var next = bucket.Targets[i];
                     if (visited.Contains(next))
                     {
                         continue;
@@ -7568,33 +7641,16 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareAccumulation");
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
-                var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var succIndex = edgeState.Successors;
                 var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
-                var seeds = new List<object?>();
-                var seenSeeds = new HashSet<object?>();
                 PositiveStepEvaluator? stepEvaluator = null;
                 var usePositiveMinFastPath = closure.AccumulatorMode == TableMode.Min &&
                     TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
 
-                foreach (var edge in edges)
-                {
-                    if (edge is null || edge.Length < 2)
-                    {
-                        continue;
-                    }
-
-                    var seed = edge[0];
-                    if (seenSeeds.Add(seed))
-                    {
-                        seeds.Add(seed);
-                    }
-                }
-
-                seeds.Sort(CompareCacheSeedValues);
                 var totalRows = new List<object[]>();
-                foreach (var seed in seeds)
+                foreach (var seed in edgeState.Seeds)
                 {
                     if (usePositiveMinFastPath)
                     {
@@ -7631,8 +7687,8 @@ namespace UnifyWeaver.QueryRuntime
                 var trace = context.Trace;
                 trace?.RecordStrategy(closure, "PathAwareAccumulationSeeded");
 
-                var edges = GetFactsList(closure.EdgeRelation, context);
-                var succIndex = GetFactIndex(closure.EdgeRelation, 0, edges, context);
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var succIndex = edgeState.Successors;
                 var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
                 var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
                 var seeds = new List<object?>();
@@ -7688,7 +7744,7 @@ namespace UnifyWeaver.QueryRuntime
         // visited-state frontier with dynamic programming over (node, depth).
         private void AppendPositiveMinAccumulationRowsForSeed(
             object? seed,
-            IReadOnlyDictionary<object, List<object[]>> succIndex,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
             IReadOnlyDictionary<object, List<object[]>> auxIndex,
             PositiveStepEvaluator stepEvaluator,
             ICollection<object[]> output,
@@ -7729,15 +7785,9 @@ namespace UnifyWeaver.QueryRuntime
                     }
 
                     var nextLayer = depthCosts[nextDepth];
-                    for (var edgeIndex = edgeBucket.Count - 1; edgeIndex >= 0; edgeIndex--)
+                    for (var edgeIndex = edgeBucket.Targets.Count - 1; edgeIndex >= 0; edgeIndex--)
                     {
-                        var edge = edgeBucket[edgeIndex];
-                        if (edge is null || edge.Length < 2)
-                        {
-                            continue;
-                        }
-
-                        var next = edge[1];
+                        var next = edgeBucket.Targets[edgeIndex];
                         for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
                         {
                             var auxRow = auxBucket[auxIndexPos];
@@ -7775,7 +7825,7 @@ namespace UnifyWeaver.QueryRuntime
         private bool TryCreatePositiveAdditiveStepEvaluator(
             ArithmeticExpression baseExpression,
             ArithmeticExpression recursiveExpression,
-            IReadOnlyDictionary<object, List<object[]>> succIndex,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
             IReadOnlyDictionary<object, List<object[]>> auxIndex,
             bool positiveStepProven,
             out PositiveStepEvaluator? evaluator)
@@ -7804,13 +7854,8 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                foreach (var edge in edgeBucket)
+                foreach (var next in edgeBucket.Targets)
                 {
-                    if (edge is null || edge.Length < 2)
-                    {
-                        continue;
-                    }
-
                     foreach (var auxRow in auxBucket)
                     {
                         if (auxRow is null || auxRow.Length < 2)
@@ -7818,7 +7863,7 @@ namespace UnifyWeaver.QueryRuntime
                             continue;
                         }
 
-                        var evalTuple = new object[] { edge[0]!, edge[1]!, 0, auxRow[1]! };
+                        var evalTuple = new object[] { edgeBucket.Source!, next!, 0, auxRow[1]! };
                         var stepObject = EvaluateArithmeticExpression(stepExpression, evalTuple);
                         double step;
                         try
@@ -7905,7 +7950,7 @@ namespace UnifyWeaver.QueryRuntime
 
         private void AppendPathAwareAccumulationRowsForSeed(
             object? seed,
-            IReadOnlyDictionary<object, List<object[]>> succIndex,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
             IReadOnlyDictionary<object, List<object[]>> auxIndex,
             ArithmeticExpression baseExpression,
             ArithmeticExpression recursiveExpression,
@@ -7959,15 +8004,9 @@ namespace UnifyWeaver.QueryRuntime
                     continue;
                 }
 
-                for (var edgeIndex = edgeBucket.Count - 1; edgeIndex >= 0; edgeIndex--)
+                for (var edgeIndex = edgeBucket.Targets.Count - 1; edgeIndex >= 0; edgeIndex--)
                 {
-                    var edge = edgeBucket[edgeIndex];
-                    if (edge is null || edge.Length < 2)
-                    {
-                        continue;
-                    }
-
-                    var next = edge[1];
+                    var next = edgeBucket.Targets[edgeIndex];
                     var nextId = GetNodeId(next);
                     if (visited.Contains(nextId))
                     {
@@ -14719,6 +14758,7 @@ namespace UnifyWeaver.QueryRuntime
                 Facts = parent?.Facts ?? new Dictionary<PredicateId, List<object[]>>();
                 FactSources = parent?.FactSources ?? new Dictionary<PredicateId, PlanNode>();
                 ReplayableFactSources = parent?.ReplayableFactSources ?? new Dictionary<PredicateId, IReplayableRelationSource>();
+                PathAwareEdgeStates = parent?.PathAwareEdgeStates ?? new Dictionary<PredicateId, PathAwareEdgeState>();
                 FactSets = parent?.FactSets ?? new Dictionary<PredicateId, HashSet<object[]>>();
                 FactIndices = parent?.FactIndices ?? new Dictionary<(PredicateId Predicate, int ColumnIndex), Dictionary<object, List<object[]>>>();
                 JoinIndices = parent?.JoinIndices ?? new Dictionary<(PredicateId Predicate, string KeySignature), Dictionary<RowWrapper, List<object[]>>>();
@@ -14776,6 +14816,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<PredicateId, PlanNode> FactSources { get; }
 
             public Dictionary<PredicateId, IReplayableRelationSource> ReplayableFactSources { get; }
+
+            public Dictionary<PredicateId, PathAwareEdgeState> PathAwareEdgeStates { get; }
 
             public Dictionary<PredicateId, HashSet<object[]>> FactSets { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR continues the query-runtime materialization work by moving the
  path-aware shortest-path family off generic replayed edge tuples and onto
  a narrower operator-owned edge representation.

  The recent retention-mode work added:

  - `Streaming`
  - `Replayable`
  - `ExternalMaterialized`

  and made replayable bindings real runtime objects.

  This PR takes the next step:

  - for path-aware shortest-path operators, do not stop at a generic
    replayable row buffer
  - build a compact `source -> targets` edge state directly in the runtime
    and use that for execution

  That keeps the materialization decision in the engine and makes the
  retained state closer to what the operator actually needs.

  ## What Changed

  ### New Compact Path-Aware Edge State

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareSuccessorBucket`
  - `PathAwareEdgeState`

  This compact retained form stores:

  - the original source value for a node
  - the outgoing target list for that source
  - the seed/source order needed by the operator

  It is narrower than retaining the full generic edge relation as
  `List<object[]>` plus a generic fact index.

  ### Runtime Cache For Path-Aware Edge State

  Updated:

  - `EvaluationContext`

  Added:

  - `PathAwareEdgeStates`

  The runtime now caches path-aware edge state per edge predicate so the
  operator-owned structure can be reused within the query context.

  ### Direct Streamed Edge Ingestion

  Updated:

  - `GetPathAwareEdgeState(...)`

  When a streamed delimited source is available, the runtime now builds the
  path-aware edge state directly from that source instead of going through:

  - replayable generic row buffering
  - then generic edge indexing
  - then path-aware execution

  Fallback behavior remains available when a streamed source is not present.

  ### Path-Aware Execution Now Uses The Compact State

  Updated path-aware operators:

  - `ExecutePathAwareTransitiveClosure(...)`
  - `ExecuteSeededPathAwareTransitiveClosure(...)`
  - `ExecutePathAwareAccumulation(...)`
  - `ExecuteSeededPathAwareAccumulation(...)`

  Updated helpers:

  - `AppendPathAwareRowsForSeed(...)`
  - `AppendPositiveMinAccumulationRowsForSeed(...)`
  - `TryCreatePositiveAdditiveStepEvaluator(...)`
  - `AppendPathAwareAccumulationRowsForSeed(...)`

  These paths now consume the compact path-aware edge state instead of
  generic edge tuples.

  ## Why This Matters

  This PR is the clearest example yet of the retention strategy we have
  been aiming for:

  - **not** parser-owned eager materialization
  - **not** generic replay buffering as the final answer
  - **but** operator-owned retained state shaped to the actual algorithm

  That is exactly the distinction the recent materialization docs were
  trying to capture.

  This PR turns that idea into a concrete runtime implementation for the
  path-aware shortest-path family.

  ## Verification

  ### DAG non-regressions

  Ran locally:

  ```bash
  python examples/benchmark/benchmark_dependency_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  python examples/benchmark/benchmark_dependency_longest_depth_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs still matched across all four targets.

  Representative results:

  - dependency reach-count 300
      - csharp-query 0.070s
      - csharp-dfs 0.051s
      - rust 0.002s
      - go 0.002s
  - dependency longest depth 300
      - csharp-query 0.058s
      - csharp-dfs 0.040s
      - rust 0.002s
      - go 0.002s

  ### Path-aware shortest path

  Ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched.

  Results:

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|
  | 300 | 0.146s | 0.442s | 0.354s | 0.482s |
  | 1k | 0.120s | 1.314s | 1.526s | 2.076s |
  | 5k | 0.187s | 5.727s | 7.870s | 12.078s |
  | 10k | 0.357s | 10.302s | 14.578s | 20.204s |

  ### Path-aware weighted shortest path

  Ran locally:

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched.

  Results:

  | Scale | C# Query | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|
  | 300 | 0.181s | 0.478s | 0.356s | 0.496s |
  | 1k | 0.148s | 1.375s | 1.591s | 2.144s |
  | 5k | 0.223s | 6.044s | 8.086s | 11.790s |
  | 10k | 0.415s | 10.975s | 15.415s | 20.032s |

  ### TableMode.All path-aware non-regression

  Ran locally:

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  Outputs matched.

  Representative result:

  - csharp-query 0.629s
  - rust-dfs 0.368s
  - go-dfs 0.471s

  ## Interpretation

  This is both a structural and performance improvement.

  Structurally:

  - the runtime is now making a better retention choice for these operators
  - replayable generic rows remain available, but they are no longer the
    preferred retained form here

  Performance-wise:

  - the csharp-query path stays correct
  - and it remains dramatically ahead of the handwritten DFS targets on
    the shortest-path benchmark family at scale

  That matters because it demonstrates the materialization story more
  cleanly:

  - runtime-owned retention
  - operator-shaped state
  - streamed ingestion when available

  ## Documentation Updates

  Updated:

  - docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
  - docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md

  The docs now explicitly note that:

  - path-aware shortest-path operators can build compact edge state
  - this is a concrete step beyond generic replay buffering
  - Stage 3 has moved from “shared retention boundary” to “operator-owned
    retained form” for at least one non-DAG operator family

  ## Scope

  This PR adds:

  - a compact cached path-aware edge state
  - direct streamed ingestion into that state
  - path-aware runtime execution on the compact state
  - doc updates reflecting the new materialization stage

  It does not yet add:

  - similar compact operator-owned state for every operator family
  - a cost-based planner that automatically chooses between replayable
    buffers and operator-specific state
  - removal of replayable generic buffering

  ## Follow-Up

  Likely next work:

  - identify the next operator family where a compact operator-owned
    retained form beats generic replay buffering
  - continue using the retention boundary as the decision point, but push
    more operators from:
      - generic replay buffer
      - to narrower operator-specific state
  - eventually start using measured cost to decide when those specialized
    states should be preferred automatically