### PR TITLE
perf(csharp-query): add grouped path minima

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -55,6 +55,9 @@ Status:
 - started for scan-oriented and path-aware benchmark paths using the shared retention boundary
 - path-aware shortest-path operators now build compact operator-owned edge state
   instead of consuming generic replayed edge tuples
+- shortest-path and weighted-shortest-path operators now emit compact
+  operator-owned `(group, root, min_value)` summaries instead of consuming
+  broad seeded path rows plus benchmark-side regrouping
 - effective-distance and category-influence operators now build compact
   operator-owned `(group, root, weight_sum)` state instead of consuming
   generic path rows plus benchmark-side regrouping

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -63,6 +63,8 @@ Examples:
 - DAG longest depth builds adjacency and scalar suffix-depth state
 - path-aware shortest-path operators can build compact source->targets edge state
   instead of retaining generic edge tuples
+- shortest-path and weighted-shortest-path operators can emit compact
+  `(group, root, min_value)` summaries instead of retaining full seeded path rows
 - effective-distance and category-influence operators can build compact
   `(group, root, weight_sum)` summaries instead of retaining full path rows
 - other operators may request replay buffers or indexes when needed
@@ -110,10 +112,12 @@ For the current benchmark/runtime surface, the streamed path is:
 4. DAG, scan, and path-aware operators read rows through that retention boundary
 5. path-aware shortest-path operators can build a compact edge-state cache
    directly from streamed facts instead of generic replayed edge rows
-6. effective-distance and category-influence operators can emit compact
+6. shortest-path and weighted-shortest-path operators can emit compact
+   grouped root minima directly from streamed edge/seed inputs
+7. effective-distance and category-influence operators can emit compact
    grouped root-weight summaries directly from streamed edge/seed inputs
-7. the operator builds only the retained state it actually needs
-8. benchmark code avoids preloading raw facts into in-memory relations first
+8. the operator builds only the retained state it actually needs
+9. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -479,35 +479,39 @@ Latest local results:
 
 | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
 |-------|---------:|-----------:|--------:|---------:|-------:|---------|
-| 300 | 0.170s | 0.117s | 0.489s | 0.388s | 0.501s | match |
-| 1k | 0.105s | 0.121s | 1.243s | 1.469s | 2.109s | match |
-| 5k | 0.187s | 0.277s | 5.777s | 7.648s | 12.378s | match |
-| 10k | 0.429s | 0.535s | 10.408s | 14.443s | 20.399s | match |
+| 300 | 0.093s | 0.112s | 0.468s | 0.364s | 0.484s | match |
+| 1k | 0.074s | 0.117s | 1.278s | 1.484s | 2.116s | match |
+| 5k | 0.110s | 0.273s | 5.889s | 8.009s | 12.535s | match |
+| 10k | 0.183s | 0.584s | 10.575s | 15.191s | 21.103s | match |
 
 Direct C# query vs Prolog seeded `min`:
 
 | Scale | Faster target | Speedup |
 |-------|---------------|--------:|
-| 300 | Prolog Min | 1.45x |
-| 1k | C# Query | 1.16x |
-| 5k | C# Query | 1.48x |
-| 10k | C# Query | 1.25x |
+| 300 | C# Query | 1.21x |
+| 1k | C# Query | 1.58x |
+| 5k | C# Query | 2.47x |
+| 10k | C# Query | 3.20x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 2.87x | 2.28x | 2.95x |
-| 1k | 11.87x | 14.02x | 20.13x |
-| 5k | 30.86x | 40.85x | 66.12x |
-| 10k | 24.24x | 33.63x | 47.50x |
+| 300 | 5.03x | 3.91x | 5.21x |
+| 1k | 17.24x | 20.02x | 28.55x |
+| 5k | 53.34x | 72.54x | 113.54x |
+| 10k | 57.86x | 83.12x | 115.47x |
 
 Comparison note:
 
-- seeded Prolog `min` is now competitive with the C# query engine on
-  this shortest-path workload: it wins at `300`, trails only slightly at
-  `1k`, and remains within about `1.25x` to `1.48x` of the C# query
-  engine at `5k` and `10k`
+- the query runtime now emits compact `(article, root, min_depth)` rows
+  directly instead of materializing broad seeded ancestor rows and then
+  regrouping them in the benchmark harness
+- on the current one-root benchmark shape, the retained row count now
+  collapses to the final article result count, which is why the C# query
+  path improves so sharply at every tested scale
+- seeded Prolog `min` remains competitive, but the C# query engine is
+  now faster at every tested scale, including `300`
 - output digests match across all five targets at every tested scale
 
 ### Cross-Target Weighted Shortest-Path Results
@@ -525,35 +529,38 @@ Latest local results:
 
 | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
 |-------|---------:|-----------:|--------:|---------:|-------:|---------|
-| 300 | 0.180s | 0.118s | 0.497s | 0.363s | 0.540s | match |
-| 1k | 0.137s | 0.140s | 1.352s | 1.526s | 2.238s | match |
-| 5k | 0.217s | 0.280s | 5.973s | 7.869s | 12.033s | match |
-| 10k | 0.391s | 0.509s | 10.975s | 14.789s | 19.974s | match |
+| 300 | 0.153s | 0.119s | 0.486s | 0.381s | 0.497s | match |
+| 1k | 0.128s | 0.122s | 1.365s | 1.487s | 2.203s | match |
+| 5k | 0.228s | 0.309s | 6.207s | 8.524s | 12.376s | match |
+| 10k | 0.361s | 0.505s | 11.272s | 15.719s | 21.160s | match |
 
 Direct C# query vs Prolog seeded `min`:
 
 | Scale | Faster target | Speedup |
 |-------|---------------|--------:|
-| 300 | Prolog Min | 1.52x |
-| 1k | C# Query | 1.02x |
-| 5k | C# Query | 1.29x |
-| 10k | C# Query | 1.30x |
+| 300 | Prolog Min | 1.29x |
+| 1k | Prolog Min | 1.04x |
+| 5k | C# Query | 1.36x |
+| 10k | C# Query | 1.40x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 2.77x | 2.02x | 3.01x |
-| 1k | 9.84x | 11.10x | 16.28x |
-| 5k | 27.55x | 36.29x | 55.49x |
-| 10k | 28.08x | 37.84x | 51.11x |
+| 300 | 3.17x | 2.49x | 3.25x |
+| 1k | 10.70x | 11.66x | 17.27x |
+| 5k | 27.27x | 37.45x | 54.38x |
+| 10k | 31.27x | 43.60x | 58.69x |
 
 Comparison note:
 
