### PR TITLE
feat(prolog): add experimental article-root accumulation helper

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -31,8 +31,8 @@ all-path semantics.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
-| **C# Query Engine** | **0.211s** | **0.190s** | **0.351s** | **0.735s** |
-| Prolog accumulated | 0.361s | 0.249s | 0.823s | 2.038s |
+| **C# Query Engine** | **0.238s** | **0.154s** | **0.361s** | **0.758s** |
+| Prolog accumulated | 0.381s | 0.301s | 0.928s | 2.296s |
 | C# DFS pipeline | 0.442s | 1.181s | 5.647s | 10.736s |
 | Rust DFS pipeline | 0.381s | 1.370s | 7.445s | 14.080s |
 | Go DFS pipeline | 0.483s | 2.066s | 11.864s | 19.701s |
@@ -105,8 +105,8 @@ For historical context, the original DFS-only pipeline comparison:
 ### Key Findings
 
 1. **The C# query engine is now the fastest effective-distance path on
-   this benchmark surface** — it beats accumulated Prolog by `1.71x` at
-   `300`, `1.31x` at `1k`, `2.35x` at `5k`, and `2.77x` at `10k`.
+   this benchmark surface** — it beats accumulated Prolog by `1.60x` at
+   `300`, `1.96x` at `1k`, `2.57x` at `5k`, and `3.03x` at `10k`.
 
 2. **The C# query engine now beats the DFS baselines by a wide margin** —
    at `10k` it is `14.60x` faster than C# DFS, `19.15x` faster than Rust
@@ -118,11 +118,17 @@ For historical context, the original DFS-only pipeline comparison:
    materialization cost that used to dominate the C# query path.
 
 4. **Accumulated Prolog is still a useful retained-state reference** — it
-   keeps only per-seed weight sums (`462` tuples at `10k`), but the query
-   engine now reaches a better end-to-end result by combining streamed
-   ingestion with operator-owned retained state.
+   keeps only per-seed weight sums (`48` tuples at `1k`, `151` at `5k`,
+   `462` at `10k`), but the query engine still reaches a better end-to-end
+   result by combining streamed ingestion with operator-owned retained
+   state.
 
-5. **The current C# query-engine path now matches the intended ownership
+5. **The new direct article/root Prolog helper is currently experimental**
+   — it emits compact `(article, root, weight_sum)` rows directly, but it
+   is slower than the seed-accumulated path on this workload, so it
+   remains an optional benchmark variant rather than the default.
+
+6. **The current C# query-engine path now matches the intended ownership
    boundary much more closely** — the parser streams tuples, and the engine
    decides what retained form the effective-distance operator actually needs.
 
@@ -189,7 +195,7 @@ Tables:
 | `generate_pipeline.py` | Generate self-contained pipeline per target |
 | `benchmark_common.py` | Shared build/run utilities for cross-target benchmark runners |
 | `compute_effective_distance.py` | Post-processing aggregation (validation tool) |
-| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, and C#/Rust/Go DFS binaries |
+| `benchmark_effective_distance.py` | Rebuild and time effective distance across the C# query engine, accumulated Prolog, optional direct article/root Prolog, and C#/Rust/Go DFS binaries |
 | `benchmark_shortest_path_cross_target.py` | Compare shortest-path-to-root across C# query, seeded Prolog `min`, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_depth_cross_target.py` | Compare synthetic dependency reach-count across C# query, C# DFS, Rust DFS, and Go DFS |
 | `benchmark_dependency_longest_depth_cross_target.py` | Compare true DAG longest dependency-chain depth across C# query, C# DFS, Rust DFS, and Go DFS |
@@ -199,8 +205,8 @@ Tables:
 | `benchmark_category_influence_cross_target.py` | Compare category influence propagation across the C# query engine, Rust DFS, Go DFS, and an optional Prolog accumulated path |
 | `generate_prolog_shortest_path_benchmark.pl` | Generate standalone SWI-Prolog shortest-path benchmark scripts with `branch_pruning(auto|false)` |
 | `benchmark_prolog_branch_pruning.py` | Compare handwritten Prolog shortest-path source against generated pruned and unpruned Prolog scripts |
-| `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse, generated accumulation helpers, and optional branch pruning |
-| `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, and accumulated Prolog effective-distance scripts and report phase/work metrics |
+| `generate_prolog_effective_distance_benchmark.pl` | Generate standalone SWI-Prolog effective-distance scripts for seeded closure reuse, generated accumulation helpers, optional direct article/root helpers, and optional branch pruning |
+| `benchmark_prolog_effective_distance.py` | Compare seeded, pruned, accumulated, and optional direct article/root Prolog effective-distance scripts and report phase/work metrics |
 | `generate_prolog_category_influence_benchmark.pl` | Generate standalone SWI-Prolog category-influence scripts using the PPV `category_ancestor/4` closure with optional seeded accumulation helpers |
 | `benchmark_prolog_category_influence.py` | Compare seeded and accumulated Prolog category-influence scripts and report phase/work metrics |
 | `generate_prolog_shortest_path_seeded_benchmark.pl` | Generate standalone SWI-Prolog shortest-path scripts for seeded `all` vs mode-directed `min` closure, loading `facts.pl` at runtime |
