### PR TITLE
feat(csharp-query): add cost-guided weight-sum retention

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -80,10 +80,13 @@ Success criteria:
 Status:
 
 - started for shortest-path and weighted-shortest-path grouped minima
-- the runtime can now choose between compact grouped minima and legacy
-  seeded-row regrouping
+- started for effective-distance and category-influence grouped weight sums
+- the runtime can now choose between compact grouped summaries and legacy
+  seeded-row regrouping for both operator families
 - `QueryExecutorOptions.PathAwareGroupedMinStrategy` can force `Auto`,
-  `CompactGrouped`, or `LegacySeededRows` for benchmarking and validation
+  `CompactGrouped`, or `LegacySeededRows` for grouped minima benchmarking
+- `QueryExecutorOptions.PathAwareWeightSumStrategy` can force `Auto`,
+  `CompactGrouped`, or `LegacySeededRows` for grouped weight-sum benchmarking
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -70,6 +70,9 @@ Examples:
   override via `QueryExecutorOptions.PathAwareGroupedMinStrategy`
 - effective-distance and category-influence operators can build compact
   `(group, root, weight_sum)` summaries instead of retaining full path rows
+- where grouped weight sums and legacy seeded-row regrouping both exist, the
+  runtime can choose between them heuristically and still expose an explicit
+  override via `QueryExecutorOptions.PathAwareWeightSumStrategy`
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -121,8 +124,10 @@ For the current benchmark/runtime surface, the streamed path is:
    can select between them heuristically or via an explicit executor option
 8. effective-distance and category-influence operators can emit compact
    grouped root-weight summaries directly from streamed edge/seed inputs
-9. the operator builds only the retained state it actually needs
-10. benchmark code avoids preloading raw facts into in-memory relations first
+9. where grouped weight sums and legacy seeded-row regrouping both exist, the
+   runtime can select between them heuristically or via an explicit executor option
+10. the operator builds only the retained state it actually needs
+11. benchmark code avoids preloading raw facts into in-memory relations first
 
 This is still a first step, not the full endpoint, but it is now broader than
 just the original DAG-only fast paths.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -27,24 +27,25 @@ rows and regrouping them in the benchmark harness, the runtime now:
 That moves the retained state into the engine and flips the old headline:
 the query engine is now faster than accumulated Prolog and all DFS
 pipelines across the full benchmark range while preserving the same
-all-path semantics.
+all-path semantics. It also now supports cost-guided selection between
+compact grouped weight sums and the legacy seeded-row regrouping path.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **C# Query Engine** | **0.211s** | **0.190s** | **0.351s** | **0.735s** |
-| Prolog accumulated | 0.361s | 0.249s | 0.823s | 2.038s |
-| C# DFS pipeline | 0.442s | 1.181s | 5.647s | 10.736s |
-| Rust DFS pipeline | 0.381s | 1.370s | 7.445s | 14.080s |
-| Go DFS pipeline | 0.483s | 2.066s | 11.864s | 19.701s |
+| **C# Query Engine** | **0.224s** | **0.182s** | **0.406s** | **0.695s** |
+| Prolog accumulated | 0.349s | 0.236s | 0.856s | 1.942s |
+| C# DFS pipeline | 0.437s | 1.313s | 5.634s | 10.196s |
+| Rust DFS pipeline | 0.365s | 1.638s | 7.164s | 13.782s |
+| Go DFS pipeline | 0.469s | 1.971s | 11.302s | 19.074s |
 
 **Speedups of the current C# query engine:**
 
 | Scale | vs Prolog accumulated | vs C# DFS | vs Rust DFS | vs Go DFS |
 |-------|----------------------:|----------:|------------:|----------:|
-| 300 art | 1.71x | 2.09x | 1.80x | 2.29x |
-| 1K art | 1.31x | 6.23x | 7.23x | 10.87x |
-| 5K art | 2.35x | 16.10x | 21.23x | 33.80x |
-| 10K art | 2.77x | 14.60x | 19.15x | 26.80x |
+| 300 art | 1.56x | 1.95x | 1.63x | 2.09x |
+| 1K art | 1.30x | 7.21x | 9.00x | 10.83x |
+| 5K art | 2.11x | 13.88x | 17.65x | 27.84x |
+| 10K art | 2.79x | 14.67x | 19.83x | 27.46x |
 
 Semantic note:
 
