### PR TITLE
feat(csharp-query): add cost-guided path minima retention

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -77,6 +77,14 @@ Success criteria:
 
 ## Stage 4: Cost-Based Strategy Selection
 
+Status:
+
+- started for shortest-path and weighted-shortest-path grouped minima
+- the runtime can now choose between compact grouped minima and legacy
+  seeded-row regrouping
+- `QueryExecutorOptions.PathAwareGroupedMinStrategy` can force `Auto`,
+  `CompactGrouped`, or `LegacySeededRows` for benchmarking and validation
+
 Work:
 
 - use measured cost buckets to guide whether the engine prefers:
@@ -89,6 +97,7 @@ Work:
 Success criteria:
 
 - the materialization strategy is chosen where operator knowledge exists
+- measured comparisons can confirm when `Auto` picks the right retained form
 - eager fallback remains available but is no longer the default instinct
 
 ## Guardrails
@@ -109,3 +118,5 @@ Near-term implementation work should continue to prefer:
 - operator-owned retained state
 - external materialization only when the streamed/operator-owned path is not yet
   available or is measurably worse
+- heuristic or measured strategy selection when multiple operator-owned retained
+  forms are already available

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -65,6 +65,9 @@ Examples:
   instead of retaining generic edge tuples
 - shortest-path and weighted-shortest-path operators can emit compact
   `(group, root, min_value)` summaries instead of retaining full seeded path rows
+- where both grouped minima and legacy seeded-row regrouping are available, the
+  runtime can choose between them heuristically and still expose an explicit
+  override via `QueryExecutorOptions.PathAwareGroupedMinStrategy`
 - effective-distance and category-influence operators can build compact
   `(group, root, weight_sum)` summaries instead of retaining full path rows
 - other operators may request replay buffers or indexes when needed
@@ -114,10 +117,12 @@ For the current benchmark/runtime surface, the streamed path is:
    directly from streamed facts instead of generic replayed edge rows
 6. shortest-path and weighted-shortest-path operators can emit compact
    grouped root minima directly from streamed edge/seed inputs
-7. effective-distance and category-influence operators can emit compact
+7. where grouped minima and legacy seeded-row regrouping both exist, the runtime
+   can select between them heuristically or via an explicit executor option
+8. effective-distance and category-influence operators can emit compact
    grouped root-weight summaries directly from streamed edge/seed inputs
-8. the operator builds only the retained state it actually needs
-9. benchmark code avoids preloading raw facts into in-memory relations first
+9. the operator builds only the retained state it actually needs
+10. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -479,28 +479,28 @@ Latest local results:
 
 | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
 |-------|---------:|-----------:|--------:|---------:|-------:|---------|
-| 300 | 0.093s | 0.112s | 0.468s | 0.364s | 0.484s | match |
-| 1k | 0.074s | 0.117s | 1.278s | 1.484s | 2.116s | match |
-| 5k | 0.110s | 0.273s | 5.889s | 8.009s | 12.535s | match |
-| 10k | 0.183s | 0.584s | 10.575s | 15.191s | 21.103s | match |
+| 300 | 0.095s | 0.131s | 0.500s | 0.437s | 0.478s | match |
+| 1k | 0.090s | 0.131s | 1.262s | 1.765s | 2.148s | match |
+| 5k | 0.121s | 0.254s | 5.822s | 8.109s | 12.126s | match |
+| 10k | 0.184s | 0.459s | 11.182s | 15.130s | 20.374s | match |
 
 Direct C# query vs Prolog seeded `min`:
 
 | Scale | Faster target | Speedup |
 |-------|---------------|--------:|
-| 300 | C# Query | 1.21x |
-| 1k | C# Query | 1.58x |
-| 5k | C# Query | 2.47x |
-| 10k | C# Query | 3.20x |
+| 300 | C# Query | 1.38x |
+| 1k | C# Query | 1.45x |
+| 5k | C# Query | 2.11x |
+| 10k | C# Query | 2.49x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 5.03x | 3.91x | 5.21x |
-| 1k | 17.24x | 20.02x | 28.55x |
-| 5k | 53.34x | 72.54x | 113.54x |
-| 10k | 57.86x | 83.12x | 115.47x |
+| 300 | 5.26x | 4.59x | 5.04x |
+| 1k | 14.03x | 19.62x | 23.88x |
+| 5k | 48.29x | 67.26x | 100.57x |
+| 10k | 60.64x | 82.06x | 110.49x |
 
 Comparison note:
 
