### PR TITLE
perf(csharp-query): add grouped path-aware weight sums

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -55,11 +55,15 @@ Status:
 - started for scan-oriented and path-aware benchmark paths using the shared retention boundary
 - path-aware shortest-path operators now build compact operator-owned edge state
   instead of consuming generic replayed edge tuples
+- effective-distance and category-influence operators now build compact
+  operator-owned `(group, root, weight_sum)` state instead of consuming
+  generic path rows plus benchmark-side regrouping
 
 Work:
 
 - identify additional operators that can ingest directly from streamed sources
 - move retained-state construction into those operators where it pays off
+- keep replacing generic replay/path rows with narrower operator-owned summaries
 - avoid generic `object[]` fact preloading when a narrower retained form is
   sufficient
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -63,6 +63,8 @@ Examples:
 - DAG longest depth builds adjacency and scalar suffix-depth state
 - path-aware shortest-path operators can build compact source->targets edge state
   instead of retaining generic edge tuples
+- effective-distance and category-influence operators can build compact
+  `(group, root, weight_sum)` summaries instead of retaining full path rows
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -108,8 +110,10 @@ For the current benchmark/runtime surface, the streamed path is:
 4. DAG, scan, and path-aware operators read rows through that retention boundary
 5. path-aware shortest-path operators can build a compact edge-state cache
    directly from streamed facts instead of generic replayed edge rows
-6. the operator builds only the retained state it actually needs
-7. benchmark code avoids preloading raw facts into in-memory relations first
+6. effective-distance and category-influence operators can emit compact
+   grouped root-weight summaries directly from streamed edge/seed inputs
+7. the operator builds only the retained state it actually needs
+8. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -14,45 +14,50 @@ and specification.
 
 ### Accumulated Prolog and Query Engine vs DFS Pipelines
 
-The effective-distance benchmark now has a generated accumulated Prolog
-path. It reuses `category_ancestor/4` once per unique category seed and
-uses a generated `'$effective_distance_sum'` helper to retain only
-per-seed summed path weights for article aggregation. On the current
-benchmark surface, that accumulated Prolog path is faster than the
-current C# query-engine path while still matching its output exactly.
+The effective-distance benchmark now has a dedicated C# query-runtime
+weight-sum path. Instead of materializing all `(seed, ancestor, hops)`
+rows and regrouping them in the benchmark harness, the runtime now:
+
+- streams `category_parent` and `article_category` into the engine
+- reuses path-aware edge state inside `QueryRuntime`
+- computes per-article/per-root weight sums directly
+- emits compact `(article, root, weight_sum)` rows for the final
+  `d_eff` calculation
+
+That moves the retained state into the engine and flips the old headline:
+the query engine is now faster than accumulated Prolog and all DFS
+pipelines across the full benchmark range while preserving the same
+all-path semantics.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **Prolog accumulated** | **0.353s** | **0.246s** | **0.852s** | **2.057s** |
-| C# Query Engine | 0.681s | 0.504s | 1.338s | 3.197s |
-| C# DFS pipeline | 0.48s | 1.27s | 5.48s | 10.15s |
-| Rust DFS pipeline | 0.35s | 1.47s | 7.30s | 13.67s |
-| Go DFS pipeline | 0.47s | 2.07s | 11.68s | 19.09s |
+| **C# Query Engine** | **0.211s** | **0.190s** | **0.351s** | **0.735s** |
+| Prolog accumulated | 0.361s | 0.249s | 0.823s | 2.038s |
+| C# DFS pipeline | 0.442s | 1.181s | 5.647s | 10.736s |
+| Rust DFS pipeline | 0.381s | 1.370s | 7.445s | 14.080s |
+| Go DFS pipeline | 0.483s | 2.066s | 11.864s | 19.701s |
 
-**Speedup of accumulated Prolog over the current C# query engine:**
+**Speedups of the current C# query engine:**
 
-| Scale | Speedup |
-|-------|---------|
-| 300 art | 1.93x |
-| 1K art | 2.05x |
-| 5K art | 1.57x |
-| 10K art | 1.55x |
+| Scale | vs Prolog accumulated | vs C# DFS | vs Rust DFS | vs Go DFS |
+|-------|----------------------:|----------:|------------:|----------:|
+| 300 art | 1.71x | 2.09x | 1.80x | 2.29x |
+| 1K art | 1.31x | 6.23x | 7.23x | 10.87x |
+| 5K art | 2.35x | 16.10x | 21.23x | 33.80x |
+| 10K art | 2.77x | 14.60x | 19.15x | 26.80x |
 
 Semantic note:
 
-- The current C# query-engine benchmark path preserves per-path cycle
+- the current C# query-engine path still preserves per-path cycle
   checks without collapsing distinct simple paths that happen to reach
-  the same ancestor with the same hop count.
-- `benchmark_effective_distance.py` now compares the query-engine output
+  the same ancestor with the same hop count
+- `benchmark_effective_distance.py` compares the query-engine output
   against both the C# DFS reference and accumulated Prolog, reporting