-- seeded Prolog `min` is now competitive with the C# query engine on
-  the weighted shortest-path workload too: it wins at `300`, is
-  effectively tied at `1k`, and remains within about `1.29x` to `1.30x`
-  of the C# query engine at `5k` and `10k`
+- the query runtime now emits compact `(article, root, min_weight)` rows
+  directly instead of materializing broad seeded weighted-path rows and
+  regrouping them afterward in the benchmark harness
+- on the current one-root benchmark shape, the retained row count now
+  also collapses to the final article result count
+- seeded Prolog `min` still wins narrowly at `300` and `1k`, but the C#
+  query engine is now clearly faster from `5k` onward
 - the cross-target weighted benchmark normalizes floating-point outputs
   with a tolerance appropriate for cross-language evaluation order
   differences

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2643,7 +2643,7 @@ def generate_csharp_query_shortest_path(article_cats, category_parents, root_cat
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
+using System.Globalization;
 using System.Linq;
 using UnifyWeaver.QueryRuntime;
 
@@ -2665,130 +2665,50 @@ class Program
 
         var provider = new InMemoryRelationProvider();
         var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_ancestor", 3);
-        var articleCategories = new Dictionary<string, List<string>>();
+        var seedId = new PredicateId("article_category", 2);
+        var rootId = new PredicateId("root_category", 1);
+        var resultId = new PredicateId("article_root_shortest_path", 3);
 
         provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
-
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {{
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }}
-
-            categories.Add(parts[1]);
-        }}
-
+        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
+        provider.AddFact(rootId, ROOT_CATEGORY);
         swLoad.Stop();
 
         var plan = new QueryPlan(
-            predId,
-            new PathAwareTransitiveClosureNode(edgeId, predId, 1, 1, MAX_DEPTH, TableMode.Min),
-            true,
-            new int[] {{ 0 }}
+            resultId,
+            new SeedGroupedPathAwareDepthMinNode(edgeId, seedId, rootId, resultId, 1, MAX_DEPTH),
+            false,
+            null
         );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var categories in articleCategories.Values)
-        {{
-            foreach (var category in categories)
-            {{
-                uniqueSeeds.Add(category);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds
-            .OrderBy(category => category, StringComparer.Ordinal)
-            .Select(category => new object[] {{ category }})
-            .ToList();
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
+        var rows = executor.Execute(plan).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, int Hops)>>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {{
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var hops = Convert.ToInt32(row[2]);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {{
-                bucket = new List<(string, int)>();
-                ancestorIndex[source] = bucket;
-            }}
-
-            bucket.Add((ancestor, hops));
-        }}
-
-        var results = new List<(int Distance, string Article)>();
-        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
-        {{
-            int? best = null;
-            foreach (var category in articleCategories[article])
-            {{
-                if (category == ROOT_CATEGORY)
-                {{
-                    best = best is null ? 1 : Math.Min(best.Value, 1);
-                }}
-
-                if (!ancestorIndex.TryGetValue(category, out var ancestors))
-                {{
-                    continue;
-                }}
-
-                foreach (var (ancestor, hops) in ancestors)
-                {{
-                    if (ancestor != ROOT_CATEGORY)
-                    {{
-                        continue;
-                    }}
-
-                    var dist = hops + 1;
-                    best = best is null ? dist : Math.Min(best.Value, dist);
-                }}
-            }}
-
-            if (best is not null)
-            {{
-                results.Add((best.Value, article));
-            }}
-        }}
+        var results = rows
+            .Select(row => (
+                Article: row[0]?.ToString() ?? "",
+                Root: row[1]?.ToString() ?? "",
+                Distance: Convert.ToInt32(row[2], CultureInfo.InvariantCulture)))
+            .Where(item => string.Equals(item.Root, ROOT_CATEGORY, StringComparison.Ordinal))
+            .OrderBy(item => item.Distance)
+            .ThenBy(item => item.Article, StringComparer.Ordinal)
+            .ToList();
         swAgg.Stop();
         swTotal.Stop();
 
-        results.Sort((a, b) =>
-        {{
-            var cmp = a.Distance.CompareTo(b.Distance);
-            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
-        }});
-
-        Console.WriteLine("article\\troot_category\\tshortest_path");
+        Console.WriteLine("article\troot_category\tshortest_path");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Article}}\\t{{ROOT_CATEGORY}}\\t{{item.Distance}}");
+            Console.WriteLine($"{{item.Article}}\t{{ROOT_CATEGORY}}\t{{item.Distance}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
     }}
@@ -2826,13 +2746,15 @@ class Program
 
         var provider = new InMemoryRelationProvider();
         var edgeId = new PredicateId("category_parent", 2);
-        var predId = new PredicateId("category_weighted_shortest", 3);
+        var seedId = new PredicateId("article_category", 2);
+        var rootId = new PredicateId("root_category", 1);
+        var resultId = new PredicateId("article_root_weighted_shortest_path", 3);
         var weightId = new PredicateId("category_weight", 2);
-        var articleCategories = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
         var sourceNodes = new HashSet<string>(StringComparer.Ordinal);
 
         provider.RegisterDelimitedSource(edgeId, new DelimitedRelationSource(args[0]));
+        provider.RegisterDelimitedSource(seedId, new DelimitedRelationSource(args[1]));
         foreach (var (line, i) in File.ReadLines(args[0]).Select((l, i) => (l, i)))
         {{
             if (i == 0 && (line.StartsWith("child") || line.StartsWith("article")))
@@ -2840,7 +2762,7 @@ class Program
                 continue;
             }}
 
-            var parts = line.Split('\\t', 2);
+            var parts = line.Split('\t', 2);
             if (parts.Length != 2)
             {{
                 continue;
@@ -2857,135 +2779,57 @@ class Program
             provider.AddFact(weightId, source, weight);
         }}
 