@@ -510,6 +510,10 @@ Comparison note:
 - on the current one-root benchmark shape, the retained row count now
   collapses to the final article result count, which is why the C# query
   path improves so sharply at every tested scale
+- the new `Auto` selector currently chooses the compact grouped minima
+  path at every tested scale; forcing legacy seeded-row regrouping is
+  materially worse (`300`: `0.160s` vs `0.083s`, `10k`: `0.419s` vs
+  `0.161s`)
 - seeded Prolog `min` remains competitive, but the C# query engine is
   now faster at every tested scale, including `300`
 - output digests match across all five targets at every tested scale
@@ -529,28 +533,28 @@ Latest local results:
 
 | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
 |-------|---------:|-----------:|--------:|---------:|-------:|---------|
-| 300 | 0.153s | 0.119s | 0.486s | 0.381s | 0.497s | match |
-| 1k | 0.128s | 0.122s | 1.365s | 1.487s | 2.203s | match |
-| 5k | 0.228s | 0.309s | 6.207s | 8.524s | 12.376s | match |
-| 10k | 0.361s | 0.505s | 11.272s | 15.719s | 21.160s | match |
+| 300 | 0.162s | 0.128s | 0.523s | 0.427s | 0.497s | match |
+| 1k | 0.147s | 0.125s | 1.402s | 1.762s | 2.186s | match |
+| 5k | 0.222s | 0.295s | 6.116s | 8.414s | 11.994s | match |
+| 10k | 0.347s | 0.514s | 11.450s | 16.019s | 20.289s | match |
 
 Direct C# query vs Prolog seeded `min`:
 
 | Scale | Faster target | Speedup |
 |-------|---------------|--------:|
-| 300 | Prolog Min | 1.29x |
-| 1k | Prolog Min | 1.04x |
-| 5k | C# Query | 1.36x |
-| 10k | C# Query | 1.40x |
+| 300 | Prolog Min | 1.26x |
+| 1k | Prolog Min | 1.17x |
+| 5k | C# Query | 1.33x |
+| 10k | C# Query | 1.48x |
 
 Speedups of C# query engine:
 
 | Scale | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------:|------------:|----------:|
-| 300 | 3.17x | 2.49x | 3.25x |
-| 1k | 10.70x | 11.66x | 17.27x |
-| 5k | 27.27x | 37.45x | 54.38x |
-| 10k | 31.27x | 43.60x | 58.69x |
+| 300 | 3.24x | 2.64x | 3.07x |
+| 1k | 9.55x | 12.00x | 14.89x |
+| 5k | 27.60x | 37.97x | 54.12x |
+| 10k | 32.99x | 46.16x | 58.46x |
 
 Comparison note:
 
@@ -559,6 +563,9 @@ Comparison note:
   regrouping them afterward in the benchmark harness
 - on the current one-root benchmark shape, the retained row count now
   also collapses to the final article result count