@@ -105,17 +106,20 @@ For historical context, the original DFS-only pipeline comparison:
 ### Key Findings
 
 1. **The C# query engine is now the fastest effective-distance path on
-   this benchmark surface** — it beats accumulated Prolog by `1.71x` at
-   `300`, `1.31x` at `1k`, `2.35x` at `5k`, and `2.77x` at `10k`.
+   this benchmark surface** — it beats accumulated Prolog by `1.56x` at
+   `300`, `1.30x` at `1k`, `2.11x` at `5k`, and `2.79x` at `10k`.
 
 2. **The C# query engine now beats the DFS baselines by a wide margin** —
-   at `10k` it is `14.60x` faster than C# DFS, `19.15x` faster than Rust
-   DFS, and `26.80x` faster than Go DFS.
+   at `10k` it is `14.67x` faster than C# DFS, `19.83x` faster than Rust
+   DFS, and `27.46x` faster than Go DFS.
 
 3. **Retained-state strategy matters more than branch pruning on this
    workload** — seeded reuse is the first big win, and moving per-article
    root-weight aggregation into the query runtime removes the huge path-row
-   materialization cost that used to dominate the C# query path.
+   materialization cost that used to dominate the C# query path. The new
+   `Auto` selector also chooses the compact grouped weight-sum path on the
+   tested scales; forcing legacy seeded-row regrouping is dramatically
+   worse (`300`: `0.726s` vs `0.275s`, `10k`: `3.106s` vs `0.828s`).
 
 4. **Accumulated Prolog is still a useful retained-state reference** — it
    keeps only per-seed weight sums (`462` tuples at `10k`), but the query
@@ -733,19 +737,19 @@ Latest local results:
 
 | Scale | C# Query | Rust DFS | Go DFS | Outputs |
 |-------|---------:|---------:|-------:|---------|
-| 300 | 0.200s | 0.388s | 0.480s | match |
-| 1k | 0.156s | 1.519s | 2.096s | match |
-| 5k | 0.331s | 7.853s | 12.002s | match |
-| 10k | 0.728s | 14.793s | 20.019s | match |
+| 300 | 0.207s | 0.484s | 0.495s | match |
+| 1k | 0.170s | 1.608s | 2.096s | match |
+| 5k | 0.382s | 8.125s | 11.640s | match |
+| 10k | 0.718s | 14.767s | 19.544s | match |
 
 Speedups of C# query engine:
 
 | Scale | vs Rust DFS | vs Go DFS |
 |-------|------------:|----------:|
-| 300 | 1.94x | 2.40x |
-| 1k | 9.76x | 13.46x |
-| 5k | 23.74x | 36.29x |
-| 10k | 20.32x | 27.49x |
+| 300 | 2.33x | 2.39x |
+| 1k | 9.48x | 12.35x |
+| 5k | 21.26x | 30.45x |
+| 10k | 20.55x | 27.20x |
 
 Comparison note:
 
@@ -754,6 +758,9 @@ Comparison note:
   instead of materializing all ancestor/hop rows and then summing them later
 - the remaining benchmark-side work is only the final per-root sum over those
   compact article/root summaries
+- the new `Auto` selector also chooses the compact grouped weight-sum path
+  here; forcing legacy seeded-row regrouping regresses badly (`300`: `0.711s`
+  vs `0.237s`, `10k`: `2.998s` vs `0.829s`)
 - Rust and Go remain generated DFS/pipeline binaries
 - so this runner is still intentionally a mixed execution-model comparison:
   query engine versus non-query target pipelines

