### PR TITLE
refactor(csharp-query): unify grouped summary retention policy

### DIFF
--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md
@@ -82,11 +82,14 @@ Status:
 - started for shortest-path and weighted-shortest-path grouped minima
 - started for effective-distance and category-influence grouped weight sums
 - the runtime can now choose between compact grouped summaries and legacy
-  seeded-row regrouping for both operator families
+  seeded-row regrouping for both operator families through a shared
+  grouped-summary policy layer
 - `QueryExecutorOptions.PathAwareGroupedMinStrategy` can force `Auto`,
   `CompactGrouped`, or `LegacySeededRows` for grouped minima benchmarking
 - `QueryExecutorOptions.PathAwareWeightSumStrategy` can force `Auto`,
   `CompactGrouped`, or `LegacySeededRows` for grouped weight-sum benchmarking
+- the current implementation shares one grouped-summary heuristic/resolution
+  path internally while keeping per-family override knobs for benchmarking
 
 Work:
 

--- a/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
+++ b/docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md
@@ -66,13 +66,15 @@ Examples:
 - shortest-path and weighted-shortest-path operators can emit compact
   `(group, root, min_value)` summaries instead of retaining full seeded path rows
 - where both grouped minima and legacy seeded-row regrouping are available, the
-  runtime can choose between them heuristically and still expose an explicit
-  override via `QueryExecutorOptions.PathAwareGroupedMinStrategy`
+  runtime can choose between them through a shared grouped-summary policy
+  layer and still expose an explicit override via
+  `QueryExecutorOptions.PathAwareGroupedMinStrategy`
 - effective-distance and category-influence operators can build compact
   `(group, root, weight_sum)` summaries instead of retaining full path rows
 - where grouped weight sums and legacy seeded-row regrouping both exist, the
-  runtime can choose between them heuristically and still expose an explicit
-  override via `QueryExecutorOptions.PathAwareWeightSumStrategy`
+  runtime can choose between them through that same grouped-summary policy
+  layer and still expose an explicit override via
+  `QueryExecutorOptions.PathAwareWeightSumStrategy`
 - other operators may request replay buffers or indexes when needed
 
 ### 3. External materialization fallback
@@ -121,11 +123,13 @@ For the current benchmark/runtime surface, the streamed path is:
 6. shortest-path and weighted-shortest-path operators can emit compact
    grouped root minima directly from streamed edge/seed inputs
 7. where grouped minima and legacy seeded-row regrouping both exist, the runtime
-   can select between them heuristically or via an explicit executor option
+   can select between them through a shared grouped-summary policy layer or
+   via an explicit executor option
 8. effective-distance and category-influence operators can emit compact
    grouped root-weight summaries directly from streamed edge/seed inputs
 9. where grouped weight sums and legacy seeded-row regrouping both exist, the
-   runtime can select between them heuristically or via an explicit executor option
+   runtime can select between them through that same grouped-summary policy
+   layer or via an explicit executor option
 10. the operator builds only the retained state it actually needs
 11. benchmark code avoids preloading raw facts into in-memory relations first
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -28,7 +28,9 @@ That moves the retained state into the engine and flips the old headline:
 the query engine is now faster than accumulated Prolog and all DFS
 pipelines across the full benchmark range while preserving the same
 all-path semantics. It also now supports cost-guided selection between
-compact grouped weight sums and the legacy seeded-row regrouping path.
+compact grouped weight sums and the legacy seeded-row regrouping path,
+using the same grouped-summary policy layer that now also drives the
+shortest-path minima family.
 
 | Target | 300 art | 1K art | 5K art | 10K art |
 |--------|---------|--------|--------|---------|
@@ -520,7 +522,9 @@ Comparison note:
   collapses to the final article result count, which is why the C# query
   path improves so sharply at every tested scale
 - the new `Auto` selector currently chooses the compact grouped minima
-  path at every tested scale; forcing legacy seeded-row regrouping is
+  path at every tested scale; this now flows through the same grouped-summary
+  policy layer used by grouped weight sums, while still preserving the
+  per-family override knob. Forcing legacy seeded-row regrouping is
   materially worse (`300`: `0.160s` vs `0.083s`, `10k`: `0.419s` vs
   `0.161s`)
 - seeded Prolog `min` remains competitive, but the C# query engine is
@@ -573,7 +577,9 @@ Comparison note:
 - on the current one-root benchmark shape, the retained row count now
   also collapses to the final article result count
 - the new `Auto` selector also chooses the compact grouped minima path