-        foreach (var (line, i) in File.ReadLines(args[1]).Select((l, i) => (l, i)))
-        {{
-            if (i == 0 && (line.StartsWith("article") || line.StartsWith("child")))
-            {{
-                continue;
-            }}
-
-            var parts = line.Split('\\t', 2);
-            if (parts.Length != 2)
-            {{
-                continue;
-            }}
-
-            if (!articleCategories.TryGetValue(parts[0], out var categories))
-            {{
-                categories = new List<string>();
-                articleCategories[parts[0]] = categories;
-            }}
-
-            categories.Add(parts[1]);
-        }}
-
+        provider.AddFact(rootId, ROOT_CATEGORY);
         swLoad.Stop();
 
         var plan = new QueryPlan(
-            predId,
-            new PathAwareAccumulationNode(
+            resultId,
+            new SeedGroupedPathAwareAccumulationMinNode(
                 edgeId,
-                predId,
+                seedId,
+                rootId,
                 weightId,
+                resultId,
                 new ColumnExpression(3),
                 new BinaryArithmeticExpression(
                     ArithmeticBinaryOperator.Add,
                     new ColumnExpression(2),
                     new ColumnExpression(3)),
+                0.0,
                 MAX_DEPTH,
-                TableMode.Min,
                 true),
-            true,
-            new int[] {{ 0 }}
+            false,
+            null
         );
-
-        var uniqueSeeds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var categories in articleCategories.Values)
-        {{
-            foreach (var category in categories)
-            {{
-                uniqueSeeds.Add(category);
-            }}
-        }}
-
-        var seedParams = uniqueSeeds
-            .OrderBy(category => category, StringComparer.Ordinal)
-            .Select(category => new object[] {{ category }})
-            .ToList();
 
         var swQuery = Stopwatch.StartNew();
         var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan, seedParams).ToList();
+        var rows = executor.Execute(plan).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
-        var ancestorIndex = new Dictionary<string, List<(string Ancestor, double Weight)>>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {{
-            var source = row[0]?.ToString() ?? "";
-            var ancestor = row[1]?.ToString() ?? "";
-            var weight = Convert.ToDouble(row[2], CultureInfo.InvariantCulture);
-            if (!ancestorIndex.TryGetValue(source, out var bucket))
-            {{
-                bucket = new List<(string, double)>();
-                ancestorIndex[source] = bucket;
-            }}
-
-            bucket.Add((ancestor, weight));
-        }}
-
-        var results = new List<(double Distance, string Article)>();
-        foreach (var article in articleCategories.Keys.OrderBy(x => x, StringComparer.Ordinal))
-        {{
-            double? best = null;
-            foreach (var category in articleCategories[article])
-            {{
-                if (category == ROOT_CATEGORY)
-                {{
-                    best = best is null ? 0.0 : Math.Min(best.Value, 0.0);
-                }}
-
-                if (!ancestorIndex.TryGetValue(category, out var ancestors))
-                {{
-                    continue;
-                }}
-
-                foreach (var (ancestor, weight) in ancestors)
-                {{
-                    if (ancestor != ROOT_CATEGORY)
-                    {{
-                        continue;
-                    }}
-
-                    best = best is null ? weight : Math.Min(best.Value, weight);
-                }}
-            }}
-
-            if (best is not null)
-            {{
-                results.Add((best.Value, article));
-            }}
-        }}
+        var results = rows
+            .Select(row => (
+                Article: row[0]?.ToString() ?? "",
+                Root: row[1]?.ToString() ?? "",
+                Distance: Convert.ToDouble(row[2], CultureInfo.InvariantCulture)))
+            .Where(item => string.Equals(item.Root, ROOT_CATEGORY, StringComparison.Ordinal))
+            .OrderBy(item => item.Distance)
+            .ThenBy(item => item.Article, StringComparer.Ordinal)
+            .ToList();
         swAgg.Stop();
         swTotal.Stop();
 