--- a/examples/benchmark/generate_pipeline.py
+++ b/examples/benchmark/generate_pipeline.py
@@ -2455,6 +2455,7 @@ fn main() {{
 '''
 
 
+
 def generate_csharp_query_category_influence(article_cats, category_parents, root_cats, n=5, max_depth=10):
     roots = sorted(root_cats) if root_cats else ["Physics"]
     root_entries = ", ".join(f'"{root}"' for root in roots)
@@ -2472,6 +2473,32 @@ class Program
     const double N = {float(n)};
     const int MAX_DEPTH = {max_depth};
     static readonly HashSet<string> ROOTS = new(new[] {{ {root_entries} }}, StringComparer.Ordinal);
+
+    static PathAwareWeightSumStrategy ReadWeightSumStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_WEIGHT_SUM_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "legacy" => PathAwareWeightSumStrategy.LegacySeededRows,
+            "grouped" => PathAwareWeightSumStrategy.CompactGrouped,
+            _ => PathAwareWeightSumStrategy.Auto
+        }};
+    }}
+
+    static void PrintWeightSumStrategies(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var strategy in trace.SnapshotStrategies()
+            .Where(s => s.NodeType == nameof(SeedGroupedPathAwareWeightSumNode))
+            .OrderBy(s => s.Strategy, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"strategy_{{strategy.Strategy}}={{strategy.Count}}");
+        }}
+    }}
 
     static void Main(string[] args)
     {{
@@ -2506,9 +2533,15 @@ class Program
             null
         );
 
+        var weightSumStrategy = ReadWeightSumStrategy();
+        var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
+        QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
+
         var swQuery = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan).ToList();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+            ReuseCaches: false,
+            PathAwareWeightSumStrategy: weightSumStrategy));
+        var rows = executor.Execute(plan, trace: trace).ToList();
         swQuery.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -2531,10 +2564,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("root_category\tinfluence_score");
+        Console.WriteLine("root_category	influence_score");
         foreach (var item in results)
         {{
-            Console.WriteLine($"{{item.Root}}\t{{item.Score.ToString(\"F12\", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{item.Root}}	{{item.Score.ToString("F12", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2544,6 +2577,8 @@ class Program
         Console.Error.WriteLine($"article_count={{articles.Count}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"root_count={{results.Count}}");
+        Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
+        PrintWeightSumStrategies(trace);
     }}
 }}
 '''
@@ -2565,6 +2600,32 @@ class Program
     const string ROOT_CATEGORY = "{root}";
     const double N = {float(n)};
     const int MAX_DEPTH = {max_depth};
+
+    static PathAwareWeightSumStrategy ReadWeightSumStrategy()
+    {{
+        var value = Environment.GetEnvironmentVariable("UNIFYWEAVER_WEIGHT_SUM_STRATEGY");
+        return value?.ToLowerInvariant() switch
+        {{
+            "legacy" => PathAwareWeightSumStrategy.LegacySeededRows,
+            "grouped" => PathAwareWeightSumStrategy.CompactGrouped,
+            _ => PathAwareWeightSumStrategy.Auto
+        }};
+    }}
+
+    static void PrintWeightSumStrategies(QueryExecutionTrace? trace)
+    {{
+        if (trace is null)
+        {{
+            return;
+        }}
+
+        foreach (var strategy in trace.SnapshotStrategies()
+            .Where(s => s.NodeType == nameof(SeedGroupedPathAwareWeightSumNode))
+            .OrderBy(s => s.Strategy, StringComparer.Ordinal))
+        {{
+            Console.Error.WriteLine($"strategy_{{strategy.Strategy}}={{strategy.Count}}");
+        }}
+    }}
 
     static void Main(string[] args)
     {{
@@ -2595,9 +2656,15 @@ class Program
             null
         );
 
+        var weightSumStrategy = ReadWeightSumStrategy();
+        var traceEnabled = string.Equals(Environment.GetEnvironmentVariable("UNIFYWEAVER_BENCH_TRACE"), "1", StringComparison.Ordinal);
+        QueryExecutionTrace? trace = traceEnabled ? new QueryExecutionTrace() : null;
+
         var swExec = Stopwatch.StartNew();
-        var executor = new QueryExecutor(provider, new QueryExecutorOptions(ReuseCaches: false));
-        var rows = executor.Execute(plan).ToList();
+        var executor = new QueryExecutor(provider, new QueryExecutorOptions(
+            ReuseCaches: false,
+            PathAwareWeightSumStrategy: weightSumStrategy));
+        var rows = executor.Execute(plan, trace: trace).ToList();
         swExec.Stop();
 
         var swAgg = Stopwatch.StartNew();
@@ -2614,10 +2681,10 @@ class Program
         swAgg.Stop();
         swTotal.Stop();
 
-        Console.WriteLine("article\troot_category\teffective_distance");
+        Console.WriteLine("article	root_category	effective_distance");
         foreach (var (deff, article) in results)
         {{
-            Console.WriteLine($"{{article}}\t{{ROOT_CATEGORY}}\t{{deff.ToString(\"F6\", CultureInfo.InvariantCulture)}}");
+            Console.WriteLine($"{{article}}	{{ROOT_CATEGORY}}	{{deff.ToString("F6", CultureInfo.InvariantCulture)}}");
         }}
 
         Console.Error.WriteLine($"load_ms={{swLoad.ElapsedMilliseconds}}");
@@ -2626,6 +2693,8 @@ class Program
         Console.Error.WriteLine($"total_ms={{swTotal.ElapsedMilliseconds}}");
         Console.Error.WriteLine($"tuple_count={{rows.Count}}");
         Console.Error.WriteLine($"article_count={{results.Count}}");
+        Console.Error.WriteLine($"weight_sum_strategy_setting={{weightSumStrategy}}");
+        PrintWeightSumStrategies(trace);
     }}
 
     static double ComputeDeff(double weightSum)
@@ -2634,8 +2703,6 @@ class Program
     }}
 }}
 '''
-
-
 
 def generate_csharp_query_shortest_path(article_cats, category_parents, root_cats, n=5, max_depth=10):
     root = sorted(root_cats)[0] if root_cats else "Physics"

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -474,9 +474,17 @@ namespace UnifyWeaver.QueryRuntime
         LegacySeededRows
     }
 
+    public enum PathAwareWeightSumStrategy
+    {
+        Auto,
+        CompactGrouped,
+        LegacySeededRows
+    }
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
+        PathAwareWeightSumStrategy PathAwareWeightSumStrategy = PathAwareWeightSumStrategy.Auto,
         int PairProbeCacheMaxEntries = 4096,
         int SeededCacheMaxEntries = 4096,
         int PairProbeCacheAdmissionMinCost = 0,
@@ -1412,6 +1420,7 @@ namespace UnifyWeaver.QueryRuntime
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
         private readonly int _maxFixpointIterations;
         private readonly PathAwareGroupedMinStrategy _pathAwareGroupedMinStrategy;
+        private readonly PathAwareWeightSumStrategy _pathAwareWeightSumStrategy;
 
         public QueryExecutor(IRelationProvider provider, QueryExecutorOptions? options = null)
         {
@@ -1426,6 +1435,7 @@ namespace UnifyWeaver.QueryRuntime
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
             _pathAwareGroupedMinStrategy = options.PathAwareGroupedMinStrategy;
+            _pathAwareWeightSumStrategy = options.PathAwareWeightSumStrategy;
         }
 
         public IEnumerable<object[]> Execute(
@@ -7596,6 +7606,105 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
+        private PathAwareWeightSumStrategy ResolvePathAwareWeightSumStrategy(
+            int groupCount,
+            int uniqueSeedCount,
+            int rootCount,
+            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
+        {
+            if (_pathAwareWeightSumStrategy != PathAwareWeightSumStrategy.Auto)
+            {
+                return _pathAwareWeightSumStrategy;
+            }
+
+            var effectiveGroups = Math.Max(1, groupCount);
+            var effectiveSeeds = Math.Max(1, uniqueSeedCount);
+            var effectiveRoots = Math.Max(1, rootCount);
+            var nodeCount = Math.Max(1, EstimatePathAwareNodeCount(succIndex));
+            var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
+            var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
+            return estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
+                ? PathAwareWeightSumStrategy.LegacySeededRows
+                : PathAwareWeightSumStrategy.CompactGrouped;
+        }
+
+        private IReadOnlyDictionary<object, Dictionary<object, double>> ExecuteSeedGroupedPathAwareWeightSumFallback(
+            SeedGroupedPathAwareWeightSumNode closure,
+            IReadOnlyList<object?> orderedUniqueSeeds,
+            ISet<object> rootKeys,
+            EvaluationContext context)
+        {
+            if (orderedUniqueSeeds.Count == 0)
+            {
+                return new Dictionary<object, Dictionary<object, double>>();
+            }
+
+            var seededClosure = new PathAwareTransitiveClosureNode(
+                closure.EdgeRelation,
+                closure.Predicate,
+                1,
+                1,
+                closure.MaxDepth,
+                TableMode.All);
+            var seedParams = orderedUniqueSeeds.Select(seed => new object[] { seed! }).ToList();
+            var rows = ExecuteSeededPathAwareTransitiveClosure(seededClosure, new[] { 0 }, seedParams, context).ToList();
+            var distanceWeightCache = new Dictionary<int, double>();
+
+            double GetDistanceWeight(int distance)
+            {
+                if (distanceWeightCache.TryGetValue(distance, out var cachedWeight))
+                {
+                    return cachedWeight;
+                }
+
+                var weight = Math.Pow(distance, -closure.DistanceExponent);
+                distanceWeightCache[distance] = weight;
+                return weight;
+            }
+
+            var seedWeightSums = new Dictionary<object, Dictionary<object, double>>();
+            foreach (var seed in orderedUniqueSeeds)
+            {
+                var seedKey = seed ?? NullFactIndexKey;
+                if (rootKeys.Contains(seedKey))
+                {
+                    seedWeightSums[seedKey] = new Dictionary<object, double>
+                    {
+                        [seedKey] = GetDistanceWeight(1)
+                    };
+                }
+            }
+
+            foreach (var row in rows)
+            {
+                if (row is null || row.Length < 3)
+                {
+                    continue;
+                }
+
+                var seed = row[0];
+                var root = row[1];
+                var rootKey = root ?? NullFactIndexKey;
+                if (!rootKeys.Contains(rootKey))
+                {
+                    continue;
+                }
+
+                var seedKey = seed ?? NullFactIndexKey;
+                if (!seedWeightSums.TryGetValue(seedKey, out var rootSums))
+                {
+                    rootSums = new Dictionary<object, double>();
+                    seedWeightSums[seedKey] = rootSums;
+                }
+
+                var distance = Convert.ToInt32(row[2], CultureInfo.InvariantCulture);
+                var weight = GetDistanceWeight(distance);
+                rootSums[rootKey] = rootSums.TryGetValue(rootKey, out var current) ? current + weight : weight;
+            }
+
+            return seedWeightSums;
+        }
+
         private IEnumerable<object[]> ExecuteSeedGroupedPathAwareWeightSum(SeedGroupedPathAwareWeightSumNode closure, EvaluationContext? parentContext)
         {
             if (closure is null) throw new ArgumentNullException(nameof(closure));
@@ -7689,43 +7798,58 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var distanceWeightCache = new Dictionary<int, double>();
-                var nodeIds = new Dictionary<object, int>();
-                var nextNodeId = 0;
+                var selectedStrategy = ResolvePathAwareWeightSumStrategy(groupValues.Count, orderedUniqueSeeds.Count, rootKeys.Count, succIndex);
+                trace?.RecordStrategy(closure, selectedStrategy == PathAwareWeightSumStrategy.LegacySeededRows
+                    ? "SeedGroupedPathAwareWeightSumLegacySeededRows"
+                    : "SeedGroupedPathAwareWeightSumCompactGrouped");
 
-                int GetNodeId(object? value)
+                IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums;
+                if (selectedStrategy == PathAwareWeightSumStrategy.LegacySeededRows)
                 {
-                    var key = value ?? NullFactIndexKey;
-                    if (nodeIds.TryGetValue(key, out var existing))
-                    {
-                        return existing;
-                    }
-
-                    var id = nextNodeId++;
-                    nodeIds[key] = id;
-                    return id;
+                    seedWeightSums = ExecuteSeedGroupedPathAwareWeightSumFallback(closure, orderedUniqueSeeds, rootKeys, context);
                 }
-
-                double GetDistanceWeight(int distance)
+                else
                 {
-                    if (distanceWeightCache.TryGetValue(distance, out var cachedWeight))
+                    var distanceWeightCache = new Dictionary<int, double>();
+                    var nodeIds = new Dictionary<object, int>();
+                    var nextNodeId = 0;
+
+                    int GetNodeId(object? value)
                     {
-                        return cachedWeight;
+                        var key = value ?? NullFactIndexKey;
+                        if (nodeIds.TryGetValue(key, out var existing))
+                        {
+                            return existing;
+                        }
+
+                        var id = nextNodeId++;
+                        nodeIds[key] = id;
+                        return id;
                     }
 
-                    var weight = Math.Pow(distance, -closure.DistanceExponent);
-                    distanceWeightCache[distance] = weight;
-                    return weight;
-                }
-
-                var seedWeightSums = new Dictionary<object, Dictionary<object, double>>();
-                foreach (var seed in orderedUniqueSeeds)
-                {
-                    var weightSums = ComputePathAwareRootWeightSumsForSeed(seed, succIndex, rootKeys, closure.MaxDepth, GetNodeId, GetDistanceWeight);
-                    if (weightSums.Count > 0)
+                    double GetDistanceWeight(int distance)
                     {
-                        seedWeightSums[seed ?? NullFactIndexKey] = weightSums;
+                        if (distanceWeightCache.TryGetValue(distance, out var cachedWeight))
+                        {
+                            return cachedWeight;
+                        }
+
+                        var weight = Math.Pow(distance, -closure.DistanceExponent);
+                        distanceWeightCache[distance] = weight;
+                        return weight;
                     }
+
+                    var directSeedWeightSums = new Dictionary<object, Dictionary<object, double>>();
+                    foreach (var seed in orderedUniqueSeeds)
+                    {
+                        var weightSums = ComputePathAwareRootWeightSumsForSeed(seed, succIndex, rootKeys, closure.MaxDepth, GetNodeId, GetDistanceWeight);
+                        if (weightSums.Count > 0)
+                        {
+                            directSeedWeightSums[seed ?? NullFactIndexKey] = weightSums;
+                        }
+                    }
+
+                    seedWeightSums = directSeedWeightSums;
                 }
 
                 var rows = new List<object[]>();


### PR DESCRIPTION
  ## Summary

  This PR extends Stage 4 of the materialization plan to the grouped
  weight-sum family used by:

  - `effective_distance`
  - `category_influence`

  Those workloads already had a strong compact retained form in the C#
  query runtime:

  - emit `(group, root, weight_sum)` rows directly

  But that retained form was still effectively hard-wired.

  This PR adds an explicit runtime strategy selector so the engine can
  choose between:

  - compact grouped weight sums
  - legacy seeded-row regrouping

  and exposes that choice through the generated benchmark programs.

  ## What Changed

  ### New Runtime Strategy Option

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareWeightSumStrategy`
    - `Auto`
    - `CompactGrouped`
    - `LegacySeededRows`

  Extended:

  - `QueryExecutorOptions`
    - `PathAwareWeightSumStrategy`

  This mirrors the earlier grouped-minima selector, but for the grouped
  weight-sum retained form.

  ### Heuristic Strategy Selection

  Updated:

  - `ExecuteSeedGroupedPathAwareWeightSum(...)`

  Added helpers:

  - `ResolvePathAwareWeightSumStrategy(...)`
  - `ExecuteSeedGroupedPathAwareWeightSumFallback(...)`

  In `Auto` mode, the runtime now uses a lightweight structural heuristic
  based on:

  - group count
  - unique seed count
  - root count
  - estimated path-aware node count

  to choose between:

  - compact grouped weight sums
  - legacy seeded-row regrouping

  The legacy path is implemented as:

  1. seeded path-aware transitive-closure rows
  2. root filtering
  3. distance-to-weight conversion
  4. regrouping into `(seed, root, weight_sum)`
  5. final regrouping by group

  So the old retained form is still available, but no longer implicit.

  ### Generated Benchmark Controls

  Updated:

  - `examples/benchmark/generate_pipeline.py`

  The generated `csharp_query` programs for:

  - `effective_distance`
  - `category_influence`

  now support:

  - `UNIFYWEAVER_WEIGHT_SUM_STRATEGY=auto|grouped|legacy`
  - `UNIFYWEAVER_BENCH_TRACE=1`

  They also print:

  - `weight_sum_strategy_setting=...`

  and, when tracing is enabled, the selected strategy, for example:

  - `strategy_SeedGroupedPathAwareWeightSumCompactGrouped=1`

  This makes the weight-sum retention choice benchmark-visible.

  ### Documentation Updates

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These now record that:

  - Stage 4 also applies to grouped weight sums
  - the runtime can choose between compact grouped weight sums and legacy
    seeded-row regrouping
  - current measurements show `Auto` correctly choosing the grouped path
  - forced legacy regrouping is dramatically worse on these workloads

  ## Why This Matters

  This PR matters for the same reason the grouped-minima selector did, but
  the result is even clearer here.

  The runtime now has multiple valid retained forms for the same operator
  family, and the engine can choose between them where operator knowledge
  actually exists.

  For grouped weight sums, the comparison is decisive:

  - the compact grouped retained form is the right answer on the current
    benchmark surface
  - the legacy seeded-row regrouping path is much more expensive
  - `Auto` correctly lands on the grouped path

  So this PR strengthens the broader materialization story:

  - parser streams tuples
  - runtime owns retained-state choice
  - operator family defines the candidate retained forms
  - benchmark can force and validate the alternatives

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py
  ```
  ### Strategy tracing: effective distance
  ```
  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1
  ```
  Observed at both 300 and 10k:
  ```
  - weight_sum_strategy_setting=Auto
  - strategy_SeedGroupedPathAwareWeightSumCompactGrouped=1
  ```
  ### Strategy tracing: category influence
  ```
  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300 \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Observed:
  ```
  - weight_sum_strategy_setting=Auto
  - strategy_SeedGroupedPathAwareWeightSumCompactGrouped=1
  ```
  ### Forced strategy comparisons

  Effective distance:
  ```
  UNIFYWEAVER_WEIGHT_SUM_STRATEGY=legacy ...
  UNIFYWEAVER_WEIGHT_SUM_STRATEGY=grouped ...
  ```
  Category influence:
  ```
  UNIFYWEAVER_WEIGHT_SUM_STRATEGY=legacy ...
  UNIFYWEAVER_WEIGHT_SUM_STRATEGY=grouped ...
  ```
  Both showed the grouped weight-sum retained form clearly outperforming
  legacy seeded-row regrouping.

  ### Full cross-target runs

  Ran locally:
  ```
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  Outputs matched.

  ### Non-regression smokes

  Also ran locally:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300 \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```
  These still matched.

  ## Strategy Comparison Highlights

  ### Effective distance

  Forced strategy comparison:

  | Scale | Legacy | Grouped | Auto |
  |---|---:|---:|---:|
  | 300 | 0.726s | 0.275s | 0.235s |
  | 10k | 3.106s | 0.828s | 0.779s |

  Interpretation:

  - Auto picks the grouped weight-sum path
  - that is overwhelmingly the correct retained form on both ends of the
    tested range

  ### Category influence

  Forced strategy comparison:

  | Scale | Legacy | Grouped | Auto |
  |---|---:|---:|---:|
  | 300 | 0.711s | 0.237s | 0.207s |
  | 10k | 2.998s | 0.829s | 0.718s |

  Interpretation:

  - Auto again picks the grouped weight-sum path
  - legacy seeded-row regrouping is catastrophically worse here

  ## Updated Effective-Distance Results

  | Scale | C# Query | Prolog Accumulated | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|---:|
  | 300 | 0.224s | 0.349s | 0.437s | 0.365s | 0.469s |
  | 1k | 0.182s | 0.236s | 1.313s | 1.638s | 1.971s |
  | 5k | 0.406s | 0.856s | 5.634s | 7.164s | 11.302s |
  | 10k | 0.695s | 1.942s | 10.196s | 13.782s | 19.074s |

  ## Updated Category-Influence Results

  | Scale | C# Query | Rust DFS | Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.207s | 0.484s | 0.495s |
  | 1k | 0.170s | 1.608s | 2.096s |
  | 5k | 0.382s | 8.125s | 11.640s |
  | 10k | 0.718s | 14.767s | 19.544s |

  ## Interpretation

  This PR confirms that cost-guided retention selection is now working on a
  second operator family, and the result is even stronger than for grouped
  minima.

  For grouped weight sums:

  - the runtime should strongly prefer compact grouped summaries
  - legacy seeded-row regrouping should remain only as a fallback
  - the heuristic Auto selector is already choosing correctly on the
    current benchmark surface

  That is a meaningful step toward a broader runtime policy where retained
  form selection is explicit, testable, and guided by measured operator
  shape rather than benchmark harness structure.

  ## Scope

  This PR adds:

  - a cost-guided grouped weight-sum strategy option
  - runtime selection for effective-distance and category-influence
  - benchmark override/trace support
  - doc updates reflecting that Stage 4 now covers both grouped minima and
    grouped weight sums

  It does not yet add:

  - a universal cost-based planner across all operator families
  - deeper cost modeling beyond the current structural heuristic
  - automatic selection between every retained-state form in the runtime

  ## Follow-Up

  Likely next work:

  - continue extending cost-guided retention selection to additional
    operator families
  - refine the heuristics using measured cost buckets rather than only
    structural estimates
  - eventually unify grouped minima and grouped weight-sum selection under
    a broader runtime retention policy