-  here; forcing legacy seeded-row regrouping regresses both ends of the
+  here; this now uses the same grouped-summary policy layer as shortest
+  path while keeping a separate benchmark override
+- forcing legacy seeded-row regrouping regresses both ends of the
   benchmark (`300`: `0.202s` vs `0.151s`, `10k`: `0.430s` vs `0.320s`)
 - seeded Prolog `min` still wins narrowly at `300` and `1k`, but the C#
   query engine is now clearly faster from `5k` onward

--- a/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
+++ b/src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs
@@ -481,6 +481,13 @@ namespace UnifyWeaver.QueryRuntime
         LegacySeededRows
     }
 
+    internal enum PathAwareGroupedSummaryStrategy
+    {
+        Auto,
+        CompactGrouped,
+        LegacySeededRows
+    }
+
     public sealed record QueryExecutorOptions(
         bool ReuseCaches = false,
         PathAwareGroupedMinStrategy PathAwareGroupedMinStrategy = PathAwareGroupedMinStrategy.Auto,
@@ -1419,8 +1426,8 @@ namespace UnifyWeaver.QueryRuntime
         private readonly int _seededCacheAdmissionMinRows;
         private readonly double _seededCacheAdmissionMinRowsPerSeed;
         private readonly int _maxFixpointIterations;
-        private readonly PathAwareGroupedMinStrategy _pathAwareGroupedMinStrategy;
-        private readonly PathAwareWeightSumStrategy _pathAwareWeightSumStrategy;
+        private readonly PathAwareGroupedSummaryStrategy _pathAwareGroupedMinStrategy;
+        private readonly PathAwareGroupedSummaryStrategy _pathAwareWeightSumStrategy;
 
         public QueryExecutor(IRelationProvider provider, QueryExecutorOptions? options = null)
         {
@@ -1434,8 +1441,8 @@ namespace UnifyWeaver.QueryRuntime
             _seededCacheAdmissionMinRows = Math.Max(0, options.SeededCacheAdmissionMinRows);
             _seededCacheAdmissionMinRowsPerSeed = Math.Max(0d, options.SeededCacheAdmissionMinRowsPerSeed);
             _maxFixpointIterations = Math.Max(0, options.MaxFixpointIterations);
-            _pathAwareGroupedMinStrategy = options.PathAwareGroupedMinStrategy;
-            _pathAwareWeightSumStrategy = options.PathAwareWeightSumStrategy;
+            _pathAwareGroupedMinStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareGroupedMinStrategy);
+            _pathAwareWeightSumStrategy = ToPathAwareGroupedSummaryStrategy(options.PathAwareWeightSumStrategy);
         }
 
         public IEnumerable<object[]> Execute(
@@ -7606,15 +7613,32 @@ namespace UnifyWeaver.QueryRuntime
             }
         }
 
