### PR TITLE
feat(prolog): add query-aware accumulation selectors

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -752,22 +752,23 @@ python examples/benchmark/benchmark_category_influence_cross_target.py \
 
 | Scale | C# Query | Rust DFS | Go DFS | Prolog Accumulated | Outputs |
 |-------|---------:|---------:|-------:|-------------------:|---------|
-| 300 | 0.649s | 0.391s | 0.485s | 1.739s | match |
-| 1k | 0.529s | 1.488s | 2.178s | 1.044s | match |
+| 300 | 0.222s | 0.381s | 0.487s | 1.748s | match |
+| 1k | 0.149s | 1.506s | 2.133s | 1.050s | match |
 
-This grouped Prolog path now uses the generated
-`category_ancestor$power_sum_grouped` helper rather than the generic
-per-root fallback. That makes the accumulated Prolog path viable again,
-but C# query is still clearly faster on this workload.
+This grouped Prolog path now calls the generated
+`category_ancestor$power_sum_selected` helper. When the root is
+unbound, that selector routes to the grouped helper rather than the
+generic per-root fallback. That makes the accumulated Prolog path viable
+again, but C# query is still clearly faster on this workload.
 
 ### Prolog Category-Influence Accumulation Results
 
-The category-influence benchmark now uses a generated grouped
-`power_sum_grouped` helper for the cycle-safe PPV `category_ancestor/4`
-closure from the effective-distance workload. The generic seeded
-accumulation helper remains available as the fallback path, but this
-grouped helper is the better fit for category influence because the
-consumer wants all root sums for a seed at once.
+The category-influence benchmark now uses the generated
+`category_ancestor$power_sum_selected` helper for the cycle-safe PPV
+`category_ancestor/4` closure from the effective-distance workload.
+Because the root argument is left unbound in this workload, the selected
+helper routes to the grouped fast path automatically. The generic seeded
+accumulation helper remains available as the fallback path.
 
 Command:
 
@@ -780,8 +781,8 @@ Latest local results:
 
 | Scale | Seeded | Accumulated | Output Match | Note |
 |-------|-------:|------------:|--------------|------|
-| 300 | 1.892s | 1.890s | match | grouped helper reaches parity |
-| 1k | 1.056s | 1.118s | match | grouped helper stays close |
+| 300 | 1.770s | 1.868s | match | selected helper keeps grouped path close |
+| 1k | 1.175s | 1.231s | match | selected helper stays close |
 
 Current interpretation:
 

