### PR TITLE
`feat(go): proper Structure/List types, deref chain, and expanded builtins

### DIFF
--- a/src/unifyweaver/targets/wam_go_target.pl
+++ b/src/unifyweaver/targets/wam_go_target.pl
@@ -198,7 +198,8 @@ wam_instruction_to_go_literal(execute(P), GoLiteral) :-
     format(atom(GoLiteral), '&Execute{Pred: "~w"}', [P]).
 wam_instruction_to_go_literal(proceed, '&Proceed{}').
 wam_instruction_to_go_literal(builtin_call(Op, N), GoLiteral) :-
-    format(atom(GoLiteral), '&BuiltinCall{Op: "~w", Arity: ~w}', [Op, N]).
+    escape_go_string(Op, EscapedOp),
+    format(atom(GoLiteral), '&BuiltinCall{Op: "~w", Arity: ~w}', [EscapedOp, N]).
 
 wam_instruction_to_go_literal(try_me_else(Label), GoLiteral) :-
     format(atom(GoLiteral), '&TryMeElse{Label: "~w"}', [Label]).
@@ -242,6 +243,7 @@ go_struct_case(Functor-Label, Case) :-
 %  slice and label map.
 compile_wam_predicate_to_go(Pred/Arity, WamCode, _Options, GoCode) :-
     atom_string(Pred, PredStr),
+    capitalize_atom(Pred, CapPred),
     %% Parse WAM code lines into instruction terms
     atom_string(WamCode, WamStr),
     split_string(WamStr, "\n", "", Lines),
@@ -261,7 +263,12 @@ var ~wCode = []Instruction{
 var ~wLabels = map[string]int{
 ~w
 }
-', [PredStr, Arity, PredStr, EntriesStr, PredStr, LabelsStr]).
+', [PredStr, Arity, CapPred, EntriesStr, CapPred, LabelsStr]).
+
+capitalize_atom(Atom, Cap) :-
+    atom_codes(Atom, [First|Rest]),
+    code_type(FirstUpper, to_upper(First)),
+    atom_codes(Cap, [FirstUpper|Rest]).
 
 %% wam_lines_to_go(+Lines, +PC, -GoLits, -LabelEntries)
 wam_lines_to_go([], _, [], []).
@@ -285,9 +292,16 @@ wam_lines_to_go([Line|Rest], PC, GoLits, Labels) :-
     ).
 
 %% wam_line_to_go_literal(+Parts, -GoLit)
+%% parse_string_to_go_val(+Str, -GoVal)
+parse_string_to_go_val(Str, GoVal) :-
+    (   number_string(N, Str)
+    ->  go_value_literal(N, GoVal)
+    ;   go_value_literal(Str, GoVal)
+    ).
+
 wam_line_to_go_literal(["get_constant", C, Ai], GoLit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
-    go_value_literal(CC, GoVal),
+    parse_string_to_go_val(CC, GoVal),
     format(atom(GoLit), '&GetConstant{C: ~w, Ai: "~w"}', [GoVal, CAi]).
 wam_line_to_go_literal(["get_variable", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
@@ -309,12 +323,12 @@ wam_line_to_go_literal(["unify_value", Xn], GoLit) :-
     format(atom(GoLit), '&UnifyValue{Xn: "~w"}', [CXn]).
 wam_line_to_go_literal(["unify_constant", C], GoLit) :-
     clean_comma(C, CC),
-    go_value_literal(CC, GoVal),
+    parse_string_to_go_val(CC, GoVal),
     format(atom(GoLit), '&UnifyConstant{C: ~w}', [GoVal]).
 
 wam_line_to_go_literal(["put_constant", C, Ai], GoLit) :-
     clean_comma(C, CC), clean_comma(Ai, CAi),
-    go_value_literal(CC, GoVal),
+    parse_string_to_go_val(CC, GoVal),
     format(atom(GoLit), '&PutConstant{C: ~w, Ai: "~w"}', [GoVal, CAi]).
 wam_line_to_go_literal(["put_variable", Xn, Ai], GoLit) :-
     clean_comma(Xn, CXn), clean_comma(Ai, CAi),
@@ -336,7 +350,7 @@ wam_line_to_go_literal(["set_value", Xn], GoLit) :-
     format(atom(GoLit), '&SetValue{Xn: "~w"}', [CXn]).
 wam_line_to_go_literal(["set_constant", C], GoLit) :-
     clean_comma(C, CC),
-    go_value_literal(CC, GoVal),
+    parse_string_to_go_val(CC, GoVal),
     format(atom(GoLit), '&SetConstant{C: ~w}', [GoVal]).
 
 wam_line_to_go_literal(["allocate"], '&Allocate{}').
@@ -350,7 +364,8 @@ wam_line_to_go_literal(["execute", P], GoLit) :-
 wam_line_to_go_literal(["proceed"], '&Proceed{}').
 wam_line_to_go_literal(["builtin_call", Op, N], GoLit) :-
     clean_comma(Op, COp), clean_comma(N, CN),
-    format(atom(GoLit), '&BuiltinCall{Op: "~w", Arity: ~w}', [COp, CN]).
+    escape_go_string(COp, EscapedOp),
+    format(atom(GoLit), '&BuiltinCall{Op: "~w", Arity: ~w}', [EscapedOp, CN]).
 
 wam_line_to_go_literal(["try_me_else", L], GoLit) :-
     clean_comma(L, CL),
@@ -463,29 +478,21 @@ wam_go_case('GetStructure', '        val, ok := vm.Regs[i.Ai]
         if !ok { return false }
         if isUnbound(val) {
             addr := len(vm.Heap)
-            vm.Heap = append(vm.Heap, &Atom{Name: "str(" + i.Functor + ")"})
+            arity := parseFunctorArity(i.Functor)
+            s := &Structure{Functor: i.Functor, Arity: arity, Args: make([]Value, arity)}
+            vm.Heap = append(vm.Heap, s)
+            vm.CurrentStruct = s
+            vm.CurrentList = nil
             vm.trailBinding(i.Ai)
             vm.Regs[i.Ai] = &Ref{Addr: addr}
-            arity := parseFunctorArity(i.Functor)
             vm.Stack = append(vm.Stack, &WriteCtx{N: arity})
             vm.PC++
             return true
         }
-        if ref, ok := val.(*Ref); ok {
-            if atom, ok := vm.Heap[ref.Addr].(*Atom); ok {
-                if atom.Name == "str("+i.Functor+")" {
-                    arity := parseFunctorArity(i.Functor)
-                    args := vm.heapSubargs(ref.Addr+1, arity)
-                    vm.Stack = append(vm.Stack, &UnifyCtx{Args: args})
-                    vm.PC++
-                    return true
-                }
-            }
-        }
-        if f, args := decompose(val); f != "" {
-            check := fmt.Sprintf("%s/%d", f, len(args))
-            if check == i.Functor {
-                vm.Stack = append(vm.Stack, &UnifyCtx{Args: args})
+        val = vm.deref(val)
+        if s, ok := val.(*Structure); ok {
+            if s.Functor == i.Functor {
+                vm.Stack = append(vm.Stack, &UnifyCtx{Args: s.Args})
                 vm.PC++
                 return true
             }
@@ -496,17 +503,19 @@ wam_go_case('GetList', '        val, ok := vm.Regs[i.Ai]
         if !ok { return false }
         if isUnbound(val) {
             addr := len(vm.Heap)
-            vm.Heap = append(vm.Heap, &Atom{Name: "str(./2)"})
+            l := &List{Elements: make([]Value, 2)}
+            vm.Heap = append(vm.Heap, l)
+            vm.CurrentList = l
+            vm.CurrentStruct = nil
             vm.trailBinding(i.Ai)
             vm.Regs[i.Ai] = &Ref{Addr: addr}
             vm.Stack = append(vm.Stack, &WriteCtx{N: 2})
             vm.PC++
             return true
         }
+        val = vm.deref(val)
         if list, ok := val.(*List); ok && len(list.Elements) > 0 {
-            head := list.Elements[0]
-            tail := &List{Elements: list.Elements[1:]}
-            vm.Stack = append(vm.Stack, &UnifyCtx{Args: []Value{head, tail}})
+            vm.Stack = append(vm.Stack, &UnifyCtx{Args: list.Elements})
             vm.PC++
             return true
         }
@@ -525,8 +534,19 @@ wam_go_case('UnifyVariable', '        if ctx := vm.peekUnifyCtx(); ctx != nil &&
             addr := len(vm.Heap)
             v := &Unbound{Name: fmt.Sprintf("_H%d", addr)}
             vm.Heap = append(vm.Heap, v)
+            if vm.CurrentStruct != nil {
+                idx := vm.CurrentStruct.Arity - wctx.N
+                vm.CurrentStruct.Args[idx] = v
+            } else if vm.CurrentList != nil {
+                idx := 2 - wctx.N
+                vm.CurrentList.Elements[idx] = v
+            }
             wctx.N--
-            if wctx.N == 0 { vm.popStack() }
+            if wctx.N == 0 { 
+                vm.popStack() 
+                vm.CurrentStruct = nil
+                vm.CurrentList = nil
+            }
             vm.putReg(i.Xn, v)
             vm.PC++
             return true
@@ -538,8 +558,7 @@ wam_go_case('UnifyValue', '        if ctx := vm.peekUnifyCtx(); ctx != nil && le
             ctx.Args = ctx.Args[1:]
             if len(ctx.Args) == 0 { vm.popStack() }
             actual := vm.getReg(i.Xn)
-            if valueEquals(expected, actual) || isUnbound(expected) || isUnbound(actual) {
-                if isUnbound(actual) { vm.putReg(i.Xn, expected) }
+            if vm.Unify(expected, actual) {
                 vm.PC++
                 return true
             }
@@ -548,8 +567,19 @@ wam_go_case('UnifyValue', '        if ctx := vm.peekUnifyCtx(); ctx != nil && le
         if wctx := vm.peekWriteCtx(); wctx != nil && wctx.N > 0 {
             val := vm.getReg(i.Xn)
             vm.Heap = append(vm.Heap, val)
+            if vm.CurrentStruct != nil {
+                idx := vm.CurrentStruct.Arity - wctx.N
+                vm.CurrentStruct.Args[idx] = val
+            } else if vm.CurrentList != nil {
+                idx := 2 - wctx.N
+                vm.CurrentList.Elements[idx] = val
+            }
             wctx.N--
-            if wctx.N == 0 { vm.popStack() }
+            if wctx.N == 0 { 
+                vm.popStack() 
+                vm.CurrentStruct = nil
+                vm.CurrentList = nil
+            }
             vm.PC++
             return true
         }
@@ -559,7 +589,7 @@ wam_go_case('UnifyConstant', '        if ctx := vm.peekUnifyCtx(); ctx != nil &&
             expected := ctx.Args[0]
             ctx.Args = ctx.Args[1:]
             if len(ctx.Args) == 0 { vm.popStack() }
-            if valueEquals(expected, i.C) || isUnbound(expected) {
+            if valueEquals(vm.deref(expected), i.C) {
                 vm.PC++
                 return true
             }
@@ -567,8 +597,19 @@ wam_go_case('UnifyConstant', '        if ctx := vm.peekUnifyCtx(); ctx != nil &&
         }
         if wctx := vm.peekWriteCtx(); wctx != nil && wctx.N > 0 {
             vm.Heap = append(vm.Heap, i.C)
+            if vm.CurrentStruct != nil {
+                idx := vm.CurrentStruct.Arity - wctx.N
+                vm.CurrentStruct.Args[idx] = i.C
+            } else if vm.CurrentList != nil {
+                idx := 2 - wctx.N
+                vm.CurrentList.Elements[idx] = i.C
+            }
             wctx.N--
-            if wctx.N == 0 { vm.popStack() }
+            if wctx.N == 0 { 
+                vm.popStack() 
+                vm.CurrentStruct = nil
+                vm.CurrentList = nil
+            }
             vm.PC++
             return true
         }
@@ -592,15 +633,21 @@ wam_go_case('PutValue', '        val := vm.getReg(i.Xn)
         return true').
 
 wam_go_case('PutStructure', '        addr := len(vm.Heap)
-        vm.Heap = append(vm.Heap, &Atom{Name: "str(" + i.Functor + ")"})
-        vm.Regs[i.Ai] = &Ref{Addr: addr}
         arity := parseFunctorArity(i.Functor)
+        s := &Structure{Functor: i.Functor, Arity: arity, Args: make([]Value, arity)}
+        vm.Heap = append(vm.Heap, s)
+        vm.CurrentStruct = s
+        vm.CurrentList = nil
+        vm.Regs[i.Ai] = &Ref{Addr: addr}
         vm.Stack = append(vm.Stack, &WriteCtx{N: arity})
         vm.PC++
         return true').
 
 wam_go_case('PutList', '        addr := len(vm.Heap)
-        vm.Heap = append(vm.Heap, &Atom{Name: "str(./2)"})
+        l := &List{Elements: make([]Value, 2)}
+        vm.Heap = append(vm.Heap, l)
+        vm.CurrentList = l
+        vm.CurrentStruct = nil
         vm.Regs[i.Ai] = &Ref{Addr: addr}
         vm.Stack = append(vm.Stack, &WriteCtx{N: 2})
         vm.PC++
@@ -609,16 +656,79 @@ wam_go_case('PutList', '        addr := len(vm.Heap)
 wam_go_case('SetVariable', '        addr := len(vm.Heap)
         v := &Unbound{Name: fmt.Sprintf("_H%d", addr)}
         vm.Heap = append(vm.Heap, v)
+        if vm.CurrentStruct != nil {
+            if wctx := vm.peekWriteCtx(); wctx != nil {
+                idx := vm.CurrentStruct.Arity - wctx.N
+                vm.CurrentStruct.Args[idx] = v
+                wctx.N--
+                if wctx.N == 0 { 
+                    vm.popStack() 
+                    vm.CurrentStruct = nil
+                }
+            }
+        } else if vm.CurrentList != nil {
+            if wctx := vm.peekWriteCtx(); wctx != nil {
+                idx := 2 - wctx.N
+                vm.CurrentList.Elements[idx] = v
+                wctx.N--
+                if wctx.N == 0 { 
+                    vm.popStack() 
+                    vm.CurrentList = nil
+                }
+            }
+        }
         vm.putReg(i.Xn, v)
         vm.PC++
         return true').
 
 wam_go_case('SetValue', '        val := vm.getReg(i.Xn)
         vm.Heap = append(vm.Heap, val)
+        if vm.CurrentStruct != nil {
+            if wctx := vm.peekWriteCtx(); wctx != nil {
+                idx := vm.CurrentStruct.Arity - wctx.N
+                vm.CurrentStruct.Args[idx] = val
+                wctx.N--
+                if wctx.N == 0 { 
+                    vm.popStack() 
+                    vm.CurrentStruct = nil
+                }
+            }
+        } else if vm.CurrentList != nil {
+            if wctx := vm.peekWriteCtx(); wctx != nil {
+                idx := 2 - wctx.N
+                vm.CurrentList.Elements[idx] = val
+                wctx.N--
+                if wctx.N == 0 { 
+                    vm.popStack() 
+                    vm.CurrentList = nil
+                }
+            }
+        }
         vm.PC++
         return true').
 
 wam_go_case('SetConstant', '        vm.Heap = append(vm.Heap, i.C)
+        if vm.CurrentStruct != nil {
+            if wctx := vm.peekWriteCtx(); wctx != nil {
+                idx := vm.CurrentStruct.Arity - wctx.N
+                vm.CurrentStruct.Args[idx] = i.C
+                wctx.N--
+                if wctx.N == 0 { 
+                    vm.popStack() 
+                    vm.CurrentStruct = nil
+                }
+            }
+        } else if vm.CurrentList != nil {
+            if wctx := vm.peekWriteCtx(); wctx != nil {
+                idx := 2 - wctx.N
+                vm.CurrentList.Elements[idx] = i.C
+                wctx.N--
+                if wctx.N == 0 { 
+                    vm.popStack() 
+                    vm.CurrentList = nil
+                }
+            }
+        }
         vm.PC++
         return true').
 
@@ -822,32 +932,9 @@ func (vm *WamState) CollectResults() []Value {
 		if !ok {
 			break
 		}
-		results = append(results, val)
+		results = append(results, vm.deref(val))
 	}
 	return results
-}
-
-// backtrack restores state from the most recent choice point.
-func (vm *WamState) backtrack() bool {
-    if len(vm.ChoicePoints) == 0 {
-        return false
-    }
-    cp := vm.ChoicePoints[len(vm.ChoicePoints)-1]
-    vm.unwindTrail(cp.TrailMark)
-    vm.Regs = copyMap(cp.Regs)
-    vm.PC = cp.NextPC
-    vm.CP = cp.CP
-    vm.Halted = false
-    return true
-}
-
-// unwindTrail restores bindings back to the given trail mark.
-func (vm *WamState) unwindTrail(mark int) {
-    for len(vm.Trail) > mark {
-        entry := vm.Trail[len(vm.Trail)-1]
-        vm.Trail = vm.Trail[:len(vm.Trail)-1]
-        delete(vm.Regs, entry.Var)
-    }
 }
 
 // fetch retrieves the instruction at the current PC.
@@ -858,3 +945,10 @@ func (vm *WamState) fetch() Instruction {
     return nil
 }
 ', []).
+
+%% escape_go_string(+Atom, -Escaped)
+%  Escapes backslashes for Go string literals.
+escape_go_string(Atom, Escaped) :-
+    atom_string(Atom, Str),
+    split_string(Str, "\\", "", Parts),
+    atomic_list_concat(Parts, "\\\\", Escaped).

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -1,6 +1,10 @@
 package {{package_name}}
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+	"strconv"
+)
 
 type TrailEntry struct {
 	Var string
@@ -44,6 +48,8 @@ type WamState struct {
 	Trail        []TrailEntry
 	ChoicePoints []ChoicePoint
 	Halted       bool
+	CurrentStruct *Structure
+	CurrentList   *List
 }
 
 func NewWamState(code []Instruction, labels map[string]int) *WamState {
@@ -124,6 +130,8 @@ func (vm *WamState) Clone() *WamState {
 		Trail:        make([]TrailEntry, len(vm.Trail)),
 		ChoicePoints: make([]ChoicePoint, len(vm.ChoicePoints)),
 		Halted:       vm.Halted,
+		CurrentStruct: vm.CurrentStruct,
+		CurrentList:   vm.CurrentList,
 	}
 	copy(newState.Heap, vm.Heap)
 	copy(newState.Stack, vm.Stack)
@@ -136,12 +144,8 @@ func (vm *WamState) ForkAtChoicePoint() *WamState {
 	if len(vm.ChoicePoints) == 0 {
 		return nil
 	}
-	// The forked state will start from the last choice point
 	clone := vm.Clone()
 	if clone.backtrack() {
-		// Remove the alternative branch from ORIGINAL VM so it doesn't try it
-		// In WamState, backtrack() updates PC to NextPC.
-		// We want the original VM to KEEP its current branch but LOSE the choice point.
 		vm.ChoicePoints = vm.ChoicePoints[:len(vm.ChoicePoints)-1]
 		return clone
 	}
@@ -157,15 +161,27 @@ func copyMap(m map[string]Value) map[string]Value {
 }
 
 func parseFunctorArity(f string) int {
-	var name string
-	var arity int
-	// Handle str(f/n) format used in WAM Go target
-	if n, _ := fmt.Sscanf(f, "str(%[^/]/%d)", &name, &arity); n == 2 {
+	// Handle str(f/n) format
+	if strings.HasPrefix(f, "str(") && strings.HasSuffix(f, ")") {
+		f = f[4 : len(f)-1]
+	}
+	parts := strings.Split(f, "/")
+	if len(parts) >= 2 {
+		arity, _ := strconv.Atoi(parts[len(parts)-1])
 		return arity
 	}
-	// Fallback for plain f/n
-	fmt.Sscanf(f, "%[^/]/%d", &name, &arity)
-	return arity
+	return 0
+}
+
+func parseFunctorName(f string) string {
+	if strings.HasPrefix(f, "str(") && strings.HasSuffix(f, ")") {
+		f = f[4 : len(f)-1]
+	}
+	parts := strings.Split(f, "/")
+	if len(parts) >= 2 {
+		return strings.Join(parts[:len(parts)-1], "/")
+	}
+	return f
 }
 
 func decompose(v Value) (string, []Value) {
@@ -173,7 +189,9 @@ func decompose(v Value) (string, []Value) {
 	case *Atom:
 		return t.Name, nil
 	case *Compound:
-		return t.Functor, t.Args
+		return parseFunctorName(t.Functor), t.Args
+	case *Structure:
+		return parseFunctorName(t.Functor), t.Args
 	case *List:
 		if len(t.Elements) > 0 {
 			head := t.Elements[0]
@@ -185,51 +203,173 @@ func decompose(v Value) (string, []Value) {
 	return "", nil
 }
 
+func (vm *WamState) Deref(v Value) Value {
+	return vm.deref(v)
+}
+
+func (vm *WamState) deref(v Value) Value {
+	for {
+		if r, ok := v.(*Ref); ok {
+			v = vm.Heap[r.Addr]
+		} else if u, ok := v.(*Unbound); ok {
+			if boundVal, exists := vm.Regs[u.Name]; exists && boundVal != v {
+				v = boundVal
+			} else {
+				return v
+			}
+		} else {
+			return v
+		}
+	}
+}
+
+func (vm *WamState) evalArithmetic(v Value) (float64, bool) {
+	v = vm.deref(v)
+	switch t := v.(type) {
+	case *Integer:
+		return float64(t.Val), true
+	case *Float:
+		return t.Val, true
+	}
+	
+	f, args := decompose(v)
+	if len(args) == 2 {
+		a, okA := vm.evalArithmetic(args[0])
+		b, okB := vm.evalArithmetic(args[1])
+		if !okA || !okB {
+			return 0, false
+		}
+		switch f {
+		case "+":
+			return a + b, true
+		case "-":
+			return a - b, true
+		case "*":
+			return a * b, true
+		case "/":
+			if b == 0 { return 0, false }
+			return a / b, true
+		case "//":
+			if b == 0 { return 0, false }
+			return float64(int64(a) / int64(b)), true
+		case "mod":
+			if b == 0 { return 0, false }
+			return float64(int64(a) % int64(b)), true
+		}
+	}
+	return 0, false
+}
+
 func (vm *WamState) executeBuiltin(op string, arity int) bool {
+	arg1 := vm.getReg("A1")
+	var arg2, arg3 Value
+	if arity >= 2 { arg2 = vm.getReg("A2") }
+	if arity >= 3 { arg3 = vm.getReg("A3") }
+
 	switch op {
 	case "write/1":
-		arg1 := vm.getReg("A1")
-		fmt.Print(arg1.String())
+		fmt.Print(vm.deref(arg1).String())
 		return true
 	case "nl/0":
 		fmt.Println()
 		return true
+	case "true/0":
+		return true
+	case "fail/0":
+		return false
+	case "!/0":
+		vm.ChoicePoints = nil
+		return true
+	case "is/2":
+		val, ok := vm.evalArithmetic(arg2)
+		if !ok { return false }
+		return vm.Unify(arg1, &Float{Val: val})
+
+	case "=:=/2" :
+		v1, ok1 := vm.evalArithmetic(arg1)
+		v2, ok2 := vm.evalArithmetic(arg2)
+		return ok1 && ok2 && v1 == v2
+	case "=\\=/2" :
+		v1, ok1 := vm.evalArithmetic(arg1)
+		v2, ok2 := vm.evalArithmetic(arg2)
+		return ok1 && ok2 && v1 != v2
 	case "</2":
-		arg1 := vm.getReg("A1")
-		arg2 := vm.getReg("A2")
-		v1, ok1 := arg1.(*Integer)
-		v2, ok2 := arg2.(*Integer)
-		if ok1 && ok2 {
-			return v1.Val < v2.Val
-		}
-		return false
+		v1, ok1 := vm.evalArithmetic(arg1)
+		v2, ok2 := vm.evalArithmetic(arg2)
+		return ok1 && ok2 && v1 < v2
 	case ">/2":
-		arg1 := vm.getReg("A1")
-		arg2 := vm.getReg("A2")
-		v1, ok1 := arg1.(*Integer)
-		v2, ok2 := arg2.(*Integer)
-		if ok1 && ok2 {
-			return v1.Val > v2.Val
+		v1, ok1 := vm.evalArithmetic(arg1)
+		v2, ok2 := vm.evalArithmetic(arg2)
+		return ok1 && ok2 && v1 > v2
+	case "=< /2":
+		v1, ok1 := vm.evalArithmetic(arg1)
+		v2, ok2 := vm.evalArithmetic(arg2)
+		return ok1 && ok2 && v1 <= v2
+	case ">=/2":
+		v1, ok1 := vm.evalArithmetic(arg1)
+		v2, ok2 := vm.evalArithmetic(arg2)
+		return ok1 && ok2 && v1 >= v2
+
+	case "var/1": return isUnbound(vm.deref(arg1))
+	case "nonvar/1": return !isUnbound(vm.deref(arg1))
+	case "atom/1": return isAtom(vm.deref(arg1))
+	case "integer/1": return isInteger(vm.deref(arg1))
+	case "float/1": return isFloat(vm.deref(arg1))
+	case "number/1": return isNumber(vm.deref(arg1))
+	case "compound/1": return isCompound(vm.deref(arg1))
+	case "atomic/1": return isAtomic(vm.deref(arg1))
+
+	case "==/2": return valueEquals(vm.deref(arg1), vm.deref(arg2))
+	case "\\==/2": return !valueEquals(vm.deref(arg1), vm.deref(arg2))
+	case "\\=/2":
+		clone := vm.Clone()
+		return !clone.Unify(arg1, arg2)
+	case "\\+/1":
+		goal := vm.deref(arg1)
+		f, args := decompose(goal)
+		if f != "" {
+			oldA1, hasA1 := vm.Regs["A1"]
+			oldA2, hasA2 := vm.Regs["A2"]
+			oldA3, hasA3 := vm.Regs["A3"]
+			if len(args) > 0 { vm.Regs["A1"] = args[0] }
+			if len(args) > 1 { vm.Regs["A2"] = args[1] }
+			if len(args) > 2 { vm.Regs["A3"] = args[2] }
+			opName := fmt.Sprintf("%s/%d", f, len(args))
+			res := vm.executeBuiltin(opName, len(args))
+			if hasA1 { vm.Regs["A1"] = oldA1 } else { delete(vm.Regs, "A1") }
+			if hasA2 { vm.Regs["A2"] = oldA2 } else { delete(vm.Regs, "A2") }
+			if hasA3 { vm.Regs["A3"] = oldA3 } else { delete(vm.Regs, "A3") }
+			return !res
 		}
 		return false
+
+	case "length/2":
+		l, ok := vm.deref(arg2).(*Integer)
+		if !ok { return false }
+		list, ok := vm.deref(arg1).(*List)
+		if !ok { return false }
+		return int64(len(list.Elements)) == l.Val
+	case "member/2":
+		list, ok := vm.deref(arg2).(*List)
+		if !ok { return false }
+		for _, e := range list.Elements {
+			if vm.Unify(arg1, e) { return true }
+		}
+		return false
+	case "append/3":
+		l1, ok1 := vm.deref(arg1).(*List)
+		l2, ok2 := vm.deref(arg2).(*List)
+		if !ok1 || !ok2 { return false }
+		combined := &List{Elements: append(l1.Elements, l2.Elements...)}
+		return vm.Unify(arg3, combined)
 	}
 	return false
 }
 
 func (vm *WamState) Unify(v1, v2 Value) bool {
-	if v1 == nil || v2 == nil {
-		return v1 == v2
-	}
+	v1 = vm.deref(v1)
+	v2 = vm.deref(v2)
 
-	// Follow references
-	if r1, ok := v1.(*Ref); ok {
-		return vm.Unify(vm.Heap[r1.Addr], v2)
-	}
-	if r2, ok := v2.(*Ref); ok {
-		return vm.Unify(v1, vm.Heap[r2.Addr])
-	}
-
-	// Handle unbound variables
 	if u1, ok := v1.(*Unbound); ok {
 		vm.trailBinding(u1.Name)
 		vm.putReg(u1.Name, v2)
@@ -241,12 +381,10 @@ func (vm *WamState) Unify(v1, v2 Value) bool {
 		return true
 	}
 
-	// Atomic equality
 	if valueEquals(v1, v2) {
 		return true
 	}
 
-	// Structural unification
 	f1, args1 := decompose(v1)
 	f2, args2 := decompose(v2)
 	if f1 != "" && f1 == f2 && len(args1) == len(args2) {
@@ -259,4 +397,25 @@ func (vm *WamState) Unify(v1, v2 Value) bool {
 	}
 
 	return false
+}
+
+func (vm *WamState) backtrack() bool {
+    if len(vm.ChoicePoints) == 0 {
+        return false
+    }
+    cp := vm.ChoicePoints[len(vm.ChoicePoints)-1]
+    vm.unwindTrail(cp.TrailMark)
+    vm.Regs = copyMap(cp.Regs)
+    vm.PC = cp.NextPC
+    vm.CP = cp.CP
+    vm.Halted = false
+    return true
+}
+
+func (vm *WamState) unwindTrail(mark int) {
+    for len(vm.Trail) > mark {
+        entry := vm.Trail[len(vm.Trail)-1]
+        vm.Trail = vm.Trail[:len(vm.Trail)-1]
+        delete(vm.Regs, entry.Var)
+    }
 }

--- a/templates/targets/go_wam/state.go.mustache
+++ b/templates/targets/go_wam/state.go.mustache
@@ -208,9 +208,12 @@ func (vm *WamState) Deref(v Value) Value {
 }
 
 func (vm *WamState) deref(v Value) Value {
-	for {
+	// Depth limit guards against circular ref chains from bugs.
+	for i := 0; i < 10000; i++ {
 		if r, ok := v.(*Ref); ok {
-			v = vm.Heap[r.Addr]
+			next := vm.Heap[r.Addr]
+			if next == v { return v }
+			v = next
 		} else if u, ok := v.(*Unbound); ok {
 			if boundVal, exists := vm.Regs[u.Name]; exists && boundVal != v {
 				v = boundVal
@@ -221,6 +224,7 @@ func (vm *WamState) deref(v Value) Value {
 			return v
 		}
 	}
+	return v
 }
 
 func (vm *WamState) evalArithmetic(v Value) (float64, bool) {
@@ -366,6 +370,8 @@ func (vm *WamState) executeBuiltin(op string, arity int) bool {
 	return false
 }
 
+// Unify implements standard WAM unification without occurs check,
+// matching ISO Prolog semantics (unify_with_occurs_check/2 is separate).
 func (vm *WamState) Unify(v1, v2 Value) bool {
 	v1 = vm.deref(v1)
 	v2 = vm.deref(v2)
@@ -409,6 +415,8 @@ func (vm *WamState) backtrack() bool {
     vm.PC = cp.NextPC
     vm.CP = cp.CP
     vm.Halted = false
+    vm.CurrentStruct = nil
+    vm.CurrentList = nil
     return true
 }
 

--- a/templates/targets/go_wam/value.go.mustache
+++ b/templates/targets/go_wam/value.go.mustache
@@ -60,7 +60,15 @@ func (v *Structure) String() string {
 }
 func (v *Structure) Equals(other Value) bool {
 	o, ok := other.(*Structure)
-	return ok && v.Functor == o.Functor && v.Arity == o.Arity
+	if !ok || v.Functor != o.Functor || v.Arity != o.Arity {
+		return false
+	}
+	for i, a := range v.Args {
+		if !valueEquals(a, o.Args[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 type List struct { Elements []Value }

--- a/templates/targets/go_wam/value.go.mustache
+++ b/templates/targets/go_wam/value.go.mustache
@@ -49,6 +49,20 @@ func (v *Compound) Equals(other Value) bool {
 	return true
 }
 
+type Structure struct {
+	Functor string
+	Arity   int
+	Args    []Value
+}
+func (v *Structure) valueTag() {}
+func (v *Structure) String() string {
+	return fmt.Sprintf("%s/%d", v.Functor, v.Arity)
+}
+func (v *Structure) Equals(other Value) bool {
+	o, ok := other.(*Structure)
+	return ok && v.Functor == o.Functor && v.Arity == o.Arity
+}
+
 type List struct { Elements []Value }
 func (v *List) valueTag() {}
 func (v *List) String() string { return fmt.Sprintf("%v", v.Elements) }
@@ -80,6 +94,55 @@ func (v *Unbound) Equals(other Value) bool {
 func isUnbound(v Value) bool {
 	_, ok := v.(*Unbound)
 	return ok
+}
+
+func isAtom(v Value) bool {
+	_, ok := v.(*Atom)
+	return ok
+}
+
+func isInteger(v Value) bool {
+	_, ok := v.(*Integer)
+	return ok
+}
+
+func isFloat(v Value) bool {
+	_, ok := v.(*Float)
+	return ok
+}
+
+func isNumber(v Value) bool {
+	switch v.(type) {
+	case *Integer, *Float:
+		return true
+	}
+	return false
+}
+
+func isCompound(v Value) bool {
+	switch v.(type) {
+	case *Compound, *Structure:
+		return true
+	}
+	return false
+}
+
+func isStructure(v Value) bool {
+	_, ok := v.(*Structure)
+	return ok
+}
+
+func isList(v Value) bool {
+	_, ok := v.(*List)
+	return ok
+}
+
+func isAtomic(v Value) bool {
+	switch v.(type) {
+	case *Atom, *Integer, *Float:
+		return true
+	}
+	return false
 }
 
 func valueEquals(a, b Value) bool {

--- a/tests/test_go_wam_builtins.pl
+++ b/tests/test_go_wam_builtins.pl
@@ -1,0 +1,97 @@
+:- encoding(utf8).
+:- use_module(library(plunit)).
+:- use_module('../src/unifyweaver/targets/wam_go_target').
+:- use_module(library(filesex)).
+
+:- begin_tests(go_wam_builtins).
+
+test(builtins_execution) :-
+    get_time(T),
+    format(atom(TmpDir), 'tmp_wam_builtins_~w', [T]),
+    % Define a predicate that uses builtins
+    assertz(user:test_builtins(X) :- (X is 1 + 2, X < 5, X =:= 3, atom(foo), \+ atom(5))),
+    
+    Predicates = [test_builtins/1],
+    Options = [module_name(builtin_test)],
+    
+    write_wam_go_project(Predicates, Options, TmpDir),
+    
+    % Verify generated code has our fixes
+    directory_file_path(TmpDir, 'value.go', ValuePath),
+    read_file_to_string(ValuePath, ValueCode, []),
+    assertion(sub_string(ValueCode, _, _, _, "type Structure struct")),
+    
+    % Add a main.go to run the test in a separate cmd directory
+    directory_file_path(TmpDir, 'cmd', CmdDir),
+    directory_file_path(CmdDir, 'test', TestDir),
+    make_directory_path(TestDir),
+    directory_file_path(TestDir, 'main.go', MainPath),
+    write_file(MainPath, 
+'package main
+
+import (
+	"fmt"
+	wam "builtin_test"
+)
+
+func main() {
+	vm := wam.NewWamState(wam.Test_builtinsCode, wam.Test_builtinsLabels)
+	// A1 will hold X — use named unbound so we can deref after execution
+	x := &wam.Unbound{Name: "X"}
+	vm.Regs["A1"] = x
+
+	if vm.Run() {
+		fmt.Printf("SUCCESS: X=%v\\n", vm.Deref(x))
+	} else {
+		fmt.Println("FAILURE")
+	}
+}
+'),
+    
+    % Update go.mod to include local replace for the module
+    directory_file_path(TmpDir, 'go.mod', GoModPath),
+    read_file_to_string(GoModPath, GoModOld, []),
+    atomic_list_concat([GoModOld, "\nreplace builtin_test => ../../\n"], GoModNew),
+    write_file(GoModPath, GoModNew),
+
+    % Verify it compiles and runs
+    (   catch(process_create(path(go), ['version'], [stdout(null), stderr(null)]), _, fail)
+    ->  format(string(RunCmd), "cd ~w && go run main.go 2>&1", [TestDir]),
+        process_create(path(sh), ['-c', RunCmd], [stdout(pipe(Out)), process(Pid)]),
+        read_string(Out, _, FullOutput),
+        process_wait(Pid, Exit),
+        format('Full output from Go: ~s~n', [FullOutput]),
+        assertion(Exit == exit(0)),
+        assertion(sub_string(FullOutput, _, _, _, "SUCCESS: X=3"))
+    ;   format("Go not found, skipping execution test.~n")
+    ),
+    
+    retractall(user:test_builtins(_)).
+
+:- end_tests(go_wam_builtins).
+
+delete_directory_and_contents(Dir) :-
+    (   exists_directory(Dir)
+    ->  delete_directory_contents(Dir),
+        delete_directory(Dir)
+    ;   true
+    ).
+
+delete_directory_contents(Dir) :-
+    directory_files(Dir, Files),
+    member(File, Files),
+    File \== '.', File \== '..',
+    directory_file_path(Dir, File, Path),
+    (   exists_directory(Path)
+    ->  delete_directory_and_contents(Path)
+    ;   delete_file(Path)
+    ),
+    fail.
+delete_directory_contents(_).
+
+write_file(Path, Content) :-
+    setup_call_cleanup(
+        open(Path, write, Stream),
+        format(Stream, "~w", [Content]),
+        close(Stream)
+    ).


### PR DESCRIPTION
## Summary

- Replace the `Atom{Name: "str(f/n)"}` hack with a dedicated `Structure` type for WAM term representation in the Go target
- Rewrite `Unify()` with proper dereferencing and structural recursion
- Add recursive arithmetic evaluation and 20+ new builtins
- Fix write-mode tracking via `CurrentStruct`/`CurrentList` fields so structure args are correctly populated during construction

## Changes

### New `Structure` value type (`value.go.mustache`, +71 lines)

- `Structure{Functor, Arity, Args}` with full `Equals()` (compares args recursively)
- Type-checking helpers: `isAtom`, `isInteger`, `isFloat`, `isNumber`, `isCompound`, `isStructure`, `isList`, `isAtomic`

### Structure-aware write mode (`state.go.mustache`, +251/-42)

- `WamState` gains `CurrentStruct *Structure` and `CurrentList *List` to track the structure/list being built during write mode
- `GetStructure`, `GetList`, `PutStructure`, `PutList` create real `*Structure`/`*List` objects
- `SetVariable`, `SetValue`, `SetConstant`, `UnifyVariable`, `UnifyValue`, `UnifyConstant` populate parent structure args during write mode
- `backtrack()` resets `CurrentStruct`/`CurrentList` to nil

### Proper `deref` chain + improved `Unify()` (`state.go.mustache`)

- `deref()` follows `*Ref` and `*Unbound` chains with cycle guard (depth limit + self-ref check)
- `Unify()` rewritten to use `deref` and proper structural unification; intentionally omits occurs check per ISO Prolog semantics
- Exported `Deref()` method for external callers
- `CollectResults()` now dereferences values before returning

### Arithmetic evaluation + expanded builtins (`state.go.mustache`)

- `evalArithmetic()` supports `+`, `-`, `*`, `/`, `//`, `mod` on compound terms
- `is/2` with recursive arithmetic evaluation
- Comparison: `=:=`, `=\=`, `<`, `>`, `=<`, `>=`
- Type checks: `var/1`, `nonvar/1`, `atom/1`, `integer/1`, `float/1`, `number/1`, `compound/1`, `atomic/1`
- Logical: `true/0`, `fail/0`, `!/0`, `\+/1`, `==/2`, `\==/2`, `\=/2`
- List: `length/2`, `member/2`, `append/3`

### Prolog-side fixes (`wam_go_target.pl`, +216/-103)

- `capitalize_atom/2` for PascalCase exported Go variable names
- `escape_go_string/2` for safe Go string literals
- `parse_string_to_go_val/2` for numeric constant parsing
- All constant instructions (`get_constant`, `put_constant`, `set_constant`, `unify_constant`) use `parse_string_to_go_val`

### New integration test (`test_go_wam_builtins.pl`, +97 lines)

- End-to-end test: compiles `test_builtins(X) :- X is 1 + 2, X < 5, X =:= 3, atom(foo), \+ atom(5)`
- Generates Go project, compiles with `go run`, verifies `SUCCESS: X=3`
- Validates `Structure` type present in generated `value.go`

## Test plan

- [x] 8 generator unit tests pass (`test_wam_go_generator.pl`)
- [x] 1 integration test passes (`test_go_wam_builtins.pl`) -- end-to-end Go compilation + execution
- [x] Review feedback addressed: `Structure.Equals()` compares args, `backtrack()` resets write-mode state, `deref()` has cycle guard, `Unify()` documents occurs check omission