-        private PathAwareWeightSumStrategy ResolvePathAwareWeightSumStrategy(
+        private static PathAwareGroupedSummaryStrategy ToPathAwareGroupedSummaryStrategy(PathAwareGroupedMinStrategy strategy)
+            => strategy switch
+            {
+                PathAwareGroupedMinStrategy.CompactGrouped => PathAwareGroupedSummaryStrategy.CompactGrouped,
+                PathAwareGroupedMinStrategy.LegacySeededRows => PathAwareGroupedSummaryStrategy.LegacySeededRows,
+                _ => PathAwareGroupedSummaryStrategy.Auto
+            };
+
+        private static PathAwareGroupedSummaryStrategy ToPathAwareGroupedSummaryStrategy(PathAwareWeightSumStrategy strategy)
+            => strategy switch
+            {
+                PathAwareWeightSumStrategy.CompactGrouped => PathAwareGroupedSummaryStrategy.CompactGrouped,
+                PathAwareWeightSumStrategy.LegacySeededRows => PathAwareGroupedSummaryStrategy.LegacySeededRows,
+                _ => PathAwareGroupedSummaryStrategy.Auto
+            };
+
+        private static PathAwareGroupedSummaryStrategy ResolvePathAwareGroupedSummaryStrategy(
+            PathAwareGroupedSummaryStrategy configuredStrategy,
             int groupCount,
             int uniqueSeedCount,
             int rootCount,
             IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
         {
-            if (_pathAwareWeightSumStrategy != PathAwareWeightSumStrategy.Auto)
+            if (configuredStrategy != PathAwareGroupedSummaryStrategy.Auto)
             {
-                return _pathAwareWeightSumStrategy;
+                return configuredStrategy;
             }
 
             var effectiveGroups = Math.Max(1, groupCount);
@@ -7624,8 +7648,19 @@ namespace UnifyWeaver.QueryRuntime
             var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
             var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
             return estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
-                ? PathAwareWeightSumStrategy.LegacySeededRows
-                : PathAwareWeightSumStrategy.CompactGrouped;
+                ? PathAwareGroupedSummaryStrategy.LegacySeededRows
+                : PathAwareGroupedSummaryStrategy.CompactGrouped;
+        }
+
+        private static void RecordPathAwareGroupedSummaryStrategy(
+            QueryExecutionTrace? trace,
+            PlanNode node,
+            string nodeStrategyPrefix,
+            PathAwareGroupedSummaryStrategy strategy)
+        {
+            trace?.RecordStrategy(node, strategy == PathAwareGroupedSummaryStrategy.LegacySeededRows
+                ? $"{nodeStrategyPrefix}LegacySeededRows"
+                : $"{nodeStrategyPrefix}CompactGrouped");
         }
 
         private IReadOnlyDictionary<object, Dictionary<object, double>> ExecuteSeedGroupedPathAwareWeightSumFallback(
@@ -7798,13 +7833,16 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var selectedStrategy = ResolvePathAwareWeightSumStrategy(groupValues.Count, orderedUniqueSeeds.Count, rootKeys.Count, succIndex);
-                trace?.RecordStrategy(closure, selectedStrategy == PathAwareWeightSumStrategy.LegacySeededRows
-                    ? "SeedGroupedPathAwareWeightSumLegacySeededRows"
-                    : "SeedGroupedPathAwareWeightSumCompactGrouped");
+                var selectedStrategy = ResolvePathAwareGroupedSummaryStrategy(
+                    _pathAwareWeightSumStrategy,
+                    groupValues.Count,
+                    orderedUniqueSeeds.Count,
+                    rootKeys.Count,
+                    succIndex);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareWeightSum", selectedStrategy);
 
                 IReadOnlyDictionary<object, Dictionary<object, double>> seedWeightSums;
-                if (selectedStrategy == PathAwareWeightSumStrategy.LegacySeededRows)
+                if (selectedStrategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
                 {
                     seedWeightSums = ExecuteSeedGroupedPathAwareWeightSumFallback(closure, orderedUniqueSeeds, rootKeys, context);
                 }
@@ -7963,28 +8001,6 @@ namespace UnifyWeaver.QueryRuntime
         }
 
 
-
-        private PathAwareGroupedMinStrategy ResolvePathAwareGroupedMinStrategy(
-            int groupCount,
-            int uniqueSeedCount,
-            int rootCount,
-            IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
-        {
-            if (_pathAwareGroupedMinStrategy != PathAwareGroupedMinStrategy.Auto)
-            {
-                return _pathAwareGroupedMinStrategy;
-            }
-
-            var effectiveGroups = Math.Max(1, groupCount);
-            var effectiveSeeds = Math.Max(1, uniqueSeedCount);
-            var effectiveRoots = Math.Max(1, rootCount);
-            var nodeCount = Math.Max(1, EstimatePathAwareNodeCount(succIndex));
-            var estimatedGroupedRows = (long)effectiveGroups * effectiveRoots;
-            var estimatedLegacyRows = (long)effectiveSeeds * nodeCount;
-            return estimatedLegacyRows <= Math.Max(64L, estimatedGroupedRows * 4L)
-                ? PathAwareGroupedMinStrategy.LegacySeededRows
-                : PathAwareGroupedMinStrategy.CompactGrouped;
-        }
 
         private static int EstimatePathAwareNodeCount(IReadOnlyDictionary<object, PathAwareSuccessorBucket> succIndex)
         {
@@ -8155,13 +8171,16 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var selectedStrategy = ResolvePathAwareGroupedMinStrategy(groupValues.Count, orderedUniqueSeeds.Count, rootKeys.Count, succIndex);
-                trace?.RecordStrategy(closure, selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows
-                    ? "SeedGroupedPathAwareDepthMinLegacySeededRows"
-                    : "SeedGroupedPathAwareDepthMinCompactGrouped");
+                var selectedStrategy = ResolvePathAwareGroupedSummaryStrategy(
+                    _pathAwareGroupedMinStrategy,
+                    groupValues.Count,
+                    orderedUniqueSeeds.Count,
+                    rootKeys.Count,
+                    succIndex);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareDepthMin", selectedStrategy);
 
                 IReadOnlyDictionary<object, Dictionary<object, int>> seedDepthMins;
-                if (selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows)
+                if (selectedStrategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
                 {
                     seedDepthMins = ExecuteSeedGroupedPathAwareDepthMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
                 }
@@ -8381,13 +8400,16 @@ namespace UnifyWeaver.QueryRuntime
 
                 orderedUniqueSeeds.Sort(CompareCacheSeedValues);
                 groupValues.Sort(CompareCacheSeedValues);
-                var selectedStrategy = ResolvePathAwareGroupedMinStrategy(groupValues.Count, orderedUniqueSeeds.Count, rootKeys.Count, succIndex);
-                trace?.RecordStrategy(closure, selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows
-                    ? "SeedGroupedPathAwareAccumulationMinLegacySeededRows"
-                    : "SeedGroupedPathAwareAccumulationMinCompactGrouped");
+                var selectedStrategy = ResolvePathAwareGroupedSummaryStrategy(
+                    _pathAwareGroupedMinStrategy,
+                    groupValues.Count,
+                    orderedUniqueSeeds.Count,
+                    rootKeys.Count,
+                    succIndex);
+                RecordPathAwareGroupedSummaryStrategy(trace, closure, "SeedGroupedPathAwareAccumulationMin", selectedStrategy);
 
                 IReadOnlyDictionary<object, Dictionary<object, object>> seedMinima;
-                if (selectedStrategy == PathAwareGroupedMinStrategy.LegacySeededRows)
+                if (selectedStrategy == PathAwareGroupedSummaryStrategy.LegacySeededRows)
                 {
                     seedMinima = ExecuteSeedGroupedPathAwareAccumulationMinFallback(closure, orderedUniqueSeeds, rootKeys, context);
                 }


### PR DESCRIPTION
  ## Summary

  This PR unifies the cost-guided retained-form selection logic for the
  path-aware grouped-summary families in the C# query runtime.

  Before this change, the runtime already supported cost-guided selection
  for:

  - grouped minima
    - `shortest_path_to_root`
    - `weighted_shortest_path`
  - grouped weight sums
    - `effective_distance`
    - `category_influence`

  But those two families still carried parallel strategy-selection plumbing:

  - separate internal selector logic
  - separate heuristic resolution paths
  - separate trace/recording code for essentially the same grouped-summary
    decision

  This PR factors that into one shared grouped-summary policy layer while
  keeping the public per-family override knobs unchanged.

  ## What Changed

  ### Shared Internal Grouped-Summary Policy

  Updated:

  - `src/unifyweaver/targets/csharp_query_runtime/QueryRuntime.cs`

  Added:

  - `PathAwareGroupedSummaryStrategy`

  This is an internal runtime strategy enum used to represent the shared
  retained-form decision:

  - `Auto`
  - `CompactGrouped`
  - `LegacySeededRows`

  It is intentionally internal.

  The existing public option surface is preserved:

  - `PathAwareGroupedMinStrategy`
  - `PathAwareWeightSumStrategy`

  ### Shared Strategy Conversion

  Added conversion helpers so the two public option types map into the same
  internal grouped-summary policy.

  That lets the runtime keep separate benchmark-visible knobs for the two
  operator families while removing the duplicated executor internals.

  ### Shared Heuristic Resolver

  Added:

  - `ResolvePathAwareGroupedSummaryStrategy(...)`

  This now holds the shared structural heuristic that was previously
  duplicated across:

  - grouped minima selection
  - grouped weight-sum selection

  The heuristic still uses the same basic shape:

  - group count
  - unique seed count
  - root count
  - estimated path-aware node count

  to choose between:

  - `CompactGrouped`
  - `LegacySeededRows`

  ### Shared Strategy Trace Recording

  Added:

  - `RecordPathAwareGroupedSummaryStrategy(...)`

  This centralizes the strategy-label recording used by trace output for:

  - `SeedGroupedPathAwareDepthMinNode`
  - `SeedGroupedPathAwareAccumulationMinNode`
  - `SeedGroupedPathAwareWeightSumNode`

  So the runtime now exposes one consistent grouped-summary strategy
  selection surface internally, even though the public override knobs remain
  per-family.

  ### Documentation Updates

  Updated:

  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_SPEC.md`
  - `docs/proposals/QUERY_ENGINE_MATERIALIZATION_PLAN.md`
  - `examples/benchmark/README.md`

  These docs now describe Stage 4 more precisely:

  - not as two unrelated heuristic stacks
  - but as a shared grouped-summary policy layer with per-family override
    knobs for benchmarking and validation

  ## Why This Matters

  The point of this PR is not a new benchmark win by itself.

  The value is structural:

  - we now have one reusable retained-form policy path for grouped-summary
    operators
  - the runtime surface is more coherent
  - adding future grouped-summary families no longer requires copying the
    same heuristic/trace plumbing again

  This is the right next step after proving the pattern on both:

  - grouped minima
  - grouped weight sums

  The runtime is moving from “multiple special cases that happen to work”
  toward “one consistent retained-form policy mechanism.”

  ## Verification

  Passed locally:

  ```bash
  python -m py_compile \
      examples/benchmark/generate_pipeline.py \
      examples/benchmark/benchmark_shortest_path_cross_target.py \
      examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      examples/benchmark/benchmark_effective_distance.py \
      examples/benchmark/benchmark_category_influence_cross_target.py
  ```
  ### Full cross-target reruns

  Ran locally:
  ```
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_weighted_shortest_path_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-min \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,csharp-dfs,rust-dfs,go-dfs,prolog-accumulated \
      --repetitions 1
  ```

  ```
  python examples/benchmark/benchmark_category_influence_cross_target.py \
      --scales 300,1k,5k,10k \
      --targets csharp-query,rust-dfs,go-dfs \
      --repetitions 1
  ```
  All completed successfully and still matched on outputs.

  ### Trace verification

  Also ran with trace enabled:
  ```
  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_shortest_path_cross_target.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1
  ```

  ```
  UNIFYWEAVER_BENCH_TRACE=1 \
  python examples/benchmark/benchmark_effective_distance.py \
      --scales 300,10k \
      --targets csharp-query \
      --repetitions 1
  ```
  Observed:
  
  - path_min_strategy_setting=Auto
  - strategy_SeedGroupedPathAwareDepthMinCompactGrouped=1
  
  and:
  
  - weight_sum_strategy_setting=Auto
  - strategy_SeedGroupedPathAwareWeightSumCompactGrouped=1
  
  So the shared policy refactor preserved the selected retained forms.

  ## Representative Results After Refactor

  ### Shortest path

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|---:|
  | 300 | 0.106s | 0.115s | 0.449s | 0.353s | 0.480s |
  | 1k | 0.080s | 0.143s | 1.351s | 1.606s | 2.176s |
  | 5k | 0.132s | 0.290s | 6.073s | 7.933s | 13.848s |
  | 10k | 0.173s | 0.470s | 11.375s | 15.501s | 22.028s |

  ### Weighted shortest path

  | Scale | C# Query | Prolog Min | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|---:|
  | 300 | 0.159s | 0.121s | 0.468s | 0.389s | 0.505s |
  | 1k | 0.129s | 0.130s | 1.363s | 1.685s | 2.263s |
  | 5k | 0.203s | 0.286s | 6.372s | 8.128s | 13.671s |
  | 10k | 0.396s | 0.669s | 12.123s | 16.791s | 21.413s |

  ### Effective distance

  | Scale | C# Query | Prolog Accumulated | C# DFS | Rust DFS | Go DFS |
  |---|---:|---:|---:|---:|---:|
  | 300 | 0.234s | 0.400s | 0.444s | 0.374s | 0.486s |
  | 1k | 0.182s | 0.300s | 1.237s | 1.485s | 2.207s |
  | 5k | 0.409s | 0.985s | 6.119s | 7.889s | 13.905s |
  | 10k | 0.850s | 2.147s | 11.562s | 15.767s | 21.554s |

  ### Category influence

  | Scale | C# Query | Rust DFS | Go DFS |
  |---|---:|---:|---:|
  | 300 | 0.229s | 0.475s | 1.100s |
  | 1k | 0.251s | 2.531s | 2.151s |
  | 5k | 0.456s | 8.483s | 12.900s |
  | 10k | 0.796s | 15.573s | 23.835s |

  ## Interpretation

  This PR confirms that the grouped-summary retention pattern is now mature
  enough to support a shared internal policy layer.

  The main result is:

  - grouped minima and grouped weight sums still behave correctly
  - Auto still picks the compact grouped path on the current benchmark
    surface
  - the runtime now has one coherent internal mechanism for that choice

  That is a better base for extending cost-guided retention to future
  operator families.

  ## Scope

  This PR adds:

  - a shared internal grouped-summary strategy enum
  - shared conversion/resolution/trace helpers
  - doc updates describing the unified grouped-summary policy

  It intentionally does not change:

  - the public per-family benchmark override knobs
  - the current grouped-summary heuristics
  - the current benchmark semantics

  ## Follow-Up

  Likely next work:

  - extend the shared retained-form policy idea beyond grouped summaries
  - refine the heuristic using measured cost buckets rather than only
    structural estimates
  - keep the public per-family override surface where it is useful for
    benchmarking, while pushing more of the selection machinery into shared
    runtime policy code