-  `query_vs_csharp_dfs` and `query_vs_prolog_accumulated`.
-- the current `csharp-query` comparison is against the retention-mode-
-  updated runtime now merged on `main`.
-- Current post-fix runs report `query_vs_csharp_dfs = match` at
-  `300`, `1k`, `5k`, and `10k`.
-- Current accumulated Prolog runs also report
-  `query_vs_prolog_accumulated = match` at `300`, `1k`, `5k`, and
-  `10k`.
+  `query_vs_csharp_dfs` and `query_vs_prolog_accumulated`
+- current runs report `query_vs_csharp_dfs = match` at `300`, `1k`,
+  `5k`, and `10k`
+- current runs also report `query_vs_prolog_accumulated = match` at
+  `300`, `1k`, `5k`, and `10k`
 
 ### Why Seeded Closures Win
 
@@ -99,38 +104,34 @@ For historical context, the original DFS-only pipeline comparison:
 
 ### Key Findings
 
-1. **Accumulated Prolog is currently the fastest effective-distance path
-   on this benchmark surface** — it beats the current C# query-engine
-   path by `1.93x` at `300`, `2.05x` at `1k`, `1.57x` at `5k`, and
-   `1.55x` at `10k`.
+1. **The C# query engine is now the fastest effective-distance path on
+   this benchmark surface** — it beats accumulated Prolog by `1.71x` at
+   `300`, `1.31x` at `1k`, `2.35x` at `5k`, and `2.77x` at `10k`.
 
-2. **The C# query engine still beats the DFS baselines comfortably** —
-   it is `2.52x` faster than C# DFS at `1k`, `4.10x` at `5k`, and
-   `3.17x` at `10k`.
+2. **The C# query engine now beats the DFS baselines by a wide margin** —
+   at `10k` it is `14.60x` faster than C# DFS, `19.15x` faster than Rust
+   DFS, and `26.80x` faster than Go DFS.
 
-3. **Among the compiled DFS targets, C# still leads at scale** — at
-   `10k` it is faster than Rust DFS (`10.15s` vs `13.67s`) and much
-   faster than Go DFS (`19.09s`).
+3. **Retained-state strategy matters more than branch pruning on this
+   workload** — seeded reuse is the first big win, and moving per-article
+   root-weight aggregation into the query runtime removes the huge path-row
+   materialization cost that used to dominate the C# query path.
 
-4. **Retained-state strategy matters more than branch pruning on this
-   workload** — seeded reuse is the first big win, and pre-aggregating
-   per-seed weight sums cuts tuple count from `105287` to `462` at
-   `10k`, while pruning still stays mostly neutral.
+4. **Accumulated Prolog is still a useful retained-state reference** — it
+   keeps only per-seed weight sums (`462` tuples at `10k`), but the query
+   engine now reaches a better end-to-end result by combining streamed
+   ingestion with operator-owned retained state.
 
-5. **The current C# query-engine path is still materializing far more
-   tuples than accumulated Prolog on this workload** — at `10k`, the C#
-   query run emits `3616699` tuples versus `462` for accumulated Prolog.
-
-6. **The effective-distance path is now showing the right next design
-   direction** — specialized retained-state strategies for accumulation
-   workloads are more promising than further branch-pruning work here.
+5. **The current C# query-engine path now matches the intended ownership
+   boundary much more closely** — the parser streams tuples, and the engine
+   decides what retained form the effective-distance operator actually needs.
 
 ### Target Recommendations by Audience
 
 | Audience | Recommended Target | Why |
 |----------|-------------------|-----|
-| SWI / Prolog-first | Accumulated Prolog | Fastest current effective-distance path, with compact retained state |
-| Enterprise / .NET | C# Query Engine | Strong seeded runtime, broad query-engine surface |
+| SWI / Prolog-first | Accumulated Prolog | Strong retained-state reference and compact effective-distance helper |
+| Enterprise / .NET | C# Query Engine | Fastest current effective-distance path, with engine-owned retained state |
 | Cloud / DevOps | Go | Fast compile, good ecosystem |
 | Systems / Embedded | Rust | No runtime overhead, strong DFS baseline |
 
@@ -701,38 +702,32 @@ Latest local results:
 
 | Scale | C# Query | Rust DFS | Go DFS | Outputs |
 |-------|---------:|---------:|-------:|---------|
-| 300 | 0.715s | 0.371s | 0.487s | match |
-| 1k | 0.554s | 1.484s | 2.141s | match |
-| 5k | 1.673s | 7.905s | 12.509s | match |
-| 10k | 4.080s | 14.932s | 20.369s | match |
+| 300 | 0.200s | 0.388s | 0.480s | match |
+| 1k | 0.156s | 1.519s | 2.096s | match |
+| 5k | 0.331s | 7.853s | 12.002s | match |
+| 10k | 0.728s | 14.793s | 20.019s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs Rust DFS | vs Go DFS |
 |-------|------------:|----------:|