@@ -387,10 +393,10 @@ Latest local results:
 
 | Scale | Seeded | Pruned | Accumulated | Output Match | Note |
 |-------|--------|--------|-------------|--------------|------|
-| 300 | 0.368s | 0.443s | 0.406s | match | selected helper routes bound queries to the new bound fast path |
-| 1k | 0.348s | 0.309s | 0.287s | match | bound fast path now wins clearly |
-| 5k | 1.125s | 1.282s | 0.910s | match | accumulated remains best |
-| 10k | 2.715s | 2.675s | 2.276s | match | accumulated stays best at the largest tested scale |
+| 300 | 0.380s | 0.416s | 0.369s | match | accumulated edges out seeded once load is amortized |
+| 1k | 0.293s | 0.364s | 0.257s | match | accumulated remains the best Prolog path |
+| 5k | 1.176s | 1.096s | 0.850s | match | retained-state reduction dominates |
+| 10k | 2.627s | 2.577s | 2.249s | match | accumulated stays best at the largest tested scale |
 
 Current interpretation:
 
@@ -399,6 +405,13 @@ Current interpretation:
 - the accumulated variant now uses the generated selected helper surface,
   which routes bound root queries to a dedicated bound-key fast path
   instead of paying the generic helper's key-enumeration overhead
+- the experimental `article_accumulated` variant now uses the generated
+  `category_ancestor$effective_distance_article_sum` helper to emit
+  compact `(article, root, weight_sum)` rows directly, but it is slower
+  than `accumulated` on this workload:
+  - `300`: `0.457s` vs `0.393s`
+  - `1k`: `0.493s` vs `0.274s`
+  - `5k`: `6.275s` vs `0.973s`
 - pre-aggregating per-seed weight sums materially reduces retained state:
   - `1k`: tuple count `10976 -> 48`
   - `5k`: tuple count `41132 -> 151`

--- a/examples/benchmark/benchmark_effective_distance.py
+++ b/examples/benchmark/benchmark_effective_distance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Benchmark the effective-distance workload for the C# query engine, seeded
-Prolog, accumulated Prolog, and the compiled DFS pipelines.
+Prolog, optional direct article/root Prolog, and the compiled DFS pipelines.
 
 Default targets:
   - csharp-query  : current C# query runtime using PathAwareTransitiveClosureNode