+- the new `Auto` selector also chooses the compact grouped minima path
+  here; forcing legacy seeded-row regrouping regresses both ends of the
+  benchmark (`300`: `0.202s` vs `0.151s`, `10k`: `0.430s` vs `0.320s`)
 - seeded Prolog `min` still wins narrowly at `300` and `1k`, but the C#
   query engine is now clearly faster from `5k` onward
 - the cross-target weighted benchmark normalizes floating-point outputs

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2636,6 +2636,7 @@ class Program
 '''
 
 
+
 def generate_csharp_query_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = sorted(root_cats)[0] if root_cats else "Physics"
 
@@ -2651,6 +2652,32 @@ class Program
 {{
     const string ROOT_CATEGORY = "{root}";
     const int MAX_DEPTH = {max_depth};
+
+    static PathAwareGroupedMinStrategy ReadPathMinStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_PATH_MIN_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "legacy" => PathAwareGroupedMinStrategy.LegacySeededRows,
+            "grouped" => PathAwareGroupedMinStrategy.CompactGrouped,
+            _ => PathAwareGroupedMinStrategy.Auto
+        }};
+    }}
+
+    static void PrintPathMinStrategies(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var strategy in trace.SnapshotStrategies()
+            .Where(s => s.NodeType == nameof(SeedGroupedPathAwareDepthMinNode))
+            .OrderBy(s => s.Strategy, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"strategy_{{strategy.Strategy}}={{strategy.Count}}");
+        }}
+    }}
 
     static void Main(string[] args)
     {{
@@ -2681,9 +2708,15 @@ class Program
             null
         );
 
+        var pathMinStrategy = ReadPathMinStrategy();
+        var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
+        QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
+
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan).ToList();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+            ReuseCaches: false,
+            PathAwareGroupedMinStrategy: pathMinStrategy));
+        var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -2699,10 +2732,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("article\troot_category\tshortest_path");
+        Console.WriteLine("article	root_category	shortest_path");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Article}}\t{{ROOT_CATEGORY}}\t{{item.Distance}}");
+            Console.WriteLine($"{{item.Article}}	{{ROOT_CATEGORY}}	{{item.Distance}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2711,9 +2744,12 @@ class Program
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
+        Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
+        PrintPathMinStrategies(trace);
     }}
 }}
 '''
+
 
 
 def generate_csharp_query_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
@@ -2732,6 +2768,32 @@ class Program
 {{
     const string ROOT_CATEGORY = "{root}";
     const int MAX_DEPTH = {max_depth};
+
+    static PathAwareGroupedMinStrategy ReadPathMinStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_PATH_MIN_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "legacy" => PathAwareGroupedMinStrategy.LegacySeededRows,
+            "grouped" => PathAwareGroupedMinStrategy.CompactGrouped,
+            _ => PathAwareGroupedMinStrategy.Auto
+        }};
+    }}
+
+    static void PrintPathMinStrategies(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var strategy in trace.SnapshotStrategies()
+            .Where(s => s.NodeType == nameof(SeedGroupedPathAwareAccumulationMinNode))
+            .OrderBy(s => s.Strategy, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"strategy_{{strategy.Strategy}}={{strategy.Count}}");
+        }}
+    }}
 
     static void Main(string[] args)
     {{
@@ -2762,7 +2824,7 @@ class Program
                 continue;
             }}
 