-| 300 | 0.52x | 0.68x |
-| 1k | 2.68x | 3.87x |
-| 5k | 4.72x | 7.47x |
-| 10k | 3.66x | 4.99x |
+| 300 | 1.94x | 2.40x |
+| 1k | 9.76x | 13.46x |
+| 5k | 23.74x | 36.29x |
+| 10k | 20.32x | 27.49x |
 
 Comparison note:
 
-- the benchmark now includes a dedicated C# query-engine path
-- that path now uses `QueryRuntime` for both:
-  - the recursive `category_ancestor` expansion
-  - the outer grouped influence sum via `AggregateNode`
-- the C# benchmark package is now generated through
-  `generate_pipeline.py` as `target=csharp_query`, including:
-  - `Program.cs`
-  - `QueryRuntime.cs`
-  - `benchmark_qe.csproj`
+- the benchmark now uses the same retained-state idea as effective distance:
+  `QueryRuntime` emits compact `(article, root, weight_sum)` rows directly
+  instead of materializing all ancestor/hop rows and then summing them later
+- the remaining benchmark-side work is only the final per-root sum over those
+  compact article/root summaries
 - Rust and Go remain generated DFS/pipeline binaries
-- so this runner is intentionally a mixed execution-model comparison:
+- so this runner is still intentionally a mixed execution-model comparison:
   query engine versus non-query target pipelines
-- the remaining benchmark-only orchestration is now just build/run
-  invocation in the runner, not embedded C# workload or package wiring
-- the C# path is still weaker only at `300` and clearly faster from `1k`
-  onward on the current workload
+- the C# path is now faster at every tested scale, and the gap widens quickly
+  once the path-row materialization cost is removed
 
 ### Weighted `Min` Results
 

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2464,7 +2464,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using UnifyWeaver.QueryRuntime;
 
@@ -2487,155 +2486,62 @@ class Program
 
         var provider = new InMemoryRelationProvider();
         var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_ancestor", 3);