@@ -73,7 +73,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated",
-        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated",
+        help="Comma-separated targets: csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated",
     )
     parser.add_argument(
         "--repetitions",
@@ -166,6 +166,7 @@ def print_summary(results: list[RunResult]) -> None:
         prolog_seeded = find_result(entries, "prolog-seeded")
         prolog_pruned = find_result(entries, "prolog-pruned")
         prolog_accumulated = find_result(entries, "prolog-accumulated")
+        prolog_article_accumulated = find_result(entries, "prolog-article-accumulated")
         dfs_like = [item for item in entries if item.target in {"csharp-dfs", "rust-dfs", "go-dfs"}]
 
         if len(dfs_like) > 1:
@@ -174,15 +175,18 @@ def print_summary(results: list[RunResult]) -> None:
         print_pair_match_status(scale, "query_vs_prolog_seeded", qe, prolog_seeded)
         print_pair_match_status(scale, "query_vs_prolog_pruned", qe, prolog_pruned)
         print_pair_match_status(scale, "query_vs_prolog_accumulated", qe, prolog_accumulated)
+        print_pair_match_status(scale, "query_vs_prolog_article_accumulated", qe, prolog_article_accumulated)
         print_speedup(scale, "speedup_vs_csharp_dfs", csharp_dfs, qe)
         print_speedup(scale, "speedup_vs_rust_dfs", rust_dfs, qe)
         print_speedup(scale, "speedup_vs_prolog_seeded", prolog_seeded, qe)
         print_speedup(scale, "speedup_vs_prolog_pruned", prolog_pruned, qe)
         print_speedup(scale, "speedup_vs_prolog_accumulated", prolog_accumulated, qe)
+        print_speedup(scale, "speedup_vs_prolog_article_accumulated", prolog_article_accumulated, qe)
         print_phase_metrics(scale, "csharp-query-metrics", qe)
         print_phase_metrics(scale, "prolog-seeded-metrics", prolog_seeded)
         print_phase_metrics(scale, "prolog-pruned-metrics", prolog_pruned)
         print_phase_metrics(scale, "prolog-accumulated-metrics", prolog_accumulated)
+        print_phase_metrics(scale, "prolog-article-accumulated-metrics", prolog_article_accumulated)
 
 
 def scale_sort_key(scale: str) -> tuple[int, str]:
@@ -229,6 +233,8 @@ def main() -> int:
                 continue
             elif target == "prolog-accumulated":
                 continue
+            elif target == "prolog-article-accumulated":
+                continue
             else:
                 raise ValueError(f"unsupported target: {target}")
 
@@ -241,6 +247,8 @@ def main() -> int:
                     command = build_prolog_effective_distance(temp_root, scale, "pruned")
                 elif target == "prolog-accumulated":
                     command = build_prolog_effective_distance(temp_root, scale, "accumulated")
+                elif target == "prolog-article-accumulated":
+                    command = build_prolog_effective_distance(temp_root, scale, "article_accumulated")
                 else:
                     command = commands[target]
                 results.append(benchmark_target(command, scale, args.repetitions, target))

--- a/examples/benchmark/benchmark_prolog_effective_distance.py
+++ b/examples/benchmark/benchmark_prolog_effective_distance.py
@@ -6,6 +6,8 @@ Targets:
   - prolog-seeded : generated Prolog using seeded counted closure reuse
   - prolog-pruned : generated Prolog using seeded closure reuse plus branch pruning
   - prolog-accumulated : generated Prolog using seeded pre-aggregated weight sums
+  - prolog-article-accumulated : generated Prolog using the experimental
+    direct article/root weight-sum helper
 """
 
 from __future__ import annotations
@@ -58,7 +60,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--targets",
         default="prolog-seeded,prolog-pruned,prolog-accumulated",
-        help="Comma-separated targets: prolog-seeded,prolog-pruned,prolog-accumulated",
+        help="Comma-separated targets: prolog-seeded,prolog-pruned,prolog-accumulated,prolog-article-accumulated",
     )
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--keep-temp", action="store_true")
@@ -69,7 +71,7 @@ def available_targets(requested: list[str]) -> list[str]:
     if shutil.which("swipl") is None:
         print("skip prolog effective-distance benchmark: swipl not found", file=sys.stderr)
         return []
-    supported = {"prolog-seeded", "prolog-pruned", "prolog-accumulated"}
+    supported = {"prolog-seeded", "prolog-pruned", "prolog-accumulated", "prolog-article-accumulated"}
     targets: list[str] = []
     for target in requested:
         if target not in supported:
@@ -125,15 +127,19 @@ def print_summary(results: list[RunResult]) -> None:
         seeded = find_result(entries, "prolog-seeded")
         pruned = find_result(entries, "prolog-pruned")
         accumulated = find_result(entries, "prolog-accumulated")
+        article_accumulated = find_result(entries, "prolog-article-accumulated")
         print_pair_match_status(scale, "seeded_vs_pruned", seeded, pruned)
         print_pair_match_status(scale, "seeded_vs_accumulated", seeded, accumulated)
         print_pair_match_status(scale, "pruned_vs_accumulated", pruned, accumulated)
+        print_pair_match_status(scale, "seeded_vs_article_accumulated", seeded, article_accumulated)
         print_speedup(scale, "speedup_pruned_vs_seeded", seeded, pruned)
         print_speedup(scale, "speedup_accumulated_vs_seeded", seeded, accumulated)
         print_speedup(scale, "speedup_accumulated_vs_pruned", pruned, accumulated)
+        print_speedup(scale, "speedup_article_accumulated_vs_seeded", seeded, article_accumulated)
         print_phase_metrics(scale, "seeded_metrics", seeded)
         print_phase_metrics(scale, "pruned_metrics", pruned)
         print_phase_metrics(scale, "accumulated_metrics", accumulated)
+        print_phase_metrics(scale, "article_accumulated_metrics", article_accumulated)
 
 
 def main() -> int:
@@ -167,6 +173,10 @@ def main() -> int:
                 elif target == "prolog-accumulated":
                     commands[target] = build_generated_script(
                         temp_root, scale, "accumulated", "effective_distance_accumulated.pl"
+                    )
+                elif target == "prolog-article-accumulated":
+                    commands[target] = build_generated_script(
+                        temp_root, scale, "article_accumulated", "effective_distance_article_accumulated.pl"
                     )
                 else:
                     raise ValueError(f"unsupported target: {target}")

--- a/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
+++ b/examples/benchmark/generate_prolog_effective_distance_benchmark.pl
@@ -12,7 +12,7 @@ main :-
     (   Argv = [FactsPath, OutputPath, VariantAtom]
     ->  true
     ;   format(user_error,
-            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned|accumulated>~n',
+            'Usage: swipl -q -s generate_prolog_effective_distance_benchmark.pl -- <facts.pl> <output-script> <seeded|pruned|accumulated|article_accumulated>~n',
             []),
         halt(1)
     ),
@@ -54,9 +54,17 @@ parse_variant('accumulated', accumulated, [
         seeded_accumulation(auto)
     ]) :-
     !.
+parse_variant('article_accumulated', article_accumulated, [
+        dialect(swi),
+        entry_point(run_benchmark),
+        branch_pruning(false),
+        min_closure(false),
+        seeded_accumulation(auto)
+    ]) :-
+    !.
 parse_variant(Atom, _, _) :-
     format(user_error,
-        'Unsupported effective-distance benchmark variant: ~w (expected seeded, pruned, or accumulated)~n',
+        'Unsupported effective-distance benchmark variant: ~w (expected seeded, pruned, accumulated, or article_accumulated)~n',
         [Atom]),
     halt(1).
 
@@ -65,12 +73,14 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
     benchmark_index_build_line(Variant, IndexBuildLine),
     benchmark_results_line(Variant, ResultsLine),
     benchmark_weight_sum_query_line(Variant, WeightSumQueryLine),
+    benchmark_article_weight_sum_query_line(Variant, ArticleWeightSumQueryLine),
     benchmark_mode_line(Variant, ModeLine),
     Lines = [
         ':- use_module(library(aggregate)).',
         ':- use_module(library(lists)).',
         ':- dynamic bench_seed_hops/3.',
         ':- dynamic bench_seed_weight_sum/3.',
+        ':- dynamic bench_article_weight_sum/3.',
         FactsPathLine,
         '',
         'load_benchmark_facts :-',
@@ -85,7 +95,8 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '',
         'clear_seed_indexes :-',
         '    retractall(bench_seed_hops(_, _, _)),',
-        '    retractall(bench_seed_weight_sum(_, _, _)).',
+        '    retractall(bench_seed_weight_sum(_, _, _)),',
+        '    retractall(bench_article_weight_sum(_, _, _)).',
         '',
         'seed_hops_query(Cat, Root, Hops) :-',
         '    category_ancestor(Cat, Root, Hops, [Cat]).',
@@ -116,6 +127,19 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '    ),',
         '    aggregate_all(count, bench_seed_weight_sum(_, _, _), TupleCount).',
         '',
+        'build_article_weight_sum_index(Root, SeedCount, TupleCount) :-',
+        '    clear_seed_indexes,',
+        '    collect_articles(Articles),',
+        '    length(Articles, SeedCount),',
+        '    forall(',
+        '        member(Article, Articles),',
+        '        forall(',
+        '            article_weight_sum_query(Article, Root, WeightSum),',
+        '            assertz(bench_article_weight_sum(Article, Root, WeightSum))',
+        '        )',
+        '    ),',
+        '    aggregate_all(count, bench_article_weight_sum(_, _, _), TupleCount).',
+        '',
         'seeded_article_root_hops(Article, Root, 1) :-',
         '    article_category(Article, Root).',
         'seeded_article_root_hops(Article, Root, Hops) :-',
@@ -133,6 +157,9 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '',
         'seed_weight_sum_query(Cat, Root, WeightSum) :-',
         WeightSumQueryLine,
+        '',
+        'article_weight_sum_query(Article, Root, WeightSum) :-',
+        ArticleWeightSumQueryLine,
         '',
         'compute_effective_distance_results_from_hops(Root, Results) :-',
         '    collect_articles(Articles),',
@@ -161,6 +188,17 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
         '            aggregate_all(sum(W),',
         '                seeded_article_root_weight(Article, Root, W),',
         '                WeightSum),',
+        '            WeightSum > 0,',
+        '            Deff is WeightSum ** InvN',
+        '        ),',
+        '        Pairs),',
+        '    sort(Pairs, Results).',
+        '',
+        'compute_effective_distance_results_from_article_sums(Root, Results) :-',
+        '    dimension_n(N),',
+        '    InvN is -1 / N,',
+        '    findall(Deff-Article,',
+        '        (   bench_article_weight_sum(Article, Root, WeightSum),',
         '            WeightSum > 0,',
         '            Deff is WeightSum ** InvN',
         '        ),',
@@ -207,15 +245,24 @@ benchmark_driver_code(Variant, FactsPath, Code) :-
 benchmark_index_build_line(seeded, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
 benchmark_index_build_line(pruned, '    build_seed_hops_index(Root, SeedCount, TupleCount),').
 benchmark_index_build_line(accumulated, '    build_seed_weight_sum_index(Root, SeedCount, TupleCount),').
+benchmark_index_build_line(article_accumulated, '    build_article_weight_sum_index(Root, SeedCount, TupleCount),').
 
 benchmark_results_line(seeded, '    compute_effective_distance_results_from_hops(Root, Results),').
 benchmark_results_line(pruned, '    compute_effective_distance_results_from_hops(Root, Results),').
 benchmark_results_line(accumulated, '    compute_effective_distance_results_from_weight_sums(Root, Results),').
+benchmark_results_line(article_accumulated, '    compute_effective_distance_results_from_article_sums(Root, Results),').
 
 benchmark_weight_sum_query_line(seeded, '    fail.').
 benchmark_weight_sum_query_line(pruned, '    fail.').
 benchmark_weight_sum_query_line(accumulated, '    ''category_ancestor$effective_distance_sum_selected''(Cat, Root, WeightSum).').
+benchmark_weight_sum_query_line(article_accumulated, '    ''category_ancestor$effective_distance_sum_selected''(Cat, Root, WeightSum).').
+
+benchmark_article_weight_sum_query_line(seeded, '    fail.').
+benchmark_article_weight_sum_query_line(pruned, '    fail.').
+benchmark_article_weight_sum_query_line(accumulated, '    fail.').
+benchmark_article_weight_sum_query_line(article_accumulated, '    ''category_ancestor$effective_distance_article_sum''(Article, Root, WeightSum).').
 
 benchmark_mode_line(seeded, '    format(user_error, ''mode=seeded~n'', []),').
 benchmark_mode_line(pruned, '    format(user_error, ''mode=pruned~n'', []),').
 benchmark_mode_line(accumulated, '    format(user_error, ''mode=accumulated~n'', []),').
+benchmark_mode_line(article_accumulated, '    format(user_error, ''mode=article_accumulated~n'', []),').

--- a/src/unifyweaver/targets/prolog_target.pl
+++ b/src/unifyweaver/targets/prolog_target.pl
@@ -500,10 +500,15 @@ maybe_generate_seeded_accumulation_helper(Pred/Arity, Options, Code) :-
     ->  Grouped = some(GroupedCode)
     ;   Grouped = none
     ),
+    (   Bound = some(_),
+        Grouped = some(_),
+        build_effective_distance_consumer_code(Pred/Arity, Shape, Formula, ConsumerCode)
+    ;   true
+    ),
     build_seeded_accumulation_selected_code(Pred/Arity, Shape, Formula, Bound, Grouped,
         SelectedCode),
     findall(Part,
-        (   member(Part0, [BaseCode, BoundCode, GroupedCode, SelectedCode]),
+        (   member(Part0, [BaseCode, BoundCode, GroupedCode, ConsumerCode, SelectedCode]),
             nonvar(Part0),
             Part = Part0
         ),
@@ -871,6 +876,133 @@ build_specialized_grouped_sum_pairs_clauses(SumPairsName, TakeSameKeyName, Claus
     TakeDoneHead =.. [TakeSameKeyName, RemainingPairs, _IgnoredKey1, WeightSum, WeightSum, RemainingPairs],
     clause_term(TakeDoneHead, true, TakeDoneClause),
     Clauses = [EmptyClause, RecClause, TakeEmptyClause, TakeSameClause, TakeDoneClause].
+
+build_effective_distance_consumer_code(Pred/_Arity,
+        accumulation_shape([1, 2], 1, _MetricPos, _VisitedInfo),
+        Formula, Code) :-
+    effective_distance_suffix_from_formula(Formula, EffectiveSuffix),
+    build_bound_alias_suffixes([EffectiveSuffix], [EffectiveBoundSuffix]),
+    helper_name_for_suffix(Pred, EffectiveBoundSuffix, EffectiveBoundHelperName),
+    build_grouped_alias_suffixes([EffectiveSuffix], [EffectiveGroupedSuffix]),
+    helper_name_for_suffix(Pred, EffectiveGroupedSuffix, EffectiveGroupedHelperName),
+    helper_name_for_suffix(Pred, effective_distance_article_sum, ArticleSumHelperName),
+    helper_name_for_suffix(Pred, effective_distance_article_sum_root_grouped, RootGroupedName),
+    helper_name_for_suffix(Pred, effective_distance_article_sum_article_grouped, ArticleGroupedName),
+    atom_concat(ArticleSumHelperName, '$sum_pairs', SumPairsName),
+    atom_concat(ArticleSumHelperName, '$take_same_key', TakeSameKeyName),
+    build_effective_distance_consumer_clauses(ArticleSumHelperName, RootGroupedName,
+        ArticleGroupedName, EffectiveBoundHelperName, EffectiveGroupedHelperName,
+        SumPairsName, TakeSameKeyName, Clauses, TableDeclCode),
+    clauses_to_code(Clauses, ClauseCode),
+    atomic_list_concat([
+        '% Effective-distance grouped consumer helper for compact (article, root, weight_sum) rows.',
+        TableDeclCode,
+        ClauseCode
+    ], '\n\n', Code).
+
+effective_distance_suffix_from_formula(
+        accumulation_formula(power_sum, _ParamPred, _Offset, PrimarySuffix, AliasSuffixes),
+        EffectiveSuffix) :-
+    member(EffectiveSuffix, [PrimarySuffix|AliasSuffixes]),
+    EffectiveSuffix == effective_distance_sum.
+
+build_effective_distance_consumer_clauses(ArticleSumHelperName, RootGroupedName,
+        ArticleGroupedName, EffectiveBoundHelperName, EffectiveGroupedHelperName,
+        SumPairsName, TakeSameKeyName, Clauses, TableDeclCode) :-
+    build_effective_distance_consumer_entry_clauses(ArticleSumHelperName, RootGroupedName,
+        ArticleGroupedName, EntryClauses),
+    build_effective_distance_consumer_root_grouped_clause(RootGroupedName,
+        EffectiveBoundHelperName, SumPairsName, RootGroupedClause),
+    build_effective_distance_consumer_article_grouped_clause(ArticleGroupedName,
+        EffectiveGroupedHelperName, SumPairsName, ArticleGroupedClause),
+    build_specialized_grouped_sum_pairs_clauses(SumPairsName, TakeSameKeyName, SumPairClauses),
+    append(EntryClauses, [RootGroupedClause, ArticleGroupedClause], Clauses0),
+    append(Clauses0, SumPairClauses, Clauses),
+    RootTableSpec =.. [RootGroupedName, +, -],
+    ArticleTableSpec =.. [ArticleGroupedName, +, -],
+    format(atom(TableDeclCode), ':- table ~q.~n:- table ~q.',
+        [RootTableSpec, ArticleTableSpec]).
+
+build_effective_distance_consumer_entry_clauses(ArticleSumHelperName, RootGroupedName,
+        ArticleGroupedName, Clauses) :-
+    RootHead =.. [ArticleSumHelperName, Article, Root, WeightSum],
+    RootGroupedCall =.. [RootGroupedName, Root, ArticlePairs],
+    RootBody = (
+        nonvar(Root),
+        !,
+        RootGroupedCall,
+        member(Article-WeightSum, ArticlePairs)
+    ),
+    clause_term(RootHead, RootBody, RootClause),
+    ArticleHead =.. [ArticleSumHelperName, Article, Root, WeightSum],
+    ArticleGroupedCall =.. [ArticleGroupedName, Article, RootPairs],
+    ArticleBody = (
+        var(Root),
+        nonvar(Article),
+        !,
+        ArticleGroupedCall,
+        member(Root-WeightSum, RootPairs)
+    ),
+    clause_term(ArticleHead, ArticleBody, ArticleClause),
+    EnumerateHead =.. [ArticleSumHelperName, Article, Root, WeightSum],
+    EnumerateBody = (
+        var(Root),
+        var(Article),
+        setof(Article0, Cat0^article_category(Article0, Cat0), Articles),
+        member(Article, Articles),
+        ArticleGroupedCall,
+        member(Root-WeightSum, RootPairs)
+    ),
+    clause_term(EnumerateHead, EnumerateBody, EnumerateClause),
+    Clauses = [RootClause, ArticleClause, EnumerateClause].
+
+build_effective_distance_consumer_root_grouped_clause(RootGroupedName,
+        EffectiveBoundHelperName, SumPairsName, ClauseTerm) :-
+    Head =.. [RootGroupedName, Root, ArticlePairs],
+    SeedCatsGoal = setof(Cat, Article^article_category(Article, Cat), SeedCats),
+    EffectiveBoundCall =.. [EffectiveBoundHelperName, Cat, Root, Weight],
+    SeedPairsGoal = findall(Cat-Weight,
+        (   member(Cat, SeedCats),
+            Cat \= Root,
+            EffectiveBoundCall
+        ),
+        SeedPairs),
+    SumPairsCall =.. [SumPairsName, SortedPairs, ArticlePairs],
+    Body = (
+        SeedCatsGoal,
+        SeedPairsGoal,
+        findall(Article-Weight,
+            (   article_category(Article, Root),
+                Weight = 1.0
+            ;   article_category(Article, Cat),
+                member(Cat-Weight, SeedPairs)
+            ),
+            RawPairs),
+        RawPairs \= [],
+        keysort(RawPairs, SortedPairs),
+        SumPairsCall
+    ),
+    clause_term(Head, Body, ClauseTerm).
+
+build_effective_distance_consumer_article_grouped_clause(ArticleGroupedName,
+        EffectiveGroupedHelperName, SumPairsName, ClauseTerm) :-
+    Head =.. [ArticleGroupedName, Article, RootPairs],
+    EffectiveGroupedCall =.. [EffectiveGroupedHelperName, Cat, Root, Weight],
+    DirectRootWeight = 1.0,
+    SumPairsCall =.. [SumPairsName, SortedPairs, RootPairs],
+    Body = (
+        findall(Root-Weight,
+            (   article_category(Article, Root),
+                Weight = DirectRootWeight
+            ;   article_category(Article, Cat),
+                EffectiveGroupedCall
+            ),
+            RawPairs),
+        RawPairs \= [],
+        keysort(RawPairs, SortedPairs),
+        SumPairsCall
+    ),
+    clause_term(Head, Body, ClauseTerm).
 
 helper_name_for_suffix(Pred, Suffix, HelperName) :-
     format(atom(HelperName), '~w$~w', [Pred, Suffix]).

--- a/tests/core/test_prolog_target.pl
+++ b/tests/core/test_prolog_target.pl
@@ -371,6 +371,10 @@ build_effective_distance_runtime_source(ModuleName, PredicateCode, Source) :-
         'test_effective_edge(a, d).',
         'test_effective_edge(d, e).',
         'test_effective_edge(e, c).',
+        'article_category(article_one, a).',
+        'article_category(article_one, d).',
+        'article_category(article_two, b).',
+        'article_category(article_three, c).',
         'dimension_n(5).',
         'max_depth(4).'
     ], '\n', FactsCode),
@@ -389,6 +393,21 @@ collect_generated_effective_distance_sums(Options, PredicateCode, Sums) :-
             Goal =.. ['test_effective_ppv_reach$effective_distance_sum_selected', a, c, Sum],
             findall(Sum, ModuleName:Goal, Sums0),
             sort(Sums0, Sums)
+        ),
+        cleanup_temp_module_source(Path)
+    ).
+
+collect_generated_effective_distance_article_sums(Options, PredicateCode, ArticleSums) :-
+    once(prolog_target:generate_predicate_code(test_effective_ppv_reach/4, Options, PredicateCode)),
+    gensym(test_effective_article_runtime_, ModuleName),
+    build_effective_distance_runtime_source(ModuleName, PredicateCode, Source),
+    write_temp_module_source(Source, Path),
+    setup_call_cleanup(
+        load_files(Path, []),
+        (
+            Goal =.. ['test_effective_ppv_reach$effective_distance_article_sum', Article, c, Sum],
+            findall(Article-Sum, ModuleName:Goal, ArticleSums0),
+            sort(ArticleSums0, ArticleSums)
         ),
         cleanup_temp_module_source(Path)
     ).
@@ -572,9 +591,30 @@ test(emits_effective_distance_accumulation_helper_for_counted_ppv,
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum_bound')),
     once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_sum_selected')),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum')),
     Expected is (3 ** -5) + (4 ** -5),
     Delta is abs(Actual - Expected),
     Delta < 1.0e-12.
+
+test(emits_effective_distance_article_sum_helper_for_bound_root_queries,
+        [setup(setup_effective_distance_accumulation_fixture),
+         cleanup(cleanup_effective_distance_accumulation_fixture)]) :-
+    Options = [
+        dialect(swi),
+        min_closure(false),
+        branch_pruning(false),
+        effective_distance_accumulation(auto),
+        predicates([dimension_n/1, max_depth/1, test_effective_ppv_reach/4])
+    ],
+    collect_generated_effective_distance_article_sums(Options, PredicateCode, ActualPairs),
+    once(sub_atom(PredicateCode, _, _, _, 'test_effective_ppv_reach$effective_distance_article_sum')),
+    ExpectedOne is (3 ** -5) + (3 ** -5) + (4 ** -5),
+    ExpectedTwo is 2 ** -5,
+    ActualPairs = [article_one-One, article_three-1.0, article_two-Two],
+    DeltaOne is abs(One - ExpectedOne),
+    DeltaTwo is abs(Two - ExpectedTwo),
+    DeltaOne < 1.0e-12,
+    DeltaTwo < 1.0e-12.
 
 test(skips_effective_distance_accumulation_helper_when_disabled_explicitly,
         [setup(setup_effective_distance_accumulation_fixture),


### PR DESCRIPTION
  ## Summary

  This adds a narrow generated Prolog helper for the canonical
  effective-distance consumer shape that emits compact
  `(article, root, weight_sum)` rows directly.

  The key result is mixed but useful:

  - the helper is correct
  - it gives the Prolog target a real generated consumer-side accumulation surface
  - but on this workload it is not faster than the existing seed-accumulated path

  So this PR keeps the existing seed-accumulated Prolog path as the default
  `prolog-accumulated` benchmark variant and exposes the new direct
  article/root helper as an explicit experimental variant:
  `prolog-article-accumulated`.

  ## What Changed

  - extended `src/unifyweaver/targets/prolog_target.pl`
    - added a narrow effective-distance consumer helper
    - generated helper name:
      - `category_ancestor$effective_distance_article_sum/3`
    - the helper materializes compact `(article, root, weight_sum)` rows
      directly for the canonical counted PPV effective-distance shape
    - kept the existing seed-level accumulation helpers intact as the
      stable default path
  - extended `tests/core/test_prolog_target.pl`
    - added execution-level coverage for the new generated
      `effective_distance_article_sum` helper
    - preserved all existing accumulation, pruning, and min-helper tests
  - updated `examples/benchmark/generate_prolog_effective_distance_benchmark.pl`
    - restored `accumulated` to the existing seed-accumulated path
    - added a new explicit `article_accumulated` benchmark variant for the
      direct article/root helper
  - updated `examples/benchmark/benchmark_prolog_effective_distance.py`
    - added `prolog-article-accumulated`
    - kept `prolog-accumulated` as the default accumulated comparison
  - updated `examples/benchmark/benchmark_effective_distance.py`
    - added optional support for `prolog-article-accumulated`
  - updated `examples/benchmark/README.md`
    - refreshed the current effective-distance numbers
    - documented that the direct article/root helper is experimental and
      currently slower than the stable seed-accumulated path

  ## Why

  The previous Prolog effective-distance work had good retained-state
  behavior at the seed/root level, but the final article/root aggregation
  still lived outside the generated helper surface.

  This PR explores the next obvious step:

  - move the effective-distance consumer shape into generated Prolog
  - emit compact article/root weight sums directly
  - compare that plan against both the stable Prolog accumulated path and
    the C# query runtime

  That gives us a cleaner target abstraction and a concrete measurement of
  whether direct article/root retained state is the right next optimization
  for SWI-Prolog.

  ## Result

  ### Stable accumulated Prolog path

  The existing seed-accumulated Prolog path remains the best Prolog
  effective-distance variant and stays the default benchmark comparison.

  Latest local standalone Prolog effective-distance results:

  | Scale | Seeded | Pruned | Accumulated | Output Match |
  |-------|-------:|-------:|------------:|--------------|
  | 300 | 0.380s | 0.416s | 0.369s | match |
  | 1k | 0.293s | 0.364s | 0.257s | match |
  | 5k | 1.176s | 1.096s | 0.850s | match |
  | 10k | 2.627s | 2.577s | 2.249s | match |

  Retained state for `accumulated` still collapses sharply:

  - `1k`: tuple count `10976 -> 48`
  - `5k`: tuple count `41132 -> 151`
  - `10k`: tuple count `105287 -> 462`

  ### Experimental direct article/root helper

  The new direct helper is semantically correct but slower than the stable
  seed-accumulated path on this workload.

  Standalone comparison:

  | Scale | Accumulated | Article Accumulated |
  |-------|------------:|--------------------:|
  | 300 | 0.393s | 0.457s |
  | 1k | 0.274s | 0.493s |
  | 5k | 0.973s | 6.275s |

  Interpretation:
  - the direct `(article, root, weight_sum)` helper works
  - but the current SWI join plan is not the faster retained-state shape
    here
  - so it should remain experimental rather than replacing the default
    accumulated path

  ### Cross-target effective distance

  Latest local `csharp-query` vs stable `prolog-accumulated` run:

  | Scale | C# Query | Prolog Accumulated | Outputs |
  |-------|---------:|-------------------:|---------|
  | 300 | 0.238s | 0.381s | match |
  | 1k | 0.154s | 0.301s | match |
  | 5k | 0.361s | 0.928s | match |
  | 10k | 0.758s | 2.296s | match |

  So this PR does not close the remaining Prolog vs C# gap. It clarifies
  where that gap still is: not in semantic ownership, but in the cost of
  the current Prolog-side join/retained-state plan.

  ## Verification

  - `swipl -q -g "use_module('tests/core/test_prolog_target.pl'), test_prolog_target:run_prolog_target_tests" -t halt`
  - `python -m py_compile examples/benchmark/benchmark_prolog_effective_distance.py examples/benchmark/
  benchmark_effective_distance.py`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 5k,10k --repetitions 1`
  - `python examples/benchmark/benchmark_prolog_effective_distance.py --scales 300,1k,5k --targets prolog-
  accumulated,prolog-article-accumulated --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 300,1k,5k,10k --targets csharp-query,prolog-
  accumulated --repetitions 1`
  - `python examples/benchmark/benchmark_effective_distance.py --scales 300 --targets csharp-query,prolog-article-
  accumulated --repetitions 1`

  ## Notes

  - the new helper is intentionally narrow: canonical counted PPV
    effective-distance only
  - this PR is worth merging because it adds a real generated consumer-side
    helper and captures a meaningful negative benchmark result
  - the next likely optimization step is not more helper selection; it is a
    better Prolog-side join/retained-state strategy for grouped
    article/root consumers, or a lower-level backend experiment such as
    hybrid WAM