### PR TITLE
feat(prolog): generalize seeded accumulation helpers

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -195,11 +195,13 @@ Tables:
 | `benchmark_path_aware_accumulation.py` | Measure counted-closure vs generalized accumulation overhead |
 | `benchmark_weighted_shortest_path.py` | Measure `PathAwareAccumulationNode` `All` vs `Min` pruning on positive weighted paths |
 | `benchmark_weighted_shortest_path_cross_target.py` | Compare positive weighted shortest path across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
-| `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, and Go DFS |
+| `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, Go DFS, and an optional Prolog accumulated path |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
 | `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse, generated accumulation helpers, and optional branch pruning |
 | `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, and accumulated Prolog effective-distance scripts and report phase/work metrics |
+| `generate_prolog_category_influence_benchmark.pl` | Generate standalone SWI-Prolog category-influence scripts using the PPV `category_ancestor/4` closure with optional seeded accumulation helpers |
+| `benchmark_prolog_category_influence.py` | Compare seeded and accumulated Prolog category-influence scripts and report phase/work metrics |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
 | `benchmark_prolog_seeded_min_closure.py` | Compare seeded Prolog `all` vs `min` closure and report `load_ms`, `query_ms`, `aggregation_ms`, and work metrics |
 | `generate_prolog_weighted_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog weighted-shortest-path scripts for seeded `all` vs mode-directed `min` closure |
@@ -298,6 +300,16 @@ python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
 python examples/benchmark/benchmark_category_influence_cross_target.py \
     --scales 300,1k,5k,10k \
     --targets csharp-query,rust-dfs,go-dfs
+
+# Compare seeded vs accumulated Prolog category influence
+python examples/benchmark/benchmark_prolog_category_influence.py \
+    --scales 300,1k \
+    --targets prolog-seeded,prolog-accumulated
+
+# Optional: add the accumulated Prolog path to the category-influence cross-target run
+python examples/benchmark/benchmark_category_influence_cross_target.py \
+    --scales 300,1k \
+    --targets csharp-query,rust-dfs,go-dfs,prolog-accumulated
 
 # Compare handwritten Prolog vs generated pruned and unpruned Prolog
 python examples/benchmark/benchmark_prolog_branch_pruning.py \
@@ -733,6 +745,38 @@ Comparison note:
   invocation in the runner, not embedded C# workload or package wiring
 - the C# path is still weaker only at `300` and clearly faster from `1k`
   onward on the current workload
+
+### Prolog Category-Influence Accumulation Results
+
+The generalized seeded accumulation helper can now be exercised on the
+category-influence workload too, using the cycle-safe PPV
+`category_ancestor/4` closure from the effective-distance workload.
+
+Command:
+
+```bash
+python examples/benchmark/benchmark_prolog_category_influence.py \
+    --scales 300,1k --repetitions 1
+```
+
+Latest local results:
+
+| Scale | Seeded | Accumulated | Output Match | Note |
+|-------|-------:|------------:|--------------|------|
+| 300 | 1.874s | 37.847s | match | accumulated helper is much slower |
+| 1k | 1.065s | 27.206s | match | grouped helper remains much slower |
+
+Current interpretation:
+
+- the generalized seeded accumulation helper is semantically correct on
+  category influence
+- but this grouped `power_sum` helper is the wrong retained-state shape
+  for the workload
+- it recomputes grouped aggregates per seed and pays heavily for that:
+  - `300`: `query_ms 1311 -> 36991`
+  - `1k`: `query_ms 714 -> 26380`
+- the accumulated Prolog path is therefore exposed as an optional
+  benchmark target here, not the new default category-influence path
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/benchmark_category_influence_cross_target.py
+++ b/examples/benchmark/benchmark_category_influence_cross_target.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """
-Benchmark category influence propagation across the C# query engine and
-generated Rust/Go binaries.
+Benchmark category influence propagation across the C# query engine,
+generated Prolog, and generated Rust/Go binaries.
 """
 
 from __future__ import annotations
 
 import argparse
 import statistics
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ ROOT = Path(__file__).resolve().parents[2]
 BENCH_DIR = ROOT / "data" / "benchmark"
 GENERATOR = ROOT / "examples" / "benchmark" / "generate_pipeline.py"
 FACTS_PATH = BENCH_DIR / "10k" / "facts.pl"
+PROLOG_GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_category_influence_benchmark.pl"
 
 
 @dataclass
@@ -57,7 +59,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="csharp-query,rust-dfs,go-dfs",
-        help="Comma-separated targets: csharp-query,rust-dfs,go-dfs",
+        help="Comma-separated targets: csharp-query,rust-dfs,go-dfs,prolog-accumulated",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -82,6 +84,26 @@ def build_go_dfs(root: Path) -> list[str]:
     )
 
 
+def build_prolog_accumulated(root: Path, scale: str) -> list[str]:
+    facts_path = require_file(BENCH_DIR / scale / "facts.pl")
+    script_path = root / "prolog_accumulated" / scale / "category_influence_accumulated.pl"
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(PROLOG_GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            "accumulated",
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
 def normalize_output(output: str) -> str:
     return normalize_two_column_float_rows(output, decimals=9, descending_numeric=True)
 
@@ -96,7 +118,10 @@ def benchmark_target(command: list[str], scale: str, repetitions: int, target: s
     stderr = ""
     for _ in range(repetitions):
         started = time.perf_counter()
-        result = run_command(command + [str(edge_path), str(article_path)])
+        if target == "prolog-accumulated":
+            result = run_command(command, cwd=ROOT)
+        else:
+            result = run_command(command + [str(edge_path), str(article_path)])
         times.append(time.perf_counter() - started)
         stdout = result.stdout
         stderr = result.stderr
@@ -115,14 +140,17 @@ def print_summary(results: list[RunResult]) -> None:
             csharp = find_result(entries, "csharp-query")
             rust = find_result(entries, "rust-dfs")
             go = find_result(entries, "go-dfs")
+            prolog = find_result(entries, "prolog-accumulated")
             print_speedup(scale, "speedup_vs_rust_dfs", rust, csharp)
             print_speedup(scale, "speedup_vs_go_dfs", go, csharp)
+            print_speedup(scale, "speedup_vs_prolog_accumulated", prolog, csharp)
             if rust and go:
                 faster = "rust-dfs" if rust.median < go.median else "go-dfs"
                 speedup = (go.median / rust.median) if faster == "rust-dfs" else (rust.median / go.median)
                 print(f"{scale}\tfaster_target\t{faster}")
                 print(f"{scale}\tspeedup\t{speedup:.2f}x")
             print_phase_metrics(scale, "csharp-query-metrics", csharp)
+            print_phase_metrics(scale, "prolog-accumulated-metrics", prolog)
 
 
 def main() -> int:
@@ -141,19 +169,25 @@ def main() -> int:
         temp_root = Path(temp_ctx.name)
 
     try:
-        commands: dict[str, list[str]] = {}
+        static_commands: dict[str, list[str]] = {}
         for target in targets:
             if target == "csharp-query":
-                commands[target] = build_csharp_query(temp_root)
+                static_commands[target] = build_csharp_query(temp_root)
             elif target == "rust-dfs":
-                commands[target] = build_rust_dfs(temp_root)
+                static_commands[target] = build_rust_dfs(temp_root)
             elif target == "go-dfs":
-                commands[target] = build_go_dfs(temp_root)
+                static_commands[target] = build_go_dfs(temp_root)
+            elif target == "prolog-accumulated":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
         results: list[RunResult] = []
         for scale in scales:
+            commands = dict(static_commands)
+            if "prolog-accumulated" in targets:
+                commands["prolog-accumulated"] = build_prolog_accumulated(temp_root, scale)
+
             for target in targets:
                 results.append(benchmark_target(commands[target], scale, args.repetitions, target))
 

--- a/examples/benchmark/benchmark_prolog_category_influence.py
+++ b/examples/benchmark/benchmark_prolog_category_influence.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Benchmark seeded category-influence generation for the Prolog target.
+
+Targets:
+  - prolog-seeded : generated Prolog using seeded counted closure reuse
+  - prolog-accumulated : generated Prolog using seeded accumulation helpers
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmark_common import (
+    digest_normalized_output,
+    find_result,
+    group_results_by_scale,
+    normalize_two_column_float_rows,
+    print_pair_match_status,
+    print_phase_metrics,
+    print_result_table,
+    print_speedup,
+    require_file,
+    run_command,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BENCH_DIR = ROOT / "data" / "benchmark"
+GENERATOR = ROOT / "examples" / "benchmark" / "generate_prolog_category_influence_benchmark.pl"
+
+
+@dataclass
+class RunResult:
+    target: str
+    scale: str
+    times: list[float]
+    stdout_sha256: str
+    row_count: int
+    stderr: str
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.times)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", default="300,1k,5k,10k")
+    parser.add_argument(
+        "--targets",
+        default="prolog-seeded,prolog-accumulated",
+        help="Comma-separated targets: prolog-seeded,prolog-accumulated",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--keep-temp", action="store_true")
+    return parser.parse_args()
+
+
+def available_targets(requested: list[str]) -> list[str]:
+    if shutil.which("swipl") is None:
+        print("skip prolog category-influence benchmark: swipl not found", file=sys.stderr)
+        return []
+    supported = {"prolog-seeded", "prolog-accumulated"}
+    targets: list[str] = []
+    for target in requested:
+        if target not in supported:
+            raise ValueError(f"unsupported target: {target}")
+        targets.append(target)
+    return targets
+
+
+def scale_facts_path(scale: str) -> Path:
+    return require_file(BENCH_DIR / scale / "facts.pl")
+
+
+def build_generated_script(root: Path, scale: str, variant: str, script_name: str) -> list[str]:
+    facts_path = scale_facts_path(scale)
+    script_path = root / scale / script_name
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(
+        [
+            "swipl",
+            "-q",
+            "-s",
+            str(GENERATOR),
+            "--",
+            str(facts_path),
+            str(script_path),
+            variant,
+        ],
+        cwd=ROOT,
+    )
+    return ["swipl", "-q", "-s", str(script_path)]
+
+
+def benchmark_target(command: list[str], scale: str, repetitions: int, target: str) -> RunResult:
+    times: list[float] = []
+    stdout = ""
+    stderr = ""
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = run_command(command, cwd=ROOT)
+        times.append(time.perf_counter() - started)
+        stdout = result.stdout
+        stderr = result.stderr
+
+    normalized = normalize_two_column_float_rows(stdout, decimals=9, descending_numeric=True)
+    digest, row_count = digest_normalized_output(normalized)
+    return RunResult(target, scale, times, digest, row_count, stderr)
+
+
+def print_summary(results: list[RunResult]) -> None:
+    print("scale\ttarget\tmedian_s\tmin_s\tmax_s\trows\tstdout_sha256")
+    for scale, entries in group_results_by_scale(results):
+        print_result_table(entries, scale)
+        seeded = find_result(entries, "prolog-seeded")
+        accumulated = find_result(entries, "prolog-accumulated")
+        print_pair_match_status(scale, "seeded_vs_accumulated", seeded, accumulated)
+        print_speedup(scale, "speedup_accumulated_vs_seeded", seeded, accumulated)
+        print_phase_metrics(scale, "seeded_metrics", seeded)
+        print_phase_metrics(scale, "accumulated_metrics", accumulated)
+
+
+def main() -> int:
+    args = parse_args()
+    scales = [part.strip() for part in args.scales.split(",") if part.strip()]
+    targets = available_targets([part.strip() for part in args.targets.split(",") if part.strip()])
+    if not targets:
+        print("no benchmark targets available", file=sys.stderr)
+        return 1
+
+    temp_ctx = None
+    if args.keep_temp:
+        temp_root = Path(tempfile.mkdtemp(prefix="uw-prolog-category-influence-"))
+    else:
+        temp_ctx = tempfile.TemporaryDirectory(prefix="uw-prolog-category-influence-")
+        temp_root = Path(temp_ctx.name)
+
+    try:
+        results: list[RunResult] = []
+        for scale in scales:
+            commands: dict[str, list[str]] = {}
+            for target in targets:
+                if target == "prolog-seeded":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "seeded", "category_influence_seeded.pl"
+                    )
+                elif target == "prolog-accumulated":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "accumulated", "category_influence_accumulated.pl"
+                    )
+                else:
+                    raise ValueError(f"unsupported target: {target}")
+
+            for target in targets:
+                results.append(benchmark_target(commands[target], scale, args.repetitions, target))
+
+        print_summary(results)
+        if args.keep_temp:
+            print(f"kept temp build directory: {temp_root}", file=sys.stderr)
+        return 0
+    finally:
+        if temp_ctx is not None:
+            temp_ctx.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/benchmark/generate_prolog_category_influence_benchmark.pl
+++ b/examples/benchmark/generate_prolog_category_influence_benchmark.pl
@@ -12,7 +12,7 @@ main :-
     (   Argv = [FactsPath, OutputPath, VariantAtom]
     ->  true
     ;   format(user_error,
-            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned|accumulated>~n',
+            'Usage: swipl -q -s generate_prolog_category_influence_benchmark.pl -- <facts.pl> <output-script> <seeded|accumulated>~n',
             []),
         halt(1)
     ),
@@ -36,14 +36,8 @@ parse_variant('seeded', seeded, [
         dialect(swi),
         entry_point(run_benchmark),
         branch_pruning(false),
-        min_closure(false)
-    ]) :-
-    !.
-parse_variant('pruned', pruned, [
-        dialect(swi),
-        entry_point(run_benchmark),
-        branch_pruning(auto),
-        min_closure(false)
+        min_closure(false),
+        seeded_accumulation(false)
     ]) :-
     !.
 parse_variant('accumulated', accumulated, [
@@ -56,7 +50,7 @@ parse_variant('accumulated', accumulated, [
     !.
 parse_variant(Atom, _, _) :-
     format(user_error,
-        'Unsupported effective-distance benchmark variant: ~w (expected seeded, pruned, or accumulated)~n',
+        'Unsupported category-influence benchmark variant: ~w (expected seeded or accumulated)~n',
         [Atom]),
     halt(1).
 
@@ -80,9 +74,6 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         'collect_seed_categories(Seeds) :-',
         '    setof(Cat, Article^article_category(Article, Cat), Seeds).',
         '',
-        'collect_articles(Articles) :-',
-        '    setof(Article, Cat^article_category(Article, Cat), Articles).',
-        '',
         'clear_seed_indexes :-',
         '    retractall(bench_seed_hops(_, _, _)),',
         '    retractall(bench_seed_weight_sum(_, _, _)).',
@@ -90,7 +81,10 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         'seed_hops_query(Cat, Root, Hops) :-',
         '    category_ancestor(Cat, Root, Hops, [Cat]).',
         '',
-        'build_seed_hops_index(Root, SeedCount, TupleCount) :-',
+        'seed_weight_sum_query(Cat, Root, WeightSum) :-',
+        WeightSumQueryLine,
+        '',
+        'build_seed_hops_index(SeedCount, TupleCount) :-',
         '    clear_seed_indexes,',
         '    collect_seed_categories(Seeds),',
         '    length(Seeds, SeedCount),',
@@ -103,7 +97,7 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    ),',
         '    aggregate_all(count, bench_seed_hops(_, _, _), TupleCount).',
         '',
-        'build_seed_weight_sum_index(Root, SeedCount, TupleCount) :-',
+        'build_seed_weight_sum_index(SeedCount, TupleCount) :-',
         '    clear_seed_indexes,',
         '    collect_seed_categories(Seeds),',
         '    length(Seeds, SeedCount),',
@@ -116,62 +110,48 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    ),',
         '    aggregate_all(count, bench_seed_weight_sum(_, _, _), TupleCount).',
         '',
-        'seeded_article_root_hops(Article, Root, 1) :-',
+        'seeded_article_root_weight_from_hops(Article, Root, 1.0) :-',
         '    article_category(Article, Root).',
-        'seeded_article_root_hops(Article, Root, Hops) :-',
+        'seeded_article_root_weight_from_hops(Article, Root, Weight) :-',
+        '    dimension_n(N),',
         '    article_category(Article, Cat),',
         '    Cat \\= Root,',
-        '    bench_seed_hops(Cat, Root, CatHops),',
-        '    Hops is CatHops + 1.',
+        '    bench_seed_hops(Cat, Root, Hops),',
+        '    Distance is Hops + 1,',
+        '    Weight is Distance ** (-N).',
         '',
-        'seeded_article_root_weight(Article, Root, 1.0) :-',
+        'seeded_article_root_weight_from_sums(Article, Root, 1.0) :-',
         '    article_category(Article, Root).',
-        'seeded_article_root_weight(Article, Root, Weight) :-',
+        'seeded_article_root_weight_from_sums(Article, Root, Weight) :-',
         '    article_category(Article, Cat),',
         '    Cat \\= Root,',
         '    bench_seed_weight_sum(Cat, Root, Weight).',
         '',
-        'seed_weight_sum_query(Cat, Root, WeightSum) :-',
-        WeightSumQueryLine,
-        '',
-        'compute_effective_distance_results_from_hops(Root, Results) :-',
-        '    collect_articles(Articles),',
-        '    dimension_n(N),',
-        '    NegN is -N,',
-        '    findall(Deff-Article,',
-        '        (   member(Article, Articles),',
-        '            aggregate_all(sum(W),',
-        '                (   seeded_article_root_hops(Article, Root, Hops),',
-        '                    W is Hops ** NegN',
-        '                ),',
-        '                WeightSum),',
-        '            WeightSum > 0,',
-        '            InvN is -1 / N,',
-        '            Deff is WeightSum ** InvN',
+        'compute_category_influence_results_from_hops(Results) :-',
+        '    setof(Root, root_category(Root), Roots),',
+        '    findall(Score-Root,',
+        '        (   member(Root, Roots),',
+        '            aggregate_all(sum(W), seeded_article_root_weight_from_hops(_, Root, W), Score),',
+        '            Score > 0',
         '        ),',
         '        Pairs),',
-        '    sort(Pairs, Results).',
+        '    sort(1, @>=, Pairs, Results).',
         '',
-        'compute_effective_distance_results_from_weight_sums(Root, Results) :-',
-        '    collect_articles(Articles),',
-        '    dimension_n(N),',
-        '    InvN is -1 / N,',
-        '    findall(Deff-Article,',
-        '        (   member(Article, Articles),',
-        '            aggregate_all(sum(W),',
-        '                seeded_article_root_weight(Article, Root, W),',
-        '                WeightSum),',
-        '            WeightSum > 0,',
-        '            Deff is WeightSum ** InvN',
+        'compute_category_influence_results_from_sums(Results) :-',
+        '    setof(Root, root_category(Root), Roots),',
+        '    findall(Score-Root,',
+        '        (   member(Root, Roots),',
+        '            aggregate_all(sum(W), seeded_article_root_weight_from_sums(_, Root, W), Score),',
+        '            Score > 0',
         '        ),',
         '        Pairs),',
-        '    sort(Pairs, Results).',
+        '    sort(1, @>=, Pairs, Results).',
         '',
-        'print_effective_distance_results(Root, Results) :-',
-        '    format("article\\troot_category\\teffective_distance~n"),',
+        'print_category_influence_results(Results) :-',
+        '    format("root_category\\tinfluence_score~n"),',
         '    forall(',
-        '        member(Distance-Article, Results),',
-        '        format("~w\\t~w\\t~6f~n", [Article, Root, Distance])',
+        '        member(Score-Root, Results),',
+        '        format("~w\\t~12f~n", [Root, Score])',
         '    ).',
         '',
         'run_benchmark :-',
@@ -179,16 +159,15 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    load_benchmark_facts,',
         '    statistics(walltime, [_, LoadMs]),',
         '    statistics(inferences, InferencesBefore),',
-        '    root_category(Root),',
         IndexBuildLine,
         '    statistics(walltime, [_, QueryMs]),',
         ResultsLine,
         '    statistics(walltime, [_, AggregationMs]),',
-        '    print_effective_distance_results(Root, Results),',
+        '    print_category_influence_results(Results),',
         '    statistics(inferences, InferencesAfter),',
         '    TotalMs is LoadMs + QueryMs + AggregationMs,',
         '    Inferences is InferencesAfter - InferencesBefore,',
-        '    length(Results, ArticleCount),',
+        '    length(Results, RootCount),',
         ModeLine,
         '    format(user_error, ''load_ms=~w~n'', [LoadMs]),',
         '    format(user_error, ''query_ms=~w~n'', [QueryMs]),',
@@ -197,22 +176,18 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    format(user_error, ''inferences=~w~n'', [Inferences]),',
         '    format(user_error, ''seed_count=~w~n'', [SeedCount]),',
         '    format(user_error, ''tuple_count=~w~n'', [TupleCount]),',
-        '    format(user_error, ''article_count=~w~n'', [ArticleCount]).'
+        '    format(user_error, ''root_count=~w~n'', [RootCount]).'
     ],
     atomic_list_concat(Lines, '\n', Code).
 
-benchmark_index_build_line(seeded, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
-benchmark_index_build_line(pruned, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
-benchmark_index_build_line(accumulated, '    build_seed_weight_sum_index(Root, SeedCount, TupleCount),').
+benchmark_index_build_line(seeded, '    build_seed_hops_index(SeedCount, TupleCount),').
+benchmark_index_build_line(accumulated, '    build_seed_weight_sum_index(SeedCount, TupleCount),').
 
-benchmark_results_line(seeded, '    compute_effective_distance_results_from_hops(Root, Results),').
-benchmark_results_line(pruned, '    compute_effective_distance_results_from_hops(Root, Results),').
-benchmark_results_line(accumulated, '    compute_effective_distance_results_from_weight_sums(Root, Results),').
+benchmark_results_line(seeded, '    compute_category_influence_results_from_hops(Results),').
+benchmark_results_line(accumulated, '    compute_category_influence_results_from_sums(Results),').
 
 benchmark_weight_sum_query_line(seeded, '    fail.').
-benchmark_weight_sum_query_line(pruned, '    fail.').
 benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$power_sum''(Cat, Root, WeightSum).').
 
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
-benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').
 benchmark_mode_line(accumulated, '    format(user_error, ''mode=accumulated~n'', []),').

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -56,10 +56,12 @@
 %         available (default: auto). This preserves the original
 %         predicate and adds a separate '$min' helper for bound
 %         shortest-path style queries.
-%       - effective_distance_accumulation(auto/false) - Emit a SWI
-%         helper for canonical counted PPV recursion that aggregates
-%         `sum((Metric+1)^(-N))` via `dimension_n/1` (default: auto).
-%         This is a narrow seeded accumulation helper used by the
+%       - seeded_accumulation(auto/false) - Emit SWI helper predicates
+%         for canonical counted recursive closures that aggregate over
+%         the derived metric (default: auto). This currently supports
+%         `power_sum` and `sum_metric` helper formulas.
+%       - effective_distance_accumulation(auto/false) - Legacy alias for
+%         seeded_accumulation/1 retained for compatibility with the
 %         effective-distance benchmark surface.
 %  @arg ScriptCode Generated script as atom
 %
@@ -241,7 +243,7 @@ generate_predicate_code(Pred/Arity, Options, Code) :-
     ;   copy_predicate_clauses(Pred/Arity, BaseCode0)
     ),
     maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode0, BaseCode1),
-    maybe_append_effective_distance_helper(Pred/Arity, Options, BaseCode1, BaseCode),
+    maybe_append_seeded_accumulation_helper(Pred/Arity, Options, BaseCode1, BaseCode),
 
     % Apply constraints if specified
     (   option(constraints(Constraints), Options)
@@ -387,13 +389,21 @@ maybe_append_min_closure_helper(Pred/Arity, Options, BaseCode, Code) :-
     ;   Code = BaseCode
     ).
 
-maybe_append_effective_distance_helper(Pred/Arity, Options, BaseCode, Code) :-
-    option(effective_distance_accumulation(Setting), Options, auto),
+maybe_append_seeded_accumulation_helper(Pred/Arity, Options, BaseCode, Code) :-
+    seeded_accumulation_setting(Options, Setting),
     (   Setting == false
     ->  Code = BaseCode
-    ;   maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, HelperCode)
+    ;   maybe_generate_seeded_accumulation_helper(Pred/Arity, Options, HelperCode)
     ->  atomic_list_concat([BaseCode, HelperCode], '\n\n', Code)
     ;   Code = BaseCode
+    ).
+
+seeded_accumulation_setting(Options, Setting) :-
+    (   option(seeded_accumulation(Setting0), Options)
+    ->  Setting = Setting0
+    ;   option(effective_distance_accumulation(Setting1), Options)
+    ->  Setting = Setting1
+    ;   Setting = auto
     ).
 
 maybe_generate_min_closure_helper(Pred/Arity, Options, Code) :-
@@ -471,10 +481,74 @@ maybe_generate_weighted_min_closure_helper(Pred/Arity, Code) :-
     build_min_closure_code(Pred/Arity, BaseClauses, RecClauses, SignaturePositions,
         MetricPos, VisitedPos, 1, 1, BudgetMode, Code).
 
-maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, Code) :-
+maybe_generate_seeded_accumulation_helper(Pred/Arity, Options, Code) :-
     option(dialect(Dialect), Options, swi),
     Dialect == swi,
-    effective_distance_dimension_available(Options),
+    seeded_accumulation_formula(Pred/Arity, Options, Formula),
+    (   seeded_accumulation_ppv_shape(Pred/Arity, Shape)
+    ;   seeded_accumulation_counted_shape(Pred/Arity, Shape)
+    ),
+    build_seeded_accumulation_code(Pred/Arity, Shape, Formula, Code).
+
+seeded_accumulation_formula(Pred/Arity, Options, Formula) :-
+    (   current_predicate(user:accumulation_formula/2),
+        user:accumulation_formula(Pred/Arity, Formula0)
+    ->  normalize_seeded_accumulation_formula(Formula0, Formula),
+        seeded_accumulation_formula_available(Options, Formula)
+    ;   seeded_accumulation_default_formula(Options, Formula)
+    ).
+
+normalize_seeded_accumulation_formula(power_sum(ParamPred/1, Offset),
+        accumulation_formula(power_sum, ParamPred, Offset, power_sum, [])) :-
+    number(Offset).
+normalize_seeded_accumulation_formula(power_sum(ParamPred/1, Offset, Suffix),
+        accumulation_formula(power_sum, ParamPred, Offset, Suffix, [])) :-
+    number(Offset),
+    atom(Suffix).
+normalize_seeded_accumulation_formula(power_sum(ParamPred/1, Offset, Suffix, AliasSuffixes),
+        accumulation_formula(power_sum, ParamPred, Offset, Suffix, AliasSuffixes)) :-
+    number(Offset),
+    atom(Suffix),
+    is_list(AliasSuffixes),
+    forall(member(Alias, AliasSuffixes), atom(Alias)).
+normalize_seeded_accumulation_formula(sum_metric(Offset),
+        accumulation_formula(sum_metric, none, Offset, sum_metric, [])) :-
+    number(Offset).
+normalize_seeded_accumulation_formula(sum_metric(Offset, Suffix),
+        accumulation_formula(sum_metric, none, Offset, Suffix, [])) :-
+    number(Offset),
+    atom(Suffix).
+normalize_seeded_accumulation_formula(sum_metric(Offset, Suffix, AliasSuffixes),
+        accumulation_formula(sum_metric, none, Offset, Suffix, AliasSuffixes)) :-
+    number(Offset),
+    atom(Suffix),
+    is_list(AliasSuffixes),
+    forall(member(Alias, AliasSuffixes), atom(Alias)).
+
+seeded_accumulation_formula_available(_Options,
+        accumulation_formula(sum_metric, none, _Offset, _Suffix, _Aliases)).
+seeded_accumulation_formula_available(Options,
+        accumulation_formula(power_sum, ParamPred, _Offset, _Suffix, _Aliases)) :-
+    helper_predicate_available(Options, ParamPred/1).
+
+seeded_accumulation_default_formula(Options, Formula) :-
+    helper_predicate_available(Options, dimension_n/1),
+    !,
+    Formula = accumulation_formula(power_sum, dimension_n, 1, power_sum, [effective_distance_sum]).
+seeded_accumulation_default_formula(Options, Formula) :-
+    helper_predicate_available(Options, influence_dimension/1),
+    Formula = accumulation_formula(power_sum, influence_dimension, 1, power_sum, [influence_sum]).
+
+helper_predicate_available(Options, Pred/Arity) :-
+    option(predicates(UserPredicates), Options, []),
+    memberchk(Pred/Arity, UserPredicates),
+    !.
+helper_predicate_available(_Options, Pred/Arity) :-
+    functor(Head, Pred, Arity),
+    clause(user:Head, _).
+
+seeded_accumulation_ppv_shape(Pred/Arity,
+        accumulation_shape(SignaturePositions, DriverPos, MetricPos, visited(VisitedPos))) :-
     findall(Head-Body,
         (   functor(Head, Pred, Arity),
             user:clause(Head, Body0),
@@ -496,54 +570,186 @@ maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, Code)
     min_closure_recursive_shape(Pred, Arity, VisitedPos, MetricPos, FirstRec, 1, BudgetMode),
     forall(member(RecClause, RestRecClauses),
         min_closure_recursive_shape_compatible(Pred, Arity, VisitedPos, MetricPos,
-            1, BudgetMode, RecClause)),
-    build_effective_distance_accumulation_code(Pred/Arity, SignaturePositions,
-        DriverPos, MetricPos, VisitedPos, Code).
+            1, BudgetMode, RecClause)).
 
-effective_distance_dimension_available(Options) :-
-    option(predicates(UserPredicates), Options, []),
-    memberchk(dimension_n/1, UserPredicates),
-    !.
-effective_distance_dimension_available(_Options) :-
-    current_predicate(user:dimension_n/1).
+seeded_accumulation_counted_shape(Pred/Arity,
+        accumulation_shape([1, 2], 1, 3, none)) :-
+    Arity =:= 3,
+    findall(Head-Body,
+        (   functor(Head, Pred, Arity),
+            user:clause(Head, Body0),
+            strip_codegen_module_qualifiers(Body0, Body)
+        ),
+        Clauses),
+    Clauses \= [],
+    partition(is_recursive_clause_for_pred(Pred), Clauses, RecClauses, BaseClauses),
+    RecClauses \= [],
+    BaseClauses \= [],
+    maplist(counted_accumulation_base_depth, BaseClauses, BaseDepths),
+    sort(BaseDepths, [1]),
+    forall(member(RecClause, RecClauses),
+        counted_accumulation_recursive_shape(Pred, RecClause, 1)).
 
-build_effective_distance_accumulation_code(Pred/Arity, SignaturePositions, DriverPos,
-        MetricPos, VisitedPos, Code) :-
-    atom_concat(Pred, '$effective_distance_sum', HelperName),
+build_seeded_accumulation_code(Pred/Arity,
+        accumulation_shape(SignaturePositions, DriverPos, MetricPos, VisitedInfo),
+        accumulation_formula(FormulaKind, ParamPred, Offset, PrimarySuffix, AliasSuffixes),
+        Code) :-
+    helper_name_for_suffix(Pred, PrimarySuffix, HelperName),
     length(SignaturePositions, SignatureCount),
     build_min_signature_vars(SignatureCount, SignatureArgs),
     append(SignatureArgs, [WeightSum], HeadArgs),
     HeadTerm =.. [HelperName|HeadArgs],
-    build_effective_distance_call_args(Arity, SignaturePositions, DriverPos,
-        MetricPos, VisitedPos, SignatureArgs, MetricVar, CallArgs),
+    build_seeded_accumulation_call_args(Arity, SignaturePositions, DriverPos,
+        MetricPos, VisitedInfo, SignatureArgs, MetricVar, CallArgs),
     PredCall =.. [Pred|CallArgs],
-    AggregateGoal = aggregate_all(sum(W),
-        (   PredCall,
-            TotalMetric is MetricVar + 1,
-            W is TotalMetric ** NegN
-        ),
-        WeightSum),
-    BodyGoals = [
-        dimension_n(N),
-        (NegN is -N),
-        AggregateGoal,
-        (WeightSum > 0)
-    ],
+    build_seeded_accumulation_key_goals(SignatureArgs, MetricVar, PredCall, KeyGoals),
+    build_seeded_accumulation_body_goals(FormulaKind, ParamPred, Offset,
+        PredCall, MetricVar, WeightSum, KeyGoals, BodyGoals),
     goals_to_body(BodyGoals, BodyTerm),
     clause_term(HeadTerm, BodyTerm, ClauseTerm),
-    clauses_to_code([ClauseTerm], ClauseCode),
+    build_seeded_accumulation_alias_clauses(Pred, HelperName, AliasSuffixes,
+        SignatureCount, AliasClauses),
+    append([ClauseTerm], AliasClauses, Clauses),
+    clauses_to_code(Clauses, ClauseCode),
     atomic_list_concat([
-        '% Mode-directed effective-distance accumulation helper for canonical counted per-path recursion.',
+        '% Mode-directed seeded accumulation helper for canonical counted recursion.',
         ClauseCode
     ], '\n\n', Code).
 
-build_effective_distance_call_args(Arity, SignaturePositions, DriverPos, MetricPos,
-        VisitedPos, SignatureArgs, MetricVar, CallArgs) :-
+helper_name_for_suffix(Pred, Suffix, HelperName) :-
+    format(atom(HelperName), '~w$~w', [Pred, Suffix]).
+
+build_seeded_accumulation_key_goals(SignatureArgs, MetricVar, PredCall, KeyGoals) :-
+    build_seeded_accumulation_key_term(SignatureArgs, KeyTerm),
+    KeyGoals = [
+        setof(KeyTerm, MetricVar^PredCall, KeyTerms),
+        member(KeyTerm, KeyTerms)
+    ].
+
+build_seeded_accumulation_key_term(SignatureArgs, KeyTerm) :-
+    length(SignatureArgs, SignatureCount),
+    format(atom(Functor), 'sig~w', [SignatureCount]),
+    KeyTerm =.. [Functor|SignatureArgs].
+
+build_seeded_accumulation_body_goals(power_sum, ParamPred, Offset,
+        PredCall, MetricVar, WeightSum, KeyGoals, BodyGoals) :-
+    ParamCall =.. [ParamPred, N],
+    accumulation_metric_with_offset_goal(MetricVar, Offset, WeightedMetric, OffsetGoals),
+    append([PredCall], OffsetGoals, AggregateGoals0),
+    append(AggregateGoals0, [(W is WeightedMetric ** NegN)], AggregateGoals),
+    goals_to_body(AggregateGoals, AggregateBody),
+    AggregateGoal = aggregate_all(sum(W), AggregateBody, WeightSum),
+    append([
+        ParamCall
+    ], KeyGoals, BodyGoals0),
+    append(BodyGoals0, [
+        (NegN is -N),
+        AggregateGoal,
+        (WeightSum > 0)
+    ], BodyGoals).
+build_seeded_accumulation_body_goals(sum_metric, _ParamPred, Offset,
+        PredCall, MetricVar, WeightSum, KeyGoals, BodyGoals) :-
+    accumulation_metric_with_offset_goal(MetricVar, Offset, WeightedMetric, OffsetGoals),
+    append([PredCall], OffsetGoals, AggregateGoals0),
+    append(AggregateGoals0, [(W is WeightedMetric)], AggregateGoals),
+    goals_to_body(AggregateGoals, AggregateBody),
+    AggregateGoal = aggregate_all(sum(W), AggregateBody, WeightSum),
+    append(KeyGoals, [
+        AggregateGoal,
+        (WeightSum > 0)
+    ], BodyGoals).
+
+accumulation_metric_with_offset_goal(MetricVar, Offset, WeightedMetric, Goals) :-
+    (   Offset =:= 0
+    ->  WeightedMetric = MetricVar,
+        Goals = []
+    ;   Goals = [(WeightedMetric is MetricVar + Offset)]
+    ).
+
+build_seeded_accumulation_alias_clauses(_Pred, _PrimaryName, [], _SignatureCount, []).
+build_seeded_accumulation_alias_clauses(Pred, PrimaryName, [Suffix|Rest],
+        SignatureCount, [ClauseTerm|ClauseTerms]) :-
+    helper_name_for_suffix(Pred, Suffix, AliasName),
+    build_min_signature_vars(SignatureCount, SignatureArgs),
+    append(SignatureArgs, [_WeightSum], HeadArgs),
+    AliasHead =.. [AliasName|HeadArgs],
+    PrimaryCall =.. [PrimaryName|HeadArgs],
+    ClauseTerm = (AliasHead :- PrimaryCall),
+    build_seeded_accumulation_alias_clauses(Pred, PrimaryName, Rest,
+        SignatureCount, ClauseTerms).
+
+build_seeded_accumulation_call_args(Arity, SignaturePositions, DriverPos, MetricPos,
+        VisitedInfo, SignatureArgs, MetricVar, CallArgs) :-
     length(CallArgs, Arity),
     bind_positions_1based(SignaturePositions, SignatureArgs, CallArgs),
     nth1(MetricPos, CallArgs, MetricVar),
-    nth1(DriverPos, CallArgs, DriverArg),
-    nth1(VisitedPos, CallArgs, [DriverArg]).
+    (   VisitedInfo = visited(VisitedPos)
+    ->  nth1(DriverPos, CallArgs, DriverArg),
+        nth1(VisitedPos, CallArgs, [DriverArg])
+    ;   true
+    ).
+
+counted_accumulation_base_depth(Head-Body, BaseDepth) :-
+    Head =.. [_Pred, From, To, MetricArg],
+    var(From),
+    var(To),
+    body_goals(Body, Goals0),
+    (   number(MetricArg)
+    ->  BaseDepth = MetricArg,
+        Goals = Goals0
+    ;   var(MetricArg),
+        select(MetricGoal, Goals0, Goals),
+        metric_constant_goal(MetricArg, MetricGoal, BaseDepth)
+    ),
+    Goals = [EdgeGoal],
+    counted_accumulation_edge_goal(From, To, EdgeGoal),
+    number(BaseDepth),
+    BaseDepth > 0.
+
+counted_accumulation_recursive_shape(Pred, Head-Body, StepIncrement) :-
+    Head =.. [Pred, From, To, MetricVar],
+    var(From),
+    var(To),
+    var(MetricVar),
+    body_goals(Body, Goals0),
+    strip_counted_accumulation_budget_goals(Goals0, MetricVar, Goals1),
+    select(EdgeGoal, Goals1, Goals2),
+    counted_accumulation_edge_goal(From, Mid, EdgeGoal),
+    select(RecGoal, Goals2, Goals3),
+    counted_accumulation_recursive_goal(Pred, Mid, To, PrevMetric, RecGoal),
+    select(MetricGoal, Goals3, RemainingGoals),
+    metric_increment_goal(MetricVar, PrevMetric, MetricGoal, StepIncrement),
+    number(StepIncrement),
+    StepIncrement > 0,
+    RemainingGoals == [].
+
+counted_accumulation_edge_goal(From, To, Goal0) :-
+    strip_module(Goal0, _, Goal),
+    functor(Goal, _Functor, 2),
+    arg(1, Goal, From),
+    arg(2, Goal, To).
+
+counted_accumulation_recursive_goal(Pred, From, To, MetricVar, Goal0) :-
+    strip_module(Goal0, _, Goal),
+    Goal =.. [Pred, From, To, MetricVar].
+
+strip_counted_accumulation_budget_goals(Goals0, MetricVar, Goals) :-
+    exclude(is_cut_goal, Goals0, GoalsNoCuts),
+    (   select(MaxGoal, GoalsNoCuts, Goals1),
+        max_depth_budget_goal(MaxGoal, MaxVar),
+        select(CompareGoal, Goals1, Goals2),
+        counted_accumulation_budget_goal(CompareGoal, MetricVar, MaxVar)
+    ->  Goals = Goals2
+    ;   Goals = GoalsNoCuts
+    ).
+
+counted_accumulation_budget_goal(Goal0, MetricVar, MaxVar) :-
+    strip_module(Goal0, _, Goal),
+    (   Goal =.. [=<, Left, Right]
+    ;   Goal =.. [<, Left, Right]
+    ),
+    Left == MetricVar,
+    Right == MaxVar.
 
 counted_ppv_visited_position(Pred, Arity, RecClauses, VisitedPos) :-
     member(Head-Body, RecClauses),
@@ -1356,7 +1562,7 @@ augment_generated_dependencies(UserPredicates, Options, Dependencies0, Dependenc
 
 generated_helper_requires_aggregate(UserPredicates, Options) :-
     member(Pred/Arity, UserPredicates),
-    maybe_generate_effective_distance_accumulation_helper(Pred/Arity, Options, _),
+    maybe_generate_seeded_accumulation_helper(Pred/Arity, Options, _),
     !.
 
 %% extract_dependencies_from_body(+Body, -Dependency)

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -223,6 +223,52 @@ cleanup_effective_distance_accumulation_fixture :-
     retractall(user:test_effective_ppv_reach(_, _, _, _)),
     retractall(user:mode(test_effective_ppv_reach(_, _, _, _))).
 
+setup_category_influence_accumulation_fixture :-
+    cleanup_category_influence_accumulation_fixture,
+    assertz(user:test_influence_edge(a, b)),
+    assertz(user:test_influence_edge(b, c)),
+    assertz(user:test_influence_edge(a, d)),
+    assertz(user:test_influence_edge(d, c)),
+    assertz(user:influence_dimension(5)),
+    assertz(user:max_depth(4)),
+    assertz(user:(test_influence_reach(Cat, Parent, 1) :-
+        test_influence_edge(Cat, Parent))),
+    assertz(user:(test_influence_reach(Cat, Ancestor, Hops) :-
+        max_depth(MaxD),
+        test_influence_edge(Cat, Mid),
+        test_influence_reach(Mid, Ancestor, H1),
+        Hops is H1 + 1,
+        Hops =< MaxD)).
+
+cleanup_category_influence_accumulation_fixture :-
+    retractall(user:test_influence_edge(_, _)),
+    retractall(user:influence_dimension(_)),
+    retractall(user:max_depth(_)),
+    retractall(user:test_influence_reach(_, _, _)).
+
+setup_sum_metric_accumulation_fixture :-
+    cleanup_sum_metric_accumulation_fixture,
+    assertz(user:test_sum_metric_edge(a, b)),
+    assertz(user:test_sum_metric_edge(b, c)),
+    assertz(user:test_sum_metric_edge(a, d)),
+    assertz(user:test_sum_metric_edge(d, c)),
+    assertz(user:max_depth(4)),
+    assertz(user:accumulation_formula(test_sum_metric_reach/3, sum_metric(0))),
+    assertz(user:(test_sum_metric_reach(Cat, Parent, 1) :-
+        test_sum_metric_edge(Cat, Parent))),
+    assertz(user:(test_sum_metric_reach(Cat, Ancestor, Hops) :-
+        max_depth(MaxD),
+        test_sum_metric_edge(Cat, Mid),
+        test_sum_metric_reach(Mid, Ancestor, H1),
+        Hops is H1 + 1,
+        Hops =< MaxD)).
+
+cleanup_sum_metric_accumulation_fixture :-
+    retractall(user:test_sum_metric_edge(_, _)),
+    retractall(user:max_depth(_)),
+    retractall(user:test_sum_metric_reach(_, _, _)),
+    retractall(user:accumulation_formula(test_sum_metric_reach/3, _)).
+
 build_execution_runtime_source(ModuleName, PredicateCode, Source) :-
     atomic_list_concat([
         'test_exec_edge(a, b).',
@@ -347,6 +393,61 @@ collect_generated_effective_distance_sums(Options, PredicateCode, Sums) :-
         cleanup_temp_module_source(Path)
     ).
 
+build_category_influence_runtime_source(ModuleName, PredicateCode, Source) :-
+    atomic_list_concat([
+        'test_influence_edge(a, b).',
+        'test_influence_edge(b, c).',
+        'test_influence_edge(a, d).',
+        'test_influence_edge(d, c).',
+        'influence_dimension(5).',
+        'max_depth(4).'
+    ], '\n', FactsCode),
+    format(atom(Source),
+        ':- module(~q, []).~n:- use_module(library(aggregate)).~n~w~n~n~w~n',
+        [ModuleName, FactsCode, PredicateCode]).
+
+collect_generated_category_influence_sums(Options, PredicateCode, Sums) :-
+    once(prolog_target:generate_predicate_code(test_influence_reach/3, Options, PredicateCode)),
+    gensym(test_influence_runtime_, ModuleName),
+    build_category_influence_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_influence_reach$power_sum', a, c, Sum],
+            findall(Sum, ModuleName:Goal, Sums0),
+            sort(Sums0, Sums)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
+build_sum_metric_runtime_source(ModuleName, PredicateCode, Source) :-
+    atomic_list_concat([
+        'test_sum_metric_edge(a, b).',
+        'test_sum_metric_edge(b, c).',
+        'test_sum_metric_edge(a, d).',
+        'test_sum_metric_edge(d, c).',
+        'max_depth(4).'
+    ], '\n', FactsCode),
+    format(atom(Source),
+        ':- module(~q, []).~n:- use_module(library(aggregate)).~n~w~n~n~w~n',
+        [ModuleName, FactsCode, PredicateCode]).
+
+collect_generated_sum_metric_sums(Options, PredicateCode, Sums) :-
+    once(prolog_target:generate_predicate_code(test_sum_metric_reach/3, Options, PredicateCode)),
+    gensym(test_sum_metric_runtime_, ModuleName),
+    build_sum_metric_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_sum_metric_reach$sum_metric', a, c, Sum],
+            findall(Sum, ModuleName:Goal, Sums0),
+            sort(Sums0, Sums)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
 test(emits_branch_pruning_helpers_for_parameterized_ppv,
         [setup(setup_branch_pruning_fixture),
          cleanup(cleanup_branch_pruning_fixture)]) :-
@@ -465,6 +566,7 @@ test(emits_effective_distance_accumulation_helper_for_counted_ppv,
         predicates([dimension_n/1, max_depth/1, test_effective_ppv_reach/4])
     ],
     collect_generated_effective_distance_sums(Options, PredicateCode, [Actual]),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$power_sum')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum')),
     Expected is (3 ** -5) + (4 ** -5),
     Delta is abs(Actual - Expected),
@@ -478,5 +580,34 @@ test(skips_effective_distance_accumulation_helper_when_disabled_explicitly,
         [dialect(swi), effective_distance_accumulation(false)],
         Code)),
     \+ sub_atom(Code, _, _, _, 'test_effective_ppv_reach$effective_distance_sum').
+
+test(emits_power_sum_helper_for_counted_non_ppv_closure,
+        [setup(setup_category_influence_accumulation_fixture),
+         cleanup(cleanup_category_influence_accumulation_fixture)]) :-
+    Options = [
+        dialect(swi),
+        min_closure(false),
+        branch_pruning(false),
+        seeded_accumulation(auto),
+        predicates([influence_dimension/1, max_depth/1, test_influence_reach/3])
+    ],
+    collect_generated_category_influence_sums(Options, _PredicateCode, [Actual]),
+    Expected is (3 ** -5) + (3 ** -5),
+    Delta is abs(Actual - Expected),
+    Delta < 1.0e-12.
+
+test(emits_sum_metric_helper_from_formula_metadata,
+        [setup(setup_sum_metric_accumulation_fixture),
+         cleanup(cleanup_sum_metric_accumulation_fixture)]) :-
+    Options = [
+        dialect(swi),
+        min_closure(false),
+        branch_pruning(false),
+        seeded_accumulation(auto),
+        predicates([max_depth/1, test_sum_metric_reach/3])
+    ],
+    collect_generated_sum_metric_sums(Options, PredicateCode, [Actual]),
+    once(sub_atom(PredicateCode, _, _, _, 'test_sum_metric_reach$sum_metric')),
+    Actual =:= 4.
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This generalizes the Prolog target's seeded accumulation support beyond the earlier one-off effective-distance helper.

  The target can now emit a reusable seeded accumulation helper for canonical counted recursive closures, with support
  for:
  - `power_sum` style accumulation
  - `sum_metric` style accumulation
  - both cycle-safe PPV closures and canonical counted non-PPV closures

  The earlier effective-distance helper is preserved as a compatibility alias, but it now rides on the generalized helper
  path.

  ## What Changed

  - extended `src/unifyweaver/targets/prolog_target.pl`
    - added `seeded_accumulation(auto|false)`
    - retained `effective_distance_accumulation(auto|false)` as a compatibility alias
    - generalized the helper emission logic so it can target:
      - canonical counted PPV closures
      - canonical counted non-PPV closures
    - generalized formula handling via accumulation metadata:
      - `power_sum(ParamPred/1, Offset, ...)`
      - `sum_metric(Offset, ...)`
    - kept helper generation additive; the original predicate semantics are unchanged
    - fixed grouped aggregation semantics so the generated helper aggregates per signature key, not existentially across
  unbound outputs
  - extended `tests/core/test_prolog_target.pl`
    - kept the earlier effective-distance execution-level helper test
    - added execution-level coverage for:
      - counted non-PPV `power_sum`
      - metadata-driven `sum_metric`
  - updated `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
    - switched it to the generalized helper path
    - fixed phase timing to use elapsed deltas correctly
  - added standalone Prolog category-influence benchmark tooling:
    - `examples/benchmark/generate_prolog_category_influence_benchmark.pl`
    - `examples/benchmark/benchmark_prolog_category_influence.py`
  - extended `examples/benchmark/benchmark_category_influence_cross_target.py`
    - added optional `prolog-accumulated` support
    - kept the default cross-target target list unchanged
  - updated `examples/benchmark/README.md`
    - documents the new generalized helper path
    - records the category-influence benchmark result and its interpretation

  ## Why

  The previous Prolog effective-distance accumulation work proved that retained-state strategy mattered more than branch
  pruning for that workload, but the helper itself was still too narrow.

  This PR makes the helper machinery reusable so we can:
  - keep the effective-distance path on a cleaner target abstraction
  - test the same retained-state idea on another accumulation workload
  - learn where the generalized helper shape does and does not pay off

  ## Result

  ### Effective distance

  The effective-distance accumulated Prolog path still works through the generalized helper and remains semantically
  correct.

  ### Category influence

  The new generalized helper is also semantically correct on category influence, but the benchmark shows it is the wrong
  retained-state shape for that workload.

  Standalone Prolog results at `300` and `1k`:

  | Scale | Seeded | Accumulated | Output Match |
  |-------|-------:|------------:|--------------|
  | 300 | 1.874s | 37.847s | match |
  | 1k | 1.065s | 27.206s | match |

  Optional cross-target run at `300` and `1k`:

  | Scale | C# Query | Rust DFS | Go DFS | Prolog Accumulated | Outputs |
  |-------|---------:|---------:|-------:|-------------------:|---------|
  | 300 | 0.707s | 0.387s | 0.474s | 37.404s | match |
  | 1k | 0.566s | 1.597s | 2.105s | 26.617s | match |

  Interpretation:
  - the generalized helper is correct
  - but this grouped `power_sum` helper should not be treated as the category-influence optimization strategy
  - it recomputes grouped aggregates per seed and is dramatically slower than the seeded baseline on this workload

  That negative result is still useful: it tells us the next Prolog accumulation optimization needs a different retained-
  state plan, not just a broader helper surface.

  ## Verification

  - `swipl -q -t halt -s src/unifyweaver/targets/prolog_target.pl`
  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python -m py_compile examples/benchmark/benchmark_prolog_category_influence.py examples/benchmark/
  benchmark_category_influence_cross_target.py examples/benchmark/benchmark_prolog_effective_distance.py`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300 --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_category_influence.py --scales 300,1k --repetitions 1`
  - `python examples/benchmark/benchmark_category_influence_cross_target.py --scales 300,1k --targets csharp-query,rust-
  dfs,go-dfs,prolog-accumulated --repetitions 1`

  ## Notes

  - this PR is worth merging for the target generalization and the benchmark learning it captures
  - it is not a claim that category influence is now optimized in Prolog
  - the next real optimization step should be an incremental retained-state accumulation plan for grouped workloads, not
  more of the current grouped-helper shape