-        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var seedId = new PredicateId("article_category", 2);
+        var rootId = new PredicateId("root_category", 1);
+        var resultId = new PredicateId("article_root_weight_sum", 3);
 
         provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {{
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }}
-
-            categories.Add(parts[1]);
-        }}
-
-        swLoad.Stop();
-
-        var plan = new QueryPlan(
-            predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.All),
-            true,
-            new int[] {{ 0 }}
-        );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var categories in articleCategories.Values)
-        {{
-            foreach (var category in categories)
-            {{
-                uniqueSeeds.Add(category);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds
-            .OrderBy(category => category, StringComparer.Ordinal)
-            .Select(category => new object[] {{ category }})
-            .ToList();
-
-        var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
-        swQuery.Stop();
-
-        var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {{
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var hops = Convert.ToInt32(row[2], CultureInfo.InvariantCulture);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {{
-                bucket = new List<(string, int)>();
-                ancestorIndex[source] = bucket;
-            }}
-
-            bucket.Add((ancestor, hops));
-        }}
-
-        var rootId = new PredicateId("root_category", 1);
-        var weightId = new PredicateId("article_root_weight", 3);
-        var resultId = new PredicateId("category_influence", 2);
-
+        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
         foreach (var root in ROOTS.OrderBy(x => x, StringComparer.Ordinal))
         {{
             provider.AddFact(rootId, root);
         }}
 
-        foreach (var (_, categories) in articleCategories.OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
-        {{
-            foreach (var category in categories)
-            {{
-                if (ROOTS.Contains(category))
-                {{
-                    provider.AddFact(weightId, "_", category, 1.0);
-                }}
+        swLoad.Stop();
 
-                if (!ancestorIndex.TryGetValue(category, out var ancestors))
-                {{
-                    continue;
-                }}
-
-                foreach (var (ancestor, hops) in ancestors)
-                {{
-                    if (!ROOTS.Contains(ancestor))
-                    {{
-                        continue;
-                    }}
-
-                    var distance = hops + 1;
-                    var weight = Math.Pow(distance, -N);
-                    provider.AddFact(weightId, "_", ancestor, weight);
-                }}
-            }}
-        }}
-
-        var aggregatePlan = new QueryPlan(
+        var plan = new QueryPlan(
             resultId,
-            new ProjectionNode(
-                new SelectionNode(
-                    new AggregateNode(
-                        new RelationScanNode(rootId),
-                        weightId,
-                        AggregateOperation.Sum,
-                        tuple => new object[] {{ Wildcard.Value, tuple[0], Wildcard.Value }},
-                        Array.Empty<int>(),
-                        2,
-                        2),
-                    tuple => QueryExecutor.CompareValues(tuple[1], 0) > 0),
-                tuple => new object[] {{ tuple[0], tuple[1] }}),
+            new SeedGroupedPathAwareWeightSumNode(edgeId, seedId, rootId, resultId, N, MAX_DEPTH),
             false,
             null
         );
 
-        var aggregateRows = executor.Execute(aggregatePlan).ToList();
-        swAgg.Stop();
-        swTotal.Stop();
+        var swQuery = Stopwatch.StartNew();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan).ToList();
+        swQuery.Stop();
 
-        var results = aggregateRows
-            .Select(row => (
-                Root: row[0]?.ToString() ?? "",
-                Score: Convert.ToDouble(row[1], CultureInfo.InvariantCulture)))
+        var swAgg = Stopwatch.StartNew();
+        var scores = new Dictionary<string, double>(StringComparer.Ordinal);
+        var articles = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {{
+            var article = row[0]?.ToString() ?? "";
+            var root = row[1]?.ToString() ?? "";
+            var weightSum = Convert.ToDouble(row[2], CultureInfo.InvariantCulture);
+            articles.Add(article);
+            scores[root] = scores.TryGetValue(root, out var current) ? current + weightSum : weightSum;
+        }}
+
+        var results = scores
+            .Select(kvp => (Root: kvp.Key, Score: kvp.Value))
             .OrderByDescending(item => item.Score)
             .ThenBy(item => item.Root, StringComparer.Ordinal)
             .ToList();
+        swAgg.Stop();
+        swTotal.Stop();
 
-        Console.WriteLine("root_category\\tinfluence_score");
+        Console.WriteLine("root_category\tinfluence_score");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Root}}\\t{{item.Score.ToString("F12", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Root}}\t{{item.Score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
+        Console.Error.WriteLine($"article_count={{articles.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"root_count={{results.Count}}");
     }}
@@ -2650,7 +2556,7 @@ def generate_csharp_query_effective_distance(article_cats, category_parents, roo
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
+using System.Globalization;
 using System.Linq;
 using UnifyWeaver.QueryRuntime;
 
@@ -2669,137 +2575,61 @@ class Program
         }}
 
         var swTotal = Stopwatch.StartNew();
+        var swLoad = Stopwatch.StartNew();
 
         var provider = new InMemoryRelationProvider();
         var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_ancestor", 3);
-        var articleCategories = new Dictionary<string, List<string>>();
+        var seedId = new PredicateId("article_category", 2);
+        var rootId = new PredicateId("root_category", 1);
+        var resultId = new PredicateId("article_root_weight_sum", 3);
 
-        var swLoad = Stopwatch.StartNew();
         provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {{
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }}
-
-            categories.Add(parts[1]);
-        }}
+        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        provider.AddFact(rootId, ROOT_CATEGORY);
         swLoad.Stop();
 
         var plan = new QueryPlan(
-            predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH),
-            true,
-            new int[] {{ 0 }}
+            resultId,
+            new SeedGroupedPathAwareWeightSumNode(edgeId, seedId, rootId, resultId, N, MAX_DEPTH),
+            false,
+            null
         );
 
-        var uniqueSeeds = new HashSet<string>();
-        foreach (var categories in articleCategories.Values)
-        {{
-            foreach (var category in categories)
-            {{
-                uniqueSeeds.Add(category);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds.Select(category => new object[] {{ category }}).ToList();
-
         var swExec = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider);
-        var rows = executor.Execute(plan, seedParams).ToList();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
+        var rows = executor.Execute(plan).ToList();
         swExec.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>();
-        foreach (var row in rows)
-        {{
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var hops = Convert.ToInt32(row[2]);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {{
-                bucket = new List<(string, int)>();
-                ancestorIndex[source] = bucket;
-            }}
-
-            bucket.Add((ancestor, hops));
-        }}
-
-        var results = new List<(double Deff, string Article)>();
-        foreach (var article in articleCategories.Keys.OrderBy(x => x))
-        {{
-            var allHops = new List<int>();
-            foreach (var category in articleCategories[article])
-            {{
-                if (category == ROOT_CATEGORY)
-                {{
-                    allHops.Add(1);
-                }}
-
-                if (ancestorIndex.TryGetValue(category, out var ancestors))
-                {{
-                    foreach (var (ancestor, hops) in ancestors)
-                    {{
-                        if (ancestor == ROOT_CATEGORY)
-                        {{
-                            allHops.Add(hops + 1);
-                        }}
-                    }}
-                }}
-            }}
-
-            if (allHops.Count > 0)
-            {{
-                results.Add((ComputeDeff(allHops), article));
-            }}
-        }}
+        var results = rows
+            .Select(row => (
+                Article: row[0]?.ToString() ?? "",
+                Root: row[1]?.ToString() ?? "",
+                WeightSum: Convert.ToDouble(row[2], CultureInfo.InvariantCulture)))
+            .Where(item => string.Equals(item.Root, ROOT_CATEGORY, StringComparison.Ordinal))
+            .Select(item => (Deff: ComputeDeff(item.WeightSum), Article: item.Article))
+            .OrderBy(item => item.Deff)
+            .ThenBy(item => item.Article, StringComparer.Ordinal)
+            .ToList();
         swAgg.Stop();
+        swTotal.Stop();
 
-        results.Sort((a, b) =>
-        {{
-            var cmp = a.Deff.CompareTo(b.Deff);
-            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
-        }});
-
-        Console.WriteLine("article\\troot_category\\teffective_distance");
+        Console.WriteLine("article\troot_category\teffective_distance");
         foreach (var (deff, article) in results)
         {{
-            Console.WriteLine($"{{article}}\\t{{ROOT_CATEGORY}}\\t{{deff:F6}}");
+            Console.WriteLine($"{{article}}\t{{ROOT_CATEGORY}}\t{{deff.ToString(\"F6\", CultureInfo.InvariantCulture)}}");
         }}
 
-        swTotal.Stop();
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"query_ms={{swExec.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
     }}
 
-    static double ComputeDeff(List<int> hops)
+    static double ComputeDeff(double weightSum)
     {{
-        if (hops.Count == 0)
-        {{
-            return double.PositiveInfinity;
-        }}
-
-        var weightSum = hops.Sum(h => Math.Pow(h, -N));
         return weightSum > 0 ? Math.Pow(weightSum, -1.0 / N) : double.PositiveInfinity;
     }}
 }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -294,6 +294,19 @@ namespace UnifyWeaver.QueryRuntime
     ) : PlanNode;
 
     /// <summary>