--- a/examples/benchmark/generate_prolog_category_influence_benchmark.pl
+++ b/examples/benchmark/generate_prolog_category_influence_benchmark.pl
@@ -187,7 +187,7 @@ benchmark_results_line(seeded, '    compute_category_influence_results_from_hops
 benchmark_results_line(accumulated, '    compute_category_influence_results_from_sums(Results),').
 
 benchmark_weight_sum_query_line(seeded, '    fail.').
-benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$power_sum_grouped''(Cat, Root, WeightSum).').
+benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$power_sum_selected''(Cat, Root, WeightSum).').
 
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
 benchmark_mode_line(accumulated, '    format(user_error, ''mode=accumulated~n'', []),').

--- a/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
@@ -211,7 +211,7 @@ benchmark_results_line(accumulated, '    compute_effective_distance_results_from
 
 benchmark_weight_sum_query_line(seeded, '    fail.').
 benchmark_weight_sum_query_line(pruned, '    fail.').
-benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$power_sum''(Cat, Root, WeightSum).').
+benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$effective_distance_sum_selected''(Cat, Root, WeightSum).').
 
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
 benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -59,7 +59,8 @@
 %       - seeded_accumulation(auto/false) - Emit SWI helper predicates
 %         for canonical counted recursive closures that aggregate over
 %         the derived metric (default: auto). This currently supports
-%         `power_sum` and `sum_metric` helper formulas, and may emit an
+%         `power_sum` and `sum_metric` helper formulas, emits a
+%         query-aware `*_selected` helper surface, and may emit an
 %         additional grouped `power_sum_grouped` helper when the
 %         canonical `(seed, key, metric)` shape is recognized.
 %       - effective_distance_accumulation(auto/false) - Legacy alias for
@@ -492,8 +493,14 @@ maybe_generate_seeded_accumulation_helper(Pred/Arity, Options, Code) :-
     ),
     build_seeded_accumulation_code(Pred/Arity, Shape, Formula, BaseCode),
     (   build_specialized_seeded_accumulation_code(Pred/Arity, Shape, Formula, SpecializedCode)
-    ->  atomic_list_concat([BaseCode, SpecializedCode], '\n\n', Code)
-    ;   Code = BaseCode
+    ->  Specialized = some(SpecializedCode)
+    ;   Specialized = none
+    ),
+    build_seeded_accumulation_selected_code(Pred/Arity, Shape, Formula, Specialized,
+        SelectedCode),
+    (   Specialized = some(SpecializedCode)
+    ->  atomic_list_concat([BaseCode, SpecializedCode, SelectedCode], '\n\n', Code)
+    ;   atomic_list_concat([BaseCode, SelectedCode], '\n\n', Code)
     ).
 
 seeded_accumulation_formula(Pred/Arity, Options, Formula) :-
@@ -648,6 +655,50 @@ build_grouped_alias_suffixes([], []).
 build_grouped_alias_suffixes([Suffix|Rest], [GroupedSuffix|GroupedRest]) :-
     format(atom(GroupedSuffix), '~w_grouped', [Suffix]),
     build_grouped_alias_suffixes(Rest, GroupedRest).
+
+selected_suffix_for_suffix(Suffix, SelectedSuffix) :-
+    format(atom(SelectedSuffix), '~w_selected', [Suffix]).
+
+selected_suffixes_for_suffixes([], []).
+selected_suffixes_for_suffixes([Suffix|Rest], [SelectedSuffix|SelectedRest]) :-
+    selected_suffix_for_suffix(Suffix, SelectedSuffix),
+    selected_suffixes_for_suffixes(Rest, SelectedRest).
+
+build_seeded_accumulation_selected_code(Pred/_Arity,
+        accumulation_shape(SignaturePositions, _DriverPos, _MetricPos, _VisitedInfo),
+        accumulation_formula(_FormulaKind, _ParamPred, _Offset, PrimarySuffix, AliasSuffixes),
+        Specialized, Code) :-
+    helper_name_for_suffix(Pred, PrimarySuffix, PrimaryName),
+    selected_suffix_for_suffix(PrimarySuffix, SelectedPrimarySuffix),
+    helper_name_for_suffix(Pred, SelectedPrimarySuffix, SelectedPrimaryName),
+    length(SignaturePositions, SignatureCount),
+    build_seeded_accumulation_selected_primary_clause(SignatureCount, SelectedPrimaryName,
+        PrimaryName, Specialized, ClauseTerm),
+    selected_suffixes_for_suffixes(AliasSuffixes, SelectedAliasSuffixes),
+    build_seeded_accumulation_alias_clauses(Pred, SelectedPrimaryName, SelectedAliasSuffixes,
+        SignatureCount, AliasClauses),
+    append([ClauseTerm], AliasClauses, Clauses),
+    clauses_to_code(Clauses, ClauseCode),
+    atomic_list_concat([
+        '% Query-aware seeded accumulation selector helper.',
+        ClauseCode
+    ], '\n\n', Code).
+
+build_seeded_accumulation_selected_primary_clause(2, SelectedPrimaryName, PrimaryName,
+        some(_SpecializedCode), ClauseTerm) :-
+    atom_concat(PrimaryName, '_grouped', GroupedPrimaryName),
+    Head =.. [SelectedPrimaryName, SeedArg, KeyArg, WeightSum],
+    GenericCall =.. [PrimaryName, SeedArg, KeyArg, WeightSum],
+    GroupedCall =.. [GroupedPrimaryName, SeedArg, KeyArg, WeightSum],
+    Body = (nonvar(KeyArg) -> GenericCall ; GroupedCall),
+    clause_term(Head, Body, ClauseTerm).
+build_seeded_accumulation_selected_primary_clause(SignatureCount, SelectedPrimaryName,
+        PrimaryName, _Specialized, ClauseTerm) :-
+    build_min_signature_vars(SignatureCount, SignatureArgs),
+    append(SignatureArgs, [_WeightSum], HeadArgs),
+    Head =.. [SelectedPrimaryName|HeadArgs],
+    PrimaryCall =.. [PrimaryName|HeadArgs],
+    clause_term(Head, PrimaryCall, ClauseTerm).
 
 build_specialized_grouped_seeded_accumulation_clauses(Pred/Arity, VisitedInfo,
         accumulation_formula(FormulaKind, ParamPred, Offset, _PrimarySuffix, AliasSuffixes),

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -386,7 +386,7 @@ collect_generated_effective_distance_sums(Options, PredicateCode, Sums) :-
     setup_call_cleanup(
         load_files(Path, []),
         (
-            Goal =.. ['test_effective_ppv_reach$effective_distance_sum', a, c, Sum],
+            Goal =.. ['test_effective_ppv_reach$effective_distance_sum_selected', a, c, Sum],
             findall(Sum, ModuleName:Goal, Sums0),
             sort(Sums0, Sums)
         ),
@@ -406,7 +406,7 @@ build_category_influence_runtime_source(ModuleName, PredicateCode, Source) :-
         ':- module(~q, []).~n:- use_module(library(aggregate)).~n~w~n~n~w~n',
         [ModuleName, FactsCode, PredicateCode]).
 
-collect_generated_category_influence_sums(Options, PredicateCode, Sums) :-
+collect_generated_category_influence_sums(Options, PredicateCode, RootSums) :-
     once(prolog_target:generate_predicate_code(test_influence_reach/3, Options, PredicateCode)),
     gensym(test_influence_runtime_, ModuleName),
     build_category_influence_runtime_source(ModuleName, PredicateCode, Source),
@@ -414,9 +414,9 @@ collect_generated_category_influence_sums(Options, PredicateCode, Sums) :-
     setup_call_cleanup(
         load_files(Path, []),
         (
-            Goal =.. ['test_influence_reach$power_sum_grouped', a, c, Sum],
-            findall(Sum, ModuleName:Goal, Sums0),
-            sort(Sums0, Sums)
+            Goal =.. ['test_influence_reach$influence_sum_selected', a, Root, Sum],
+            findall(Root-Sum, ModuleName:Goal, RootSums0),
+            sort(RootSums0, RootSums)
         ),
         cleanup_temp_module_source(Path)
     ).
@@ -441,7 +441,7 @@ collect_generated_sum_metric_sums(Options, PredicateCode, Sums) :-
     setup_call_cleanup(
         load_files(Path, []),
         (
-            Goal =.. ['test_sum_metric_reach$sum_metric', a, c, Sum],
+            Goal =.. ['test_sum_metric_reach$sum_metric_selected', a, c, Sum],
             findall(Sum, ModuleName:Goal, Sums0),
             sort(Sums0, Sums)
         ),
@@ -569,6 +569,7 @@ test(emits_effective_distance_accumulation_helper_for_counted_ppv,
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$power_sum')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$power_sum_grouped')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum_selected')),
     Expected is (3 ** -5) + (4 ** -5),
     Delta is abs(Actual - Expected),
     Delta < 1.0e-12.
@@ -592,11 +593,17 @@ test(emits_power_sum_helper_for_counted_non_ppv_closure,
         seeded_accumulation(auto),
         predicates([influence_dimension/1, max_depth/1, test_influence_reach/3])
     ],
-    collect_generated_category_influence_sums(Options, PredicateCode, [Actual]),
+    collect_generated_category_influence_sums(Options, PredicateCode, [b-B, c-C, d-D]),
     once(sub_atom(PredicateCode, _, _, _, 'test_influence_reach$power_sum_grouped')),
-    Expected is (3 ** -5) + (3 ** -5),
-    Delta is abs(Actual - Expected),
-    Delta < 1.0e-12.
+    once(sub_atom(PredicateCode, _, _, _, 'test_influence_reach$influence_sum_selected')),
+    ExpectedEdge is 2 ** -5,
+    ExpectedMid is (3 ** -5) + (3 ** -5),
+    DeltaB is abs(B - ExpectedEdge),
+    DeltaC is abs(C - ExpectedMid),
+    DeltaD is abs(D - ExpectedEdge),
+    DeltaB < 1.0e-12,
+    DeltaC < 1.0e-12,
+    DeltaD < 1.0e-12.
 
 test(emits_sum_metric_helper_from_formula_metadata,
         [setup(setup_sum_metric_accumulation_fixture),
@@ -611,6 +618,7 @@ test(emits_sum_metric_helper_from_formula_metadata,
     collect_generated_sum_metric_sums(Options, PredicateCode, [Actual]),
     once(sub_atom(PredicateCode, _, _, _, 'test_sum_metric_reach$sum_metric')),
     \+ sub_atom(PredicateCode, _, _, _, 'test_sum_metric_reach$sum_metric$grouped'),
+    once(sub_atom(PredicateCode, _, _, _, 'test_sum_metric_reach$sum_metric_selected')),
     Actual =:= 4.
 
 :- end_tests(prolog_target).


### PR DESCRIPTION
  ## Summary

  This adds a query-aware selector layer for generated Prolog accumulation helpers.

  Previously, generated consumers had to know which helper family to call:

  - generic seeded accumulation helper for point queries
  - grouped helper for grouped consumers

  This PR moves that decision into generated Prolog by emitting `*_selected`
  helpers that choose the right implementation based on binding shape.

  That means the specialization/fallback split is now represented in the
  generated target surface rather than hardcoded in benchmark drivers.

  ## What Changed

  - extended `src/unifyweaver/targets/prolog_target.pl`
    - kept the existing generic seeded accumulation helpers
    - kept the grouped `power_sum_grouped` helper generation
    - added query-aware `*_selected` helper generation
    - selected helper behavior:
      - bound key: route to the generic helper
      - unbound key: route to the grouped helper when available
    - emitted selector aliases for compatibility suffixes such as:
      - `effective_distance_sum_selected`
      - `influence_sum_selected`
      - `sum_metric_selected`
  - updated `tests/core/test_prolog_target.pl`
    - switched execution-level helper tests to the selected helper surface
    - added a real unbound-key grouped-dispatch check for category-influence-style accumulation
    - kept the existing correctness coverage for generic accumulation and min/pruning helpers
  - updated benchmark generators:
    - `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
      now calls `category_ancestor$effective_distance_sum_selected/3`
    - `examples/benchmark/generate_prolog_category_influence_benchmark.pl`
      now calls `category_ancestor$power_sum_selected/3`
  - updated `examples/benchmark/README.md`
    - documents that benchmark drivers now use the selected helper surface
    - refreshes the small selector-based benchmark numbers

  ## Why

  The previous Prolog work had reached the right architectural point:

  - the generalized accumulation helper is the fallback
  - the grouped helper is the faster path when the consumer wants all grouped sums for a seed

  But callers still had to choose manually by naming the helper suffix.

  This PR removes that leakage. Generated code can now ask for the
  accumulation result once and let the emitted selector decide which helper
  shape to use.

  That is a cleaner target abstraction and a better foundation for future
  consumer-aware lowerings.

  ## Result

  ### Effective distance

  The selected helper keeps effective distance on the generic path:

  - `300`: seeded `0.365s`, accumulated `0.506s`
  - `1k`: seeded `0.322s`, accumulated `0.370s`

  Outputs still match.

  ### Category influence

  The selected helper keeps category influence on the grouped path:

  - `300`: seeded `1.770s`, accumulated `1.868s`
  - `1k`: seeded `1.175s`, accumulated `1.231s`

  Outputs still match, and the accumulated path still retains much less
  state:

  - `300`: tuple count `602808 -> 30968`
  - `1k`: tuple count `352522 -> 10328`

  ### Cross-target spot check

  Selector-based category-influence cross-target run:

  | Scale | C# Query | Rust DFS | Go DFS | Prolog Accumulated | Outputs |
  |-------|---------:|---------:|-------:|-------------------:|---------|
  | 300 | 0.222s | 0.381s | 0.487s | 1.748s | match |
  | 1k | 0.149s | 1.506s | 2.133s | 1.050s | match |

  So this PR is not claiming a new performance win by itself. The win is
  that the right helper choice is now encoded in generated Prolog rather
  than in benchmark-specific knowledge.

  ## Verification

  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_category_influence.py --scales 300,1k --repetitions 1`
  - `python examples/benchmark/benchmark_category_influence_cross_target.py --scales 300,1k --targets csharp-query,rust-
  dfs,go-dfs,prolog-accumulated --repetitions 1`

  ## Notes

  - this PR does not yet attempt broader automatic consumer-shape inference outside the generated helper selection surface
  - the grouped helper still only exists for the canonical counted `(seed, key, metric)` `power_sum` shape
  - the next natural step is to let more generated Prolog consumers target the selected helper surface automatically,
  beyond the current benchmark drivers