-            var parts = line.Split('\t', 2);
+            var parts = line.Split('	', 2);
             if (parts.Length != 2)
             {{
                 continue;
@@ -2802,9 +2864,15 @@ class Program
             null
         );
 
+        var pathMinStrategy = ReadPathMinStrategy();
+        var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
+        QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
+
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan).ToList();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+            ReuseCaches: false,
+            PathAwareGroupedMinStrategy: pathMinStrategy));
+        var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -2820,10 +2888,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("article\troot_category\tweighted_shortest_path");
+        Console.WriteLine("article	root_category	weighted_shortest_path");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Article}}\t{{ROOT_CATEGORY}}\t{{item.Distance.ToString("F12", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Article}}	{{ROOT_CATEGORY}}	{{item.Distance.ToString("F12", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2832,10 +2900,11 @@ class Program
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
+        Console.Error.WriteLine($"path_min_strategy_setting={{pathMinStrategy}}");
+        PrintPathMinStrategies(trace);
     }}
 }}
 '''
-
 
 def generate_csharp_weighted_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = list(root_cats)[0] if root_cats else "Physics"

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -467,8 +467,16 @@ namespace UnifyWeaver.QueryRuntime
         IReadOnlyList<int>? InputPositions = null
     );
 
+    public enum PathAwareGroupedMinStrategy
+    {
+        Auto,
+        CompactGrouped,
+        LegacySeededRows
+    }
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
+        PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
         int PairProbeCacheMaxEntries = 4096,
         int SeededCacheMaxEntries = 4096,
         int PairProbeCacheAdmissionMinCost = 0,
@@ -1403,6 +1411,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly int _seededCacheAdmissionMinRows;
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
         private readonly int _maxFixpointIterations;
+        private readonly PathAwareGroupedMinStrategy _pathAwareGroupedMinStrategy;
 
         public QueryExecutor(IRelationProvider provider, QueryExecutorOptions? options = null)
         {
@@ -1416,6 +1425,7 @@ namespace UnifyWeaver.QueryRuntime
             _seededCacheAdmissionMinRows = Math.Max(0, options.SeededCacheAdmissionMinRows);
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
+            _pathAwareGroupedMinStrategy = options.PathAwareGroupedMinStrategy;
         }
 
         public IEnumerable<object[]> Execute(
@@ -7829,6 +7839,110 @@ namespace UnifyWeaver.QueryRuntime
         }
 
 
+
+        private PathAwareGroupedMinStrategy ResolvePathAwareGroupedMinStrategy(
+            int groupCount,
+            int uniqueSeedCount,
+            int rootCount,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
+        {
+            if (_pathAwareGroupedMinStrategy != PathAwareGroupedMinStrategy.Auto)
+            {
+                return _pathAwareGroupedMinStrategy;
+            }
+
+            var effectiveGroups = Math.Max(1, groupCount);
+            var effectiveSeeds = Math.Max(1, uniqueSeedCount);
+            var effectiveRoots = Math.Max(1, rootCount);
+            var nodeCount = Math.Max(1, EstimatePathAwareNodeCount(succIndex));
+            var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
+            var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
+            return estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
+                ? PathAwareGroupedMinStrategy.LegacySeededRows
+                : PathAwareGroupedMinStrategy.CompactGrouped;
+        }
+
+        private static int EstimatePathAwareNodeCount(IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
+        {
+            var nodes = new HashSet<object>();
+            foreach (var (key, bucket) in succIndex)
+            {
+                nodes.Add(key);
+                foreach (var target in bucket.Targets)
+                {
+                    nodes.Add(target ?? NullFactIndexKey);
+                }
+            }
+
+            return nodes.Count;
+        }
+
+        private IReadOnlyDictionary<object, Dictionary<object, int>> ExecuteSeedGroupedPathAwareDepthMinFallback(
+            SeedGroupedPathAwareDepthMinNode closure,
+            IReadOnlyList<object?> orderedUniqueSeeds,
+            ISet<object> rootKeys,
+            EvaluationContext context)
+        {
+            if (orderedUniqueSeeds.Count == 0)
+            {
+                return new Dictionary<object, Dictionary<object, int>>();
+            }
+
+            var seededClosure = new PathAwareTransitiveClosureNode(
+                closure.EdgeRelation,
+                closure.Predicate,
+                closure.DirectSeedDepth,
+                1,
+                closure.MaxDepth,
+                TableMode.Min);
+            var seedParams = orderedUniqueSeeds.Select(seed => new object[] { seed! }).ToList();
+            var rows = ExecuteSeededPathAwareTransitiveClosure(seededClosure, new[] { 0 }, seedParams, context).ToList();
+            var seedMinima = new Dictionary<object, Dictionary<object, int>>();
+
+            foreach (var seed in orderedUniqueSeeds)
+            {
+                var seedKey = seed ?? NullFactIndexKey;
+                if (rootKeys.Contains(seedKey))
+                {
+                    seedMinima[seedKey] = new Dictionary<object, int>
+                    {
+                        [seedKey] = closure.DirectSeedDepth
+                    };
+                }
+            }
+
+            foreach (var row in rows)
+            {
+                if (row is null || row.Length < 3)
+                {
+                    continue;
+                }
+
+                var seed = row[0];
+                var root = row[1];
+                var rootKey = root ?? NullFactIndexKey;
+                if (!rootKeys.Contains(rootKey))
+                {
+                    continue;
+                }
+
+                var seedKey = seed ?? NullFactIndexKey;
+                if (!seedMinima.TryGetValue(seedKey, out var rootMins))
+                {
+                    rootMins = new Dictionary<object, int>();
+                    seedMinima[seedKey] = rootMins;
+                }
+
+                var value = Convert.ToInt32(row[2], CultureInfo.InvariantCulture);
+                if (!rootMins.TryGetValue(rootKey, out var current) || value < current)
+                {
+                    rootMins[rootKey] = value;
+                }
+            }
+
+            return seedMinima;
+        }
+
         private IEnumerable<object[]> ExecuteSeedGroupedPathAwareDepthMin(SeedGroupedPathAwareDepthMinNode closure, EvaluationContext? parentContext)
         {
             if (closure is null) throw new ArgumentNullException(nameof(closure));
@@ -7917,15 +8031,29 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
+                var selectedStrategy = ResolvePathAwareGroupedMinStrategy(groupValues.Count, orderedUniqueSeeds.Count, rootKeys.Count, succIndex);
+                trace?.RecordStrategy(closure, selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows
+                    ? "SeedGroupedPathAwareDepthMinLegacySeededRows"
+                    : "SeedGroupedPathAwareDepthMinCompactGrouped");
 
-                var seedDepthMins = new Dictionary<object, Dictionary<object, int>>();
-                foreach (var seed in orderedUniqueSeeds)
+                IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins;
+                if (selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows)
                 {
-                    var mins = ComputePathAwareRootDepthMinsForSeed(seed, succIndex, rootKeys, closure.DirectSeedDepth, closure.MaxDepth);
-                    if (mins.Count > 0)
+                    seedDepthMins = ExecuteSeedGroupedPathAwareDepthMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
+                }
+                else
+                {
+                    var directSeedMins = new Dictionary<object, Dictionary<object, int>>();
+                    foreach (var seed in orderedUniqueSeeds)
                     {
-                        seedDepthMins[seed ?? NullFactIndexKey] = mins;
+                        var mins = ComputePathAwareRootDepthMinsForSeed(seed, succIndex, rootKeys, closure.DirectSeedDepth, closure.MaxDepth);
+                        if (mins.Count > 0)
+                        {
+                            directSeedMins[seed ?? NullFactIndexKey] = mins;
+                        }
                     }
+
+                    seedDepthMins = directSeedMins;
                 }
 
                 var rows = new List<object[]>();
@@ -8129,32 +8257,44 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-
-                var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
-                var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
-                PositiveStepEvaluator? stepEvaluator = null;
-                var usePositiveMinFastPath = closure.MaxDepth > 0 &&
-                    TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
+                var selectedStrategy = ResolvePathAwareGroupedMinStrategy(groupValues.Count, orderedUniqueSeeds.Count, rootKeys.Count, succIndex);
+                trace?.RecordStrategy(closure, selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows
+                    ? "SeedGroupedPathAwareAccumulationMinLegacySeededRows"
+                    : "SeedGroupedPathAwareAccumulationMinCompactGrouped");
 
                 IReadOnlyDictionary<object, Dictionary<object, object>> seedMinima;
-                if (usePositiveMinFastPath)
+                if (selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows)
                 {
-                    var directSeedValue = Convert.ToDouble(closure.DirectSeedValue, CultureInfo.InvariantCulture);
-                    var fastSeedMinima = new Dictionary<object, Dictionary<object, object>>();
-                    foreach (var seed in orderedUniqueSeeds)
-                    {
-                        var mins = ComputePositiveMinRootAccumulationsForSeed(seed, succIndex, auxIndex, rootKeys, stepEvaluator!, directSeedValue, closure.MaxDepth);
-                        if (mins.Count > 0)
-                        {
-                            fastSeedMinima[seed ?? NullFactIndexKey] = mins.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
-                        }
-                    }
-
-                    seedMinima = fastSeedMinima;
+                    seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
                 }
                 else
                 {
-                    seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
+                    var auxRows = GetFactsList(closure.AuxiliaryRelation, context);
+                    var auxIndex = GetFactIndex(closure.AuxiliaryRelation, 0, auxRows, context);
+                    PositiveStepEvaluator? stepEvaluator = null;
+                    var usePositiveMinFastPath = closure.MaxDepth > 0 &&
+                        TryCreatePositiveAdditiveStepEvaluator(closure.BaseExpression, closure.RecursiveExpression, succIndex, auxIndex, closure.PositiveStepProven, out stepEvaluator);
+
+                    if (usePositiveMinFastPath)
+                    {
+                        var directSeedValue = Convert.ToDouble(closure.DirectSeedValue, CultureInfo.InvariantCulture);
+                        var fastSeedMinima = new Dictionary<object, Dictionary<object, object>>();
+                        foreach (var seed in orderedUniqueSeeds)
+                        {
+                            var mins = ComputePositiveMinRootAccumulationsForSeed(seed, succIndex, auxIndex, rootKeys, stepEvaluator!, directSeedValue, closure.MaxDepth);
+                            if (mins.Count > 0)
+                            {
+                                fastSeedMinima[seed ?? NullFactIndexKey] = mins.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
+                            }
+                        }
+
+                        seedMinima = fastSeedMinima;
+                    }
+                    else
+                    {
+                        trace?.RecordStrategy(closure, "SeedGroupedPathAwareAccumulationMinLegacySeededRowsNoPositiveFastPath");
+                        seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
+                    }
                 }
 
                 var rows = new List<object[]>();


### PR DESCRIPTION
  ## Summary

  This PR starts Stage 4 of the materialization plan for the C# query
  runtime:

  - cost-guided retained-state selection

  The recent path-aware work added compact grouped-minima runtime nodes for:

  - shortest path to root
  - weighted shortest path to root

  Those nodes were already the right retained form for the current
  benchmark shape, but the selection was still effectively hard-wired.

  This PR adds an explicit runtime strategy selector for that choice and
  makes it measurable from the generated benchmark programs.

  The immediate goal is narrow:

  - shortest-path family only
  - compact grouped minima vs legacy seeded-row regrouping
  - benchmark-visible, overridable, and validated

  ## What Changed

  ### New Runtime Strategy Option

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareGroupedMinStrategy`
    - `Auto`
    - `CompactGrouped`
    - `LegacySeededRows`

  Extended:

  - `QueryExecutorOptions`
    - `PathAwareGroupedMinStrategy`

  This makes the grouped-minima retention choice explicit in the runtime
  configuration instead of leaving it fully implicit inside the operator
  implementation.

  ### Heuristic Strategy Selection

  Updated:

  - `ExecuteSeedGroupedPathAwareDepthMin(...)`
  - `ExecuteSeedGroupedPathAwareAccumulationMin(...)`

  Added helpers:

  - `ResolvePathAwareGroupedMinStrategy(...)`
  - `EstimatePathAwareNodeCount(...)`
  - fallback regrouping helpers for the shortest-path minima family

  In `Auto` mode, the runtime now uses a lightweight heuristic based on:

  - group count
  - unique seed count
  - root count
  - estimated path-aware node count

  to choose between:

  - compact grouped minima
  - legacy seeded-row regrouping

  This is intentionally simple. The point of this PR is not a full planner.
  It is to get the selection logic into the runtime where operator
  knowledge exists and to validate that the heuristic is choosing the right
  retained form.

  ### Generated Benchmark Controls

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` programs for:

  - `shortest_path_to_root`
  - `weighted_shortest_path`

  now support:

  - `UNIFYWEAVER_PATH_MIN_STRATEGY=auto|grouped|legacy`
  - `UNIFYWEAVER_BENCH_TRACE=1`

  They also print:

  - `path_min_strategy_setting=...`

  and, when tracing is enabled, the selected runtime strategy, e.g.:

  - `strategy_SeedGroupedPathAwareDepthMinCompactGrouped=1`
  - `strategy_SeedGroupedPathAwareAccumulationMinCompactGrouped=1`

  That makes the retention choice benchmark-visible.

  ### Documentation Updates

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now record that:

  - Stage 4 has started
  - grouped minima vs legacy seeded-row regrouping is the first
    cost-guided retained-state choice
  - current measurements show `Auto` choosing the grouped minima path
  - forced legacy regrouping is measurably worse on the current benchmark
    surface

  ## Why This Matters

  This PR is important because the runtime now has multiple valid retained
  forms for the same operator family.

  At that point, the next missing capability is no longer “add another
  specialized node.” It is:

  - let the runtime choose among retained forms based on workload shape

  This PR is the first concrete version of that idea.

  It keeps the selection close to operator knowledge and makes the choice
  visible and testable through the benchmark programs.

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py

  ### Strategy tracing: shortest path

  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1

  Observed:

  - path_min_strategy_setting=Auto
  - strategy_SeedGroupedPathAwareDepthMinCompactGrouped=1

  at both 300 and 10k.

  ### Strategy tracing: weighted shortest path

  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1

  Observed:

  - path_min_strategy_setting=Auto
  - strategy_SeedGroupedPathAwareAccumulationMinCompactGrouped=1

  at both 300 and 10k.

  ### Forced strategy comparisons

  Shortest path:

  UNIFYWEAVER_PATH_MIN_STRATEGY=legacy ...
  UNIFYWEAVER_PATH_MIN_STRATEGY=grouped ...

  Weighted shortest path:

  UNIFYWEAVER_PATH_MIN_STRATEGY=legacy ...
  UNIFYWEAVER_PATH_MIN_STRATEGY=grouped ...

  Results showed grouped minima clearly outperforming legacy seeded-row
  regrouping at both small and large scales.

  ### Full cross-target runs

  Ran locally:

  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1

  Outputs matched across all targets.

  ### Non-regression smokes

  Also ran locally:

  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1

  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1

  These still matched.

  ## Strategy Comparison Highlights

  ### Shortest path

  Forced strategy comparison:

  | Scale | Legacy | Grouped | Auto |
  |---|---:|---:|---:|
  | 300 | 0.160s | 0.083s | 0.090s |
  | 10k | 0.419s | 0.161s | 0.171s |

  Interpretation:

  - Auto picks the grouped minima path
  - that is the correct choice on both ends of the tested range

  ### Weighted shortest path

  Forced strategy comparison:

  | Scale | Legacy | Grouped | Auto |
  |---|---:|---:|---:|
  | 300 | 0.202s | 0.151s | 0.161s |
  | 10k | 0.430s | 0.320s | 0.357s |

  Interpretation:

  - Auto again picks grouped minima
  - legacy seeded-row regrouping is still clearly worse

  ## Updated Cross-Target Shortest-Path Results

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.095s | 0.131s | 0.500s | 0.437s | 0.478s | match |
  | 1k | 0.090s | 0.131s | 1.262s | 1.765s | 2.148s | match |
  | 5k | 0.121s | 0.254s | 5.822s | 8.109s | 12.126s | match |
  | 10k | 0.184s | 0.459s | 11.182s | 15.130s | 20.374s | match |

  ## Updated Cross-Target Weighted Shortest-Path Results

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS | Outputs |
  |---|---:|---:|---:|---:|---:|---|
  | 300 | 0.162s | 0.128s | 0.523s | 0.427s | 0.497s | match |
  | 1k | 0.147s | 0.125s | 1.402s | 1.762s | 2.186s | match |
  | 5k | 0.222s | 0.295s | 6.116s | 8.414s | 11.994s | match |
  | 10k | 0.347s | 0.514s | 11.450s | 16.019s | 20.289s | match |

  ## Interpretation

  This PR is not a full cost-based planner.

  What it does do is establish the first real runtime retention choice of
  that kind:

  - same operator family
  - multiple valid retained forms
  - runtime chooses one
  - benchmark can force and validate the alternatives

  That is exactly the right next step after adding multiple specialized
  retained-state techniques.

  On the current benchmark shape, the conclusion is clear:

  - grouped minima are the right retained form
  - Auto chooses that correctly
  - legacy seeded-row regrouping should remain a fallback, not the default

  ## Scope

  This PR adds:

  - a cost-guided grouped-minima strategy option
  - runtime selection for shortest-path and weighted-shortest-path minima
  - benchmark override/trace support
  - updated docs/results reflecting the new selection boundary

  It does not yet add:

  - a general planner across all operator families
  - automatic selection between all possible retained-state forms in the
    engine
  - deeper cost modeling beyond the current heuristic

  ## Follow-Up

  Likely next work:

  - extend cost-guided retention selection to another operator family
  - refine the current heuristic using measured cost buckets rather than
    only structural estimates
  - continue making retained-state choices explicit, visible, and
    benchmarkable at the runtime boundary