+    /// Computes per-group root weight sums over all simple seed-to-root paths,
+    /// producing (group, root, weight_sum) rows directly.
+    /// </summary>
+    public sealed record SeedGroupedPathAwareWeightSumNode(
+        PredicateId EdgeRelation,
+        PredicateId SeedRelation,
+        PredicateId RootRelation,
+        PredicateId Predicate,
+        double DistanceExponent,
+        int MaxDepth = 0
+    ) : PlanNode;
+
+    /// <summary>
     /// Computes a counted transitive closure while preventing cycles on each
     /// derivation path instead of deduplicating globally by node or tuple.
     /// </summary>
@@ -1096,6 +1109,7 @@ namespace UnifyWeaver.QueryRuntime
                 SeedGroupedTransitiveClosureNode closure => $"SeedGroupedTransitiveClosure edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 SeedGroupedTransitiveClosureCountNode closure => $"SeedGroupedTransitiveClosureCount edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 SeedGroupedDagLongestDepthNode closure => $"SeedGroupedDagLongestDepth edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
+                SeedGroupedPathAwareWeightSumNode closure => $"SeedGroupedPathAwareWeightSum edge={closure.EdgeRelation} seeds={closure.SeedRelation} roots={closure.RootRelation} exponent={closure.DistanceExponent.ToString(CultureInfo.InvariantCulture)} maxDepth={closure.MaxDepth}",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode} positiveStep={closure.PositiveStepProven}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
@@ -1496,6 +1510,20 @@ namespace UnifyWeaver.QueryRuntime
                     return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedDepth, rows);
                 }
 