-        results.Sort((a, b) =>
-        {{
-            var cmp = a.Distance.CompareTo(b.Distance);
-            return cmp != 0 ? cmp : string.Compare(a.Article, b.Article, StringComparison.Ordinal);
-        }});
-
-        Console.WriteLine("article\\troot_category\\tweighted_shortest_path");
+        Console.WriteLine("article\troot_category\tweighted_shortest_path");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Article}}\\t{{ROOT_CATEGORY}}\\t{{item.Distance.ToString("F12", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Article}}\t{{ROOT_CATEGORY}}\t{{item.Distance.ToString("F12", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"query_ms={{swQuery.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"aggregation_ms={{swAgg.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
-        Console.Error.WriteLine($"seed_count={{seedParams.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
     }}

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -307,6 +307,36 @@ namespace UnifyWeaver.QueryRuntime
     ) : PlanNode;
 
     /// <summary>
+    /// Computes per-group minimum root depths, producing
+    /// (group, root, min_depth) rows directly.
+    /// </summary>
+    public sealed record SeedGroupedPathAwareDepthMinNode(
+        PredicateId EdgeRelation,
+        PredicateId SeedRelation,
+        PredicateId RootRelation,
+        PredicateId Predicate,
+        int DirectSeedDepth = 1,
+        int MaxDepth = 0
+    ) : PlanNode;
+
+    /// <summary>
+    /// Computes per-group minimum accumulated root values, producing
+    /// (group, root, min_value) rows directly.
+    /// </summary>
+    public sealed record SeedGroupedPathAwareAccumulationMinNode(
+        PredicateId EdgeRelation,
+        PredicateId SeedRelation,
+        PredicateId RootRelation,
+        PredicateId AuxiliaryRelation,
+        PredicateId Predicate,
+        ArithmeticExpression BaseExpression,
+        ArithmeticExpression RecursiveExpression,
+        object DirectSeedValue,
+        int MaxDepth = 0,
+        bool PositiveStepProven = false
+    ) : PlanNode;
+
+    /// <summary>
     /// Computes a counted transitive closure while preventing cycles on each
     /// derivation path instead of deduplicating globally by node or tuple.
     /// </summary>
@@ -1110,6 +1140,8 @@ namespace UnifyWeaver.QueryRuntime
                 SeedGroupedTransitiveClosureCountNode closure => $"SeedGroupedTransitiveClosureCount edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 SeedGroupedDagLongestDepthNode closure => $"SeedGroupedDagLongestDepth edge={closure.EdgeRelation} seeds={closure.SeedRelation}",
                 SeedGroupedPathAwareWeightSumNode closure => $"SeedGroupedPathAwareWeightSum edge={closure.EdgeRelation} seeds={closure.SeedRelation} roots={closure.RootRelation} exponent={closure.DistanceExponent.ToString(CultureInfo.InvariantCulture)} maxDepth={closure.MaxDepth}",
+                SeedGroupedPathAwareDepthMinNode closure => $"SeedGroupedPathAwareDepthMin edge={closure.EdgeRelation} seeds={closure.SeedRelation} roots={closure.RootRelation} directSeedDepth={closure.DirectSeedDepth} maxDepth={closure.MaxDepth}",
+                SeedGroupedPathAwareAccumulationMinNode closure => $"SeedGroupedPathAwareAccumulationMin edge={closure.EdgeRelation} seeds={closure.SeedRelation} roots={closure.RootRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} positiveStep={closure.PositiveStepProven}",
                 PathAwareTransitiveClosureNode closure => $"PathAwareTransitiveClosure edge={closure.EdgeRelation} base={closure.BaseDepth} increment={closure.DepthIncrement} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode}",
                 PathAwareAccumulationNode closure => $"PathAwareAccumulation edge={closure.EdgeRelation} aux={closure.AuxiliaryRelation} maxDepth={closure.MaxDepth} mode={closure.AccumulatorMode} positiveStep={closure.PositiveStepProven}",
                 FixpointNode fixpoint => $"Fixpoint predicate={fixpoint.Predicate} recursivePlans={fixpoint.RecursivePlans.Count}",
@@ -1524,6 +1556,34 @@ namespace UnifyWeaver.QueryRuntime
                     return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedPathAwareWeightSum, rows);
                 }
 
+                if (plan.Root is SeedGroupedPathAwareDepthMinNode seedGroupedPathAwareDepthMin)
+                {
+                    var rows = ExecuteSeedGroupedPathAwareDepthMin(seedGroupedPathAwareDepthMin, context);
+                    var contextCancellationToken = context.CancellationToken;
+                    if (contextCancellationToken.CanBeCanceled)
+                    {
+                        rows = WithCancellation(rows, contextCancellationToken);
+                    }
+
+                    var activeTrace = context.Trace;
+                    activeTrace?.RecordInvocation(seedGroupedPathAwareDepthMin);
+                    return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedPathAwareDepthMin, rows);
+                }
+
+                if (plan.Root is SeedGroupedPathAwareAccumulationMinNode seedGroupedPathAwareAccumulationMin)
+                {
+                    var rows = ExecuteSeedGroupedPathAwareAccumulationMin(seedGroupedPathAwareAccumulationMin, context);
+                    var contextCancellationToken = context.CancellationToken;
+                    if (contextCancellationToken.CanBeCanceled)
+                    {
+                        rows = WithCancellation(rows, contextCancellationToken);
+                    }
+
+                    var activeTrace = context.Trace;
+                    activeTrace?.RecordInvocation(seedGroupedPathAwareAccumulationMin);
+                    return activeTrace is null ? rows : activeTrace.WrapEnumeration(seedGroupedPathAwareAccumulationMin, rows);
+                }
+
                 if (plan.Root is PathAwareTransitiveClosureNode pathAwareClosure)
                 {
                     IEnumerable<object[]> rows;
@@ -1625,6 +1685,8 @@ namespace UnifyWeaver.QueryRuntime
             _cacheContext.SeedGroupedTransitiveClosureCountResults.Clear();
             _cacheContext.SeedGroupedDagLongestDepthResults.Clear();
             _cacheContext.SeedGroupedPathAwareWeightSumResults.Clear();
+            _cacheContext.SeedGroupedPathAwareDepthMinResults.Clear();
+            _cacheContext.SeedGroupedPathAwareAccumulationMinResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededResults.Clear();
             _cacheContext.GroupedTransitiveClosureSeededByTargetResults.Clear();
             _cacheContext.GroupedTransitiveClosurePairProbeResults.Clear();
@@ -1738,6 +1800,14 @@ namespace UnifyWeaver.QueryRuntime
 
                 case SeedGroupedPathAwareWeightSumNode closure:
                     result = ExecuteSeedGroupedPathAwareWeightSum(closure, context);
+                    break;
+
+                case SeedGroupedPathAwareDepthMinNode closure:
+                    result = ExecuteSeedGroupedPathAwareDepthMin(closure, context);
+                    break;
+
+                case SeedGroupedPathAwareAccumulationMinNode closure:
+                    result = ExecuteSeedGroupedPathAwareAccumulationMin(closure, context);
                     break;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -2194,6 +2264,19 @@ namespace UnifyWeaver.QueryRuntime
                     predicates.Add(closure.EdgeRelation);
                     predicates.Add(closure.SeedRelation);
                     predicates.Add(closure.RootRelation);
+                    return;
+
+                case SeedGroupedPathAwareDepthMinNode closure:
+                    predicates.Add(closure.EdgeRelation);
+                    predicates.Add(closure.SeedRelation);
+                    predicates.Add(closure.RootRelation);
+                    return;
+
+                case SeedGroupedPathAwareAccumulationMinNode closure:
+                    predicates.Add(closure.EdgeRelation);
+                    predicates.Add(closure.SeedRelation);
+                    predicates.Add(closure.RootRelation);
+                    predicates.Add(closure.AuxiliaryRelation);
                     return;
 
                 case PathAwareTransitiveClosureNode closure:
@@ -7743,6 +7826,532 @@ namespace UnifyWeaver.QueryRuntime
             }
 
             return sums;
+        }
+
+
+        private IEnumerable<object[]> ExecuteSeedGroupedPathAwareDepthMin(SeedGroupedPathAwareDepthMinNode closure, EvaluationContext? parentContext)
+        {
+            if (closure is null) throw new ArgumentNullException(nameof(closure));
+
+            var width = closure.Predicate.Arity;
+            if (width < 3)
+            {
+                return Array.Empty<object[]>();
+            }
+
+            var context = parentContext ?? new EvaluationContext();
+            context.FixpointDepth++;
+            try
+            {
+                var trace = context.Trace;
+                trace?.RecordStrategy(closure, "SeedGroupedPathAwareDepthMin");
+
+                if (context.SeedGroupedPathAwareDepthMinResults.TryGetValue(closure, out var cachedRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedPathAwareDepthMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: true, built: false);
+                    return cachedRows;
+                }
+
+                trace?.RecordCacheLookup("SeedGroupedPathAwareDepthMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: false, built: true);
+
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var succIndex = edgeState.Successors;
+                var rootKeys = new HashSet<object>();
+                var rootValues = new Dictionary<object, object?>();
+                foreach (var row in GetFactStream(closure.RootRelation, context))
+                {
+                    if (row is null || row.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var root = row[0];
+                    var rootKey = root ?? NullFactIndexKey;
+                    if (rootKeys.Add(rootKey))
+                    {
+                        rootValues[rootKey] = root;
+                    }
+                }
+
+                if (rootKeys.Count == 0)
+                {
+                    var empty = Array.Empty<object[]>();
+                    context.SeedGroupedPathAwareDepthMinResults[closure] = empty;
+                    return empty;
+                }
+
+                var groupedSeeds = new Dictionary<object, List<object?>>();
+                var groupValues = new List<object?>();
+                var uniqueSeeds = new HashSet<object?>();
+                var orderedUniqueSeeds = new List<object?>();
+                foreach (var row in GetFactStream(closure.SeedRelation, context))
+                {
+                    if (row is null || row.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    var group = row[0];
+                    var seed = row[1];
+                    var groupKey = group ?? NullFactIndexKey;
+                    if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
+                    {
+                        bucket = new List<object?>();
+                        groupedSeeds[groupKey] = bucket;
+                        groupValues.Add(group);
+                    }
+
+                    bucket.Add(seed);
+                    if (uniqueSeeds.Add(seed))
+                    {
+                        orderedUniqueSeeds.Add(seed);
+                    }
+                }
+
+                if (groupValues.Count == 0)
+                {
+                    var empty = Array.Empty<object[]>();
+                    context.SeedGroupedPathAwareDepthMinResults[closure] = empty;
+                    return empty;
+                }
+
+                orderedUniqueSeeds.Sort(CompareCacheSeedValues);
+                groupValues.Sort(CompareCacheSeedValues);
+
+                var seedDepthMins = new Dictionary<object, Dictionary<object, int>>();
+                foreach (var seed in orderedUniqueSeeds)
+                {
+                    var mins = ComputePathAwareRootDepthMinsForSeed(seed, succIndex, rootKeys, closure.DirectSeedDepth, closure.MaxDepth);
+                    if (mins.Count > 0)
+                    {
+                        seedDepthMins[seed ?? NullFactIndexKey] = mins;
+                    }
+                }
+
+                var rows = new List<object[]>();
+                foreach (var group in groupValues)
+                {
+                    var groupKey = group ?? NullFactIndexKey;
+                    if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
+                    {
+                        continue;
+                    }
+
+                    Dictionary<object, int>? groupMins = null;
+                    foreach (var seed in seedsForGroup)
+                    {
+                        if (!seedDepthMins.TryGetValue(seed ?? NullFactIndexKey, out var rootMins))
+                        {
+                            continue;
+                        }
+
+                        groupMins ??= new Dictionary<object, int>();
+                        foreach (var entry in rootMins)
+                        {
+                            if (!groupMins.TryGetValue(entry.Key, out var current) || entry.Value < current)
+                            {
+                                groupMins[entry.Key] = entry.Value;
+                            }
+                        }
+                    }
+
+                    if (groupMins is null)
+                    {
+                        continue;
+                    }
+
+                    var orderedRoots = groupMins.Keys.ToList();
+                    orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
+                    foreach (var rootKey in orderedRoots)
+                    {
+                        rows.Add(new object[] { group!, rootValues[rootKey]!, groupMins[rootKey] });
+                    }
+                }
+
+                context.SeedGroupedPathAwareDepthMinResults[closure] = rows;
+                return rows;
+            }
+            finally
+            {
+                context.FixpointDepth--;
+            }
+        }
+
+        private static Dictionary<object, int> ComputePathAwareRootDepthMinsForSeed(
+            object? seed,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            HashSet<object> rootKeys,
+            int directSeedDepth,
+            int maxDepth)
+        {
+            var mins = new Dictionary<object, int>();
+
+            void Record(object? root, int depth)
+            {
+                var rootKey = root ?? NullFactIndexKey;
+                if (!mins.TryGetValue(rootKey, out var current) || depth < current)
+                {
+                    mins[rootKey] = depth;
+                }
+            }
+
+            var seedKey = seed ?? NullFactIndexKey;
+            if (rootKeys.Contains(seedKey))
+            {
+                Record(seed, directSeedDepth);
+            }
+
+            var visited = new Dictionary<object, int> { [seedKey] = 0 };
+            var queue = new Queue<(object? Node, int Depth)>();
+            queue.Enqueue((seed, 0));
+
+            while (queue.Count > 0)
+            {
+                var (current, depth) = queue.Dequeue();
+                if (maxDepth > 0 && depth >= maxDepth)
+                {
+                    continue;
+                }
+
+                var currentKey = current ?? NullFactIndexKey;
+                if (!succIndex.TryGetValue(currentKey, out var bucket))
+                {
+                    continue;
+                }
+
+                foreach (var next in bucket.Targets)
+                {
+                    var nextDepth = depth + 1;
+                    var nextKey = next ?? NullFactIndexKey;
+                    if (visited.TryGetValue(nextKey, out var bestDepth) && bestDepth <= nextDepth)
+                    {
+                        continue;
+                    }
+
+                    visited[nextKey] = nextDepth;
+                    if (rootKeys.Contains(nextKey))
+                    {
+                        Record(next, directSeedDepth + nextDepth);
+                    }
+
+                    queue.Enqueue((next, nextDepth));
+                }
+            }
+
+            return mins;
+        }
+
+        private IEnumerable<object[]> ExecuteSeedGroupedPathAwareAccumulationMin(SeedGroupedPathAwareAccumulationMinNode closure, EvaluationContext? parentContext)
+        {
+            if (closure is null) throw new ArgumentNullException(nameof(closure));
+
+            var width = closure.Predicate.Arity;
+            if (width < 3)
+            {
+                return Array.Empty<object[]>();
+            }
+
+            var context = parentContext ?? new EvaluationContext();
+            context.FixpointDepth++;
+            try
+            {
+                var trace = context.Trace;
+                trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMin");
+
+                if (context.SeedGroupedPathAwareAccumulationMinResults.TryGetValue(closure, out var cachedRows))
+                {
+                    trace?.RecordCacheLookup("SeedGroupedPathAwareAccumulationMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: true, built: false);
+                    return cachedRows;
+                }
+
+                trace?.RecordCacheLookup("SeedGroupedPathAwareAccumulationMin", $"{closure.Predicate.Name}/{closure.Predicate.Arity}", hit: false, built: true);
+
+                var edgeState = GetPathAwareEdgeState(closure.EdgeRelation, context);
+                var succIndex = edgeState.Successors;
+                var rootKeys = new HashSet<object>();
+                var rootValues = new Dictionary<object, object?>();
+                foreach (var row in GetFactStream(closure.RootRelation, context))
+                {
+                    if (row is null || row.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var root = row[0];
+                    var rootKey = root ?? NullFactIndexKey;
+                    if (rootKeys.Add(rootKey))
+                    {
+                        rootValues[rootKey] = root;
+                    }
+                }
+
+                if (rootKeys.Count == 0)
+                {
+                    var empty = Array.Empty<object[]>();
+                    context.SeedGroupedPathAwareAccumulationMinResults[closure] = empty;
+                    return empty;
+                }
+
+                var groupedSeeds = new Dictionary<object, List<object?>>();
+                var groupValues = new List<object?>();
+                var uniqueSeeds = new HashSet<object?>();
+                var orderedUniqueSeeds = new List<object?>();
+                foreach (var row in GetFactStream(closure.SeedRelation, context))
+                {
+                    if (row is null || row.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    var group = row[0];
+                    var seed = row[1];
+                    var groupKey = group ?? NullFactIndexKey;
+                    if (!groupedSeeds.TryGetValue(groupKey, out var bucket))
+                    {
+                        bucket = new List<object?>();
+                        groupedSeeds[groupKey] = bucket;
+                        groupValues.Add(group);
+                    }
+
+                    bucket.Add(seed);
+                    if (uniqueSeeds.Add(seed))
+                    {
+                        orderedUniqueSeeds.Add(seed);
+                    }
+                }
+
+                if (groupValues.Count == 0)
+                {
+                    var empty = Array.Empty<object[]>();
+                    context.SeedGroupedPathAwareAccumulationMinResults[closure] = empty;
+                    return empty;
+                }
+
+                orderedUniqueSeeds.Sort(CompareCacheSeedValues);
+                groupValues.Sort(CompareCacheSeedValues);
+
+                var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
+                var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
+                PositiveStepEvaluator? stepEvaluator = null;
+                var usePositiveMinFastPath = closure.MaxDepth > 0 &&
+                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
+
+                IReadOnlyDictionary<object, Dictionary<object, object>> seedMinima;
+                if (usePositiveMinFastPath)
+                {
+                    var directSeedValue = Convert.ToDouble(closure.DirectSeedValue, CultureInfo.InvariantCulture);
+                    var fastSeedMinima = new Dictionary<object, Dictionary<object, object>>();
+                    foreach (var seed in orderedUniqueSeeds)
+                    {
+                        var mins = ComputePositiveMinRootAccumulationsForSeed(seed, succIndex, auxIndex, rootKeys, stepEvaluator!, directSeedValue, closure.MaxDepth);
+                        if (mins.Count > 0)
+                        {
+                            fastSeedMinima[seed ?? NullFactIndexKey] = mins.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
+                        }
+                    }
+
+                    seedMinima = fastSeedMinima;
+                }
+                else
+                {
+                    seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
+                }
+
+                var rows = new List<object[]>();
+                foreach (var group in groupValues)
+                {
+                    var groupKey = group ?? NullFactIndexKey;
+                    if (!groupedSeeds.TryGetValue(groupKey, out var seedsForGroup))
+                    {
+                        continue;
+                    }
+
+                    Dictionary<object, object>? groupMins = null;
+                    foreach (var seed in seedsForGroup)
+                    {
+                        if (!seedMinima.TryGetValue(seed ?? NullFactIndexKey, out var rootMins))
+                        {
+                            continue;
+                        }
+
+                        groupMins ??= new Dictionary<object, object>();
+                        foreach (var entry in rootMins)
+                        {
+                            if (!groupMins.TryGetValue(entry.Key, out var current) || CompareValues(entry.Value, current) < 0)
+                            {
+                                groupMins[entry.Key] = entry.Value;
+                            }
+                        }
+                    }
+
+                    if (groupMins is null)
+                    {
+                        continue;
+                    }
+
+                    var orderedRoots = groupMins.Keys.ToList();
+                    orderedRoots.Sort((left, right) => CompareCacheSeedValues(rootValues[left], rootValues[right]));
+                    foreach (var rootKey in orderedRoots)
+                    {
+                        rows.Add(new object[] { group!, rootValues[rootKey]!, groupMins[rootKey] });
+                    }
+                }
+
+                context.SeedGroupedPathAwareAccumulationMinResults[closure] = rows;
+                return rows;
+            }
+            finally
+            {
+                context.FixpointDepth--;
+            }
+        }
+
+        private IReadOnlyDictionary<object, Dictionary<object, object>> ExecuteSeedGroupedPathAwareAccumulationMinFallback(
+            SeedGroupedPathAwareAccumulationMinNode closure,
+            IReadOnlyList<object?> orderedUniqueSeeds,
+            ISet<object> rootKeys,
+            EvaluationContext context)
+        {
+            if (orderedUniqueSeeds.Count == 0)
+            {
+                return new Dictionary<object, Dictionary<object, object>>();
+            }
+
+            var seededClosure = new PathAwareAccumulationNode(
+                closure.EdgeRelation,
+                closure.Predicate,
+                closure.AuxiliaryRelation,
+                closure.BaseExpression,
+                closure.RecursiveExpression,
+                closure.MaxDepth,
+                TableMode.Min,
+                closure.PositiveStepProven);
+            var seedParams = orderedUniqueSeeds.Select(seed => new object[] { seed! }).ToList();
+            var rows = ExecuteSeededPathAwareAccumulation(seededClosure, new[] { 0 }, seedParams, context).ToList();
+            var seedMinima = new Dictionary<object, Dictionary<object, object>>();
+
+            foreach (var seed in orderedUniqueSeeds)
+            {
+                var seedKey = seed ?? NullFactIndexKey;
+                if (rootKeys.Contains(seedKey))
+                {
+                    seedMinima[seedKey] = new Dictionary<object, object>
+                    {
+                        [seedKey] = closure.DirectSeedValue
+                    };
+                }
+            }
+
+            foreach (var row in rows)
+            {
+                if (row is null || row.Length < 3)
+                {
+                    continue;
+                }
+
+                var seed = row[0];
+                var root = row[1];
+                var rootKey = root ?? NullFactIndexKey;
+                if (!rootKeys.Contains(rootKey))
+                {
+                    continue;
+                }
+
+                var seedKey = seed ?? NullFactIndexKey;
+                if (!seedMinima.TryGetValue(seedKey, out var rootMins))
+                {
+                    rootMins = new Dictionary<object, object>();
+                    seedMinima[seedKey] = rootMins;
+                }
+
+                var value = row[2];
+                if (!rootMins.TryGetValue(rootKey, out var current) || CompareValues(value, current) < 0)
+                {
+                    rootMins[rootKey] = value;
+                }
+            }
+
+            return seedMinima;
+        }
+
+        private static Dictionary<object, double> ComputePositiveMinRootAccumulationsForSeed(
+            object? seed,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex,
+            IReadOnlyDictionary<object, List<object[]>> auxIndex,
+            ISet<object> rootKeys,
+            PositiveStepEvaluator stepEvaluator,
+            double directSeedValue,
+            int maxDepth)
+        {
+            var mins = new Dictionary<object, double>();
+            var seedKey = seed ?? NullFactIndexKey;
+            if (rootKeys.Contains(seedKey))
+            {
+                mins[seedKey] = directSeedValue;
+            }
+
+            var depthCosts = new List<Dictionary<object?, double>>(maxDepth + 1)
+            {
+                new Dictionary<object?, double> { [seed] = 0d }
+            };
+
+            for (var depth = 0; depth < maxDepth && depth < depthCosts.Count; depth++)
+            {
+                var currentLayer = depthCosts[depth];
+                if (currentLayer.Count == 0)
+                {
+                    continue;
+                }
+
+                foreach (var (current, currentCost) in currentLayer)
+                {
+                    var currentKey = current ?? NullFactIndexKey;
+                    if (!succIndex.TryGetValue(currentKey, out var edgeBucket) || !auxIndex.TryGetValue(currentKey, out var auxBucket))
+                    {
+                        continue;
+                    }
+
+                    var nextDepth = depth + 1;
+                    while (depthCosts.Count <= nextDepth)
+                    {
+                        depthCosts.Add(new Dictionary<object?, double>());
+                    }
+
+                    var nextLayer = depthCosts[nextDepth];
+                    for (var edgeIndex = edgeBucket.Targets.Count - 1; edgeIndex >= 0; edgeIndex--)
+                    {
+                        var next = edgeBucket.Targets[edgeIndex];
+                        var nextKey = next ?? NullFactIndexKey;
+                        for (var auxIndexPos = auxBucket.Count - 1; auxIndexPos >= 0; auxIndexPos--)
+                        {
+                            var auxRow = auxBucket[auxIndexPos];
+                            if (auxRow is null || auxRow.Length < 2)
+                            {
+                                continue;
+                            }
+
+                            var step = stepEvaluator(current!, next!, auxRow[1]!);
+                            var nextCost = currentCost + step;
+                            if (!nextLayer.TryGetValue(next, out var existingCost) || nextCost < existingCost)
+                            {
+                                nextLayer[next] = nextCost;
+                            }
+
+                            if (!rootKeys.Contains(nextKey))
+                            {
+                                continue;
+                            }
+
+                            if (!mins.TryGetValue(nextKey, out var currentMin) || nextCost < currentMin)
+                            {
+                                mins[nextKey] = nextCost;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return mins;
         }
 
         private IEnumerable<object[]> ExecutePathAwareTransitiveClosure(PathAwareTransitiveClosureNode closure, EvaluationContext? parentContext)
@@ -15059,6 +15668,10 @@ namespace UnifyWeaver.QueryRuntime
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>>();
                 SeedGroupedPathAwareWeightSumResults = parent?.SeedGroupedPathAwareWeightSumResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId RootRelation, PredicateId Predicate, double DistanceExponent, int MaxDepth), IReadOnlyList<object[]>>();
+                SeedGroupedPathAwareDepthMinResults = parent?.SeedGroupedPathAwareDepthMinResults
+                    ?? new Dictionary<SeedGroupedPathAwareDepthMinNode, IReadOnlyList<object[]>>();
+                SeedGroupedPathAwareAccumulationMinResults = parent?.SeedGroupedPathAwareAccumulationMinResults
+                    ?? new Dictionary<SeedGroupedPathAwareAccumulationMinNode, IReadOnlyList<object[]>>();
                 GroupedTransitiveClosureSeededResults = parent?.GroupedTransitiveClosureSeededResults
                     ?? new Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>>();
                 GroupedTransitiveClosureSeededByTargetResults = parent?.GroupedTransitiveClosureSeededByTargetResults
@@ -15123,6 +15736,10 @@ namespace UnifyWeaver.QueryRuntime
             public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId Predicate), IReadOnlyList<object[]>> SeedGroupedDagLongestDepthResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId SeedRelation, PredicateId RootRelation, PredicateId Predicate, double DistanceExponent, int MaxDepth), IReadOnlyList<object[]>> SeedGroupedPathAwareWeightSumResults { get; }
+
+            public Dictionary<SeedGroupedPathAwareDepthMinNode, IReadOnlyList<object[]>> SeedGroupedPathAwareDepthMinResults { get; }
+
+            public Dictionary<SeedGroupedPathAwareAccumulationMinNode, IReadOnlyList<object[]>> SeedGroupedPathAwareAccumulationMinResults { get; }
 
             public Dictionary<(PredicateId EdgeRelation, PredicateId Predicate, string Groups), Dictionary<RowWrapper, IReadOnlyList<object[]>>> GroupedTransitiveClosureSeededResults { get; }
 


### PR DESCRIPTION
  ## Summary

  This PR extends the runtime-owned materialization work to the
  shortest-path and weighted-shortest-path benchmark family.

  Previously, the `csharp-query` versions of these workloads still followed
  the older retained-state shape:

  1. execute a broad path-aware query
  2. materialize many `(seed, ancestor, value)` rows
  3. regroup them in the benchmark harness to derive:
     - `(article, root, shortest_path)`
     - `(article, root, weighted_shortest_path)`

  That was correct, but it kept the most important retained-state decision
  in the wrong place.

  This PR adds dedicated grouped-minima runtime nodes so the query runtime
  can emit the compact per-article root minima directly.

  ## What Changed

  ### New Query Runtime Nodes

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `SeedGroupedPathAwareDepthMinNode`
  - `SeedGroupedPathAwareAccumulationMinNode`

  These nodes compute compact grouped minima directly:

  - `SeedGroupedPathAwareDepthMinNode`
    - emits `(group, root, min_depth)`
  - `SeedGroupedPathAwareAccumulationMinNode`
    - emits `(group, root, min_value)`

  For the current benchmark family, that means:

  - `group = article`
  - `root = root category`
  - `min_depth = minimum hop count from any article seed category to root`
  - `min_value = minimum positive weighted path value from any article seed
    category to root`

  ### Runtime-Owned Retained State

  The new nodes:

  - stream edge and seed relations through the existing retention boundary
  - reuse `PathAwareEdgeState`
  - consume compact seed/root relations directly from the runtime
  - avoid materializing broad seeded path rows when the benchmark only
    needs grouped minima

  The weighted version uses:

  - the positive-additive fast path when available
  - fallback regrouping through the existing path-aware accumulation path
    when necessary

  So this is the next step after:

  - replayable relation bindings
  - compact path-aware edge state
  - grouped root-weight sums

  The runtime is now building yet another narrower operator-owned retained
  form instead of stopping at generic replay buffers.

  ### Generator Changes

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` versions of:

  - `shortest_path_to_root`
  - `weighted_shortest_path`

  now:

  - register `article_category` as a streamed seed relation
  - register `root_category` as a small runtime fact relation
  - execute the new grouped-minima runtime nodes
  - only sort/format final result rows in the benchmark program

  They no longer build benchmark-side per-category ancestor indexes from
  full path-aware result sets.

  ### Materialization Docs

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`

  These docs now explicitly record that:

  - shortest-path and weighted-shortest-path operators can emit compact
    `(group, root, min_value)` summaries
  - this is another concrete example of operator-owned retained state
    replacing generic replay/path-row materialization

  ### Benchmark Docs

  Updated:

  - `examples/benchmark/README.md`

  The README now reflects:

  - the new grouped-minima runtime path
  - the updated shortest-path and weighted-shortest-path results
  - the fact that tuple count now collapses to the final result count on
    the current one-root benchmark shape

  ## Why This Matters

  This PR is the same architectural pattern that recently paid off for:

  - effective distance
  - category influence

  The important point is not “C# vs Prolog” or “C# vs Rust/Go” by itself.

  The important point is:

  - once the runtime owns the retained-state shape,
  - and emits only the compact grouped minima the workload actually needs,
  - the performance profile changes dramatically.

  That is the retained-state story this PR validates for the shortest-path
  family.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py
  ```
  ### Shortest path

  Ran locally:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```
  Outputs matched:

  - query_vs_csharp_dfs = match
  - query_vs_prolog_min = match

  ### Weighted shortest path

  Ran locally:
  ```
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```
  Outputs matched.

  ### Non-regression smokes

  Ran locally:
  ```
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Outputs still matched.

  ## Updated Shortest-Path Results

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.093s | 0.112s | 0.468s | 0.364s | 0.484s | match |
  | 1k | 0.074s | 0.117s | 1.278s | 1.484s | 2.116s | match |
  | 5k | 0.110s | 0.273s | 5.889s | 8.009s | 12.535s | match |
  | 10k | 0.183s | 0.584s | 10.575s | 15.191s | 21.103s | match |

  Direct C# query vs Prolog seeded min:

  | Scale | Faster target | Speedup |
  |---|---|---:|
  | 300 | C# Query | 1.21x |
  | 1k | C# Query | 1.58x |
  | 5k | C# Query | 2.47x |
  | 10k | C# Query | 3.20x |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 5.03x | 3.91x | 5.21x |
  | 1k | 17.24x | 20.02x | 28.55x |
  | 5k | 53.34x | 72.54x | 113.54x |
  | 10k | 57.86x | 83.12x | 115.47x |

  ## Updated Weighted Shortest-Path Results

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.153s | 0.119s | 0.486s | 0.381s | 0.497s | match |
  | 1k | 0.128s | 0.122s | 1.365s | 1.487s | 2.203s | match |
  | 5k | 0.228s | 0.309s | 6.207s | 8.524s | 12.376s | match |
  | 10k | 0.361s | 0.505s | 11.272s | 15.719s | 21.160s | match |

  Direct C# query vs Prolog seeded min:

  | Scale | Faster target | Speedup |
  |---|---|---:|
  | 300 | Prolog Min | 1.29x |
  | 1k | Prolog Min | 1.04x |
  | 5k | C# Query | 1.36x |
  | 10k | C# Query | 1.40x |

  Speedups of C# query engine:

  | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
  |---|---:|---:|---:|
  | 300 | 3.17x | 2.49x | 3.25x |
  | 1k | 10.70x | 11.66x | 17.27x |
  | 5k | 27.27x | 37.45x | 54.38x |
  | 10k | 31.27x | 43.60x | 58.69x |

  ## Interpretation

  This is a strong retained-state win.

  Before this change:

  - shortest-path workloads still paid too much for generic seeded
    path-row materialization plus benchmark-side regrouping

  After this change:

  - the runtime emits compact grouped minima directly
  - tuple count now collapses to final result count on the one-root
    benchmark shape
  - shortest path improves dramatically at every tested scale
  - weighted shortest path also improves materially and is clearly ahead
    from 5k onward

  So this PR is another concrete validation that the query engine gets much
  stronger when the retained-state technique is moved into the runtime
  where it belongs.

  ## Scope

  This PR adds:

  - grouped path-minima runtime nodes
  - generator integration for shortest path and weighted shortest path
  - doc updates tying the result back to the materialization plan

  It does not yet add:

  - automatic cost-based selection between grouped minima and other
    retained-state strategies
  - equivalent compact grouped minima for every recursive operator family

  ## Follow-Up

  Likely next work:

  - identify the next operator family where broad replay/path rows should
    be replaced by a narrower grouped summary
  - keep moving materialization decisions inward:
      - parser streams
      - runtime binds retention mode
      - operator chooses retained form
  - start using measured cost to decide when the runtime should prefer
    these specialized retained summaries automatically