+                if (plan.Root is SeedGroupedPathAwareWeightSumNode seedGroupedPathAwareWeightSum)
+                {
+                    var rows = ExecuteSeedGroupedPathAwareWeightSum(seedGroupedPathAwareWeightSum, context);
+                    var contextCancellationToken = context.CancellationToken;
+                    if (contextCancellationToken.CanBeCanceled)
+                    {
+                        rows = WithCancellation(rows, contextCancellationToken);
+                    }
+
+                    var activeTrace = context.Trace;
+                    activeTrace?.RecordInvocation(seedGroupedPathAwareWeightSum);
+                    return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedPathAwareWeightSum, rows);
+                }
+
                 if (plan.Root is PathAwareTransitiveClosureNode pathAwareClosure)
                 {
                     IEnumerable<object[]> rows;
@@ -1596,6 +1624,7 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.GroupedTransitiveClosureResults.Clear();
             _cacheContext.SeedGroupedTransitiveClosureCountResults.Clear();
             _cacheContext.SeedGroupedDagLongestDepthResults.Clear();
+            _cacheContext.SeedGroupedPathAwareWeightSumResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededByTargetResults.Clear();
             _cacheContext.GroupedTransitiveClosurePairProbeResults.Clear();
@@ -1705,6 +1734,10 @@ namespace UnifyWeaver.QueryRuntime
 
                 case SeedGroupedDagLongestDepthNode closure:
                     result = ExecuteSeedGroupedDagLongestDepth(closure, context);
+                    break;
+
+                case SeedGroupedPathAwareWeightSumNode closure:
+                    result = ExecuteSeedGroupedPathAwareWeightSum(closure, context);
                     break;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -2155,6 +2188,12 @@ namespace UnifyWeaver.QueryRuntime
                 case SeedGroupedDagLongestDepthNode closure:
                     predicates.Add(closure.EdgeRelation);
                     predicates.Add(closure.SeedRelation);
+                    return;
+
+                case SeedGroupedPathAwareWeightSumNode closure:
+                    predicates.Add(closure.EdgeRelation);
+                    predicates.Add(closure.SeedRelation);
+                    predicates.Add(closure.RootRelation);
                     return;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -7462,6 +7501,248 @@ namespace UnifyWeaver.QueryRuntime
             {
                 context.FixpointDepth--;
             }
+        }
+
+        private IEnumerable<object[]> ExecuteSeedGroupedPathAwareWeightSum(SeedGroupedPathAwareWeightSumNode closure, EvaluationContext? parentContext)
+        {
+            if (closure is null) throw new ArgumentNullException(nameof(closure));
+
+            var width = closure.Predicate.Arity;
+            if (width < 3)
+            {
+                return Array.Empty<object[]>();
+            }
+
+            var context = parentContext ?? new EvaluationContext();
+            context.FixpointDepth++;
+            try
+            {
+                var trace = context.Trace;
+                trace?.RecordStrategy(closure, "SeedGroupedPathAwareWeightSum");
+
+                var predicate = closure.Predicate;
+                var cacheKey = (closure.EdgeRelation, closure.SeedRelation, closure.RootRelation, predicate, closure.DistanceExponent, closure.MaxDepth);
+                var traceKey = $"{predicate.Name}/{predicate.Arity}:edge={closure.EdgeRelation.Name}/{closure.EdgeRelation.Arity}:seeds={closure.SeedRelation.Name}/{closure.SeedRelation.Arity}:roots={closure.RootRelation.Name}/{closure.RootRelation.Arity}:exp={closure.DistanceExponent.ToString(CultureInfo.InvariantCulture)}:max={closure.MaxDepth}";
+                if (context.SeedGroupedPathAwareWeightSumResults.TryGetValue(cacheKey, out var cachedRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedPathAwareWeightSum", traceKey, hit: true, built: false);
+                    return cachedRows;
+                }
+
+                trace?.RecordCacheLookup("SeedGroupedPathAwareWeightSum", traceKey, hit: false, built: true);
+
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var succIndex = edgeState.Successors;
+
+                var rootKeys = new HashSet<object>();
+                var rootValues = new Dictionary<object, object?>();
+                foreach (var row in GetFactStream(closure.RootRelation, context))
+                {
+                    if (row is null || row.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var root = row[0];
+                    var rootKey = root ?? NullFactIndexKey;
+                    if (rootKeys.Add(rootKey))
+                    {
+                        rootValues[rootKey] = root;
+                    }
+                }
+
+                if (rootKeys.Count == 0)
+                {
+                    var empty = Array.Empty<object[]>();
+                    context.SeedGroupedPathAwareWeightSumResults[cacheKey] = empty;
+                    return empty;
+                }
+
+                var groupedSeeds = new Dictionary<object, List<object?>>();
+                var groupValues = new List<object?>();
+                var uniqueSeeds = new HashSet<object?>();
+                var orderedUniqueSeeds = new List<object?>();
+
+                foreach (var row in GetFactStream(closure.SeedRelation, context))
+                {
+                    if (row is null || row.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    var group = row[0];
+                    var seed = row[1];
+                    var groupKey = group ?? NullFactIndexKey;
+                    if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
+                    {
+                        bucket = new List<object?>();
+                        groupedSeeds[groupKey] = bucket;
+                        groupValues.Add(group);
+                    }
+
+                    bucket.Add(seed);
+                    if (uniqueSeeds.Add(seed))
+                    {
+                        orderedUniqueSeeds.Add(seed);
+                    }
+                }
+
+                if (groupValues.Count == 0)
+                {
+                    var empty = Array.Empty<object[]>();
+                    context.SeedGroupedPathAwareWeightSumResults[cacheKey] = empty;
+                    return empty;
+                }
+
+                orderedUniqueSeeds.Sort(CompareCacheSeedValues);
+                groupValues.Sort(CompareCacheSeedValues);
+                var distanceWeightCache = new Dictionary<int, double>();
+                var nodeIds = new Dictionary<object, int>();
+                var nextNodeId = 0;
+
+                int GetNodeId(object? value)
+                {
+                    var key = value ?? NullFactIndexKey;
+                    if (nodeIds.TryGetValue(key, out var existing))
+                    {
+                        return existing;
+                    }
+
+                    var id = nextNodeId++;
+                    nodeIds[key] = id;
+                    return id;
+                }
+
+                double GetDistanceWeight(int distance)
+                {
+                    if (distanceWeightCache.TryGetValue(distance, out var cachedWeight))
+                    {
+                        return cachedWeight;
+                    }
+
+                    var weight = Math.Pow(distance, -closure.DistanceExponent);
+                    distanceWeightCache[distance] = weight;
+                    return weight;
+                }
+
+                var seedWeightSums = new Dictionary<object, Dictionary<object, double>>();
+                foreach (var seed in orderedUniqueSeeds)
+                {
+                    var weightSums = ComputePathAwareRootWeightSumsForSeed(seed, succIndex, rootKeys, closure.MaxDepth, GetNodeId, GetDistanceWeight);
+                    if (weightSums.Count > 0)
+                    {
+                        seedWeightSums[seed ?? NullFactIndexKey] = weightSums;
+                    }
+                }
+
+                var rows = new List<object[]>();
+                foreach (var group in groupValues)
+                {
+                    var groupKey = group ?? NullFactIndexKey;
+                    if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
+                    {
+                        continue;
+                    }
+
+                    Dictionary<object, double>? groupSums = null;
+                    foreach (var seed in seedsForGroup)
+                    {
+                        if (!seedWeightSums.TryGetValue(seed ?? NullFactIndexKey, out var rootSums))
+                        {
+                            continue;
+                        }
+
+                        groupSums ??= new Dictionary<object, double>();
+                        foreach (var entry in rootSums)
+                        {
+                            groupSums[entry.Key] = groupSums.TryGetValue(entry.Key, out var current) ? current + entry.Value : entry.Value;
+                        }
+                    }
+
+                    if (groupSums is null)
+                    {
+                        continue;
+                    }
+
+                    var orderedRoots = groupSums.Keys.ToList();
+                    orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
+                    foreach (var rootKey in orderedRoots)
+                    {
+                        rows.Add(new object[] { group!, rootValues[rootKey]!, groupSums[rootKey] });
+                    }
+                }
+
+                context.SeedGroupedPathAwareWeightSumResults[cacheKey] = rows;
+                return rows;
+            }
+            finally
+            {
+                context.FixpointDepth--;
+            }
+        }
+
+        private static Dictionary<object, double> ComputePathAwareRootWeightSumsForSeed(
+            object? seed,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            HashSet<object> rootKeys,
+            int maxDepth,
+            Func<object?, int> getNodeId,
+            Func<int, double> getDistanceWeight)
+        {
+            var sums = new Dictionary<object, double>();
+
+            void AddContribution(object? root, int distance)
+            {
+                var rootKey = root ?? NullFactIndexKey;
+                var weight = getDistanceWeight(distance);
+                sums[rootKey] = sums.TryGetValue(rootKey, out var current) ? current + weight : weight;
+            }
+
+            var seedKey = seed ?? NullFactIndexKey;
+            if (rootKeys.Contains(seedKey))
+            {
+                AddContribution(seed, 1);
+            }
+
+            var initialPath = CompactVisitedPath.Create(getNodeId(seed));
+            var stack = new Stack<(object? Node, int Depth, CompactVisitedPath Path)>();
+            stack.Push((seed, 0, initialPath));
+
+            while (stack.Count > 0)
+            {
+                var (current, depth, path) = stack.Pop();
+                var lookupKey = current ?? NullFactIndexKey;
+                if (!succIndex.TryGetValue(lookupKey, out var bucket))
+                {
+                    continue;
+                }
+
+                for (var i = bucket.Targets.Count - 1; i >= 0; i--)
+                {
+                    var next = bucket.Targets[i];
+                    var nextId = getNodeId(next);
+                    if (path.Contains(nextId))
+                    {
+                        continue;
+                    }
+
+                    var nextDepth = depth + 1;
+                    if (maxDepth > 0 && nextDepth > maxDepth)
+                    {
+                        continue;
+                    }
+
+                    var nextKey = next ?? NullFactIndexKey;
+                    if (rootKeys.Contains(nextKey))
+                    {
+                        AddContribution(next, nextDepth + 1);
+                    }
+
+                    stack.Push((next, nextDepth, path.Extend(nextId)));
+                }
+            }
+
+            return sums;
         }
 
         private IEnumerable<object[]> ExecutePathAwareTransitiveClosure(PathAwareTransitiveClosureNode closure, EvaluationContext? parentContext)
@@ -14776,6 +15057,8 @@ namespace UnifyWeaver.QueryRuntime
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
                 SeedGroupedDagLongestDepthResults = parent?.SeedGroupedDagLongestDepthResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
+                SeedGroupedPathAwareWeightSumResults = parent?.SeedGroupedPathAwareWeightSumResults
+                    ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId RootRelation, PredicateId Predicate, double DistanceExponent, int MaxDepth), IReadOnlyList<object[]>>();
                 GroupedTransitiveClosureSeededResults = parent?.GroupedTransitiveClosureSeededResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
                 GroupedTransitiveClosureSeededByTargetResults = parent?.GroupedTransitiveClosureSeededByTargetResults
@@ -14838,6 +15121,8 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>> SeedGroupedTransitiveClosureCountResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>> SeedGroupedDagLongestDepthResults { get; }
+
+            public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId RootRelation, PredicateId Predicate, double DistanceExponent, int MaxDepth), IReadOnlyList<object[]>> SeedGroupedPathAwareWeightSumResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>> GroupedTransitiveClosureSeededResults { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR extends the runtime-owned materialization work to the
  effective-distance and category-influence family.

  Previously, the `csharp-query` versions of these workloads still paid a
  large retained-state cost outside the runtime:

  - execute a broad path-aware query
  - materialize many `(seed, ancestor, hops)` or accumulated path rows
  - regroup and aggregate them in the benchmark harness

  That was correct, but it kept the most important retained-state decision
  in the wrong place.

  This PR adds a dedicated query-runtime node that computes grouped
  root-weight sums directly from streamed inputs and emits only the compact
  summary rows the workloads actually need.

  ## What Changed

  ### New Query Runtime Node

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `SeedGroupedPathAwareWeightSumNode`

  This node takes:

  - an edge relation
  - a grouped seed relation
  - a root relation
  - a distance exponent
  - an optional max depth

  and produces:

  - `(group, root, weight_sum)`

  rows directly.

  For the current benchmark workloads, that means:

  - `group = article`
  - `root = root category`
  - `weight_sum = Σ distance^(-n)` over all simple paths from the article’s
    seed categories to that root

  ### Runtime-Owned Retained State

  The new node:

  - streams edge facts through the existing retention boundary
  - reuses the compact `PathAwareEdgeState`
  - reads grouped seed facts and root facts directly from the runtime
  - computes grouped root-weight sums without materializing the full
    ancestor/path relation first

  So this is the next step after replayable bindings and path-aware edge
  state:

  - not just replay buffering
  - not just compact edge state
  - but a narrower operator-owned retained summary

  ### Generator Changes

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` versions of:

  - `effective_distance`
  - `category_influence`

  now:

  - register `article_category` as a streamed relation source
  - register roots as a small runtime fact relation
  - execute `SeedGroupedPathAwareWeightSumNode`
  - do only the final workload-specific scalar reduction in the benchmark
    program

  They no longer build a large benchmark-side ancestor index from raw
  path-aware rows.

  ### Materialization Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`

  These docs now explicitly note that:

  - effective-distance and category-influence operators can build compact
    `(group, root, weight_sum)` summaries
  - this is another concrete example of operator-owned retained state
    replacing generic replay/path-row materialization

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects that:

  - the C# query engine is now the fastest effective-distance path on the
    current benchmark surface
  - category influence also now uses the same compact grouped weight-sum
    idea
  - the main lesson is about retained-state technique, not language as an
    end in itself

  ## Why This Matters

  This PR makes the benchmark story much cleaner.

  The important point is not “C# beat Prolog” or “Prolog beat C#.”

  The important point is:

  - once the retained-state technique moved into the runtime,
  - and the runtime built only the compact summary the operator actually
    needed,
  - the performance profile changed dramatically.

  That is the architectural story this PR validates.

  It also matches the materialization vision we have been documenting:

  - parser streams tuples
  - runtime chooses retention
  - operator owns the retained form it actually needs
  - external materialization remains fallback, not the preferred path

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py
  ```
  ### Effective distance

  Ran locally:
  ```
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1
  ```
  Outputs matched:

  - query_vs_csharp_dfs = match
  - query_vs_prolog_accumulated = match

  ### Category influence

  Ran locally:
  ```
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Outputs matched.

  ### Path-aware non-regression smokes

  Ran locally:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Outputs still matched.

  ## Updated Effective-Distance Results

  | Scale | C# Query | Prolog Accumulated | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|---:|
  | 300 | 0.211s | 0.361s | 0.442s | 0.381s | 0.483s |
  | 1k | 0.190s | 0.249s | 1.181s | 1.370s | 2.066s |
  | 5k | 0.351s | 0.823s | 5.647s | 7.445s | 11.864s |
  | 10k | 0.735s | 2.038s | 10.736s | 14.080s | 19.701s |

  Speedups of C# query engine:

  | Scale | vs Prolog Accumulated | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|---:|
  | 300 | 1.71x | 2.09x | 1.80x | 2.29x |
  | 1k | 1.31x | 6.23x | 7.23x | 10.87x |
  | 5k | 2.35x | 16.10x | 21.23x | 33.80x |
  | 10k | 2.77x | 14.60x | 19.15x | 26.80x |

  ## Updated Category-Influence Results

  | Scale | C# Query | Rust DFS | Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.200s | 0.388s | 0.480s |
  | 1k | 0.156s | 1.519s | 2.096s |
  | 5k | 0.331s | 7.853s | 12.002s |
  | 10k | 0.728s | 14.793s | 20.019s |

  Speedups of C# query engine:

  | Scale | vs Rust DFS | vs Go DFS |
  |---|---:|---:|
  | 300 | 1.94x | 2.40x |
  | 1k | 9.76x | 13.46x |
  | 5k | 23.74x | 36.29x |
  | 10k | 20.32x | 27.49x |

  ## Interpretation

  This PR is a strong validation of the retained-state direction.

  Before this change:

  - effective distance and category influence still paid too much for
    generic path-row materialization and benchmark-side regrouping

  After this change:

  - the runtime emits the compact grouped summary directly
  - both workloads improve dramatically
  - effective distance is now faster than accumulated Prolog on the same
    semantics
  - category influence is now faster than the DFS targets at every tested
    scale

  So the real takeaway is not target branding. It is that the query engine
  gets much stronger when the retained-state technique is moved into the
  runtime where it belongs.

  ## Scope

  This PR adds:

  - a grouped path-aware weight-sum runtime node
  - generator integration for effective distance and category influence
  - doc updates tying the result back to the materialization plan

  It does not yet add:

  - automatic cost-based selection between this summary node and other
    retained-state strategies
  - equivalent compact retained summaries for every recursive operator
    family

  ## Follow-Up

  Likely next work:

  - identify the next operator family where generic replay/path rows should
    be replaced by a narrower operator-owned summary
  - keep moving materialization decisions inward:
      - parser streams
      - runtime binds retention mode
      - operator chooses retained form
  - start using measured cost to decide when the runtime should prefer
    these specialized retained summaries automatically